### PR TITLE
Ascribe `if` conditions to `bool`.

### DIFF
--- a/src/ocaml-output/FStar_Errors.ml
+++ b/src/ocaml-output/FStar_Errors.ml
@@ -2677,51 +2677,45 @@ let (mk_issue :
           }
 let (get_err_count : unit -> Prims.int) =
   fun uu____3263 ->
-    let uu____3264 =
-      let uu____3269 = FStar_ST.op_Bang current_handler in
-      uu____3269.eh_count_errors in
-    uu____3264 ()
+    let uu____3264 = FStar_ST.op_Bang current_handler in
+    uu____3264.eh_count_errors ()
 let (wrapped_eh_add_one : error_handler -> issue -> unit) =
   fun h ->
     fun issue1 ->
       h.eh_add_one issue1;
       if issue1.issue_level <> EInfo
       then
-        ((let uu____3288 =
-            let uu____3289 = FStar_ST.op_Bang FStar_Options.abort_counter in
-            uu____3289 - Prims.int_one in
-          FStar_ST.op_Colon_Equals FStar_Options.abort_counter uu____3288);
-         (let uu____3302 =
-            let uu____3303 = FStar_ST.op_Bang FStar_Options.abort_counter in
-            uu____3303 = Prims.int_zero in
-          if uu____3302 then failwith "Aborting due to --abort_on" else ()))
+        ((let uu____3283 =
+            let uu____3284 = FStar_ST.op_Bang FStar_Options.abort_counter in
+            uu____3284 - Prims.int_one in
+          FStar_ST.op_Colon_Equals FStar_Options.abort_counter uu____3283);
+         (let uu____3297 =
+            let uu____3298 = FStar_ST.op_Bang FStar_Options.abort_counter in
+            uu____3298 = Prims.int_zero in
+          if uu____3297 then failwith "Aborting due to --abort_on" else ()))
       else ()
 let (add_one : issue -> unit) =
   fun issue1 ->
     FStar_Util.atomically
-      (fun uu____3319 ->
-         let uu____3320 = FStar_ST.op_Bang current_handler in
-         wrapped_eh_add_one uu____3320 issue1)
+      (fun uu____3314 ->
+         let uu____3315 = FStar_ST.op_Bang current_handler in
+         wrapped_eh_add_one uu____3315 issue1)
 let (add_many : issue Prims.list -> unit) =
   fun issues ->
     FStar_Util.atomically
-      (fun uu____3338 ->
-         let uu____3339 =
-           let uu____3344 = FStar_ST.op_Bang current_handler in
-           wrapped_eh_add_one uu____3344 in
-         FStar_List.iter uu____3339 issues)
+      (fun uu____3333 ->
+         let uu____3334 =
+           let uu____3339 = FStar_ST.op_Bang current_handler in
+           wrapped_eh_add_one uu____3339 in
+         FStar_List.iter uu____3334 issues)
 let (report_all : unit -> issue Prims.list) =
-  fun uu____3357 ->
-    let uu____3358 =
-      let uu____3365 = FStar_ST.op_Bang current_handler in
-      uu____3365.eh_report in
-    uu____3358 ()
+  fun uu____3352 ->
+    let uu____3353 = FStar_ST.op_Bang current_handler in
+    uu____3353.eh_report ()
 let (clear : unit -> unit) =
-  fun uu____3376 ->
-    let uu____3377 =
-      let uu____3382 = FStar_ST.op_Bang current_handler in
-      uu____3382.eh_clear in
-    uu____3377 ()
+  fun uu____3364 ->
+    let uu____3365 = FStar_ST.op_Bang current_handler in
+    uu____3365.eh_clear ()
 let (set_handler : error_handler -> unit) =
   fun handler ->
     let issues = report_all () in
@@ -2761,28 +2755,28 @@ let (__proj__Mkerror_message_prefix__item__append_prefixs :
 let (message_prefix : error_message_prefix) =
   let pfxs = FStar_Util.mk_ref [] in
   let push_prefix s =
-    let uu____3570 =
-      let uu____3573 = FStar_ST.op_Bang pfxs in s :: uu____3573 in
-    FStar_ST.op_Colon_Equals pfxs uu____3570 in
+    let uu____3553 =
+      let uu____3556 = FStar_ST.op_Bang pfxs in s :: uu____3556 in
+    FStar_ST.op_Colon_Equals pfxs uu____3553 in
   let pop_prefix s =
-    let uu____3602 = FStar_ST.op_Bang pfxs in
-    match uu____3602 with
+    let uu____3585 = FStar_ST.op_Bang pfxs in
+    match uu____3585 with
     | h::t -> (FStar_ST.op_Colon_Equals pfxs t; h)
-    | uu____3630 -> failwith "cannot pop error prefix..." in
-  let clear_prefixs uu____3638 = FStar_ST.op_Colon_Equals pfxs [] in
+    | uu____3613 -> failwith "cannot pop error prefix..." in
+  let clear_prefixs uu____3621 = FStar_ST.op_Colon_Equals pfxs [] in
   let append_prefixs s =
-    let uu____3655 = FStar_ST.op_Bang pfxs in
+    let uu____3638 = FStar_ST.op_Bang pfxs in
     FStar_List.fold_left
       (fun s1 ->
          fun p ->
-           let uu____3673 = FStar_String.op_Hat ":\n\t" s1 in
-           FStar_String.op_Hat p uu____3673) s uu____3655 in
+           let uu____3656 = FStar_String.op_Hat ":\n\t" s1 in
+           FStar_String.op_Hat p uu____3656) s uu____3638 in
   { push_prefix; pop_prefix; clear_prefixs; append_prefixs }
 let (diag : FStar_Range.range -> Prims.string -> unit) =
   fun r ->
     fun msg ->
-      let uu____3684 = FStar_Options.debug_any () in
-      if uu____3684
+      let uu____3667 = FStar_Options.debug_any () in
+      if uu____3667
       then
         add_one
           (mk_issue EInfo (FStar_Pervasives_Native.Some r) msg
@@ -2792,25 +2786,25 @@ let (warn_unsafe_options :
   FStar_Range.range FStar_Pervasives_Native.option -> Prims.string -> unit) =
   fun rng_opt ->
     fun msg ->
-      let uu____3700 = FStar_Options.report_assumes () in
-      match uu____3700 with
+      let uu____3683 = FStar_Options.report_assumes () in
+      match uu____3683 with
       | FStar_Pervasives_Native.Some "warn" ->
-          let uu____3703 =
-            let uu____3704 =
+          let uu____3686 =
+            let uu____3687 =
               FStar_String.op_Hat
                 "Every use of this option triggers a warning: " msg in
-            mk_issue EWarning rng_opt uu____3704
+            mk_issue EWarning rng_opt uu____3687
               (FStar_Pervasives_Native.Some warn_on_use_errno) in
-          add_one uu____3703
+          add_one uu____3686
       | FStar_Pervasives_Native.Some "error" ->
-          let uu____3705 =
-            let uu____3706 =
+          let uu____3688 =
+            let uu____3689 =
               FStar_String.op_Hat
                 "Every use of this option triggers an error: " msg in
-            mk_issue EError rng_opt uu____3706
+            mk_issue EError rng_opt uu____3689
               (FStar_Pervasives_Native.Some warn_on_use_errno) in
-          add_one uu____3705
-      | uu____3707 -> ()
+          add_one uu____3688
+      | uu____3690 -> ()
 let (set_option_warning_callback_range :
   FStar_Range.range FStar_Pervasives_Native.option -> unit) =
   fun ropt ->
@@ -2821,16 +2815,16 @@ let (uu___222 :
   =
   let parser_callback = FStar_Util.mk_ref FStar_Pervasives_Native.None in
   let error_flags = FStar_Util.smap_create (Prims.of_int (10)) in
-  let set_error_flags uu____3774 =
+  let set_error_flags uu____3757 =
     let parse s =
-      let uu____3783 = FStar_ST.op_Bang parser_callback in
-      match uu____3783 with
+      let uu____3766 = FStar_ST.op_Bang parser_callback in
+      match uu____3766 with
       | FStar_Pervasives_Native.None ->
           failwith "Callback for parsing warn_error strings is not set"
       | FStar_Pervasives_Native.Some f -> f s in
     let we = FStar_Options.warn_error () in
     try
-      (fun uu___234_3835 ->
+      (fun uu___234_3818 ->
          match () with
          | () ->
              let r = parse we in
@@ -2840,15 +2834,15 @@ let (uu___222 :
     with
     | Invalid_warn_error_setting msg ->
         (FStar_Util.smap_add error_flags we FStar_Pervasives_Native.None;
-         (let uu____3859 =
+         (let uu____3842 =
             FStar_String.op_Hat "Invalid --warn_error setting: " msg in
-          FStar_Getopt.Error uu____3859)) in
-  let get_error_flags uu____3867 =
+          FStar_Getopt.Error uu____3842)) in
+  let get_error_flags uu____3850 =
     let we = FStar_Options.warn_error () in
-    let uu____3869 = FStar_Util.smap_try_find error_flags we in
-    match uu____3869 with
+    let uu____3852 = FStar_Util.smap_try_find error_flags we in
+    match uu____3852 with
     | FStar_Pervasives_Native.Some (FStar_Pervasives_Native.Some w) -> w
-    | uu____3891 -> default_settings in
+    | uu____3874 -> default_settings in
   let set_callbacks f =
     FStar_ST.op_Colon_Equals parser_callback (FStar_Pervasives_Native.Some f);
     FStar_Options.set_error_flags_callback set_error_flags;
@@ -2864,8 +2858,8 @@ let (error_flags : unit -> error_setting Prims.list) =
 let (lookup : raw_error -> (raw_error * error_flag * Prims.int)) =
   fun err ->
     let flags = error_flags () in
-    let uu____4051 = lookup_error flags err in
-    match uu____4051 with
+    let uu____4034 = lookup_error flags err in
+    match uu____4034 with
     | (v, level, i) ->
         let with_level level1 = (v, level1, i) in
         (match v with
@@ -2875,117 +2869,117 @@ let (lookup : raw_error -> (raw_error * error_flag * Prims.int)) =
              -> with_level CAlwaysError
          | Warning_WarnOnUse ->
              let level' =
-               let uu____4086 = FStar_Options.report_assumes () in
-               match uu____4086 with
+               let uu____4069 = FStar_Options.report_assumes () in
+               match uu____4069 with
                | FStar_Pervasives_Native.None -> level
                | FStar_Pervasives_Native.Some "warn" ->
                    (match level with
                     | CSilent -> CWarning
-                    | uu____4089 -> level)
+                    | uu____4072 -> level)
                | FStar_Pervasives_Native.Some "error" ->
                    (match level with
                     | CWarning -> CError
                     | CSilent -> CError
-                    | uu____4090 -> level)
-               | FStar_Pervasives_Native.Some uu____4091 -> level in
+                    | uu____4073 -> level)
+               | FStar_Pervasives_Native.Some uu____4074 -> level in
              with_level level'
-         | uu____4092 -> with_level level)
+         | uu____4075 -> with_level level)
 let (log_issue : FStar_Range.range -> (raw_error * Prims.string) -> unit) =
   fun r ->
-    fun uu____4106 ->
-      match uu____4106 with
+    fun uu____4089 ->
+      match uu____4089 with
       | (e, msg) ->
-          let uu____4113 = lookup e in
-          (match uu____4113 with
-           | (uu____4120, CAlwaysError, errno) ->
+          let uu____4096 = lookup e in
+          (match uu____4096 with
+           | (uu____4103, CAlwaysError, errno) ->
                add_one
                  (mk_issue EError (FStar_Pervasives_Native.Some r) msg
                     (FStar_Pervasives_Native.Some errno))
-           | (uu____4122, CError, errno) ->
+           | (uu____4105, CError, errno) ->
                add_one
                  (mk_issue EError (FStar_Pervasives_Native.Some r) msg
                     (FStar_Pervasives_Native.Some errno))
-           | (uu____4124, CWarning, errno) ->
+           | (uu____4107, CWarning, errno) ->
                add_one
                  (mk_issue EWarning (FStar_Pervasives_Native.Some r) msg
                     (FStar_Pervasives_Native.Some errno))
-           | (uu____4126, CSilent, uu____4127) -> ()
-           | (uu____4128, CFatal, errno) ->
+           | (uu____4109, CSilent, uu____4110) -> ()
+           | (uu____4111, CFatal, errno) ->
                let i =
                  mk_issue EError (FStar_Pervasives_Native.Some r) msg
                    (FStar_Pervasives_Native.Some errno) in
-               let uu____4131 = FStar_Options.ide () in
-               if uu____4131
+               let uu____4114 = FStar_Options.ide () in
+               if uu____4114
                then add_one i
                else
-                 (let uu____4133 =
-                    let uu____4134 = format_issue i in
+                 (let uu____4116 =
+                    let uu____4117 = format_issue i in
                     FStar_String.op_Hat
                       "don't use log_issue to report fatal error, should use raise_error: "
-                      uu____4134 in
-                  failwith uu____4133))
+                      uu____4117 in
+                  failwith uu____4116))
 let (add_errors :
   (raw_error * Prims.string * FStar_Range.range) Prims.list -> unit) =
   fun errs ->
     FStar_Util.atomically
-      (fun uu____4157 ->
+      (fun uu____4140 ->
          FStar_List.iter
-           (fun uu____4169 ->
-              match uu____4169 with
+           (fun uu____4152 ->
+              match uu____4152 with
               | (e, msg, r) ->
-                  let uu____4179 =
-                    let uu____4184 = message_prefix.append_prefixs msg in
-                    (e, uu____4184) in
-                  log_issue r uu____4179) errs)
+                  let uu____4162 =
+                    let uu____4167 = message_prefix.append_prefixs msg in
+                    (e, uu____4167) in
+                  log_issue r uu____4162) errs)
 let (issue_of_exn : Prims.exn -> issue FStar_Pervasives_Native.option) =
-  fun uu___0_4191 ->
-    match uu___0_4191 with
+  fun uu___0_4174 ->
+    match uu___0_4174 with
     | Error (e, msg, r) ->
-        let errno = let uu____4198 = lookup e in error_number uu____4198 in
-        let uu____4205 =
-          let uu____4206 = message_prefix.append_prefixs msg in
-          mk_issue EError (FStar_Pervasives_Native.Some r) uu____4206
+        let errno = let uu____4181 = lookup e in error_number uu____4181 in
+        let uu____4188 =
+          let uu____4189 = message_prefix.append_prefixs msg in
+          mk_issue EError (FStar_Pervasives_Native.Some r) uu____4189
             (FStar_Pervasives_Native.Some errno) in
-        FStar_Pervasives_Native.Some uu____4205
+        FStar_Pervasives_Native.Some uu____4188
     | Err (e, msg) ->
-        let errno = let uu____4210 = lookup e in error_number uu____4210 in
-        let uu____4217 =
-          let uu____4218 = message_prefix.append_prefixs msg in
-          mk_issue EError FStar_Pervasives_Native.None uu____4218
+        let errno = let uu____4193 = lookup e in error_number uu____4193 in
+        let uu____4200 =
+          let uu____4201 = message_prefix.append_prefixs msg in
+          mk_issue EError FStar_Pervasives_Native.None uu____4201
             (FStar_Pervasives_Native.Some errno) in
-        FStar_Pervasives_Native.Some uu____4217
-    | uu____4219 -> FStar_Pervasives_Native.None
+        FStar_Pervasives_Native.Some uu____4200
+    | uu____4202 -> FStar_Pervasives_Native.None
 let (err_exn : Prims.exn -> unit) =
   fun exn ->
     if exn = Stop
     then ()
     else
-      (let uu____4226 = issue_of_exn exn in
-       match uu____4226 with
+      (let uu____4209 = issue_of_exn exn in
+       match uu____4209 with
        | FStar_Pervasives_Native.Some issue1 -> add_one issue1
        | FStar_Pervasives_Native.None -> FStar_Exn.raise exn)
 let (handleable : Prims.exn -> Prims.bool) =
-  fun uu___1_4234 ->
-    match uu___1_4234 with
-    | Error uu____4235 -> true
+  fun uu___1_4217 ->
+    match uu___1_4217 with
+    | Error uu____4218 -> true
     | Stop -> true
-    | Err uu____4236 -> true
-    | uu____4241 -> false
+    | Err uu____4219 -> true
+    | uu____4224 -> false
 let (stop_if_err : unit -> unit) =
-  fun uu____4246 ->
-    let uu____4247 =
-      let uu____4248 = get_err_count () in uu____4248 > Prims.int_zero in
-    if uu____4247 then FStar_Exn.raise Stop else ()
+  fun uu____4229 ->
+    let uu____4230 =
+      let uu____4231 = get_err_count () in uu____4231 > Prims.int_zero in
+    if uu____4230 then FStar_Exn.raise Stop else ()
 let raise_error :
-  'uuuuuu4256 .
-    (raw_error * Prims.string) -> FStar_Range.range -> 'uuuuuu4256
+  'uuuuuu4239 .
+    (raw_error * Prims.string) -> FStar_Range.range -> 'uuuuuu4239
   =
-  fun uu____4269 ->
+  fun uu____4252 ->
     fun r ->
-      match uu____4269 with | (e, msg) -> FStar_Exn.raise (Error (e, msg, r))
-let raise_err : 'uuuuuu4281 . (raw_error * Prims.string) -> 'uuuuuu4281 =
-  fun uu____4290 ->
-    match uu____4290 with | (e, msg) -> FStar_Exn.raise (Err (e, msg))
+      match uu____4252 with | (e, msg) -> FStar_Exn.raise (Error (e, msg, r))
+let raise_err : 'uuuuuu4264 . (raw_error * Prims.string) -> 'uuuuuu4264 =
+  fun uu____4273 ->
+    match uu____4273 with | (e, msg) -> FStar_Exn.raise (Err (e, msg))
 let catch_errors :
   'a . (unit -> 'a) -> (issue Prims.list * 'a FStar_Pervasives_Native.option)
   =
@@ -2995,17 +2989,17 @@ let catch_errors :
     FStar_ST.op_Colon_Equals current_handler newh;
     (let r =
        try
-         (fun uu___355_4342 ->
+         (fun uu___355_4325 ->
             match () with
             | () -> let r = f () in FStar_Pervasives_Native.Some r) ()
        with
-       | uu___354_4348 ->
-           (err_exn uu___354_4348; FStar_Pervasives_Native.None) in
+       | uu___354_4331 ->
+           (err_exn uu___354_4331; FStar_Pervasives_Native.None) in
      let all_issues = newh.eh_report () in
      FStar_ST.op_Colon_Equals current_handler old;
-     (let uu____4362 =
+     (let uu____4345 =
         FStar_List.partition (fun i -> i.issue_level = EError) all_issues in
-      match uu____4362 with
+      match uu____4345 with
       | (errs, rest) -> (FStar_List.iter old.eh_add_one rest; (errs, r))))
 let (find_multiset_discrepancy :
   Prims.int Prims.list ->
@@ -3019,22 +3013,22 @@ let (find_multiset_discrepancy :
         match l with
         | [] -> []
         | hd::tl ->
-            let uu____4472 = collect tl in
-            (match uu____4472 with
+            let uu____4455 = collect tl in
+            (match uu____4455 with
              | [] -> [(hd, Prims.int_one)]
              | (h, n)::t ->
                  if h = hd
                  then (h, (n + Prims.int_one)) :: t
                  else (hd, Prims.int_one) :: (h, n) :: t) in
       let summ l = collect l in
-      let l11 = let uu____4552 = sort l1 in summ uu____4552 in
-      let l21 = let uu____4562 = sort l2 in summ uu____4562 in
+      let l11 = let uu____4535 = sort l1 in summ uu____4535 in
+      let l21 = let uu____4545 = sort l2 in summ uu____4545 in
       let rec aux l12 l22 =
         match (l12, l22) with
         | ([], []) -> FStar_Pervasives_Native.None
-        | ((e, n)::uu____4656, []) ->
+        | ((e, n)::uu____4639, []) ->
             FStar_Pervasives_Native.Some (e, n, Prims.int_zero)
-        | ([], (e, n)::uu____4691) ->
+        | ([], (e, n)::uu____4674) ->
             FStar_Pervasives_Native.Some (e, Prims.int_zero, n)
         | ((hd1, n1)::tl1, (hd2, n2)::tl2) ->
             if hd1 < hd2

--- a/src/ocaml-output/FStar_Extraction_ML_Modul.ml
+++ b/src/ocaml-output/FStar_Extraction_ML_Modul.ml
@@ -1035,113 +1035,113 @@ let (extract_reifiable_effect :
              let uu____2754 =
                match a_let.FStar_Extraction_ML_Syntax.expr with
                | FStar_Extraction_ML_Syntax.MLE_Let
-                   ((uu____2771, mllb::[]), uu____2773) ->
+                   ((uu____2775, mllb::[]), uu____2777) ->
                    (match mllb.FStar_Extraction_ML_Syntax.mllb_tysc with
                     | FStar_Pervasives_Native.Some tysc ->
                         ((mllb.FStar_Extraction_ML_Syntax.mllb_def), tysc)
                     | FStar_Pervasives_Native.None ->
                         failwith "No type scheme")
-               | uu____2803 -> failwith "Impossible" in
+               | uu____2813 -> failwith "Impossible" in
              (match uu____2754 with
               | (exp, tysc) ->
-                  let uu____2830 =
+                  let uu____2846 =
                     FStar_Extraction_ML_UEnv.extend_with_action_name g1 ed a
                       tysc in
-                  (match uu____2830 with
+                  (match uu____2846 with
                    | (a_nm, a_lid, exp_b, g2) ->
-                       ((let uu____2852 =
-                           let uu____2853 =
-                             let uu____2858 =
+                       ((let uu____2868 =
+                           let uu____2869 =
+                             let uu____2874 =
                                FStar_Extraction_ML_UEnv.tcenv_of_uenv g2 in
-                             FStar_TypeChecker_Env.debug uu____2858 in
-                           FStar_All.pipe_left uu____2853
+                             FStar_TypeChecker_Env.debug uu____2874 in
+                           FStar_All.pipe_left uu____2869
                              (FStar_Options.Other "ExtractionReify") in
-                         if uu____2852
+                         if uu____2868
                          then
-                           let uu____2859 =
+                           let uu____2875 =
                              FStar_Extraction_ML_Code.string_of_mlexpr a_nm
                                a_let in
                            FStar_Util.print1 "Extracted action term: %s\n"
-                             uu____2859
+                             uu____2875
                          else ());
-                        (let uu____2862 =
-                           let uu____2863 =
-                             let uu____2868 =
+                        (let uu____2878 =
+                           let uu____2879 =
+                             let uu____2884 =
                                FStar_Extraction_ML_UEnv.tcenv_of_uenv g2 in
-                             FStar_TypeChecker_Env.debug uu____2868 in
-                           FStar_All.pipe_left uu____2863
+                             FStar_TypeChecker_Env.debug uu____2884 in
+                           FStar_All.pipe_left uu____2879
                              (FStar_Options.Other "ExtractionReify") in
-                         if uu____2862
+                         if uu____2878
                          then
-                           ((let uu____2870 =
+                           ((let uu____2886 =
                                FStar_Extraction_ML_Code.string_of_mlty a_nm
                                  (FStar_Pervasives_Native.snd tysc) in
                              FStar_Util.print1 "Extracted action type: %s\n"
-                               uu____2870);
+                               uu____2886);
                             FStar_List.iter
                               (fun x ->
                                  FStar_Util.print1 "and binders: %s\n" x)
                               (FStar_Pervasives_Native.fst tysc))
                          else ());
-                        (let uu____2874 = extend_iface a_lid a_nm exp exp_b in
-                         match uu____2874 with
+                        (let uu____2894 = extend_iface a_lid a_nm exp exp_b in
+                         match uu____2894 with
                          | (iface1, impl) -> (g2, (iface1, impl))))))) in
-      let uu____2893 =
-        let uu____2900 =
-          let uu____2905 =
-            let uu____2908 =
-              let uu____2917 =
+      let uu____2913 =
+        let uu____2920 =
+          let uu____2925 =
+            let uu____2928 =
+              let uu____2937 =
                 FStar_All.pipe_right ed FStar_Syntax_Util.get_return_repr in
-              FStar_All.pipe_right uu____2917 FStar_Util.must in
-            FStar_All.pipe_right uu____2908 FStar_Pervasives_Native.snd in
-          extract_fv uu____2905 in
-        match uu____2900 with
+              FStar_All.pipe_right uu____2937 FStar_Util.must in
+            FStar_All.pipe_right uu____2928 FStar_Pervasives_Native.snd in
+          extract_fv uu____2925 in
+        match uu____2920 with
         | (return_tm, ty_sc) ->
-            let uu____2986 =
+            let uu____3006 =
               FStar_Extraction_ML_UEnv.extend_with_monad_op_name g ed
                 "return" ty_sc in
-            (match uu____2986 with
+            (match uu____3006 with
              | (return_nm, return_lid, return_b, g1) ->
-                 let uu____3005 =
+                 let uu____3025 =
                    extend_iface return_lid return_nm return_tm return_b in
-                 (match uu____3005 with
+                 (match uu____3025 with
                   | (iface1, impl) -> (g1, iface1, impl))) in
-      match uu____2893 with
+      match uu____2913 with
       | (g1, return_iface, return_decl) ->
-          let uu____3029 =
-            let uu____3036 =
-              let uu____3041 =
-                let uu____3044 =
-                  let uu____3053 =
+          let uu____3049 =
+            let uu____3056 =
+              let uu____3061 =
+                let uu____3064 =
+                  let uu____3073 =
                     FStar_All.pipe_right ed FStar_Syntax_Util.get_bind_repr in
-                  FStar_All.pipe_right uu____3053 FStar_Util.must in
-                FStar_All.pipe_right uu____3044 FStar_Pervasives_Native.snd in
-              extract_fv uu____3041 in
-            match uu____3036 with
+                  FStar_All.pipe_right uu____3073 FStar_Util.must in
+                FStar_All.pipe_right uu____3064 FStar_Pervasives_Native.snd in
+              extract_fv uu____3061 in
+            match uu____3056 with
             | (bind_tm, ty_sc) ->
-                let uu____3122 =
+                let uu____3142 =
                   FStar_Extraction_ML_UEnv.extend_with_monad_op_name g1 ed
                     "bind" ty_sc in
-                (match uu____3122 with
+                (match uu____3142 with
                  | (bind_nm, bind_lid, bind_b, g2) ->
-                     let uu____3141 =
+                     let uu____3161 =
                        extend_iface bind_lid bind_nm bind_tm bind_b in
-                     (match uu____3141 with
+                     (match uu____3161 with
                       | (iface1, impl) -> (g2, iface1, impl))) in
-          (match uu____3029 with
+          (match uu____3049 with
            | (g2, bind_iface, bind_decl) ->
-               let uu____3165 =
+               let uu____3185 =
                  FStar_Util.fold_map extract_action g2
                    ed.FStar_Syntax_Syntax.actions in
-               (match uu____3165 with
+               (match uu____3185 with
                 | (g3, actions) ->
-                    let uu____3202 = FStar_List.unzip actions in
-                    (match uu____3202 with
+                    let uu____3222 = FStar_List.unzip actions in
+                    (match uu____3222 with
                      | (actions_iface, actions1) ->
-                         let uu____3229 =
+                         let uu____3249 =
                            iface_union_l (return_iface :: bind_iface ::
                              actions_iface) in
-                         (g3, uu____3229, (return_decl :: bind_decl ::
+                         (g3, uu____3249, (return_decl :: bind_decl ::
                            actions1)))))
 let (extract_let_rec_types :
   FStar_Syntax_Syntax.sigelt ->
@@ -1153,48 +1153,48 @@ let (extract_let_rec_types :
   fun se ->
     fun env ->
       fun lbs ->
-        let uu____3259 =
+        let uu____3279 =
           FStar_Util.for_some
             (fun lb ->
-               let uu____3263 =
+               let uu____3283 =
                  FStar_Extraction_ML_Term.is_arity env
                    lb.FStar_Syntax_Syntax.lbtyp in
-               Prims.op_Negation uu____3263) lbs in
-        if uu____3259
+               Prims.op_Negation uu____3283) lbs in
+        if uu____3279
         then
           FStar_Errors.raise_error
             (FStar_Errors.Fatal_ExtractionUnsupported,
               "Mutually recursively defined typed and terms cannot yet be extracted")
             se.FStar_Syntax_Syntax.sigrng
         else
-          (let uu____3281 =
+          (let uu____3301 =
              FStar_List.fold_left
-               (fun uu____3316 ->
+               (fun uu____3336 ->
                   fun lb ->
-                    match uu____3316 with
+                    match uu____3336 with
                     | (env1, iface_opt, impls) ->
-                        let uu____3357 =
+                        let uu____3377 =
                           extract_let_rec_type env1
                             se.FStar_Syntax_Syntax.sigquals
                             se.FStar_Syntax_Syntax.sigattrs lb in
-                        (match uu____3357 with
+                        (match uu____3377 with
                          | (env2, iface1, impl) ->
                              let iface_opt1 =
                                match iface_opt with
                                | FStar_Pervasives_Native.None ->
                                    FStar_Pervasives_Native.Some iface1
                                | FStar_Pervasives_Native.Some iface' ->
-                                   let uu____3391 = iface_union iface' iface1 in
-                                   FStar_Pervasives_Native.Some uu____3391 in
+                                   let uu____3411 = iface_union iface' iface1 in
+                                   FStar_Pervasives_Native.Some uu____3411 in
                              (env2, iface_opt1, (impl :: impls))))
                (env, FStar_Pervasives_Native.None, []) lbs in
-           match uu____3281 with
+           match uu____3301 with
            | (env1, iface_opt, impls) ->
-               let uu____3431 = FStar_Option.get iface_opt in
-               let uu____3432 =
+               let uu____3451 = FStar_Option.get iface_opt in
+               let uu____3452 =
                  FStar_All.pipe_right (FStar_List.rev impls)
                    FStar_List.flatten in
-               (env1, uu____3431, uu____3432))
+               (env1, uu____3451, uu____3452))
 let (extract_sigelt_iface :
   FStar_Extraction_ML_UEnv.uenv ->
     FStar_Syntax_Syntax.sigelt -> (FStar_Extraction_ML_UEnv.uenv * iface))
@@ -1202,83 +1202,83 @@ let (extract_sigelt_iface :
   fun g ->
     fun se ->
       match se.FStar_Syntax_Syntax.sigel with
-      | FStar_Syntax_Syntax.Sig_bundle uu____3463 ->
+      | FStar_Syntax_Syntax.Sig_bundle uu____3483 ->
           extract_bundle_iface g se
-      | FStar_Syntax_Syntax.Sig_inductive_typ uu____3472 ->
+      | FStar_Syntax_Syntax.Sig_inductive_typ uu____3492 ->
           extract_bundle_iface g se
-      | FStar_Syntax_Syntax.Sig_datacon uu____3489 ->
+      | FStar_Syntax_Syntax.Sig_datacon uu____3509 ->
           extract_bundle_iface g se
       | FStar_Syntax_Syntax.Sig_declare_typ (lid, univs, t) when
           FStar_Extraction_ML_Term.is_arity g t ->
-          let uu____3507 =
+          let uu____3527 =
             extract_type_declaration g lid se.FStar_Syntax_Syntax.sigquals
               se.FStar_Syntax_Syntax.sigattrs univs t in
-          (match uu____3507 with | (env, iface1, uu____3522) -> (env, iface1))
-      | FStar_Syntax_Syntax.Sig_let ((false, lb::[]), uu____3528) when
+          (match uu____3527 with | (env, iface1, uu____3542) -> (env, iface1))
+      | FStar_Syntax_Syntax.Sig_let ((false, lb::[]), uu____3548) when
           FStar_Extraction_ML_Term.is_arity g lb.FStar_Syntax_Syntax.lbtyp ->
-          let uu____3535 =
+          let uu____3555 =
             extract_typ_abbrev g se.FStar_Syntax_Syntax.sigquals
               se.FStar_Syntax_Syntax.sigattrs lb in
-          (match uu____3535 with | (env, iface1, uu____3550) -> (env, iface1))
-      | FStar_Syntax_Syntax.Sig_let ((true, lbs), uu____3556) when
+          (match uu____3555 with | (env, iface1, uu____3570) -> (env, iface1))
+      | FStar_Syntax_Syntax.Sig_let ((true, lbs), uu____3576) when
           FStar_Util.for_some
             (fun lb ->
                FStar_Extraction_ML_Term.is_arity g
                  lb.FStar_Syntax_Syntax.lbtyp) lbs
           ->
-          let uu____3567 = extract_let_rec_types se g lbs in
-          (match uu____3567 with | (env, iface1, uu____3582) -> (env, iface1))
+          let uu____3587 = extract_let_rec_types se g lbs in
+          (match uu____3587 with | (env, iface1, uu____3602) -> (env, iface1))
       | FStar_Syntax_Syntax.Sig_declare_typ (lid, _univs, t) ->
           let quals = se.FStar_Syntax_Syntax.sigquals in
-          let uu____3593 =
+          let uu____3613 =
             (FStar_All.pipe_right quals
                (FStar_List.contains FStar_Syntax_Syntax.Assumption))
               &&
-              (let uu____3597 =
-                 let uu____3598 = FStar_Extraction_ML_UEnv.tcenv_of_uenv g in
-                 FStar_TypeChecker_Util.must_erase_for_extraction uu____3598
+              (let uu____3617 =
+                 let uu____3618 = FStar_Extraction_ML_UEnv.tcenv_of_uenv g in
+                 FStar_TypeChecker_Util.must_erase_for_extraction uu____3618
                    t in
-               Prims.op_Negation uu____3597) in
-          if uu____3593
+               Prims.op_Negation uu____3617) in
+          if uu____3613
           then
-            let uu____3603 =
-              let uu____3614 =
-                let uu____3615 =
-                  let uu____3618 = always_fail lid t in [uu____3618] in
-                (false, uu____3615) in
-              FStar_Extraction_ML_Term.extract_lb_iface g uu____3614 in
-            (match uu____3603 with
+            let uu____3623 =
+              let uu____3634 =
+                let uu____3635 =
+                  let uu____3638 = always_fail lid t in [uu____3638] in
+                (false, uu____3635) in
+              FStar_Extraction_ML_Term.extract_lb_iface g uu____3634 in
+            (match uu____3623 with
              | (g1, bindings) -> (g1, (iface_of_bindings bindings)))
           else (g, empty_iface)
-      | FStar_Syntax_Syntax.Sig_let (lbs, uu____3641) ->
-          let uu____3646 = FStar_Extraction_ML_Term.extract_lb_iface g lbs in
-          (match uu____3646 with
+      | FStar_Syntax_Syntax.Sig_let (lbs, uu____3661) ->
+          let uu____3666 = FStar_Extraction_ML_Term.extract_lb_iface g lbs in
+          (match uu____3666 with
            | (g1, bindings) -> (g1, (iface_of_bindings bindings)))
-      | FStar_Syntax_Syntax.Sig_assume uu____3675 -> (g, empty_iface)
-      | FStar_Syntax_Syntax.Sig_sub_effect uu____3682 -> (g, empty_iface)
-      | FStar_Syntax_Syntax.Sig_effect_abbrev uu____3683 -> (g, empty_iface)
-      | FStar_Syntax_Syntax.Sig_polymonadic_bind uu____3696 ->
+      | FStar_Syntax_Syntax.Sig_assume uu____3695 -> (g, empty_iface)
+      | FStar_Syntax_Syntax.Sig_sub_effect uu____3702 -> (g, empty_iface)
+      | FStar_Syntax_Syntax.Sig_effect_abbrev uu____3703 -> (g, empty_iface)
+      | FStar_Syntax_Syntax.Sig_polymonadic_bind uu____3716 ->
           (g, empty_iface)
-      | FStar_Syntax_Syntax.Sig_polymonadic_subcomp uu____3707 ->
+      | FStar_Syntax_Syntax.Sig_polymonadic_subcomp uu____3727 ->
           (g, empty_iface)
       | FStar_Syntax_Syntax.Sig_pragma p ->
           (FStar_Syntax_Util.process_pragma p se.FStar_Syntax_Syntax.sigrng;
            (g, empty_iface))
-      | FStar_Syntax_Syntax.Sig_splice uu____3718 ->
+      | FStar_Syntax_Syntax.Sig_splice uu____3738 ->
           failwith "impossible: trying to extract splice"
-      | FStar_Syntax_Syntax.Sig_fail uu____3729 ->
+      | FStar_Syntax_Syntax.Sig_fail uu____3749 ->
           failwith "impossible: trying to extract Sig_fail"
       | FStar_Syntax_Syntax.Sig_new_effect ed ->
-          let uu____3745 =
-            (let uu____3748 = FStar_Extraction_ML_UEnv.tcenv_of_uenv g in
-             FStar_TypeChecker_Env.is_reifiable_effect uu____3748
+          let uu____3765 =
+            (let uu____3768 = FStar_Extraction_ML_UEnv.tcenv_of_uenv g in
+             FStar_TypeChecker_Env.is_reifiable_effect uu____3768
                ed.FStar_Syntax_Syntax.mname)
               && (FStar_List.isEmpty ed.FStar_Syntax_Syntax.binders) in
-          if uu____3745
+          if uu____3765
           then
-            let uu____3759 = extract_reifiable_effect g ed in
-            (match uu____3759 with
-             | (env, iface1, uu____3774) -> (env, iface1))
+            let uu____3779 = extract_reifiable_effect g ed in
+            (match uu____3779 with
+             | (env, iface1, uu____3794) -> (env, iface1))
           else (g, empty_iface)
 let (extract_iface' :
   env_t ->
@@ -1286,34 +1286,34 @@ let (extract_iface' :
   =
   fun g ->
     fun modul ->
-      let uu____3794 = FStar_Options.interactive () in
-      if uu____3794
+      let uu____3814 = FStar_Options.interactive () in
+      if uu____3814
       then (g, empty_iface)
       else
-        (let uu____3800 = FStar_Options.restore_cmd_line_options true in
+        (let uu____3820 = FStar_Options.restore_cmd_line_options true in
          let decls = modul.FStar_Syntax_Syntax.declarations in
          let iface1 =
-           let uu___649_3803 = empty_iface in
-           let uu____3804 = FStar_Extraction_ML_UEnv.current_module_of_uenv g in
+           let uu___649_3823 = empty_iface in
+           let uu____3824 = FStar_Extraction_ML_UEnv.current_module_of_uenv g in
            {
-             iface_module_name = uu____3804;
-             iface_bindings = (uu___649_3803.iface_bindings);
-             iface_tydefs = (uu___649_3803.iface_tydefs);
-             iface_type_names = (uu___649_3803.iface_type_names)
+             iface_module_name = uu____3824;
+             iface_bindings = (uu___649_3823.iface_bindings);
+             iface_tydefs = (uu___649_3823.iface_tydefs);
+             iface_type_names = (uu___649_3823.iface_type_names)
            } in
          let res =
            FStar_List.fold_left
-             (fun uu____3822 ->
+             (fun uu____3842 ->
                 fun se ->
-                  match uu____3822 with
+                  match uu____3842 with
                   | (g1, iface2) ->
-                      let uu____3834 = extract_sigelt_iface g1 se in
-                      (match uu____3834 with
+                      let uu____3854 = extract_sigelt_iface g1 se in
+                      (match uu____3854 with
                        | (g2, iface') ->
-                           let uu____3845 = iface_union iface2 iface' in
-                           (g2, uu____3845))) (g, iface1) decls in
-         (let uu____3847 = FStar_Options.restore_cmd_line_options true in
-          FStar_All.pipe_left (fun uu____3848 -> ()) uu____3847);
+                           let uu____3865 = iface_union iface2 iface' in
+                           (g2, uu____3865))) (g, iface1) decls in
+         (let uu____3867 = FStar_Options.restore_cmd_line_options true in
+          FStar_All.pipe_left (fun uu____3868 -> ()) uu____3867);
          res)
 let (extract_iface :
   FStar_Extraction_ML_UEnv.uenv ->
@@ -1321,23 +1321,23 @@ let (extract_iface :
   =
   fun g ->
     fun modul ->
-      let uu____3863 =
+      let uu____3883 =
         FStar_Syntax_Unionfind.with_uf_enabled
-          (fun uu____3875 ->
-             let uu____3876 = FStar_Options.debug_any () in
-             if uu____3876
+          (fun uu____3895 ->
+             let uu____3896 = FStar_Options.debug_any () in
+             if uu____3896
              then
-               let uu____3881 =
-                 let uu____3882 =
+               let uu____3901 =
+                 let uu____3902 =
                    FStar_Ident.string_of_lid modul.FStar_Syntax_Syntax.name in
-                 FStar_Util.format1 "Extracted interface of %s" uu____3882 in
-               FStar_Util.measure_execution_time uu____3881
-                 (fun uu____3888 -> extract_iface' g modul)
+                 FStar_Util.format1 "Extracted interface of %s" uu____3902 in
+               FStar_Util.measure_execution_time uu____3901
+                 (fun uu____3908 -> extract_iface' g modul)
              else extract_iface' g modul) in
-      match uu____3863 with
+      match uu____3883 with
       | (g1, iface1) ->
-          let uu____3896 = FStar_Extraction_ML_UEnv.exit_module g1 in
-          (uu____3896, iface1)
+          let uu____3916 = FStar_Extraction_ML_UEnv.exit_module g1 in
+          (uu____3916, iface1)
 let (extract_bundle :
   FStar_Extraction_ML_UEnv.uenv ->
     FStar_Syntax_Syntax.sigelt ->
@@ -1348,10 +1348,10 @@ let (extract_bundle :
     fun se ->
       let extract_ctor env_iparams ml_tyvars env1 ctor =
         let mlt =
-          let uu____3967 =
+          let uu____3987 =
             FStar_Extraction_ML_Term.term_as_mlty env_iparams ctor.dtyp in
           FStar_Extraction_ML_Util.eraseTypeDeep
-            (FStar_Extraction_ML_Util.udelta_unfold env_iparams) uu____3967 in
+            (FStar_Extraction_ML_Util.udelta_unfold env_iparams) uu____3987 in
         let steps =
           [FStar_TypeChecker_Env.Inlining;
           FStar_TypeChecker_Env.UnfoldUntil
@@ -1360,150 +1360,150 @@ let (extract_bundle :
           FStar_TypeChecker_Env.AllowUnboundUniverses;
           FStar_TypeChecker_Env.ForExtraction] in
         let names =
-          let uu____3974 =
-            let uu____3975 =
-              let uu____3978 =
-                let uu____3979 =
+          let uu____3994 =
+            let uu____3995 =
+              let uu____3998 =
+                let uu____3999 =
                   FStar_Extraction_ML_UEnv.tcenv_of_uenv env_iparams in
-                FStar_TypeChecker_Normalize.normalize steps uu____3979
+                FStar_TypeChecker_Normalize.normalize steps uu____3999
                   ctor.dtyp in
-              FStar_Syntax_Subst.compress uu____3978 in
-            uu____3975.FStar_Syntax_Syntax.n in
-          match uu____3974 with
-          | FStar_Syntax_Syntax.Tm_arrow (bs, uu____3983) ->
+              FStar_Syntax_Subst.compress uu____3998 in
+            uu____3995.FStar_Syntax_Syntax.n in
+          match uu____3994 with
+          | FStar_Syntax_Syntax.Tm_arrow (bs, uu____4003) ->
               FStar_List.map
-                (fun uu____4015 ->
-                   match uu____4015 with
+                (fun uu____4035 ->
+                   match uu____4035 with
                    | ({ FStar_Syntax_Syntax.ppname = ppname;
-                        FStar_Syntax_Syntax.index = uu____4023;
-                        FStar_Syntax_Syntax.sort = uu____4024;_},
-                      uu____4025) -> FStar_Ident.string_of_id ppname) bs
-          | uu____4032 -> [] in
+                        FStar_Syntax_Syntax.index = uu____4043;
+                        FStar_Syntax_Syntax.sort = uu____4044;_},
+                      uu____4045) -> FStar_Ident.string_of_id ppname) bs
+          | uu____4052 -> [] in
         let tys = (ml_tyvars, mlt) in
         let fvv =
           FStar_Syntax_Syntax.lid_as_fv ctor.dname
             FStar_Syntax_Syntax.delta_constant FStar_Pervasives_Native.None in
-        let uu____4039 =
+        let uu____4059 =
           FStar_Extraction_ML_UEnv.extend_fv env1 fvv tys false in
-        match uu____4039 with
-        | (env2, mls, uu____4062) ->
-            let uu____4063 =
-              let uu____4074 =
-                let uu____4081 = FStar_Extraction_ML_Util.argTypes mlt in
-                FStar_List.zip names uu____4081 in
-              (mls, uu____4074) in
-            (env2, uu____4063) in
+        match uu____4059 with
+        | (env2, mls, uu____4082) ->
+            let uu____4083 =
+              let uu____4094 =
+                let uu____4101 = FStar_Extraction_ML_Util.argTypes mlt in
+                FStar_List.zip names uu____4101 in
+              (mls, uu____4094) in
+            (env2, uu____4083) in
       let extract_one_family env1 ind =
-        let uu____4133 = binders_as_mlty_binders env1 ind.iparams in
-        match uu____4133 with
+        let uu____4153 = binders_as_mlty_binders env1 ind.iparams in
+        match uu____4153 with
         | (env_iparams, vars) ->
-            let uu____4170 =
+            let uu____4190 =
               FStar_All.pipe_right ind.idatas
                 (FStar_Util.fold_map (extract_ctor env_iparams vars) env1) in
-            (match uu____4170 with
+            (match uu____4190 with
              | (env2, ctors) ->
-                 let uu____4263 = FStar_Syntax_Util.arrow_formals ind.ityp in
-                 (match uu____4263 with
-                  | (indices, uu____4293) ->
+                 let uu____4283 = FStar_Syntax_Util.arrow_formals ind.ityp in
+                 (match uu____4283 with
+                  | (indices, uu____4313) ->
                       let ml_params =
-                        let uu____4301 =
+                        let uu____4321 =
                           FStar_All.pipe_right indices
                             (FStar_List.mapi
                                (fun i ->
-                                  fun uu____4324 ->
-                                    let uu____4331 =
+                                  fun uu____4344 ->
+                                    let uu____4351 =
                                       FStar_Util.string_of_int i in
-                                    Prims.op_Hat "'dummyV" uu____4331)) in
-                        FStar_List.append vars uu____4301 in
-                      let uu____4332 =
-                        let uu____4339 =
+                                    Prims.op_Hat "'dummyV" uu____4351)) in
+                        FStar_List.append vars uu____4321 in
+                      let uu____4352 =
+                        let uu____4359 =
                           FStar_Util.find_opt
-                            (fun uu___7_4344 ->
-                               match uu___7_4344 with
-                               | FStar_Syntax_Syntax.RecordType uu____4345 ->
+                            (fun uu___7_4364 ->
+                               match uu___7_4364 with
+                               | FStar_Syntax_Syntax.RecordType uu____4365 ->
                                    true
-                               | uu____4354 -> false) ind.iquals in
-                        match uu____4339 with
+                               | uu____4374 -> false) ind.iquals in
+                        match uu____4359 with
                         | FStar_Pervasives_Native.Some
                             (FStar_Syntax_Syntax.RecordType (ns, ids)) ->
-                            let uu____4371 = FStar_List.hd ctors in
-                            (match uu____4371 with
-                             | (uu____4398, c_ty) ->
-                                 let uu____4413 =
+                            let uu____4391 = FStar_List.hd ctors in
+                            (match uu____4391 with
+                             | (uu____4418, c_ty) ->
+                                 let uu____4433 =
                                    FStar_List.fold_right2
                                      (fun id ->
-                                        fun uu____4449 ->
-                                          fun uu____4450 ->
-                                            match (uu____4449, uu____4450)
+                                        fun uu____4469 ->
+                                          fun uu____4470 ->
+                                            match (uu____4469, uu____4470)
                                             with
-                                            | ((uu____4489, ty), (fields, g))
+                                            | ((uu____4509, ty), (fields, g))
                                                 ->
-                                                let uu____4519 =
+                                                let uu____4539 =
                                                   FStar_Extraction_ML_UEnv.extend_record_field_name
                                                     g ((ind.iname), id) in
-                                                (match uu____4519 with
+                                                (match uu____4539 with
                                                  | (mlid, g1) ->
                                                      (((mlid, ty) :: fields),
                                                        g1))) ids c_ty
                                      ([], env2) in
-                                 (match uu____4413 with
+                                 (match uu____4433 with
                                   | (fields, g) ->
                                       ((FStar_Pervasives_Native.Some
                                           (FStar_Extraction_ML_Syntax.MLTD_Record
                                              fields)), g)))
-                        | uu____4578 when
+                        | uu____4598 when
                             (FStar_List.length ctors) = Prims.int_zero ->
                             (FStar_Pervasives_Native.None, env2)
-                        | uu____4593 ->
+                        | uu____4613 ->
                             ((FStar_Pervasives_Native.Some
                                 (FStar_Extraction_ML_Syntax.MLTD_DType ctors)),
                               env2) in
-                      (match uu____4332 with
+                      (match uu____4352 with
                        | (tbody, env3) ->
-                           let uu____4626 =
-                             let uu____4645 =
-                               let uu____4646 =
+                           let uu____4646 =
+                             let uu____4665 =
+                               let uu____4666 =
                                  FStar_Extraction_ML_UEnv.mlpath_of_lident
                                    env3 ind.iname in
-                               FStar_Pervasives_Native.snd uu____4646 in
-                             (false, uu____4645,
+                               FStar_Pervasives_Native.snd uu____4666 in
+                             (false, uu____4665,
                                FStar_Pervasives_Native.None, ml_params,
                                (ind.imetadata), tbody) in
-                           (env3, uu____4626)))) in
+                           (env3, uu____4646)))) in
       match ((se.FStar_Syntax_Syntax.sigel),
               (se.FStar_Syntax_Syntax.sigquals))
       with
       | (FStar_Syntax_Syntax.Sig_bundle
          ({
             FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_datacon
-              (l, uu____4688, t, uu____4690, uu____4691, uu____4692);
-            FStar_Syntax_Syntax.sigrng = uu____4693;
-            FStar_Syntax_Syntax.sigquals = uu____4694;
-            FStar_Syntax_Syntax.sigmeta = uu____4695;
-            FStar_Syntax_Syntax.sigattrs = uu____4696;
-            FStar_Syntax_Syntax.sigopts = uu____4697;_}::[],
-          uu____4698),
+              (l, uu____4708, t, uu____4710, uu____4711, uu____4712);
+            FStar_Syntax_Syntax.sigrng = uu____4713;
+            FStar_Syntax_Syntax.sigquals = uu____4714;
+            FStar_Syntax_Syntax.sigmeta = uu____4715;
+            FStar_Syntax_Syntax.sigattrs = uu____4716;
+            FStar_Syntax_Syntax.sigopts = uu____4717;_}::[],
+          uu____4718),
          (FStar_Syntax_Syntax.ExceptionConstructor)::[]) ->
-          let uu____4717 = extract_ctor env [] env { dname = l; dtyp = t } in
-          (match uu____4717 with
+          let uu____4737 = extract_ctor env [] env { dname = l; dtyp = t } in
+          (match uu____4737 with
            | (env1, ctor) ->
                (env1, [FStar_Extraction_ML_Syntax.MLM_Exn ctor]))
-      | (FStar_Syntax_Syntax.Sig_bundle (ses, uu____4763), quals) ->
-          let uu____4777 =
+      | (FStar_Syntax_Syntax.Sig_bundle (ses, uu____4783), quals) ->
+          let uu____4797 =
             FStar_Syntax_Util.has_attribute se.FStar_Syntax_Syntax.sigattrs
               FStar_Parser_Const.erasable_attr in
-          if uu____4777
+          if uu____4797
           then (env, [])
           else
-            (let uu____4787 = bundle_as_inductive_families env ses quals in
-             match uu____4787 with
+            (let uu____4807 = bundle_as_inductive_families env ses quals in
+             match uu____4807 with
              | (env1, ifams) ->
-                 let uu____4806 =
+                 let uu____4826 =
                    FStar_Util.fold_map extract_one_family env1 ifams in
-                 (match uu____4806 with
+                 (match uu____4826 with
                   | (env2, td) ->
                       (env2, [FStar_Extraction_ML_Syntax.MLM_Ty td])))
-      | uu____4899 -> failwith "Unexpected signature element"
+      | uu____4919 -> failwith "Unexpected signature element"
 let (maybe_register_plugin :
   env_t ->
     FStar_Syntax_Syntax.sigelt ->
@@ -1517,40 +1517,40 @@ let (maybe_register_plugin :
       let plugin_with_arity attrs =
         FStar_Util.find_map attrs
           (fun t ->
-             let uu____4953 = FStar_Syntax_Util.head_and_args t in
-             match uu____4953 with
+             let uu____4973 = FStar_Syntax_Util.head_and_args t in
+             match uu____4973 with
              | (head, args) ->
-                 let uu____5000 =
-                   let uu____5001 =
+                 let uu____5020 =
+                   let uu____5021 =
                      FStar_Syntax_Util.is_fvar FStar_Parser_Const.plugin_attr
                        head in
-                   Prims.op_Negation uu____5001 in
-                 if uu____5000
+                   Prims.op_Negation uu____5021 in
+                 if uu____5020
                  then FStar_Pervasives_Native.None
                  else
                    (match args with
                     | ({
                          FStar_Syntax_Syntax.n =
                            FStar_Syntax_Syntax.Tm_constant
-                           (FStar_Const.Const_int (s, uu____5014));
-                         FStar_Syntax_Syntax.pos = uu____5015;
-                         FStar_Syntax_Syntax.vars = uu____5016;_},
-                       uu____5017)::[] ->
-                        let uu____5054 =
-                          let uu____5057 = FStar_Util.int_of_string s in
-                          FStar_Pervasives_Native.Some uu____5057 in
-                        FStar_Pervasives_Native.Some uu____5054
-                    | uu____5060 ->
+                           (FStar_Const.Const_int (s, uu____5034));
+                         FStar_Syntax_Syntax.pos = uu____5035;
+                         FStar_Syntax_Syntax.vars = uu____5036;_},
+                       uu____5037)::[] ->
+                        let uu____5074 =
+                          let uu____5077 = FStar_Util.int_of_string s in
+                          FStar_Pervasives_Native.Some uu____5077 in
+                        FStar_Pervasives_Native.Some uu____5074
+                    | uu____5080 ->
                         FStar_Pervasives_Native.Some
                           FStar_Pervasives_Native.None)) in
-      let uu____5073 =
-        let uu____5074 = FStar_Options.codegen () in
-        uu____5074 <> (FStar_Pervasives_Native.Some FStar_Options.Plugin) in
-      if uu____5073
+      let uu____5093 =
+        let uu____5094 = FStar_Options.codegen () in
+        uu____5094 <> (FStar_Pervasives_Native.Some FStar_Options.Plugin) in
+      if uu____5093
       then []
       else
-        (let uu____5082 = plugin_with_arity se.FStar_Syntax_Syntax.sigattrs in
-         match uu____5082 with
+        (let uu____5102 = plugin_with_arity se.FStar_Syntax_Syntax.sigattrs in
+         match uu____5102 with
          | FStar_Pervasives_Native.None -> []
          | FStar_Pervasives_Native.Some arity_opt ->
              (match se.FStar_Syntax_Syntax.sigel with
@@ -1561,17 +1561,17 @@ let (maybe_register_plugin :
                       (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
                     let fv_t = lb.FStar_Syntax_Syntax.lbtyp in
                     let ml_name_str =
-                      let uu____5120 =
-                        let uu____5121 = FStar_Ident.string_of_lid fv_lid in
-                        FStar_Extraction_ML_Syntax.MLC_String uu____5121 in
-                      FStar_Extraction_ML_Syntax.MLE_Const uu____5120 in
-                    let uu____5122 =
+                      let uu____5140 =
+                        let uu____5141 = FStar_Ident.string_of_lid fv_lid in
+                        FStar_Extraction_ML_Syntax.MLC_String uu____5141 in
+                      FStar_Extraction_ML_Syntax.MLE_Const uu____5140 in
+                    let uu____5142 =
                       FStar_Extraction_ML_Util.interpret_plugin_as_term_fun g
                         fv fv_t arity_opt ml_name_str in
-                    match uu____5122 with
+                    match uu____5142 with
                     | FStar_Pervasives_Native.Some
                         (interp, nbe_interp, arity, plugin) ->
-                        let uu____5147 =
+                        let uu____5167 =
                           if plugin
                           then
                             ((["FStar_Tactics_Native"], "register_plugin"),
@@ -1579,7 +1579,7 @@ let (maybe_register_plugin :
                           else
                             ((["FStar_Tactics_Native"], "register_tactic"),
                               [interp]) in
-                        (match uu____5147 with
+                        (match uu____5167 with
                          | (register, args) ->
                              let h =
                                FStar_All.pipe_left
@@ -1588,15 +1588,15 @@ let (maybe_register_plugin :
                                  (FStar_Extraction_ML_Syntax.MLE_Name
                                     register) in
                              let arity1 =
-                               let uu____5179 =
-                                 let uu____5180 =
-                                   let uu____5191 =
+                               let uu____5199 =
+                                 let uu____5200 =
+                                   let uu____5211 =
                                      FStar_Util.string_of_int arity in
-                                   (uu____5191, FStar_Pervasives_Native.None) in
+                                   (uu____5211, FStar_Pervasives_Native.None) in
                                  FStar_Extraction_ML_Syntax.MLC_Int
-                                   uu____5180 in
+                                   uu____5200 in
                                FStar_Extraction_ML_Syntax.MLE_Const
-                                 uu____5179 in
+                                 uu____5199 in
                              let app =
                                FStar_All.pipe_left
                                  (FStar_Extraction_ML_Syntax.with_ty
@@ -1609,7 +1609,7 @@ let (maybe_register_plugin :
                     | FStar_Pervasives_Native.None -> [] in
                   FStar_List.collect mk_registration
                     (FStar_Pervasives_Native.snd lbs)
-              | uu____5215 -> []))
+              | uu____5235 -> []))
 let rec (extract_sig :
   env_t ->
     FStar_Syntax_Syntax.sigelt ->
@@ -1619,376 +1619,376 @@ let rec (extract_sig :
     fun se ->
       FStar_Extraction_ML_UEnv.debug g
         (fun u ->
-           let uu____5242 = FStar_Syntax_Print.sigelt_to_string se in
-           FStar_Util.print1 ">>>> extract_sig %s \n" uu____5242);
+           let uu____5262 = FStar_Syntax_Print.sigelt_to_string se in
+           FStar_Util.print1 ">>>> extract_sig %s \n" uu____5262);
       (match se.FStar_Syntax_Syntax.sigel with
-       | FStar_Syntax_Syntax.Sig_bundle uu____5249 -> extract_bundle g se
-       | FStar_Syntax_Syntax.Sig_inductive_typ uu____5258 ->
+       | FStar_Syntax_Syntax.Sig_bundle uu____5269 -> extract_bundle g se
+       | FStar_Syntax_Syntax.Sig_inductive_typ uu____5278 ->
            extract_bundle g se
-       | FStar_Syntax_Syntax.Sig_datacon uu____5275 -> extract_bundle g se
+       | FStar_Syntax_Syntax.Sig_datacon uu____5295 -> extract_bundle g se
        | FStar_Syntax_Syntax.Sig_new_effect ed when
-           let uu____5291 = FStar_Extraction_ML_UEnv.tcenv_of_uenv g in
-           FStar_TypeChecker_Env.is_reifiable_effect uu____5291
+           let uu____5311 = FStar_Extraction_ML_UEnv.tcenv_of_uenv g in
+           FStar_TypeChecker_Env.is_reifiable_effect uu____5311
              ed.FStar_Syntax_Syntax.mname
            ->
-           let uu____5292 = extract_reifiable_effect g ed in
-           (match uu____5292 with | (env, _iface, impl) -> (env, impl))
-       | FStar_Syntax_Syntax.Sig_splice uu____5316 ->
+           let uu____5312 = extract_reifiable_effect g ed in
+           (match uu____5312 with | (env, _iface, impl) -> (env, impl))
+       | FStar_Syntax_Syntax.Sig_splice uu____5336 ->
            failwith "impossible: trying to extract splice"
-       | FStar_Syntax_Syntax.Sig_fail uu____5329 ->
+       | FStar_Syntax_Syntax.Sig_fail uu____5349 ->
            failwith "impossible: trying to extract Sig_fail"
-       | FStar_Syntax_Syntax.Sig_new_effect uu____5346 -> (g, [])
+       | FStar_Syntax_Syntax.Sig_new_effect uu____5366 -> (g, [])
        | FStar_Syntax_Syntax.Sig_declare_typ (lid, univs, t) when
            FStar_Extraction_ML_Term.is_arity g t ->
-           let uu____5352 =
+           let uu____5372 =
              extract_type_declaration g lid se.FStar_Syntax_Syntax.sigquals
                se.FStar_Syntax_Syntax.sigattrs univs t in
-           (match uu____5352 with | (env, uu____5368, impl) -> (env, impl))
-       | FStar_Syntax_Syntax.Sig_let ((false, lb::[]), uu____5377) when
+           (match uu____5372 with | (env, uu____5388, impl) -> (env, impl))
+       | FStar_Syntax_Syntax.Sig_let ((false, lb::[]), uu____5397) when
            FStar_Extraction_ML_Term.is_arity g lb.FStar_Syntax_Syntax.lbtyp
            ->
-           let uu____5384 =
+           let uu____5404 =
              extract_typ_abbrev g se.FStar_Syntax_Syntax.sigquals
                se.FStar_Syntax_Syntax.sigattrs lb in
-           (match uu____5384 with | (env, uu____5400, impl) -> (env, impl))
-       | FStar_Syntax_Syntax.Sig_let ((true, lbs), uu____5409) when
+           (match uu____5404 with | (env, uu____5420, impl) -> (env, impl))
+       | FStar_Syntax_Syntax.Sig_let ((true, lbs), uu____5429) when
            FStar_Util.for_some
              (fun lb ->
                 FStar_Extraction_ML_Term.is_arity g
                   lb.FStar_Syntax_Syntax.lbtyp) lbs
            ->
-           let uu____5420 = extract_let_rec_types se g lbs in
-           (match uu____5420 with | (env, uu____5436, impl) -> (env, impl))
-       | FStar_Syntax_Syntax.Sig_let (lbs, uu____5445) ->
+           let uu____5440 = extract_let_rec_types se g lbs in
+           (match uu____5440 with | (env, uu____5456, impl) -> (env, impl))
+       | FStar_Syntax_Syntax.Sig_let (lbs, uu____5465) ->
            let attrs = se.FStar_Syntax_Syntax.sigattrs in
            let quals = se.FStar_Syntax_Syntax.sigquals in
-           let uu____5456 =
-             let uu____5465 =
+           let uu____5476 =
+             let uu____5485 =
                FStar_Syntax_Util.extract_attr'
                  FStar_Parser_Const.postprocess_extr_with attrs in
-             match uu____5465 with
+             match uu____5485 with
              | FStar_Pervasives_Native.None ->
                  (attrs, FStar_Pervasives_Native.None)
              | FStar_Pervasives_Native.Some
-                 (ats, (tau, FStar_Pervasives_Native.None)::uu____5494) ->
+                 (ats, (tau, FStar_Pervasives_Native.None)::uu____5514) ->
                  (ats, (FStar_Pervasives_Native.Some tau))
              | FStar_Pervasives_Native.Some (ats, args) ->
                  (FStar_Errors.log_issue se.FStar_Syntax_Syntax.sigrng
                     (FStar_Errors.Warning_UnrecognizedAttribute,
                       "Ill-formed application of `postprocess_for_extraction_with`");
                   (attrs, FStar_Pervasives_Native.None)) in
-           (match uu____5456 with
+           (match uu____5476 with
             | (attrs1, post_tau) ->
                 let postprocess_lb tau lb =
                   let lbdef =
-                    let uu____5578 = FStar_Extraction_ML_UEnv.tcenv_of_uenv g in
-                    FStar_TypeChecker_Env.postprocess uu____5578 tau
+                    let uu____5598 = FStar_Extraction_ML_UEnv.tcenv_of_uenv g in
+                    FStar_TypeChecker_Env.postprocess uu____5598 tau
                       lb.FStar_Syntax_Syntax.lbtyp
                       lb.FStar_Syntax_Syntax.lbdef in
-                  let uu___911_5579 = lb in
+                  let uu___911_5599 = lb in
                   {
                     FStar_Syntax_Syntax.lbname =
-                      (uu___911_5579.FStar_Syntax_Syntax.lbname);
+                      (uu___911_5599.FStar_Syntax_Syntax.lbname);
                     FStar_Syntax_Syntax.lbunivs =
-                      (uu___911_5579.FStar_Syntax_Syntax.lbunivs);
+                      (uu___911_5599.FStar_Syntax_Syntax.lbunivs);
                     FStar_Syntax_Syntax.lbtyp =
-                      (uu___911_5579.FStar_Syntax_Syntax.lbtyp);
+                      (uu___911_5599.FStar_Syntax_Syntax.lbtyp);
                     FStar_Syntax_Syntax.lbeff =
-                      (uu___911_5579.FStar_Syntax_Syntax.lbeff);
+                      (uu___911_5599.FStar_Syntax_Syntax.lbeff);
                     FStar_Syntax_Syntax.lbdef = lbdef;
                     FStar_Syntax_Syntax.lbattrs =
-                      (uu___911_5579.FStar_Syntax_Syntax.lbattrs);
+                      (uu___911_5599.FStar_Syntax_Syntax.lbattrs);
                     FStar_Syntax_Syntax.lbpos =
-                      (uu___911_5579.FStar_Syntax_Syntax.lbpos)
+                      (uu___911_5599.FStar_Syntax_Syntax.lbpos)
                   } in
                 let lbs1 =
-                  let uu____5587 =
+                  let uu____5607 =
                     match post_tau with
                     | FStar_Pervasives_Native.Some tau ->
                         FStar_List.map (postprocess_lb tau)
                           (FStar_Pervasives_Native.snd lbs)
                     | FStar_Pervasives_Native.None ->
                         FStar_Pervasives_Native.snd lbs in
-                  ((FStar_Pervasives_Native.fst lbs), uu____5587) in
-                let uu____5601 =
-                  let uu____5608 =
+                  ((FStar_Pervasives_Native.fst lbs), uu____5607) in
+                let uu____5621 =
+                  let uu____5628 =
                     FStar_Syntax_Syntax.mk
                       (FStar_Syntax_Syntax.Tm_let
                          (lbs1, FStar_Syntax_Util.exp_false_bool))
                       se.FStar_Syntax_Syntax.sigrng in
-                  FStar_Extraction_ML_Term.term_as_mlexpr g uu____5608 in
-                (match uu____5601 with
-                 | (ml_let, uu____5624, uu____5625) ->
+                  FStar_Extraction_ML_Term.term_as_mlexpr g uu____5628 in
+                (match uu____5621 with
+                 | (ml_let, uu____5644, uu____5645) ->
                      (match ml_let.FStar_Extraction_ML_Syntax.expr with
                       | FStar_Extraction_ML_Syntax.MLE_Let
-                          ((flavor, bindings), uu____5634) ->
+                          ((flavor, bindings), uu____5654) ->
                           let flags = FStar_List.choose flag_of_qual quals in
                           let flags' = extract_metadata attrs1 in
-                          let uu____5651 =
+                          let uu____5671 =
                             FStar_List.fold_left2
-                              (fun uu____5677 ->
+                              (fun uu____5697 ->
                                  fun ml_lb ->
-                                   fun uu____5679 ->
-                                     match (uu____5677, uu____5679) with
+                                   fun uu____5699 ->
+                                     match (uu____5697, uu____5699) with
                                      | ((env, ml_lbs),
                                         {
                                           FStar_Syntax_Syntax.lbname = lbname;
                                           FStar_Syntax_Syntax.lbunivs =
-                                            uu____5701;
+                                            uu____5721;
                                           FStar_Syntax_Syntax.lbtyp = t;
                                           FStar_Syntax_Syntax.lbeff =
-                                            uu____5703;
+                                            uu____5723;
                                           FStar_Syntax_Syntax.lbdef =
-                                            uu____5704;
+                                            uu____5724;
                                           FStar_Syntax_Syntax.lbattrs =
-                                            uu____5705;
+                                            uu____5725;
                                           FStar_Syntax_Syntax.lbpos =
-                                            uu____5706;_})
+                                            uu____5726;_})
                                          ->
-                                         let uu____5731 =
+                                         let uu____5751 =
                                            FStar_All.pipe_right
                                              ml_lb.FStar_Extraction_ML_Syntax.mllb_meta
                                              (FStar_List.contains
                                                 FStar_Extraction_ML_Syntax.Erased) in
-                                         if uu____5731
+                                         if uu____5751
                                          then (env, ml_lbs)
                                          else
                                            (let lb_lid =
-                                              let uu____5744 =
-                                                let uu____5747 =
+                                              let uu____5764 =
+                                                let uu____5767 =
                                                   FStar_Util.right lbname in
-                                                uu____5747.FStar_Syntax_Syntax.fv_name in
-                                              uu____5744.FStar_Syntax_Syntax.v in
+                                                uu____5767.FStar_Syntax_Syntax.fv_name in
+                                              uu____5764.FStar_Syntax_Syntax.v in
                                             let flags'' =
-                                              let uu____5751 =
-                                                let uu____5752 =
+                                              let uu____5771 =
+                                                let uu____5772 =
                                                   FStar_Syntax_Subst.compress
                                                     t in
-                                                uu____5752.FStar_Syntax_Syntax.n in
-                                              match uu____5751 with
+                                                uu____5772.FStar_Syntax_Syntax.n in
+                                              match uu____5771 with
                                               | FStar_Syntax_Syntax.Tm_arrow
-                                                  (uu____5757,
+                                                  (uu____5777,
                                                    {
                                                      FStar_Syntax_Syntax.n =
                                                        FStar_Syntax_Syntax.Comp
                                                        {
                                                          FStar_Syntax_Syntax.comp_univs
-                                                           = uu____5758;
+                                                           = uu____5778;
                                                          FStar_Syntax_Syntax.effect_name
                                                            = e;
                                                          FStar_Syntax_Syntax.result_typ
-                                                           = uu____5760;
+                                                           = uu____5780;
                                                          FStar_Syntax_Syntax.effect_args
-                                                           = uu____5761;
+                                                           = uu____5781;
                                                          FStar_Syntax_Syntax.flags
-                                                           = uu____5762;_};
+                                                           = uu____5782;_};
                                                      FStar_Syntax_Syntax.pos
-                                                       = uu____5763;
+                                                       = uu____5783;
                                                      FStar_Syntax_Syntax.vars
-                                                       = uu____5764;_})
+                                                       = uu____5784;_})
                                                   when
-                                                  let uu____5799 =
+                                                  let uu____5819 =
                                                     FStar_Ident.string_of_lid
                                                       e in
-                                                  uu____5799 =
+                                                  uu____5819 =
                                                     "FStar.HyperStack.ST.StackInline"
                                                   ->
                                                   [FStar_Extraction_ML_Syntax.StackInline]
-                                              | uu____5800 -> [] in
+                                              | uu____5820 -> [] in
                                             let meta =
                                               FStar_List.append flags
                                                 (FStar_List.append flags'
                                                    flags'') in
                                             let ml_lb1 =
-                                              let uu___959_5805 = ml_lb in
+                                              let uu___959_5825 = ml_lb in
                                               {
                                                 FStar_Extraction_ML_Syntax.mllb_name
                                                   =
-                                                  (uu___959_5805.FStar_Extraction_ML_Syntax.mllb_name);
+                                                  (uu___959_5825.FStar_Extraction_ML_Syntax.mllb_name);
                                                 FStar_Extraction_ML_Syntax.mllb_tysc
                                                   =
-                                                  (uu___959_5805.FStar_Extraction_ML_Syntax.mllb_tysc);
+                                                  (uu___959_5825.FStar_Extraction_ML_Syntax.mllb_tysc);
                                                 FStar_Extraction_ML_Syntax.mllb_add_unit
                                                   =
-                                                  (uu___959_5805.FStar_Extraction_ML_Syntax.mllb_add_unit);
+                                                  (uu___959_5825.FStar_Extraction_ML_Syntax.mllb_add_unit);
                                                 FStar_Extraction_ML_Syntax.mllb_def
                                                   =
-                                                  (uu___959_5805.FStar_Extraction_ML_Syntax.mllb_def);
+                                                  (uu___959_5825.FStar_Extraction_ML_Syntax.mllb_def);
                                                 FStar_Extraction_ML_Syntax.mllb_meta
                                                   = meta;
                                                 FStar_Extraction_ML_Syntax.print_typ
                                                   =
-                                                  (uu___959_5805.FStar_Extraction_ML_Syntax.print_typ)
+                                                  (uu___959_5825.FStar_Extraction_ML_Syntax.print_typ)
                                               } in
-                                            let uu____5806 =
-                                              let uu____5811 =
+                                            let uu____5826 =
+                                              let uu____5831 =
                                                 FStar_All.pipe_right quals
                                                   (FStar_Util.for_some
-                                                     (fun uu___8_5816 ->
-                                                        match uu___8_5816
+                                                     (fun uu___8_5836 ->
+                                                        match uu___8_5836
                                                         with
                                                         | FStar_Syntax_Syntax.Projector
-                                                            uu____5817 ->
+                                                            uu____5837 ->
                                                             true
-                                                        | uu____5822 -> false)) in
-                                              if uu____5811
+                                                        | uu____5842 -> false)) in
+                                              if uu____5831
                                               then
-                                                let uu____5827 =
-                                                  let uu____5834 =
+                                                let uu____5847 =
+                                                  let uu____5854 =
                                                     FStar_Util.right lbname in
-                                                  let uu____5835 =
+                                                  let uu____5855 =
                                                     FStar_Util.must
                                                       ml_lb1.FStar_Extraction_ML_Syntax.mllb_tysc in
                                                   FStar_Extraction_ML_UEnv.extend_fv
-                                                    env uu____5834 uu____5835
+                                                    env uu____5854 uu____5855
                                                     ml_lb1.FStar_Extraction_ML_Syntax.mllb_add_unit in
-                                                match uu____5827 with
-                                                | (env1, mls, uu____5842) ->
+                                                match uu____5847 with
+                                                | (env1, mls, uu____5862) ->
                                                     (env1,
-                                                      (let uu___971_5844 =
+                                                      (let uu___971_5864 =
                                                          ml_lb1 in
                                                        {
                                                          FStar_Extraction_ML_Syntax.mllb_name
                                                            = mls;
                                                          FStar_Extraction_ML_Syntax.mllb_tysc
                                                            =
-                                                           (uu___971_5844.FStar_Extraction_ML_Syntax.mllb_tysc);
+                                                           (uu___971_5864.FStar_Extraction_ML_Syntax.mllb_tysc);
                                                          FStar_Extraction_ML_Syntax.mllb_add_unit
                                                            =
-                                                           (uu___971_5844.FStar_Extraction_ML_Syntax.mllb_add_unit);
+                                                           (uu___971_5864.FStar_Extraction_ML_Syntax.mllb_add_unit);
                                                          FStar_Extraction_ML_Syntax.mllb_def
                                                            =
-                                                           (uu___971_5844.FStar_Extraction_ML_Syntax.mllb_def);
+                                                           (uu___971_5864.FStar_Extraction_ML_Syntax.mllb_def);
                                                          FStar_Extraction_ML_Syntax.mllb_meta
                                                            =
-                                                           (uu___971_5844.FStar_Extraction_ML_Syntax.mllb_meta);
+                                                           (uu___971_5864.FStar_Extraction_ML_Syntax.mllb_meta);
                                                          FStar_Extraction_ML_Syntax.print_typ
                                                            =
-                                                           (uu___971_5844.FStar_Extraction_ML_Syntax.print_typ)
+                                                           (uu___971_5864.FStar_Extraction_ML_Syntax.print_typ)
                                                        }))
                                               else
-                                                (let uu____5846 =
-                                                   let uu____5853 =
+                                                (let uu____5866 =
+                                                   let uu____5873 =
                                                      FStar_Util.must
                                                        ml_lb1.FStar_Extraction_ML_Syntax.mllb_tysc in
                                                    FStar_Extraction_ML_UEnv.extend_lb
-                                                     env lbname t uu____5853
+                                                     env lbname t uu____5873
                                                      ml_lb1.FStar_Extraction_ML_Syntax.mllb_add_unit in
-                                                 match uu____5846 with
-                                                 | (env1, uu____5859,
-                                                    uu____5860) ->
+                                                 match uu____5866 with
+                                                 | (env1, uu____5879,
+                                                    uu____5880) ->
                                                      (env1, ml_lb1)) in
-                                            match uu____5806 with
+                                            match uu____5826 with
                                             | (g1, ml_lb2) ->
                                                 (g1, (ml_lb2 :: ml_lbs))))
                               (g, []) bindings
                               (FStar_Pervasives_Native.snd lbs1) in
-                          (match uu____5651 with
+                          (match uu____5671 with
                            | (g1, ml_lbs') ->
-                               let uu____5887 =
-                                 let uu____5890 =
-                                   let uu____5893 =
-                                     let uu____5894 =
+                               let uu____5907 =
+                                 let uu____5910 =
+                                   let uu____5913 =
+                                     let uu____5914 =
                                        FStar_Extraction_ML_Util.mlloc_of_range
                                          se.FStar_Syntax_Syntax.sigrng in
                                      FStar_Extraction_ML_Syntax.MLM_Loc
-                                       uu____5894 in
-                                   [uu____5893;
+                                       uu____5914 in
+                                   [uu____5913;
                                    FStar_Extraction_ML_Syntax.MLM_Let
                                      (flavor, (FStar_List.rev ml_lbs'))] in
-                                 let uu____5897 = maybe_register_plugin g1 se in
-                                 FStar_List.append uu____5890 uu____5897 in
-                               (g1, uu____5887))
-                      | uu____5902 ->
-                          let uu____5903 =
-                            let uu____5904 =
-                              let uu____5905 =
+                                 let uu____5917 = maybe_register_plugin g1 se in
+                                 FStar_List.append uu____5910 uu____5917 in
+                               (g1, uu____5907))
+                      | uu____5922 ->
+                          let uu____5923 =
+                            let uu____5924 =
+                              let uu____5925 =
                                 FStar_Extraction_ML_UEnv.current_module_of_uenv
                                   g in
                               FStar_Extraction_ML_Code.string_of_mlexpr
-                                uu____5905 ml_let in
+                                uu____5925 ml_let in
                             FStar_Util.format1
                               "Impossible: Translated a let to a non-let: %s"
-                              uu____5904 in
-                          failwith uu____5903)))
-       | FStar_Syntax_Syntax.Sig_declare_typ (lid, uu____5913, t) ->
+                              uu____5924 in
+                          failwith uu____5923)))
+       | FStar_Syntax_Syntax.Sig_declare_typ (lid, uu____5933, t) ->
            let quals = se.FStar_Syntax_Syntax.sigquals in
-           let uu____5918 =
+           let uu____5938 =
              (FStar_All.pipe_right quals
                 (FStar_List.contains FStar_Syntax_Syntax.Assumption))
                &&
-               (let uu____5922 =
-                  let uu____5923 = FStar_Extraction_ML_UEnv.tcenv_of_uenv g in
-                  FStar_TypeChecker_Util.must_erase_for_extraction uu____5923
+               (let uu____5942 =
+                  let uu____5943 = FStar_Extraction_ML_UEnv.tcenv_of_uenv g in
+                  FStar_TypeChecker_Util.must_erase_for_extraction uu____5943
                     t in
-                Prims.op_Negation uu____5922) in
-           if uu____5918
+                Prims.op_Negation uu____5942) in
+           if uu____5938
            then
              let always_fail1 =
-               let uu___991_5931 = se in
-               let uu____5932 =
-                 let uu____5933 =
-                   let uu____5940 =
-                     let uu____5941 =
-                       let uu____5944 = always_fail lid t in [uu____5944] in
-                     (false, uu____5941) in
-                   (uu____5940, []) in
-                 FStar_Syntax_Syntax.Sig_let uu____5933 in
+               let uu___991_5951 = se in
+               let uu____5952 =
+                 let uu____5953 =
+                   let uu____5960 =
+                     let uu____5961 =
+                       let uu____5964 = always_fail lid t in [uu____5964] in
+                     (false, uu____5961) in
+                   (uu____5960, []) in
+                 FStar_Syntax_Syntax.Sig_let uu____5953 in
                {
-                 FStar_Syntax_Syntax.sigel = uu____5932;
+                 FStar_Syntax_Syntax.sigel = uu____5952;
                  FStar_Syntax_Syntax.sigrng =
-                   (uu___991_5931.FStar_Syntax_Syntax.sigrng);
+                   (uu___991_5951.FStar_Syntax_Syntax.sigrng);
                  FStar_Syntax_Syntax.sigquals =
-                   (uu___991_5931.FStar_Syntax_Syntax.sigquals);
+                   (uu___991_5951.FStar_Syntax_Syntax.sigquals);
                  FStar_Syntax_Syntax.sigmeta =
-                   (uu___991_5931.FStar_Syntax_Syntax.sigmeta);
+                   (uu___991_5951.FStar_Syntax_Syntax.sigmeta);
                  FStar_Syntax_Syntax.sigattrs =
-                   (uu___991_5931.FStar_Syntax_Syntax.sigattrs);
+                   (uu___991_5951.FStar_Syntax_Syntax.sigattrs);
                  FStar_Syntax_Syntax.sigopts =
-                   (uu___991_5931.FStar_Syntax_Syntax.sigopts)
+                   (uu___991_5951.FStar_Syntax_Syntax.sigopts)
                } in
-             let uu____5949 = extract_sig g always_fail1 in
-             (match uu____5949 with
+             let uu____5969 = extract_sig g always_fail1 in
+             (match uu____5969 with
               | (g1, mlm) ->
-                  let uu____5968 =
+                  let uu____5988 =
                     FStar_Util.find_map quals
-                      (fun uu___9_5973 ->
-                         match uu___9_5973 with
+                      (fun uu___9_5993 ->
+                         match uu___9_5993 with
                          | FStar_Syntax_Syntax.Discriminator l ->
                              FStar_Pervasives_Native.Some l
-                         | uu____5977 -> FStar_Pervasives_Native.None) in
-                  (match uu____5968 with
+                         | uu____5997 -> FStar_Pervasives_Native.None) in
+                  (match uu____5988 with
                    | FStar_Pervasives_Native.Some l ->
-                       let uu____5985 =
-                         let uu____5988 =
-                           let uu____5989 =
+                       let uu____6005 =
+                         let uu____6008 =
+                           let uu____6009 =
                              FStar_Extraction_ML_Util.mlloc_of_range
                                se.FStar_Syntax_Syntax.sigrng in
-                           FStar_Extraction_ML_Syntax.MLM_Loc uu____5989 in
-                         let uu____5990 =
-                           let uu____5993 =
+                           FStar_Extraction_ML_Syntax.MLM_Loc uu____6009 in
+                         let uu____6010 =
+                           let uu____6013 =
                              FStar_Extraction_ML_Term.ind_discriminator_body
                                g1 lid l in
-                           [uu____5993] in
-                         uu____5988 :: uu____5990 in
-                       (g1, uu____5985)
-                   | uu____5996 ->
-                       let uu____5999 =
+                           [uu____6013] in
+                         uu____6008 :: uu____6010 in
+                       (g1, uu____6005)
+                   | uu____6016 ->
+                       let uu____6019 =
                          FStar_Util.find_map quals
-                           (fun uu___10_6005 ->
-                              match uu___10_6005 with
-                              | FStar_Syntax_Syntax.Projector (l, uu____6009)
+                           (fun uu___10_6025 ->
+                              match uu___10_6025 with
+                              | FStar_Syntax_Syntax.Projector (l, uu____6029)
                                   -> FStar_Pervasives_Native.Some l
-                              | uu____6010 -> FStar_Pervasives_Native.None) in
-                       (match uu____5999 with
-                        | FStar_Pervasives_Native.Some uu____6017 -> (g1, [])
-                        | uu____6020 -> (g1, mlm))))
+                              | uu____6030 -> FStar_Pervasives_Native.None) in
+                       (match uu____6019 with
+                        | FStar_Pervasives_Native.Some uu____6037 -> (g1, [])
+                        | uu____6040 -> (g1, mlm))))
            else (g, [])
-       | FStar_Syntax_Syntax.Sig_assume uu____6028 -> (g, [])
-       | FStar_Syntax_Syntax.Sig_sub_effect uu____6037 -> (g, [])
-       | FStar_Syntax_Syntax.Sig_effect_abbrev uu____6040 -> (g, [])
-       | FStar_Syntax_Syntax.Sig_polymonadic_bind uu____6055 -> (g, [])
-       | FStar_Syntax_Syntax.Sig_polymonadic_subcomp uu____6068 -> (g, [])
+       | FStar_Syntax_Syntax.Sig_assume uu____6048 -> (g, [])
+       | FStar_Syntax_Syntax.Sig_sub_effect uu____6057 -> (g, [])
+       | FStar_Syntax_Syntax.Sig_effect_abbrev uu____6060 -> (g, [])
+       | FStar_Syntax_Syntax.Sig_polymonadic_bind uu____6075 -> (g, [])
+       | FStar_Syntax_Syntax.Sig_polymonadic_subcomp uu____6088 -> (g, [])
        | FStar_Syntax_Syntax.Sig_pragma p ->
            (FStar_Syntax_Util.process_pragma p se.FStar_Syntax_Syntax.sigrng;
             (g, [])))
@@ -2000,66 +2000,66 @@ let (extract' :
   =
   fun g ->
     fun m ->
-      let uu____6105 = FStar_Options.restore_cmd_line_options true in
-      let uu____6106 =
+      let uu____6125 = FStar_Options.restore_cmd_line_options true in
+      let uu____6126 =
         FStar_Extraction_ML_UEnv.extend_with_module_name g
           m.FStar_Syntax_Syntax.name in
-      match uu____6106 with
+      match uu____6126 with
       | (name, g1) ->
           let g2 =
-            let uu____6120 =
-              let uu____6121 = FStar_Extraction_ML_UEnv.tcenv_of_uenv g1 in
-              FStar_TypeChecker_Env.set_current_module uu____6121
+            let uu____6140 =
+              let uu____6141 = FStar_Extraction_ML_UEnv.tcenv_of_uenv g1 in
+              FStar_TypeChecker_Env.set_current_module uu____6141
                 m.FStar_Syntax_Syntax.name in
-            FStar_Extraction_ML_UEnv.set_tcenv g1 uu____6120 in
+            FStar_Extraction_ML_UEnv.set_tcenv g1 uu____6140 in
           let g3 = FStar_Extraction_ML_UEnv.set_current_module g2 name in
-          let uu____6123 =
+          let uu____6143 =
             FStar_Util.fold_map
               (fun g4 ->
                  fun se ->
-                   let uu____6142 =
-                     let uu____6143 =
+                   let uu____6162 =
+                     let uu____6163 =
                        FStar_Ident.string_of_lid m.FStar_Syntax_Syntax.name in
-                     FStar_Options.debug_module uu____6143 in
-                   if uu____6142
+                     FStar_Options.debug_module uu____6163 in
+                   if uu____6162
                    then
                      let nm =
-                       let uu____6151 =
+                       let uu____6171 =
                          FStar_All.pipe_right
                            (FStar_Syntax_Util.lids_of_sigelt se)
                            (FStar_List.map FStar_Ident.string_of_lid) in
-                       FStar_All.pipe_right uu____6151
+                       FStar_All.pipe_right uu____6171
                          (FStar_String.concat ", ") in
                      (FStar_Util.print1 "+++About to extract {%s}\n" nm;
-                      (let uu____6161 =
+                      (let uu____6181 =
                          FStar_Util.format1 "---Extracted {%s}" nm in
-                       FStar_Util.measure_execution_time uu____6161
-                         (fun uu____6169 -> extract_sig g4 se)))
+                       FStar_Util.measure_execution_time uu____6181
+                         (fun uu____6189 -> extract_sig g4 se)))
                    else extract_sig g4 se) g3
               m.FStar_Syntax_Syntax.declarations in
-          (match uu____6123 with
+          (match uu____6143 with
            | (g4, sigs) ->
                let mlm = FStar_List.flatten sigs in
                let is_kremlin =
-                 let uu____6189 = FStar_Options.codegen () in
-                 uu____6189 =
+                 let uu____6209 = FStar_Options.codegen () in
+                 uu____6209 =
                    (FStar_Pervasives_Native.Some FStar_Options.Kremlin) in
-               let uu____6194 =
-                 (let uu____6197 =
+               let uu____6214 =
+                 (let uu____6217 =
                     FStar_Ident.string_of_lid m.FStar_Syntax_Syntax.name in
-                  uu____6197 <> "Prims") &&
+                  uu____6217 <> "Prims") &&
                    (is_kremlin ||
                       (Prims.op_Negation m.FStar_Syntax_Syntax.is_interface)) in
-               if uu____6194
+               if uu____6214
                then
-                 ((let uu____6205 =
-                     let uu____6206 = FStar_Options.silent () in
-                     Prims.op_Negation uu____6206 in
-                   if uu____6205
+                 ((let uu____6225 =
+                     let uu____6226 = FStar_Options.silent () in
+                     Prims.op_Negation uu____6226 in
+                   if uu____6225
                    then
-                     let uu____6207 =
+                     let uu____6227 =
                        FStar_Ident.string_of_lid m.FStar_Syntax_Syntax.name in
-                     FStar_Util.print1 "Extracted module %s\n" uu____6207
+                     FStar_Util.print1 "Extracted module %s\n" uu____6227
                    else ());
                   (g4,
                     (FStar_Pervasives_Native.Some
@@ -2075,45 +2075,45 @@ let (extract :
   =
   fun g ->
     fun m ->
-      (let uu____6277 = FStar_Options.restore_cmd_line_options true in
-       FStar_All.pipe_left (fun uu____6278 -> ()) uu____6277);
-      (let uu____6280 =
-         let uu____6281 =
-           let uu____6282 =
+      (let uu____6297 = FStar_Options.restore_cmd_line_options true in
+       FStar_All.pipe_left (fun uu____6298 -> ()) uu____6297);
+      (let uu____6300 =
+         let uu____6301 =
+           let uu____6302 =
              FStar_Ident.string_of_lid m.FStar_Syntax_Syntax.name in
-           FStar_Options.should_extract uu____6282 in
-         Prims.op_Negation uu____6281 in
-       if uu____6280
+           FStar_Options.should_extract uu____6302 in
+         Prims.op_Negation uu____6301 in
+       if uu____6300
        then
-         let uu____6283 =
-           let uu____6284 =
+         let uu____6303 =
+           let uu____6304 =
              FStar_Ident.string_of_lid m.FStar_Syntax_Syntax.name in
            FStar_Util.format1
              "Extract called on a module %s that should not be extracted"
-             uu____6284 in
-         failwith uu____6283
+             uu____6304 in
+         failwith uu____6303
        else ());
-      (let uu____6286 = FStar_Options.interactive () in
-       if uu____6286
+      (let uu____6306 = FStar_Options.interactive () in
+       if uu____6306
        then (g, FStar_Pervasives_Native.None)
        else
-         (let uu____6296 =
+         (let uu____6316 =
             FStar_Syntax_Unionfind.with_uf_enabled
-              (fun uu____6312 ->
-                 let uu____6313 = FStar_Options.debug_any () in
-                 if uu____6313
+              (fun uu____6332 ->
+                 let uu____6333 = FStar_Options.debug_any () in
+                 if uu____6333
                  then
                    let msg =
-                     let uu____6321 =
+                     let uu____6341 =
                        FStar_Syntax_Print.lid_to_string
                          m.FStar_Syntax_Syntax.name in
-                     FStar_Util.format1 "Extracting module %s" uu____6321 in
+                     FStar_Util.format1 "Extracting module %s" uu____6341 in
                    FStar_Util.measure_execution_time msg
-                     (fun uu____6329 -> extract' g m)
+                     (fun uu____6349 -> extract' g m)
                  else extract' g m) in
-          match uu____6296 with
+          match uu____6316 with
           | (g1, mllib) ->
-              ((let uu____6344 = FStar_Options.restore_cmd_line_options true in
-                FStar_All.pipe_left (fun uu____6345 -> ()) uu____6344);
-               (let uu____6346 = FStar_Extraction_ML_UEnv.exit_module g1 in
-                (uu____6346, mllib)))))
+              ((let uu____6364 = FStar_Options.restore_cmd_line_options true in
+                FStar_All.pipe_left (fun uu____6365 -> ()) uu____6364);
+               (let uu____6366 = FStar_Extraction_ML_UEnv.exit_module g1 in
+                (uu____6366, mllib)))))

--- a/src/ocaml-output/FStar_SMTEncoding_Z3.ml
+++ b/src/ocaml-output/FStar_SMTEncoding_Z3.ml
@@ -629,32 +629,28 @@ let (doZ3Exe :
                  | "unknown"::[] -> UNKNOWN (labels, reason_unknown)
                  | "timeout"::[] -> TIMEOUT (labels, reason_unknown)
                  | "killed"::[] ->
-                     ((let uu____2446 =
-                         let uu____2451 = FStar_ST.op_Bang bg_z3_proc in
-                         uu____2451.restart in
-                       uu____2446 ());
+                     ((let uu____2446 = FStar_ST.op_Bang bg_z3_proc in
+                       uu____2446.restart ());
                       KILLED)
-                 | uu____2458 ->
-                     let uu____2459 =
+                 | uu____2453 ->
+                     let uu____2454 =
                        FStar_Util.format1
                          "Unexpected output from Z3: got output result: %s\n"
                          (FStar_String.concat "\n" smt_output1.smt_result) in
-                     failwith uu____2459) in
+                     failwith uu____2454) in
               (status, statistics) in
             let stdout =
               if fresh
               then
                 let proc =
-                  let uu____2462 = z3_cmd_and_args () in
-                  new_z3proc_with_id uu____2462 in
-                let kill_handler uu____2474 = "\nkilled\n" in
+                  let uu____2457 = z3_cmd_and_args () in
+                  new_z3proc_with_id uu____2457 in
+                let kill_handler uu____2469 = "\nkilled\n" in
                 let out = FStar_Util.ask_process proc input kill_handler in
                 (FStar_Util.kill_process proc; out)
               else
-                (let uu____2478 =
-                   let uu____2483 = FStar_ST.op_Bang bg_z3_proc in
-                   uu____2483.ask in
-                 uu____2478 input) in
+                (let uu____2473 = FStar_ST.op_Bang bg_z3_proc in
+                 uu____2473.ask input) in
             parse (FStar_Util.trim_string stdout)
 let (z3_options : Prims.string FStar_ST.ref) =
   FStar_Util.mk_ref
@@ -696,127 +692,125 @@ let (__proj__Mkz3result__item__z3result_log_file :
     match projectee with
     | { z3result_status; z3result_time; z3result_statistics;
         z3result_query_hash; z3result_log_file;_} -> z3result_log_file
-let (init : unit -> unit) = fun uu____2614 -> ()
-let (finish : unit -> unit) = fun uu____2619 -> ()
+let (init : unit -> unit) = fun uu____2604 -> ()
+let (finish : unit -> unit) = fun uu____2609 -> ()
 type scope_t = FStar_SMTEncoding_Term.decl Prims.list Prims.list
 let (fresh_scope : scope_t FStar_ST.ref) = FStar_Util.mk_ref [[]]
 let (mk_fresh_scope : unit -> scope_t) =
-  fun uu____2634 -> FStar_ST.op_Bang fresh_scope
+  fun uu____2624 -> FStar_ST.op_Bang fresh_scope
 let (flatten_fresh_scope : unit -> FStar_SMTEncoding_Term.decl Prims.list) =
-  fun uu____2647 ->
-    let uu____2648 =
-      let uu____2653 = FStar_ST.op_Bang fresh_scope in
-      FStar_List.rev uu____2653 in
-    FStar_List.flatten uu____2648
+  fun uu____2637 ->
+    let uu____2638 =
+      let uu____2643 = FStar_ST.op_Bang fresh_scope in
+      FStar_List.rev uu____2643 in
+    FStar_List.flatten uu____2638
 let (bg_scope : FStar_SMTEncoding_Term.decl Prims.list FStar_ST.ref) =
   FStar_Util.mk_ref []
 let (push : Prims.string -> unit) =
   fun msg ->
     FStar_Util.atomically
-      (fun uu____2680 ->
-         (let uu____2682 =
-            let uu____2683 = FStar_ST.op_Bang fresh_scope in
+      (fun uu____2670 ->
+         (let uu____2672 =
+            let uu____2673 = FStar_ST.op_Bang fresh_scope in
             [FStar_SMTEncoding_Term.Caption msg; FStar_SMTEncoding_Term.Push]
-              :: uu____2683 in
-          FStar_ST.op_Colon_Equals fresh_scope uu____2682);
-         (let uu____2702 =
-            let uu____2705 = FStar_ST.op_Bang bg_scope in
-            FStar_List.append uu____2705
+              :: uu____2673 in
+          FStar_ST.op_Colon_Equals fresh_scope uu____2672);
+         (let uu____2692 =
+            let uu____2695 = FStar_ST.op_Bang bg_scope in
+            FStar_List.append uu____2695
               [FStar_SMTEncoding_Term.Push;
               FStar_SMTEncoding_Term.Caption msg] in
-          FStar_ST.op_Colon_Equals bg_scope uu____2702))
+          FStar_ST.op_Colon_Equals bg_scope uu____2692))
 let (pop : Prims.string -> unit) =
   fun msg ->
     FStar_Util.atomically
-      (fun uu____2736 ->
-         (let uu____2738 =
-            let uu____2739 = FStar_ST.op_Bang fresh_scope in
-            FStar_List.tl uu____2739 in
-          FStar_ST.op_Colon_Equals fresh_scope uu____2738);
-         (let uu____2758 =
-            let uu____2761 = FStar_ST.op_Bang bg_scope in
-            FStar_List.append uu____2761
+      (fun uu____2726 ->
+         (let uu____2728 =
+            let uu____2729 = FStar_ST.op_Bang fresh_scope in
+            FStar_List.tl uu____2729 in
+          FStar_ST.op_Colon_Equals fresh_scope uu____2728);
+         (let uu____2748 =
+            let uu____2751 = FStar_ST.op_Bang bg_scope in
+            FStar_List.append uu____2751
               [FStar_SMTEncoding_Term.Caption msg;
               FStar_SMTEncoding_Term.Pop] in
-          FStar_ST.op_Colon_Equals bg_scope uu____2758))
+          FStar_ST.op_Colon_Equals bg_scope uu____2748))
 let (snapshot : Prims.string -> (Prims.int * unit)) =
   fun msg -> FStar_Common.snapshot push fresh_scope msg
 let (rollback :
   Prims.string -> Prims.int FStar_Pervasives_Native.option -> unit) =
   fun msg ->
     fun depth ->
-      FStar_Common.rollback (fun uu____2812 -> pop msg) fresh_scope depth
+      FStar_Common.rollback (fun uu____2802 -> pop msg) fresh_scope depth
 let (giveZ3 : FStar_SMTEncoding_Term.decl Prims.list -> unit) =
   fun decls ->
     FStar_All.pipe_right decls
       (FStar_List.iter
-         (fun uu___1_2826 ->
-            match uu___1_2826 with
+         (fun uu___1_2816 ->
+            match uu___1_2816 with
             | FStar_SMTEncoding_Term.Push -> failwith "Unexpected push/pop"
             | FStar_SMTEncoding_Term.Pop -> failwith "Unexpected push/pop"
-            | uu____2827 -> ()));
-    (let uu____2829 = FStar_ST.op_Bang fresh_scope in
-     match uu____2829 with
+            | uu____2817 -> ()));
+    (let uu____2819 = FStar_ST.op_Bang fresh_scope in
+     match uu____2819 with
      | hd::tl ->
          FStar_ST.op_Colon_Equals fresh_scope ((FStar_List.append hd decls)
            :: tl)
-     | uu____2854 -> failwith "Impossible");
-    (let uu____2855 =
-       let uu____2858 = FStar_ST.op_Bang bg_scope in
-       FStar_List.append uu____2858 decls in
-     FStar_ST.op_Colon_Equals bg_scope uu____2855)
+     | uu____2844 -> failwith "Impossible");
+    (let uu____2845 =
+       let uu____2848 = FStar_ST.op_Bang bg_scope in
+       FStar_List.append uu____2848 decls in
+     FStar_ST.op_Colon_Equals bg_scope uu____2845)
 let (refresh : unit -> unit) =
-  fun uu____2885 ->
-    (let uu____2887 =
-       let uu____2892 = FStar_ST.op_Bang bg_z3_proc in uu____2892.refresh in
-     uu____2887 ());
-    (let uu____2899 = flatten_fresh_scope () in
-     FStar_ST.op_Colon_Equals bg_scope uu____2899)
+  fun uu____2875 ->
+    (let uu____2877 = FStar_ST.op_Bang bg_z3_proc in uu____2877.refresh ());
+    (let uu____2884 = flatten_fresh_scope () in
+     FStar_ST.op_Colon_Equals bg_scope uu____2884)
 let (context_profile : FStar_SMTEncoding_Term.decl Prims.list -> unit) =
   fun theory ->
-    let uu____2921 =
+    let uu____2906 =
       FStar_List.fold_left
-        (fun uu____2950 ->
+        (fun uu____2935 ->
            fun d ->
-             match uu____2950 with
+             match uu____2935 with
              | (out, _total) ->
                  (match d with
                   | FStar_SMTEncoding_Term.Module (name, decls) ->
                       let decls1 =
                         FStar_List.filter
-                          (fun uu___2_3007 ->
-                             match uu___2_3007 with
-                             | FStar_SMTEncoding_Term.Assume uu____3008 ->
+                          (fun uu___2_2992 ->
+                             match uu___2_2992 with
+                             | FStar_SMTEncoding_Term.Assume uu____2993 ->
                                  true
-                             | uu____3009 -> false) decls in
+                             | uu____2994 -> false) decls in
                       let n = FStar_List.length decls1 in
                       (((name, n) :: out), (n + _total))
-                  | uu____3021 -> (out, _total))) ([], Prims.int_zero) theory in
-    match uu____2921 with
+                  | uu____3006 -> (out, _total))) ([], Prims.int_zero) theory in
+    match uu____2906 with
     | (modules, total_decls) ->
         let modules1 =
           FStar_List.sortWith
-            (fun uu____3069 ->
-               fun uu____3070 ->
-                 match (uu____3069, uu____3070) with
-                 | ((uu____3087, n), (uu____3089, m)) -> m - n) modules in
+            (fun uu____3054 ->
+               fun uu____3055 ->
+                 match (uu____3054, uu____3055) with
+                 | ((uu____3072, n), (uu____3074, m)) -> m - n) modules in
         (if modules1 <> []
          then
-           (let uu____3110 = FStar_Util.string_of_int total_decls in
+           (let uu____3095 = FStar_Util.string_of_int total_decls in
             FStar_Util.print1
               "Z3 Proof Stats: context_profile with %s assertions\n"
-              uu____3110)
+              uu____3095)
          else ();
          FStar_List.iter
-           (fun uu____3120 ->
-              match uu____3120 with
+           (fun uu____3105 ->
+              match uu____3105 with
               | (m, n) ->
                   if n <> Prims.int_zero
                   then
-                    let uu____3127 = FStar_Util.string_of_int n in
+                    let uu____3112 = FStar_Util.string_of_int n in
                     FStar_Util.print2
                       "Z3 Proof Stats: %s produced %s SMT decls\n" m
-                      uu____3127
+                      uu____3112
                   else ()) modules1)
 let (mk_input :
   Prims.bool ->
@@ -827,25 +821,25 @@ let (mk_input :
   fun fresh ->
     fun theory ->
       let options = FStar_ST.op_Bang z3_options in
-      (let uu____3161 = FStar_Options.print_z3_statistics () in
-       if uu____3161 then context_profile theory else ());
-      (let uu____3163 =
-         let uu____3170 =
+      (let uu____3146 = FStar_Options.print_z3_statistics () in
+       if uu____3146 then context_profile theory else ());
+      (let uu____3148 =
+         let uu____3155 =
            (FStar_Options.record_hints ()) ||
              ((FStar_Options.use_hints ()) &&
                 (FStar_Options.use_hint_hashes ())) in
-         if uu____3170
+         if uu____3155
          then
-           let uu____3177 =
-             let uu____3188 =
+           let uu____3162 =
+             let uu____3173 =
                FStar_All.pipe_right theory
                  (FStar_Util.prefix_until
-                    (fun uu___3_3216 ->
-                       match uu___3_3216 with
+                    (fun uu___3_3201 ->
+                       match uu___3_3201 with
                        | FStar_SMTEncoding_Term.CheckSat -> true
-                       | uu____3217 -> false)) in
-             FStar_All.pipe_right uu____3188 FStar_Option.get in
-           match uu____3177 with
+                       | uu____3202 -> false)) in
+             FStar_All.pipe_right uu____3173 FStar_Option.get in
+           match uu____3162 with
            | (prefix, check_sat, suffix) ->
                let pp =
                  FStar_List.map (FStar_SMTEncoding_Term.declToSmt options) in
@@ -855,34 +849,34 @@ let (mk_input :
                let ps = FStar_String.concat "\n" ps_lines in
                let ss = FStar_String.concat "\n" ss_lines in
                let hs =
-                 let uu____3288 = FStar_Options.keep_query_captions () in
-                 if uu____3288
+                 let uu____3273 = FStar_Options.keep_query_captions () in
+                 if uu____3273
                  then
-                   let uu____3289 =
+                   let uu____3274 =
                      FStar_All.pipe_right prefix
                        (FStar_List.map
                           (FStar_SMTEncoding_Term.declToSmt_no_caps options)) in
-                   FStar_All.pipe_right uu____3289 (FStar_String.concat "\n")
+                   FStar_All.pipe_right uu____3274 (FStar_String.concat "\n")
                  else ps in
-               let uu____3299 =
-                 let uu____3302 = FStar_Util.digest_of_string hs in
-                 FStar_Pervasives_Native.Some uu____3302 in
-               ((Prims.op_Hat ps (Prims.op_Hat "\n" ss)), uu____3299)
+               let uu____3284 =
+                 let uu____3287 = FStar_Util.digest_of_string hs in
+                 FStar_Pervasives_Native.Some uu____3287 in
+               ((Prims.op_Hat ps (Prims.op_Hat "\n" ss)), uu____3284)
          else
-           (let uu____3306 =
-              let uu____3307 =
+           (let uu____3291 =
+              let uu____3292 =
                 FStar_List.map (FStar_SMTEncoding_Term.declToSmt options)
                   theory in
-              FStar_All.pipe_right uu____3307 (FStar_String.concat "\n") in
-            (uu____3306, FStar_Pervasives_Native.None)) in
-       match uu____3163 with
+              FStar_All.pipe_right uu____3292 (FStar_String.concat "\n") in
+            (uu____3291, FStar_Pervasives_Native.None)) in
+       match uu____3148 with
        | (r, hash) ->
            let log_file_name =
-             let uu____3333 = FStar_Options.log_queries () in
-             if uu____3333
+             let uu____3318 = FStar_Options.log_queries () in
+             if uu____3318
              then
-               let uu____3336 = query_logging.write_to_log fresh r in
-               FStar_Pervasives_Native.Some uu____3336
+               let uu____3321 = query_logging.write_to_log fresh r in
+               FStar_Pervasives_Native.Some uu____3321
              else FStar_Pervasives_Native.None in
            (r, hash, log_file_name))
 let (cache_hit :
@@ -894,9 +888,9 @@ let (cache_hit :
   fun log_file ->
     fun cache ->
       fun qhash ->
-        let uu____3373 =
+        let uu____3358 =
           (FStar_Options.use_hints ()) && (FStar_Options.use_hint_hashes ()) in
-        if uu____3373
+        if uu____3358
         then
           match qhash with
           | FStar_Pervasives_Native.Some x when qhash = cache ->
@@ -911,7 +905,7 @@ let (cache_hit :
                     z3result_log_file = log_file
                   } in
                 FStar_Pervasives_Native.Some result))
-          | uu____3386 -> FStar_Pervasives_Native.None
+          | uu____3371 -> FStar_Pervasives_Native.None
         else FStar_Pervasives_Native.None
 let (z3_job :
   Prims.string FStar_Pervasives_Native.option ->
@@ -927,26 +921,26 @@ let (z3_job :
         fun label_messages ->
           fun input ->
             fun qhash ->
-              fun uu____3428 ->
-                let uu____3433 =
-                  let uu____3442 =
-                    let uu____3445 = query_logging.get_module_name () in
-                    FStar_Pervasives_Native.Some uu____3445 in
+              fun uu____3413 ->
+                let uu____3418 =
+                  let uu____3427 =
+                    let uu____3430 = query_logging.get_module_name () in
+                    FStar_Pervasives_Native.Some uu____3430 in
                   FStar_Profiling.profile
-                    (fun uu____3455 ->
+                    (fun uu____3440 ->
                        try
-                         (fun uu___487_3465 ->
+                         (fun uu___487_3450 ->
                             match () with
                             | () ->
                                 FStar_Util.record_time
-                                  (fun uu____3479 ->
+                                  (fun uu____3464 ->
                                      doZ3Exe log_file r fresh input
                                        label_messages)) ()
                        with
-                       | uu___486_3482 ->
-                           (refresh (); FStar_Exn.raise uu___486_3482))
-                    uu____3442 "FStar.SMTEncoding.Z3 (aggregate query time)" in
-                match uu____3433 with
+                       | uu___486_3467 ->
+                           (refresh (); FStar_Exn.raise uu___486_3467))
+                    uu____3427 "FStar.SMTEncoding.Z3 (aggregate query time)" in
+                match uu____3418 with
                 | ((status, statistics), elapsed_time) ->
                     {
                       z3result_status = status;
@@ -982,20 +976,20 @@ let (ask :
                   FStar_List.append theory
                     (FStar_List.append [FStar_SMTEncoding_Term.Push]
                        (FStar_List.append qry [FStar_SMTEncoding_Term.Pop])) in
-                let uu____3608 = filter_theory theory1 in
-                match uu____3608 with
+                let uu____3593 = filter_theory theory1 in
+                match uu____3593 with
                 | (theory2, _used_unsat_core) ->
-                    let uu____3621 = mk_input fresh theory2 in
-                    (match uu____3621 with
+                    let uu____3606 = mk_input fresh theory2 in
+                    (match uu____3606 with
                      | (input, qhash, log_file_name) ->
-                         let just_ask uu____3648 =
+                         let just_ask uu____3633 =
                            z3_job log_file_name r fresh label_messages input
                              qhash () in
                          if fresh
                          then
-                           let uu____3649 =
+                           let uu____3634 =
                              cache_hit log_file_name cache qhash in
-                           (match uu____3649 with
+                           (match uu____3634 with
                             | FStar_Pervasives_Native.Some z3r -> z3r
                             | FStar_Pervasives_Native.None -> just_ask ())
                          else just_ask ())

--- a/src/ocaml-output/FStar_ToSyntax_ToSyntax.ml
+++ b/src/ocaml-output/FStar_ToSyntax_ToSyntax.ml
@@ -2964,45 +2964,46 @@ and (desugar_term_maybe_top :
             aux [] top
         | FStar_Parser_AST.App uu____10348 ->
             let rec aux args aqs e =
-              let uu____10425 =
-                let uu____10426 = unparen e in
-                uu____10426.FStar_Parser_AST.tm in
-              match uu____10425 with
+              let uu____10423 =
+                let uu____10424 = unparen e in
+                uu____10424.FStar_Parser_AST.tm in
+              match uu____10423 with
               | FStar_Parser_AST.App (e1, t, imp) when
                   imp <> FStar_Parser_AST.UnivApp ->
-                  let uu____10444 = desugar_term_aq env t in
-                  (match uu____10444 with
+                  let uu____10440 = desugar_term_aq env t in
+                  (match uu____10440 with
                    | (t1, aq) ->
                        let arg = arg_withimp_e imp t1 in
                        aux (arg :: args) (aq :: aqs) e1)
-              | uu____10492 ->
-                  let uu____10493 = desugar_term_aq env e in
-                  (match uu____10493 with
+              | uu____10486 ->
+                  let uu____10487 = desugar_term_aq env e in
+                  (match uu____10487 with
                    | (head, aq) ->
-                       let uu____10514 =
-                         mk (FStar_Syntax_Syntax.Tm_app (head, args)) in
-                       (uu____10514, (join_aqs (aq :: aqs)))) in
+                       let uu____10506 =
+                         FStar_Syntax_Syntax.extend_app_n head args
+                           top.FStar_Parser_AST.range in
+                       (uu____10506, (join_aqs (aq :: aqs)))) in
             aux [] [] top
         | FStar_Parser_AST.Bind (x, t1, t2) ->
             let xpat =
-              let uu____10567 = FStar_Ident.range_of_id x in
+              let uu____10543 = FStar_Ident.range_of_id x in
               FStar_Parser_AST.mk_pattern
                 (FStar_Parser_AST.PatVar (x, FStar_Pervasives_Native.None))
-                uu____10567 in
+                uu____10543 in
             let k =
               FStar_Parser_AST.mk_term (FStar_Parser_AST.Abs ([xpat], t2))
                 t2.FStar_Parser_AST.range t2.FStar_Parser_AST.level in
             let bind_lid =
-              let uu____10574 = FStar_Ident.range_of_id x in
-              FStar_Ident.lid_of_path ["bind"] uu____10574 in
+              let uu____10550 = FStar_Ident.range_of_id x in
+              FStar_Ident.lid_of_path ["bind"] uu____10550 in
             let bind =
-              let uu____10576 = FStar_Ident.range_of_id x in
+              let uu____10552 = FStar_Ident.range_of_id x in
               FStar_Parser_AST.mk_term (FStar_Parser_AST.Var bind_lid)
-                uu____10576 FStar_Parser_AST.Expr in
-            let uu____10577 =
+                uu____10552 FStar_Parser_AST.Expr in
+            let uu____10553 =
               FStar_Parser_AST.mkExplicitApp bind [t1; k]
                 top.FStar_Parser_AST.range in
-            desugar_term_aq env uu____10577
+            desugar_term_aq env uu____10553
         | FStar_Parser_AST.Seq (t1, t2) ->
             let t =
               FStar_Parser_AST.mk_term
@@ -3014,141 +3015,141 @@ and (desugar_term_maybe_top :
                                FStar_Pervasives_Native.None)
                             t1.FStar_Parser_AST.range), t1))], t2))
                 top.FStar_Parser_AST.range FStar_Parser_AST.Expr in
-            let uu____10629 = desugar_term_aq env t in
-            (match uu____10629 with
+            let uu____10605 = desugar_term_aq env t in
+            (match uu____10605 with
              | (tm, s) ->
-                 let uu____10640 =
+                 let uu____10616 =
                    mk
                      (FStar_Syntax_Syntax.Tm_meta
                         (tm,
                           (FStar_Syntax_Syntax.Meta_desugared
                              FStar_Syntax_Syntax.Sequence))) in
-                 (uu____10640, s))
+                 (uu____10616, s))
         | FStar_Parser_AST.LetOpen (lid, e) ->
             let env1 = FStar_Syntax_DsEnv.push_namespace env lid in
-            let uu____10646 =
-              let uu____10659 = FStar_Syntax_DsEnv.expect_typ env1 in
-              if uu____10659 then desugar_typ_aq else desugar_term_aq in
-            uu____10646 env1 e
+            let uu____10622 =
+              let uu____10635 = FStar_Syntax_DsEnv.expect_typ env1 in
+              if uu____10635 then desugar_typ_aq else desugar_term_aq in
+            uu____10622 env1 e
         | FStar_Parser_AST.Let (qual, lbs, body) ->
             let is_rec = qual = FStar_Parser_AST.Rec in
-            let ds_let_rec_or_app uu____10722 =
+            let ds_let_rec_or_app uu____10698 =
               let bindings = lbs in
               let funs =
                 FStar_All.pipe_right bindings
                   (FStar_List.map
-                     (fun uu____10865 ->
-                        match uu____10865 with
+                     (fun uu____10841 ->
+                        match uu____10841 with
                         | (attr_opt, (p, def)) ->
-                            let uu____10923 = is_app_pattern p in
-                            if uu____10923
+                            let uu____10899 = is_app_pattern p in
+                            if uu____10899
                             then
-                              let uu____10954 =
+                              let uu____10930 =
                                 destruct_app_pattern env top_level p in
-                              (attr_opt, uu____10954, def)
+                              (attr_opt, uu____10930, def)
                             else
                               (match FStar_Parser_AST.un_function p def with
                                | FStar_Pervasives_Native.Some (p1, def1) ->
-                                   let uu____11036 =
+                                   let uu____11012 =
                                      destruct_app_pattern env top_level p1 in
-                                   (attr_opt, uu____11036, def1)
-                               | uu____11081 ->
+                                   (attr_opt, uu____11012, def1)
+                               | uu____11057 ->
                                    (match p.FStar_Parser_AST.pat with
                                     | FStar_Parser_AST.PatAscribed
                                         ({
                                            FStar_Parser_AST.pat =
                                              FStar_Parser_AST.PatVar
-                                             (id, uu____11119);
+                                             (id, uu____11095);
                                            FStar_Parser_AST.prange =
-                                             uu____11120;_},
+                                             uu____11096;_},
                                          t)
                                         ->
                                         if top_level
                                         then
-                                          let uu____11168 =
-                                            let uu____11189 =
-                                              let uu____11194 =
+                                          let uu____11144 =
+                                            let uu____11165 =
+                                              let uu____11170 =
                                                 FStar_Syntax_DsEnv.qualify
                                                   env id in
-                                              FStar_Util.Inr uu____11194 in
-                                            (uu____11189, [],
+                                              FStar_Util.Inr uu____11170 in
+                                            (uu____11165, [],
                                               (FStar_Pervasives_Native.Some t)) in
-                                          (attr_opt, uu____11168, def)
+                                          (attr_opt, uu____11144, def)
                                         else
                                           (attr_opt,
                                             ((FStar_Util.Inl id), [],
                                               (FStar_Pervasives_Native.Some t)),
                                             def)
                                     | FStar_Parser_AST.PatVar
-                                        (id, uu____11285) ->
+                                        (id, uu____11261) ->
                                         if top_level
                                         then
-                                          let uu____11320 =
-                                            let uu____11341 =
-                                              let uu____11346 =
+                                          let uu____11296 =
+                                            let uu____11317 =
+                                              let uu____11322 =
                                                 FStar_Syntax_DsEnv.qualify
                                                   env id in
-                                              FStar_Util.Inr uu____11346 in
-                                            (uu____11341, [],
+                                              FStar_Util.Inr uu____11322 in
+                                            (uu____11317, [],
                                               FStar_Pervasives_Native.None) in
-                                          (attr_opt, uu____11320, def)
+                                          (attr_opt, uu____11296, def)
                                         else
                                           (attr_opt,
                                             ((FStar_Util.Inl id), [],
                                               FStar_Pervasives_Native.None),
                                             def)
-                                    | uu____11436 ->
+                                    | uu____11412 ->
                                         FStar_Errors.raise_error
                                           (FStar_Errors.Fatal_UnexpectedLetBinding,
                                             "Unexpected let binding")
                                           p.FStar_Parser_AST.prange)))) in
-              let uu____11467 =
+              let uu____11443 =
                 FStar_List.fold_left
-                  (fun uu____11554 ->
-                     fun uu____11555 ->
-                       match (uu____11554, uu____11555) with
+                  (fun uu____11530 ->
+                     fun uu____11531 ->
+                       match (uu____11530, uu____11531) with
                        | ((env1, fnames, rec_bindings, used_markers),
-                          (_attr_opt, (f, uu____11682, uu____11683),
-                           uu____11684)) ->
-                           let uu____11815 =
+                          (_attr_opt, (f, uu____11658, uu____11659),
+                           uu____11660)) ->
+                           let uu____11791 =
                              match f with
                              | FStar_Util.Inl x ->
-                                 let uu____11853 =
+                                 let uu____11829 =
                                    FStar_Syntax_DsEnv.push_bv' env1 x in
-                                 (match uu____11853 with
+                                 (match uu____11829 with
                                   | (env2, xx, used_marker) ->
                                       let dummy_ref = FStar_Util.mk_ref true in
-                                      let uu____11884 =
-                                        let uu____11887 =
+                                      let uu____11860 =
+                                        let uu____11863 =
                                           FStar_Syntax_Syntax.mk_binder xx in
-                                        uu____11887 :: rec_bindings in
+                                        uu____11863 :: rec_bindings in
                                       (env2, (FStar_Util.Inl xx),
-                                        uu____11884, (used_marker ::
+                                        uu____11860, (used_marker ::
                                         used_markers)))
                              | FStar_Util.Inr l ->
-                                 let uu____11901 =
-                                   let uu____11908 =
+                                 let uu____11877 =
+                                   let uu____11884 =
                                      FStar_Ident.ident_of_lid l in
                                    FStar_Syntax_DsEnv.push_top_level_rec_binding
-                                     env1 uu____11908
+                                     env1 uu____11884
                                      FStar_Syntax_Syntax.delta_equational in
-                                 (match uu____11901 with
+                                 (match uu____11877 with
                                   | (env2, used_marker) ->
                                       (env2, (FStar_Util.Inr l),
                                         rec_bindings, (used_marker ::
                                         used_markers))) in
-                           (match uu____11815 with
+                           (match uu____11791 with
                             | (env2, lbname, rec_bindings1, used_markers1) ->
                                 (env2, (lbname :: fnames), rec_bindings1,
                                   used_markers1))) (env, [], [], []) funs in
-              match uu____11467 with
+              match uu____11443 with
               | (env', fnames, rec_bindings, used_markers) ->
                   let fnames1 = FStar_List.rev fnames in
                   let rec_bindings1 = FStar_List.rev rec_bindings in
                   let used_markers1 = FStar_List.rev used_markers in
-                  let desugar_one_def env1 lbname uu____12139 =
-                    match uu____12139 with
-                    | (attrs_opt, (uu____12179, args, result_t), def) ->
+                  let desugar_one_def env1 lbname uu____12115 =
+                    match uu____12115 with
+                    | (attrs_opt, (uu____12155, args, result_t), def) ->
                         let args1 =
                           FStar_All.pipe_right args
                             (FStar_List.map replace_unit_pattern) in
@@ -3158,17 +3159,17 @@ and (desugar_term_maybe_top :
                           | FStar_Pervasives_Native.None -> def
                           | FStar_Pervasives_Native.Some (t, tacopt) ->
                               let t1 =
-                                let uu____12271 = is_comp_type env1 t in
-                                if uu____12271
+                                let uu____12247 = is_comp_type env1 t in
+                                if uu____12247
                                 then
-                                  ((let uu____12273 =
+                                  ((let uu____12249 =
                                       FStar_All.pipe_right args1
                                         (FStar_List.tryFind
                                            (fun x ->
-                                              let uu____12283 =
+                                              let uu____12259 =
                                                 is_var_pattern x in
-                                              Prims.op_Negation uu____12283)) in
-                                    match uu____12273 with
+                                              Prims.op_Negation uu____12259)) in
+                                    match uu____12249 with
                                     | FStar_Pervasives_Native.None -> ()
                                     | FStar_Pervasives_Native.Some p ->
                                         FStar_Errors.raise_error
@@ -3177,18 +3178,18 @@ and (desugar_term_maybe_top :
                                           p.FStar_Parser_AST.prange);
                                    t)
                                 else
-                                  (let uu____12286 =
+                                  (let uu____12262 =
                                      ((FStar_Options.ml_ish ()) &&
-                                        (let uu____12288 =
+                                        (let uu____12264 =
                                            FStar_Syntax_DsEnv.try_lookup_effect_name
                                              env1
                                              FStar_Parser_Const.effect_ML_lid in
-                                         FStar_Option.isSome uu____12288))
+                                         FStar_Option.isSome uu____12264))
                                        &&
                                        ((Prims.op_Negation is_rec) ||
                                           ((FStar_List.length args1) <>
                                              Prims.int_zero)) in
-                                   if uu____12286
+                                   if uu____12262
                                    then FStar_Parser_AST.ml_comp t
                                    else FStar_Parser_AST.tot_comp t) in
                               FStar_Parser_AST.mk_term
@@ -3198,26 +3199,26 @@ and (desugar_term_maybe_top :
                         let def2 =
                           match args1 with
                           | [] -> def1
-                          | uu____12295 ->
+                          | uu____12271 ->
                               FStar_Parser_AST.mk_term
                                 (FStar_Parser_AST.un_curry_abs args1 def1)
                                 top.FStar_Parser_AST.range
                                 top.FStar_Parser_AST.level in
-                        let uu____12298 = desugar_term_aq env1 def2 in
-                        (match uu____12298 with
+                        let uu____12274 = desugar_term_aq env1 def2 in
+                        (match uu____12274 with
                          | (body1, aq) ->
                              let lbname1 =
                                match lbname with
                                | FStar_Util.Inl x -> FStar_Util.Inl x
                                | FStar_Util.Inr l ->
-                                   let uu____12320 =
-                                     let uu____12321 =
+                                   let uu____12296 =
+                                     let uu____12297 =
                                        FStar_Syntax_Util.incr_delta_qualifier
                                          body1 in
                                      FStar_Syntax_Syntax.lid_as_fv l
-                                       uu____12321
+                                       uu____12297
                                        FStar_Pervasives_Native.None in
-                                   FStar_Util.Inr uu____12320 in
+                                   FStar_Util.Inr uu____12296 in
                              let body2 =
                                if is_rec
                                then
@@ -3232,74 +3233,74 @@ and (desugar_term_maybe_top :
                                  (attrs, lbname1,
                                    (setpos FStar_Syntax_Syntax.tun), body2,
                                    pos)), aq)) in
-                  let uu____12360 =
-                    let uu____12377 =
+                  let uu____12336 =
+                    let uu____12353 =
                       FStar_List.map2
                         (desugar_one_def (if is_rec then env' else env))
                         fnames1 funs in
-                    FStar_All.pipe_right uu____12377 FStar_List.unzip in
-                  (match uu____12360 with
+                    FStar_All.pipe_right uu____12353 FStar_List.unzip in
+                  (match uu____12336 with
                    | (lbs1, aqss) ->
-                       let uu____12517 = desugar_term_aq env' body in
-                       (match uu____12517 with
+                       let uu____12493 = desugar_term_aq env' body in
+                       (match uu____12493 with
                         | (body1, aq) ->
                             (if is_rec
                              then
                                FStar_List.iter2
-                                 (fun uu____12594 ->
+                                 (fun uu____12570 ->
                                     fun used_marker ->
-                                      match uu____12594 with
+                                      match uu____12570 with
                                       | (_attr_opt,
-                                         (f, uu____12640, uu____12641),
-                                         uu____12642) ->
-                                          let uu____12699 =
-                                            let uu____12700 =
+                                         (f, uu____12616, uu____12617),
+                                         uu____12618) ->
+                                          let uu____12675 =
+                                            let uu____12676 =
                                               FStar_ST.op_Bang used_marker in
-                                            Prims.op_Negation uu____12700 in
-                                          if uu____12699
+                                            Prims.op_Negation uu____12676 in
+                                          if uu____12675
                                           then
-                                            let uu____12707 =
+                                            let uu____12683 =
                                               match f with
                                               | FStar_Util.Inl x ->
-                                                  let uu____12721 =
+                                                  let uu____12697 =
                                                     FStar_Ident.string_of_id
                                                       x in
-                                                  let uu____12722 =
+                                                  let uu____12698 =
                                                     FStar_Ident.range_of_id x in
-                                                  (uu____12721, "Local",
-                                                    uu____12722)
+                                                  (uu____12697, "Local",
+                                                    uu____12698)
                                               | FStar_Util.Inr l ->
-                                                  let uu____12724 =
+                                                  let uu____12700 =
                                                     FStar_Ident.string_of_lid
                                                       l in
-                                                  let uu____12725 =
+                                                  let uu____12701 =
                                                     FStar_Ident.range_of_lid
                                                       l in
-                                                  (uu____12724, "Global",
-                                                    uu____12725) in
-                                            (match uu____12707 with
+                                                  (uu____12700, "Global",
+                                                    uu____12701) in
+                                            (match uu____12683 with
                                              | (nm, gl, rng) ->
-                                                 let uu____12729 =
-                                                   let uu____12734 =
+                                                 let uu____12705 =
+                                                   let uu____12710 =
                                                      FStar_Util.format2
                                                        "%s binding %s is recursive but not used in its body"
                                                        gl nm in
                                                    (FStar_Errors.Warning_UnusedLetRec,
-                                                     uu____12734) in
+                                                     uu____12710) in
                                                  FStar_Errors.log_issue rng
-                                                   uu____12729)
+                                                   uu____12705)
                                           else ()) funs used_markers1
                              else ();
-                             (let uu____12737 =
-                                let uu____12740 =
-                                  let uu____12741 =
-                                    let uu____12754 =
+                             (let uu____12713 =
+                                let uu____12716 =
+                                  let uu____12717 =
+                                    let uu____12730 =
                                       FStar_Syntax_Subst.close rec_bindings1
                                         body1 in
-                                    ((is_rec, lbs1), uu____12754) in
-                                  FStar_Syntax_Syntax.Tm_let uu____12741 in
-                                FStar_All.pipe_left mk uu____12740 in
-                              (uu____12737,
+                                    ((is_rec, lbs1), uu____12730) in
+                                  FStar_Syntax_Syntax.Tm_let uu____12717 in
+                                FStar_All.pipe_left mk uu____12716 in
+                              (uu____12713,
                                 (FStar_List.append aq
                                    (FStar_List.flatten aqss))))))) in
             let ds_non_rec attrs_opt pat t1 t2 =
@@ -3308,27 +3309,27 @@ and (desugar_term_maybe_top :
                 | FStar_Pervasives_Native.None -> []
                 | FStar_Pervasives_Native.Some l ->
                     FStar_List.map (desugar_term env) l in
-              let uu____12854 = desugar_term_aq env t1 in
-              match uu____12854 with
+              let uu____12830 = desugar_term_aq env t1 in
+              match uu____12830 with
               | (t11, aq0) ->
-                  let uu____12875 =
+                  let uu____12851 =
                     desugar_binding_pat_maybe_top top_level env pat in
-                  (match uu____12875 with
+                  (match uu____12851 with
                    | (env1, binder, pat1) ->
-                       let uu____12905 =
+                       let uu____12881 =
                          match binder with
                          | LetBinder (l, (t, _tacopt)) ->
-                             let uu____12947 = desugar_term_aq env1 t2 in
-                             (match uu____12947 with
+                             let uu____12923 = desugar_term_aq env1 t2 in
+                             (match uu____12923 with
                               | (body1, aq) ->
                                   let fv =
-                                    let uu____12969 =
+                                    let uu____12945 =
                                       FStar_Syntax_Util.incr_delta_qualifier
                                         t11 in
                                     FStar_Syntax_Syntax.lid_as_fv l
-                                      uu____12969
+                                      uu____12945
                                       FStar_Pervasives_Native.None in
-                                  let uu____12970 =
+                                  let uu____12946 =
                                     FStar_All.pipe_left mk
                                       (FStar_Syntax_Syntax.Tm_let
                                          ((false,
@@ -3337,10 +3338,10 @@ and (desugar_term_maybe_top :
                                                  t, t11,
                                                  (t11.FStar_Syntax_Syntax.pos))]),
                                            body1)) in
-                                  (uu____12970, aq))
-                         | LocalBinder (x, uu____13008) ->
-                             let uu____13009 = desugar_term_aq env1 t2 in
-                             (match uu____13009 with
+                                  (uu____12946, aq))
+                         | LocalBinder (x, uu____12984) ->
+                             let uu____12985 = desugar_term_aq env1 t2 in
+                             (match uu____12985 with
                               | (body1, aq) ->
                                   let body2 =
                                     match pat1 with
@@ -3348,103 +3349,106 @@ and (desugar_term_maybe_top :
                                     | ({
                                          FStar_Syntax_Syntax.v =
                                            FStar_Syntax_Syntax.Pat_wild
-                                           uu____13031;
-                                         FStar_Syntax_Syntax.p = uu____13032;_},
-                                       uu____13033)::[] -> body1
-                                    | uu____13046 ->
-                                        let uu____13049 =
-                                          let uu____13050 =
-                                            let uu____13073 =
+                                           uu____13007;
+                                         FStar_Syntax_Syntax.p = uu____13008;_},
+                                       uu____13009)::[] -> body1
+                                    | uu____13022 ->
+                                        let uu____13025 =
+                                          let uu____13026 =
+                                            let uu____13049 =
                                               FStar_Syntax_Syntax.bv_to_name
                                                 x in
-                                            let uu____13076 =
+                                            let uu____13052 =
                                               desugar_disjunctive_pattern
                                                 pat1
                                                 FStar_Pervasives_Native.None
                                                 body1 in
-                                            (uu____13073, uu____13076) in
+                                            (uu____13049, uu____13052) in
                                           FStar_Syntax_Syntax.Tm_match
-                                            uu____13050 in
-                                        FStar_Syntax_Syntax.mk uu____13049
+                                            uu____13026 in
+                                        FStar_Syntax_Syntax.mk uu____13025
                                           top.FStar_Parser_AST.range in
-                                  let uu____13113 =
-                                    let uu____13116 =
-                                      let uu____13117 =
-                                        let uu____13130 =
-                                          let uu____13133 =
-                                            let uu____13134 =
+                                  let uu____13089 =
+                                    let uu____13092 =
+                                      let uu____13093 =
+                                        let uu____13106 =
+                                          let uu____13109 =
+                                            let uu____13110 =
                                               FStar_Syntax_Syntax.mk_binder x in
-                                            [uu____13134] in
+                                            [uu____13110] in
                                           FStar_Syntax_Subst.close
-                                            uu____13133 body2 in
+                                            uu____13109 body2 in
                                         ((false,
                                            [mk_lb
                                               (attrs, (FStar_Util.Inl x),
                                                 (x.FStar_Syntax_Syntax.sort),
                                                 t11,
                                                 (t11.FStar_Syntax_Syntax.pos))]),
-                                          uu____13130) in
-                                      FStar_Syntax_Syntax.Tm_let uu____13117 in
-                                    FStar_All.pipe_left mk uu____13116 in
-                                  (uu____13113, aq)) in
-                       (match uu____12905 with
+                                          uu____13106) in
+                                      FStar_Syntax_Syntax.Tm_let uu____13093 in
+                                    FStar_All.pipe_left mk uu____13092 in
+                                  (uu____13089, aq)) in
+                       (match uu____12881 with
                         | (tm, aq1) -> (tm, (FStar_List.append aq0 aq1)))) in
-            let uu____13239 = FStar_List.hd lbs in
-            (match uu____13239 with
+            let uu____13215 = FStar_List.hd lbs in
+            (match uu____13215 with
              | (attrs, (head_pat, defn)) ->
-                 let uu____13283 = is_rec || (is_app_pattern head_pat) in
-                 if uu____13283
+                 let uu____13259 = is_rec || (is_app_pattern head_pat) in
+                 if uu____13259
                  then ds_let_rec_or_app ()
                  else ds_non_rec attrs head_pat defn body)
         | FStar_Parser_AST.If (t1, t2, t3) ->
             let x =
-              let uu____13293 = tun_r t3.FStar_Parser_AST.range in
+              let uu____13269 = tun_r t3.FStar_Parser_AST.range in
               FStar_Syntax_Syntax.new_bv
                 (FStar_Pervasives_Native.Some (t3.FStar_Parser_AST.range))
-                uu____13293 in
+                uu____13269 in
             let t_bool =
-              let uu____13297 =
-                let uu____13298 =
+              let uu____13273 =
+                let uu____13274 =
                   FStar_Syntax_Syntax.lid_as_fv FStar_Parser_Const.bool_lid
                     FStar_Syntax_Syntax.delta_constant
                     FStar_Pervasives_Native.None in
-                FStar_Syntax_Syntax.Tm_fvar uu____13298 in
-              mk uu____13297 in
-            let uu____13299 = desugar_term_aq env t1 in
-            (match uu____13299 with
+                FStar_Syntax_Syntax.Tm_fvar uu____13274 in
+              mk uu____13273 in
+            let uu____13275 = desugar_term_aq env t1 in
+            (match uu____13275 with
              | (t1', aq1) ->
-                 let uu____13310 = desugar_term_aq env t2 in
-                 (match uu____13310 with
+                 let t1'1 =
+                   FStar_Syntax_Util.ascribe t1'
+                     ((FStar_Util.Inl t_bool), FStar_Pervasives_Native.None) in
+                 let uu____13307 = desugar_term_aq env t2 in
+                 (match uu____13307 with
                   | (t2', aq2) ->
-                      let uu____13321 = desugar_term_aq env t3 in
-                      (match uu____13321 with
+                      let uu____13318 = desugar_term_aq env t3 in
+                      (match uu____13318 with
                        | (t3', aq3) ->
-                           let uu____13332 =
-                             let uu____13333 =
-                               let uu____13334 =
-                                 let uu____13357 =
-                                   let uu____13374 =
-                                     let uu____13389 =
+                           let uu____13329 =
+                             let uu____13330 =
+                               let uu____13331 =
+                                 let uu____13354 =
+                                   let uu____13371 =
+                                     let uu____13386 =
                                        FStar_Syntax_Syntax.withinfo
                                          (FStar_Syntax_Syntax.Pat_constant
                                             (FStar_Const.Const_bool true))
                                          t1.FStar_Parser_AST.range in
-                                     (uu____13389,
+                                     (uu____13386,
                                        FStar_Pervasives_Native.None, t2') in
-                                   let uu____13402 =
-                                     let uu____13419 =
-                                       let uu____13434 =
+                                   let uu____13399 =
+                                     let uu____13416 =
+                                       let uu____13431 =
                                          FStar_Syntax_Syntax.withinfo
                                            (FStar_Syntax_Syntax.Pat_wild x)
                                            t1.FStar_Parser_AST.range in
-                                       (uu____13434,
+                                       (uu____13431,
                                          FStar_Pervasives_Native.None, t3') in
-                                     [uu____13419] in
-                                   uu____13374 :: uu____13402 in
-                                 (t1', uu____13357) in
-                               FStar_Syntax_Syntax.Tm_match uu____13334 in
-                             mk uu____13333 in
-                           (uu____13332, (join_aqs [aq1; aq2; aq3])))))
+                                     [uu____13416] in
+                                   uu____13371 :: uu____13399 in
+                                 (t1'1, uu____13354) in
+                               FStar_Syntax_Syntax.Tm_match uu____13331 in
+                             mk uu____13330 in
+                           (uu____13329, (join_aqs [aq1; aq2; aq3])))))
         | FStar_Parser_AST.TryWith (e, branches) ->
             let r = top.FStar_Parser_AST.range in
             let handler = FStar_Parser_AST.mk_function branches r r in
@@ -3468,105 +3472,105 @@ and (desugar_term_maybe_top :
                 r top.FStar_Parser_AST.level in
             desugar_term_aq env a2
         | FStar_Parser_AST.Match (e, branches) ->
-            let desugar_branch uu____13627 =
-              match uu____13627 with
+            let desugar_branch uu____13624 =
+              match uu____13624 with
               | (pat, wopt, b) ->
-                  let uu____13649 = desugar_match_pat env pat in
-                  (match uu____13649 with
+                  let uu____13646 = desugar_match_pat env pat in
+                  (match uu____13646 with
                    | (env1, pat1) ->
                        let wopt1 =
                          match wopt with
                          | FStar_Pervasives_Native.None ->
                              FStar_Pervasives_Native.None
                          | FStar_Pervasives_Native.Some e1 ->
-                             let uu____13680 = desugar_term env1 e1 in
-                             FStar_Pervasives_Native.Some uu____13680 in
-                       let uu____13685 = desugar_term_aq env1 b in
-                       (match uu____13685 with
+                             let uu____13677 = desugar_term env1 e1 in
+                             FStar_Pervasives_Native.Some uu____13677 in
+                       let uu____13682 = desugar_term_aq env1 b in
+                       (match uu____13682 with
                         | (b1, aq) ->
-                            let uu____13698 =
+                            let uu____13695 =
                               desugar_disjunctive_pattern pat1 wopt1 b1 in
-                            (uu____13698, aq))) in
-            let uu____13703 = desugar_term_aq env e in
-            (match uu____13703 with
+                            (uu____13695, aq))) in
+            let uu____13700 = desugar_term_aq env e in
+            (match uu____13700 with
              | (e1, aq) ->
-                 let uu____13714 =
-                   let uu____13745 =
-                     let uu____13778 = FStar_List.map desugar_branch branches in
-                     FStar_All.pipe_right uu____13778 FStar_List.unzip in
-                   FStar_All.pipe_right uu____13745
-                     (fun uu____13996 ->
-                        match uu____13996 with
+                 let uu____13711 =
+                   let uu____13742 =
+                     let uu____13775 = FStar_List.map desugar_branch branches in
+                     FStar_All.pipe_right uu____13775 FStar_List.unzip in
+                   FStar_All.pipe_right uu____13742
+                     (fun uu____13993 ->
+                        match uu____13993 with
                         | (x, y) -> ((FStar_List.flatten x), y)) in
-                 (match uu____13714 with
+                 (match uu____13711 with
                   | (brs, aqs) ->
-                      let uu____14215 =
+                      let uu____14212 =
                         FStar_All.pipe_left mk
                           (FStar_Syntax_Syntax.Tm_match (e1, brs)) in
-                      (uu____14215, (join_aqs (aq :: aqs)))))
+                      (uu____14212, (join_aqs (aq :: aqs)))))
         | FStar_Parser_AST.Ascribed (e, t, tac_opt) ->
-            let uu____14249 =
-              let uu____14270 = is_comp_type env t in
-              if uu____14270
+            let uu____14246 =
+              let uu____14267 = is_comp_type env t in
+              if uu____14267
               then
                 let comp = desugar_comp t.FStar_Parser_AST.range true env t in
                 ((FStar_Util.Inr comp), [])
               else
-                (let uu____14321 = desugar_term_aq env t in
-                 match uu____14321 with
+                (let uu____14318 = desugar_term_aq env t in
+                 match uu____14318 with
                  | (tm, aq) -> ((FStar_Util.Inl tm), aq)) in
-            (match uu____14249 with
+            (match uu____14246 with
              | (annot, aq0) ->
                  let tac_opt1 = FStar_Util.map_opt tac_opt (desugar_term env) in
-                 let uu____14413 = desugar_term_aq env e in
-                 (match uu____14413 with
+                 let uu____14410 = desugar_term_aq env e in
+                 (match uu____14410 with
                   | (e1, aq) ->
-                      let uu____14424 =
+                      let uu____14421 =
                         FStar_All.pipe_left mk
                           (FStar_Syntax_Syntax.Tm_ascribed
                              (e1, (annot, tac_opt1),
                                FStar_Pervasives_Native.None)) in
-                      (uu____14424, (FStar_List.append aq0 aq))))
-        | FStar_Parser_AST.Record (uu____14463, []) ->
+                      (uu____14421, (FStar_List.append aq0 aq))))
+        | FStar_Parser_AST.Record (uu____14460, []) ->
             FStar_Errors.raise_error
               (FStar_Errors.Fatal_UnexpectedEmptyRecord,
                 "Unexpected empty record") top.FStar_Parser_AST.range
         | FStar_Parser_AST.Record (eopt, fields) ->
             let record = check_fields env fields top.FStar_Parser_AST.range in
             let user_ns =
-              let uu____14504 = FStar_List.hd fields in
-              match uu____14504 with
-              | (f, uu____14516) -> FStar_Ident.ns_of_lid f in
+              let uu____14501 = FStar_List.hd fields in
+              match uu____14501 with
+              | (f, uu____14513) -> FStar_Ident.ns_of_lid f in
             let get_field xopt f =
               let found =
                 FStar_All.pipe_right fields
                   (FStar_Util.find_opt
-                     (fun uu____14564 ->
-                        match uu____14564 with
-                        | (g, uu____14570) ->
-                            let uu____14571 = FStar_Ident.string_of_id f in
-                            let uu____14572 =
-                              let uu____14573 = FStar_Ident.ident_of_lid g in
-                              FStar_Ident.string_of_id uu____14573 in
-                            uu____14571 = uu____14572)) in
+                     (fun uu____14561 ->
+                        match uu____14561 with
+                        | (g, uu____14567) ->
+                            let uu____14568 = FStar_Ident.string_of_id f in
+                            let uu____14569 =
+                              let uu____14570 = FStar_Ident.ident_of_lid g in
+                              FStar_Ident.string_of_id uu____14570 in
+                            uu____14568 = uu____14569)) in
               let fn = FStar_Ident.lid_of_ids (FStar_List.append user_ns [f]) in
               match found with
-              | FStar_Pervasives_Native.Some (uu____14579, e) -> (fn, e)
+              | FStar_Pervasives_Native.Some (uu____14576, e) -> (fn, e)
               | FStar_Pervasives_Native.None ->
                   (match xopt with
                    | FStar_Pervasives_Native.None ->
-                       let uu____14593 =
-                         let uu____14598 =
-                           let uu____14599 = FStar_Ident.string_of_id f in
-                           let uu____14600 =
+                       let uu____14590 =
+                         let uu____14595 =
+                           let uu____14596 = FStar_Ident.string_of_id f in
+                           let uu____14597 =
                              FStar_Ident.string_of_lid
                                record.FStar_Syntax_DsEnv.typename in
                            FStar_Util.format2
                              "Field %s of record type %s is missing"
-                             uu____14599 uu____14600 in
+                             uu____14596 uu____14597 in
                          (FStar_Errors.Fatal_MissingFieldInRecord,
-                           uu____14598) in
-                       FStar_Errors.raise_error uu____14593
+                           uu____14595) in
+                       FStar_Errors.raise_error uu____14590
                          top.FStar_Parser_AST.range
                    | FStar_Pervasives_Native.Some x ->
                        (fn,
@@ -3580,184 +3584,184 @@ and (desugar_term_maybe_top :
             let recterm =
               match eopt with
               | FStar_Pervasives_Native.None ->
-                  let uu____14608 =
-                    let uu____14619 =
+                  let uu____14605 =
+                    let uu____14616 =
                       FStar_All.pipe_right record.FStar_Syntax_DsEnv.fields
                         (FStar_List.map
-                           (fun uu____14650 ->
-                              match uu____14650 with
-                              | (f, uu____14660) ->
-                                  let uu____14661 =
-                                    let uu____14662 =
+                           (fun uu____14647 ->
+                              match uu____14647 with
+                              | (f, uu____14657) ->
+                                  let uu____14658 =
+                                    let uu____14659 =
                                       get_field FStar_Pervasives_Native.None
                                         f in
                                     FStar_All.pipe_left
-                                      FStar_Pervasives_Native.snd uu____14662 in
-                                  (uu____14661, FStar_Parser_AST.Nothing))) in
-                    (user_constrname, uu____14619) in
-                  FStar_Parser_AST.Construct uu____14608
+                                      FStar_Pervasives_Native.snd uu____14659 in
+                                  (uu____14658, FStar_Parser_AST.Nothing))) in
+                    (user_constrname, uu____14616) in
+                  FStar_Parser_AST.Construct uu____14605
               | FStar_Pervasives_Native.Some e ->
                   let x = FStar_Ident.gen e.FStar_Parser_AST.range in
                   let xterm =
-                    let uu____14680 =
-                      let uu____14681 = FStar_Ident.lid_of_ids [x] in
-                      FStar_Parser_AST.Var uu____14681 in
-                    let uu____14682 = FStar_Ident.range_of_id x in
-                    FStar_Parser_AST.mk_term uu____14680 uu____14682
+                    let uu____14677 =
+                      let uu____14678 = FStar_Ident.lid_of_ids [x] in
+                      FStar_Parser_AST.Var uu____14678 in
+                    let uu____14679 = FStar_Ident.range_of_id x in
+                    FStar_Parser_AST.mk_term uu____14677 uu____14679
                       FStar_Parser_AST.Expr in
                   let record1 =
-                    let uu____14684 =
-                      let uu____14697 =
+                    let uu____14681 =
+                      let uu____14694 =
                         FStar_All.pipe_right record.FStar_Syntax_DsEnv.fields
                           (FStar_List.map
-                             (fun uu____14727 ->
-                                match uu____14727 with
-                                | (f, uu____14737) ->
+                             (fun uu____14724 ->
+                                match uu____14724 with
+                                | (f, uu____14734) ->
                                     get_field
                                       (FStar_Pervasives_Native.Some xterm) f)) in
-                      (FStar_Pervasives_Native.None, uu____14697) in
-                    FStar_Parser_AST.Record uu____14684 in
-                  let uu____14746 =
-                    let uu____14767 =
-                      let uu____14782 =
-                        let uu____14795 =
-                          let uu____14800 =
-                            let uu____14801 = FStar_Ident.range_of_id x in
+                      (FStar_Pervasives_Native.None, uu____14694) in
+                    FStar_Parser_AST.Record uu____14681 in
+                  let uu____14743 =
+                    let uu____14764 =
+                      let uu____14779 =
+                        let uu____14792 =
+                          let uu____14797 =
+                            let uu____14798 = FStar_Ident.range_of_id x in
                             FStar_Parser_AST.mk_pattern
                               (FStar_Parser_AST.PatVar
                                  (x, FStar_Pervasives_Native.None))
-                              uu____14801 in
-                          (uu____14800, e) in
-                        (FStar_Pervasives_Native.None, uu____14795) in
-                      [uu____14782] in
-                    (FStar_Parser_AST.NoLetQualifier, uu____14767,
+                              uu____14798 in
+                          (uu____14797, e) in
+                        (FStar_Pervasives_Native.None, uu____14792) in
+                      [uu____14779] in
+                    (FStar_Parser_AST.NoLetQualifier, uu____14764,
                       (FStar_Parser_AST.mk_term record1
                          top.FStar_Parser_AST.range
                          top.FStar_Parser_AST.level)) in
-                  FStar_Parser_AST.Let uu____14746 in
+                  FStar_Parser_AST.Let uu____14743 in
             let recterm1 =
               FStar_Parser_AST.mk_term recterm top.FStar_Parser_AST.range
                 top.FStar_Parser_AST.level in
-            let uu____14853 = desugar_term_aq env recterm1 in
-            (match uu____14853 with
+            let uu____14850 = desugar_term_aq env recterm1 in
+            (match uu____14850 with
              | (e, s) ->
                  (match e.FStar_Syntax_Syntax.n with
                   | FStar_Syntax_Syntax.Tm_app
                       ({
                          FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar
                            fv;
-                         FStar_Syntax_Syntax.pos = uu____14869;
-                         FStar_Syntax_Syntax.vars = uu____14870;_},
+                         FStar_Syntax_Syntax.pos = uu____14866;
+                         FStar_Syntax_Syntax.vars = uu____14867;_},
                        args)
                       ->
-                      let uu____14896 =
-                        let uu____14897 =
-                          let uu____14898 =
-                            let uu____14915 =
-                              let uu____14918 =
+                      let uu____14893 =
+                        let uu____14894 =
+                          let uu____14895 =
+                            let uu____14912 =
+                              let uu____14915 =
                                 FStar_Ident.set_lid_range
                                   (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
                                   e.FStar_Syntax_Syntax.pos in
-                              let uu____14919 =
-                                let uu____14922 =
-                                  let uu____14923 =
-                                    let uu____14930 =
+                              let uu____14916 =
+                                let uu____14919 =
+                                  let uu____14920 =
+                                    let uu____14927 =
                                       FStar_All.pipe_right
                                         record.FStar_Syntax_DsEnv.fields
                                         (FStar_List.map
                                            FStar_Pervasives_Native.fst) in
                                     ((record.FStar_Syntax_DsEnv.typename),
-                                      uu____14930) in
-                                  FStar_Syntax_Syntax.Record_ctor uu____14923 in
-                                FStar_Pervasives_Native.Some uu____14922 in
-                              FStar_Syntax_Syntax.fvar uu____14918
+                                      uu____14927) in
+                                  FStar_Syntax_Syntax.Record_ctor uu____14920 in
+                                FStar_Pervasives_Native.Some uu____14919 in
+                              FStar_Syntax_Syntax.fvar uu____14915
                                 FStar_Syntax_Syntax.delta_constant
-                                uu____14919 in
-                            (uu____14915, args) in
-                          FStar_Syntax_Syntax.Tm_app uu____14898 in
-                        FStar_All.pipe_left mk uu____14897 in
-                      (uu____14896, s)
-                  | uu____14959 -> (e, s)))
+                                uu____14916 in
+                            (uu____14912, args) in
+                          FStar_Syntax_Syntax.Tm_app uu____14895 in
+                        FStar_All.pipe_left mk uu____14894 in
+                      (uu____14893, s)
+                  | uu____14956 -> (e, s)))
         | FStar_Parser_AST.Project (e, f) ->
-            let uu____14962 =
+            let uu____14959 =
               FStar_Syntax_DsEnv.fail_or env
                 (FStar_Syntax_DsEnv.try_lookup_dc_by_field_name env) f in
-            (match uu____14962 with
+            (match uu____14959 with
              | (constrname, is_rec) ->
-                 let uu____14977 = desugar_term_aq env e in
-                 (match uu____14977 with
+                 let uu____14974 = desugar_term_aq env e in
+                 (match uu____14974 with
                   | (e1, s) ->
                       let projname =
-                        let uu____14989 = FStar_Ident.ident_of_lid f in
+                        let uu____14986 = FStar_Ident.ident_of_lid f in
                         FStar_Syntax_Util.mk_field_projector_name_from_ident
-                          constrname uu____14989 in
+                          constrname uu____14986 in
                       let qual =
                         if is_rec
                         then
-                          let uu____14995 =
-                            let uu____14996 =
-                              let uu____15001 = FStar_Ident.ident_of_lid f in
-                              (constrname, uu____15001) in
-                            FStar_Syntax_Syntax.Record_projector uu____14996 in
-                          FStar_Pervasives_Native.Some uu____14995
+                          let uu____14992 =
+                            let uu____14993 =
+                              let uu____14998 = FStar_Ident.ident_of_lid f in
+                              (constrname, uu____14998) in
+                            FStar_Syntax_Syntax.Record_projector uu____14993 in
+                          FStar_Pervasives_Native.Some uu____14992
                         else FStar_Pervasives_Native.None in
-                      let uu____15003 =
-                        let uu____15004 =
-                          let uu____15005 =
-                            let uu____15022 =
-                              let uu____15025 =
+                      let uu____15000 =
+                        let uu____15001 =
+                          let uu____15002 =
+                            let uu____15019 =
+                              let uu____15022 =
                                 FStar_Ident.set_lid_range projname
                                   top.FStar_Parser_AST.range in
-                              FStar_Syntax_Syntax.fvar uu____15025
+                              FStar_Syntax_Syntax.fvar uu____15022
                                 (FStar_Syntax_Syntax.Delta_equational_at_level
                                    Prims.int_one) qual in
-                            let uu____15026 =
-                              let uu____15037 = FStar_Syntax_Syntax.as_arg e1 in
-                              [uu____15037] in
-                            (uu____15022, uu____15026) in
-                          FStar_Syntax_Syntax.Tm_app uu____15005 in
-                        FStar_All.pipe_left mk uu____15004 in
-                      (uu____15003, s)))
+                            let uu____15023 =
+                              let uu____15034 = FStar_Syntax_Syntax.as_arg e1 in
+                              [uu____15034] in
+                            (uu____15019, uu____15023) in
+                          FStar_Syntax_Syntax.Tm_app uu____15002 in
+                        FStar_All.pipe_left mk uu____15001 in
+                      (uu____15000, s)))
         | FStar_Parser_AST.NamedTyp (n, e) ->
-            ((let uu____15077 = FStar_Ident.range_of_id n in
-              FStar_Errors.log_issue uu____15077
+            ((let uu____15074 = FStar_Ident.range_of_id n in
+              FStar_Errors.log_issue uu____15074
                 (FStar_Errors.Warning_IgnoredBinding,
                   "This name is being ignored"));
              desugar_term_aq env e)
         | FStar_Parser_AST.Paren e -> failwith "impossible"
         | FStar_Parser_AST.VQuote e ->
             let tm = desugar_term env e in
-            let uu____15085 =
-              let uu____15086 = FStar_Syntax_Subst.compress tm in
-              uu____15086.FStar_Syntax_Syntax.n in
-            (match uu____15085 with
+            let uu____15082 =
+              let uu____15083 = FStar_Syntax_Subst.compress tm in
+              uu____15083.FStar_Syntax_Syntax.n in
+            (match uu____15082 with
              | FStar_Syntax_Syntax.Tm_fvar fv ->
-                 let uu____15094 =
-                   let uu___2065_15095 =
-                     let uu____15096 =
-                       let uu____15097 = FStar_Syntax_Syntax.lid_of_fv fv in
-                       FStar_Ident.string_of_lid uu____15097 in
-                     FStar_Syntax_Util.exp_string uu____15096 in
+                 let uu____15091 =
+                   let uu___2066_15092 =
+                     let uu____15093 =
+                       let uu____15094 = FStar_Syntax_Syntax.lid_of_fv fv in
+                       FStar_Ident.string_of_lid uu____15094 in
+                     FStar_Syntax_Util.exp_string uu____15093 in
                    {
                      FStar_Syntax_Syntax.n =
-                       (uu___2065_15095.FStar_Syntax_Syntax.n);
+                       (uu___2066_15092.FStar_Syntax_Syntax.n);
                      FStar_Syntax_Syntax.pos = (e.FStar_Parser_AST.range);
                      FStar_Syntax_Syntax.vars =
-                       (uu___2065_15095.FStar_Syntax_Syntax.vars)
+                       (uu___2066_15092.FStar_Syntax_Syntax.vars)
                    } in
-                 (uu____15094, noaqs)
-             | uu____15098 ->
-                 let uu____15099 =
-                   let uu____15104 =
-                     let uu____15105 = FStar_Syntax_Print.term_to_string tm in
+                 (uu____15091, noaqs)
+             | uu____15095 ->
+                 let uu____15096 =
+                   let uu____15101 =
+                     let uu____15102 = FStar_Syntax_Print.term_to_string tm in
                      Prims.op_Hat "VQuote, expected an fvar, got: "
-                       uu____15105 in
-                   (FStar_Errors.Fatal_UnexpectedTermVQuote, uu____15104) in
-                 FStar_Errors.raise_error uu____15099
+                       uu____15102 in
+                   (FStar_Errors.Fatal_UnexpectedTermVQuote, uu____15101) in
+                 FStar_Errors.raise_error uu____15096
                    top.FStar_Parser_AST.range)
         | FStar_Parser_AST.Quote (e, FStar_Parser_AST.Static) ->
-            let uu____15111 = desugar_term_aq env e in
-            (match uu____15111 with
+            let uu____15108 = desugar_term_aq env e in
+            (match uu____15108 with
              | (tm, vts) ->
                  let qi =
                    {
@@ -3765,34 +3769,34 @@ and (desugar_term_maybe_top :
                        FStar_Syntax_Syntax.Quote_static;
                      FStar_Syntax_Syntax.antiquotes = vts
                    } in
-                 let uu____15123 =
+                 let uu____15120 =
                    FStar_All.pipe_left mk
                      (FStar_Syntax_Syntax.Tm_quoted (tm, qi)) in
-                 (uu____15123, noaqs))
+                 (uu____15120, noaqs))
         | FStar_Parser_AST.Antiquote e ->
             let bv =
               FStar_Syntax_Syntax.new_bv
                 (FStar_Pervasives_Native.Some (e.FStar_Parser_AST.range))
                 FStar_Syntax_Syntax.tun in
-            let uu____15128 = FStar_Syntax_Syntax.bv_to_name bv in
-            let uu____15129 =
-              let uu____15130 =
-                let uu____15137 = desugar_term env e in (bv, uu____15137) in
-              [uu____15130] in
-            (uu____15128, uu____15129)
+            let uu____15125 = FStar_Syntax_Syntax.bv_to_name bv in
+            let uu____15126 =
+              let uu____15127 =
+                let uu____15134 = desugar_term env e in (bv, uu____15134) in
+              [uu____15127] in
+            (uu____15125, uu____15126)
         | FStar_Parser_AST.Quote (e, FStar_Parser_AST.Dynamic) ->
             let qi =
               {
                 FStar_Syntax_Syntax.qkind = FStar_Syntax_Syntax.Quote_dynamic;
                 FStar_Syntax_Syntax.antiquotes = []
               } in
-            let uu____15162 =
-              let uu____15163 =
-                let uu____15164 =
-                  let uu____15171 = desugar_term env e in (uu____15171, qi) in
-                FStar_Syntax_Syntax.Tm_quoted uu____15164 in
-              FStar_All.pipe_left mk uu____15163 in
-            (uu____15162, noaqs)
+            let uu____15159 =
+              let uu____15160 =
+                let uu____15161 =
+                  let uu____15168 = desugar_term env e in (uu____15168, qi) in
+                FStar_Syntax_Syntax.Tm_quoted uu____15161 in
+              FStar_All.pipe_left mk uu____15160 in
+            (uu____15159, noaqs)
         | FStar_Parser_AST.CalcProof (rel, init_expr, steps) ->
             let is_impl rel1 =
               let is_impl_t t =
@@ -3800,27 +3804,27 @@ and (desugar_term_maybe_top :
                 | FStar_Syntax_Syntax.Tm_fvar fv ->
                     FStar_Syntax_Syntax.fv_eq_lid fv
                       FStar_Parser_Const.imp_lid
-                | uu____15196 -> false in
-              let uu____15197 =
-                let uu____15198 = unparen rel1 in
-                uu____15198.FStar_Parser_AST.tm in
-              match uu____15197 with
-              | FStar_Parser_AST.Op (id, uu____15200) ->
-                  let uu____15205 = op_as_term env (Prims.of_int (2)) id in
-                  (match uu____15205 with
+                | uu____15193 -> false in
+              let uu____15194 =
+                let uu____15195 = unparen rel1 in
+                uu____15195.FStar_Parser_AST.tm in
+              match uu____15194 with
+              | FStar_Parser_AST.Op (id, uu____15197) ->
+                  let uu____15202 = op_as_term env (Prims.of_int (2)) id in
+                  (match uu____15202 with
                    | FStar_Pervasives_Native.Some t -> is_impl_t t
                    | FStar_Pervasives_Native.None -> false)
               | FStar_Parser_AST.Var lid ->
-                  let uu____15210 = desugar_name' (fun x -> x) env true lid in
-                  (match uu____15210 with
+                  let uu____15207 = desugar_name' (fun x -> x) env true lid in
+                  (match uu____15207 with
                    | FStar_Pervasives_Native.Some t -> is_impl_t t
                    | FStar_Pervasives_Native.None -> false)
               | FStar_Parser_AST.Tvar id ->
-                  let uu____15218 = FStar_Syntax_DsEnv.try_lookup_id env id in
-                  (match uu____15218 with
+                  let uu____15215 = FStar_Syntax_DsEnv.try_lookup_id env id in
+                  (match uu____15215 with
                    | FStar_Pervasives_Native.Some t -> is_impl_t t
                    | FStar_Pervasives_Native.None -> false)
-              | uu____15222 -> false in
+              | uu____15219 -> false in
             let eta_and_annot rel1 =
               let x = FStar_Ident.gen' "x" rel1.FStar_Parser_AST.range in
               let y = FStar_Ident.gen' "y" rel1.FStar_Parser_AST.range in
@@ -3837,30 +3841,30 @@ and (desugar_term_maybe_top :
                 FStar_Parser_AST.mk_pattern
                   (FStar_Parser_AST.PatVar (y, FStar_Pervasives_Native.None))
                   rel1.FStar_Parser_AST.range] in
-              let uu____15240 =
-                let uu____15241 =
-                  let uu____15248 =
-                    let uu____15249 =
-                      let uu____15250 =
-                        let uu____15259 =
+              let uu____15237 =
+                let uu____15238 =
+                  let uu____15245 =
+                    let uu____15246 =
+                      let uu____15247 =
+                        let uu____15256 =
                           FStar_Parser_AST.mkApp rel1
                             [(xt, FStar_Parser_AST.Nothing);
                             (yt, FStar_Parser_AST.Nothing)]
                             rel1.FStar_Parser_AST.range in
-                        let uu____15272 =
-                          let uu____15273 =
-                            let uu____15274 = FStar_Ident.lid_of_str "Type0" in
-                            FStar_Parser_AST.Name uu____15274 in
-                          FStar_Parser_AST.mk_term uu____15273
+                        let uu____15269 =
+                          let uu____15270 =
+                            let uu____15271 = FStar_Ident.lid_of_str "Type0" in
+                            FStar_Parser_AST.Name uu____15271 in
+                          FStar_Parser_AST.mk_term uu____15270
                             rel1.FStar_Parser_AST.range FStar_Parser_AST.Expr in
-                        (uu____15259, uu____15272,
+                        (uu____15256, uu____15269,
                           FStar_Pervasives_Native.None) in
-                      FStar_Parser_AST.Ascribed uu____15250 in
-                    FStar_Parser_AST.mk_term uu____15249
+                      FStar_Parser_AST.Ascribed uu____15247 in
+                    FStar_Parser_AST.mk_term uu____15246
                       rel1.FStar_Parser_AST.range FStar_Parser_AST.Expr in
-                  (pats, uu____15248) in
-                FStar_Parser_AST.Abs uu____15241 in
-              FStar_Parser_AST.mk_term uu____15240
+                  (pats, uu____15245) in
+                FStar_Parser_AST.Abs uu____15238 in
+              FStar_Parser_AST.mk_term uu____15237
                 rel1.FStar_Parser_AST.range FStar_Parser_AST.Expr in
             let rel1 = eta_and_annot rel in
             let wild r =
@@ -3875,10 +3879,10 @@ and (desugar_term_maybe_top :
                 (FStar_Parser_AST.Var FStar_Parser_Const.calc_push_impl_lid)
                 r FStar_Parser_AST.Expr in
             let last_expr =
-              let uu____15294 = FStar_List.last steps in
-              match uu____15294 with
+              let uu____15291 = FStar_List.last steps in
+              match uu____15291 with
               | FStar_Pervasives_Native.Some (FStar_Parser_AST.CalcStep
-                  (uu____15297, uu____15298, last_expr)) -> last_expr
+                  (uu____15294, uu____15295, last_expr)) -> last_expr
               | FStar_Pervasives_Native.None -> init_expr in
             let step r =
               FStar_Parser_AST.mk_term
@@ -3894,87 +3898,87 @@ and (desugar_term_maybe_top :
               FStar_Parser_AST.mkApp init
                 [(init_expr, FStar_Parser_AST.Nothing)]
                 init_expr.FStar_Parser_AST.range in
-            let uu____15324 =
+            let uu____15321 =
               FStar_List.fold_left
-                (fun uu____15342 ->
-                   fun uu____15343 ->
-                     match (uu____15342, uu____15343) with
+                (fun uu____15339 ->
+                   fun uu____15340 ->
+                     match (uu____15339, uu____15340) with
                      | ((e1, prev), FStar_Parser_AST.CalcStep
                         (rel2, just, next_expr)) ->
                          let just1 =
-                           let uu____15366 = is_impl rel2 in
-                           if uu____15366
+                           let uu____15363 = is_impl rel2 in
+                           if uu____15363
                            then
-                             let uu____15367 =
-                               let uu____15374 =
-                                 let uu____15379 =
+                             let uu____15364 =
+                               let uu____15371 =
+                                 let uu____15376 =
                                    FStar_Parser_AST.thunk just in
-                                 (uu____15379, FStar_Parser_AST.Nothing) in
-                               [uu____15374] in
+                                 (uu____15376, FStar_Parser_AST.Nothing) in
+                               [uu____15371] in
                              FStar_Parser_AST.mkApp
                                (push_impl just.FStar_Parser_AST.range)
-                               uu____15367 just.FStar_Parser_AST.range
+                               uu____15364 just.FStar_Parser_AST.range
                            else just in
                          let pf =
-                           let uu____15390 =
-                             let uu____15397 =
-                               let uu____15404 =
-                                 let uu____15411 =
-                                   let uu____15418 =
-                                     let uu____15423 = eta_and_annot rel2 in
-                                     (uu____15423, FStar_Parser_AST.Nothing) in
-                                   let uu____15424 =
-                                     let uu____15431 =
-                                       let uu____15438 =
-                                         let uu____15443 =
+                           let uu____15387 =
+                             let uu____15394 =
+                               let uu____15401 =
+                                 let uu____15408 =
+                                   let uu____15415 =
+                                     let uu____15420 = eta_and_annot rel2 in
+                                     (uu____15420, FStar_Parser_AST.Nothing) in
+                                   let uu____15421 =
+                                     let uu____15428 =
+                                       let uu____15435 =
+                                         let uu____15440 =
                                            FStar_Parser_AST.thunk e1 in
-                                         (uu____15443,
+                                         (uu____15440,
                                            FStar_Parser_AST.Nothing) in
-                                       let uu____15444 =
-                                         let uu____15451 =
-                                           let uu____15456 =
+                                       let uu____15441 =
+                                         let uu____15448 =
+                                           let uu____15453 =
                                              FStar_Parser_AST.thunk just1 in
-                                           (uu____15456,
+                                           (uu____15453,
                                              FStar_Parser_AST.Nothing) in
-                                         [uu____15451] in
-                                       uu____15438 :: uu____15444 in
+                                         [uu____15448] in
+                                       uu____15435 :: uu____15441 in
                                      (next_expr, FStar_Parser_AST.Nothing) ::
-                                       uu____15431 in
-                                   uu____15418 :: uu____15424 in
-                                 (prev, FStar_Parser_AST.Hash) :: uu____15411 in
+                                       uu____15428 in
+                                   uu____15415 :: uu____15421 in
+                                 (prev, FStar_Parser_AST.Hash) :: uu____15408 in
                                (init_expr, FStar_Parser_AST.Hash) ::
-                                 uu____15404 in
+                                 uu____15401 in
                              ((wild rel2.FStar_Parser_AST.range),
-                               FStar_Parser_AST.Hash) :: uu____15397 in
+                               FStar_Parser_AST.Hash) :: uu____15394 in
                            FStar_Parser_AST.mkApp
-                             (step rel2.FStar_Parser_AST.range) uu____15390
+                             (step rel2.FStar_Parser_AST.range) uu____15387
                              FStar_Range.dummyRange in
                          (pf, next_expr)) (e, init_expr) steps in
-            (match uu____15324 with
-             | (e1, uu____15494) ->
+            (match uu____15321 with
+             | (e1, uu____15491) ->
                  let e2 =
-                   let uu____15496 =
-                     let uu____15503 =
-                       let uu____15510 =
-                         let uu____15517 =
-                           let uu____15522 = FStar_Parser_AST.thunk e1 in
-                           (uu____15522, FStar_Parser_AST.Nothing) in
-                         [uu____15517] in
-                       (last_expr, FStar_Parser_AST.Hash) :: uu____15510 in
-                     (init_expr, FStar_Parser_AST.Hash) :: uu____15503 in
-                   FStar_Parser_AST.mkApp finish uu____15496
+                   let uu____15493 =
+                     let uu____15500 =
+                       let uu____15507 =
+                         let uu____15514 =
+                           let uu____15519 = FStar_Parser_AST.thunk e1 in
+                           (uu____15519, FStar_Parser_AST.Nothing) in
+                         [uu____15514] in
+                       (last_expr, FStar_Parser_AST.Hash) :: uu____15507 in
+                     (init_expr, FStar_Parser_AST.Hash) :: uu____15500 in
+                   FStar_Parser_AST.mkApp finish uu____15493
                      top.FStar_Parser_AST.range in
                  desugar_term_maybe_top top_level env e2)
-        | uu____15539 when
+        | uu____15536 when
             top.FStar_Parser_AST.level = FStar_Parser_AST.Formula ->
-            let uu____15540 = desugar_formula env top in (uu____15540, noaqs)
-        | uu____15541 ->
-            let uu____15542 =
-              let uu____15547 =
-                let uu____15548 = FStar_Parser_AST.term_to_string top in
-                Prims.op_Hat "Unexpected term: " uu____15548 in
-              (FStar_Errors.Fatal_UnexpectedTerm, uu____15547) in
-            FStar_Errors.raise_error uu____15542 top.FStar_Parser_AST.range
+            let uu____15537 = desugar_formula env top in (uu____15537, noaqs)
+        | uu____15538 ->
+            let uu____15539 =
+              let uu____15544 =
+                let uu____15545 = FStar_Parser_AST.term_to_string top in
+                Prims.op_Hat "Unexpected term: " uu____15545 in
+              (FStar_Errors.Fatal_UnexpectedTerm, uu____15544) in
+            FStar_Errors.raise_error uu____15539 top.FStar_Parser_AST.range
 and (desugar_args :
   FStar_Syntax_DsEnv.env ->
     (FStar_Parser_AST.term * FStar_Parser_AST.imp) Prims.list ->
@@ -3985,11 +3989,11 @@ and (desugar_args :
     fun args ->
       FStar_All.pipe_right args
         (FStar_List.map
-           (fun uu____15589 ->
-              match uu____15589 with
+           (fun uu____15586 ->
+              match uu____15586 with
               | (a, imp) ->
-                  let uu____15602 = desugar_term env a in
-                  arg_withimp_e imp uu____15602))
+                  let uu____15599 = desugar_term env a in
+                  arg_withimp_e imp uu____15599))
 and (desugar_comp :
   FStar_Range.range ->
     Prims.bool ->
@@ -4002,92 +4006,92 @@ and (desugar_comp :
       fun env ->
         fun t ->
           let fail err = FStar_Errors.raise_error err r in
-          let is_requires uu____15635 =
-            match uu____15635 with
-            | (t1, uu____15641) ->
-                let uu____15642 =
-                  let uu____15643 = unparen t1 in
-                  uu____15643.FStar_Parser_AST.tm in
-                (match uu____15642 with
-                 | FStar_Parser_AST.Requires uu____15644 -> true
-                 | uu____15651 -> false) in
-          let is_ensures uu____15661 =
-            match uu____15661 with
-            | (t1, uu____15667) ->
-                let uu____15668 =
-                  let uu____15669 = unparen t1 in
-                  uu____15669.FStar_Parser_AST.tm in
-                (match uu____15668 with
-                 | FStar_Parser_AST.Ensures uu____15670 -> true
-                 | uu____15677 -> false) in
-          let is_app head uu____15692 =
-            match uu____15692 with
-            | (t1, uu____15698) ->
-                let uu____15699 =
-                  let uu____15700 = unparen t1 in
-                  uu____15700.FStar_Parser_AST.tm in
-                (match uu____15699 with
+          let is_requires uu____15632 =
+            match uu____15632 with
+            | (t1, uu____15638) ->
+                let uu____15639 =
+                  let uu____15640 = unparen t1 in
+                  uu____15640.FStar_Parser_AST.tm in
+                (match uu____15639 with
+                 | FStar_Parser_AST.Requires uu____15641 -> true
+                 | uu____15648 -> false) in
+          let is_ensures uu____15658 =
+            match uu____15658 with
+            | (t1, uu____15664) ->
+                let uu____15665 =
+                  let uu____15666 = unparen t1 in
+                  uu____15666.FStar_Parser_AST.tm in
+                (match uu____15665 with
+                 | FStar_Parser_AST.Ensures uu____15667 -> true
+                 | uu____15674 -> false) in
+          let is_app head uu____15689 =
+            match uu____15689 with
+            | (t1, uu____15695) ->
+                let uu____15696 =
+                  let uu____15697 = unparen t1 in
+                  uu____15697.FStar_Parser_AST.tm in
+                (match uu____15696 with
                  | FStar_Parser_AST.App
                      ({ FStar_Parser_AST.tm = FStar_Parser_AST.Var d;
-                        FStar_Parser_AST.range = uu____15702;
-                        FStar_Parser_AST.level = uu____15703;_},
-                      uu____15704, uu____15705)
+                        FStar_Parser_AST.range = uu____15699;
+                        FStar_Parser_AST.level = uu____15700;_},
+                      uu____15701, uu____15702)
                      ->
-                     let uu____15706 =
-                       let uu____15707 = FStar_Ident.ident_of_lid d in
-                       FStar_Ident.string_of_id uu____15707 in
-                     uu____15706 = head
-                 | uu____15708 -> false) in
-          let is_smt_pat uu____15718 =
-            match uu____15718 with
-            | (t1, uu____15724) ->
-                let uu____15725 =
-                  let uu____15726 = unparen t1 in
-                  uu____15726.FStar_Parser_AST.tm in
-                (match uu____15725 with
+                     let uu____15703 =
+                       let uu____15704 = FStar_Ident.ident_of_lid d in
+                       FStar_Ident.string_of_id uu____15704 in
+                     uu____15703 = head
+                 | uu____15705 -> false) in
+          let is_smt_pat uu____15715 =
+            match uu____15715 with
+            | (t1, uu____15721) ->
+                let uu____15722 =
+                  let uu____15723 = unparen t1 in
+                  uu____15723.FStar_Parser_AST.tm in
+                (match uu____15722 with
                  | FStar_Parser_AST.Construct
                      (cons,
                       ({
                          FStar_Parser_AST.tm = FStar_Parser_AST.Construct
-                           (smtpat, uu____15729);
-                         FStar_Parser_AST.range = uu____15730;
-                         FStar_Parser_AST.level = uu____15731;_},
-                       uu____15732)::uu____15733::[])
+                           (smtpat, uu____15726);
+                         FStar_Parser_AST.range = uu____15727;
+                         FStar_Parser_AST.level = uu____15728;_},
+                       uu____15729)::uu____15730::[])
                      ->
                      (FStar_Ident.lid_equals cons FStar_Parser_Const.cons_lid)
                        &&
                        (FStar_Util.for_some
                           (fun s ->
-                             let uu____15771 =
+                             let uu____15768 =
                                FStar_Ident.string_of_lid smtpat in
-                             uu____15771 = s)
+                             uu____15768 = s)
                           ["SMTPat"; "SMTPatT"; "SMTPatOr"])
                  | FStar_Parser_AST.Construct
                      (cons,
                       ({ FStar_Parser_AST.tm = FStar_Parser_AST.Var smtpat;
-                         FStar_Parser_AST.range = uu____15774;
-                         FStar_Parser_AST.level = uu____15775;_},
-                       uu____15776)::uu____15777::[])
+                         FStar_Parser_AST.range = uu____15771;
+                         FStar_Parser_AST.level = uu____15772;_},
+                       uu____15773)::uu____15774::[])
                      ->
                      (FStar_Ident.lid_equals cons FStar_Parser_Const.cons_lid)
                        &&
                        (FStar_Util.for_some
                           (fun s ->
-                             let uu____15803 =
+                             let uu____15800 =
                                FStar_Ident.string_of_lid smtpat in
-                             uu____15803 = s) ["smt_pat"; "smt_pat_or"])
-                 | uu____15804 -> false) in
+                             uu____15800 = s) ["smt_pat"; "smt_pat_or"])
+                 | uu____15801 -> false) in
           let is_decreases = is_app "decreases" in
           let pre_process_comp_typ t1 =
-            let uu____15836 = head_and_args t1 in
-            match uu____15836 with
+            let uu____15833 = head_and_args t1 in
+            match uu____15833 with
             | (head, args) ->
                 (match head.FStar_Parser_AST.tm with
                  | FStar_Parser_AST.Name lemma when
-                     let uu____15894 =
-                       let uu____15895 = FStar_Ident.ident_of_lid lemma in
-                       FStar_Ident.string_of_id uu____15895 in
-                     uu____15894 = "Lemma" ->
+                     let uu____15891 =
+                       let uu____15892 = FStar_Ident.ident_of_lid lemma in
+                       FStar_Ident.string_of_id uu____15892 in
+                     uu____15891 = "Lemma" ->
                      let unit_tm =
                        ((FStar_Parser_AST.mk_term
                            (FStar_Parser_AST.Name FStar_Parser_Const.unit_lid)
@@ -4112,12 +4116,12 @@ and (desugar_comp :
                            t1.FStar_Parser_AST.range
                            FStar_Parser_AST.Type_level),
                          FStar_Parser_AST.Nothing) in
-                     let thunk_ens uu____15927 =
-                       match uu____15927 with
+                     let thunk_ens uu____15924 =
+                       match uu____15924 with
                        | (e, i) ->
-                           let uu____15938 = FStar_Parser_AST.thunk e in
-                           (uu____15938, i) in
-                     let fail_lemma uu____15950 =
+                           let uu____15935 = FStar_Parser_AST.thunk e in
+                           (uu____15935, i) in
+                     let fail_lemma uu____15947 =
                        let expected_one_of =
                          ["Lemma post";
                          "Lemma (ensures post)";
@@ -4142,85 +4146,85 @@ and (desugar_comp :
                        | smtpat::[] when is_smt_pat smtpat -> fail_lemma ()
                        | dec::[] when is_decreases dec -> fail_lemma ()
                        | ens::[] ->
-                           let uu____16030 =
-                             let uu____16037 =
-                               let uu____16044 = thunk_ens ens in
-                               [uu____16044; nil_pat] in
-                             req_true :: uu____16037 in
-                           unit_tm :: uu____16030
+                           let uu____16027 =
+                             let uu____16034 =
+                               let uu____16041 = thunk_ens ens in
+                               [uu____16041; nil_pat] in
+                             req_true :: uu____16034 in
+                           unit_tm :: uu____16027
                        | req::ens::[] when
                            (is_requires req) && (is_ensures ens) ->
-                           let uu____16091 =
-                             let uu____16098 =
-                               let uu____16105 = thunk_ens ens in
-                               [uu____16105; nil_pat] in
-                             req :: uu____16098 in
-                           unit_tm :: uu____16091
+                           let uu____16088 =
+                             let uu____16095 =
+                               let uu____16102 = thunk_ens ens in
+                               [uu____16102; nil_pat] in
+                             req :: uu____16095 in
+                           unit_tm :: uu____16088
                        | ens::smtpat::[] when
-                           (((let uu____16154 = is_requires ens in
-                              Prims.op_Negation uu____16154) &&
-                               (let uu____16156 = is_smt_pat ens in
-                                Prims.op_Negation uu____16156))
+                           (((let uu____16151 = is_requires ens in
+                              Prims.op_Negation uu____16151) &&
+                               (let uu____16153 = is_smt_pat ens in
+                                Prims.op_Negation uu____16153))
                               &&
-                              (let uu____16158 = is_decreases ens in
-                               Prims.op_Negation uu____16158))
+                              (let uu____16155 = is_decreases ens in
+                               Prims.op_Negation uu____16155))
                              && (is_smt_pat smtpat)
                            ->
-                           let uu____16159 =
-                             let uu____16166 =
-                               let uu____16173 = thunk_ens ens in
-                               [uu____16173; smtpat] in
-                             req_true :: uu____16166 in
-                           unit_tm :: uu____16159
+                           let uu____16156 =
+                             let uu____16163 =
+                               let uu____16170 = thunk_ens ens in
+                               [uu____16170; smtpat] in
+                             req_true :: uu____16163 in
+                           unit_tm :: uu____16156
                        | ens::dec::[] when
                            (is_ensures ens) && (is_decreases dec) ->
-                           let uu____16220 =
-                             let uu____16227 =
-                               let uu____16234 = thunk_ens ens in
-                               [uu____16234; nil_pat; dec] in
-                             req_true :: uu____16227 in
-                           unit_tm :: uu____16220
+                           let uu____16217 =
+                             let uu____16224 =
+                               let uu____16231 = thunk_ens ens in
+                               [uu____16231; nil_pat; dec] in
+                             req_true :: uu____16224 in
+                           unit_tm :: uu____16217
                        | ens::dec::smtpat::[] when
                            ((is_ensures ens) && (is_decreases dec)) &&
                              (is_smt_pat smtpat)
                            ->
-                           let uu____16294 =
-                             let uu____16301 =
-                               let uu____16308 = thunk_ens ens in
-                               [uu____16308; smtpat; dec] in
-                             req_true :: uu____16301 in
-                           unit_tm :: uu____16294
+                           let uu____16291 =
+                             let uu____16298 =
+                               let uu____16305 = thunk_ens ens in
+                               [uu____16305; smtpat; dec] in
+                             req_true :: uu____16298 in
+                           unit_tm :: uu____16291
                        | req::ens::dec::[] when
                            ((is_requires req) && (is_ensures ens)) &&
                              (is_decreases dec)
                            ->
-                           let uu____16368 =
-                             let uu____16375 =
-                               let uu____16382 = thunk_ens ens in
-                               [uu____16382; nil_pat; dec] in
-                             req :: uu____16375 in
-                           unit_tm :: uu____16368
+                           let uu____16365 =
+                             let uu____16372 =
+                               let uu____16379 = thunk_ens ens in
+                               [uu____16379; nil_pat; dec] in
+                             req :: uu____16372 in
+                           unit_tm :: uu____16365
                        | req::ens::smtpat::[] when
                            ((is_requires req) && (is_ensures ens)) &&
                              (is_smt_pat smtpat)
                            ->
-                           let uu____16442 =
-                             let uu____16449 =
-                               let uu____16456 = thunk_ens ens in
-                               [uu____16456; smtpat] in
-                             req :: uu____16449 in
-                           unit_tm :: uu____16442
+                           let uu____16439 =
+                             let uu____16446 =
+                               let uu____16453 = thunk_ens ens in
+                               [uu____16453; smtpat] in
+                             req :: uu____16446 in
+                           unit_tm :: uu____16439
                        | req::ens::dec::smtpat::[] when
                            (((is_requires req) && (is_ensures ens)) &&
                               (is_smt_pat smtpat))
                              && (is_decreases dec)
                            ->
-                           let uu____16521 =
-                             let uu____16528 =
-                               let uu____16535 = thunk_ens ens in
-                               [uu____16535; dec; smtpat] in
-                             req :: uu____16528 in
-                           unit_tm :: uu____16521
+                           let uu____16518 =
+                             let uu____16525 =
+                               let uu____16532 = thunk_ens ens in
+                               [uu____16532; dec; smtpat] in
+                             req :: uu____16525 in
+                           unit_tm :: uu____16518
                        | _other -> fail_lemma () in
                      let head_and_attributes =
                        FStar_Syntax_DsEnv.fail_or env
@@ -4229,76 +4233,76 @@ and (desugar_comp :
                      (head_and_attributes, args1)
                  | FStar_Parser_AST.Name l when
                      FStar_Syntax_DsEnv.is_effect_name env l ->
-                     let uu____16597 =
+                     let uu____16594 =
                        FStar_Syntax_DsEnv.fail_or env
                          (FStar_Syntax_DsEnv.try_lookup_effect_name_and_attributes
                             env) l in
-                     (uu____16597, args)
+                     (uu____16594, args)
                  | FStar_Parser_AST.Name l when
-                     (let uu____16625 = FStar_Syntax_DsEnv.current_module env in
-                      FStar_Ident.lid_equals uu____16625
+                     (let uu____16622 = FStar_Syntax_DsEnv.current_module env in
+                      FStar_Ident.lid_equals uu____16622
                         FStar_Parser_Const.prims_lid)
                        &&
-                       (let uu____16627 =
-                          let uu____16628 = FStar_Ident.ident_of_lid l in
-                          FStar_Ident.string_of_id uu____16628 in
-                        uu____16627 = "Tot")
+                       (let uu____16624 =
+                          let uu____16625 = FStar_Ident.ident_of_lid l in
+                          FStar_Ident.string_of_id uu____16625 in
+                        uu____16624 = "Tot")
                      ->
-                     let uu____16629 =
-                       let uu____16636 =
+                     let uu____16626 =
+                       let uu____16633 =
                          FStar_Ident.set_lid_range
                            FStar_Parser_Const.effect_Tot_lid
                            head.FStar_Parser_AST.range in
-                       (uu____16636, []) in
-                     (uu____16629, args)
+                       (uu____16633, []) in
+                     (uu____16626, args)
                  | FStar_Parser_AST.Name l when
-                     (let uu____16654 = FStar_Syntax_DsEnv.current_module env in
-                      FStar_Ident.lid_equals uu____16654
+                     (let uu____16651 = FStar_Syntax_DsEnv.current_module env in
+                      FStar_Ident.lid_equals uu____16651
                         FStar_Parser_Const.prims_lid)
                        &&
-                       (let uu____16656 =
-                          let uu____16657 = FStar_Ident.ident_of_lid l in
-                          FStar_Ident.string_of_id uu____16657 in
-                        uu____16656 = "GTot")
+                       (let uu____16653 =
+                          let uu____16654 = FStar_Ident.ident_of_lid l in
+                          FStar_Ident.string_of_id uu____16654 in
+                        uu____16653 = "GTot")
                      ->
-                     let uu____16658 =
-                       let uu____16665 =
+                     let uu____16655 =
+                       let uu____16662 =
                          FStar_Ident.set_lid_range
                            FStar_Parser_Const.effect_GTot_lid
                            head.FStar_Parser_AST.range in
-                       (uu____16665, []) in
-                     (uu____16658, args)
+                       (uu____16662, []) in
+                     (uu____16655, args)
                  | FStar_Parser_AST.Name l when
-                     ((let uu____16683 =
-                         let uu____16684 = FStar_Ident.ident_of_lid l in
-                         FStar_Ident.string_of_id uu____16684 in
-                       uu____16683 = "Type") ||
-                        (let uu____16686 =
-                           let uu____16687 = FStar_Ident.ident_of_lid l in
-                           FStar_Ident.string_of_id uu____16687 in
-                         uu____16686 = "Type0"))
+                     ((let uu____16680 =
+                         let uu____16681 = FStar_Ident.ident_of_lid l in
+                         FStar_Ident.string_of_id uu____16681 in
+                       uu____16680 = "Type") ||
+                        (let uu____16683 =
+                           let uu____16684 = FStar_Ident.ident_of_lid l in
+                           FStar_Ident.string_of_id uu____16684 in
+                         uu____16683 = "Type0"))
                        ||
-                       (let uu____16689 =
-                          let uu____16690 = FStar_Ident.ident_of_lid l in
-                          FStar_Ident.string_of_id uu____16690 in
-                        uu____16689 = "Effect")
+                       (let uu____16686 =
+                          let uu____16687 = FStar_Ident.ident_of_lid l in
+                          FStar_Ident.string_of_id uu____16687 in
+                        uu____16686 = "Effect")
                      ->
-                     let uu____16691 =
-                       let uu____16698 =
+                     let uu____16688 =
+                       let uu____16695 =
                          FStar_Ident.set_lid_range
                            FStar_Parser_Const.effect_Tot_lid
                            head.FStar_Parser_AST.range in
-                       (uu____16698, []) in
-                     (uu____16691, [(t1, FStar_Parser_AST.Nothing)])
-                 | uu____16721 when allow_type_promotion ->
+                       (uu____16695, []) in
+                     (uu____16688, [(t1, FStar_Parser_AST.Nothing)])
+                 | uu____16718 when allow_type_promotion ->
                      let default_effect =
-                       let uu____16723 = FStar_Options.ml_ish () in
-                       if uu____16723
+                       let uu____16720 = FStar_Options.ml_ish () in
+                       if uu____16720
                        then FStar_Parser_Const.effect_ML_lid
                        else
-                         ((let uu____16726 =
+                         ((let uu____16723 =
                              FStar_Options.warn_default_effects () in
-                           if uu____16726
+                           if uu____16723
                            then
                              FStar_Errors.log_issue
                                head.FStar_Parser_AST.range
@@ -4306,147 +4310,147 @@ and (desugar_comp :
                                  "Using default effect Tot")
                            else ());
                           FStar_Parser_Const.effect_Tot_lid) in
-                     let uu____16728 =
-                       let uu____16735 =
+                     let uu____16725 =
+                       let uu____16732 =
                          FStar_Ident.set_lid_range default_effect
                            head.FStar_Parser_AST.range in
-                       (uu____16735, []) in
-                     (uu____16728, [(t1, FStar_Parser_AST.Nothing)])
-                 | uu____16758 ->
+                       (uu____16732, []) in
+                     (uu____16725, [(t1, FStar_Parser_AST.Nothing)])
+                 | uu____16755 ->
                      FStar_Errors.raise_error
                        (FStar_Errors.Fatal_EffectNotFound,
                          "Expected an effect constructor")
                        t1.FStar_Parser_AST.range) in
-          let uu____16775 = pre_process_comp_typ t in
-          match uu____16775 with
+          let uu____16772 = pre_process_comp_typ t in
+          match uu____16772 with
           | ((eff, cattributes), args) ->
               (if (FStar_List.length args) = Prims.int_zero
                then
-                 (let uu____16824 =
-                    let uu____16829 =
-                      let uu____16830 = FStar_Syntax_Print.lid_to_string eff in
+                 (let uu____16821 =
+                    let uu____16826 =
+                      let uu____16827 = FStar_Syntax_Print.lid_to_string eff in
                       FStar_Util.format1 "Not enough args to effect %s"
-                        uu____16830 in
-                    (FStar_Errors.Fatal_NotEnoughArgsToEffect, uu____16829) in
-                  fail uu____16824)
+                        uu____16827 in
+                    (FStar_Errors.Fatal_NotEnoughArgsToEffect, uu____16826) in
+                  fail uu____16821)
                else ();
-               (let is_universe uu____16841 =
-                  match uu____16841 with
-                  | (uu____16846, imp) -> imp = FStar_Parser_AST.UnivApp in
-                let uu____16848 = FStar_Util.take is_universe args in
-                match uu____16848 with
+               (let is_universe uu____16838 =
+                  match uu____16838 with
+                  | (uu____16843, imp) -> imp = FStar_Parser_AST.UnivApp in
+                let uu____16845 = FStar_Util.take is_universe args in
+                match uu____16845 with
                 | (universes, args1) ->
                     let universes1 =
                       FStar_List.map
-                        (fun uu____16907 ->
-                           match uu____16907 with
+                        (fun uu____16904 ->
+                           match uu____16904 with
                            | (u, imp) -> desugar_universe u) universes in
-                    let uu____16914 =
-                      let uu____16929 = FStar_List.hd args1 in
-                      let uu____16938 = FStar_List.tl args1 in
-                      (uu____16929, uu____16938) in
-                    (match uu____16914 with
+                    let uu____16911 =
+                      let uu____16926 = FStar_List.hd args1 in
+                      let uu____16935 = FStar_List.tl args1 in
+                      (uu____16926, uu____16935) in
+                    (match uu____16911 with
                      | (result_arg, rest) ->
                          let result_typ =
                            desugar_typ env
                              (FStar_Pervasives_Native.fst result_arg) in
                          let rest1 = desugar_args env rest in
-                         let uu____16993 =
-                           let is_decrease uu____17031 =
-                             match uu____17031 with
-                             | (t1, uu____17041) ->
+                         let uu____16990 =
+                           let is_decrease uu____17028 =
+                             match uu____17028 with
+                             | (t1, uu____17038) ->
                                  (match t1.FStar_Syntax_Syntax.n with
                                   | FStar_Syntax_Syntax.Tm_app
                                       ({
                                          FStar_Syntax_Syntax.n =
                                            FStar_Syntax_Syntax.Tm_fvar fv;
                                          FStar_Syntax_Syntax.pos =
-                                           uu____17051;
+                                           uu____17048;
                                          FStar_Syntax_Syntax.vars =
-                                           uu____17052;_},
-                                       uu____17053::[])
+                                           uu____17049;_},
+                                       uu____17050::[])
                                       ->
                                       FStar_Syntax_Syntax.fv_eq_lid fv
                                         FStar_Parser_Const.decreases_lid
-                                  | uu____17092 -> false) in
+                                  | uu____17089 -> false) in
                            FStar_All.pipe_right rest1
                              (FStar_List.partition is_decrease) in
-                         (match uu____16993 with
+                         (match uu____16990 with
                           | (dec, rest2) ->
                               let decreases_clause =
                                 FStar_All.pipe_right dec
                                   (FStar_List.map
-                                     (fun uu____17208 ->
-                                        match uu____17208 with
-                                        | (t1, uu____17218) ->
+                                     (fun uu____17205 ->
+                                        match uu____17205 with
+                                        | (t1, uu____17215) ->
                                             (match t1.FStar_Syntax_Syntax.n
                                              with
                                              | FStar_Syntax_Syntax.Tm_app
-                                                 (uu____17227,
-                                                  (arg, uu____17229)::[])
+                                                 (uu____17224,
+                                                  (arg, uu____17226)::[])
                                                  ->
                                                  FStar_Syntax_Syntax.DECREASES
                                                    arg
-                                             | uu____17268 ->
+                                             | uu____17265 ->
                                                  failwith "impos"))) in
                               let no_additional_args =
                                 let is_empty l =
                                   match l with
                                   | [] -> true
-                                  | uu____17285 -> false in
+                                  | uu____17282 -> false in
                                 (((is_empty decreases_clause) &&
                                     (is_empty rest2))
                                    && (is_empty cattributes))
                                   && (is_empty universes1) in
-                              let uu____17296 =
+                              let uu____17293 =
                                 no_additional_args &&
                                   (FStar_Ident.lid_equals eff
                                      FStar_Parser_Const.effect_Tot_lid) in
-                              if uu____17296
+                              if uu____17293
                               then FStar_Syntax_Syntax.mk_Total result_typ
                               else
-                                (let uu____17300 =
+                                (let uu____17297 =
                                    no_additional_args &&
                                      (FStar_Ident.lid_equals eff
                                         FStar_Parser_Const.effect_GTot_lid) in
-                                 if uu____17300
+                                 if uu____17297
                                  then
                                    FStar_Syntax_Syntax.mk_GTotal result_typ
                                  else
                                    (let flags =
-                                      let uu____17307 =
+                                      let uu____17304 =
                                         FStar_Ident.lid_equals eff
                                           FStar_Parser_Const.effect_Lemma_lid in
-                                      if uu____17307
+                                      if uu____17304
                                       then [FStar_Syntax_Syntax.LEMMA]
                                       else
-                                        (let uu____17311 =
+                                        (let uu____17308 =
                                            FStar_Ident.lid_equals eff
                                              FStar_Parser_Const.effect_Tot_lid in
-                                         if uu____17311
+                                         if uu____17308
                                          then [FStar_Syntax_Syntax.TOTAL]
                                          else
-                                           (let uu____17315 =
+                                           (let uu____17312 =
                                               FStar_Ident.lid_equals eff
                                                 FStar_Parser_Const.effect_ML_lid in
-                                            if uu____17315
+                                            if uu____17312
                                             then
                                               [FStar_Syntax_Syntax.MLEFFECT]
                                             else
-                                              (let uu____17319 =
+                                              (let uu____17316 =
                                                  FStar_Ident.lid_equals eff
                                                    FStar_Parser_Const.effect_GTot_lid in
-                                               if uu____17319
+                                               if uu____17316
                                                then
                                                  [FStar_Syntax_Syntax.SOMETRIVIAL]
                                                else []))) in
                                     let flags1 =
                                       FStar_List.append flags cattributes in
                                     let rest3 =
-                                      let uu____17337 =
+                                      let uu____17334 =
                                         FStar_Ident.lid_equals eff
                                           FStar_Parser_Const.effect_Lemma_lid in
-                                      if uu____17337
+                                      if uu____17334
                                       then
                                         match rest2 with
                                         | req::ens::(pat, aq)::[] ->
@@ -4464,12 +4468,12 @@ and (desugar_comp :
                                                       pat
                                                       [FStar_Syntax_Syntax.U_zero] in
                                                   let pattern =
-                                                    let uu____17426 =
+                                                    let uu____17423 =
                                                       FStar_Ident.set_lid_range
                                                         FStar_Parser_Const.pattern_lid
                                                         pat.FStar_Syntax_Syntax.pos in
                                                     FStar_Syntax_Syntax.fvar
-                                                      uu____17426
+                                                      uu____17423
                                                       FStar_Syntax_Syntax.delta_constant
                                                       FStar_Pervasives_Native.None in
                                                   FStar_Syntax_Syntax.mk_Tm_app
@@ -4478,22 +4482,22 @@ and (desugar_comp :
                                                        (FStar_Pervasives_Native.Some
                                                           FStar_Syntax_Syntax.imp_tag))]
                                                     pat.FStar_Syntax_Syntax.pos
-                                              | uu____17447 -> pat in
-                                            let uu____17448 =
-                                              let uu____17459 =
-                                                let uu____17470 =
-                                                  let uu____17479 =
+                                              | uu____17444 -> pat in
+                                            let uu____17445 =
+                                              let uu____17456 =
+                                                let uu____17467 =
+                                                  let uu____17476 =
                                                     FStar_Syntax_Syntax.mk
                                                       (FStar_Syntax_Syntax.Tm_meta
                                                          (pat1,
                                                            (FStar_Syntax_Syntax.Meta_desugared
                                                               FStar_Syntax_Syntax.Meta_smt_pat)))
                                                       pat1.FStar_Syntax_Syntax.pos in
-                                                  (uu____17479, aq) in
-                                                [uu____17470] in
-                                              ens :: uu____17459 in
-                                            req :: uu____17448
-                                        | uu____17520 -> rest2
+                                                  (uu____17476, aq) in
+                                                [uu____17467] in
+                                              ens :: uu____17456 in
+                                            req :: uu____17445
+                                        | uu____17517 -> rest2
                                       else rest2 in
                                     FStar_Syntax_Syntax.mk_Comp
                                       {
@@ -4515,48 +4519,48 @@ and (desugar_formula :
     fun f ->
       let mk t = FStar_Syntax_Syntax.mk t f.FStar_Parser_AST.range in
       let setpos t =
-        let uu___2390_17554 = t in
+        let uu___2391_17551 = t in
         {
-          FStar_Syntax_Syntax.n = (uu___2390_17554.FStar_Syntax_Syntax.n);
+          FStar_Syntax_Syntax.n = (uu___2391_17551.FStar_Syntax_Syntax.n);
           FStar_Syntax_Syntax.pos = (f.FStar_Parser_AST.range);
           FStar_Syntax_Syntax.vars =
-            (uu___2390_17554.FStar_Syntax_Syntax.vars)
+            (uu___2391_17551.FStar_Syntax_Syntax.vars)
         } in
       let desugar_quant q b pats body =
         let tk =
           desugar_binder env
-            (let uu___2397_17608 = b in
+            (let uu___2398_17605 = b in
              {
-               FStar_Parser_AST.b = (uu___2397_17608.FStar_Parser_AST.b);
+               FStar_Parser_AST.b = (uu___2398_17605.FStar_Parser_AST.b);
                FStar_Parser_AST.brange =
-                 (uu___2397_17608.FStar_Parser_AST.brange);
+                 (uu___2398_17605.FStar_Parser_AST.brange);
                FStar_Parser_AST.blevel = FStar_Parser_AST.Formula;
                FStar_Parser_AST.aqual =
-                 (uu___2397_17608.FStar_Parser_AST.aqual)
+                 (uu___2398_17605.FStar_Parser_AST.aqual)
              }) in
-        let with_pats env1 uu____17637 body1 =
-          match uu____17637 with
+        let with_pats env1 uu____17634 body1 =
+          match uu____17634 with
           | (names, pats1) ->
               (match (names, pats1) with
                | ([], []) -> body1
-               | ([], uu____17683::uu____17684) ->
+               | ([], uu____17680::uu____17681) ->
                    failwith
                      "Impossible: Annotated pattern without binders in scope"
-               | uu____17701 ->
+               | uu____17698 ->
                    let names1 =
                      FStar_All.pipe_right names
                        (FStar_List.map
                           (fun i ->
-                             let uu___2416_17729 =
+                             let uu___2417_17726 =
                                FStar_Syntax_DsEnv.fail_or2
                                  (FStar_Syntax_DsEnv.try_lookup_id env1) i in
-                             let uu____17730 = FStar_Ident.range_of_id i in
+                             let uu____17727 = FStar_Ident.range_of_id i in
                              {
                                FStar_Syntax_Syntax.n =
-                                 (uu___2416_17729.FStar_Syntax_Syntax.n);
-                               FStar_Syntax_Syntax.pos = uu____17730;
+                                 (uu___2417_17726.FStar_Syntax_Syntax.n);
+                               FStar_Syntax_Syntax.pos = uu____17727;
                                FStar_Syntax_Syntax.vars =
-                                 (uu___2416_17729.FStar_Syntax_Syntax.vars)
+                                 (uu___2417_17726.FStar_Syntax_Syntax.vars)
                              })) in
                    let pats2 =
                      FStar_All.pipe_right pats1
@@ -4565,72 +4569,72 @@ and (desugar_formula :
                              FStar_All.pipe_right es
                                (FStar_List.map
                                   (fun e ->
-                                     let uu____17793 = desugar_term env1 e in
+                                     let uu____17790 = desugar_term env1 e in
                                      FStar_All.pipe_left
                                        (arg_withimp_t
                                           FStar_Parser_AST.Nothing)
-                                       uu____17793)))) in
+                                       uu____17790)))) in
                    mk
                      (FStar_Syntax_Syntax.Tm_meta
                         (body1,
                           (FStar_Syntax_Syntax.Meta_pattern (names1, pats2))))) in
         match tk with
         | (FStar_Pervasives_Native.Some a, k) ->
-            let uu____17824 = FStar_Syntax_DsEnv.push_bv env a in
-            (match uu____17824 with
+            let uu____17821 = FStar_Syntax_DsEnv.push_bv env a in
+            (match uu____17821 with
              | (env1, a1) ->
                  let a2 =
-                   let uu___2429_17834 = a1 in
+                   let uu___2430_17831 = a1 in
                    {
                      FStar_Syntax_Syntax.ppname =
-                       (uu___2429_17834.FStar_Syntax_Syntax.ppname);
+                       (uu___2430_17831.FStar_Syntax_Syntax.ppname);
                      FStar_Syntax_Syntax.index =
-                       (uu___2429_17834.FStar_Syntax_Syntax.index);
+                       (uu___2430_17831.FStar_Syntax_Syntax.index);
                      FStar_Syntax_Syntax.sort = k
                    } in
                  let body1 = desugar_formula env1 body in
                  let body2 = with_pats env1 pats body1 in
                  let body3 =
-                   let uu____17840 =
-                     let uu____17843 =
-                       let uu____17844 = FStar_Syntax_Syntax.mk_binder a2 in
-                       [uu____17844] in
-                     no_annot_abs uu____17843 body2 in
-                   FStar_All.pipe_left setpos uu____17840 in
-                 let uu____17865 =
-                   let uu____17866 =
-                     let uu____17883 =
-                       let uu____17886 =
+                   let uu____17837 =
+                     let uu____17840 =
+                       let uu____17841 = FStar_Syntax_Syntax.mk_binder a2 in
+                       [uu____17841] in
+                     no_annot_abs uu____17840 body2 in
+                   FStar_All.pipe_left setpos uu____17837 in
+                 let uu____17862 =
+                   let uu____17863 =
+                     let uu____17880 =
+                       let uu____17883 =
                          FStar_Ident.set_lid_range q
                            b.FStar_Parser_AST.brange in
-                       FStar_Syntax_Syntax.fvar uu____17886
+                       FStar_Syntax_Syntax.fvar uu____17883
                          (FStar_Syntax_Syntax.Delta_constant_at_level
                             Prims.int_one) FStar_Pervasives_Native.None in
-                     let uu____17887 =
-                       let uu____17898 = FStar_Syntax_Syntax.as_arg body3 in
-                       [uu____17898] in
-                     (uu____17883, uu____17887) in
-                   FStar_Syntax_Syntax.Tm_app uu____17866 in
-                 FStar_All.pipe_left mk uu____17865)
-        | uu____17937 -> failwith "impossible" in
+                     let uu____17884 =
+                       let uu____17895 = FStar_Syntax_Syntax.as_arg body3 in
+                       [uu____17895] in
+                     (uu____17880, uu____17884) in
+                   FStar_Syntax_Syntax.Tm_app uu____17863 in
+                 FStar_All.pipe_left mk uu____17862)
+        | uu____17934 -> failwith "impossible" in
       let push_quant q binders pats body =
         match binders with
         | b::b'::_rest ->
             let rest = b' :: _rest in
             let body1 =
-              let uu____18001 = q (rest, pats, body) in
-              let uu____18004 =
+              let uu____17998 = q (rest, pats, body) in
+              let uu____18001 =
                 FStar_Range.union_ranges b'.FStar_Parser_AST.brange
                   body.FStar_Parser_AST.range in
-              FStar_Parser_AST.mk_term uu____18001 uu____18004
+              FStar_Parser_AST.mk_term uu____17998 uu____18001
                 FStar_Parser_AST.Formula in
-            let uu____18005 = q ([b], ([], []), body1) in
-            FStar_Parser_AST.mk_term uu____18005 f.FStar_Parser_AST.range
+            let uu____18002 = q ([b], ([], []), body1) in
+            FStar_Parser_AST.mk_term uu____18002 f.FStar_Parser_AST.range
               FStar_Parser_AST.Formula
-        | uu____18016 -> failwith "impossible" in
-      let uu____18019 =
-        let uu____18020 = unparen f in uu____18020.FStar_Parser_AST.tm in
-      match uu____18019 with
+        | uu____18013 -> failwith "impossible" in
+      let uu____18016 =
+        let uu____18017 = unparen f in uu____18017.FStar_Parser_AST.tm in
+      match uu____18016 with
       | FStar_Parser_AST.Labeled (f1, l, p) ->
           let f2 = desugar_formula env f1 in
           FStar_All.pipe_left mk
@@ -4638,28 +4642,28 @@ and (desugar_formula :
                (f2,
                  (FStar_Syntax_Syntax.Meta_labeled
                     (l, (f2.FStar_Syntax_Syntax.pos), p))))
-      | FStar_Parser_AST.QForall ([], uu____18027, uu____18028) ->
+      | FStar_Parser_AST.QForall ([], uu____18024, uu____18025) ->
           failwith "Impossible: Quantifier without binders"
-      | FStar_Parser_AST.QExists ([], uu____18051, uu____18052) ->
+      | FStar_Parser_AST.QExists ([], uu____18048, uu____18049) ->
           failwith "Impossible: Quantifier without binders"
       | FStar_Parser_AST.QForall (_1::_2::_3, pats, body) ->
           let binders = _1 :: _2 :: _3 in
-          let uu____18107 =
+          let uu____18104 =
             push_quant (fun x -> FStar_Parser_AST.QForall x) binders pats
               body in
-          desugar_formula env uu____18107
+          desugar_formula env uu____18104
       | FStar_Parser_AST.QExists (_1::_2::_3, pats, body) ->
           let binders = _1 :: _2 :: _3 in
-          let uu____18151 =
+          let uu____18148 =
             push_quant (fun x -> FStar_Parser_AST.QExists x) binders pats
               body in
-          desugar_formula env uu____18151
+          desugar_formula env uu____18148
       | FStar_Parser_AST.QForall (b::[], pats, body) ->
           desugar_quant FStar_Parser_Const.forall_lid b pats body
       | FStar_Parser_AST.QExists (b::[], pats, body) ->
           desugar_quant FStar_Parser_Const.exists_lid b pats body
       | FStar_Parser_AST.Paren f1 -> failwith "impossible"
-      | uu____18214 -> desugar_term env f
+      | uu____18211 -> desugar_term env f
 and (desugar_binder :
   FStar_Syntax_DsEnv.env ->
     FStar_Parser_AST.binder ->
@@ -4670,25 +4674,25 @@ and (desugar_binder :
     fun b ->
       match b.FStar_Parser_AST.b with
       | FStar_Parser_AST.TAnnotated (x, t) ->
-          let uu____18225 = desugar_typ env t in
-          ((FStar_Pervasives_Native.Some x), uu____18225)
+          let uu____18222 = desugar_typ env t in
+          ((FStar_Pervasives_Native.Some x), uu____18222)
       | FStar_Parser_AST.Annotated (x, t) ->
-          let uu____18230 = desugar_typ env t in
-          ((FStar_Pervasives_Native.Some x), uu____18230)
+          let uu____18227 = desugar_typ env t in
+          ((FStar_Pervasives_Native.Some x), uu____18227)
       | FStar_Parser_AST.TVariable x ->
-          let uu____18234 =
-            let uu____18235 = FStar_Ident.range_of_id x in
+          let uu____18231 =
+            let uu____18232 = FStar_Ident.range_of_id x in
             FStar_Syntax_Syntax.mk
               (FStar_Syntax_Syntax.Tm_type FStar_Syntax_Syntax.U_unknown)
-              uu____18235 in
-          ((FStar_Pervasives_Native.Some x), uu____18234)
+              uu____18232 in
+          ((FStar_Pervasives_Native.Some x), uu____18231)
       | FStar_Parser_AST.NoName t ->
-          let uu____18239 = desugar_typ env t in
-          (FStar_Pervasives_Native.None, uu____18239)
+          let uu____18236 = desugar_typ env t in
+          (FStar_Pervasives_Native.None, uu____18236)
       | FStar_Parser_AST.Variable x ->
-          let uu____18243 =
-            let uu____18244 = FStar_Ident.range_of_id x in tun_r uu____18244 in
-          ((FStar_Pervasives_Native.Some x), uu____18243)
+          let uu____18240 =
+            let uu____18241 = FStar_Ident.range_of_id x in tun_r uu____18241 in
+          ((FStar_Pervasives_Native.Some x), uu____18240)
 and (as_binder :
   FStar_Syntax_DsEnv.env ->
     FStar_Parser_AST.arg_qualifier FStar_Pervasives_Native.option ->
@@ -4699,46 +4703,46 @@ and (as_binder :
   =
   fun env ->
     fun imp ->
-      fun uu___11_18249 ->
-        match uu___11_18249 with
+      fun uu___11_18246 ->
+        match uu___11_18246 with
         | (FStar_Pervasives_Native.None, k) ->
-            let uu____18271 = FStar_Syntax_Syntax.null_binder k in
-            (uu____18271, env)
+            let uu____18268 = FStar_Syntax_Syntax.null_binder k in
+            (uu____18268, env)
         | (FStar_Pervasives_Native.Some a, k) ->
-            let uu____18288 = FStar_Syntax_DsEnv.push_bv env a in
-            (match uu____18288 with
+            let uu____18285 = FStar_Syntax_DsEnv.push_bv env a in
+            (match uu____18285 with
              | (env1, a1) ->
-                 let uu____18305 =
-                   let uu____18312 = trans_aqual env1 imp in
-                   ((let uu___2529_18318 = a1 in
+                 let uu____18302 =
+                   let uu____18309 = trans_aqual env1 imp in
+                   ((let uu___2530_18315 = a1 in
                      {
                        FStar_Syntax_Syntax.ppname =
-                         (uu___2529_18318.FStar_Syntax_Syntax.ppname);
+                         (uu___2530_18315.FStar_Syntax_Syntax.ppname);
                        FStar_Syntax_Syntax.index =
-                         (uu___2529_18318.FStar_Syntax_Syntax.index);
+                         (uu___2530_18315.FStar_Syntax_Syntax.index);
                        FStar_Syntax_Syntax.sort = k
-                     }), uu____18312) in
-                 (uu____18305, env1))
+                     }), uu____18309) in
+                 (uu____18302, env1))
 and (trans_aqual :
   env_t ->
     FStar_Parser_AST.arg_qualifier FStar_Pervasives_Native.option ->
       FStar_Syntax_Syntax.aqual)
   =
   fun env ->
-    fun uu___12_18326 ->
-      match uu___12_18326 with
+    fun uu___12_18323 ->
+      match uu___12_18323 with
       | FStar_Pervasives_Native.Some (FStar_Parser_AST.Implicit) ->
           FStar_Pervasives_Native.Some FStar_Syntax_Syntax.imp_tag
       | FStar_Pervasives_Native.Some (FStar_Parser_AST.Equality) ->
           FStar_Pervasives_Native.Some FStar_Syntax_Syntax.Equality
       | FStar_Pervasives_Native.Some (FStar_Parser_AST.Meta
           (FStar_Parser_AST.Arg_qualifier_meta_tac t)) ->
-          let uu____18330 =
-            let uu____18331 =
-              let uu____18332 = desugar_term env t in
-              FStar_Syntax_Syntax.Arg_qualifier_meta_tac uu____18332 in
-            FStar_Syntax_Syntax.Meta uu____18331 in
-          FStar_Pervasives_Native.Some uu____18330
+          let uu____18327 =
+            let uu____18328 =
+              let uu____18329 = desugar_term env t in
+              FStar_Syntax_Syntax.Arg_qualifier_meta_tac uu____18329 in
+            FStar_Syntax_Syntax.Meta uu____18328 in
+          FStar_Pervasives_Native.Some uu____18327
       | FStar_Pervasives_Native.Some (FStar_Parser_AST.Meta
           (FStar_Parser_AST.Arg_qualifier_meta_attr t)) ->
           let t1 = desugar_term env t in
@@ -4757,51 +4761,51 @@ let (typars_of_binders :
   =
   fun env ->
     fun bs ->
-      let uu____18362 =
+      let uu____18359 =
         FStar_List.fold_left
-          (fun uu____18395 ->
+          (fun uu____18392 ->
              fun b ->
-               match uu____18395 with
+               match uu____18392 with
                | (env1, out) ->
                    let tk =
                      desugar_binder env1
-                       (let uu___2554_18439 = b in
+                       (let uu___2555_18436 = b in
                         {
                           FStar_Parser_AST.b =
-                            (uu___2554_18439.FStar_Parser_AST.b);
+                            (uu___2555_18436.FStar_Parser_AST.b);
                           FStar_Parser_AST.brange =
-                            (uu___2554_18439.FStar_Parser_AST.brange);
+                            (uu___2555_18436.FStar_Parser_AST.brange);
                           FStar_Parser_AST.blevel = FStar_Parser_AST.Formula;
                           FStar_Parser_AST.aqual =
-                            (uu___2554_18439.FStar_Parser_AST.aqual)
+                            (uu___2555_18436.FStar_Parser_AST.aqual)
                         }) in
                    (match tk with
                     | (FStar_Pervasives_Native.Some a, k) ->
-                        let uu____18454 = FStar_Syntax_DsEnv.push_bv env1 a in
-                        (match uu____18454 with
+                        let uu____18451 = FStar_Syntax_DsEnv.push_bv env1 a in
+                        (match uu____18451 with
                          | (env2, a1) ->
                              let a2 =
-                               let uu___2564_18472 = a1 in
+                               let uu___2565_18469 = a1 in
                                {
                                  FStar_Syntax_Syntax.ppname =
-                                   (uu___2564_18472.FStar_Syntax_Syntax.ppname);
+                                   (uu___2565_18469.FStar_Syntax_Syntax.ppname);
                                  FStar_Syntax_Syntax.index =
-                                   (uu___2564_18472.FStar_Syntax_Syntax.index);
+                                   (uu___2565_18469.FStar_Syntax_Syntax.index);
                                  FStar_Syntax_Syntax.sort = k
                                } in
-                             let uu____18473 =
-                               let uu____18480 =
-                                 let uu____18485 =
+                             let uu____18470 =
+                               let uu____18477 =
+                                 let uu____18482 =
                                    trans_aqual env2 b.FStar_Parser_AST.aqual in
-                                 (a2, uu____18485) in
-                               uu____18480 :: out in
-                             (env2, uu____18473))
-                    | uu____18496 ->
+                                 (a2, uu____18482) in
+                               uu____18477 :: out in
+                             (env2, uu____18470))
+                    | uu____18493 ->
                         FStar_Errors.raise_error
                           (FStar_Errors.Fatal_UnexpectedBinder,
                             "Unexpected binder") b.FStar_Parser_AST.brange))
           (env, []) bs in
-      match uu____18362 with
+      match uu____18359 with
       | (env1, tpars) -> (env1, (FStar_List.rev tpars))
 let (desugar_attributes :
   env_t ->
@@ -4810,39 +4814,39 @@ let (desugar_attributes :
   fun env ->
     fun cattributes ->
       let desugar_attribute t =
-        let uu____18581 =
-          let uu____18582 = unparen t in uu____18582.FStar_Parser_AST.tm in
-        match uu____18581 with
+        let uu____18578 =
+          let uu____18579 = unparen t in uu____18579.FStar_Parser_AST.tm in
+        match uu____18578 with
         | FStar_Parser_AST.Var lid when
-            let uu____18584 = FStar_Ident.string_of_lid lid in
-            uu____18584 = "cps" -> FStar_Syntax_Syntax.CPS
-        | uu____18585 ->
-            let uu____18586 =
-              let uu____18591 =
-                let uu____18592 = FStar_Parser_AST.term_to_string t in
-                Prims.op_Hat "Unknown attribute " uu____18592 in
-              (FStar_Errors.Fatal_UnknownAttribute, uu____18591) in
-            FStar_Errors.raise_error uu____18586 t.FStar_Parser_AST.range in
+            let uu____18581 = FStar_Ident.string_of_lid lid in
+            uu____18581 = "cps" -> FStar_Syntax_Syntax.CPS
+        | uu____18582 ->
+            let uu____18583 =
+              let uu____18588 =
+                let uu____18589 = FStar_Parser_AST.term_to_string t in
+                Prims.op_Hat "Unknown attribute " uu____18589 in
+              (FStar_Errors.Fatal_UnknownAttribute, uu____18588) in
+            FStar_Errors.raise_error uu____18583 t.FStar_Parser_AST.range in
       FStar_List.map desugar_attribute cattributes
 let (binder_ident :
   FStar_Parser_AST.binder -> FStar_Ident.ident FStar_Pervasives_Native.option)
   =
   fun b ->
     match b.FStar_Parser_AST.b with
-    | FStar_Parser_AST.TAnnotated (x, uu____18605) ->
+    | FStar_Parser_AST.TAnnotated (x, uu____18602) ->
         FStar_Pervasives_Native.Some x
-    | FStar_Parser_AST.Annotated (x, uu____18607) ->
+    | FStar_Parser_AST.Annotated (x, uu____18604) ->
         FStar_Pervasives_Native.Some x
     | FStar_Parser_AST.TVariable x -> FStar_Pervasives_Native.Some x
     | FStar_Parser_AST.Variable x -> FStar_Pervasives_Native.Some x
-    | FStar_Parser_AST.NoName uu____18610 -> FStar_Pervasives_Native.None
+    | FStar_Parser_AST.NoName uu____18607 -> FStar_Pervasives_Native.None
 let (binder_idents :
   FStar_Parser_AST.binder Prims.list -> FStar_Ident.ident Prims.list) =
   fun bs ->
     FStar_List.collect
       (fun b ->
-         let uu____18627 = binder_ident b in
-         FStar_Common.list_of_option uu____18627) bs
+         let uu____18624 = binder_ident b in
+         FStar_Common.list_of_option uu____18624) bs
 let (mk_data_discriminators :
   FStar_Syntax_Syntax.qualifier Prims.list ->
     FStar_Syntax_DsEnv.env ->
@@ -4854,25 +4858,25 @@ let (mk_data_discriminators :
         let quals1 =
           FStar_All.pipe_right quals
             (FStar_List.filter
-               (fun uu___13_18663 ->
-                  match uu___13_18663 with
+               (fun uu___13_18660 ->
+                  match uu___13_18660 with
                   | FStar_Syntax_Syntax.NoExtract -> true
                   | FStar_Syntax_Syntax.Private -> true
-                  | uu____18664 -> false)) in
+                  | uu____18661 -> false)) in
         let quals2 q =
-          let uu____18677 =
-            (let uu____18680 = FStar_Syntax_DsEnv.iface env in
-             Prims.op_Negation uu____18680) ||
+          let uu____18674 =
+            (let uu____18677 = FStar_Syntax_DsEnv.iface env in
+             Prims.op_Negation uu____18677) ||
               (FStar_Syntax_DsEnv.admitted_iface env) in
-          if uu____18677
+          if uu____18674
           then FStar_List.append (FStar_Syntax_Syntax.Assumption :: q) quals1
           else FStar_List.append q quals1 in
         FStar_All.pipe_right datas
           (FStar_List.map
              (fun d ->
                 let disc_name = FStar_Syntax_Util.mk_discriminator d in
-                let uu____18694 = FStar_Ident.range_of_lid disc_name in
-                let uu____18695 =
+                let uu____18691 = FStar_Ident.range_of_lid disc_name in
+                let uu____18692 =
                   quals2
                     [FStar_Syntax_Syntax.OnlyName;
                     FStar_Syntax_Syntax.Discriminator d] in
@@ -4880,8 +4884,8 @@ let (mk_data_discriminators :
                   FStar_Syntax_Syntax.sigel =
                     (FStar_Syntax_Syntax.Sig_declare_typ
                        (disc_name, [], FStar_Syntax_Syntax.tun));
-                  FStar_Syntax_Syntax.sigrng = uu____18694;
-                  FStar_Syntax_Syntax.sigquals = uu____18695;
+                  FStar_Syntax_Syntax.sigrng = uu____18691;
+                  FStar_Syntax_Syntax.sigquals = uu____18692;
                   FStar_Syntax_Syntax.sigmeta =
                     FStar_Syntax_Syntax.default_sigmeta;
                   FStar_Syntax_Syntax.sigattrs = [];
@@ -4901,29 +4905,29 @@ let (mk_indexed_projector_names :
         fun lid ->
           fun fields ->
             let p = FStar_Ident.range_of_lid lid in
-            let uu____18734 =
+            let uu____18731 =
               FStar_All.pipe_right fields
                 (FStar_List.mapi
                    (fun i ->
-                      fun uu____18770 ->
-                        match uu____18770 with
-                        | (x, uu____18780) ->
+                      fun uu____18767 ->
+                        match uu____18767 with
+                        | (x, uu____18777) ->
                             let field_name =
                               FStar_Syntax_Util.mk_field_projector_name lid x
                                 i in
                             let only_decl =
-                              ((let uu____18789 =
+                              ((let uu____18786 =
                                   FStar_Syntax_DsEnv.current_module env in
                                 FStar_Ident.lid_equals
-                                  FStar_Parser_Const.prims_lid uu____18789)
+                                  FStar_Parser_Const.prims_lid uu____18786)
                                  || (fvq <> FStar_Syntax_Syntax.Data_ctor))
                                 ||
-                                (let uu____18791 =
-                                   let uu____18792 =
+                                (let uu____18788 =
+                                   let uu____18789 =
                                      FStar_Syntax_DsEnv.current_module env in
-                                   FStar_Ident.string_of_lid uu____18792 in
+                                   FStar_Ident.string_of_lid uu____18789 in
                                  FStar_Options.dont_gen_projectors
-                                   uu____18791) in
+                                   uu____18788) in
                             let no_decl =
                               FStar_Syntax_Syntax.is_type
                                 x.FStar_Syntax_Syntax.sort in
@@ -4935,25 +4939,25 @@ let (mk_indexed_projector_names :
                               let iquals1 =
                                 FStar_All.pipe_right iquals
                                   (FStar_List.filter
-                                     (fun uu___14_18820 ->
-                                        match uu___14_18820 with
+                                     (fun uu___14_18817 ->
+                                        match uu___14_18817 with
                                         | FStar_Syntax_Syntax.NoExtract ->
                                             true
                                         | FStar_Syntax_Syntax.Private -> true
-                                        | uu____18821 -> false)) in
+                                        | uu____18818 -> false)) in
                               quals (FStar_Syntax_Syntax.OnlyName ::
                                 (FStar_Syntax_Syntax.Projector
                                    (lid, (x.FStar_Syntax_Syntax.ppname))) ::
                                 iquals1) in
                             let decl =
-                              let uu____18823 =
+                              let uu____18820 =
                                 FStar_Ident.range_of_lid field_name in
                               {
                                 FStar_Syntax_Syntax.sigel =
                                   (FStar_Syntax_Syntax.Sig_declare_typ
                                      (field_name, [],
                                        FStar_Syntax_Syntax.tun));
-                                FStar_Syntax_Syntax.sigrng = uu____18823;
+                                FStar_Syntax_Syntax.sigrng = uu____18820;
                                 FStar_Syntax_Syntax.sigquals = quals1;
                                 FStar_Syntax_Syntax.sigmeta =
                                   FStar_Syntax_Syntax.default_sigmeta;
@@ -4968,13 +4972,13 @@ let (mk_indexed_projector_names :
                                  FStar_Syntax_Syntax.Delta_equational_at_level
                                    Prims.int_one in
                                let lb =
-                                 let uu____18829 =
-                                   let uu____18834 =
+                                 let uu____18826 =
+                                   let uu____18831 =
                                      FStar_Syntax_Syntax.lid_as_fv field_name
                                        dd FStar_Pervasives_Native.None in
-                                   FStar_Util.Inr uu____18834 in
+                                   FStar_Util.Inr uu____18831 in
                                  {
-                                   FStar_Syntax_Syntax.lbname = uu____18829;
+                                   FStar_Syntax_Syntax.lbname = uu____18826;
                                    FStar_Syntax_Syntax.lbunivs = [];
                                    FStar_Syntax_Syntax.lbtyp =
                                      FStar_Syntax_Syntax.tun;
@@ -4987,22 +4991,22 @@ let (mk_indexed_projector_names :
                                      FStar_Range.dummyRange
                                  } in
                                let impl =
-                                 let uu____18838 =
-                                   let uu____18839 =
-                                     let uu____18846 =
-                                       let uu____18849 =
-                                         let uu____18850 =
+                                 let uu____18835 =
+                                   let uu____18836 =
+                                     let uu____18843 =
+                                       let uu____18846 =
+                                         let uu____18847 =
                                            FStar_All.pipe_right
                                              lb.FStar_Syntax_Syntax.lbname
                                              FStar_Util.right in
-                                         FStar_All.pipe_right uu____18850
+                                         FStar_All.pipe_right uu____18847
                                            (fun fv ->
                                               (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v) in
-                                       [uu____18849] in
-                                     ((false, [lb]), uu____18846) in
-                                   FStar_Syntax_Syntax.Sig_let uu____18839 in
+                                       [uu____18846] in
+                                     ((false, [lb]), uu____18843) in
+                                   FStar_Syntax_Syntax.Sig_let uu____18836 in
                                  {
-                                   FStar_Syntax_Syntax.sigel = uu____18838;
+                                   FStar_Syntax_Syntax.sigel = uu____18835;
                                    FStar_Syntax_Syntax.sigrng = p;
                                    FStar_Syntax_Syntax.sigquals = quals1;
                                    FStar_Syntax_Syntax.sigmeta =
@@ -5012,7 +5016,7 @@ let (mk_indexed_projector_names :
                                      FStar_Pervasives_Native.None
                                  } in
                                if no_decl then [impl] else [decl; impl]))) in
-            FStar_All.pipe_right uu____18734 FStar_List.flatten
+            FStar_All.pipe_right uu____18731 FStar_List.flatten
 let (mk_data_projector_names :
   FStar_Syntax_Syntax.qualifier Prims.list ->
     FStar_Syntax_DsEnv.env ->
@@ -5023,37 +5027,37 @@ let (mk_data_projector_names :
       fun se ->
         match se.FStar_Syntax_Syntax.sigel with
         | FStar_Syntax_Syntax.Sig_datacon
-            (lid, uu____18894, t, uu____18896, n, uu____18898) when
-            let uu____18903 =
+            (lid, uu____18891, t, uu____18893, n, uu____18895) when
+            let uu____18900 =
               FStar_Ident.lid_equals lid FStar_Parser_Const.lexcons_lid in
-            Prims.op_Negation uu____18903 ->
-            let uu____18904 = FStar_Syntax_Util.arrow_formals t in
-            (match uu____18904 with
-             | (formals, uu____18914) ->
+            Prims.op_Negation uu____18900 ->
+            let uu____18901 = FStar_Syntax_Util.arrow_formals t in
+            (match uu____18901 with
+             | (formals, uu____18911) ->
                  (match formals with
                   | [] -> []
-                  | uu____18927 ->
-                      let filter_records uu___15_18935 =
-                        match uu___15_18935 with
+                  | uu____18924 ->
+                      let filter_records uu___15_18932 =
+                        match uu___15_18932 with
                         | FStar_Syntax_Syntax.RecordConstructor
-                            (uu____18938, fns) ->
+                            (uu____18935, fns) ->
                             FStar_Pervasives_Native.Some
                               (FStar_Syntax_Syntax.Record_ctor (lid, fns))
-                        | uu____18950 -> FStar_Pervasives_Native.None in
+                        | uu____18947 -> FStar_Pervasives_Native.None in
                       let fv_qual =
-                        let uu____18952 =
+                        let uu____18949 =
                           FStar_Util.find_map se.FStar_Syntax_Syntax.sigquals
                             filter_records in
-                        match uu____18952 with
+                        match uu____18949 with
                         | FStar_Pervasives_Native.None ->
                             FStar_Syntax_Syntax.Data_ctor
                         | FStar_Pervasives_Native.Some q -> q in
-                      let uu____18956 = FStar_Util.first_N n formals in
-                      (match uu____18956 with
-                       | (uu____18985, rest) ->
+                      let uu____18953 = FStar_Util.first_N n formals in
+                      (match uu____18953 with
+                       | (uu____18982, rest) ->
                            mk_indexed_projector_names iquals fv_qual env lid
                              rest)))
-        | uu____19019 -> []
+        | uu____19016 -> []
 let (mk_typ_abbrev :
   FStar_Syntax_DsEnv.env ->
     FStar_Parser_AST.decl ->
@@ -5081,35 +5085,35 @@ let (mk_typ_abbrev :
                         FStar_List.map (desugar_term env)
                           d.FStar_Parser_AST.attrs in
                       let val_attrs =
-                        let uu____19112 =
+                        let uu____19109 =
                           FStar_Syntax_DsEnv.lookup_letbinding_quals_and_attrs
                             env lid in
-                        FStar_All.pipe_right uu____19112
+                        FStar_All.pipe_right uu____19109
                           FStar_Pervasives_Native.snd in
                       let dd = FStar_Syntax_Util.incr_delta_qualifier t in
                       let lb =
-                        let uu____19137 =
-                          let uu____19142 =
+                        let uu____19134 =
+                          let uu____19139 =
                             FStar_Syntax_Syntax.lid_as_fv lid dd
                               FStar_Pervasives_Native.None in
-                          FStar_Util.Inr uu____19142 in
-                        let uu____19143 =
+                          FStar_Util.Inr uu____19139 in
+                        let uu____19140 =
                           if FStar_Util.is_some kopt
                           then
-                            let uu____19148 =
-                              let uu____19151 =
+                            let uu____19145 =
+                              let uu____19148 =
                                 FStar_All.pipe_right kopt FStar_Util.must in
-                              FStar_Syntax_Syntax.mk_Total uu____19151 in
-                            FStar_Syntax_Util.arrow typars uu____19148
+                              FStar_Syntax_Syntax.mk_Total uu____19148 in
+                            FStar_Syntax_Util.arrow typars uu____19145
                           else FStar_Syntax_Syntax.tun in
-                        let uu____19155 = no_annot_abs typars t in
+                        let uu____19152 = no_annot_abs typars t in
                         {
-                          FStar_Syntax_Syntax.lbname = uu____19137;
+                          FStar_Syntax_Syntax.lbname = uu____19134;
                           FStar_Syntax_Syntax.lbunivs = uvs;
-                          FStar_Syntax_Syntax.lbtyp = uu____19143;
+                          FStar_Syntax_Syntax.lbtyp = uu____19140;
                           FStar_Syntax_Syntax.lbeff =
                             FStar_Parser_Const.effect_Tot_lid;
-                          FStar_Syntax_Syntax.lbdef = uu____19155;
+                          FStar_Syntax_Syntax.lbdef = uu____19152;
                           FStar_Syntax_Syntax.lbattrs = [];
                           FStar_Syntax_Syntax.lbpos = rng
                         } in
@@ -5137,40 +5141,40 @@ let rec (desugar_tycon :
       fun quals ->
         fun tcs ->
           let rng = d.FStar_Parser_AST.drange in
-          let tycon_id uu___16_19206 =
-            match uu___16_19206 with
-            | FStar_Parser_AST.TyconAbstract (id, uu____19208, uu____19209)
+          let tycon_id uu___16_19203 =
+            match uu___16_19203 with
+            | FStar_Parser_AST.TyconAbstract (id, uu____19205, uu____19206)
                 -> id
             | FStar_Parser_AST.TyconAbbrev
-                (id, uu____19219, uu____19220, uu____19221) -> id
+                (id, uu____19216, uu____19217, uu____19218) -> id
             | FStar_Parser_AST.TyconRecord
-                (id, uu____19231, uu____19232, uu____19233) -> id
+                (id, uu____19228, uu____19229, uu____19230) -> id
             | FStar_Parser_AST.TyconVariant
-                (id, uu____19255, uu____19256, uu____19257) -> id in
+                (id, uu____19252, uu____19253, uu____19254) -> id in
           let binder_to_term b =
             match b.FStar_Parser_AST.b with
-            | FStar_Parser_AST.Annotated (x, uu____19293) ->
-                let uu____19294 =
-                  let uu____19295 = FStar_Ident.lid_of_ids [x] in
-                  FStar_Parser_AST.Var uu____19295 in
-                let uu____19296 = FStar_Ident.range_of_id x in
-                FStar_Parser_AST.mk_term uu____19294 uu____19296
+            | FStar_Parser_AST.Annotated (x, uu____19290) ->
+                let uu____19291 =
+                  let uu____19292 = FStar_Ident.lid_of_ids [x] in
+                  FStar_Parser_AST.Var uu____19292 in
+                let uu____19293 = FStar_Ident.range_of_id x in
+                FStar_Parser_AST.mk_term uu____19291 uu____19293
                   FStar_Parser_AST.Expr
             | FStar_Parser_AST.Variable x ->
-                let uu____19298 =
-                  let uu____19299 = FStar_Ident.lid_of_ids [x] in
-                  FStar_Parser_AST.Var uu____19299 in
-                let uu____19300 = FStar_Ident.range_of_id x in
-                FStar_Parser_AST.mk_term uu____19298 uu____19300
+                let uu____19295 =
+                  let uu____19296 = FStar_Ident.lid_of_ids [x] in
+                  FStar_Parser_AST.Var uu____19296 in
+                let uu____19297 = FStar_Ident.range_of_id x in
+                FStar_Parser_AST.mk_term uu____19295 uu____19297
                   FStar_Parser_AST.Expr
-            | FStar_Parser_AST.TAnnotated (a, uu____19302) ->
-                let uu____19303 = FStar_Ident.range_of_id a in
+            | FStar_Parser_AST.TAnnotated (a, uu____19299) ->
+                let uu____19300 = FStar_Ident.range_of_id a in
                 FStar_Parser_AST.mk_term (FStar_Parser_AST.Tvar a)
-                  uu____19303 FStar_Parser_AST.Type_level
+                  uu____19300 FStar_Parser_AST.Type_level
             | FStar_Parser_AST.TVariable a ->
-                let uu____19305 = FStar_Ident.range_of_id a in
+                let uu____19302 = FStar_Ident.range_of_id a in
                 FStar_Parser_AST.mk_term (FStar_Parser_AST.Tvar a)
-                  uu____19305 FStar_Parser_AST.Type_level
+                  uu____19302 FStar_Parser_AST.Type_level
             | FStar_Parser_AST.NoName t -> t in
           let tot =
             FStar_Parser_AST.mk_term
@@ -5185,89 +5189,89 @@ let rec (desugar_tycon :
               match b.FStar_Parser_AST.aqual with
               | FStar_Pervasives_Native.Some (FStar_Parser_AST.Implicit) ->
                   FStar_Parser_AST.Hash
-              | uu____19335 -> FStar_Parser_AST.Nothing in
+              | uu____19332 -> FStar_Parser_AST.Nothing in
             FStar_List.fold_left
               (fun out ->
                  fun b ->
-                   let uu____19343 =
-                     let uu____19344 =
-                       let uu____19351 = binder_to_term b in
-                       (out, uu____19351, (imp_of_aqual b)) in
-                     FStar_Parser_AST.App uu____19344 in
-                   FStar_Parser_AST.mk_term uu____19343
+                   let uu____19340 =
+                     let uu____19341 =
+                       let uu____19348 = binder_to_term b in
+                       (out, uu____19348, (imp_of_aqual b)) in
+                     FStar_Parser_AST.App uu____19341 in
+                   FStar_Parser_AST.mk_term uu____19340
                      out.FStar_Parser_AST.range out.FStar_Parser_AST.level) t
               binders in
-          let tycon_record_as_variant uu___17_19363 =
-            match uu___17_19363 with
+          let tycon_record_as_variant uu___17_19360 =
+            match uu___17_19360 with
             | FStar_Parser_AST.TyconRecord (id, parms, kopt, fields) ->
                 let constrName =
-                  let uu____19395 =
-                    let uu____19400 =
-                      let uu____19401 = FStar_Ident.string_of_id id in
-                      Prims.op_Hat "Mk" uu____19401 in
-                    let uu____19402 = FStar_Ident.range_of_id id in
-                    (uu____19400, uu____19402) in
-                  FStar_Ident.mk_ident uu____19395 in
+                  let uu____19392 =
+                    let uu____19397 =
+                      let uu____19398 = FStar_Ident.string_of_id id in
+                      Prims.op_Hat "Mk" uu____19398 in
+                    let uu____19399 = FStar_Ident.range_of_id id in
+                    (uu____19397, uu____19399) in
+                  FStar_Ident.mk_ident uu____19392 in
                 let mfields =
                   FStar_List.map
-                    (fun uu____19414 ->
-                       match uu____19414 with
+                    (fun uu____19411 ->
+                       match uu____19411 with
                        | (x, t) ->
-                           let uu____19421 = FStar_Ident.range_of_id x in
+                           let uu____19418 = FStar_Ident.range_of_id x in
                            FStar_Parser_AST.mk_binder
-                             (FStar_Parser_AST.Annotated (x, t)) uu____19421
+                             (FStar_Parser_AST.Annotated (x, t)) uu____19418
                              FStar_Parser_AST.Expr
                              FStar_Pervasives_Native.None) fields in
                 let result =
-                  let uu____19423 =
-                    let uu____19424 =
-                      let uu____19425 = FStar_Ident.lid_of_ids [id] in
-                      FStar_Parser_AST.Var uu____19425 in
-                    let uu____19426 = FStar_Ident.range_of_id id in
-                    FStar_Parser_AST.mk_term uu____19424 uu____19426
+                  let uu____19420 =
+                    let uu____19421 =
+                      let uu____19422 = FStar_Ident.lid_of_ids [id] in
+                      FStar_Parser_AST.Var uu____19422 in
+                    let uu____19423 = FStar_Ident.range_of_id id in
+                    FStar_Parser_AST.mk_term uu____19421 uu____19423
                       FStar_Parser_AST.Type_level in
-                  apply_binders uu____19423 parms in
+                  apply_binders uu____19420 parms in
                 let constrTyp =
-                  let uu____19428 = FStar_Ident.range_of_id id in
+                  let uu____19425 = FStar_Ident.range_of_id id in
                   FStar_Parser_AST.mk_term
                     (FStar_Parser_AST.Product
                        (mfields, (with_constructor_effect result)))
-                    uu____19428 FStar_Parser_AST.Type_level in
+                    uu____19425 FStar_Parser_AST.Type_level in
                 let names =
-                  let uu____19434 = binder_idents parms in id :: uu____19434 in
+                  let uu____19431 = binder_idents parms in id :: uu____19431 in
                 (FStar_List.iter
-                   (fun uu____19448 ->
-                      match uu____19448 with
-                      | (f, uu____19454) ->
-                          let uu____19455 =
+                   (fun uu____19445 ->
+                      match uu____19445 with
+                      | (f, uu____19451) ->
+                          let uu____19452 =
                             FStar_Util.for_some
                               (fun i -> FStar_Ident.ident_equals f i) names in
-                          if uu____19455
+                          if uu____19452
                           then
-                            let uu____19458 =
-                              let uu____19463 =
-                                let uu____19464 = FStar_Ident.string_of_id f in
+                            let uu____19455 =
+                              let uu____19460 =
+                                let uu____19461 = FStar_Ident.string_of_id f in
                                 FStar_Util.format1
                                   "Field %s shadows the record's name or a parameter of it, please rename it"
-                                  uu____19464 in
-                              (FStar_Errors.Error_FieldShadow, uu____19463) in
-                            let uu____19465 = FStar_Ident.range_of_id f in
-                            FStar_Errors.raise_error uu____19458 uu____19465
+                                  uu____19461 in
+                              (FStar_Errors.Error_FieldShadow, uu____19460) in
+                            let uu____19462 = FStar_Ident.range_of_id f in
+                            FStar_Errors.raise_error uu____19455 uu____19462
                           else ()) fields;
-                 (let uu____19467 =
+                 (let uu____19464 =
                     FStar_All.pipe_right fields
                       (FStar_List.map FStar_Pervasives_Native.fst) in
                   ((FStar_Parser_AST.TyconVariant
                       (id, parms, kopt,
                         [(constrName,
                            (FStar_Pervasives_Native.Some constrTyp), false)])),
-                    uu____19467)))
-            | uu____19516 -> failwith "impossible" in
-          let desugar_abstract_tc quals1 _env mutuals uu___18_19555 =
-            match uu___18_19555 with
+                    uu____19464)))
+            | uu____19513 -> failwith "impossible" in
+          let desugar_abstract_tc quals1 _env mutuals uu___18_19552 =
+            match uu___18_19552 with
             | FStar_Parser_AST.TyconAbstract (id, binders, kopt) ->
-                let uu____19579 = typars_of_binders _env binders in
-                (match uu____19579 with
+                let uu____19576 = typars_of_binders _env binders in
+                (match uu____19576 with
                  | (_env', typars) ->
                      let k =
                        match kopt with
@@ -5276,14 +5280,14 @@ let rec (desugar_tycon :
                        | FStar_Pervasives_Native.Some k ->
                            desugar_term _env' k in
                      let tconstr =
-                       let uu____19615 =
-                         let uu____19616 =
-                           let uu____19617 = FStar_Ident.lid_of_ids [id] in
-                           FStar_Parser_AST.Var uu____19617 in
-                         let uu____19618 = FStar_Ident.range_of_id id in
-                         FStar_Parser_AST.mk_term uu____19616 uu____19618
+                       let uu____19612 =
+                         let uu____19613 =
+                           let uu____19614 = FStar_Ident.lid_of_ids [id] in
+                           FStar_Parser_AST.Var uu____19614 in
+                         let uu____19615 = FStar_Ident.range_of_id id in
+                         FStar_Parser_AST.mk_term uu____19613 uu____19615
                            FStar_Parser_AST.Type_level in
-                       apply_binders uu____19615 binders in
+                       apply_binders uu____19612 binders in
                      let qlid = FStar_Syntax_DsEnv.qualify _env id in
                      let typars1 = FStar_Syntax_Subst.close_binders typars in
                      let k1 = FStar_Syntax_Subst.close typars1 k in
@@ -5300,51 +5304,51 @@ let rec (desugar_tycon :
                          FStar_Syntax_Syntax.sigopts =
                            FStar_Pervasives_Native.None
                        } in
-                     let uu____19627 =
+                     let uu____19624 =
                        FStar_Syntax_DsEnv.push_top_level_rec_binding _env id
                          FStar_Syntax_Syntax.delta_constant in
-                     (match uu____19627 with
-                      | (_env1, uu____19643) ->
-                          let uu____19648 =
+                     (match uu____19624 with
+                      | (_env1, uu____19640) ->
+                          let uu____19645 =
                             FStar_Syntax_DsEnv.push_top_level_rec_binding
                               _env' id FStar_Syntax_Syntax.delta_constant in
-                          (match uu____19648 with
-                           | (_env2, uu____19664) ->
+                          (match uu____19645 with
+                           | (_env2, uu____19661) ->
                                (_env1, _env2, se, tconstr))))
-            | uu____19669 -> failwith "Unexpected tycon" in
+            | uu____19666 -> failwith "Unexpected tycon" in
           let push_tparams env1 bs =
-            let uu____19711 =
+            let uu____19708 =
               FStar_List.fold_left
-                (fun uu____19745 ->
-                   fun uu____19746 ->
-                     match (uu____19745, uu____19746) with
+                (fun uu____19742 ->
+                   fun uu____19743 ->
+                     match (uu____19742, uu____19743) with
                      | ((env2, tps), (x, imp)) ->
-                         let uu____19815 =
+                         let uu____19812 =
                            FStar_Syntax_DsEnv.push_bv env2
                              x.FStar_Syntax_Syntax.ppname in
-                         (match uu____19815 with
+                         (match uu____19812 with
                           | (env3, y) -> (env3, ((y, imp) :: tps))))
                 (env1, []) bs in
-            match uu____19711 with
+            match uu____19708 with
             | (env2, bs1) -> (env2, (FStar_List.rev bs1)) in
           match tcs with
           | (FStar_Parser_AST.TyconAbstract (id, bs, kopt))::[] ->
               let kopt1 =
                 match kopt with
                 | FStar_Pervasives_Native.None ->
-                    let uu____19906 =
-                      let uu____19907 = FStar_Ident.range_of_id id in
-                      tm_type_z uu____19907 in
-                    FStar_Pervasives_Native.Some uu____19906
-                | uu____19908 -> kopt in
+                    let uu____19903 =
+                      let uu____19904 = FStar_Ident.range_of_id id in
+                      tm_type_z uu____19904 in
+                    FStar_Pervasives_Native.Some uu____19903
+                | uu____19905 -> kopt in
               let tc = FStar_Parser_AST.TyconAbstract (id, bs, kopt1) in
-              let uu____19916 = desugar_abstract_tc quals env [] tc in
-              (match uu____19916 with
-               | (uu____19929, uu____19930, se, uu____19932) ->
+              let uu____19913 = desugar_abstract_tc quals env [] tc in
+              (match uu____19913 with
+               | (uu____19926, uu____19927, se, uu____19929) ->
                    let se1 =
                      match se.FStar_Syntax_Syntax.sigel with
                      | FStar_Syntax_Syntax.Sig_inductive_typ
-                         (l, uu____19935, typars, k, [], []) ->
+                         (l, uu____19932, typars, k, [], []) ->
                          let quals1 = se.FStar_Syntax_Syntax.sigquals in
                          let quals2 =
                            if
@@ -5352,22 +5356,22 @@ let rec (desugar_tycon :
                                FStar_Syntax_Syntax.Assumption quals1
                            then quals1
                            else
-                             ((let uu____19952 =
-                                 let uu____19953 = FStar_Options.ml_ish () in
-                                 Prims.op_Negation uu____19953 in
-                               if uu____19952
+                             ((let uu____19949 =
+                                 let uu____19950 = FStar_Options.ml_ish () in
+                                 Prims.op_Negation uu____19950 in
+                               if uu____19949
                                then
-                                 let uu____19954 =
-                                   let uu____19959 =
-                                     let uu____19960 =
+                                 let uu____19951 =
+                                   let uu____19956 =
+                                     let uu____19957 =
                                        FStar_Syntax_Print.lid_to_string l in
                                      FStar_Util.format1
                                        "Adding an implicit 'assume new' qualifier on %s"
-                                       uu____19960 in
+                                       uu____19957 in
                                    (FStar_Errors.Warning_AddImplicitAssumeNewQualifier,
-                                     uu____19959) in
+                                     uu____19956) in
                                  FStar_Errors.log_issue
-                                   se.FStar_Syntax_Syntax.sigrng uu____19954
+                                   se.FStar_Syntax_Syntax.sigrng uu____19951
                                else ());
                               FStar_Syntax_Syntax.Assumption
                               ::
@@ -5377,63 +5381,63 @@ let rec (desugar_tycon :
                          let t =
                            match typars with
                            | [] -> k
-                           | uu____19969 ->
-                               let uu____19970 =
-                                 let uu____19971 =
-                                   let uu____19986 =
+                           | uu____19966 ->
+                               let uu____19967 =
+                                 let uu____19968 =
+                                   let uu____19983 =
                                      FStar_Syntax_Syntax.mk_Total k in
-                                   (typars, uu____19986) in
-                                 FStar_Syntax_Syntax.Tm_arrow uu____19971 in
-                               FStar_Syntax_Syntax.mk uu____19970
+                                   (typars, uu____19983) in
+                                 FStar_Syntax_Syntax.Tm_arrow uu____19968 in
+                               FStar_Syntax_Syntax.mk uu____19967
                                  se.FStar_Syntax_Syntax.sigrng in
-                         let uu___2832_19999 = se in
+                         let uu___2833_19996 = se in
                          {
                            FStar_Syntax_Syntax.sigel =
                              (FStar_Syntax_Syntax.Sig_declare_typ (l, [], t));
                            FStar_Syntax_Syntax.sigrng =
-                             (uu___2832_19999.FStar_Syntax_Syntax.sigrng);
+                             (uu___2833_19996.FStar_Syntax_Syntax.sigrng);
                            FStar_Syntax_Syntax.sigquals = quals2;
                            FStar_Syntax_Syntax.sigmeta =
-                             (uu___2832_19999.FStar_Syntax_Syntax.sigmeta);
+                             (uu___2833_19996.FStar_Syntax_Syntax.sigmeta);
                            FStar_Syntax_Syntax.sigattrs =
-                             (uu___2832_19999.FStar_Syntax_Syntax.sigattrs);
+                             (uu___2833_19996.FStar_Syntax_Syntax.sigattrs);
                            FStar_Syntax_Syntax.sigopts =
-                             (uu___2832_19999.FStar_Syntax_Syntax.sigopts)
+                             (uu___2833_19996.FStar_Syntax_Syntax.sigopts)
                          }
-                     | uu____20000 -> failwith "Impossible" in
+                     | uu____19997 -> failwith "Impossible" in
                    let env1 = FStar_Syntax_DsEnv.push_sigelt env se1 in
                    (env1, [se1]))
           | (FStar_Parser_AST.TyconAbbrev (id, binders, kopt, t))::[] ->
-              let uu____20014 = typars_of_binders env binders in
-              (match uu____20014 with
+              let uu____20011 = typars_of_binders env binders in
+              (match uu____20011 with
                | (env', typars) ->
                    let kopt1 =
                      match kopt with
                      | FStar_Pervasives_Native.None ->
-                         let uu____20048 =
+                         let uu____20045 =
                            FStar_Util.for_some
-                             (fun uu___19_20050 ->
-                                match uu___19_20050 with
+                             (fun uu___19_20047 ->
+                                match uu___19_20047 with
                                 | FStar_Syntax_Syntax.Effect -> true
-                                | uu____20051 -> false) quals in
-                         if uu____20048
+                                | uu____20048 -> false) quals in
+                         if uu____20045
                          then
                            FStar_Pervasives_Native.Some
                              FStar_Syntax_Syntax.teff
                          else FStar_Pervasives_Native.None
                      | FStar_Pervasives_Native.Some k ->
-                         let uu____20056 = desugar_term env' k in
-                         FStar_Pervasives_Native.Some uu____20056 in
+                         let uu____20053 = desugar_term env' k in
+                         FStar_Pervasives_Native.Some uu____20053 in
                    let t0 = t in
                    let quals1 =
-                     let uu____20061 =
+                     let uu____20058 =
                        FStar_All.pipe_right quals
                          (FStar_Util.for_some
-                            (fun uu___20_20065 ->
-                               match uu___20_20065 with
+                            (fun uu___20_20062 ->
+                               match uu___20_20062 with
                                | FStar_Syntax_Syntax.Logic -> true
-                               | uu____20066 -> false)) in
-                     if uu____20061
+                               | uu____20063 -> false)) in
+                     if uu____20058
                      then quals
                      else
                        if
@@ -5442,39 +5446,39 @@ let rec (desugar_tycon :
                        else quals in
                    let qlid = FStar_Syntax_DsEnv.qualify env id in
                    let se =
-                     let uu____20075 =
+                     let uu____20072 =
                        FStar_All.pipe_right quals1
                          (FStar_List.contains FStar_Syntax_Syntax.Effect) in
-                     if uu____20075
+                     if uu____20072
                      then
-                       let uu____20078 =
-                         let uu____20085 =
-                           let uu____20086 = unparen t in
-                           uu____20086.FStar_Parser_AST.tm in
-                         match uu____20085 with
+                       let uu____20075 =
+                         let uu____20082 =
+                           let uu____20083 = unparen t in
+                           uu____20083.FStar_Parser_AST.tm in
+                         match uu____20082 with
                          | FStar_Parser_AST.Construct (head, args) ->
-                             let uu____20107 =
+                             let uu____20104 =
                                match FStar_List.rev args with
-                               | (last_arg, uu____20137)::args_rev ->
-                                   let uu____20149 =
-                                     let uu____20150 = unparen last_arg in
-                                     uu____20150.FStar_Parser_AST.tm in
-                                   (match uu____20149 with
+                               | (last_arg, uu____20134)::args_rev ->
+                                   let uu____20146 =
+                                     let uu____20147 = unparen last_arg in
+                                     uu____20147.FStar_Parser_AST.tm in
+                                   (match uu____20146 with
                                     | FStar_Parser_AST.Attributes ts ->
                                         (ts, (FStar_List.rev args_rev))
-                                    | uu____20178 -> ([], args))
-                               | uu____20187 -> ([], args) in
-                             (match uu____20107 with
+                                    | uu____20175 -> ([], args))
+                               | uu____20184 -> ([], args) in
+                             (match uu____20104 with
                               | (cattributes, args1) ->
-                                  let uu____20226 =
+                                  let uu____20223 =
                                     desugar_attributes env cattributes in
                                   ((FStar_Parser_AST.mk_term
                                       (FStar_Parser_AST.Construct
                                          (head, args1))
                                       t.FStar_Parser_AST.range
-                                      t.FStar_Parser_AST.level), uu____20226))
-                         | uu____20237 -> (t, []) in
-                       match uu____20078 with
+                                      t.FStar_Parser_AST.level), uu____20223))
+                         | uu____20234 -> (t, []) in
+                       match uu____20075 with
                        | (t1, cattributes) ->
                            let c =
                              desugar_comp t1.FStar_Parser_AST.range false
@@ -5485,10 +5489,10 @@ let rec (desugar_tycon :
                            let quals2 =
                              FStar_All.pipe_right quals1
                                (FStar_List.filter
-                                  (fun uu___21_20259 ->
-                                     match uu___21_20259 with
+                                  (fun uu___21_20256 ->
+                                     match uu___21_20256 with
                                      | FStar_Syntax_Syntax.Effect -> false
-                                     | uu____20260 -> true)) in
+                                     | uu____20257 -> true)) in
                            {
                              FStar_Syntax_Syntax.sigel =
                                (FStar_Syntax_Syntax.Sig_effect_abbrev
@@ -5509,23 +5513,23 @@ let rec (desugar_tycon :
                           quals1 rng) in
                    let env1 = FStar_Syntax_DsEnv.push_sigelt env se in
                    (env1, [se]))
-          | (FStar_Parser_AST.TyconRecord uu____20266)::[] ->
+          | (FStar_Parser_AST.TyconRecord uu____20263)::[] ->
               let trec = FStar_List.hd tcs in
-              let uu____20286 = tycon_record_as_variant trec in
-              (match uu____20286 with
+              let uu____20283 = tycon_record_as_variant trec in
+              (match uu____20283 with
                | (t, fs) ->
-                   let uu____20303 =
-                     let uu____20306 =
-                       let uu____20307 =
-                         let uu____20316 =
-                           let uu____20319 =
+                   let uu____20300 =
+                     let uu____20303 =
+                       let uu____20304 =
+                         let uu____20313 =
+                           let uu____20316 =
                              FStar_Syntax_DsEnv.current_module env in
-                           FStar_Ident.ids_of_lid uu____20319 in
-                         (uu____20316, fs) in
-                       FStar_Syntax_Syntax.RecordType uu____20307 in
-                     uu____20306 :: quals in
-                   desugar_tycon env d uu____20303 [t])
-          | uu____20324::uu____20325 ->
+                           FStar_Ident.ids_of_lid uu____20316 in
+                         (uu____20313, fs) in
+                       FStar_Syntax_Syntax.RecordType uu____20304 in
+                     uu____20303 :: quals in
+                   desugar_tycon env d uu____20300 [t])
+          | uu____20321::uu____20322 ->
               let env0 = env in
               let mutuals =
                 FStar_List.map
@@ -5533,87 +5537,87 @@ let rec (desugar_tycon :
                      FStar_All.pipe_left (FStar_Syntax_DsEnv.qualify env)
                        (tycon_id x)) tcs in
               let rec collect_tcs quals1 et tc =
-                let uu____20480 = et in
-                match uu____20480 with
+                let uu____20477 = et in
+                match uu____20477 with
                 | (env1, tcs1) ->
                     (match tc with
-                     | FStar_Parser_AST.TyconRecord uu____20685 ->
+                     | FStar_Parser_AST.TyconRecord uu____20682 ->
                          let trec = tc in
-                         let uu____20705 = tycon_record_as_variant trec in
-                         (match uu____20705 with
+                         let uu____20702 = tycon_record_as_variant trec in
+                         (match uu____20702 with
                           | (t, fs) ->
-                              let uu____20760 =
-                                let uu____20763 =
-                                  let uu____20764 =
-                                    let uu____20773 =
-                                      let uu____20776 =
+                              let uu____20757 =
+                                let uu____20760 =
+                                  let uu____20761 =
+                                    let uu____20770 =
+                                      let uu____20773 =
                                         FStar_Syntax_DsEnv.current_module
                                           env1 in
-                                      FStar_Ident.ids_of_lid uu____20776 in
-                                    (uu____20773, fs) in
-                                  FStar_Syntax_Syntax.RecordType uu____20764 in
-                                uu____20763 :: quals1 in
-                              collect_tcs uu____20760 (env1, tcs1) t)
+                                      FStar_Ident.ids_of_lid uu____20773 in
+                                    (uu____20770, fs) in
+                                  FStar_Syntax_Syntax.RecordType uu____20761 in
+                                uu____20760 :: quals1 in
+                              collect_tcs uu____20757 (env1, tcs1) t)
                      | FStar_Parser_AST.TyconVariant
                          (id, binders, kopt, constructors) ->
-                         let uu____20851 =
+                         let uu____20848 =
                            desugar_abstract_tc quals1 env1 mutuals
                              (FStar_Parser_AST.TyconAbstract
                                 (id, binders, kopt)) in
-                         (match uu____20851 with
-                          | (env2, uu____20907, se, tconstr) ->
+                         (match uu____20848 with
+                          | (env2, uu____20904, se, tconstr) ->
                               (env2,
                                 ((FStar_Util.Inl
                                     (se, constructors, tconstr, quals1)) ::
                                 tcs1)))
                      | FStar_Parser_AST.TyconAbbrev (id, binders, kopt, t) ->
-                         let uu____21040 =
+                         let uu____21037 =
                            desugar_abstract_tc quals1 env1 mutuals
                              (FStar_Parser_AST.TyconAbstract
                                 (id, binders, kopt)) in
-                         (match uu____21040 with
-                          | (env2, uu____21096, se, tconstr) ->
+                         (match uu____21037 with
+                          | (env2, uu____21093, se, tconstr) ->
                               (env2,
                                 ((FStar_Util.Inr (se, binders, t, quals1)) ::
                                 tcs1)))
-                     | uu____21209 ->
+                     | uu____21206 ->
                          FStar_Errors.raise_error
                            (FStar_Errors.Fatal_NonInductiveInMutuallyDefinedType,
                              "Mutually defined type contains a non-inductive element")
                            rng) in
-              let uu____21252 =
+              let uu____21249 =
                 FStar_List.fold_left (collect_tcs quals) (env, []) tcs in
-              (match uu____21252 with
+              (match uu____21249 with
                | (env1, tcs1) ->
                    let tcs2 = FStar_List.rev tcs1 in
                    let tps_sigelts =
                      FStar_All.pipe_right tcs2
                        (FStar_List.collect
-                          (fun uu___23_21694 ->
-                             match uu___23_21694 with
+                          (fun uu___23_21691 ->
+                             match uu___23_21691 with
                              | FStar_Util.Inr
                                  ({
                                     FStar_Syntax_Syntax.sigel =
                                       FStar_Syntax_Syntax.Sig_inductive_typ
-                                      (id, uvs, tpars, k, uu____21747,
-                                       uu____21748);
-                                    FStar_Syntax_Syntax.sigrng = uu____21749;
+                                      (id, uvs, tpars, k, uu____21744,
+                                       uu____21745);
+                                    FStar_Syntax_Syntax.sigrng = uu____21746;
                                     FStar_Syntax_Syntax.sigquals =
-                                      uu____21750;
-                                    FStar_Syntax_Syntax.sigmeta = uu____21751;
+                                      uu____21747;
+                                    FStar_Syntax_Syntax.sigmeta = uu____21748;
                                     FStar_Syntax_Syntax.sigattrs =
-                                      uu____21752;
-                                    FStar_Syntax_Syntax.sigopts = uu____21753;_},
+                                      uu____21749;
+                                    FStar_Syntax_Syntax.sigopts = uu____21750;_},
                                   binders, t, quals1)
                                  ->
                                  let t1 =
-                                   let uu____21814 =
+                                   let uu____21811 =
                                      typars_of_binders env1 binders in
-                                   match uu____21814 with
+                                   match uu____21811 with
                                    | (env2, tpars1) ->
-                                       let uu____21841 =
+                                       let uu____21838 =
                                          push_tparams env2 tpars1 in
-                                       (match uu____21841 with
+                                       (match uu____21838 with
                                         | (env_tps, tpars2) ->
                                             let t1 = desugar_typ env_tps t in
                                             let tpars3 =
@@ -5621,26 +5625,26 @@ let rec (desugar_tycon :
                                                 tpars2 in
                                             FStar_Syntax_Subst.close tpars3
                                               t1) in
-                                 let uu____21870 =
-                                   let uu____21881 =
+                                 let uu____21867 =
+                                   let uu____21878 =
                                      mk_typ_abbrev env1 d id uvs tpars
                                        (FStar_Pervasives_Native.Some k) t1
                                        [id] quals1 rng in
-                                   ([], uu____21881) in
-                                 [uu____21870]
+                                   ([], uu____21878) in
+                                 [uu____21867]
                              | FStar_Util.Inl
                                  ({
                                     FStar_Syntax_Syntax.sigel =
                                       FStar_Syntax_Syntax.Sig_inductive_typ
                                       (tname, univs, tpars, k, mutuals1,
-                                       uu____21917);
-                                    FStar_Syntax_Syntax.sigrng = uu____21918;
+                                       uu____21914);
+                                    FStar_Syntax_Syntax.sigrng = uu____21915;
                                     FStar_Syntax_Syntax.sigquals =
                                       tname_quals;
-                                    FStar_Syntax_Syntax.sigmeta = uu____21920;
+                                    FStar_Syntax_Syntax.sigmeta = uu____21917;
                                     FStar_Syntax_Syntax.sigattrs =
-                                      uu____21921;
-                                    FStar_Syntax_Syntax.sigopts = uu____21922;_},
+                                      uu____21918;
+                                    FStar_Syntax_Syntax.sigopts = uu____21919;_},
                                   constrs, tconstr, quals1)
                                  ->
                                  let mk_tot t =
@@ -5656,14 +5660,14 @@ let rec (desugar_tycon :
                                      t.FStar_Parser_AST.range
                                      t.FStar_Parser_AST.level in
                                  let tycon = (tname, tpars, k) in
-                                 let uu____22010 = push_tparams env1 tpars in
-                                 (match uu____22010 with
+                                 let uu____22007 = push_tparams env1 tpars in
+                                 (match uu____22007 with
                                   | (env_tps, tps) ->
                                       let data_tpars =
                                         FStar_List.map
-                                          (fun uu____22069 ->
-                                             match uu____22069 with
-                                             | (x, uu____22081) ->
+                                          (fun uu____22066 ->
+                                             match uu____22066 with
+                                             | (x, uu____22078) ->
                                                  (x,
                                                    (FStar_Pervasives_Native.Some
                                                       (FStar_Syntax_Syntax.Implicit
@@ -5673,17 +5677,17 @@ let rec (desugar_tycon :
                                         FStar_List.map (desugar_term env1)
                                           d.FStar_Parser_AST.attrs in
                                       let val_attrs =
-                                        let uu____22091 =
+                                        let uu____22088 =
                                           FStar_Syntax_DsEnv.lookup_letbinding_quals_and_attrs
                                             env1 tname in
-                                        FStar_All.pipe_right uu____22091
+                                        FStar_All.pipe_right uu____22088
                                           FStar_Pervasives_Native.snd in
-                                      let uu____22114 =
-                                        let uu____22133 =
+                                      let uu____22111 =
+                                        let uu____22130 =
                                           FStar_All.pipe_right constrs
                                             (FStar_List.map
-                                               (fun uu____22208 ->
-                                                  match uu____22208 with
+                                               (fun uu____22205 ->
+                                                  match uu____22205 with
                                                   | (id, topt, of_notation)
                                                       ->
                                                       let t =
@@ -5715,10 +5719,10 @@ let rec (desugar_tycon :
                                                            | FStar_Pervasives_Native.Some
                                                                t -> t) in
                                                       let t1 =
-                                                        let uu____22245 =
+                                                        let uu____22242 =
                                                           close env_tps t in
                                                         desugar_term env_tps
-                                                          uu____22245 in
+                                                          uu____22242 in
                                                       let name =
                                                         FStar_Syntax_DsEnv.qualify
                                                           env1 id in
@@ -5727,47 +5731,47 @@ let rec (desugar_tycon :
                                                           tname_quals
                                                           (FStar_List.collect
                                                              (fun
-                                                                uu___22_22256
+                                                                uu___22_22253
                                                                 ->
-                                                                match uu___22_22256
+                                                                match uu___22_22253
                                                                 with
                                                                 | FStar_Syntax_Syntax.RecordType
                                                                     fns ->
                                                                     [
                                                                     FStar_Syntax_Syntax.RecordConstructor
                                                                     fns]
-                                                                | uu____22268
+                                                                | uu____22265
                                                                     -> [])) in
                                                       let ntps =
                                                         FStar_List.length
                                                           data_tpars in
-                                                      let uu____22276 =
-                                                        let uu____22287 =
-                                                          let uu____22288 =
-                                                            let uu____22289 =
-                                                              let uu____22304
+                                                      let uu____22273 =
+                                                        let uu____22284 =
+                                                          let uu____22285 =
+                                                            let uu____22286 =
+                                                              let uu____22301
                                                                 =
-                                                                let uu____22305
+                                                                let uu____22302
                                                                   =
-                                                                  let uu____22308
+                                                                  let uu____22305
                                                                     =
                                                                     FStar_All.pipe_right
                                                                     t1
                                                                     FStar_Syntax_Util.name_function_binders in
                                                                   FStar_Syntax_Syntax.mk_Total
-                                                                    uu____22308 in
+                                                                    uu____22305 in
                                                                 FStar_Syntax_Util.arrow
                                                                   data_tpars
-                                                                  uu____22305 in
+                                                                  uu____22302 in
                                                               (name, univs,
-                                                                uu____22304,
+                                                                uu____22301,
                                                                 tname, ntps,
                                                                 mutuals1) in
                                                             FStar_Syntax_Syntax.Sig_datacon
-                                                              uu____22289 in
+                                                              uu____22286 in
                                                           {
                                                             FStar_Syntax_Syntax.sigel
-                                                              = uu____22288;
+                                                              = uu____22285;
                                                             FStar_Syntax_Syntax.sigrng
                                                               = rng;
                                                             FStar_Syntax_Syntax.sigquals
@@ -5784,11 +5788,11 @@ let rec (desugar_tycon :
                                                               =
                                                               FStar_Pervasives_Native.None
                                                           } in
-                                                        (tps, uu____22287) in
-                                                      (name, uu____22276))) in
+                                                        (tps, uu____22284) in
+                                                      (name, uu____22273))) in
                                         FStar_All.pipe_left FStar_List.split
-                                          uu____22133 in
-                                      (match uu____22114 with
+                                          uu____22130 in
+                                      (match uu____22111 with
                                        | (constrNames, constrs1) ->
                                            ([],
                                              {
@@ -5809,19 +5813,19 @@ let rec (desugar_tycon :
                                                  FStar_Pervasives_Native.None
                                              })
                                            :: constrs1))
-                             | uu____22439 -> failwith "impossible")) in
+                             | uu____22436 -> failwith "impossible")) in
                    let sigelts =
                      FStar_All.pipe_right tps_sigelts
                        (FStar_List.map
-                          (fun uu____22518 ->
-                             match uu____22518 with | (uu____22529, se) -> se)) in
-                   let uu____22543 =
-                     let uu____22550 =
+                          (fun uu____22515 ->
+                             match uu____22515 with | (uu____22526, se) -> se)) in
+                   let uu____22540 =
+                     let uu____22547 =
                        FStar_List.collect FStar_Syntax_Util.lids_of_sigelt
                          sigelts in
                      FStar_Syntax_MutRecTy.disentangle_abbrevs_from_bundle
-                       sigelts quals uu____22550 rng in
-                   (match uu____22543 with
+                       sigelts quals uu____22547 rng in
+                   (match uu____22540 with
                     | (bundle, abbrevs) ->
                         let env2 = FStar_Syntax_DsEnv.push_sigelt env0 bundle in
                         let env3 =
@@ -5830,8 +5834,8 @@ let rec (desugar_tycon :
                         let data_ops =
                           FStar_All.pipe_right tps_sigelts
                             (FStar_List.collect
-                               (fun uu____22595 ->
-                                  match uu____22595 with
+                               (fun uu____22592 ->
+                                  match uu____22592 with
                                   | (tps, se) ->
                                       mk_data_projector_names quals env3 se)) in
                         let discs =
@@ -5840,18 +5844,18 @@ let rec (desugar_tycon :
                                (fun se ->
                                   match se.FStar_Syntax_Syntax.sigel with
                                   | FStar_Syntax_Syntax.Sig_inductive_typ
-                                      (tname, uu____22642, tps, k,
-                                       uu____22645, constrs)
+                                      (tname, uu____22639, tps, k,
+                                       uu____22642, constrs)
                                       ->
                                       let quals1 =
                                         se.FStar_Syntax_Syntax.sigquals in
-                                      let uu____22658 =
+                                      let uu____22655 =
                                         FStar_All.pipe_right constrs
                                           (FStar_List.filter
                                              (fun data_lid ->
                                                 let data_quals =
                                                   let data_se =
-                                                    let uu____22673 =
+                                                    let uu____22670 =
                                                       FStar_All.pipe_right
                                                         sigelts
                                                         (FStar_List.find
@@ -5860,37 +5864,37 @@ let rec (desugar_tycon :
                                                               with
                                                               | FStar_Syntax_Syntax.Sig_datacon
                                                                   (name,
+                                                                   uu____22686,
+                                                                   uu____22687,
+                                                                   uu____22688,
                                                                    uu____22689,
-                                                                   uu____22690,
-                                                                   uu____22691,
-                                                                   uu____22692,
-                                                                   uu____22693)
+                                                                   uu____22690)
                                                                   ->
                                                                   FStar_Ident.lid_equals
                                                                     name
                                                                     data_lid
-                                                              | uu____22698
+                                                              | uu____22695
                                                                   -> false)) in
                                                     FStar_All.pipe_right
-                                                      uu____22673
+                                                      uu____22670
                                                       FStar_Util.must in
                                                   data_se.FStar_Syntax_Syntax.sigquals in
-                                                let uu____22701 =
+                                                let uu____22698 =
                                                   FStar_All.pipe_right
                                                     data_quals
                                                     (FStar_List.existsb
-                                                       (fun uu___24_22706 ->
-                                                          match uu___24_22706
+                                                       (fun uu___24_22703 ->
+                                                          match uu___24_22703
                                                           with
                                                           | FStar_Syntax_Syntax.RecordConstructor
-                                                              uu____22707 ->
+                                                              uu____22704 ->
                                                               true
-                                                          | uu____22716 ->
+                                                          | uu____22713 ->
                                                               false)) in
-                                                Prims.op_Negation uu____22701)) in
+                                                Prims.op_Negation uu____22698)) in
                                       mk_data_discriminators quals1 env3
-                                        uu____22658
-                                  | uu____22717 -> [])) in
+                                        uu____22655
+                                  | uu____22714 -> [])) in
                         let ops = FStar_List.append discs data_ops in
                         let env4 =
                           FStar_List.fold_left FStar_Syntax_DsEnv.push_sigelt
@@ -5908,26 +5912,26 @@ let (desugar_binders :
   =
   fun env ->
     fun binders ->
-      let uu____22752 =
+      let uu____22749 =
         FStar_List.fold_left
-          (fun uu____22787 ->
+          (fun uu____22784 ->
              fun b ->
-               match uu____22787 with
+               match uu____22784 with
                | (env1, binders1) ->
-                   let uu____22831 = desugar_binder env1 b in
-                   (match uu____22831 with
+                   let uu____22828 = desugar_binder env1 b in
+                   (match uu____22828 with
                     | (FStar_Pervasives_Native.Some a, k) ->
-                        let uu____22854 =
+                        let uu____22851 =
                           as_binder env1 b.FStar_Parser_AST.aqual
                             ((FStar_Pervasives_Native.Some a), k) in
-                        (match uu____22854 with
+                        (match uu____22851 with
                          | (binder, env2) -> (env2, (binder :: binders1)))
-                    | uu____22907 ->
+                    | uu____22904 ->
                         FStar_Errors.raise_error
                           (FStar_Errors.Fatal_MissingNameInBinder,
                             "Missing name in binder")
                           b.FStar_Parser_AST.brange)) (env, []) binders in
-      match uu____22752 with
+      match uu____22749 with
       | (env1, binders1) -> (env1, (FStar_List.rev binders1))
 let (push_reflect_effect :
   FStar_Syntax_DsEnv.env ->
@@ -5938,21 +5942,21 @@ let (push_reflect_effect :
     fun quals ->
       fun effect_name ->
         fun range ->
-          let uu____23008 =
+          let uu____23005 =
             FStar_All.pipe_right quals
               (FStar_Util.for_some
-                 (fun uu___25_23013 ->
-                    match uu___25_23013 with
-                    | FStar_Syntax_Syntax.Reflectable uu____23014 -> true
-                    | uu____23015 -> false)) in
-          if uu____23008
+                 (fun uu___25_23010 ->
+                    match uu___25_23010 with
+                    | FStar_Syntax_Syntax.Reflectable uu____23011 -> true
+                    | uu____23012 -> false)) in
+          if uu____23005
           then
             let monad_env =
-              let uu____23017 = FStar_Ident.ident_of_lid effect_name in
-              FStar_Syntax_DsEnv.enter_monad_scope env uu____23017 in
+              let uu____23014 = FStar_Ident.ident_of_lid effect_name in
+              FStar_Syntax_DsEnv.enter_monad_scope env uu____23014 in
             let reflect_lid =
-              let uu____23019 = FStar_Ident.id_of_text "reflect" in
-              FStar_All.pipe_right uu____23019
+              let uu____23016 = FStar_Ident.id_of_text "reflect" in
+              FStar_All.pipe_right uu____23016
                 (FStar_Syntax_DsEnv.qualify monad_env) in
             let quals1 =
               [FStar_Syntax_Syntax.Assumption;
@@ -5980,49 +5984,49 @@ let (parse_attr_with_list :
   fun warn ->
     fun at ->
       fun head ->
-        let warn1 uu____23061 =
+        let warn1 uu____23058 =
           if warn
           then
-            let uu____23062 =
-              let uu____23067 =
-                let uu____23068 = FStar_Ident.string_of_lid head in
+            let uu____23059 =
+              let uu____23064 =
+                let uu____23065 = FStar_Ident.string_of_lid head in
                 FStar_Util.format1
                   "Found ill-applied '%s', argument should be a non-empty list of integer literals"
-                  uu____23068 in
-              (FStar_Errors.Warning_UnappliedFail, uu____23067) in
-            FStar_Errors.log_issue at.FStar_Syntax_Syntax.pos uu____23062
+                  uu____23065 in
+              (FStar_Errors.Warning_UnappliedFail, uu____23064) in
+            FStar_Errors.log_issue at.FStar_Syntax_Syntax.pos uu____23059
           else () in
-        let uu____23070 = FStar_Syntax_Util.head_and_args at in
-        match uu____23070 with
+        let uu____23067 = FStar_Syntax_Util.head_and_args at in
+        match uu____23067 with
         | (hd, args) ->
-            let uu____23121 =
-              let uu____23122 = FStar_Syntax_Subst.compress hd in
-              uu____23122.FStar_Syntax_Syntax.n in
-            (match uu____23121 with
+            let uu____23118 =
+              let uu____23119 = FStar_Syntax_Subst.compress hd in
+              uu____23119.FStar_Syntax_Syntax.n in
+            (match uu____23118 with
              | FStar_Syntax_Syntax.Tm_fvar fv when
                  FStar_Syntax_Syntax.fv_eq_lid fv head ->
                  (match args with
                   | [] -> ((FStar_Pervasives_Native.Some []), true)
-                  | (a1, uu____23157)::[] ->
-                      let uu____23182 =
-                        let uu____23187 =
-                          let uu____23196 =
+                  | (a1, uu____23154)::[] ->
+                      let uu____23179 =
+                        let uu____23184 =
+                          let uu____23193 =
                             FStar_Syntax_Embeddings.e_list
                               FStar_Syntax_Embeddings.e_int in
-                          FStar_Syntax_Embeddings.unembed uu____23196 a1 in
-                        uu____23187 true FStar_Syntax_Embeddings.id_norm_cb in
-                      (match uu____23182 with
+                          FStar_Syntax_Embeddings.unembed uu____23193 a1 in
+                        uu____23184 true FStar_Syntax_Embeddings.id_norm_cb in
+                      (match uu____23179 with
                        | FStar_Pervasives_Native.Some es ->
-                           let uu____23216 =
-                             let uu____23221 =
+                           let uu____23213 =
+                             let uu____23218 =
                                FStar_List.map FStar_BigInt.to_int_fs es in
-                             FStar_Pervasives_Native.Some uu____23221 in
-                           (uu____23216, true)
-                       | uu____23230 ->
+                             FStar_Pervasives_Native.Some uu____23218 in
+                           (uu____23213, true)
+                       | uu____23227 ->
                            (warn1 (); (FStar_Pervasives_Native.None, true)))
-                  | uu____23242 ->
+                  | uu____23239 ->
                       (warn1 (); (FStar_Pervasives_Native.None, true)))
-             | uu____23260 -> (FStar_Pervasives_Native.None, false))
+             | uu____23257 -> (FStar_Pervasives_Native.None, false))
 let (get_fail_attr1 :
   Prims.bool ->
     FStar_Syntax_Syntax.term ->
@@ -6035,16 +6039,16 @@ let (get_fail_attr1 :
         | FStar_Pervasives_Native.None -> FStar_Pervasives_Native.None
         | FStar_Pervasives_Native.Some l ->
             FStar_Pervasives_Native.Some (l, b) in
-      let uu____23349 =
+      let uu____23346 =
         parse_attr_with_list warn at FStar_Parser_Const.fail_attr in
-      match uu____23349 with
+      match uu____23346 with
       | (res, matched) ->
           if matched
           then rebind res false
           else
-            (let uu____23385 =
+            (let uu____23382 =
                parse_attr_with_list warn at FStar_Parser_Const.fail_lax_attr in
-             match uu____23385 with | (res1, uu____23403) -> rebind res1 true)
+             match uu____23382 with | (res1, uu____23400) -> rebind res1 true)
 let (get_fail_attr :
   Prims.bool ->
     FStar_Syntax_Syntax.term Prims.list ->
@@ -6062,11 +6066,11 @@ let (get_fail_attr :
             -> FStar_Pervasives_Native.Some (e, l)
         | (FStar_Pervasives_Native.None, FStar_Pervasives_Native.Some (e, l))
             -> FStar_Pervasives_Native.Some (e, l)
-        | uu____23649 -> FStar_Pervasives_Native.None in
+        | uu____23646 -> FStar_Pervasives_Native.None in
       FStar_List.fold_right
         (fun at ->
            fun acc ->
-             let uu____23697 = get_fail_attr1 warn at in comb uu____23697 acc)
+             let uu____23694 = get_fail_attr1 warn at in comb uu____23694 acc)
         ats FStar_Pervasives_Native.None
 let (lookup_effect_lid :
   FStar_Syntax_DsEnv.env ->
@@ -6075,17 +6079,17 @@ let (lookup_effect_lid :
   fun env ->
     fun l ->
       fun r ->
-        let uu____23727 = FStar_Syntax_DsEnv.try_lookup_effect_defn env l in
-        match uu____23727 with
+        let uu____23724 = FStar_Syntax_DsEnv.try_lookup_effect_defn env l in
+        match uu____23724 with
         | FStar_Pervasives_Native.None ->
-            let uu____23730 =
-              let uu____23735 =
-                let uu____23736 =
-                  let uu____23737 = FStar_Syntax_Print.lid_to_string l in
-                  Prims.op_Hat uu____23737 " not found" in
-                Prims.op_Hat "Effect name " uu____23736 in
-              (FStar_Errors.Fatal_EffectNotFound, uu____23735) in
-            FStar_Errors.raise_error uu____23730 r
+            let uu____23727 =
+              let uu____23732 =
+                let uu____23733 =
+                  let uu____23734 = FStar_Syntax_Print.lid_to_string l in
+                  Prims.op_Hat uu____23734 " not found" in
+                Prims.op_Hat "Effect name " uu____23733 in
+              (FStar_Errors.Fatal_EffectNotFound, uu____23732) in
+            FStar_Errors.raise_error uu____23727 r
         | FStar_Pervasives_Native.Some l1 -> l1
 let rec (desugar_effect :
   FStar_Syntax_DsEnv.env ->
@@ -6112,29 +6116,29 @@ let rec (desugar_effect :
                     let env0 = env in
                     let monad_env =
                       FStar_Syntax_DsEnv.enter_monad_scope env eff_name in
-                    let uu____23886 = desugar_binders monad_env eff_binders in
-                    match uu____23886 with
+                    let uu____23883 = desugar_binders monad_env eff_binders in
+                    match uu____23883 with
                     | (env1, binders) ->
                         let eff_t = desugar_term env1 eff_typ in
                         let num_indices =
-                          let uu____23925 =
-                            let uu____23934 =
+                          let uu____23922 =
+                            let uu____23931 =
                               FStar_Syntax_Util.arrow_formals eff_t in
-                            FStar_Pervasives_Native.fst uu____23934 in
-                          FStar_List.length uu____23925 in
+                            FStar_Pervasives_Native.fst uu____23931 in
+                          FStar_List.length uu____23922 in
                         (if is_layered && (num_indices <= Prims.int_one)
                          then
-                           (let uu____23950 =
-                              let uu____23955 =
-                                let uu____23956 =
-                                  let uu____23957 =
+                           (let uu____23947 =
+                              let uu____23952 =
+                                let uu____23953 =
+                                  let uu____23954 =
                                     FStar_Ident.string_of_id eff_name in
-                                  Prims.op_Hat uu____23957
+                                  Prims.op_Hat uu____23954
                                     "is defined as a layered effect but has no indices" in
-                                Prims.op_Hat "Effect " uu____23956 in
+                                Prims.op_Hat "Effect " uu____23953 in
                               (FStar_Errors.Fatal_NotEnoughArgumentsForEffect,
-                                uu____23955) in
-                            FStar_Errors.raise_error uu____23950
+                                uu____23952) in
+                            FStar_Errors.raise_error uu____23947
                               d.FStar_Parser_AST.drange)
                          else ();
                          (let for_free = num_indices = Prims.int_one in
@@ -6159,40 +6163,40 @@ let rec (desugar_effect :
                           let name_of_eff_decl decl =
                             match decl.FStar_Parser_AST.d with
                             | FStar_Parser_AST.Tycon
-                                (uu____23978, uu____23979,
+                                (uu____23975, uu____23976,
                                  (FStar_Parser_AST.TyconAbbrev
-                                 (name, uu____23981, uu____23982,
-                                  uu____23983))::[])
+                                 (name, uu____23978, uu____23979,
+                                  uu____23980))::[])
                                 -> FStar_Ident.string_of_id name
-                            | uu____23994 ->
+                            | uu____23991 ->
                                 failwith
                                   "Malformed effect member declaration." in
-                          let uu____23995 =
+                          let uu____23992 =
                             FStar_List.partition
                               (fun decl ->
-                                 let uu____24007 = name_of_eff_decl decl in
-                                 FStar_List.mem uu____24007 mandatory_members)
+                                 let uu____24004 = name_of_eff_decl decl in
+                                 FStar_List.mem uu____24004 mandatory_members)
                               eff_decls in
-                          match uu____23995 with
+                          match uu____23992 with
                           | (mandatory_members_decls, actions) ->
-                              let uu____24024 =
+                              let uu____24021 =
                                 FStar_All.pipe_right mandatory_members_decls
                                   (FStar_List.fold_left
-                                     (fun uu____24053 ->
+                                     (fun uu____24050 ->
                                         fun decl ->
-                                          match uu____24053 with
+                                          match uu____24050 with
                                           | (env2, out) ->
-                                              let uu____24073 =
+                                              let uu____24070 =
                                                 desugar_decl env2 decl in
-                                              (match uu____24073 with
+                                              (match uu____24070 with
                                                | (env3, ses) ->
-                                                   let uu____24086 =
-                                                     let uu____24089 =
+                                                   let uu____24083 =
+                                                     let uu____24086 =
                                                        FStar_List.hd ses in
-                                                     uu____24089 :: out in
-                                                   (env3, uu____24086)))
+                                                     uu____24086 :: out in
+                                                   (env3, uu____24083)))
                                      (env1, [])) in
-                              (match uu____24024 with
+                              (match uu____24021 with
                                | (env2, decls) ->
                                    let binders1 =
                                      FStar_Syntax_Subst.close_binders binders in
@@ -6202,56 +6206,56 @@ let rec (desugar_effect :
                                           (fun d1 ->
                                              match d1.FStar_Parser_AST.d with
                                              | FStar_Parser_AST.Tycon
-                                                 (uu____24135, uu____24136,
+                                                 (uu____24132, uu____24133,
                                                   (FStar_Parser_AST.TyconAbbrev
                                                   (name, action_params,
-                                                   uu____24139,
+                                                   uu____24136,
                                                    {
                                                      FStar_Parser_AST.tm =
                                                        FStar_Parser_AST.Construct
-                                                       (uu____24140,
-                                                        (def, uu____24142)::
+                                                       (uu____24137,
+                                                        (def, uu____24139)::
                                                         (cps_type,
-                                                         uu____24144)::[]);
+                                                         uu____24141)::[]);
                                                      FStar_Parser_AST.range =
-                                                       uu____24145;
+                                                       uu____24142;
                                                      FStar_Parser_AST.level =
-                                                       uu____24146;_}))::[])
+                                                       uu____24143;_}))::[])
                                                  when
                                                  Prims.op_Negation for_free
                                                  ->
-                                                 let uu____24175 =
+                                                 let uu____24172 =
                                                    desugar_binders env2
                                                      action_params in
-                                                 (match uu____24175 with
+                                                 (match uu____24172 with
                                                   | (env3, action_params1) ->
                                                       let action_params2 =
                                                         FStar_Syntax_Subst.close_binders
                                                           action_params1 in
-                                                      let uu____24207 =
+                                                      let uu____24204 =
                                                         FStar_Syntax_DsEnv.qualify
                                                           env3 name in
-                                                      let uu____24208 =
-                                                        let uu____24209 =
+                                                      let uu____24205 =
+                                                        let uu____24206 =
                                                           desugar_term env3
                                                             def in
                                                         FStar_Syntax_Subst.close
                                                           (FStar_List.append
                                                              binders1
                                                              action_params2)
-                                                          uu____24209 in
-                                                      let uu____24216 =
-                                                        let uu____24217 =
+                                                          uu____24206 in
+                                                      let uu____24213 =
+                                                        let uu____24214 =
                                                           desugar_typ env3
                                                             cps_type in
                                                         FStar_Syntax_Subst.close
                                                           (FStar_List.append
                                                              binders1
                                                              action_params2)
-                                                          uu____24217 in
+                                                          uu____24214 in
                                                       {
                                                         FStar_Syntax_Syntax.action_name
-                                                          = uu____24207;
+                                                          = uu____24204;
                                                         FStar_Syntax_Syntax.action_unqualified_name
                                                           = name;
                                                         FStar_Syntax_Syntax.action_univs
@@ -6259,40 +6263,40 @@ let rec (desugar_effect :
                                                         FStar_Syntax_Syntax.action_params
                                                           = action_params2;
                                                         FStar_Syntax_Syntax.action_defn
-                                                          = uu____24208;
+                                                          = uu____24205;
                                                         FStar_Syntax_Syntax.action_typ
-                                                          = uu____24216
+                                                          = uu____24213
                                                       })
                                              | FStar_Parser_AST.Tycon
-                                                 (uu____24224, uu____24225,
+                                                 (uu____24221, uu____24222,
                                                   (FStar_Parser_AST.TyconAbbrev
                                                   (name, action_params,
-                                                   uu____24228, defn))::[])
+                                                   uu____24225, defn))::[])
                                                  when for_free || is_layered
                                                  ->
-                                                 let uu____24240 =
+                                                 let uu____24237 =
                                                    desugar_binders env2
                                                      action_params in
-                                                 (match uu____24240 with
+                                                 (match uu____24237 with
                                                   | (env3, action_params1) ->
                                                       let action_params2 =
                                                         FStar_Syntax_Subst.close_binders
                                                           action_params1 in
-                                                      let uu____24272 =
+                                                      let uu____24269 =
                                                         FStar_Syntax_DsEnv.qualify
                                                           env3 name in
-                                                      let uu____24273 =
-                                                        let uu____24274 =
+                                                      let uu____24270 =
+                                                        let uu____24271 =
                                                           desugar_term env3
                                                             defn in
                                                         FStar_Syntax_Subst.close
                                                           (FStar_List.append
                                                              binders1
                                                              action_params2)
-                                                          uu____24274 in
+                                                          uu____24271 in
                                                       {
                                                         FStar_Syntax_Syntax.action_name
-                                                          = uu____24272;
+                                                          = uu____24269;
                                                         FStar_Syntax_Syntax.action_unqualified_name
                                                           = name;
                                                         FStar_Syntax_Syntax.action_univs
@@ -6300,12 +6304,12 @@ let rec (desugar_effect :
                                                         FStar_Syntax_Syntax.action_params
                                                           = action_params2;
                                                         FStar_Syntax_Syntax.action_defn
-                                                          = uu____24273;
+                                                          = uu____24270;
                                                         FStar_Syntax_Syntax.action_typ
                                                           =
                                                           FStar_Syntax_Syntax.tun
                                                       })
-                                             | uu____24281 ->
+                                             | uu____24278 ->
                                                  FStar_Errors.raise_error
                                                    (FStar_Errors.Fatal_MalformedActionDeclaration,
                                                      "Malformed action declaration; if this is an \"effect for free\", just provide the direct-style declaration. If this is not an \"effect for free\", please provide a pair of the definition and its cps-type with arrows inserted in the right place (see examples).")
@@ -6314,20 +6318,20 @@ let rec (desugar_effect :
                                      FStar_Syntax_Subst.close binders1 eff_t in
                                    let lookup s =
                                      let l =
-                                       let uu____24296 =
+                                       let uu____24293 =
                                          FStar_Ident.mk_ident
                                            (s, (d.FStar_Parser_AST.drange)) in
                                        FStar_Syntax_DsEnv.qualify env2
-                                         uu____24296 in
-                                     let uu____24297 =
-                                       let uu____24298 =
+                                         uu____24293 in
+                                     let uu____24294 =
+                                       let uu____24295 =
                                          FStar_Syntax_DsEnv.fail_or env2
                                            (FStar_Syntax_DsEnv.try_lookup_definition
                                               env2) l in
                                        FStar_All.pipe_left
                                          (FStar_Syntax_Subst.close binders1)
-                                         uu____24298 in
-                                     ([], uu____24297) in
+                                         uu____24295 in
+                                     ([], uu____24294) in
                                    let mname =
                                      FStar_Syntax_DsEnv.qualify env0 eff_name in
                                    let qualifiers =
@@ -6340,19 +6344,19 @@ let rec (desugar_effect :
                                    let combinators =
                                      if for_free
                                      then
-                                       let uu____24319 =
-                                         let uu____24320 =
-                                           let uu____24323 = lookup "repr" in
+                                       let uu____24316 =
+                                         let uu____24317 =
+                                           let uu____24320 = lookup "repr" in
                                            FStar_Pervasives_Native.Some
-                                             uu____24323 in
-                                         let uu____24324 =
-                                           let uu____24327 = lookup "return" in
+                                             uu____24320 in
+                                         let uu____24321 =
+                                           let uu____24324 = lookup "return" in
                                            FStar_Pervasives_Native.Some
-                                             uu____24327 in
-                                         let uu____24328 =
-                                           let uu____24331 = lookup "bind" in
+                                             uu____24324 in
+                                         let uu____24325 =
+                                           let uu____24328 = lookup "bind" in
                                            FStar_Pervasives_Native.Some
-                                             uu____24331 in
+                                             uu____24328 in
                                          {
                                            FStar_Syntax_Syntax.ret_wp =
                                              dummy_tscheme;
@@ -6369,162 +6373,162 @@ let rec (desugar_effect :
                                            FStar_Syntax_Syntax.trivial =
                                              dummy_tscheme;
                                            FStar_Syntax_Syntax.repr =
-                                             uu____24320;
+                                             uu____24317;
                                            FStar_Syntax_Syntax.return_repr =
-                                             uu____24324;
+                                             uu____24321;
                                            FStar_Syntax_Syntax.bind_repr =
-                                             uu____24328
+                                             uu____24325
                                          } in
                                        FStar_Syntax_Syntax.DM4F_eff
-                                         uu____24319
+                                         uu____24316
                                      else
                                        if is_layered
                                        then
                                          (let has_subcomp =
                                             FStar_List.existsb
                                               (fun decl ->
-                                                 let uu____24337 =
+                                                 let uu____24334 =
                                                    name_of_eff_decl decl in
-                                                 uu____24337 = "subcomp")
+                                                 uu____24334 = "subcomp")
                                               eff_decls in
                                           let has_if_then_else =
                                             FStar_List.existsb
                                               (fun decl ->
-                                                 let uu____24342 =
+                                                 let uu____24339 =
                                                    name_of_eff_decl decl in
-                                                 uu____24342 = "if_then_else")
+                                                 uu____24339 = "if_then_else")
                                               eff_decls in
-                                          let to_comb uu____24372 =
-                                            match uu____24372 with
+                                          let to_comb uu____24369 =
+                                            match uu____24369 with
                                             | (us, t) ->
                                                 ((us, t), dummy_tscheme) in
-                                          let uu____24419 =
-                                            let uu____24420 =
-                                              let uu____24425 = lookup "repr" in
+                                          let uu____24416 =
+                                            let uu____24417 =
+                                              let uu____24422 = lookup "repr" in
                                               FStar_All.pipe_right
-                                                uu____24425 to_comb in
-                                            let uu____24442 =
-                                              let uu____24447 =
+                                                uu____24422 to_comb in
+                                            let uu____24439 =
+                                              let uu____24444 =
                                                 lookup "return" in
                                               FStar_All.pipe_right
-                                                uu____24447 to_comb in
-                                            let uu____24464 =
-                                              let uu____24469 = lookup "bind" in
+                                                uu____24444 to_comb in
+                                            let uu____24461 =
+                                              let uu____24466 = lookup "bind" in
                                               FStar_All.pipe_right
-                                                uu____24469 to_comb in
-                                            let uu____24486 =
+                                                uu____24466 to_comb in
+                                            let uu____24483 =
                                               if has_subcomp
                                               then
-                                                let uu____24495 =
+                                                let uu____24492 =
                                                   lookup "subcomp" in
                                                 FStar_All.pipe_right
-                                                  uu____24495 to_comb
+                                                  uu____24492 to_comb
                                               else
                                                 (dummy_tscheme,
                                                   dummy_tscheme) in
-                                            let uu____24513 =
+                                            let uu____24510 =
                                               if has_if_then_else
                                               then
-                                                let uu____24522 =
+                                                let uu____24519 =
                                                   lookup "if_then_else" in
                                                 FStar_All.pipe_right
-                                                  uu____24522 to_comb
+                                                  uu____24519 to_comb
                                               else
                                                 (dummy_tscheme,
                                                   dummy_tscheme) in
                                             {
                                               FStar_Syntax_Syntax.l_repr =
-                                                uu____24420;
+                                                uu____24417;
                                               FStar_Syntax_Syntax.l_return =
-                                                uu____24442;
+                                                uu____24439;
                                               FStar_Syntax_Syntax.l_bind =
-                                                uu____24464;
+                                                uu____24461;
                                               FStar_Syntax_Syntax.l_subcomp =
-                                                uu____24486;
+                                                uu____24483;
                                               FStar_Syntax_Syntax.l_if_then_else
-                                                = uu____24513
+                                                = uu____24510
                                             } in
                                           FStar_Syntax_Syntax.Layered_eff
-                                            uu____24419)
+                                            uu____24416)
                                        else
                                          (let rr =
                                             FStar_Util.for_some
-                                              (fun uu___26_24543 ->
-                                                 match uu___26_24543 with
+                                              (fun uu___26_24540 ->
+                                                 match uu___26_24540 with
                                                  | FStar_Syntax_Syntax.Reifiable
                                                      -> true
                                                  | FStar_Syntax_Syntax.Reflectable
-                                                     uu____24544 -> true
-                                                 | uu____24545 -> false)
+                                                     uu____24541 -> true
+                                                 | uu____24542 -> false)
                                               qualifiers in
-                                          let uu____24546 =
-                                            let uu____24547 =
+                                          let uu____24543 =
+                                            let uu____24544 =
                                               lookup "return_wp" in
-                                            let uu____24548 =
+                                            let uu____24545 =
                                               lookup "bind_wp" in
-                                            let uu____24549 =
+                                            let uu____24546 =
                                               lookup "stronger" in
-                                            let uu____24550 =
+                                            let uu____24547 =
                                               lookup "if_then_else" in
-                                            let uu____24551 = lookup "ite_wp" in
-                                            let uu____24552 =
+                                            let uu____24548 = lookup "ite_wp" in
+                                            let uu____24549 =
                                               lookup "close_wp" in
-                                            let uu____24553 =
+                                            let uu____24550 =
                                               lookup "trivial" in
-                                            let uu____24554 =
+                                            let uu____24551 =
                                               if rr
                                               then
-                                                let uu____24559 =
+                                                let uu____24556 =
                                                   lookup "repr" in
                                                 FStar_Pervasives_Native.Some
-                                                  uu____24559
+                                                  uu____24556
                                               else
                                                 FStar_Pervasives_Native.None in
-                                            let uu____24561 =
+                                            let uu____24558 =
                                               if rr
                                               then
-                                                let uu____24566 =
+                                                let uu____24563 =
                                                   lookup "return" in
                                                 FStar_Pervasives_Native.Some
-                                                  uu____24566
+                                                  uu____24563
                                               else
                                                 FStar_Pervasives_Native.None in
-                                            let uu____24568 =
+                                            let uu____24565 =
                                               if rr
                                               then
-                                                let uu____24573 =
+                                                let uu____24570 =
                                                   lookup "bind" in
                                                 FStar_Pervasives_Native.Some
-                                                  uu____24573
+                                                  uu____24570
                                               else
                                                 FStar_Pervasives_Native.None in
                                             {
                                               FStar_Syntax_Syntax.ret_wp =
-                                                uu____24547;
+                                                uu____24544;
                                               FStar_Syntax_Syntax.bind_wp =
-                                                uu____24548;
+                                                uu____24545;
                                               FStar_Syntax_Syntax.stronger =
-                                                uu____24549;
+                                                uu____24546;
                                               FStar_Syntax_Syntax.if_then_else
-                                                = uu____24550;
+                                                = uu____24547;
                                               FStar_Syntax_Syntax.ite_wp =
-                                                uu____24551;
+                                                uu____24548;
                                               FStar_Syntax_Syntax.close_wp =
-                                                uu____24552;
+                                                uu____24549;
                                               FStar_Syntax_Syntax.trivial =
-                                                uu____24553;
+                                                uu____24550;
                                               FStar_Syntax_Syntax.repr =
-                                                uu____24554;
+                                                uu____24551;
                                               FStar_Syntax_Syntax.return_repr
-                                                = uu____24561;
+                                                = uu____24558;
                                               FStar_Syntax_Syntax.bind_repr =
-                                                uu____24568
+                                                uu____24565
                                             } in
                                           FStar_Syntax_Syntax.Primitive_eff
-                                            uu____24546) in
+                                            uu____24543) in
                                    let sigel =
-                                     let uu____24576 =
-                                       let uu____24577 =
+                                     let uu____24573 =
+                                       let uu____24574 =
                                          FStar_List.map (desugar_term env2)
                                            attrs in
                                        {
@@ -6540,10 +6544,10 @@ let rec (desugar_effect :
                                          FStar_Syntax_Syntax.actions =
                                            actions1;
                                          FStar_Syntax_Syntax.eff_attrs =
-                                           uu____24577
+                                           uu____24574
                                        } in
                                      FStar_Syntax_Syntax.Sig_new_effect
-                                       uu____24576 in
+                                       uu____24573 in
                                    let se =
                                      {
                                        FStar_Syntax_Syntax.sigel = sigel;
@@ -6564,12 +6568,12 @@ let rec (desugar_effect :
                                        (FStar_List.fold_left
                                           (fun env4 ->
                                              fun a ->
-                                               let uu____24594 =
+                                               let uu____24591 =
                                                  FStar_Syntax_Util.action_as_lb
                                                    mname a
                                                    (a.FStar_Syntax_Syntax.action_defn).FStar_Syntax_Syntax.pos in
                                                FStar_Syntax_DsEnv.push_sigelt
-                                                 env4 uu____24594) env3) in
+                                                 env4 uu____24591) env3) in
                                    let env5 =
                                      push_reflect_effect env4 qualifiers
                                        mname d.FStar_Parser_AST.drange in
@@ -6596,50 +6600,50 @@ and (desugar_redefine_effect :
               fun defn ->
                 let env0 = env in
                 let env1 = FStar_Syntax_DsEnv.enter_monad_scope env eff_name in
-                let uu____24617 = desugar_binders env1 eff_binders in
-                match uu____24617 with
+                let uu____24614 = desugar_binders env1 eff_binders in
+                match uu____24614 with
                 | (env2, binders) ->
-                    let uu____24654 =
-                      let uu____24665 = head_and_args defn in
-                      match uu____24665 with
+                    let uu____24651 =
+                      let uu____24662 = head_and_args defn in
+                      match uu____24662 with
                       | (head, args) ->
                           let lid =
                             match head.FStar_Parser_AST.tm with
                             | FStar_Parser_AST.Name l -> l
-                            | uu____24702 ->
-                                let uu____24703 =
-                                  let uu____24708 =
-                                    let uu____24709 =
-                                      let uu____24710 =
+                            | uu____24699 ->
+                                let uu____24700 =
+                                  let uu____24705 =
+                                    let uu____24706 =
+                                      let uu____24707 =
                                         FStar_Parser_AST.term_to_string head in
-                                      Prims.op_Hat uu____24710 " not found" in
-                                    Prims.op_Hat "Effect " uu____24709 in
+                                      Prims.op_Hat uu____24707 " not found" in
+                                    Prims.op_Hat "Effect " uu____24706 in
                                   (FStar_Errors.Fatal_EffectNotFound,
-                                    uu____24708) in
-                                FStar_Errors.raise_error uu____24703
+                                    uu____24705) in
+                                FStar_Errors.raise_error uu____24700
                                   d.FStar_Parser_AST.drange in
                           let ed =
                             FStar_Syntax_DsEnv.fail_or env2
                               (FStar_Syntax_DsEnv.try_lookup_effect_defn env2)
                               lid in
-                          let uu____24712 =
+                          let uu____24709 =
                             match FStar_List.rev args with
-                            | (last_arg, uu____24742)::args_rev ->
-                                let uu____24754 =
-                                  let uu____24755 = unparen last_arg in
-                                  uu____24755.FStar_Parser_AST.tm in
-                                (match uu____24754 with
+                            | (last_arg, uu____24739)::args_rev ->
+                                let uu____24751 =
+                                  let uu____24752 = unparen last_arg in
+                                  uu____24752.FStar_Parser_AST.tm in
+                                (match uu____24751 with
                                  | FStar_Parser_AST.Attributes ts ->
                                      (ts, (FStar_List.rev args_rev))
-                                 | uu____24783 -> ([], args))
-                            | uu____24792 -> ([], args) in
-                          (match uu____24712 with
+                                 | uu____24780 -> ([], args))
+                            | uu____24789 -> ([], args) in
+                          (match uu____24709 with
                            | (cattributes, args1) ->
-                               let uu____24835 = desugar_args env2 args1 in
-                               let uu____24836 =
+                               let uu____24832 = desugar_args env2 args1 in
+                               let uu____24833 =
                                  desugar_attributes env2 cattributes in
-                               (lid, ed, uu____24835, uu____24836)) in
-                    (match uu____24654 with
+                               (lid, ed, uu____24832, uu____24833)) in
+                    (match uu____24651 with
                      | (ed_lid, ed, args, cattributes) ->
                          let binders1 =
                            FStar_Syntax_Subst.close_binders binders in
@@ -6653,65 +6657,65 @@ and (desugar_redefine_effect :
                                 "Unexpected number of arguments to effect constructor")
                               defn.FStar_Parser_AST.range
                           else ();
-                          (let uu____24872 =
+                          (let uu____24869 =
                              FStar_Syntax_Subst.open_term'
                                ed.FStar_Syntax_Syntax.binders
                                FStar_Syntax_Syntax.t_unit in
-                           match uu____24872 with
-                           | (ed_binders, uu____24886, ed_binders_opening) ->
-                               let sub' shift_n uu____24904 =
-                                 match uu____24904 with
+                           match uu____24869 with
+                           | (ed_binders, uu____24883, ed_binders_opening) ->
+                               let sub' shift_n uu____24901 =
+                                 match uu____24901 with
                                  | (us, x) ->
                                      let x1 =
-                                       let uu____24918 =
+                                       let uu____24915 =
                                          FStar_Syntax_Subst.shift_subst
                                            (shift_n + (FStar_List.length us))
                                            ed_binders_opening in
-                                       FStar_Syntax_Subst.subst uu____24918 x in
+                                       FStar_Syntax_Subst.subst uu____24915 x in
                                      let s =
                                        FStar_Syntax_Util.subst_of_list
                                          ed_binders args in
-                                     let uu____24922 =
-                                       let uu____24923 =
+                                     let uu____24919 =
+                                       let uu____24920 =
                                          FStar_Syntax_Subst.subst s x1 in
-                                       (us, uu____24923) in
+                                       (us, uu____24920) in
                                      FStar_Syntax_Subst.close_tscheme
-                                       binders1 uu____24922 in
+                                       binders1 uu____24919 in
                                let sub = sub' Prims.int_zero in
                                let mname =
                                  FStar_Syntax_DsEnv.qualify env0 eff_name in
                                let ed1 =
-                                 let uu____24943 =
+                                 let uu____24940 =
                                    sub ed.FStar_Syntax_Syntax.signature in
-                                 let uu____24944 =
+                                 let uu____24941 =
                                    FStar_Syntax_Util.apply_eff_combinators
                                      sub ed.FStar_Syntax_Syntax.combinators in
-                                 let uu____24945 =
+                                 let uu____24942 =
                                    FStar_List.map
                                      (fun action ->
                                         let nparam =
                                           FStar_List.length
                                             action.FStar_Syntax_Syntax.action_params in
-                                        let uu____24961 =
+                                        let uu____24958 =
                                           FStar_Syntax_DsEnv.qualify env2
                                             action.FStar_Syntax_Syntax.action_unqualified_name in
-                                        let uu____24962 =
-                                          let uu____24963 =
+                                        let uu____24959 =
+                                          let uu____24960 =
                                             sub' nparam
                                               ([],
                                                 (action.FStar_Syntax_Syntax.action_defn)) in
                                           FStar_Pervasives_Native.snd
-                                            uu____24963 in
-                                        let uu____24978 =
-                                          let uu____24979 =
+                                            uu____24960 in
+                                        let uu____24975 =
+                                          let uu____24976 =
                                             sub' nparam
                                               ([],
                                                 (action.FStar_Syntax_Syntax.action_typ)) in
                                           FStar_Pervasives_Native.snd
-                                            uu____24979 in
+                                            uu____24976 in
                                         {
                                           FStar_Syntax_Syntax.action_name =
-                                            uu____24961;
+                                            uu____24958;
                                           FStar_Syntax_Syntax.action_unqualified_name
                                             =
                                             (action.FStar_Syntax_Syntax.action_unqualified_name);
@@ -6720,9 +6724,9 @@ and (desugar_redefine_effect :
                                           FStar_Syntax_Syntax.action_params =
                                             (action.FStar_Syntax_Syntax.action_params);
                                           FStar_Syntax_Syntax.action_defn =
-                                            uu____24962;
+                                            uu____24959;
                                           FStar_Syntax_Syntax.action_typ =
-                                            uu____24978
+                                            uu____24975
                                         }) ed.FStar_Syntax_Syntax.actions in
                                  {
                                    FStar_Syntax_Syntax.mname = mname;
@@ -6732,25 +6736,25 @@ and (desugar_redefine_effect :
                                      (ed.FStar_Syntax_Syntax.univs);
                                    FStar_Syntax_Syntax.binders = binders1;
                                    FStar_Syntax_Syntax.signature =
-                                     uu____24943;
+                                     uu____24940;
                                    FStar_Syntax_Syntax.combinators =
-                                     uu____24944;
-                                   FStar_Syntax_Syntax.actions = uu____24945;
+                                     uu____24941;
+                                   FStar_Syntax_Syntax.actions = uu____24942;
                                    FStar_Syntax_Syntax.eff_attrs =
                                      (ed.FStar_Syntax_Syntax.eff_attrs)
                                  } in
                                let se =
-                                 let uu____24995 =
-                                   let uu____24998 =
+                                 let uu____24992 =
+                                   let uu____24995 =
                                      trans_qual1
                                        (FStar_Pervasives_Native.Some mname) in
-                                   FStar_List.map uu____24998 quals in
+                                   FStar_List.map uu____24995 quals in
                                  {
                                    FStar_Syntax_Syntax.sigel =
                                      (FStar_Syntax_Syntax.Sig_new_effect ed1);
                                    FStar_Syntax_Syntax.sigrng =
                                      (d.FStar_Parser_AST.drange);
-                                   FStar_Syntax_Syntax.sigquals = uu____24995;
+                                   FStar_Syntax_Syntax.sigquals = uu____24992;
                                    FStar_Syntax_Syntax.sigmeta =
                                      FStar_Syntax_Syntax.default_sigmeta;
                                    FStar_Syntax_Syntax.sigattrs = [];
@@ -6766,23 +6770,23 @@ and (desugar_redefine_effect :
                                    (FStar_List.fold_left
                                       (fun env4 ->
                                          fun a ->
-                                           let uu____25013 =
+                                           let uu____25010 =
                                              FStar_Syntax_Util.action_as_lb
                                                mname a
                                                (a.FStar_Syntax_Syntax.action_defn).FStar_Syntax_Syntax.pos in
                                            FStar_Syntax_DsEnv.push_sigelt
-                                             env4 uu____25013) env3) in
+                                             env4 uu____25010) env3) in
                                let env5 =
-                                 let uu____25015 =
+                                 let uu____25012 =
                                    FStar_All.pipe_right quals
                                      (FStar_List.contains
                                         FStar_Parser_AST.Reflectable) in
-                                 if uu____25015
+                                 if uu____25012
                                  then
                                    let reflect_lid =
-                                     let uu____25019 =
+                                     let uu____25016 =
                                        FStar_Ident.id_of_text "reflect" in
-                                     FStar_All.pipe_right uu____25019
+                                     FStar_All.pipe_right uu____25016
                                        (FStar_Syntax_DsEnv.qualify monad_env) in
                                    let quals1 =
                                      [FStar_Syntax_Syntax.Assumption;
@@ -6815,52 +6819,52 @@ and (desugar_decl_aux :
       let no_fail_attrs ats =
         FStar_List.filter
           (fun at ->
-             let uu____25050 = get_fail_attr1 false at in
-             FStar_Option.isNone uu____25050) ats in
+             let uu____25047 = get_fail_attr1 false at in
+             FStar_Option.isNone uu____25047) ats in
       let env0 =
-        let uu____25066 = FStar_Syntax_DsEnv.snapshot env in
-        FStar_All.pipe_right uu____25066 FStar_Pervasives_Native.snd in
+        let uu____25063 = FStar_Syntax_DsEnv.snapshot env in
+        FStar_All.pipe_right uu____25063 FStar_Pervasives_Native.snd in
       let attrs = FStar_List.map (desugar_term env) d.FStar_Parser_AST.attrs in
-      let uu____25078 =
-        let uu____25085 = get_fail_attr false attrs in
-        match uu____25085 with
+      let uu____25075 =
+        let uu____25082 = get_fail_attr false attrs in
+        match uu____25082 with
         | FStar_Pervasives_Native.Some (expected_errs, lax) ->
             let d1 =
-              let uu___3391_25113 = d in
+              let uu___3392_25110 = d in
               {
-                FStar_Parser_AST.d = (uu___3391_25113.FStar_Parser_AST.d);
+                FStar_Parser_AST.d = (uu___3392_25110.FStar_Parser_AST.d);
                 FStar_Parser_AST.drange =
-                  (uu___3391_25113.FStar_Parser_AST.drange);
+                  (uu___3392_25110.FStar_Parser_AST.drange);
                 FStar_Parser_AST.quals =
-                  (uu___3391_25113.FStar_Parser_AST.quals);
+                  (uu___3392_25110.FStar_Parser_AST.quals);
                 FStar_Parser_AST.attrs = []
               } in
-            let uu____25114 =
+            let uu____25111 =
               FStar_Errors.catch_errors
-                (fun uu____25132 ->
+                (fun uu____25129 ->
                    FStar_Options.with_saved_options
-                     (fun uu____25138 -> desugar_decl_noattrs env d1)) in
-            (match uu____25114 with
+                     (fun uu____25135 -> desugar_decl_noattrs env d1)) in
+            (match uu____25111 with
              | (errs, r) ->
                  (match (errs, r) with
                   | ([], FStar_Pervasives_Native.Some (env1, ses)) ->
                       let ses1 =
                         FStar_List.map
                           (fun se ->
-                             let uu___3406_25198 = se in
-                             let uu____25199 = no_fail_attrs attrs in
+                             let uu___3407_25195 = se in
+                             let uu____25196 = no_fail_attrs attrs in
                              {
                                FStar_Syntax_Syntax.sigel =
-                                 (uu___3406_25198.FStar_Syntax_Syntax.sigel);
+                                 (uu___3407_25195.FStar_Syntax_Syntax.sigel);
                                FStar_Syntax_Syntax.sigrng =
-                                 (uu___3406_25198.FStar_Syntax_Syntax.sigrng);
+                                 (uu___3407_25195.FStar_Syntax_Syntax.sigrng);
                                FStar_Syntax_Syntax.sigquals =
-                                 (uu___3406_25198.FStar_Syntax_Syntax.sigquals);
+                                 (uu___3407_25195.FStar_Syntax_Syntax.sigquals);
                                FStar_Syntax_Syntax.sigmeta =
-                                 (uu___3406_25198.FStar_Syntax_Syntax.sigmeta);
-                               FStar_Syntax_Syntax.sigattrs = uu____25199;
+                                 (uu___3407_25195.FStar_Syntax_Syntax.sigmeta);
+                               FStar_Syntax_Syntax.sigattrs = uu____25196;
                                FStar_Syntax_Syntax.sigopts =
-                                 (uu___3406_25198.FStar_Syntax_Syntax.sigopts)
+                                 (uu___3407_25195.FStar_Syntax_Syntax.sigopts)
                              }) ses in
                       let se =
                         {
@@ -6886,118 +6890,118 @@ and (desugar_decl_aux :
                       if expected_errs = []
                       then (env0, [])
                       else
-                        (let uu____25243 =
+                        (let uu____25240 =
                            FStar_Errors.find_multiset_discrepancy
                              expected_errs errnos in
-                         match uu____25243 with
+                         match uu____25240 with
                          | FStar_Pervasives_Native.None -> (env0, [])
                          | FStar_Pervasives_Native.Some (e, n1, n2) ->
                              (FStar_List.iter FStar_Errors.print_issue errs1;
-                              (let uu____25277 =
-                                 let uu____25282 =
-                                   let uu____25283 =
+                              (let uu____25274 =
+                                 let uu____25279 =
+                                   let uu____25280 =
                                      FStar_Common.string_of_list
                                        FStar_Util.string_of_int expected_errs in
-                                   let uu____25284 =
+                                   let uu____25281 =
                                      FStar_Common.string_of_list
                                        FStar_Util.string_of_int errnos in
-                                   let uu____25285 =
+                                   let uu____25282 =
                                      FStar_Util.string_of_int e in
-                                   let uu____25286 =
+                                   let uu____25283 =
                                      FStar_Util.string_of_int n2 in
-                                   let uu____25287 =
+                                   let uu____25284 =
                                      FStar_Util.string_of_int n1 in
                                    FStar_Util.format5
                                      "This top-level definition was expected to raise error codes %s, but it raised %s (at desugaring time). Error #%s was raised %s times, instead of %s."
-                                     uu____25283 uu____25284 uu____25285
-                                     uu____25286 uu____25287 in
-                                 (FStar_Errors.Error_DidNotFail, uu____25282) in
+                                     uu____25280 uu____25281 uu____25282
+                                     uu____25283 uu____25284 in
+                                 (FStar_Errors.Error_DidNotFail, uu____25279) in
                                FStar_Errors.log_issue
-                                 d1.FStar_Parser_AST.drange uu____25277);
+                                 d1.FStar_Parser_AST.drange uu____25274);
                               (env0, [])))))
         | FStar_Pervasives_Native.None -> desugar_decl_noattrs env d in
-      match uu____25078 with
+      match uu____25075 with
       | (env1, sigelts) ->
           let rec val_attrs ses =
             match ses with
             | {
                 FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_let
-                  uu____25320;
-                FStar_Syntax_Syntax.sigrng = uu____25321;
-                FStar_Syntax_Syntax.sigquals = uu____25322;
-                FStar_Syntax_Syntax.sigmeta = uu____25323;
-                FStar_Syntax_Syntax.sigattrs = uu____25324;
-                FStar_Syntax_Syntax.sigopts = uu____25325;_}::[] ->
-                let uu____25338 =
-                  let uu____25341 = FStar_List.hd sigelts in
-                  FStar_Syntax_Util.lids_of_sigelt uu____25341 in
-                FStar_All.pipe_right uu____25338
+                  uu____25317;
+                FStar_Syntax_Syntax.sigrng = uu____25318;
+                FStar_Syntax_Syntax.sigquals = uu____25319;
+                FStar_Syntax_Syntax.sigmeta = uu____25320;
+                FStar_Syntax_Syntax.sigattrs = uu____25321;
+                FStar_Syntax_Syntax.sigopts = uu____25322;_}::[] ->
+                let uu____25335 =
+                  let uu____25338 = FStar_List.hd sigelts in
+                  FStar_Syntax_Util.lids_of_sigelt uu____25338 in
+                FStar_All.pipe_right uu____25335
                   (FStar_List.collect
                      (fun nm ->
-                        let uu____25349 =
+                        let uu____25346 =
                           FStar_Syntax_DsEnv.lookup_letbinding_quals_and_attrs
                             env0 nm in
-                        FStar_Pervasives_Native.snd uu____25349))
+                        FStar_Pervasives_Native.snd uu____25346))
             | {
                 FStar_Syntax_Syntax.sigel =
-                  FStar_Syntax_Syntax.Sig_inductive_typ uu____25362;
-                FStar_Syntax_Syntax.sigrng = uu____25363;
-                FStar_Syntax_Syntax.sigquals = uu____25364;
-                FStar_Syntax_Syntax.sigmeta = uu____25365;
-                FStar_Syntax_Syntax.sigattrs = uu____25366;
-                FStar_Syntax_Syntax.sigopts = uu____25367;_}::uu____25368 ->
-                let uu____25393 =
-                  let uu____25396 = FStar_List.hd sigelts in
-                  FStar_Syntax_Util.lids_of_sigelt uu____25396 in
-                FStar_All.pipe_right uu____25393
+                  FStar_Syntax_Syntax.Sig_inductive_typ uu____25359;
+                FStar_Syntax_Syntax.sigrng = uu____25360;
+                FStar_Syntax_Syntax.sigquals = uu____25361;
+                FStar_Syntax_Syntax.sigmeta = uu____25362;
+                FStar_Syntax_Syntax.sigattrs = uu____25363;
+                FStar_Syntax_Syntax.sigopts = uu____25364;_}::uu____25365 ->
+                let uu____25390 =
+                  let uu____25393 = FStar_List.hd sigelts in
+                  FStar_Syntax_Util.lids_of_sigelt uu____25393 in
+                FStar_All.pipe_right uu____25390
                   (FStar_List.collect
                      (fun nm ->
-                        let uu____25404 =
+                        let uu____25401 =
                           FStar_Syntax_DsEnv.lookup_letbinding_quals_and_attrs
                             env0 nm in
-                        FStar_Pervasives_Native.snd uu____25404))
+                        FStar_Pervasives_Native.snd uu____25401))
             | {
                 FStar_Syntax_Syntax.sigel = FStar_Syntax_Syntax.Sig_fail
                   (_errs, _lax, ses1);
-                FStar_Syntax_Syntax.sigrng = uu____25420;
-                FStar_Syntax_Syntax.sigquals = uu____25421;
-                FStar_Syntax_Syntax.sigmeta = uu____25422;
-                FStar_Syntax_Syntax.sigattrs = uu____25423;
-                FStar_Syntax_Syntax.sigopts = uu____25424;_}::[] ->
+                FStar_Syntax_Syntax.sigrng = uu____25417;
+                FStar_Syntax_Syntax.sigquals = uu____25418;
+                FStar_Syntax_Syntax.sigmeta = uu____25419;
+                FStar_Syntax_Syntax.sigattrs = uu____25420;
+                FStar_Syntax_Syntax.sigopts = uu____25421;_}::[] ->
                 FStar_List.collect (fun se -> val_attrs [se]) ses1
-            | uu____25441 -> [] in
+            | uu____25438 -> [] in
           let attrs1 =
-            let uu____25447 = val_attrs sigelts in
-            FStar_List.append attrs uu____25447 in
-          let uu____25450 =
+            let uu____25444 = val_attrs sigelts in
+            FStar_List.append attrs uu____25444 in
+          let uu____25447 =
             FStar_List.map
               (fun sigelt ->
-                 let uu___3466_25454 = sigelt in
+                 let uu___3467_25451 = sigelt in
                  {
                    FStar_Syntax_Syntax.sigel =
-                     (uu___3466_25454.FStar_Syntax_Syntax.sigel);
+                     (uu___3467_25451.FStar_Syntax_Syntax.sigel);
                    FStar_Syntax_Syntax.sigrng =
-                     (uu___3466_25454.FStar_Syntax_Syntax.sigrng);
+                     (uu___3467_25451.FStar_Syntax_Syntax.sigrng);
                    FStar_Syntax_Syntax.sigquals =
-                     (uu___3466_25454.FStar_Syntax_Syntax.sigquals);
+                     (uu___3467_25451.FStar_Syntax_Syntax.sigquals);
                    FStar_Syntax_Syntax.sigmeta =
-                     (uu___3466_25454.FStar_Syntax_Syntax.sigmeta);
+                     (uu___3467_25451.FStar_Syntax_Syntax.sigmeta);
                    FStar_Syntax_Syntax.sigattrs = attrs1;
                    FStar_Syntax_Syntax.sigopts =
-                     (uu___3466_25454.FStar_Syntax_Syntax.sigopts)
+                     (uu___3467_25451.FStar_Syntax_Syntax.sigopts)
                  }) sigelts in
-          (env1, uu____25450)
+          (env1, uu____25447)
 and (desugar_decl :
   env_t -> FStar_Parser_AST.decl -> (env_t * FStar_Syntax_Syntax.sigelts)) =
   fun env ->
     fun d ->
-      let uu____25461 = desugar_decl_aux env d in
-      match uu____25461 with
+      let uu____25458 = desugar_decl_aux env d in
+      match uu____25458 with
       | (env1, ses) ->
-          let uu____25472 =
+          let uu____25469 =
             FStar_All.pipe_right ses
               (FStar_List.map generalize_annotated_univs) in
-          (env1, uu____25472)
+          (env1, uu____25469)
 and (desugar_decl_noattrs :
   FStar_Syntax_DsEnv.env ->
     FStar_Parser_AST.decl -> (env_t * FStar_Syntax_Syntax.sigelts))
@@ -7025,47 +7029,47 @@ and (desugar_decl_noattrs :
       | FStar_Parser_AST.Open lid ->
           let env1 = FStar_Syntax_DsEnv.push_namespace env lid in (env1, [])
       | FStar_Parser_AST.Friend lid ->
-          let uu____25504 = FStar_Syntax_DsEnv.iface env in
-          if uu____25504
+          let uu____25501 = FStar_Syntax_DsEnv.iface env in
+          if uu____25501
           then
             FStar_Errors.raise_error
               (FStar_Errors.Fatal_FriendInterface,
                 "'friend' declarations are not allowed in interfaces")
               d.FStar_Parser_AST.drange
           else
-            (let uu____25514 =
-               let uu____25515 =
-                 let uu____25516 = FStar_Syntax_DsEnv.dep_graph env in
-                 let uu____25517 = FStar_Syntax_DsEnv.current_module env in
-                 FStar_Parser_Dep.module_has_interface uu____25516
-                   uu____25517 in
-               Prims.op_Negation uu____25515 in
-             if uu____25514
+            (let uu____25511 =
+               let uu____25512 =
+                 let uu____25513 = FStar_Syntax_DsEnv.dep_graph env in
+                 let uu____25514 = FStar_Syntax_DsEnv.current_module env in
+                 FStar_Parser_Dep.module_has_interface uu____25513
+                   uu____25514 in
+               Prims.op_Negation uu____25512 in
+             if uu____25511
              then
                FStar_Errors.raise_error
                  (FStar_Errors.Fatal_FriendInterface,
                    "'friend' declarations are not allowed in modules that lack interfaces")
                  d.FStar_Parser_AST.drange
              else
-               (let uu____25527 =
-                  let uu____25528 =
-                    let uu____25529 = FStar_Syntax_DsEnv.dep_graph env in
-                    FStar_Parser_Dep.module_has_interface uu____25529 lid in
-                  Prims.op_Negation uu____25528 in
-                if uu____25527
+               (let uu____25524 =
+                  let uu____25525 =
+                    let uu____25526 = FStar_Syntax_DsEnv.dep_graph env in
+                    FStar_Parser_Dep.module_has_interface uu____25526 lid in
+                  Prims.op_Negation uu____25525 in
+                if uu____25524
                 then
                   FStar_Errors.raise_error
                     (FStar_Errors.Fatal_FriendInterface,
                       "'friend' declarations cannot refer to modules that lack interfaces")
                     d.FStar_Parser_AST.drange
                 else
-                  (let uu____25539 =
-                     let uu____25540 =
-                       let uu____25541 = FStar_Syntax_DsEnv.dep_graph env in
-                       FStar_Parser_Dep.deps_has_implementation uu____25541
+                  (let uu____25536 =
+                     let uu____25537 =
+                       let uu____25538 = FStar_Syntax_DsEnv.dep_graph env in
+                       FStar_Parser_Dep.deps_has_implementation uu____25538
                          lid in
-                     Prims.op_Negation uu____25540 in
-                   if uu____25539
+                     Prims.op_Negation uu____25537 in
+                   if uu____25536
                    then
                      FStar_Errors.raise_error
                        (FStar_Errors.Fatal_FriendInterface,
@@ -7075,8 +7079,8 @@ and (desugar_decl_noattrs :
       | FStar_Parser_AST.Include lid ->
           let env1 = FStar_Syntax_DsEnv.push_include env lid in (env1, [])
       | FStar_Parser_AST.ModuleAbbrev (x, l) ->
-          let uu____25555 = FStar_Syntax_DsEnv.push_module_abbrev env x l in
-          (uu____25555, [])
+          let uu____25552 = FStar_Syntax_DsEnv.push_module_abbrev env x l in
+          (uu____25552, [])
       | FStar_Parser_AST.Tycon (is_effect, typeclass, tcs) ->
           let quals = d.FStar_Parser_AST.quals in
           let quals1 =
@@ -7087,75 +7091,75 @@ and (desugar_decl_noattrs :
             if typeclass
             then
               match tcs with
-              | (FStar_Parser_AST.TyconRecord uu____25577)::[] ->
+              | (FStar_Parser_AST.TyconRecord uu____25574)::[] ->
                   FStar_Parser_AST.Noeq :: quals1
-              | uu____25596 ->
+              | uu____25593 ->
                   FStar_Errors.raise_error
                     (FStar_Errors.Error_BadClassDecl,
                       "Ill-formed `class` declaration: definition must be a record type")
                     d.FStar_Parser_AST.drange
             else quals1 in
-          let uu____25602 =
-            let uu____25607 =
+          let uu____25599 =
+            let uu____25604 =
               FStar_List.map (trans_qual1 FStar_Pervasives_Native.None)
                 quals2 in
-            desugar_tycon env d uu____25607 tcs in
-          (match uu____25602 with
+            desugar_tycon env d uu____25604 tcs in
+          (match uu____25599 with
            | (env1, ses) ->
                let mkclass lid =
                  let r = FStar_Ident.range_of_lid lid in
-                 let uu____25625 =
-                   let uu____25626 =
-                     let uu____25633 =
-                       let uu____25634 = tun_r r in
+                 let uu____25622 =
+                   let uu____25623 =
+                     let uu____25630 =
+                       let uu____25631 = tun_r r in
                        FStar_Syntax_Syntax.new_bv
-                         (FStar_Pervasives_Native.Some r) uu____25634 in
-                     FStar_Syntax_Syntax.mk_binder uu____25633 in
-                   [uu____25626] in
-                 let uu____25647 =
-                   let uu____25650 =
+                         (FStar_Pervasives_Native.Some r) uu____25631 in
+                     FStar_Syntax_Syntax.mk_binder uu____25630 in
+                   [uu____25623] in
+                 let uu____25644 =
+                   let uu____25647 =
                      FStar_Syntax_Syntax.tabbrev
                        FStar_Parser_Const.mk_class_lid in
-                   let uu____25653 =
-                     let uu____25664 =
-                       let uu____25673 =
-                         let uu____25674 = FStar_Ident.string_of_lid lid in
-                         FStar_Syntax_Util.exp_string uu____25674 in
-                       FStar_Syntax_Syntax.as_arg uu____25673 in
-                     [uu____25664] in
-                   FStar_Syntax_Util.mk_app uu____25650 uu____25653 in
-                 FStar_Syntax_Util.abs uu____25625 uu____25647
+                   let uu____25650 =
+                     let uu____25661 =
+                       let uu____25670 =
+                         let uu____25671 = FStar_Ident.string_of_lid lid in
+                         FStar_Syntax_Util.exp_string uu____25671 in
+                       FStar_Syntax_Syntax.as_arg uu____25670 in
+                     [uu____25661] in
+                   FStar_Syntax_Util.mk_app uu____25647 uu____25650 in
+                 FStar_Syntax_Util.abs uu____25622 uu____25644
                    FStar_Pervasives_Native.None in
                let get_meths se =
                  let rec get_fname quals3 =
                    match quals3 with
                    | (FStar_Syntax_Syntax.Projector
-                       (uu____25713, id))::uu____25715 ->
+                       (uu____25710, id))::uu____25712 ->
                        FStar_Pervasives_Native.Some id
-                   | uu____25718::quals4 -> get_fname quals4
+                   | uu____25715::quals4 -> get_fname quals4
                    | [] -> FStar_Pervasives_Native.None in
-                 let uu____25722 = get_fname se.FStar_Syntax_Syntax.sigquals in
-                 match uu____25722 with
+                 let uu____25719 = get_fname se.FStar_Syntax_Syntax.sigquals in
+                 match uu____25719 with
                  | FStar_Pervasives_Native.None -> []
                  | FStar_Pervasives_Native.Some id ->
-                     let uu____25728 = FStar_Syntax_DsEnv.qualify env1 id in
-                     [uu____25728] in
+                     let uu____25725 = FStar_Syntax_DsEnv.qualify env1 id in
+                     [uu____25725] in
                let rec splice_decl meths se =
                  match se.FStar_Syntax_Syntax.sigel with
-                 | FStar_Syntax_Syntax.Sig_bundle (ses1, uu____25749) ->
+                 | FStar_Syntax_Syntax.Sig_bundle (ses1, uu____25746) ->
                      FStar_List.concatMap (splice_decl meths) ses1
                  | FStar_Syntax_Syntax.Sig_inductive_typ
-                     (lid, uu____25759, uu____25760, uu____25761,
-                      uu____25762, uu____25763)
+                     (lid, uu____25756, uu____25757, uu____25758,
+                      uu____25759, uu____25760)
                      ->
-                     let uu____25772 =
-                       let uu____25773 =
-                         let uu____25774 =
-                           let uu____25781 = mkclass lid in
-                           (meths, uu____25781) in
-                         FStar_Syntax_Syntax.Sig_splice uu____25774 in
+                     let uu____25769 =
+                       let uu____25770 =
+                         let uu____25771 =
+                           let uu____25778 = mkclass lid in
+                           (meths, uu____25778) in
+                         FStar_Syntax_Syntax.Sig_splice uu____25771 in
                        {
-                         FStar_Syntax_Syntax.sigel = uu____25773;
+                         FStar_Syntax_Syntax.sigel = uu____25770;
                          FStar_Syntax_Syntax.sigrng =
                            (d.FStar_Parser_AST.drange);
                          FStar_Syntax_Syntax.sigquals = [];
@@ -7165,8 +7169,8 @@ and (desugar_decl_noattrs :
                          FStar_Syntax_Syntax.sigopts =
                            FStar_Pervasives_Native.None
                        } in
-                     [uu____25772]
-                 | uu____25784 -> [] in
+                     [uu____25769]
+                 | uu____25781 -> [] in
                let extra =
                  if typeclass
                  then
@@ -7183,36 +7187,36 @@ and (desugar_decl_noattrs :
             (isrec = FStar_Parser_AST.NoLetQualifier) &&
               (match lets with
                | ({
-                    FStar_Parser_AST.pat = FStar_Parser_AST.PatOp uu____25814;
-                    FStar_Parser_AST.prange = uu____25815;_},
-                  uu____25816)::[] -> false
+                    FStar_Parser_AST.pat = FStar_Parser_AST.PatOp uu____25811;
+                    FStar_Parser_AST.prange = uu____25812;_},
+                  uu____25813)::[] -> false
                | ({
                     FStar_Parser_AST.pat = FStar_Parser_AST.PatVar
-                      uu____25825;
-                    FStar_Parser_AST.prange = uu____25826;_},
-                  uu____25827)::[] -> false
+                      uu____25822;
+                    FStar_Parser_AST.prange = uu____25823;_},
+                  uu____25824)::[] -> false
                | ({
                     FStar_Parser_AST.pat = FStar_Parser_AST.PatAscribed
                       ({
                          FStar_Parser_AST.pat = FStar_Parser_AST.PatOp
-                           uu____25842;
-                         FStar_Parser_AST.prange = uu____25843;_},
-                       uu____25844);
-                    FStar_Parser_AST.prange = uu____25845;_},
-                  uu____25846)::[] -> false
+                           uu____25839;
+                         FStar_Parser_AST.prange = uu____25840;_},
+                       uu____25841);
+                    FStar_Parser_AST.prange = uu____25842;_},
+                  uu____25843)::[] -> false
                | ({
                     FStar_Parser_AST.pat = FStar_Parser_AST.PatAscribed
                       ({
                          FStar_Parser_AST.pat = FStar_Parser_AST.PatVar
-                           uu____25867;
-                         FStar_Parser_AST.prange = uu____25868;_},
-                       uu____25869);
-                    FStar_Parser_AST.prange = uu____25870;_},
-                  uu____25871)::[] -> false
-               | (p, uu____25899)::[] ->
-                   let uu____25908 = is_app_pattern p in
-                   Prims.op_Negation uu____25908
-               | uu____25909 -> false) in
+                           uu____25864;
+                         FStar_Parser_AST.prange = uu____25865;_},
+                       uu____25866);
+                    FStar_Parser_AST.prange = uu____25867;_},
+                  uu____25868)::[] -> false
+               | (p, uu____25896)::[] ->
+                   let uu____25905 = is_app_pattern p in
+                   Prims.op_Negation uu____25905
+               | uu____25906 -> false) in
           if Prims.op_Negation expand_toplevel_pattern
           then
             let lets1 =
@@ -7226,17 +7230,17 @@ and (desugar_decl_noattrs :
                         (FStar_Parser_AST.Const FStar_Const.Const_unit)
                         d.FStar_Parser_AST.drange FStar_Parser_AST.Expr)))
                 d.FStar_Parser_AST.drange FStar_Parser_AST.Expr in
-            let uu____25982 = desugar_term_maybe_top true env as_inner_let in
-            (match uu____25982 with
+            let uu____25979 = desugar_term_maybe_top true env as_inner_let in
+            (match uu____25979 with
              | (ds_lets, aq) ->
                  (check_no_aq aq;
-                  (let uu____25994 =
-                     let uu____25995 =
+                  (let uu____25991 =
+                     let uu____25992 =
                        FStar_All.pipe_left FStar_Syntax_Subst.compress
                          ds_lets in
-                     uu____25995.FStar_Syntax_Syntax.n in
-                   match uu____25994 with
-                   | FStar_Syntax_Syntax.Tm_let (lbs, uu____26005) ->
+                     uu____25992.FStar_Syntax_Syntax.n in
+                   match uu____25991 with
+                   | FStar_Syntax_Syntax.Tm_let (lbs, uu____26002) ->
                        let fvs =
                          FStar_All.pipe_right
                            (FStar_Pervasives_Native.snd lbs)
@@ -7244,40 +7248,40 @@ and (desugar_decl_noattrs :
                               (fun lb ->
                                  FStar_Util.right
                                    lb.FStar_Syntax_Syntax.lbname)) in
-                       let uu____26033 =
+                       let uu____26030 =
                          FStar_List.fold_right
                            (fun fv ->
-                              fun uu____26058 ->
-                                match uu____26058 with
+                              fun uu____26055 ->
+                                match uu____26055 with
                                 | (qs, ats) ->
-                                    let uu____26085 =
+                                    let uu____26082 =
                                       FStar_Syntax_DsEnv.lookup_letbinding_quals_and_attrs
                                         env
                                         (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-                                    (match uu____26085 with
+                                    (match uu____26082 with
                                      | (qs', ats') ->
                                          ((FStar_List.append qs' qs),
                                            (FStar_List.append ats' ats))))
                            fvs ([], []) in
-                       (match uu____26033 with
+                       (match uu____26030 with
                         | (val_quals, val_attrs) ->
                             let quals1 =
                               match quals with
-                              | uu____26139::uu____26140 ->
+                              | uu____26136::uu____26137 ->
                                   FStar_List.map
                                     (trans_qual1 FStar_Pervasives_Native.None)
                                     quals
-                              | uu____26143 -> val_quals in
+                              | uu____26140 -> val_quals in
                             let quals2 =
-                              let uu____26147 =
+                              let uu____26144 =
                                 FStar_All.pipe_right lets1
                                   (FStar_Util.for_some
-                                     (fun uu____26178 ->
-                                        match uu____26178 with
-                                        | (uu____26191, (uu____26192, t)) ->
+                                     (fun uu____26175 ->
+                                        match uu____26175 with
+                                        | (uu____26188, (uu____26189, t)) ->
                                             t.FStar_Parser_AST.level =
                                               FStar_Parser_AST.Formula)) in
-                              if uu____26147
+                              if uu____26144
                               then FStar_Syntax_Syntax.Logic :: quals1
                               else quals1 in
                             let names =
@@ -7304,16 +7308,16 @@ and (desugar_decl_noattrs :
                               } in
                             let env1 = FStar_Syntax_DsEnv.push_sigelt env s in
                             (env1, [s]))
-                   | uu____26225 ->
+                   | uu____26222 ->
                        failwith "Desugaring a let did not produce a let")))
           else
-            (let uu____26231 =
+            (let uu____26228 =
                match lets with
                | (pat, body)::[] -> (pat, body)
-               | uu____26250 ->
+               | uu____26247 ->
                    failwith
                      "expand_toplevel_pattern should only allow single definition lets" in
-             match uu____26231 with
+             match uu____26228 with
              | (pat, body) ->
                  let fresh_toplevel_name =
                    FStar_Ident.gen FStar_Range.dummyRange in
@@ -7325,14 +7329,14 @@ and (desugar_decl_noattrs :
                        FStar_Range.dummyRange in
                    match pat.FStar_Parser_AST.pat with
                    | FStar_Parser_AST.PatAscribed (pat1, ty) ->
-                       let uu___3661_26286 = pat1 in
+                       let uu___3662_26283 = pat1 in
                        {
                          FStar_Parser_AST.pat =
                            (FStar_Parser_AST.PatAscribed (var_pat, ty));
                          FStar_Parser_AST.prange =
-                           (uu___3661_26286.FStar_Parser_AST.prange)
+                           (uu___3662_26283.FStar_Parser_AST.prange)
                        }
-                   | uu____26293 -> var_pat in
+                   | uu____26290 -> var_pat in
                  let main_let =
                    let quals1 =
                      if
@@ -7342,42 +7346,42 @@ and (desugar_decl_noattrs :
                      else FStar_Parser_AST.Private ::
                        (d.FStar_Parser_AST.quals) in
                    desugar_decl env
-                     (let uu___3667_26302 = d in
+                     (let uu___3668_26299 = d in
                       {
                         FStar_Parser_AST.d =
                           (FStar_Parser_AST.TopLevelLet
                              (isrec, [(fresh_pat, body)]));
                         FStar_Parser_AST.drange =
-                          (uu___3667_26302.FStar_Parser_AST.drange);
+                          (uu___3668_26299.FStar_Parser_AST.drange);
                         FStar_Parser_AST.quals = quals1;
                         FStar_Parser_AST.attrs =
-                          (uu___3667_26302.FStar_Parser_AST.attrs)
+                          (uu___3668_26299.FStar_Parser_AST.attrs)
                       }) in
                  let main =
-                   let uu____26318 =
-                     let uu____26319 =
+                   let uu____26315 =
+                     let uu____26316 =
                        FStar_Ident.lid_of_ids [fresh_toplevel_name] in
-                     FStar_Parser_AST.Var uu____26319 in
-                   FStar_Parser_AST.mk_term uu____26318
+                     FStar_Parser_AST.Var uu____26316 in
+                   FStar_Parser_AST.mk_term uu____26315
                      pat.FStar_Parser_AST.prange FStar_Parser_AST.Expr in
-                 let build_generic_projection uu____26343 id_opt =
-                   match uu____26343 with
+                 let build_generic_projection uu____26340 id_opt =
+                   match uu____26340 with
                    | (env1, ses) ->
-                       let uu____26365 =
+                       let uu____26362 =
                          match id_opt with
                          | FStar_Pervasives_Native.Some id ->
                              let lid = FStar_Ident.lid_of_ids [id] in
                              let branch =
-                               let uu____26377 = FStar_Ident.range_of_lid lid in
+                               let uu____26374 = FStar_Ident.range_of_lid lid in
                                FStar_Parser_AST.mk_term
-                                 (FStar_Parser_AST.Var lid) uu____26377
+                                 (FStar_Parser_AST.Var lid) uu____26374
                                  FStar_Parser_AST.Expr in
                              let bv_pat =
-                               let uu____26379 = FStar_Ident.range_of_id id in
+                               let uu____26376 = FStar_Ident.range_of_id id in
                                FStar_Parser_AST.mk_pattern
                                  (FStar_Parser_AST.PatVar
                                     (id, FStar_Pervasives_Native.None))
-                                 uu____26379 in
+                                 uu____26376 in
                              (bv_pat, branch)
                          | FStar_Pervasives_Native.None ->
                              let id = FStar_Ident.gen FStar_Range.dummyRange in
@@ -7387,28 +7391,28 @@ and (desugar_decl_noattrs :
                                     FStar_Const.Const_unit)
                                  FStar_Range.dummyRange FStar_Parser_AST.Expr in
                              let bv_pat =
-                               let uu____26385 = FStar_Ident.range_of_id id in
+                               let uu____26382 = FStar_Ident.range_of_id id in
                                FStar_Parser_AST.mk_pattern
                                  (FStar_Parser_AST.PatVar
                                     (id, FStar_Pervasives_Native.None))
-                                 uu____26385 in
+                                 uu____26382 in
                              let bv_pat1 =
-                               let uu____26389 =
-                                 let uu____26390 =
-                                   let uu____26401 =
-                                     let uu____26408 =
-                                       let uu____26409 =
+                               let uu____26386 =
+                                 let uu____26387 =
+                                   let uu____26398 =
+                                     let uu____26405 =
+                                       let uu____26406 =
                                          FStar_Ident.range_of_id id in
-                                       unit_ty uu____26409 in
-                                     (uu____26408,
+                                       unit_ty uu____26406 in
+                                     (uu____26405,
                                        FStar_Pervasives_Native.None) in
-                                   (bv_pat, uu____26401) in
-                                 FStar_Parser_AST.PatAscribed uu____26390 in
-                               let uu____26418 = FStar_Ident.range_of_id id in
-                               FStar_Parser_AST.mk_pattern uu____26389
-                                 uu____26418 in
+                                   (bv_pat, uu____26398) in
+                                 FStar_Parser_AST.PatAscribed uu____26387 in
+                               let uu____26415 = FStar_Ident.range_of_id id in
+                               FStar_Parser_AST.mk_pattern uu____26386
+                                 uu____26415 in
                              (bv_pat1, branch) in
-                       (match uu____26365 with
+                       (match uu____26362 with
                         | (bv_pat, branch) ->
                             let body1 =
                               FStar_Parser_AST.mk_term
@@ -7425,39 +7429,39 @@ and (desugar_decl_noattrs :
                                      [(bv_pat, body1)]))
                                 FStar_Range.dummyRange [] in
                             let id_decl1 =
-                              let uu___3691_26472 = id_decl in
+                              let uu___3692_26469 = id_decl in
                               {
                                 FStar_Parser_AST.d =
-                                  (uu___3691_26472.FStar_Parser_AST.d);
+                                  (uu___3692_26469.FStar_Parser_AST.d);
                                 FStar_Parser_AST.drange =
-                                  (uu___3691_26472.FStar_Parser_AST.drange);
+                                  (uu___3692_26469.FStar_Parser_AST.drange);
                                 FStar_Parser_AST.quals =
                                   (d.FStar_Parser_AST.quals);
                                 FStar_Parser_AST.attrs =
-                                  (uu___3691_26472.FStar_Parser_AST.attrs)
+                                  (uu___3692_26469.FStar_Parser_AST.attrs)
                               } in
-                            let uu____26473 = desugar_decl env1 id_decl1 in
-                            (match uu____26473 with
+                            let uu____26470 = desugar_decl env1 id_decl1 in
+                            (match uu____26470 with
                              | (env2, ses') ->
                                  (env2, (FStar_List.append ses ses')))) in
-                 let build_projection uu____26509 id =
-                   match uu____26509 with
+                 let build_projection uu____26506 id =
+                   match uu____26506 with
                    | (env1, ses) ->
                        build_generic_projection (env1, ses)
                          (FStar_Pervasives_Native.Some id) in
-                 let build_coverage_check uu____26548 =
-                   match uu____26548 with
+                 let build_coverage_check uu____26545 =
+                   match uu____26545 with
                    | (env1, ses) ->
                        build_generic_projection (env1, ses)
                          FStar_Pervasives_Native.None in
                  let bvs =
-                   let uu____26572 = gather_pattern_bound_vars pat in
-                   FStar_All.pipe_right uu____26572 FStar_Util.set_elements in
-                 let uu____26579 =
+                   let uu____26569 = gather_pattern_bound_vars pat in
+                   FStar_All.pipe_right uu____26569 FStar_Util.set_elements in
+                 let uu____26576 =
                    (FStar_List.isEmpty bvs) &&
-                     (let uu____26581 = is_var_pattern pat in
-                      Prims.op_Negation uu____26581) in
-                 if uu____26579
+                     (let uu____26578 = is_var_pattern pat in
+                      Prims.op_Negation uu____26578) in
+                 if uu____26576
                  then build_coverage_check main_let
                  else FStar_List.fold_left build_projection main_let bvs)
       | FStar_Parser_AST.Assume (id, t) ->
@@ -7478,26 +7482,26 @@ and (desugar_decl_noattrs :
       | FStar_Parser_AST.Val (id, t) ->
           let quals = d.FStar_Parser_AST.quals in
           let t1 =
-            let uu____26599 = close_fun env t in desugar_term env uu____26599 in
+            let uu____26596 = close_fun env t in desugar_term env uu____26596 in
           let quals1 =
-            let uu____26603 =
+            let uu____26600 =
               (FStar_Syntax_DsEnv.iface env) &&
                 (FStar_Syntax_DsEnv.admitted_iface env) in
-            if uu____26603
+            if uu____26600
             then FStar_Parser_AST.Assumption :: quals
             else quals in
           let lid = FStar_Syntax_DsEnv.qualify env id in
           let attrs =
             FStar_List.map (desugar_term env) d.FStar_Parser_AST.attrs in
           let se =
-            let uu____26612 =
+            let uu____26609 =
               FStar_List.map (trans_qual1 FStar_Pervasives_Native.None)
                 quals1 in
             {
               FStar_Syntax_Syntax.sigel =
                 (FStar_Syntax_Syntax.Sig_declare_typ (lid, [], t1));
               FStar_Syntax_Syntax.sigrng = (d.FStar_Parser_AST.drange);
-              FStar_Syntax_Syntax.sigquals = uu____26612;
+              FStar_Syntax_Syntax.sigquals = uu____26609;
               FStar_Syntax_Syntax.sigmeta =
                 FStar_Syntax_Syntax.default_sigmeta;
               FStar_Syntax_Syntax.sigattrs = attrs;
@@ -7513,17 +7517,17 @@ and (desugar_decl_noattrs :
                   FStar_Parser_Const.exn_lid
             | FStar_Pervasives_Native.Some term ->
                 let t = desugar_term env term in
-                let uu____26625 =
-                  let uu____26634 = FStar_Syntax_Syntax.null_binder t in
-                  [uu____26634] in
-                let uu____26653 =
-                  let uu____26656 =
+                let uu____26622 =
+                  let uu____26631 = FStar_Syntax_Syntax.null_binder t in
+                  [uu____26631] in
+                let uu____26650 =
+                  let uu____26653 =
                     FStar_Syntax_DsEnv.fail_or env
                       (FStar_Syntax_DsEnv.try_lookup_lid env)
                       FStar_Parser_Const.exn_lid in
                   FStar_All.pipe_left FStar_Syntax_Syntax.mk_Total
-                    uu____26656 in
-                FStar_Syntax_Util.arrow uu____26625 uu____26653 in
+                    uu____26653 in
+                FStar_Syntax_Util.arrow uu____26622 uu____26650 in
           let l = FStar_Syntax_DsEnv.qualify env id in
           let qual = [FStar_Syntax_Syntax.ExceptionConstructor] in
           let se =
@@ -7575,7 +7579,7 @@ and (desugar_decl_noattrs :
           desugar_effect env d quals true eff_name eff_binders eff_typ
             eff_decls attrs
       | FStar_Parser_AST.LayeredEffect (FStar_Parser_AST.RedefineEffect
-          uu____26715) ->
+          uu____26712) ->
           failwith
             "Impossible: LayeredEffect (RedefineEffect _) (should not be parseable)"
       | FStar_Parser_AST.SubEffect l ->
@@ -7585,42 +7589,42 @@ and (desugar_decl_noattrs :
           let dst_ed =
             lookup_effect_lid env l.FStar_Parser_AST.mdest
               d.FStar_Parser_AST.drange in
-          let uu____26731 =
-            let uu____26732 =
+          let uu____26728 =
+            let uu____26729 =
               (FStar_Syntax_Util.is_layered src_ed) ||
                 (FStar_Syntax_Util.is_layered dst_ed) in
-            Prims.op_Negation uu____26732 in
-          if uu____26731
+            Prims.op_Negation uu____26729 in
+          if uu____26728
           then
-            let uu____26737 =
+            let uu____26734 =
               match l.FStar_Parser_AST.lift_op with
               | FStar_Parser_AST.NonReifiableLift t ->
-                  let uu____26755 =
-                    let uu____26758 =
-                      let uu____26759 = desugar_term env t in
-                      ([], uu____26759) in
-                    FStar_Pervasives_Native.Some uu____26758 in
-                  (uu____26755, FStar_Pervasives_Native.None)
+                  let uu____26752 =
+                    let uu____26755 =
+                      let uu____26756 = desugar_term env t in
+                      ([], uu____26756) in
+                    FStar_Pervasives_Native.Some uu____26755 in
+                  (uu____26752, FStar_Pervasives_Native.None)
               | FStar_Parser_AST.ReifiableLift (wp, t) ->
-                  let uu____26772 =
-                    let uu____26775 =
-                      let uu____26776 = desugar_term env wp in
-                      ([], uu____26776) in
-                    FStar_Pervasives_Native.Some uu____26775 in
-                  let uu____26783 =
-                    let uu____26786 =
-                      let uu____26787 = desugar_term env t in
-                      ([], uu____26787) in
-                    FStar_Pervasives_Native.Some uu____26786 in
-                  (uu____26772, uu____26783)
+                  let uu____26769 =
+                    let uu____26772 =
+                      let uu____26773 = desugar_term env wp in
+                      ([], uu____26773) in
+                    FStar_Pervasives_Native.Some uu____26772 in
+                  let uu____26780 =
+                    let uu____26783 =
+                      let uu____26784 = desugar_term env t in
+                      ([], uu____26784) in
+                    FStar_Pervasives_Native.Some uu____26783 in
+                  (uu____26769, uu____26780)
               | FStar_Parser_AST.LiftForFree t ->
-                  let uu____26799 =
-                    let uu____26802 =
-                      let uu____26803 = desugar_term env t in
-                      ([], uu____26803) in
-                    FStar_Pervasives_Native.Some uu____26802 in
-                  (FStar_Pervasives_Native.None, uu____26799) in
-            (match uu____26737 with
+                  let uu____26796 =
+                    let uu____26799 =
+                      let uu____26800 = desugar_term env t in
+                      ([], uu____26800) in
+                    FStar_Pervasives_Native.Some uu____26799 in
+                  (FStar_Pervasives_Native.None, uu____26796) in
+            (match uu____26734 with
              | (lift_wp, lift) ->
                  let se =
                    {
@@ -7647,11 +7651,11 @@ and (desugar_decl_noattrs :
             (match l.FStar_Parser_AST.lift_op with
              | FStar_Parser_AST.NonReifiableLift t ->
                  let sub_eff =
-                   let uu____26836 =
-                     let uu____26839 =
-                       let uu____26840 = desugar_term env t in
-                       ([], uu____26840) in
-                     FStar_Pervasives_Native.Some uu____26839 in
+                   let uu____26833 =
+                     let uu____26836 =
+                       let uu____26837 = desugar_term env t in
+                       ([], uu____26837) in
+                     FStar_Pervasives_Native.Some uu____26836 in
                    {
                      FStar_Syntax_Syntax.source =
                        (src_ed.FStar_Syntax_Syntax.mname);
@@ -7659,7 +7663,7 @@ and (desugar_decl_noattrs :
                        (dst_ed.FStar_Syntax_Syntax.mname);
                      FStar_Syntax_Syntax.lift_wp =
                        FStar_Pervasives_Native.None;
-                     FStar_Syntax_Syntax.lift = uu____26836
+                     FStar_Syntax_Syntax.lift = uu____26833
                    } in
                  (env,
                    [{
@@ -7674,27 +7678,27 @@ and (desugar_decl_noattrs :
                       FStar_Syntax_Syntax.sigopts =
                         FStar_Pervasives_Native.None
                     }])
-             | uu____26847 ->
+             | uu____26844 ->
                  failwith
                    "Impossible! unexpected lift_op for lift to a layered effect")
       | FStar_Parser_AST.Polymonadic_bind (m_eff, n_eff, p_eff, bind) ->
           let m = lookup_effect_lid env m_eff d.FStar_Parser_AST.drange in
           let n = lookup_effect_lid env n_eff d.FStar_Parser_AST.drange in
           let p = lookup_effect_lid env p_eff d.FStar_Parser_AST.drange in
-          let uu____26859 =
-            let uu____26860 =
-              let uu____26861 =
-                let uu____26862 =
-                  let uu____26873 =
-                    let uu____26874 = desugar_term env bind in
-                    ([], uu____26874) in
+          let uu____26856 =
+            let uu____26857 =
+              let uu____26858 =
+                let uu____26859 =
+                  let uu____26870 =
+                    let uu____26871 = desugar_term env bind in
+                    ([], uu____26871) in
                   ((m.FStar_Syntax_Syntax.mname),
                     (n.FStar_Syntax_Syntax.mname),
-                    (p.FStar_Syntax_Syntax.mname), uu____26873,
+                    (p.FStar_Syntax_Syntax.mname), uu____26870,
                     ([], FStar_Syntax_Syntax.tun)) in
-                FStar_Syntax_Syntax.Sig_polymonadic_bind uu____26862 in
+                FStar_Syntax_Syntax.Sig_polymonadic_bind uu____26859 in
               {
-                FStar_Syntax_Syntax.sigel = uu____26861;
+                FStar_Syntax_Syntax.sigel = uu____26858;
                 FStar_Syntax_Syntax.sigrng = (d.FStar_Parser_AST.drange);
                 FStar_Syntax_Syntax.sigquals = [];
                 FStar_Syntax_Syntax.sigmeta =
@@ -7702,24 +7706,24 @@ and (desugar_decl_noattrs :
                 FStar_Syntax_Syntax.sigattrs = [];
                 FStar_Syntax_Syntax.sigopts = FStar_Pervasives_Native.None
               } in
-            [uu____26860] in
-          (env, uu____26859)
+            [uu____26857] in
+          (env, uu____26856)
       | FStar_Parser_AST.Polymonadic_subcomp (m_eff, n_eff, subcomp) ->
           let m = lookup_effect_lid env m_eff d.FStar_Parser_AST.drange in
           let n = lookup_effect_lid env n_eff d.FStar_Parser_AST.drange in
-          let uu____26890 =
-            let uu____26891 =
-              let uu____26892 =
-                let uu____26893 =
-                  let uu____26902 =
-                    let uu____26903 = desugar_term env subcomp in
-                    ([], uu____26903) in
+          let uu____26887 =
+            let uu____26888 =
+              let uu____26889 =
+                let uu____26890 =
+                  let uu____26899 =
+                    let uu____26900 = desugar_term env subcomp in
+                    ([], uu____26900) in
                   ((m.FStar_Syntax_Syntax.mname),
-                    (n.FStar_Syntax_Syntax.mname), uu____26902,
+                    (n.FStar_Syntax_Syntax.mname), uu____26899,
                     ([], FStar_Syntax_Syntax.tun)) in
-                FStar_Syntax_Syntax.Sig_polymonadic_subcomp uu____26893 in
+                FStar_Syntax_Syntax.Sig_polymonadic_subcomp uu____26890 in
               {
-                FStar_Syntax_Syntax.sigel = uu____26892;
+                FStar_Syntax_Syntax.sigel = uu____26889;
                 FStar_Syntax_Syntax.sigrng = (d.FStar_Parser_AST.drange);
                 FStar_Syntax_Syntax.sigquals = [];
                 FStar_Syntax_Syntax.sigmeta =
@@ -7727,19 +7731,19 @@ and (desugar_decl_noattrs :
                 FStar_Syntax_Syntax.sigattrs = [];
                 FStar_Syntax_Syntax.sigopts = FStar_Pervasives_Native.None
               } in
-            [uu____26891] in
-          (env, uu____26890)
+            [uu____26888] in
+          (env, uu____26887)
       | FStar_Parser_AST.Splice (ids, t) ->
           let t1 = desugar_term env t in
           let se =
-            let uu____26922 =
-              let uu____26923 =
-                let uu____26930 =
+            let uu____26919 =
+              let uu____26920 =
+                let uu____26927 =
                   FStar_List.map (FStar_Syntax_DsEnv.qualify env) ids in
-                (uu____26930, t1) in
-              FStar_Syntax_Syntax.Sig_splice uu____26923 in
+                (uu____26927, t1) in
+              FStar_Syntax_Syntax.Sig_splice uu____26920 in
             {
-              FStar_Syntax_Syntax.sigel = uu____26922;
+              FStar_Syntax_Syntax.sigel = uu____26919;
               FStar_Syntax_Syntax.sigrng = (d.FStar_Parser_AST.drange);
               FStar_Syntax_Syntax.sigquals = [];
               FStar_Syntax_Syntax.sigmeta =
@@ -7755,17 +7759,17 @@ let (desugar_decls :
   =
   fun env ->
     fun decls ->
-      let uu____26956 =
+      let uu____26953 =
         FStar_List.fold_left
-          (fun uu____26976 ->
+          (fun uu____26973 ->
              fun d ->
-               match uu____26976 with
+               match uu____26973 with
                | (env1, sigelts) ->
-                   let uu____26996 = desugar_decl env1 d in
-                   (match uu____26996 with
+                   let uu____26993 = desugar_decl env1 d in
+                   (match uu____26993 with
                     | (env2, se) -> (env2, (FStar_List.append sigelts se))))
           (env, []) decls in
-      match uu____26956 with | (env1, sigelts) -> (env1, sigelts)
+      match uu____26953 with | (env1, sigelts) -> (env1, sigelts)
 let (open_prims_all :
   (FStar_Parser_AST.decoration Prims.list -> FStar_Parser_AST.decl)
     Prims.list)
@@ -7786,35 +7790,35 @@ let (desugar_modul_common :
       fun m ->
         let env1 =
           match (curmod, m) with
-          | (FStar_Pervasives_Native.None, uu____27083) -> env
+          | (FStar_Pervasives_Native.None, uu____27080) -> env
           | (FStar_Pervasives_Native.Some
              { FStar_Syntax_Syntax.name = prev_lid;
-               FStar_Syntax_Syntax.declarations = uu____27087;
-               FStar_Syntax_Syntax.is_interface = uu____27088;_},
-             FStar_Parser_AST.Module (current_lid, uu____27090)) when
+               FStar_Syntax_Syntax.declarations = uu____27084;
+               FStar_Syntax_Syntax.is_interface = uu____27085;_},
+             FStar_Parser_AST.Module (current_lid, uu____27087)) when
               (FStar_Ident.lid_equals prev_lid current_lid) &&
                 (FStar_Options.interactive ())
               -> env
-          | (FStar_Pervasives_Native.Some prev_mod, uu____27098) ->
-              let uu____27101 =
+          | (FStar_Pervasives_Native.Some prev_mod, uu____27095) ->
+              let uu____27098 =
                 FStar_Syntax_DsEnv.finish_module_or_interface env prev_mod in
-              FStar_Pervasives_Native.fst uu____27101 in
-        let uu____27106 =
+              FStar_Pervasives_Native.fst uu____27098 in
+        let uu____27103 =
           match m with
           | FStar_Parser_AST.Interface (mname, decls, admitted) ->
-              let uu____27142 =
+              let uu____27139 =
                 FStar_Syntax_DsEnv.prepare_module_or_interface true admitted
                   env1 mname FStar_Syntax_DsEnv.default_mii in
-              (uu____27142, mname, decls, true)
+              (uu____27139, mname, decls, true)
           | FStar_Parser_AST.Module (mname, decls) ->
-              let uu____27159 =
+              let uu____27156 =
                 FStar_Syntax_DsEnv.prepare_module_or_interface false false
                   env1 mname FStar_Syntax_DsEnv.default_mii in
-              (uu____27159, mname, decls, false) in
-        match uu____27106 with
+              (uu____27156, mname, decls, false) in
+        match uu____27103 with
         | ((env2, pop_when_done), mname, decls, intf) ->
-            let uu____27189 = desugar_decls env2 decls in
-            (match uu____27189 with
+            let uu____27186 = desugar_decls env2 decls in
+            (match uu____27186 with
              | (env3, sigelts) ->
                  let modul =
                    {
@@ -7837,22 +7841,22 @@ let (desugar_partial_modul :
     fun env ->
       fun m ->
         let m1 =
-          let uu____27251 =
+          let uu____27248 =
             (FStar_Options.interactive ()) &&
-              (let uu____27253 =
-                 let uu____27254 =
-                   let uu____27255 = FStar_Options.file_list () in
-                   FStar_List.hd uu____27255 in
-                 FStar_Util.get_file_extension uu____27254 in
-               FStar_List.mem uu____27253 ["fsti"; "fsi"]) in
-          if uu____27251 then as_interface m else m in
-        let uu____27259 = desugar_modul_common curmod env m1 in
-        match uu____27259 with
+              (let uu____27250 =
+                 let uu____27251 =
+                   let uu____27252 = FStar_Options.file_list () in
+                   FStar_List.hd uu____27252 in
+                 FStar_Util.get_file_extension uu____27251 in
+               FStar_List.mem uu____27250 ["fsti"; "fsi"]) in
+          if uu____27248 then as_interface m else m in
+        let uu____27256 = desugar_modul_common curmod env m1 in
+        match uu____27256 with
         | (env1, modul, pop_when_done) ->
             if pop_when_done
             then
-              let uu____27277 = FStar_Syntax_DsEnv.pop () in
-              (uu____27277, modul)
+              let uu____27274 = FStar_Syntax_DsEnv.pop () in
+              (uu____27274, modul)
             else (env1, modul)
 let (desugar_modul :
   FStar_Syntax_DsEnv.env ->
@@ -7860,33 +7864,33 @@ let (desugar_modul :
   =
   fun env ->
     fun m ->
-      let uu____27297 =
+      let uu____27294 =
         desugar_modul_common FStar_Pervasives_Native.None env m in
-      match uu____27297 with
+      match uu____27294 with
       | (env1, modul, pop_when_done) ->
-          let uu____27311 =
+          let uu____27308 =
             FStar_Syntax_DsEnv.finish_module_or_interface env1 modul in
-          (match uu____27311 with
+          (match uu____27308 with
            | (env2, modul1) ->
-               ((let uu____27323 =
-                   let uu____27324 =
+               ((let uu____27320 =
+                   let uu____27321 =
                      FStar_Ident.string_of_lid
                        modul1.FStar_Syntax_Syntax.name in
-                   FStar_Options.dump_module uu____27324 in
-                 if uu____27323
+                   FStar_Options.dump_module uu____27321 in
+                 if uu____27320
                  then
-                   let uu____27325 =
+                   let uu____27322 =
                      FStar_Syntax_Print.modul_to_string modul1 in
                    FStar_Util.print1 "Module after desugaring:\n%s\n"
-                     uu____27325
+                     uu____27322
                  else ());
-                (let uu____27327 =
+                (let uu____27324 =
                    if pop_when_done
                    then
                      FStar_Syntax_DsEnv.export_interface
                        modul1.FStar_Syntax_Syntax.name env2
                    else env2 in
-                 (uu____27327, modul1))))
+                 (uu____27324, modul1))))
 let with_options : 'a . (unit -> 'a) -> 'a =
   fun f ->
     FStar_Options.push ();
@@ -7902,9 +7906,9 @@ let (ast_modul_to_modul :
   fun modul ->
     fun env ->
       with_options
-        (fun uu____27370 ->
-           let uu____27371 = desugar_modul env modul in
-           match uu____27371 with | (e, m) -> (m, e))
+        (fun uu____27367 ->
+           let uu____27368 = desugar_modul env modul in
+           match uu____27368 with | (e, m) -> (m, e))
 let (decls_to_sigelts :
   FStar_Parser_AST.decl Prims.list ->
     FStar_Syntax_Syntax.sigelts FStar_Syntax_DsEnv.withenv)
@@ -7912,9 +7916,9 @@ let (decls_to_sigelts :
   fun decls ->
     fun env ->
       with_options
-        (fun uu____27408 ->
-           let uu____27409 = desugar_decls env decls in
-           match uu____27409 with | (env1, sigelts) -> (sigelts, env1))
+        (fun uu____27405 ->
+           let uu____27406 = desugar_decls env decls in
+           match uu____27406 with | (env1, sigelts) -> (sigelts, env1))
 let (partial_ast_modul_to_modul :
   FStar_Syntax_Syntax.modul FStar_Pervasives_Native.option ->
     FStar_Parser_AST.modul ->
@@ -7924,9 +7928,9 @@ let (partial_ast_modul_to_modul :
     fun a_modul ->
       fun env ->
         with_options
-          (fun uu____27459 ->
-             let uu____27460 = desugar_partial_modul modul env a_modul in
-             match uu____27460 with | (env1, modul1) -> (modul1, env1))
+          (fun uu____27456 ->
+             let uu____27457 = desugar_partial_modul modul env a_modul in
+             match uu____27457 with | (env1, modul1) -> (modul1, env1))
 let (add_modul_to_env :
   FStar_Syntax_Syntax.modul ->
     FStar_Syntax_DsEnv.module_inclusion_info ->
@@ -7941,46 +7945,46 @@ let (add_modul_to_env :
             let erase_binders bs =
               match bs with
               | [] -> []
-              | uu____27554 ->
+              | uu____27551 ->
                   let t =
-                    let uu____27564 =
+                    let uu____27561 =
                       FStar_Syntax_Syntax.mk
                         (FStar_Syntax_Syntax.Tm_abs
                            (bs, FStar_Syntax_Syntax.t_unit,
                              FStar_Pervasives_Native.None))
                         FStar_Range.dummyRange in
-                    erase_univs uu____27564 in
-                  let uu____27577 =
-                    let uu____27578 = FStar_Syntax_Subst.compress t in
-                    uu____27578.FStar_Syntax_Syntax.n in
-                  (match uu____27577 with
+                    erase_univs uu____27561 in
+                  let uu____27574 =
+                    let uu____27575 = FStar_Syntax_Subst.compress t in
+                    uu____27575.FStar_Syntax_Syntax.n in
+                  (match uu____27574 with
                    | FStar_Syntax_Syntax.Tm_abs
-                       (bs1, uu____27590, uu____27591) -> bs1
-                   | uu____27616 -> failwith "Impossible") in
-            let uu____27625 =
-              let uu____27632 = erase_binders ed.FStar_Syntax_Syntax.binders in
-              FStar_Syntax_Subst.open_term' uu____27632
+                       (bs1, uu____27587, uu____27588) -> bs1
+                   | uu____27613 -> failwith "Impossible") in
+            let uu____27622 =
+              let uu____27629 = erase_binders ed.FStar_Syntax_Syntax.binders in
+              FStar_Syntax_Subst.open_term' uu____27629
                 FStar_Syntax_Syntax.t_unit in
-            match uu____27625 with
-            | (binders, uu____27634, binders_opening) ->
+            match uu____27622 with
+            | (binders, uu____27631, binders_opening) ->
                 let erase_term t =
-                  let uu____27642 =
-                    let uu____27643 =
+                  let uu____27639 =
+                    let uu____27640 =
                       FStar_Syntax_Subst.subst binders_opening t in
-                    erase_univs uu____27643 in
-                  FStar_Syntax_Subst.close binders uu____27642 in
-                let erase_tscheme uu____27661 =
-                  match uu____27661 with
+                    erase_univs uu____27640 in
+                  FStar_Syntax_Subst.close binders uu____27639 in
+                let erase_tscheme uu____27658 =
+                  match uu____27658 with
                   | (us, t) ->
                       let t1 =
-                        let uu____27681 =
+                        let uu____27678 =
                           FStar_Syntax_Subst.shift_subst
                             (FStar_List.length us) binders_opening in
-                        FStar_Syntax_Subst.subst uu____27681 t in
-                      let uu____27684 =
-                        let uu____27685 = erase_univs t1 in
-                        FStar_Syntax_Subst.close binders uu____27685 in
-                      ([], uu____27684) in
+                        FStar_Syntax_Subst.subst uu____27678 t in
+                      let uu____27681 =
+                        let uu____27682 = erase_univs t1 in
+                        FStar_Syntax_Subst.close binders uu____27682 in
+                      ([], uu____27681) in
                 let erase_action action =
                   let opening =
                     FStar_Syntax_Subst.shift_subst
@@ -7990,111 +7994,111 @@ let (add_modul_to_env :
                   let erased_action_params =
                     match action.FStar_Syntax_Syntax.action_params with
                     | [] -> []
-                    | uu____27708 ->
+                    | uu____27705 ->
                         let bs =
-                          let uu____27718 =
+                          let uu____27715 =
                             FStar_Syntax_Subst.subst_binders opening
                               action.FStar_Syntax_Syntax.action_params in
-                          FStar_All.pipe_left erase_binders uu____27718 in
+                          FStar_All.pipe_left erase_binders uu____27715 in
                         let t =
                           FStar_Syntax_Syntax.mk
                             (FStar_Syntax_Syntax.Tm_abs
                                (bs, FStar_Syntax_Syntax.t_unit,
                                  FStar_Pervasives_Native.None))
                             FStar_Range.dummyRange in
-                        let uu____27758 =
-                          let uu____27759 =
-                            let uu____27762 =
+                        let uu____27755 =
+                          let uu____27756 =
+                            let uu____27759 =
                               FStar_Syntax_Subst.close binders t in
-                            FStar_Syntax_Subst.compress uu____27762 in
-                          uu____27759.FStar_Syntax_Syntax.n in
-                        (match uu____27758 with
+                            FStar_Syntax_Subst.compress uu____27759 in
+                          uu____27756.FStar_Syntax_Syntax.n in
+                        (match uu____27755 with
                          | FStar_Syntax_Syntax.Tm_abs
-                             (bs1, uu____27764, uu____27765) -> bs1
-                         | uu____27790 -> failwith "Impossible") in
+                             (bs1, uu____27761, uu____27762) -> bs1
+                         | uu____27787 -> failwith "Impossible") in
                   let erase_term1 t =
-                    let uu____27797 =
-                      let uu____27798 = FStar_Syntax_Subst.subst opening t in
-                      erase_univs uu____27798 in
-                    FStar_Syntax_Subst.close binders uu____27797 in
-                  let uu___3968_27799 = action in
-                  let uu____27800 =
+                    let uu____27794 =
+                      let uu____27795 = FStar_Syntax_Subst.subst opening t in
+                      erase_univs uu____27795 in
+                    FStar_Syntax_Subst.close binders uu____27794 in
+                  let uu___3969_27796 = action in
+                  let uu____27797 =
                     erase_term1 action.FStar_Syntax_Syntax.action_defn in
-                  let uu____27801 =
+                  let uu____27798 =
                     erase_term1 action.FStar_Syntax_Syntax.action_typ in
                   {
                     FStar_Syntax_Syntax.action_name =
-                      (uu___3968_27799.FStar_Syntax_Syntax.action_name);
+                      (uu___3969_27796.FStar_Syntax_Syntax.action_name);
                     FStar_Syntax_Syntax.action_unqualified_name =
-                      (uu___3968_27799.FStar_Syntax_Syntax.action_unqualified_name);
+                      (uu___3969_27796.FStar_Syntax_Syntax.action_unqualified_name);
                     FStar_Syntax_Syntax.action_univs = [];
                     FStar_Syntax_Syntax.action_params = erased_action_params;
-                    FStar_Syntax_Syntax.action_defn = uu____27800;
-                    FStar_Syntax_Syntax.action_typ = uu____27801
+                    FStar_Syntax_Syntax.action_defn = uu____27797;
+                    FStar_Syntax_Syntax.action_typ = uu____27798
                   } in
-                let uu___3970_27802 = ed in
-                let uu____27803 = FStar_Syntax_Subst.close_binders binders in
-                let uu____27804 =
+                let uu___3971_27799 = ed in
+                let uu____27800 = FStar_Syntax_Subst.close_binders binders in
+                let uu____27801 =
                   erase_tscheme ed.FStar_Syntax_Syntax.signature in
-                let uu____27805 =
+                let uu____27802 =
                   FStar_Syntax_Util.apply_eff_combinators erase_tscheme
                     ed.FStar_Syntax_Syntax.combinators in
-                let uu____27806 =
+                let uu____27803 =
                   FStar_List.map erase_action ed.FStar_Syntax_Syntax.actions in
                 {
                   FStar_Syntax_Syntax.mname =
-                    (uu___3970_27802.FStar_Syntax_Syntax.mname);
+                    (uu___3971_27799.FStar_Syntax_Syntax.mname);
                   FStar_Syntax_Syntax.cattributes =
-                    (uu___3970_27802.FStar_Syntax_Syntax.cattributes);
+                    (uu___3971_27799.FStar_Syntax_Syntax.cattributes);
                   FStar_Syntax_Syntax.univs = [];
-                  FStar_Syntax_Syntax.binders = uu____27803;
-                  FStar_Syntax_Syntax.signature = uu____27804;
-                  FStar_Syntax_Syntax.combinators = uu____27805;
-                  FStar_Syntax_Syntax.actions = uu____27806;
+                  FStar_Syntax_Syntax.binders = uu____27800;
+                  FStar_Syntax_Syntax.signature = uu____27801;
+                  FStar_Syntax_Syntax.combinators = uu____27802;
+                  FStar_Syntax_Syntax.actions = uu____27803;
                   FStar_Syntax_Syntax.eff_attrs =
-                    (uu___3970_27802.FStar_Syntax_Syntax.eff_attrs)
+                    (uu___3971_27799.FStar_Syntax_Syntax.eff_attrs)
                 } in
           let push_sigelt env se =
             match se.FStar_Syntax_Syntax.sigel with
             | FStar_Syntax_Syntax.Sig_new_effect ed ->
                 let se' =
-                  let uu___3977_27822 = se in
-                  let uu____27823 =
-                    let uu____27824 = erase_univs_ed ed in
-                    FStar_Syntax_Syntax.Sig_new_effect uu____27824 in
+                  let uu___3978_27819 = se in
+                  let uu____27820 =
+                    let uu____27821 = erase_univs_ed ed in
+                    FStar_Syntax_Syntax.Sig_new_effect uu____27821 in
                   {
-                    FStar_Syntax_Syntax.sigel = uu____27823;
+                    FStar_Syntax_Syntax.sigel = uu____27820;
                     FStar_Syntax_Syntax.sigrng =
-                      (uu___3977_27822.FStar_Syntax_Syntax.sigrng);
+                      (uu___3978_27819.FStar_Syntax_Syntax.sigrng);
                     FStar_Syntax_Syntax.sigquals =
-                      (uu___3977_27822.FStar_Syntax_Syntax.sigquals);
+                      (uu___3978_27819.FStar_Syntax_Syntax.sigquals);
                     FStar_Syntax_Syntax.sigmeta =
-                      (uu___3977_27822.FStar_Syntax_Syntax.sigmeta);
+                      (uu___3978_27819.FStar_Syntax_Syntax.sigmeta);
                     FStar_Syntax_Syntax.sigattrs =
-                      (uu___3977_27822.FStar_Syntax_Syntax.sigattrs);
+                      (uu___3978_27819.FStar_Syntax_Syntax.sigattrs);
                     FStar_Syntax_Syntax.sigopts =
-                      (uu___3977_27822.FStar_Syntax_Syntax.sigopts)
+                      (uu___3978_27819.FStar_Syntax_Syntax.sigopts)
                   } in
                 let env1 = FStar_Syntax_DsEnv.push_sigelt env se' in
                 push_reflect_effect env1 se.FStar_Syntax_Syntax.sigquals
                   ed.FStar_Syntax_Syntax.mname se.FStar_Syntax_Syntax.sigrng
-            | uu____27826 -> FStar_Syntax_DsEnv.push_sigelt env se in
-          let uu____27827 =
+            | uu____27823 -> FStar_Syntax_DsEnv.push_sigelt env se in
+          let uu____27824 =
             FStar_Syntax_DsEnv.prepare_module_or_interface false false en
               m.FStar_Syntax_Syntax.name mii in
-          match uu____27827 with
+          match uu____27824 with
           | (en1, pop_when_done) ->
               let en2 =
-                let uu____27839 =
+                let uu____27836 =
                   FStar_Syntax_DsEnv.set_current_module en1
                     m.FStar_Syntax_Syntax.name in
-                FStar_List.fold_left push_sigelt uu____27839
+                FStar_List.fold_left push_sigelt uu____27836
                   m.FStar_Syntax_Syntax.declarations in
               let env = FStar_Syntax_DsEnv.finish en2 m in
-              let uu____27841 =
+              let uu____27838 =
                 if pop_when_done
                 then
                   FStar_Syntax_DsEnv.export_interface
                     m.FStar_Syntax_Syntax.name env
                 else env in
-              ((), uu____27841)
+              ((), uu____27838)

--- a/src/ocaml-output/FStar_TypeChecker_Normalize.ml
+++ b/src/ocaml-output/FStar_TypeChecker_Normalize.ml
@@ -1745,20 +1745,19 @@ let (nbe_eval :
              let uu____6252 = FStar_Syntax_Print.term_to_string tm in
              FStar_Util.print1 "Invoking NBE with  %s\n" uu____6252);
         (let tm_norm =
-           let uu____6254 =
-             let uu____6269 = FStar_TypeChecker_Cfg.cfg_env cfg in
-             uu____6269.FStar_TypeChecker_Env.nbe in
-           uu____6254 s cfg.FStar_TypeChecker_Cfg.tcenv tm in
+           let uu____6254 = FStar_TypeChecker_Cfg.cfg_env cfg in
+           uu____6254.FStar_TypeChecker_Env.nbe s
+             cfg.FStar_TypeChecker_Cfg.tcenv tm in
          FStar_TypeChecker_Cfg.log_nbe cfg
-           (fun uu____6273 ->
-              let uu____6274 = FStar_Syntax_Print.term_to_string tm_norm in
-              FStar_Util.print1 "Result of NBE is  %s\n" uu____6274);
+           (fun uu____6258 ->
+              let uu____6259 = FStar_Syntax_Print.term_to_string tm_norm in
+              FStar_Util.print1 "Result of NBE is  %s\n" uu____6259);
          tm_norm)
 let firstn :
-  'uuuuuu6281 .
+  'uuuuuu6266 .
     Prims.int ->
-      'uuuuuu6281 Prims.list ->
-        ('uuuuuu6281 Prims.list * 'uuuuuu6281 Prims.list)
+      'uuuuuu6266 Prims.list ->
+        ('uuuuuu6266 Prims.list * 'uuuuuu6266 Prims.list)
   =
   fun k ->
     fun l ->
@@ -1767,63 +1766,63 @@ let (should_reify :
   FStar_TypeChecker_Cfg.cfg -> stack_elt Prims.list -> Prims.bool) =
   fun cfg ->
     fun stack1 ->
-      let rec drop_irrel uu___11_6332 =
-        match uu___11_6332 with
-        | (MemoLazy uu____6337)::s -> drop_irrel s
-        | (UnivArgs uu____6347)::s -> drop_irrel s
+      let rec drop_irrel uu___11_6317 =
+        match uu___11_6317 with
+        | (MemoLazy uu____6322)::s -> drop_irrel s
+        | (UnivArgs uu____6332)::s -> drop_irrel s
         | s -> s in
-      let uu____6360 = drop_irrel stack1 in
-      match uu____6360 with
+      let uu____6345 = drop_irrel stack1 in
+      match uu____6345 with
       | (App
-          (uu____6363,
+          (uu____6348,
            {
              FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
                (FStar_Const.Const_reify);
-             FStar_Syntax_Syntax.pos = uu____6364;
-             FStar_Syntax_Syntax.vars = uu____6365;_},
-           uu____6366, uu____6367))::uu____6368
+             FStar_Syntax_Syntax.pos = uu____6349;
+             FStar_Syntax_Syntax.vars = uu____6350;_},
+           uu____6351, uu____6352))::uu____6353
           -> (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.reify_
-      | uu____6373 -> false
+      | uu____6358 -> false
 let rec (maybe_weakly_reduced :
   FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax -> Prims.bool) =
   fun tm ->
     let aux_comp c =
       match c.FStar_Syntax_Syntax.n with
-      | FStar_Syntax_Syntax.GTotal (t, uu____6396) -> maybe_weakly_reduced t
-      | FStar_Syntax_Syntax.Total (t, uu____6406) -> maybe_weakly_reduced t
+      | FStar_Syntax_Syntax.GTotal (t, uu____6381) -> maybe_weakly_reduced t
+      | FStar_Syntax_Syntax.Total (t, uu____6391) -> maybe_weakly_reduced t
       | FStar_Syntax_Syntax.Comp ct ->
           (maybe_weakly_reduced ct.FStar_Syntax_Syntax.result_typ) ||
             (FStar_Util.for_some
-               (fun uu____6427 ->
-                  match uu____6427 with
-                  | (a, uu____6437) -> maybe_weakly_reduced a)
+               (fun uu____6412 ->
+                  match uu____6412 with
+                  | (a, uu____6422) -> maybe_weakly_reduced a)
                ct.FStar_Syntax_Syntax.effect_args) in
     let t = FStar_Syntax_Subst.compress tm in
     match t.FStar_Syntax_Syntax.n with
-    | FStar_Syntax_Syntax.Tm_delayed uu____6447 -> failwith "Impossible"
-    | FStar_Syntax_Syntax.Tm_name uu____6462 -> false
-    | FStar_Syntax_Syntax.Tm_uvar uu____6463 -> false
-    | FStar_Syntax_Syntax.Tm_type uu____6476 -> false
-    | FStar_Syntax_Syntax.Tm_bvar uu____6477 -> false
-    | FStar_Syntax_Syntax.Tm_fvar uu____6478 -> false
-    | FStar_Syntax_Syntax.Tm_constant uu____6479 -> false
-    | FStar_Syntax_Syntax.Tm_lazy uu____6480 -> false
+    | FStar_Syntax_Syntax.Tm_delayed uu____6432 -> failwith "Impossible"
+    | FStar_Syntax_Syntax.Tm_name uu____6447 -> false
+    | FStar_Syntax_Syntax.Tm_uvar uu____6448 -> false
+    | FStar_Syntax_Syntax.Tm_type uu____6461 -> false
+    | FStar_Syntax_Syntax.Tm_bvar uu____6462 -> false
+    | FStar_Syntax_Syntax.Tm_fvar uu____6463 -> false
+    | FStar_Syntax_Syntax.Tm_constant uu____6464 -> false
+    | FStar_Syntax_Syntax.Tm_lazy uu____6465 -> false
     | FStar_Syntax_Syntax.Tm_unknown -> false
-    | FStar_Syntax_Syntax.Tm_uinst uu____6481 -> false
-    | FStar_Syntax_Syntax.Tm_quoted uu____6488 -> false
-    | FStar_Syntax_Syntax.Tm_let uu____6495 -> true
-    | FStar_Syntax_Syntax.Tm_abs uu____6508 -> true
-    | FStar_Syntax_Syntax.Tm_arrow uu____6527 -> true
-    | FStar_Syntax_Syntax.Tm_refine uu____6542 -> true
-    | FStar_Syntax_Syntax.Tm_match uu____6549 -> true
+    | FStar_Syntax_Syntax.Tm_uinst uu____6466 -> false
+    | FStar_Syntax_Syntax.Tm_quoted uu____6473 -> false
+    | FStar_Syntax_Syntax.Tm_let uu____6480 -> true
+    | FStar_Syntax_Syntax.Tm_abs uu____6493 -> true
+    | FStar_Syntax_Syntax.Tm_arrow uu____6512 -> true
+    | FStar_Syntax_Syntax.Tm_refine uu____6527 -> true
+    | FStar_Syntax_Syntax.Tm_match uu____6534 -> true
     | FStar_Syntax_Syntax.Tm_app (t1, args) ->
         (maybe_weakly_reduced t1) ||
           (FStar_All.pipe_right args
              (FStar_Util.for_some
-                (fun uu____6619 ->
-                   match uu____6619 with
-                   | (a, uu____6629) -> maybe_weakly_reduced a)))
-    | FStar_Syntax_Syntax.Tm_ascribed (t1, asc, uu____6640) ->
+                (fun uu____6604 ->
+                   match uu____6604 with
+                   | (a, uu____6614) -> maybe_weakly_reduced a)))
+    | FStar_Syntax_Syntax.Tm_ascribed (t1, asc, uu____6625) ->
         ((maybe_weakly_reduced t1) ||
            (match FStar_Pervasives_Native.fst asc with
             | FStar_Util.Inl t2 -> maybe_weakly_reduced t2
@@ -1835,19 +1834,19 @@ let rec (maybe_weakly_reduced :
     | FStar_Syntax_Syntax.Tm_meta (t1, m) ->
         (maybe_weakly_reduced t1) ||
           ((match m with
-            | FStar_Syntax_Syntax.Meta_pattern (uu____6735, args) ->
+            | FStar_Syntax_Syntax.Meta_pattern (uu____6720, args) ->
                 FStar_Util.for_some
                   (FStar_Util.for_some
-                     (fun uu____6790 ->
-                        match uu____6790 with
-                        | (a, uu____6800) -> maybe_weakly_reduced a)) args
+                     (fun uu____6775 ->
+                        match uu____6775 with
+                        | (a, uu____6785) -> maybe_weakly_reduced a)) args
             | FStar_Syntax_Syntax.Meta_monadic_lift
-                (uu____6809, uu____6810, t') -> maybe_weakly_reduced t'
-            | FStar_Syntax_Syntax.Meta_monadic (uu____6816, t') ->
+                (uu____6794, uu____6795, t') -> maybe_weakly_reduced t'
+            | FStar_Syntax_Syntax.Meta_monadic (uu____6801, t') ->
                 maybe_weakly_reduced t'
-            | FStar_Syntax_Syntax.Meta_labeled uu____6822 -> false
-            | FStar_Syntax_Syntax.Meta_desugared uu____6829 -> false
-            | FStar_Syntax_Syntax.Meta_named uu____6830 -> false))
+            | FStar_Syntax_Syntax.Meta_labeled uu____6807 -> false
+            | FStar_Syntax_Syntax.Meta_desugared uu____6814 -> false
+            | FStar_Syntax_Syntax.Meta_named uu____6815 -> false))
 type should_unfold_res =
   | Should_unfold_no 
   | Should_unfold_yes 
@@ -1855,16 +1854,16 @@ type should_unfold_res =
   | Should_unfold_reify 
 let (uu___is_Should_unfold_no : should_unfold_res -> Prims.bool) =
   fun projectee ->
-    match projectee with | Should_unfold_no -> true | uu____6836 -> false
+    match projectee with | Should_unfold_no -> true | uu____6821 -> false
 let (uu___is_Should_unfold_yes : should_unfold_res -> Prims.bool) =
   fun projectee ->
-    match projectee with | Should_unfold_yes -> true | uu____6842 -> false
+    match projectee with | Should_unfold_yes -> true | uu____6827 -> false
 let (uu___is_Should_unfold_fully : should_unfold_res -> Prims.bool) =
   fun projectee ->
-    match projectee with | Should_unfold_fully -> true | uu____6848 -> false
+    match projectee with | Should_unfold_fully -> true | uu____6833 -> false
 let (uu___is_Should_unfold_reify : should_unfold_res -> Prims.bool) =
   fun projectee ->
-    match projectee with | Should_unfold_reify -> true | uu____6854 -> false
+    match projectee with | Should_unfold_reify -> true | uu____6839 -> false
 let (should_unfold :
   FStar_TypeChecker_Cfg.cfg ->
     (FStar_TypeChecker_Cfg.cfg -> Prims.bool) ->
@@ -1876,8 +1875,8 @@ let (should_unfold :
       fun fv ->
         fun qninfo ->
           let attrs =
-            let uu____6883 = FStar_TypeChecker_Env.attrs_of_qninfo qninfo in
-            match uu____6883 with
+            let uu____6868 = FStar_TypeChecker_Env.attrs_of_qninfo qninfo in
+            match uu____6868 with
             | FStar_Pervasives_Native.None -> []
             | FStar_Pervasives_Native.Some ats -> ats in
           let yes = (true, false, false) in
@@ -1888,38 +1887,38 @@ let (should_unfold :
           let fullyno b = if b then fully else no in
           let comb_or l =
             FStar_List.fold_right
-              (fun uu____7011 ->
-                 fun uu____7012 ->
-                   match (uu____7011, uu____7012) with
+              (fun uu____6996 ->
+                 fun uu____6997 ->
+                   match (uu____6996, uu____6997) with
                    | ((a, b, c), (x, y, z)) -> ((a || x), (b || y), (c || z)))
               l (false, false, false) in
-          let string_of_res uu____7072 =
-            match uu____7072 with
+          let string_of_res uu____7057 =
+            match uu____7057 with
             | (x, y, z) ->
-                let uu____7082 = FStar_Util.string_of_bool x in
-                let uu____7083 = FStar_Util.string_of_bool y in
-                let uu____7084 = FStar_Util.string_of_bool z in
-                FStar_Util.format3 "(%s,%s,%s)" uu____7082 uu____7083
-                  uu____7084 in
+                let uu____7067 = FStar_Util.string_of_bool x in
+                let uu____7068 = FStar_Util.string_of_bool y in
+                let uu____7069 = FStar_Util.string_of_bool z in
+                FStar_Util.format3 "(%s,%s,%s)" uu____7067 uu____7068
+                  uu____7069 in
           let res =
             if FStar_TypeChecker_Env.qninfo_is_action qninfo
             then
               let b = should_reify1 cfg in
               (FStar_TypeChecker_Cfg.log_unfolding cfg
-                 (fun uu____7103 ->
-                    let uu____7104 = FStar_Syntax_Print.fv_to_string fv in
-                    let uu____7105 = FStar_Util.string_of_bool b in
+                 (fun uu____7088 ->
+                    let uu____7089 = FStar_Syntax_Print.fv_to_string fv in
+                    let uu____7090 = FStar_Util.string_of_bool b in
                     FStar_Util.print2
                       "should_unfold: For DM4F action %s, should_reify = %s\n"
-                      uu____7104 uu____7105);
+                      uu____7089 uu____7090);
                if b then reif else no)
             else
               if
-                (let uu____7113 = FStar_TypeChecker_Cfg.find_prim_step cfg fv in
-                 FStar_Option.isSome uu____7113)
+                (let uu____7098 = FStar_TypeChecker_Cfg.find_prim_step cfg fv in
+                 FStar_Option.isSome uu____7098)
               then
                 (FStar_TypeChecker_Cfg.log_unfolding cfg
-                   (fun uu____7118 ->
+                   (fun uu____7103 ->
                       FStar_Util.print_string
                         " >> It's a primop, not unfolding\n");
                  no)
@@ -1934,24 +1933,24 @@ let (should_unfold :
                      ({
                         FStar_Syntax_Syntax.sigel =
                           FStar_Syntax_Syntax.Sig_let
-                          ((is_rec, uu____7152), uu____7153);
-                        FStar_Syntax_Syntax.sigrng = uu____7154;
+                          ((is_rec, uu____7137), uu____7138);
+                        FStar_Syntax_Syntax.sigrng = uu____7139;
                         FStar_Syntax_Syntax.sigquals = qs;
-                        FStar_Syntax_Syntax.sigmeta = uu____7156;
-                        FStar_Syntax_Syntax.sigattrs = uu____7157;
-                        FStar_Syntax_Syntax.sigopts = uu____7158;_},
-                      uu____7159),
-                     uu____7160),
-                    uu____7161, uu____7162, uu____7163) when
+                        FStar_Syntax_Syntax.sigmeta = uu____7141;
+                        FStar_Syntax_Syntax.sigattrs = uu____7142;
+                        FStar_Syntax_Syntax.sigopts = uu____7143;_},
+                      uu____7144),
+                     uu____7145),
+                    uu____7146, uu____7147, uu____7148) when
                      FStar_List.contains FStar_Syntax_Syntax.HasMaskedEffect
                        qs
                      ->
                      (FStar_TypeChecker_Cfg.log_unfolding cfg
-                        (fun uu____7270 ->
+                        (fun uu____7255 ->
                            FStar_Util.print_string
                              " >> HasMaskedEffect, not unfolding\n");
                       no)
-                 | (uu____7271, uu____7272, uu____7273, uu____7274) when
+                 | (uu____7256, uu____7257, uu____7258, uu____7259) when
                      (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.unfold_tac
                        &&
                        (FStar_Util.for_some
@@ -1959,7 +1958,7 @@ let (should_unfold :
                              FStar_Syntax_Util.tac_opaque_attr) attrs)
                      ->
                      (FStar_TypeChecker_Cfg.log_unfolding cfg
-                        (fun uu____7341 ->
+                        (fun uu____7326 ->
                            FStar_Util.print_string
                              " >> tac_opaque, not unfolding\n");
                       no)
@@ -1968,15 +1967,15 @@ let (should_unfold :
                      ({
                         FStar_Syntax_Syntax.sigel =
                           FStar_Syntax_Syntax.Sig_let
-                          ((is_rec, uu____7343), uu____7344);
-                        FStar_Syntax_Syntax.sigrng = uu____7345;
+                          ((is_rec, uu____7328), uu____7329);
+                        FStar_Syntax_Syntax.sigrng = uu____7330;
                         FStar_Syntax_Syntax.sigquals = qs;
-                        FStar_Syntax_Syntax.sigmeta = uu____7347;
-                        FStar_Syntax_Syntax.sigattrs = uu____7348;
-                        FStar_Syntax_Syntax.sigopts = uu____7349;_},
-                      uu____7350),
-                     uu____7351),
-                    uu____7352, uu____7353, uu____7354) when
+                        FStar_Syntax_Syntax.sigmeta = uu____7332;
+                        FStar_Syntax_Syntax.sigattrs = uu____7333;
+                        FStar_Syntax_Syntax.sigopts = uu____7334;_},
+                      uu____7335),
+                     uu____7336),
+                    uu____7337, uu____7338, uu____7339) when
                      (is_rec &&
                         (Prims.op_Negation
                            (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.zeta))
@@ -1985,214 +1984,214 @@ let (should_unfold :
                           (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.zeta_full)
                      ->
                      (FStar_TypeChecker_Cfg.log_unfolding cfg
-                        (fun uu____7461 ->
+                        (fun uu____7446 ->
                            FStar_Util.print_string
                              " >> It's a recursive definition but we're not doing Zeta, not unfolding\n");
                       no)
-                 | (uu____7462, FStar_Pervasives_Native.Some uu____7463,
-                    uu____7464, uu____7465) ->
+                 | (uu____7447, FStar_Pervasives_Native.Some uu____7448,
+                    uu____7449, uu____7450) ->
                      (FStar_TypeChecker_Cfg.log_unfolding cfg
-                        (fun uu____7533 ->
-                           let uu____7534 =
+                        (fun uu____7518 ->
+                           let uu____7519 =
                              FStar_Syntax_Print.fv_to_string fv in
                            FStar_Util.print1
                              "should_unfold: Reached a %s with selective unfolding\n"
-                             uu____7534);
-                      (let uu____7535 =
-                         let uu____7544 =
+                             uu____7519);
+                      (let uu____7520 =
+                         let uu____7529 =
                            match (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.unfold_only
                            with
                            | FStar_Pervasives_Native.None -> no
                            | FStar_Pervasives_Native.Some lids ->
-                               let uu____7564 =
+                               let uu____7549 =
                                  FStar_Util.for_some
                                    (FStar_Syntax_Syntax.fv_eq_lid fv) lids in
-                               FStar_All.pipe_left yesno uu____7564 in
-                         let uu____7571 =
-                           let uu____7580 =
+                               FStar_All.pipe_left yesno uu____7549 in
+                         let uu____7556 =
+                           let uu____7565 =
                              match (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.unfold_attr
                              with
                              | FStar_Pervasives_Native.None -> no
                              | FStar_Pervasives_Native.Some lids ->
-                                 let uu____7600 =
+                                 let uu____7585 =
                                    FStar_Util.for_some
                                      (fun at ->
                                         FStar_Util.for_some
                                           (fun lid ->
                                              FStar_Syntax_Util.is_fvar lid at)
                                           lids) attrs in
-                                 FStar_All.pipe_left yesno uu____7600 in
-                           let uu____7611 =
-                             let uu____7620 =
+                                 FStar_All.pipe_left yesno uu____7585 in
+                           let uu____7596 =
+                             let uu____7605 =
                                match (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.unfold_fully
                                with
                                | FStar_Pervasives_Native.None -> no
                                | FStar_Pervasives_Native.Some lids ->
-                                   let uu____7640 =
+                                   let uu____7625 =
                                      FStar_Util.for_some
                                        (FStar_Syntax_Syntax.fv_eq_lid fv)
                                        lids in
-                                   FStar_All.pipe_left fullyno uu____7640 in
-                             [uu____7620] in
-                           uu____7580 :: uu____7611 in
-                         uu____7544 :: uu____7571 in
-                       comb_or uu____7535))
-                 | (uu____7671, uu____7672, FStar_Pervasives_Native.Some
-                    uu____7673, uu____7674) ->
+                                   FStar_All.pipe_left fullyno uu____7625 in
+                             [uu____7605] in
+                           uu____7565 :: uu____7596 in
+                         uu____7529 :: uu____7556 in
+                       comb_or uu____7520))
+                 | (uu____7656, uu____7657, FStar_Pervasives_Native.Some
+                    uu____7658, uu____7659) ->
                      (FStar_TypeChecker_Cfg.log_unfolding cfg
-                        (fun uu____7742 ->
-                           let uu____7743 =
+                        (fun uu____7727 ->
+                           let uu____7728 =
                              FStar_Syntax_Print.fv_to_string fv in
                            FStar_Util.print1
                              "should_unfold: Reached a %s with selective unfolding\n"
-                             uu____7743);
-                      (let uu____7744 =
-                         let uu____7753 =
+                             uu____7728);
+                      (let uu____7729 =
+                         let uu____7738 =
                            match (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.unfold_only
                            with
                            | FStar_Pervasives_Native.None -> no
                            | FStar_Pervasives_Native.Some lids ->
-                               let uu____7773 =
+                               let uu____7758 =
                                  FStar_Util.for_some
                                    (FStar_Syntax_Syntax.fv_eq_lid fv) lids in
-                               FStar_All.pipe_left yesno uu____7773 in
-                         let uu____7780 =
-                           let uu____7789 =
+                               FStar_All.pipe_left yesno uu____7758 in
+                         let uu____7765 =
+                           let uu____7774 =
                              match (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.unfold_attr
                              with
                              | FStar_Pervasives_Native.None -> no
                              | FStar_Pervasives_Native.Some lids ->
-                                 let uu____7809 =
+                                 let uu____7794 =
                                    FStar_Util.for_some
                                      (fun at ->
                                         FStar_Util.for_some
                                           (fun lid ->
                                              FStar_Syntax_Util.is_fvar lid at)
                                           lids) attrs in
-                                 FStar_All.pipe_left yesno uu____7809 in
-                           let uu____7820 =
-                             let uu____7829 =
+                                 FStar_All.pipe_left yesno uu____7794 in
+                           let uu____7805 =
+                             let uu____7814 =
                                match (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.unfold_fully
                                with
                                | FStar_Pervasives_Native.None -> no
                                | FStar_Pervasives_Native.Some lids ->
-                                   let uu____7849 =
+                                   let uu____7834 =
                                      FStar_Util.for_some
                                        (FStar_Syntax_Syntax.fv_eq_lid fv)
                                        lids in
-                                   FStar_All.pipe_left fullyno uu____7849 in
-                             [uu____7829] in
-                           uu____7789 :: uu____7820 in
-                         uu____7753 :: uu____7780 in
-                       comb_or uu____7744))
-                 | (uu____7880, uu____7881, uu____7882,
-                    FStar_Pervasives_Native.Some uu____7883) ->
+                                   FStar_All.pipe_left fullyno uu____7834 in
+                             [uu____7814] in
+                           uu____7774 :: uu____7805 in
+                         uu____7738 :: uu____7765 in
+                       comb_or uu____7729))
+                 | (uu____7865, uu____7866, uu____7867,
+                    FStar_Pervasives_Native.Some uu____7868) ->
                      (FStar_TypeChecker_Cfg.log_unfolding cfg
-                        (fun uu____7951 ->
-                           let uu____7952 =
+                        (fun uu____7936 ->
+                           let uu____7937 =
                              FStar_Syntax_Print.fv_to_string fv in
                            FStar_Util.print1
                              "should_unfold: Reached a %s with selective unfolding\n"
-                             uu____7952);
-                      (let uu____7953 =
-                         let uu____7962 =
+                             uu____7937);
+                      (let uu____7938 =
+                         let uu____7947 =
                            match (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.unfold_only
                            with
                            | FStar_Pervasives_Native.None -> no
                            | FStar_Pervasives_Native.Some lids ->
-                               let uu____7982 =
+                               let uu____7967 =
                                  FStar_Util.for_some
                                    (FStar_Syntax_Syntax.fv_eq_lid fv) lids in
-                               FStar_All.pipe_left yesno uu____7982 in
-                         let uu____7989 =
-                           let uu____7998 =
+                               FStar_All.pipe_left yesno uu____7967 in
+                         let uu____7974 =
+                           let uu____7983 =
                              match (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.unfold_attr
                              with
                              | FStar_Pervasives_Native.None -> no
                              | FStar_Pervasives_Native.Some lids ->
-                                 let uu____8018 =
+                                 let uu____8003 =
                                    FStar_Util.for_some
                                      (fun at ->
                                         FStar_Util.for_some
                                           (fun lid ->
                                              FStar_Syntax_Util.is_fvar lid at)
                                           lids) attrs in
-                                 FStar_All.pipe_left yesno uu____8018 in
-                           let uu____8029 =
-                             let uu____8038 =
+                                 FStar_All.pipe_left yesno uu____8003 in
+                           let uu____8014 =
+                             let uu____8023 =
                                match (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.unfold_fully
                                with
                                | FStar_Pervasives_Native.None -> no
                                | FStar_Pervasives_Native.Some lids ->
-                                   let uu____8058 =
+                                   let uu____8043 =
                                      FStar_Util.for_some
                                        (FStar_Syntax_Syntax.fv_eq_lid fv)
                                        lids in
-                                   FStar_All.pipe_left fullyno uu____8058 in
-                             [uu____8038] in
-                           uu____7998 :: uu____8029 in
-                         uu____7962 :: uu____7989 in
-                       comb_or uu____7953))
-                 | uu____8089 ->
+                                   FStar_All.pipe_left fullyno uu____8043 in
+                             [uu____8023] in
+                           uu____7983 :: uu____8014 in
+                         uu____7947 :: uu____7974 in
+                       comb_or uu____7938))
+                 | uu____8074 ->
                      (FStar_TypeChecker_Cfg.log_unfolding cfg
-                        (fun uu____8135 ->
-                           let uu____8136 =
+                        (fun uu____8120 ->
+                           let uu____8121 =
                              FStar_Syntax_Print.fv_to_string fv in
-                           let uu____8137 =
+                           let uu____8122 =
                              FStar_Syntax_Print.delta_depth_to_string
                                fv.FStar_Syntax_Syntax.fv_delta in
-                           let uu____8138 =
+                           let uu____8123 =
                              FStar_Common.string_of_list
                                FStar_TypeChecker_Env.string_of_delta_level
                                cfg.FStar_TypeChecker_Cfg.delta_level in
                            FStar_Util.print3
                              "should_unfold: Reached a %s with delta_depth = %s\n >> Our delta_level is %s\n"
-                             uu____8136 uu____8137 uu____8138);
-                      (let uu____8139 =
+                             uu____8121 uu____8122 uu____8123);
+                      (let uu____8124 =
                          FStar_All.pipe_right
                            cfg.FStar_TypeChecker_Cfg.delta_level
                            (FStar_Util.for_some
-                              (fun uu___12_8143 ->
-                                 match uu___12_8143 with
+                              (fun uu___12_8128 ->
+                                 match uu___12_8128 with
                                  | FStar_TypeChecker_Env.NoDelta -> false
                                  | FStar_TypeChecker_Env.InliningDelta ->
                                      true
                                  | FStar_TypeChecker_Env.Eager_unfolding_only
                                      -> true
                                  | FStar_TypeChecker_Env.Unfold l ->
-                                     let uu____8145 =
+                                     let uu____8130 =
                                        FStar_TypeChecker_Env.delta_depth_of_fv
                                          cfg.FStar_TypeChecker_Cfg.tcenv fv in
                                      FStar_TypeChecker_Common.delta_depth_greater_than
-                                       uu____8145 l)) in
-                       FStar_All.pipe_left yesno uu____8139))) in
+                                       uu____8130 l)) in
+                       FStar_All.pipe_left yesno uu____8124))) in
           FStar_TypeChecker_Cfg.log_unfolding cfg
-            (fun uu____8157 ->
-               let uu____8158 = FStar_Syntax_Print.fv_to_string fv in
-               let uu____8159 =
-                 let uu____8160 = FStar_Syntax_Syntax.range_of_fv fv in
-                 FStar_Range.string_of_range uu____8160 in
-               let uu____8161 = string_of_res res in
+            (fun uu____8142 ->
+               let uu____8143 = FStar_Syntax_Print.fv_to_string fv in
+               let uu____8144 =
+                 let uu____8145 = FStar_Syntax_Syntax.range_of_fv fv in
+                 FStar_Range.string_of_range uu____8145 in
+               let uu____8146 = string_of_res res in
                FStar_Util.print3
                  "should_unfold: For %s (%s), unfolding res = %s\n"
-                 uu____8158 uu____8159 uu____8161);
+                 uu____8143 uu____8144 uu____8146);
           (match res with
-           | (false, uu____8162, uu____8163) -> Should_unfold_no
+           | (false, uu____8147, uu____8148) -> Should_unfold_no
            | (true, false, false) -> Should_unfold_yes
            | (true, true, false) -> Should_unfold_fully
            | (true, false, true) -> Should_unfold_reify
-           | uu____8164 ->
-               let uu____8171 =
-                 let uu____8172 = string_of_res res in
+           | uu____8149 ->
+               let uu____8156 =
+                 let uu____8157 = string_of_res res in
                  FStar_Util.format1 "Unexpected unfolding result: %s"
-                   uu____8172 in
-               FStar_All.pipe_left failwith uu____8171)
+                   uu____8157 in
+               FStar_All.pipe_left failwith uu____8156)
 let decide_unfolding :
-  'uuuuuu8187 .
+  'uuuuuu8172 .
     FStar_TypeChecker_Cfg.cfg ->
       env ->
         stack_elt Prims.list ->
-          'uuuuuu8187 ->
+          'uuuuuu8172 ->
             FStar_Syntax_Syntax.fv ->
               FStar_TypeChecker_Env.qninfo ->
                 (FStar_TypeChecker_Cfg.cfg * stack_elt Prims.list)
@@ -2213,27 +2212,27 @@ let decide_unfolding :
                   FStar_Pervasives_Native.Some (cfg, stack1)
               | Should_unfold_fully ->
                   let cfg' =
-                    let uu___1168_8256 = cfg in
+                    let uu___1168_8241 = cfg in
                     {
                       FStar_TypeChecker_Cfg.steps =
-                        (let uu___1170_8259 = cfg.FStar_TypeChecker_Cfg.steps in
+                        (let uu___1170_8244 = cfg.FStar_TypeChecker_Cfg.steps in
                          {
                            FStar_TypeChecker_Cfg.beta =
-                             (uu___1170_8259.FStar_TypeChecker_Cfg.beta);
+                             (uu___1170_8244.FStar_TypeChecker_Cfg.beta);
                            FStar_TypeChecker_Cfg.iota =
-                             (uu___1170_8259.FStar_TypeChecker_Cfg.iota);
+                             (uu___1170_8244.FStar_TypeChecker_Cfg.iota);
                            FStar_TypeChecker_Cfg.zeta =
-                             (uu___1170_8259.FStar_TypeChecker_Cfg.zeta);
+                             (uu___1170_8244.FStar_TypeChecker_Cfg.zeta);
                            FStar_TypeChecker_Cfg.zeta_full =
-                             (uu___1170_8259.FStar_TypeChecker_Cfg.zeta_full);
+                             (uu___1170_8244.FStar_TypeChecker_Cfg.zeta_full);
                            FStar_TypeChecker_Cfg.weak =
-                             (uu___1170_8259.FStar_TypeChecker_Cfg.weak);
+                             (uu___1170_8244.FStar_TypeChecker_Cfg.weak);
                            FStar_TypeChecker_Cfg.hnf =
-                             (uu___1170_8259.FStar_TypeChecker_Cfg.hnf);
+                             (uu___1170_8244.FStar_TypeChecker_Cfg.hnf);
                            FStar_TypeChecker_Cfg.primops =
-                             (uu___1170_8259.FStar_TypeChecker_Cfg.primops);
+                             (uu___1170_8244.FStar_TypeChecker_Cfg.primops);
                            FStar_TypeChecker_Cfg.do_not_unfold_pure_lets =
-                             (uu___1170_8259.FStar_TypeChecker_Cfg.do_not_unfold_pure_lets);
+                             (uu___1170_8244.FStar_TypeChecker_Cfg.do_not_unfold_pure_lets);
                            FStar_TypeChecker_Cfg.unfold_until =
                              (FStar_Pervasives_Native.Some
                                 FStar_Syntax_Syntax.delta_constant);
@@ -2244,53 +2243,53 @@ let decide_unfolding :
                            FStar_TypeChecker_Cfg.unfold_attr =
                              FStar_Pervasives_Native.None;
                            FStar_TypeChecker_Cfg.unfold_tac =
-                             (uu___1170_8259.FStar_TypeChecker_Cfg.unfold_tac);
+                             (uu___1170_8244.FStar_TypeChecker_Cfg.unfold_tac);
                            FStar_TypeChecker_Cfg.pure_subterms_within_computations
                              =
-                             (uu___1170_8259.FStar_TypeChecker_Cfg.pure_subterms_within_computations);
+                             (uu___1170_8244.FStar_TypeChecker_Cfg.pure_subterms_within_computations);
                            FStar_TypeChecker_Cfg.simplify =
-                             (uu___1170_8259.FStar_TypeChecker_Cfg.simplify);
+                             (uu___1170_8244.FStar_TypeChecker_Cfg.simplify);
                            FStar_TypeChecker_Cfg.erase_universes =
-                             (uu___1170_8259.FStar_TypeChecker_Cfg.erase_universes);
+                             (uu___1170_8244.FStar_TypeChecker_Cfg.erase_universes);
                            FStar_TypeChecker_Cfg.allow_unbound_universes =
-                             (uu___1170_8259.FStar_TypeChecker_Cfg.allow_unbound_universes);
+                             (uu___1170_8244.FStar_TypeChecker_Cfg.allow_unbound_universes);
                            FStar_TypeChecker_Cfg.reify_ =
-                             (uu___1170_8259.FStar_TypeChecker_Cfg.reify_);
+                             (uu___1170_8244.FStar_TypeChecker_Cfg.reify_);
                            FStar_TypeChecker_Cfg.compress_uvars =
-                             (uu___1170_8259.FStar_TypeChecker_Cfg.compress_uvars);
+                             (uu___1170_8244.FStar_TypeChecker_Cfg.compress_uvars);
                            FStar_TypeChecker_Cfg.no_full_norm =
-                             (uu___1170_8259.FStar_TypeChecker_Cfg.no_full_norm);
+                             (uu___1170_8244.FStar_TypeChecker_Cfg.no_full_norm);
                            FStar_TypeChecker_Cfg.check_no_uvars =
-                             (uu___1170_8259.FStar_TypeChecker_Cfg.check_no_uvars);
+                             (uu___1170_8244.FStar_TypeChecker_Cfg.check_no_uvars);
                            FStar_TypeChecker_Cfg.unmeta =
-                             (uu___1170_8259.FStar_TypeChecker_Cfg.unmeta);
+                             (uu___1170_8244.FStar_TypeChecker_Cfg.unmeta);
                            FStar_TypeChecker_Cfg.unascribe =
-                             (uu___1170_8259.FStar_TypeChecker_Cfg.unascribe);
+                             (uu___1170_8244.FStar_TypeChecker_Cfg.unascribe);
                            FStar_TypeChecker_Cfg.in_full_norm_request =
-                             (uu___1170_8259.FStar_TypeChecker_Cfg.in_full_norm_request);
+                             (uu___1170_8244.FStar_TypeChecker_Cfg.in_full_norm_request);
                            FStar_TypeChecker_Cfg.weakly_reduce_scrutinee =
-                             (uu___1170_8259.FStar_TypeChecker_Cfg.weakly_reduce_scrutinee);
+                             (uu___1170_8244.FStar_TypeChecker_Cfg.weakly_reduce_scrutinee);
                            FStar_TypeChecker_Cfg.nbe_step =
-                             (uu___1170_8259.FStar_TypeChecker_Cfg.nbe_step);
+                             (uu___1170_8244.FStar_TypeChecker_Cfg.nbe_step);
                            FStar_TypeChecker_Cfg.for_extraction =
-                             (uu___1170_8259.FStar_TypeChecker_Cfg.for_extraction)
+                             (uu___1170_8244.FStar_TypeChecker_Cfg.for_extraction)
                          });
                       FStar_TypeChecker_Cfg.tcenv =
-                        (uu___1168_8256.FStar_TypeChecker_Cfg.tcenv);
+                        (uu___1168_8241.FStar_TypeChecker_Cfg.tcenv);
                       FStar_TypeChecker_Cfg.debug =
-                        (uu___1168_8256.FStar_TypeChecker_Cfg.debug);
+                        (uu___1168_8241.FStar_TypeChecker_Cfg.debug);
                       FStar_TypeChecker_Cfg.delta_level =
-                        (uu___1168_8256.FStar_TypeChecker_Cfg.delta_level);
+                        (uu___1168_8241.FStar_TypeChecker_Cfg.delta_level);
                       FStar_TypeChecker_Cfg.primitive_steps =
-                        (uu___1168_8256.FStar_TypeChecker_Cfg.primitive_steps);
+                        (uu___1168_8241.FStar_TypeChecker_Cfg.primitive_steps);
                       FStar_TypeChecker_Cfg.strong =
-                        (uu___1168_8256.FStar_TypeChecker_Cfg.strong);
+                        (uu___1168_8241.FStar_TypeChecker_Cfg.strong);
                       FStar_TypeChecker_Cfg.memoize_lazy =
-                        (uu___1168_8256.FStar_TypeChecker_Cfg.memoize_lazy);
+                        (uu___1168_8241.FStar_TypeChecker_Cfg.memoize_lazy);
                       FStar_TypeChecker_Cfg.normalize_pure_lets =
-                        (uu___1168_8256.FStar_TypeChecker_Cfg.normalize_pure_lets);
+                        (uu___1168_8241.FStar_TypeChecker_Cfg.normalize_pure_lets);
                       FStar_TypeChecker_Cfg.reifying =
-                        (uu___1168_8256.FStar_TypeChecker_Cfg.reifying)
+                        (uu___1168_8241.FStar_TypeChecker_Cfg.reifying)
                     } in
                   let stack' =
                     match stack1 with
@@ -2303,16 +2302,16 @@ let decide_unfolding :
                     match s with
                     | [] -> [e]
                     | (UnivArgs (us, r))::t ->
-                        let uu____8321 = push e t in (UnivArgs (us, r)) ::
-                          uu____8321
+                        let uu____8306 = push e t in (UnivArgs (us, r)) ::
+                          uu____8306
                     | h::t -> e :: h :: t in
                   let ref =
-                    let uu____8333 =
-                      let uu____8334 =
-                        let uu____8335 = FStar_Syntax_Syntax.lid_of_fv fv in
-                        FStar_Const.Const_reflect uu____8335 in
-                      FStar_Syntax_Syntax.Tm_constant uu____8334 in
-                    FStar_Syntax_Syntax.mk uu____8333 FStar_Range.dummyRange in
+                    let uu____8318 =
+                      let uu____8319 =
+                        let uu____8320 = FStar_Syntax_Syntax.lid_of_fv fv in
+                        FStar_Const.Const_reflect uu____8320 in
+                      FStar_Syntax_Syntax.Tm_constant uu____8319 in
+                    FStar_Syntax_Syntax.mk uu____8318 FStar_Range.dummyRange in
                   let stack2 =
                     push
                       (App
@@ -2333,48 +2332,48 @@ let (is_fext_on_domain :
     let is_on_dom fv =
       FStar_All.pipe_right on_domain_lids
         (FStar_List.existsb (fun l -> FStar_Syntax_Syntax.fv_eq_lid fv l)) in
-    let uu____8378 =
-      let uu____8379 = FStar_Syntax_Subst.compress t in
-      uu____8379.FStar_Syntax_Syntax.n in
-    match uu____8378 with
+    let uu____8363 =
+      let uu____8364 = FStar_Syntax_Subst.compress t in
+      uu____8364.FStar_Syntax_Syntax.n in
+    match uu____8363 with
     | FStar_Syntax_Syntax.Tm_app (hd, args) ->
-        let uu____8410 =
-          let uu____8411 = FStar_Syntax_Util.un_uinst hd in
-          uu____8411.FStar_Syntax_Syntax.n in
-        (match uu____8410 with
+        let uu____8395 =
+          let uu____8396 = FStar_Syntax_Util.un_uinst hd in
+          uu____8396.FStar_Syntax_Syntax.n in
+        (match uu____8395 with
          | FStar_Syntax_Syntax.Tm_fvar fv when
              (is_on_dom fv) &&
                ((FStar_List.length args) = (Prims.of_int (3)))
              ->
              let f =
-               let uu____8426 =
-                 let uu____8433 =
-                   let uu____8444 = FStar_All.pipe_right args FStar_List.tl in
-                   FStar_All.pipe_right uu____8444 FStar_List.tl in
-                 FStar_All.pipe_right uu____8433 FStar_List.hd in
-               FStar_All.pipe_right uu____8426 FStar_Pervasives_Native.fst in
+               let uu____8411 =
+                 let uu____8418 =
+                   let uu____8429 = FStar_All.pipe_right args FStar_List.tl in
+                   FStar_All.pipe_right uu____8429 FStar_List.tl in
+                 FStar_All.pipe_right uu____8418 FStar_List.hd in
+               FStar_All.pipe_right uu____8411 FStar_Pervasives_Native.fst in
              FStar_Pervasives_Native.Some f
-         | uu____8543 -> FStar_Pervasives_Native.None)
-    | uu____8544 -> FStar_Pervasives_Native.None
+         | uu____8528 -> FStar_Pervasives_Native.None)
+    | uu____8529 -> FStar_Pervasives_Native.None
 let (is_partial_primop_app :
   FStar_TypeChecker_Cfg.cfg -> FStar_Syntax_Syntax.term -> Prims.bool) =
   fun cfg ->
     fun t ->
-      let uu____8555 = FStar_Syntax_Util.head_and_args t in
-      match uu____8555 with
+      let uu____8540 = FStar_Syntax_Util.head_and_args t in
+      match uu____8540 with
       | (hd, args) ->
-          let uu____8598 =
-            let uu____8599 = FStar_Syntax_Util.un_uinst hd in
-            uu____8599.FStar_Syntax_Syntax.n in
-          (match uu____8598 with
+          let uu____8583 =
+            let uu____8584 = FStar_Syntax_Util.un_uinst hd in
+            uu____8584.FStar_Syntax_Syntax.n in
+          (match uu____8583 with
            | FStar_Syntax_Syntax.Tm_fvar fv ->
-               let uu____8603 = FStar_TypeChecker_Cfg.find_prim_step cfg fv in
-               (match uu____8603 with
+               let uu____8588 = FStar_TypeChecker_Cfg.find_prim_step cfg fv in
+               (match uu____8588 with
                 | FStar_Pervasives_Native.Some prim_step ->
                     prim_step.FStar_TypeChecker_Cfg.arity >
                       (FStar_List.length args)
                 | FStar_Pervasives_Native.None -> false)
-           | uu____8615 -> false)
+           | uu____8600 -> false)
 let rec (norm :
   FStar_TypeChecker_Cfg.cfg ->
     env -> stack -> FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term)
@@ -2388,109 +2387,109 @@ let rec (norm :
               (cfg.FStar_TypeChecker_Cfg.debug).FStar_TypeChecker_Cfg.norm_delayed
             then
               (match t.FStar_Syntax_Syntax.n with
-               | FStar_Syntax_Syntax.Tm_delayed uu____8892 ->
-                   let uu____8907 = FStar_Syntax_Print.term_to_string t in
-                   FStar_Util.print1 "NORM delayed: %s\n" uu____8907
-               | uu____8908 -> ())
+               | FStar_Syntax_Syntax.Tm_delayed uu____8877 ->
+                   let uu____8892 = FStar_Syntax_Print.term_to_string t in
+                   FStar_Util.print1 "NORM delayed: %s\n" uu____8892
+               | uu____8893 -> ())
             else ();
             FStar_Syntax_Subst.compress t in
           FStar_TypeChecker_Cfg.log cfg
-            (fun uu____8917 ->
-               let uu____8918 = FStar_Syntax_Print.tag_of_term t1 in
-               let uu____8919 =
+            (fun uu____8902 ->
+               let uu____8903 = FStar_Syntax_Print.tag_of_term t1 in
+               let uu____8904 =
                  FStar_Util.string_of_bool
                    (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.no_full_norm in
-               let uu____8920 = FStar_Syntax_Print.term_to_string t1 in
-               let uu____8921 =
+               let uu____8905 = FStar_Syntax_Print.term_to_string t1 in
+               let uu____8906 =
                  FStar_Util.string_of_int (FStar_List.length env1) in
-               let uu____8928 =
-                 let uu____8929 =
-                   let uu____8932 = firstn (Prims.of_int (4)) stack1 in
-                   FStar_All.pipe_left FStar_Pervasives_Native.fst uu____8932 in
-                 stack_to_string uu____8929 in
+               let uu____8913 =
+                 let uu____8914 =
+                   let uu____8917 = firstn (Prims.of_int (4)) stack1 in
+                   FStar_All.pipe_left FStar_Pervasives_Native.fst uu____8917 in
+                 stack_to_string uu____8914 in
                FStar_Util.print5
                  ">>> %s (no_full_norm=%s)\nNorm %s  with with %s env elements top of the stack %s \n"
-                 uu____8918 uu____8919 uu____8920 uu____8921 uu____8928);
+                 uu____8903 uu____8904 uu____8905 uu____8906 uu____8913);
           FStar_TypeChecker_Cfg.log_cfg cfg
-            (fun uu____8958 ->
-               let uu____8959 = FStar_TypeChecker_Cfg.cfg_to_string cfg in
-               FStar_Util.print1 ">>> cfg = %s\n" uu____8959);
+            (fun uu____8943 ->
+               let uu____8944 = FStar_TypeChecker_Cfg.cfg_to_string cfg in
+               FStar_Util.print1 ">>> cfg = %s\n" uu____8944);
           (match t1.FStar_Syntax_Syntax.n with
            | FStar_Syntax_Syntax.Tm_unknown ->
                (FStar_TypeChecker_Cfg.log_unfolding cfg
-                  (fun uu____8963 ->
-                     let uu____8964 = FStar_Syntax_Print.term_to_string t1 in
+                  (fun uu____8948 ->
+                     let uu____8949 = FStar_Syntax_Print.term_to_string t1 in
                      FStar_Util.print1 ">>> Tm_fvar case 0 for %s\n"
-                       uu____8964);
+                       uu____8949);
                 rebuild cfg env1 stack1 t1)
-           | FStar_Syntax_Syntax.Tm_constant uu____8965 ->
+           | FStar_Syntax_Syntax.Tm_constant uu____8950 ->
                (FStar_TypeChecker_Cfg.log_unfolding cfg
-                  (fun uu____8969 ->
-                     let uu____8970 = FStar_Syntax_Print.term_to_string t1 in
+                  (fun uu____8954 ->
+                     let uu____8955 = FStar_Syntax_Print.term_to_string t1 in
                      FStar_Util.print1 ">>> Tm_fvar case 0 for %s\n"
-                       uu____8970);
+                       uu____8955);
                 rebuild cfg env1 stack1 t1)
-           | FStar_Syntax_Syntax.Tm_name uu____8971 ->
+           | FStar_Syntax_Syntax.Tm_name uu____8956 ->
                (FStar_TypeChecker_Cfg.log_unfolding cfg
-                  (fun uu____8975 ->
-                     let uu____8976 = FStar_Syntax_Print.term_to_string t1 in
+                  (fun uu____8960 ->
+                     let uu____8961 = FStar_Syntax_Print.term_to_string t1 in
                      FStar_Util.print1 ">>> Tm_fvar case 0 for %s\n"
-                       uu____8976);
+                       uu____8961);
                 rebuild cfg env1 stack1 t1)
-           | FStar_Syntax_Syntax.Tm_lazy uu____8977 ->
+           | FStar_Syntax_Syntax.Tm_lazy uu____8962 ->
                (FStar_TypeChecker_Cfg.log_unfolding cfg
-                  (fun uu____8981 ->
-                     let uu____8982 = FStar_Syntax_Print.term_to_string t1 in
+                  (fun uu____8966 ->
+                     let uu____8967 = FStar_Syntax_Print.term_to_string t1 in
                      FStar_Util.print1 ">>> Tm_fvar case 0 for %s\n"
-                       uu____8982);
+                       uu____8967);
                 rebuild cfg env1 stack1 t1)
            | FStar_Syntax_Syntax.Tm_fvar
-               { FStar_Syntax_Syntax.fv_name = uu____8983;
-                 FStar_Syntax_Syntax.fv_delta = uu____8984;
+               { FStar_Syntax_Syntax.fv_name = uu____8968;
+                 FStar_Syntax_Syntax.fv_delta = uu____8969;
                  FStar_Syntax_Syntax.fv_qual = FStar_Pervasives_Native.Some
                    (FStar_Syntax_Syntax.Data_ctor);_}
                ->
                (FStar_TypeChecker_Cfg.log_unfolding cfg
-                  (fun uu____8988 ->
-                     let uu____8989 = FStar_Syntax_Print.term_to_string t1 in
+                  (fun uu____8973 ->
+                     let uu____8974 = FStar_Syntax_Print.term_to_string t1 in
                      FStar_Util.print1 ">>> Tm_fvar case 0 for %s\n"
-                       uu____8989);
+                       uu____8974);
                 rebuild cfg env1 stack1 t1)
            | FStar_Syntax_Syntax.Tm_fvar
-               { FStar_Syntax_Syntax.fv_name = uu____8990;
-                 FStar_Syntax_Syntax.fv_delta = uu____8991;
+               { FStar_Syntax_Syntax.fv_name = uu____8975;
+                 FStar_Syntax_Syntax.fv_delta = uu____8976;
                  FStar_Syntax_Syntax.fv_qual = FStar_Pervasives_Native.Some
-                   (FStar_Syntax_Syntax.Record_ctor uu____8992);_}
+                   (FStar_Syntax_Syntax.Record_ctor uu____8977);_}
                ->
                (FStar_TypeChecker_Cfg.log_unfolding cfg
-                  (fun uu____9002 ->
-                     let uu____9003 = FStar_Syntax_Print.term_to_string t1 in
+                  (fun uu____8987 ->
+                     let uu____8988 = FStar_Syntax_Print.term_to_string t1 in
                      FStar_Util.print1 ">>> Tm_fvar case 0 for %s\n"
-                       uu____9003);
+                       uu____8988);
                 rebuild cfg env1 stack1 t1)
            | FStar_Syntax_Syntax.Tm_fvar fv ->
                let lid = FStar_Syntax_Syntax.lid_of_fv fv in
                let qninfo =
                  FStar_TypeChecker_Env.lookup_qname
                    cfg.FStar_TypeChecker_Cfg.tcenv lid in
-               let uu____9007 =
+               let uu____8992 =
                  FStar_TypeChecker_Env.delta_depth_of_qninfo fv qninfo in
-               (match uu____9007 with
+               (match uu____8992 with
                 | FStar_Pervasives_Native.Some
-                    (FStar_Syntax_Syntax.Delta_constant_at_level uu____9010)
-                    when uu____9010 = Prims.int_zero ->
+                    (FStar_Syntax_Syntax.Delta_constant_at_level uu____8995)
+                    when uu____8995 = Prims.int_zero ->
                     (FStar_TypeChecker_Cfg.log_unfolding cfg
-                       (fun uu____9014 ->
-                          let uu____9015 =
+                       (fun uu____8999 ->
+                          let uu____9000 =
                             FStar_Syntax_Print.term_to_string t1 in
                           FStar_Util.print1 ">>> Tm_fvar case 0 for %s\n"
-                            uu____9015);
+                            uu____9000);
                      rebuild cfg env1 stack1 t1)
-                | uu____9016 ->
-                    let uu____9019 =
+                | uu____9001 ->
+                    let uu____9004 =
                       decide_unfolding cfg env1 stack1
                         t1.FStar_Syntax_Syntax.pos fv qninfo in
-                    (match uu____9019 with
+                    (match uu____9004 with
                      | FStar_Pervasives_Native.Some (cfg1, stack2) ->
                          do_unfold_fv cfg1 env1 stack2 t1 qninfo fv
                      | FStar_Pervasives_Native.None ->
@@ -2502,110 +2501,110 @@ let rec (norm :
                  FStar_Syntax_Syntax.mk
                    (FStar_Syntax_Syntax.Tm_quoted (qt, qi1))
                    t1.FStar_Syntax_Syntax.pos in
-               let uu____9058 = closure_as_term cfg env1 t2 in
-               rebuild cfg env1 stack1 uu____9058
+               let uu____9043 = closure_as_term cfg env1 t2 in
+               rebuild cfg env1 stack1 uu____9043
            | FStar_Syntax_Syntax.Tm_app (hd, args) when
                (should_consider_norm_requests cfg) &&
-                 (let uu____9086 = is_norm_request hd args in
-                  uu____9086 = Norm_request_requires_rejig)
+                 (let uu____9071 = is_norm_request hd args in
+                  uu____9071 = Norm_request_requires_rejig)
                ->
                (if
                   (cfg.FStar_TypeChecker_Cfg.debug).FStar_TypeChecker_Cfg.print_normalized
                 then FStar_Util.print_string "Rejigging norm request ... \n"
                 else ();
-                (let uu____9089 = rejig_norm_request hd args in
-                 norm cfg env1 stack1 uu____9089))
+                (let uu____9074 = rejig_norm_request hd args in
+                 norm cfg env1 stack1 uu____9074))
            | FStar_Syntax_Syntax.Tm_app (hd, args) when
                (should_consider_norm_requests cfg) &&
-                 (let uu____9117 = is_norm_request hd args in
-                  uu____9117 = Norm_request_ready)
+                 (let uu____9102 = is_norm_request hd args in
+                  uu____9102 = Norm_request_ready)
                ->
                (if
                   (cfg.FStar_TypeChecker_Cfg.debug).FStar_TypeChecker_Cfg.print_normalized
                 then FStar_Util.print_string "Potential norm request ... \n"
                 else ();
                 (let cfg' =
-                   let uu___1292_9121 = cfg in
+                   let uu___1292_9106 = cfg in
                    {
                      FStar_TypeChecker_Cfg.steps =
-                       (let uu___1294_9124 = cfg.FStar_TypeChecker_Cfg.steps in
+                       (let uu___1294_9109 = cfg.FStar_TypeChecker_Cfg.steps in
                         {
                           FStar_TypeChecker_Cfg.beta =
-                            (uu___1294_9124.FStar_TypeChecker_Cfg.beta);
+                            (uu___1294_9109.FStar_TypeChecker_Cfg.beta);
                           FStar_TypeChecker_Cfg.iota =
-                            (uu___1294_9124.FStar_TypeChecker_Cfg.iota);
+                            (uu___1294_9109.FStar_TypeChecker_Cfg.iota);
                           FStar_TypeChecker_Cfg.zeta =
-                            (uu___1294_9124.FStar_TypeChecker_Cfg.zeta);
+                            (uu___1294_9109.FStar_TypeChecker_Cfg.zeta);
                           FStar_TypeChecker_Cfg.zeta_full =
-                            (uu___1294_9124.FStar_TypeChecker_Cfg.zeta_full);
+                            (uu___1294_9109.FStar_TypeChecker_Cfg.zeta_full);
                           FStar_TypeChecker_Cfg.weak =
-                            (uu___1294_9124.FStar_TypeChecker_Cfg.weak);
+                            (uu___1294_9109.FStar_TypeChecker_Cfg.weak);
                           FStar_TypeChecker_Cfg.hnf =
-                            (uu___1294_9124.FStar_TypeChecker_Cfg.hnf);
+                            (uu___1294_9109.FStar_TypeChecker_Cfg.hnf);
                           FStar_TypeChecker_Cfg.primops =
-                            (uu___1294_9124.FStar_TypeChecker_Cfg.primops);
+                            (uu___1294_9109.FStar_TypeChecker_Cfg.primops);
                           FStar_TypeChecker_Cfg.do_not_unfold_pure_lets =
                             false;
                           FStar_TypeChecker_Cfg.unfold_until =
-                            (uu___1294_9124.FStar_TypeChecker_Cfg.unfold_until);
+                            (uu___1294_9109.FStar_TypeChecker_Cfg.unfold_until);
                           FStar_TypeChecker_Cfg.unfold_only =
                             FStar_Pervasives_Native.None;
                           FStar_TypeChecker_Cfg.unfold_fully =
                             FStar_Pervasives_Native.None;
                           FStar_TypeChecker_Cfg.unfold_attr =
-                            (uu___1294_9124.FStar_TypeChecker_Cfg.unfold_attr);
+                            (uu___1294_9109.FStar_TypeChecker_Cfg.unfold_attr);
                           FStar_TypeChecker_Cfg.unfold_tac =
-                            (uu___1294_9124.FStar_TypeChecker_Cfg.unfold_tac);
+                            (uu___1294_9109.FStar_TypeChecker_Cfg.unfold_tac);
                           FStar_TypeChecker_Cfg.pure_subterms_within_computations
                             =
-                            (uu___1294_9124.FStar_TypeChecker_Cfg.pure_subterms_within_computations);
+                            (uu___1294_9109.FStar_TypeChecker_Cfg.pure_subterms_within_computations);
                           FStar_TypeChecker_Cfg.simplify =
-                            (uu___1294_9124.FStar_TypeChecker_Cfg.simplify);
+                            (uu___1294_9109.FStar_TypeChecker_Cfg.simplify);
                           FStar_TypeChecker_Cfg.erase_universes =
-                            (uu___1294_9124.FStar_TypeChecker_Cfg.erase_universes);
+                            (uu___1294_9109.FStar_TypeChecker_Cfg.erase_universes);
                           FStar_TypeChecker_Cfg.allow_unbound_universes =
-                            (uu___1294_9124.FStar_TypeChecker_Cfg.allow_unbound_universes);
+                            (uu___1294_9109.FStar_TypeChecker_Cfg.allow_unbound_universes);
                           FStar_TypeChecker_Cfg.reify_ =
-                            (uu___1294_9124.FStar_TypeChecker_Cfg.reify_);
+                            (uu___1294_9109.FStar_TypeChecker_Cfg.reify_);
                           FStar_TypeChecker_Cfg.compress_uvars =
-                            (uu___1294_9124.FStar_TypeChecker_Cfg.compress_uvars);
+                            (uu___1294_9109.FStar_TypeChecker_Cfg.compress_uvars);
                           FStar_TypeChecker_Cfg.no_full_norm =
-                            (uu___1294_9124.FStar_TypeChecker_Cfg.no_full_norm);
+                            (uu___1294_9109.FStar_TypeChecker_Cfg.no_full_norm);
                           FStar_TypeChecker_Cfg.check_no_uvars =
-                            (uu___1294_9124.FStar_TypeChecker_Cfg.check_no_uvars);
+                            (uu___1294_9109.FStar_TypeChecker_Cfg.check_no_uvars);
                           FStar_TypeChecker_Cfg.unmeta =
-                            (uu___1294_9124.FStar_TypeChecker_Cfg.unmeta);
+                            (uu___1294_9109.FStar_TypeChecker_Cfg.unmeta);
                           FStar_TypeChecker_Cfg.unascribe =
-                            (uu___1294_9124.FStar_TypeChecker_Cfg.unascribe);
+                            (uu___1294_9109.FStar_TypeChecker_Cfg.unascribe);
                           FStar_TypeChecker_Cfg.in_full_norm_request =
-                            (uu___1294_9124.FStar_TypeChecker_Cfg.in_full_norm_request);
+                            (uu___1294_9109.FStar_TypeChecker_Cfg.in_full_norm_request);
                           FStar_TypeChecker_Cfg.weakly_reduce_scrutinee =
-                            (uu___1294_9124.FStar_TypeChecker_Cfg.weakly_reduce_scrutinee);
+                            (uu___1294_9109.FStar_TypeChecker_Cfg.weakly_reduce_scrutinee);
                           FStar_TypeChecker_Cfg.nbe_step =
-                            (uu___1294_9124.FStar_TypeChecker_Cfg.nbe_step);
+                            (uu___1294_9109.FStar_TypeChecker_Cfg.nbe_step);
                           FStar_TypeChecker_Cfg.for_extraction =
-                            (uu___1294_9124.FStar_TypeChecker_Cfg.for_extraction)
+                            (uu___1294_9109.FStar_TypeChecker_Cfg.for_extraction)
                         });
                      FStar_TypeChecker_Cfg.tcenv =
-                       (uu___1292_9121.FStar_TypeChecker_Cfg.tcenv);
+                       (uu___1292_9106.FStar_TypeChecker_Cfg.tcenv);
                      FStar_TypeChecker_Cfg.debug =
-                       (uu___1292_9121.FStar_TypeChecker_Cfg.debug);
+                       (uu___1292_9106.FStar_TypeChecker_Cfg.debug);
                      FStar_TypeChecker_Cfg.delta_level =
                        [FStar_TypeChecker_Env.Unfold
                           FStar_Syntax_Syntax.delta_constant];
                      FStar_TypeChecker_Cfg.primitive_steps =
-                       (uu___1292_9121.FStar_TypeChecker_Cfg.primitive_steps);
+                       (uu___1292_9106.FStar_TypeChecker_Cfg.primitive_steps);
                      FStar_TypeChecker_Cfg.strong =
-                       (uu___1292_9121.FStar_TypeChecker_Cfg.strong);
+                       (uu___1292_9106.FStar_TypeChecker_Cfg.strong);
                      FStar_TypeChecker_Cfg.memoize_lazy =
-                       (uu___1292_9121.FStar_TypeChecker_Cfg.memoize_lazy);
+                       (uu___1292_9106.FStar_TypeChecker_Cfg.memoize_lazy);
                      FStar_TypeChecker_Cfg.normalize_pure_lets = true;
                      FStar_TypeChecker_Cfg.reifying =
-                       (uu___1292_9121.FStar_TypeChecker_Cfg.reifying)
+                       (uu___1292_9106.FStar_TypeChecker_Cfg.reifying)
                    } in
-                 let uu____9129 =
+                 let uu____9114 =
                    get_norm_request cfg (norm cfg' env1 []) args in
-                 match uu____9129 with
+                 match uu____9114 with
                  | FStar_Pervasives_Native.None ->
                      (if
                         (cfg.FStar_TypeChecker_Cfg.debug).FStar_TypeChecker_Cfg.print_normalized
@@ -2614,30 +2613,30 @@ let rec (norm :
                       (let stack2 =
                          FStar_All.pipe_right stack1
                            (FStar_List.fold_right
-                              (fun uu____9162 ->
+                              (fun uu____9147 ->
                                  fun stack2 ->
-                                   match uu____9162 with
+                                   match uu____9147 with
                                    | (a, aq) ->
-                                       let uu____9174 =
-                                         let uu____9175 =
-                                           let uu____9182 =
-                                             let uu____9183 =
-                                               let uu____9214 =
+                                       let uu____9159 =
+                                         let uu____9160 =
+                                           let uu____9167 =
+                                             let uu____9168 =
+                                               let uu____9199 =
                                                  FStar_Util.mk_ref
                                                    FStar_Pervasives_Native.None in
-                                               (env1, a, uu____9214, false) in
-                                             Clos uu____9183 in
-                                           (uu____9182, aq,
+                                               (env1, a, uu____9199, false) in
+                                             Clos uu____9168 in
+                                           (uu____9167, aq,
                                              (t1.FStar_Syntax_Syntax.pos)) in
-                                         Arg uu____9175 in
-                                       uu____9174 :: stack2) args) in
+                                         Arg uu____9160 in
+                                       uu____9159 :: stack2) args) in
                        FStar_TypeChecker_Cfg.log cfg
-                         (fun uu____9280 ->
-                            let uu____9281 =
+                         (fun uu____9265 ->
+                            let uu____9266 =
                               FStar_All.pipe_left FStar_Util.string_of_int
                                 (FStar_List.length args) in
                             FStar_Util.print1 "\tPushed %s arguments\n"
-                              uu____9281);
+                              uu____9266);
                        norm cfg env1 stack2 hd))
                  | FStar_Pervasives_Native.Some (s, tm) when is_nbe_request s
                      ->
@@ -2651,154 +2650,154 @@ let rec (norm :
                         (let cfg'1 =
                            FStar_TypeChecker_Cfg.config' [] s
                              cfg.FStar_TypeChecker_Cfg.tcenv in
-                         let uu____9308 =
-                           let uu____9309 =
-                             let uu____9310 = FStar_Util.time_diff start fin in
-                             FStar_Pervasives_Native.snd uu____9310 in
-                           FStar_Util.string_of_int uu____9309 in
-                         let uu____9315 =
+                         let uu____9293 =
+                           let uu____9294 =
+                             let uu____9295 = FStar_Util.time_diff start fin in
+                             FStar_Pervasives_Native.snd uu____9295 in
+                           FStar_Util.string_of_int uu____9294 in
+                         let uu____9300 =
                            FStar_Syntax_Print.term_to_string tm' in
-                         let uu____9316 =
+                         let uu____9301 =
                            FStar_TypeChecker_Cfg.cfg_to_string cfg'1 in
-                         let uu____9317 =
+                         let uu____9302 =
                            FStar_Syntax_Print.term_to_string tm_norm in
                          FStar_Util.print4
                            "NBE result timing (%s ms){\nOn term {\n%s\n}\nwith steps {%s}\nresult is{\n\n%s\n}\n}\n"
-                           uu____9308 uu____9315 uu____9316 uu____9317)
+                           uu____9293 uu____9300 uu____9301 uu____9302)
                       else ();
                       rebuild cfg env1 stack1 tm_norm)
                  | FStar_Pervasives_Native.Some (s, tm) ->
                      let delta_level =
-                       let uu____9334 =
+                       let uu____9319 =
                          FStar_All.pipe_right s
                            (FStar_Util.for_some
-                              (fun uu___13_9339 ->
-                                 match uu___13_9339 with
+                              (fun uu___13_9324 ->
+                                 match uu___13_9324 with
                                  | FStar_TypeChecker_Env.UnfoldUntil
-                                     uu____9340 -> true
+                                     uu____9325 -> true
                                  | FStar_TypeChecker_Env.UnfoldOnly
-                                     uu____9341 -> true
+                                     uu____9326 -> true
                                  | FStar_TypeChecker_Env.UnfoldFully
-                                     uu____9344 -> true
-                                 | uu____9347 -> false)) in
-                       if uu____9334
+                                     uu____9329 -> true
+                                 | uu____9332 -> false)) in
+                       if uu____9319
                        then
                          [FStar_TypeChecker_Env.Unfold
                             FStar_Syntax_Syntax.delta_constant]
                        else [FStar_TypeChecker_Env.NoDelta] in
                      let cfg'1 =
-                       let uu___1332_9352 = cfg in
-                       let uu____9353 =
-                         let uu___1334_9354 =
+                       let uu___1332_9337 = cfg in
+                       let uu____9338 =
+                         let uu___1334_9339 =
                            FStar_TypeChecker_Cfg.to_fsteps s in
                          {
                            FStar_TypeChecker_Cfg.beta =
-                             (uu___1334_9354.FStar_TypeChecker_Cfg.beta);
+                             (uu___1334_9339.FStar_TypeChecker_Cfg.beta);
                            FStar_TypeChecker_Cfg.iota =
-                             (uu___1334_9354.FStar_TypeChecker_Cfg.iota);
+                             (uu___1334_9339.FStar_TypeChecker_Cfg.iota);
                            FStar_TypeChecker_Cfg.zeta =
-                             (uu___1334_9354.FStar_TypeChecker_Cfg.zeta);
+                             (uu___1334_9339.FStar_TypeChecker_Cfg.zeta);
                            FStar_TypeChecker_Cfg.zeta_full =
-                             (uu___1334_9354.FStar_TypeChecker_Cfg.zeta_full);
+                             (uu___1334_9339.FStar_TypeChecker_Cfg.zeta_full);
                            FStar_TypeChecker_Cfg.weak =
-                             (uu___1334_9354.FStar_TypeChecker_Cfg.weak);
+                             (uu___1334_9339.FStar_TypeChecker_Cfg.weak);
                            FStar_TypeChecker_Cfg.hnf =
-                             (uu___1334_9354.FStar_TypeChecker_Cfg.hnf);
+                             (uu___1334_9339.FStar_TypeChecker_Cfg.hnf);
                            FStar_TypeChecker_Cfg.primops =
-                             (uu___1334_9354.FStar_TypeChecker_Cfg.primops);
+                             (uu___1334_9339.FStar_TypeChecker_Cfg.primops);
                            FStar_TypeChecker_Cfg.do_not_unfold_pure_lets =
-                             (uu___1334_9354.FStar_TypeChecker_Cfg.do_not_unfold_pure_lets);
+                             (uu___1334_9339.FStar_TypeChecker_Cfg.do_not_unfold_pure_lets);
                            FStar_TypeChecker_Cfg.unfold_until =
-                             (uu___1334_9354.FStar_TypeChecker_Cfg.unfold_until);
+                             (uu___1334_9339.FStar_TypeChecker_Cfg.unfold_until);
                            FStar_TypeChecker_Cfg.unfold_only =
-                             (uu___1334_9354.FStar_TypeChecker_Cfg.unfold_only);
+                             (uu___1334_9339.FStar_TypeChecker_Cfg.unfold_only);
                            FStar_TypeChecker_Cfg.unfold_fully =
-                             (uu___1334_9354.FStar_TypeChecker_Cfg.unfold_fully);
+                             (uu___1334_9339.FStar_TypeChecker_Cfg.unfold_fully);
                            FStar_TypeChecker_Cfg.unfold_attr =
-                             (uu___1334_9354.FStar_TypeChecker_Cfg.unfold_attr);
+                             (uu___1334_9339.FStar_TypeChecker_Cfg.unfold_attr);
                            FStar_TypeChecker_Cfg.unfold_tac =
-                             (uu___1334_9354.FStar_TypeChecker_Cfg.unfold_tac);
+                             (uu___1334_9339.FStar_TypeChecker_Cfg.unfold_tac);
                            FStar_TypeChecker_Cfg.pure_subterms_within_computations
                              =
-                             (uu___1334_9354.FStar_TypeChecker_Cfg.pure_subterms_within_computations);
+                             (uu___1334_9339.FStar_TypeChecker_Cfg.pure_subterms_within_computations);
                            FStar_TypeChecker_Cfg.simplify =
-                             (uu___1334_9354.FStar_TypeChecker_Cfg.simplify);
+                             (uu___1334_9339.FStar_TypeChecker_Cfg.simplify);
                            FStar_TypeChecker_Cfg.erase_universes =
-                             (uu___1334_9354.FStar_TypeChecker_Cfg.erase_universes);
+                             (uu___1334_9339.FStar_TypeChecker_Cfg.erase_universes);
                            FStar_TypeChecker_Cfg.allow_unbound_universes =
-                             (uu___1334_9354.FStar_TypeChecker_Cfg.allow_unbound_universes);
+                             (uu___1334_9339.FStar_TypeChecker_Cfg.allow_unbound_universes);
                            FStar_TypeChecker_Cfg.reify_ =
-                             (uu___1334_9354.FStar_TypeChecker_Cfg.reify_);
+                             (uu___1334_9339.FStar_TypeChecker_Cfg.reify_);
                            FStar_TypeChecker_Cfg.compress_uvars =
-                             (uu___1334_9354.FStar_TypeChecker_Cfg.compress_uvars);
+                             (uu___1334_9339.FStar_TypeChecker_Cfg.compress_uvars);
                            FStar_TypeChecker_Cfg.no_full_norm =
-                             (uu___1334_9354.FStar_TypeChecker_Cfg.no_full_norm);
+                             (uu___1334_9339.FStar_TypeChecker_Cfg.no_full_norm);
                            FStar_TypeChecker_Cfg.check_no_uvars =
-                             (uu___1334_9354.FStar_TypeChecker_Cfg.check_no_uvars);
+                             (uu___1334_9339.FStar_TypeChecker_Cfg.check_no_uvars);
                            FStar_TypeChecker_Cfg.unmeta =
-                             (uu___1334_9354.FStar_TypeChecker_Cfg.unmeta);
+                             (uu___1334_9339.FStar_TypeChecker_Cfg.unmeta);
                            FStar_TypeChecker_Cfg.unascribe =
-                             (uu___1334_9354.FStar_TypeChecker_Cfg.unascribe);
+                             (uu___1334_9339.FStar_TypeChecker_Cfg.unascribe);
                            FStar_TypeChecker_Cfg.in_full_norm_request = true;
                            FStar_TypeChecker_Cfg.weakly_reduce_scrutinee =
-                             (uu___1334_9354.FStar_TypeChecker_Cfg.weakly_reduce_scrutinee);
+                             (uu___1334_9339.FStar_TypeChecker_Cfg.weakly_reduce_scrutinee);
                            FStar_TypeChecker_Cfg.nbe_step =
-                             (uu___1334_9354.FStar_TypeChecker_Cfg.nbe_step);
+                             (uu___1334_9339.FStar_TypeChecker_Cfg.nbe_step);
                            FStar_TypeChecker_Cfg.for_extraction =
-                             (uu___1334_9354.FStar_TypeChecker_Cfg.for_extraction)
+                             (uu___1334_9339.FStar_TypeChecker_Cfg.for_extraction)
                          } in
                        {
-                         FStar_TypeChecker_Cfg.steps = uu____9353;
+                         FStar_TypeChecker_Cfg.steps = uu____9338;
                          FStar_TypeChecker_Cfg.tcenv =
-                           (uu___1332_9352.FStar_TypeChecker_Cfg.tcenv);
+                           (uu___1332_9337.FStar_TypeChecker_Cfg.tcenv);
                          FStar_TypeChecker_Cfg.debug =
-                           (uu___1332_9352.FStar_TypeChecker_Cfg.debug);
+                           (uu___1332_9337.FStar_TypeChecker_Cfg.debug);
                          FStar_TypeChecker_Cfg.delta_level = delta_level;
                          FStar_TypeChecker_Cfg.primitive_steps =
-                           (uu___1332_9352.FStar_TypeChecker_Cfg.primitive_steps);
+                           (uu___1332_9337.FStar_TypeChecker_Cfg.primitive_steps);
                          FStar_TypeChecker_Cfg.strong =
-                           (uu___1332_9352.FStar_TypeChecker_Cfg.strong);
+                           (uu___1332_9337.FStar_TypeChecker_Cfg.strong);
                          FStar_TypeChecker_Cfg.memoize_lazy =
-                           (uu___1332_9352.FStar_TypeChecker_Cfg.memoize_lazy);
+                           (uu___1332_9337.FStar_TypeChecker_Cfg.memoize_lazy);
                          FStar_TypeChecker_Cfg.normalize_pure_lets = true;
                          FStar_TypeChecker_Cfg.reifying =
-                           (uu___1332_9352.FStar_TypeChecker_Cfg.reifying)
+                           (uu___1332_9337.FStar_TypeChecker_Cfg.reifying)
                        } in
                      let stack' =
                        let tail = (Cfg cfg) :: stack1 in
                        if
                          (cfg.FStar_TypeChecker_Cfg.debug).FStar_TypeChecker_Cfg.print_normalized
                        then
-                         let uu____9359 =
-                           let uu____9360 =
-                             let uu____9365 = FStar_Util.now () in
-                             (tm, uu____9365) in
-                           Debug uu____9360 in
-                         uu____9359 :: tail
+                         let uu____9344 =
+                           let uu____9345 =
+                             let uu____9350 = FStar_Util.now () in
+                             (tm, uu____9350) in
+                           Debug uu____9345 in
+                         uu____9344 :: tail
                        else tail in
                      norm cfg'1 env1 stack' tm))
            | FStar_Syntax_Syntax.Tm_type u ->
                let u1 = norm_universe cfg env1 u in
-               let uu____9369 =
+               let uu____9354 =
                  FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_type u1)
                    t1.FStar_Syntax_Syntax.pos in
-               rebuild cfg env1 stack1 uu____9369
+               rebuild cfg env1 stack1 uu____9354
            | FStar_Syntax_Syntax.Tm_uinst (t', us) ->
                if
                  (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.erase_universes
                then norm cfg env1 stack1 t'
                else
                  (let us1 =
-                    let uu____9378 =
-                      let uu____9385 =
+                    let uu____9363 =
+                      let uu____9370 =
                         FStar_List.map (norm_universe cfg env1) us in
-                      (uu____9385, (t1.FStar_Syntax_Syntax.pos)) in
-                    UnivArgs uu____9378 in
+                      (uu____9370, (t1.FStar_Syntax_Syntax.pos)) in
+                    UnivArgs uu____9363 in
                   let stack2 = us1 :: stack1 in norm cfg env1 stack2 t')
            | FStar_Syntax_Syntax.Tm_bvar x ->
-               let uu____9394 = lookup_bvar env1 x in
-               (match uu____9394 with
-                | Univ uu____9395 ->
+               let uu____9379 = lookup_bvar env1 x in
+               (match uu____9379 with
+                | Univ uu____9380 ->
                     failwith
                       "Impossible: term variable is bound to a universe"
                 | Dummy -> failwith "Term variable not found"
@@ -2809,20 +2808,20 @@ let rec (norm :
                         ||
                         (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.zeta_full
                     then
-                      let uu____9444 = FStar_ST.op_Bang r in
-                      (match uu____9444 with
+                      let uu____9429 = FStar_ST.op_Bang r in
+                      (match uu____9429 with
                        | FStar_Pervasives_Native.Some (env3, t') ->
                            (FStar_TypeChecker_Cfg.log cfg
-                              (fun uu____9527 ->
-                                 let uu____9528 =
+                              (fun uu____9512 ->
+                                 let uu____9513 =
                                    FStar_Syntax_Print.term_to_string t1 in
-                                 let uu____9529 =
+                                 let uu____9514 =
                                    FStar_Syntax_Print.term_to_string t' in
                                  FStar_Util.print2
-                                   "Lazy hit: %s cached to %s\n" uu____9528
-                                   uu____9529);
-                            (let uu____9530 = maybe_weakly_reduced t' in
-                             if uu____9530
+                                   "Lazy hit: %s cached to %s\n" uu____9513
+                                   uu____9514);
+                            (let uu____9515 = maybe_weakly_reduced t' in
+                             if uu____9515
                              then
                                match stack1 with
                                | [] when
@@ -2830,39 +2829,39 @@ let rec (norm :
                                      ||
                                      (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.compress_uvars
                                    -> rebuild cfg env3 stack1 t'
-                               | uu____9531 -> norm cfg env3 stack1 t'
+                               | uu____9516 -> norm cfg env3 stack1 t'
                              else rebuild cfg env3 stack1 t'))
                        | FStar_Pervasives_Native.None ->
                            norm cfg env2 ((MemoLazy r) :: stack1) t0)
                     else norm cfg env2 stack1 t0)
            | FStar_Syntax_Syntax.Tm_abs (bs, body, lopt) ->
                (match stack1 with
-                | (UnivArgs uu____9573)::uu____9574 ->
+                | (UnivArgs uu____9558)::uu____9559 ->
                     failwith
                       "Ill-typed term: universes cannot be applied to term abstraction"
-                | (Arg (c, uu____9584, uu____9585))::stack_rest ->
+                | (Arg (c, uu____9569, uu____9570))::stack_rest ->
                     (match c with
-                     | Univ uu____9589 ->
+                     | Univ uu____9574 ->
                          norm cfg ((FStar_Pervasives_Native.None, c) :: env1)
                            stack_rest t1
-                     | uu____9598 ->
+                     | uu____9583 ->
                          (match bs with
                           | [] -> failwith "Impossible"
                           | b::[] ->
                               (FStar_TypeChecker_Cfg.log cfg
-                                 (fun uu____9627 ->
-                                    let uu____9628 = closure_to_string c in
+                                 (fun uu____9612 ->
+                                    let uu____9613 = closure_to_string c in
                                     FStar_Util.print1 "\tShifted %s\n"
-                                      uu____9628);
+                                      uu____9613);
                                norm cfg
                                  (((FStar_Pervasives_Native.Some b), c) ::
                                  env1) stack_rest body)
                           | b::tl ->
                               (FStar_TypeChecker_Cfg.log cfg
-                                 (fun uu____9662 ->
-                                    let uu____9663 = closure_to_string c in
+                                 (fun uu____9647 ->
+                                    let uu____9648 = closure_to_string c in
                                     FStar_Util.print1 "\tShifted %s\n"
-                                      uu____9663);
+                                      uu____9648);
                                (let body1 =
                                   FStar_Syntax_Syntax.mk
                                     (FStar_Syntax_Syntax.Tm_abs
@@ -2875,26 +2874,26 @@ let rec (norm :
                 | (MemoLazy r)::stack2 ->
                     (set_memo cfg r (env1, t1);
                      FStar_TypeChecker_Cfg.log cfg
-                       (fun uu____9709 ->
-                          let uu____9710 =
+                       (fun uu____9694 ->
+                          let uu____9695 =
                             FStar_Syntax_Print.term_to_string t1 in
-                          FStar_Util.print1 "\tSet memo %s\n" uu____9710);
+                          FStar_Util.print1 "\tSet memo %s\n" uu____9695);
                      norm cfg env1 stack2 t1)
-                | (Match uu____9711)::uu____9712 ->
+                | (Match uu____9696)::uu____9697 ->
                     if
                       (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.weak
                     then
                       let t2 = closure_as_term cfg env1 t1 in
                       rebuild cfg env1 stack1 t2
                     else
-                      (let uu____9725 = FStar_Syntax_Subst.open_term' bs body in
-                       match uu____9725 with
+                      (let uu____9710 = FStar_Syntax_Subst.open_term' bs body in
+                       match uu____9710 with
                        | (bs1, body1, opening) ->
                            let env' =
                              FStar_All.pipe_right bs1
                                (FStar_List.fold_left
                                   (fun env2 ->
-                                     fun uu____9761 -> dummy :: env2) env1) in
+                                     fun uu____9746 -> dummy :: env2) env1) in
                            let lopt1 =
                              match lopt with
                              | FStar_Pervasives_Native.Some rc ->
@@ -2905,74 +2904,74 @@ let rec (norm :
                                      FStar_Util.map_opt
                                        rc.FStar_Syntax_Syntax.residual_typ
                                        (fun t2 ->
-                                          let uu____9804 =
+                                          let uu____9789 =
                                             FStar_Syntax_Subst.subst opening
                                               t2 in
-                                          norm cfg env' [] uu____9804)
+                                          norm cfg env' [] uu____9789)
                                    else
                                      FStar_Util.map_opt
                                        rc.FStar_Syntax_Syntax.residual_typ
                                        (FStar_Syntax_Subst.subst opening) in
                                  FStar_Pervasives_Native.Some
-                                   (let uu___1456_9811 = rc in
+                                   (let uu___1456_9796 = rc in
                                     {
                                       FStar_Syntax_Syntax.residual_effect =
-                                        (uu___1456_9811.FStar_Syntax_Syntax.residual_effect);
+                                        (uu___1456_9796.FStar_Syntax_Syntax.residual_effect);
                                       FStar_Syntax_Syntax.residual_typ = rct;
                                       FStar_Syntax_Syntax.residual_flags =
-                                        (uu___1456_9811.FStar_Syntax_Syntax.residual_flags)
+                                        (uu___1456_9796.FStar_Syntax_Syntax.residual_flags)
                                     })
-                             | uu____9812 -> lopt in
+                             | uu____9797 -> lopt in
                            (FStar_TypeChecker_Cfg.log cfg
-                              (fun uu____9818 ->
-                                 let uu____9819 =
+                              (fun uu____9803 ->
+                                 let uu____9804 =
                                    FStar_All.pipe_left
                                      FStar_Util.string_of_int
                                      (FStar_List.length bs1) in
                                  FStar_Util.print1 "\tShifted %s dummies\n"
-                                   uu____9819);
+                                   uu____9804);
                             (let stack2 = (Cfg cfg) :: stack1 in
                              let cfg1 =
-                               let uu___1463_9830 = cfg in
+                               let uu___1463_9815 = cfg in
                                {
                                  FStar_TypeChecker_Cfg.steps =
-                                   (uu___1463_9830.FStar_TypeChecker_Cfg.steps);
+                                   (uu___1463_9815.FStar_TypeChecker_Cfg.steps);
                                  FStar_TypeChecker_Cfg.tcenv =
-                                   (uu___1463_9830.FStar_TypeChecker_Cfg.tcenv);
+                                   (uu___1463_9815.FStar_TypeChecker_Cfg.tcenv);
                                  FStar_TypeChecker_Cfg.debug =
-                                   (uu___1463_9830.FStar_TypeChecker_Cfg.debug);
+                                   (uu___1463_9815.FStar_TypeChecker_Cfg.debug);
                                  FStar_TypeChecker_Cfg.delta_level =
-                                   (uu___1463_9830.FStar_TypeChecker_Cfg.delta_level);
+                                   (uu___1463_9815.FStar_TypeChecker_Cfg.delta_level);
                                  FStar_TypeChecker_Cfg.primitive_steps =
-                                   (uu___1463_9830.FStar_TypeChecker_Cfg.primitive_steps);
+                                   (uu___1463_9815.FStar_TypeChecker_Cfg.primitive_steps);
                                  FStar_TypeChecker_Cfg.strong = true;
                                  FStar_TypeChecker_Cfg.memoize_lazy =
-                                   (uu___1463_9830.FStar_TypeChecker_Cfg.memoize_lazy);
+                                   (uu___1463_9815.FStar_TypeChecker_Cfg.memoize_lazy);
                                  FStar_TypeChecker_Cfg.normalize_pure_lets =
-                                   (uu___1463_9830.FStar_TypeChecker_Cfg.normalize_pure_lets);
+                                   (uu___1463_9815.FStar_TypeChecker_Cfg.normalize_pure_lets);
                                  FStar_TypeChecker_Cfg.reifying =
-                                   (uu___1463_9830.FStar_TypeChecker_Cfg.reifying)
+                                   (uu___1463_9815.FStar_TypeChecker_Cfg.reifying)
                                } in
                              norm cfg1 env'
                                ((Abs
                                    (env1, bs1, env', lopt1,
                                      (t1.FStar_Syntax_Syntax.pos))) ::
                                stack2) body1)))
-                | (Debug uu____9833)::uu____9834 ->
+                | (Debug uu____9818)::uu____9819 ->
                     if
                       (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.weak
                     then
                       let t2 = closure_as_term cfg env1 t1 in
                       rebuild cfg env1 stack1 t2
                     else
-                      (let uu____9843 = FStar_Syntax_Subst.open_term' bs body in
-                       match uu____9843 with
+                      (let uu____9828 = FStar_Syntax_Subst.open_term' bs body in
+                       match uu____9828 with
                        | (bs1, body1, opening) ->
                            let env' =
                              FStar_All.pipe_right bs1
                                (FStar_List.fold_left
                                   (fun env2 ->
-                                     fun uu____9879 -> dummy :: env2) env1) in
+                                     fun uu____9864 -> dummy :: env2) env1) in
                            let lopt1 =
                              match lopt with
                              | FStar_Pervasives_Native.Some rc ->
@@ -2983,74 +2982,74 @@ let rec (norm :
                                      FStar_Util.map_opt
                                        rc.FStar_Syntax_Syntax.residual_typ
                                        (fun t2 ->
-                                          let uu____9922 =
+                                          let uu____9907 =
                                             FStar_Syntax_Subst.subst opening
                                               t2 in
-                                          norm cfg env' [] uu____9922)
+                                          norm cfg env' [] uu____9907)
                                    else
                                      FStar_Util.map_opt
                                        rc.FStar_Syntax_Syntax.residual_typ
                                        (FStar_Syntax_Subst.subst opening) in
                                  FStar_Pervasives_Native.Some
-                                   (let uu___1456_9929 = rc in
+                                   (let uu___1456_9914 = rc in
                                     {
                                       FStar_Syntax_Syntax.residual_effect =
-                                        (uu___1456_9929.FStar_Syntax_Syntax.residual_effect);
+                                        (uu___1456_9914.FStar_Syntax_Syntax.residual_effect);
                                       FStar_Syntax_Syntax.residual_typ = rct;
                                       FStar_Syntax_Syntax.residual_flags =
-                                        (uu___1456_9929.FStar_Syntax_Syntax.residual_flags)
+                                        (uu___1456_9914.FStar_Syntax_Syntax.residual_flags)
                                     })
-                             | uu____9930 -> lopt in
+                             | uu____9915 -> lopt in
                            (FStar_TypeChecker_Cfg.log cfg
-                              (fun uu____9936 ->
-                                 let uu____9937 =
+                              (fun uu____9921 ->
+                                 let uu____9922 =
                                    FStar_All.pipe_left
                                      FStar_Util.string_of_int
                                      (FStar_List.length bs1) in
                                  FStar_Util.print1 "\tShifted %s dummies\n"
-                                   uu____9937);
+                                   uu____9922);
                             (let stack2 = (Cfg cfg) :: stack1 in
                              let cfg1 =
-                               let uu___1463_9948 = cfg in
+                               let uu___1463_9933 = cfg in
                                {
                                  FStar_TypeChecker_Cfg.steps =
-                                   (uu___1463_9948.FStar_TypeChecker_Cfg.steps);
+                                   (uu___1463_9933.FStar_TypeChecker_Cfg.steps);
                                  FStar_TypeChecker_Cfg.tcenv =
-                                   (uu___1463_9948.FStar_TypeChecker_Cfg.tcenv);
+                                   (uu___1463_9933.FStar_TypeChecker_Cfg.tcenv);
                                  FStar_TypeChecker_Cfg.debug =
-                                   (uu___1463_9948.FStar_TypeChecker_Cfg.debug);
+                                   (uu___1463_9933.FStar_TypeChecker_Cfg.debug);
                                  FStar_TypeChecker_Cfg.delta_level =
-                                   (uu___1463_9948.FStar_TypeChecker_Cfg.delta_level);
+                                   (uu___1463_9933.FStar_TypeChecker_Cfg.delta_level);
                                  FStar_TypeChecker_Cfg.primitive_steps =
-                                   (uu___1463_9948.FStar_TypeChecker_Cfg.primitive_steps);
+                                   (uu___1463_9933.FStar_TypeChecker_Cfg.primitive_steps);
                                  FStar_TypeChecker_Cfg.strong = true;
                                  FStar_TypeChecker_Cfg.memoize_lazy =
-                                   (uu___1463_9948.FStar_TypeChecker_Cfg.memoize_lazy);
+                                   (uu___1463_9933.FStar_TypeChecker_Cfg.memoize_lazy);
                                  FStar_TypeChecker_Cfg.normalize_pure_lets =
-                                   (uu___1463_9948.FStar_TypeChecker_Cfg.normalize_pure_lets);
+                                   (uu___1463_9933.FStar_TypeChecker_Cfg.normalize_pure_lets);
                                  FStar_TypeChecker_Cfg.reifying =
-                                   (uu___1463_9948.FStar_TypeChecker_Cfg.reifying)
+                                   (uu___1463_9933.FStar_TypeChecker_Cfg.reifying)
                                } in
                              norm cfg1 env'
                                ((Abs
                                    (env1, bs1, env', lopt1,
                                      (t1.FStar_Syntax_Syntax.pos))) ::
                                stack2) body1)))
-                | (Meta uu____9951)::uu____9952 ->
+                | (Meta uu____9936)::uu____9937 ->
                     if
                       (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.weak
                     then
                       let t2 = closure_as_term cfg env1 t1 in
                       rebuild cfg env1 stack1 t2
                     else
-                      (let uu____9963 = FStar_Syntax_Subst.open_term' bs body in
-                       match uu____9963 with
+                      (let uu____9948 = FStar_Syntax_Subst.open_term' bs body in
+                       match uu____9948 with
                        | (bs1, body1, opening) ->
                            let env' =
                              FStar_All.pipe_right bs1
                                (FStar_List.fold_left
                                   (fun env2 ->
-                                     fun uu____9999 -> dummy :: env2) env1) in
+                                     fun uu____9984 -> dummy :: env2) env1) in
                            let lopt1 =
                              match lopt with
                              | FStar_Pervasives_Native.Some rc ->
@@ -3061,75 +3060,75 @@ let rec (norm :
                                      FStar_Util.map_opt
                                        rc.FStar_Syntax_Syntax.residual_typ
                                        (fun t2 ->
-                                          let uu____10042 =
+                                          let uu____10027 =
                                             FStar_Syntax_Subst.subst opening
                                               t2 in
-                                          norm cfg env' [] uu____10042)
+                                          norm cfg env' [] uu____10027)
                                    else
                                      FStar_Util.map_opt
                                        rc.FStar_Syntax_Syntax.residual_typ
                                        (FStar_Syntax_Subst.subst opening) in
                                  FStar_Pervasives_Native.Some
-                                   (let uu___1456_10049 = rc in
+                                   (let uu___1456_10034 = rc in
                                     {
                                       FStar_Syntax_Syntax.residual_effect =
-                                        (uu___1456_10049.FStar_Syntax_Syntax.residual_effect);
+                                        (uu___1456_10034.FStar_Syntax_Syntax.residual_effect);
                                       FStar_Syntax_Syntax.residual_typ = rct;
                                       FStar_Syntax_Syntax.residual_flags =
-                                        (uu___1456_10049.FStar_Syntax_Syntax.residual_flags)
+                                        (uu___1456_10034.FStar_Syntax_Syntax.residual_flags)
                                     })
-                             | uu____10050 -> lopt in
+                             | uu____10035 -> lopt in
                            (FStar_TypeChecker_Cfg.log cfg
-                              (fun uu____10056 ->
-                                 let uu____10057 =
+                              (fun uu____10041 ->
+                                 let uu____10042 =
                                    FStar_All.pipe_left
                                      FStar_Util.string_of_int
                                      (FStar_List.length bs1) in
                                  FStar_Util.print1 "\tShifted %s dummies\n"
-                                   uu____10057);
+                                   uu____10042);
                             (let stack2 = (Cfg cfg) :: stack1 in
                              let cfg1 =
-                               let uu___1463_10068 = cfg in
+                               let uu___1463_10053 = cfg in
                                {
                                  FStar_TypeChecker_Cfg.steps =
-                                   (uu___1463_10068.FStar_TypeChecker_Cfg.steps);
+                                   (uu___1463_10053.FStar_TypeChecker_Cfg.steps);
                                  FStar_TypeChecker_Cfg.tcenv =
-                                   (uu___1463_10068.FStar_TypeChecker_Cfg.tcenv);
+                                   (uu___1463_10053.FStar_TypeChecker_Cfg.tcenv);
                                  FStar_TypeChecker_Cfg.debug =
-                                   (uu___1463_10068.FStar_TypeChecker_Cfg.debug);
+                                   (uu___1463_10053.FStar_TypeChecker_Cfg.debug);
                                  FStar_TypeChecker_Cfg.delta_level =
-                                   (uu___1463_10068.FStar_TypeChecker_Cfg.delta_level);
+                                   (uu___1463_10053.FStar_TypeChecker_Cfg.delta_level);
                                  FStar_TypeChecker_Cfg.primitive_steps =
-                                   (uu___1463_10068.FStar_TypeChecker_Cfg.primitive_steps);
+                                   (uu___1463_10053.FStar_TypeChecker_Cfg.primitive_steps);
                                  FStar_TypeChecker_Cfg.strong = true;
                                  FStar_TypeChecker_Cfg.memoize_lazy =
-                                   (uu___1463_10068.FStar_TypeChecker_Cfg.memoize_lazy);
+                                   (uu___1463_10053.FStar_TypeChecker_Cfg.memoize_lazy);
                                  FStar_TypeChecker_Cfg.normalize_pure_lets =
-                                   (uu___1463_10068.FStar_TypeChecker_Cfg.normalize_pure_lets);
+                                   (uu___1463_10053.FStar_TypeChecker_Cfg.normalize_pure_lets);
                                  FStar_TypeChecker_Cfg.reifying =
-                                   (uu___1463_10068.FStar_TypeChecker_Cfg.reifying)
+                                   (uu___1463_10053.FStar_TypeChecker_Cfg.reifying)
                                } in
                              norm cfg1 env'
                                ((Abs
                                    (env1, bs1, env', lopt1,
                                      (t1.FStar_Syntax_Syntax.pos))) ::
                                stack2) body1)))
-                | (Let uu____10071)::uu____10072 ->
+                | (Let uu____10056)::uu____10057 ->
                     if
                       (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.weak
                     then
                       let t2 = closure_as_term cfg env1 t1 in
                       rebuild cfg env1 stack1 t2
                     else
-                      (let uu____10085 =
+                      (let uu____10070 =
                          FStar_Syntax_Subst.open_term' bs body in
-                       match uu____10085 with
+                       match uu____10070 with
                        | (bs1, body1, opening) ->
                            let env' =
                              FStar_All.pipe_right bs1
                                (FStar_List.fold_left
                                   (fun env2 ->
-                                     fun uu____10121 -> dummy :: env2) env1) in
+                                     fun uu____10106 -> dummy :: env2) env1) in
                            let lopt1 =
                              match lopt with
                              | FStar_Pervasives_Native.Some rc ->
@@ -3140,75 +3139,75 @@ let rec (norm :
                                      FStar_Util.map_opt
                                        rc.FStar_Syntax_Syntax.residual_typ
                                        (fun t2 ->
-                                          let uu____10164 =
+                                          let uu____10149 =
                                             FStar_Syntax_Subst.subst opening
                                               t2 in
-                                          norm cfg env' [] uu____10164)
+                                          norm cfg env' [] uu____10149)
                                    else
                                      FStar_Util.map_opt
                                        rc.FStar_Syntax_Syntax.residual_typ
                                        (FStar_Syntax_Subst.subst opening) in
                                  FStar_Pervasives_Native.Some
-                                   (let uu___1456_10171 = rc in
+                                   (let uu___1456_10156 = rc in
                                     {
                                       FStar_Syntax_Syntax.residual_effect =
-                                        (uu___1456_10171.FStar_Syntax_Syntax.residual_effect);
+                                        (uu___1456_10156.FStar_Syntax_Syntax.residual_effect);
                                       FStar_Syntax_Syntax.residual_typ = rct;
                                       FStar_Syntax_Syntax.residual_flags =
-                                        (uu___1456_10171.FStar_Syntax_Syntax.residual_flags)
+                                        (uu___1456_10156.FStar_Syntax_Syntax.residual_flags)
                                     })
-                             | uu____10172 -> lopt in
+                             | uu____10157 -> lopt in
                            (FStar_TypeChecker_Cfg.log cfg
-                              (fun uu____10178 ->
-                                 let uu____10179 =
+                              (fun uu____10163 ->
+                                 let uu____10164 =
                                    FStar_All.pipe_left
                                      FStar_Util.string_of_int
                                      (FStar_List.length bs1) in
                                  FStar_Util.print1 "\tShifted %s dummies\n"
-                                   uu____10179);
+                                   uu____10164);
                             (let stack2 = (Cfg cfg) :: stack1 in
                              let cfg1 =
-                               let uu___1463_10190 = cfg in
+                               let uu___1463_10175 = cfg in
                                {
                                  FStar_TypeChecker_Cfg.steps =
-                                   (uu___1463_10190.FStar_TypeChecker_Cfg.steps);
+                                   (uu___1463_10175.FStar_TypeChecker_Cfg.steps);
                                  FStar_TypeChecker_Cfg.tcenv =
-                                   (uu___1463_10190.FStar_TypeChecker_Cfg.tcenv);
+                                   (uu___1463_10175.FStar_TypeChecker_Cfg.tcenv);
                                  FStar_TypeChecker_Cfg.debug =
-                                   (uu___1463_10190.FStar_TypeChecker_Cfg.debug);
+                                   (uu___1463_10175.FStar_TypeChecker_Cfg.debug);
                                  FStar_TypeChecker_Cfg.delta_level =
-                                   (uu___1463_10190.FStar_TypeChecker_Cfg.delta_level);
+                                   (uu___1463_10175.FStar_TypeChecker_Cfg.delta_level);
                                  FStar_TypeChecker_Cfg.primitive_steps =
-                                   (uu___1463_10190.FStar_TypeChecker_Cfg.primitive_steps);
+                                   (uu___1463_10175.FStar_TypeChecker_Cfg.primitive_steps);
                                  FStar_TypeChecker_Cfg.strong = true;
                                  FStar_TypeChecker_Cfg.memoize_lazy =
-                                   (uu___1463_10190.FStar_TypeChecker_Cfg.memoize_lazy);
+                                   (uu___1463_10175.FStar_TypeChecker_Cfg.memoize_lazy);
                                  FStar_TypeChecker_Cfg.normalize_pure_lets =
-                                   (uu___1463_10190.FStar_TypeChecker_Cfg.normalize_pure_lets);
+                                   (uu___1463_10175.FStar_TypeChecker_Cfg.normalize_pure_lets);
                                  FStar_TypeChecker_Cfg.reifying =
-                                   (uu___1463_10190.FStar_TypeChecker_Cfg.reifying)
+                                   (uu___1463_10175.FStar_TypeChecker_Cfg.reifying)
                                } in
                              norm cfg1 env'
                                ((Abs
                                    (env1, bs1, env', lopt1,
                                      (t1.FStar_Syntax_Syntax.pos))) ::
                                stack2) body1)))
-                | (App uu____10193)::uu____10194 ->
+                | (App uu____10178)::uu____10179 ->
                     if
                       (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.weak
                     then
                       let t2 = closure_as_term cfg env1 t1 in
                       rebuild cfg env1 stack1 t2
                     else
-                      (let uu____10207 =
+                      (let uu____10192 =
                          FStar_Syntax_Subst.open_term' bs body in
-                       match uu____10207 with
+                       match uu____10192 with
                        | (bs1, body1, opening) ->
                            let env' =
                              FStar_All.pipe_right bs1
                                (FStar_List.fold_left
                                   (fun env2 ->
-                                     fun uu____10243 -> dummy :: env2) env1) in
+                                     fun uu____10228 -> dummy :: env2) env1) in
                            let lopt1 =
                              match lopt with
                              | FStar_Pervasives_Native.Some rc ->
@@ -3219,75 +3218,75 @@ let rec (norm :
                                      FStar_Util.map_opt
                                        rc.FStar_Syntax_Syntax.residual_typ
                                        (fun t2 ->
-                                          let uu____10286 =
+                                          let uu____10271 =
                                             FStar_Syntax_Subst.subst opening
                                               t2 in
-                                          norm cfg env' [] uu____10286)
+                                          norm cfg env' [] uu____10271)
                                    else
                                      FStar_Util.map_opt
                                        rc.FStar_Syntax_Syntax.residual_typ
                                        (FStar_Syntax_Subst.subst opening) in
                                  FStar_Pervasives_Native.Some
-                                   (let uu___1456_10293 = rc in
+                                   (let uu___1456_10278 = rc in
                                     {
                                       FStar_Syntax_Syntax.residual_effect =
-                                        (uu___1456_10293.FStar_Syntax_Syntax.residual_effect);
+                                        (uu___1456_10278.FStar_Syntax_Syntax.residual_effect);
                                       FStar_Syntax_Syntax.residual_typ = rct;
                                       FStar_Syntax_Syntax.residual_flags =
-                                        (uu___1456_10293.FStar_Syntax_Syntax.residual_flags)
+                                        (uu___1456_10278.FStar_Syntax_Syntax.residual_flags)
                                     })
-                             | uu____10294 -> lopt in
+                             | uu____10279 -> lopt in
                            (FStar_TypeChecker_Cfg.log cfg
-                              (fun uu____10300 ->
-                                 let uu____10301 =
+                              (fun uu____10285 ->
+                                 let uu____10286 =
                                    FStar_All.pipe_left
                                      FStar_Util.string_of_int
                                      (FStar_List.length bs1) in
                                  FStar_Util.print1 "\tShifted %s dummies\n"
-                                   uu____10301);
+                                   uu____10286);
                             (let stack2 = (Cfg cfg) :: stack1 in
                              let cfg1 =
-                               let uu___1463_10312 = cfg in
+                               let uu___1463_10297 = cfg in
                                {
                                  FStar_TypeChecker_Cfg.steps =
-                                   (uu___1463_10312.FStar_TypeChecker_Cfg.steps);
+                                   (uu___1463_10297.FStar_TypeChecker_Cfg.steps);
                                  FStar_TypeChecker_Cfg.tcenv =
-                                   (uu___1463_10312.FStar_TypeChecker_Cfg.tcenv);
+                                   (uu___1463_10297.FStar_TypeChecker_Cfg.tcenv);
                                  FStar_TypeChecker_Cfg.debug =
-                                   (uu___1463_10312.FStar_TypeChecker_Cfg.debug);
+                                   (uu___1463_10297.FStar_TypeChecker_Cfg.debug);
                                  FStar_TypeChecker_Cfg.delta_level =
-                                   (uu___1463_10312.FStar_TypeChecker_Cfg.delta_level);
+                                   (uu___1463_10297.FStar_TypeChecker_Cfg.delta_level);
                                  FStar_TypeChecker_Cfg.primitive_steps =
-                                   (uu___1463_10312.FStar_TypeChecker_Cfg.primitive_steps);
+                                   (uu___1463_10297.FStar_TypeChecker_Cfg.primitive_steps);
                                  FStar_TypeChecker_Cfg.strong = true;
                                  FStar_TypeChecker_Cfg.memoize_lazy =
-                                   (uu___1463_10312.FStar_TypeChecker_Cfg.memoize_lazy);
+                                   (uu___1463_10297.FStar_TypeChecker_Cfg.memoize_lazy);
                                  FStar_TypeChecker_Cfg.normalize_pure_lets =
-                                   (uu___1463_10312.FStar_TypeChecker_Cfg.normalize_pure_lets);
+                                   (uu___1463_10297.FStar_TypeChecker_Cfg.normalize_pure_lets);
                                  FStar_TypeChecker_Cfg.reifying =
-                                   (uu___1463_10312.FStar_TypeChecker_Cfg.reifying)
+                                   (uu___1463_10297.FStar_TypeChecker_Cfg.reifying)
                                } in
                              norm cfg1 env'
                                ((Abs
                                    (env1, bs1, env', lopt1,
                                      (t1.FStar_Syntax_Syntax.pos))) ::
                                stack2) body1)))
-                | (CBVApp uu____10315)::uu____10316 ->
+                | (CBVApp uu____10300)::uu____10301 ->
                     if
                       (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.weak
                     then
                       let t2 = closure_as_term cfg env1 t1 in
                       rebuild cfg env1 stack1 t2
                     else
-                      (let uu____10329 =
+                      (let uu____10314 =
                          FStar_Syntax_Subst.open_term' bs body in
-                       match uu____10329 with
+                       match uu____10314 with
                        | (bs1, body1, opening) ->
                            let env' =
                              FStar_All.pipe_right bs1
                                (FStar_List.fold_left
                                   (fun env2 ->
-                                     fun uu____10365 -> dummy :: env2) env1) in
+                                     fun uu____10350 -> dummy :: env2) env1) in
                            let lopt1 =
                              match lopt with
                              | FStar_Pervasives_Native.Some rc ->
@@ -3298,75 +3297,75 @@ let rec (norm :
                                      FStar_Util.map_opt
                                        rc.FStar_Syntax_Syntax.residual_typ
                                        (fun t2 ->
-                                          let uu____10408 =
+                                          let uu____10393 =
                                             FStar_Syntax_Subst.subst opening
                                               t2 in
-                                          norm cfg env' [] uu____10408)
+                                          norm cfg env' [] uu____10393)
                                    else
                                      FStar_Util.map_opt
                                        rc.FStar_Syntax_Syntax.residual_typ
                                        (FStar_Syntax_Subst.subst opening) in
                                  FStar_Pervasives_Native.Some
-                                   (let uu___1456_10415 = rc in
+                                   (let uu___1456_10400 = rc in
                                     {
                                       FStar_Syntax_Syntax.residual_effect =
-                                        (uu___1456_10415.FStar_Syntax_Syntax.residual_effect);
+                                        (uu___1456_10400.FStar_Syntax_Syntax.residual_effect);
                                       FStar_Syntax_Syntax.residual_typ = rct;
                                       FStar_Syntax_Syntax.residual_flags =
-                                        (uu___1456_10415.FStar_Syntax_Syntax.residual_flags)
+                                        (uu___1456_10400.FStar_Syntax_Syntax.residual_flags)
                                     })
-                             | uu____10416 -> lopt in
+                             | uu____10401 -> lopt in
                            (FStar_TypeChecker_Cfg.log cfg
-                              (fun uu____10422 ->
-                                 let uu____10423 =
+                              (fun uu____10407 ->
+                                 let uu____10408 =
                                    FStar_All.pipe_left
                                      FStar_Util.string_of_int
                                      (FStar_List.length bs1) in
                                  FStar_Util.print1 "\tShifted %s dummies\n"
-                                   uu____10423);
+                                   uu____10408);
                             (let stack2 = (Cfg cfg) :: stack1 in
                              let cfg1 =
-                               let uu___1463_10434 = cfg in
+                               let uu___1463_10419 = cfg in
                                {
                                  FStar_TypeChecker_Cfg.steps =
-                                   (uu___1463_10434.FStar_TypeChecker_Cfg.steps);
+                                   (uu___1463_10419.FStar_TypeChecker_Cfg.steps);
                                  FStar_TypeChecker_Cfg.tcenv =
-                                   (uu___1463_10434.FStar_TypeChecker_Cfg.tcenv);
+                                   (uu___1463_10419.FStar_TypeChecker_Cfg.tcenv);
                                  FStar_TypeChecker_Cfg.debug =
-                                   (uu___1463_10434.FStar_TypeChecker_Cfg.debug);
+                                   (uu___1463_10419.FStar_TypeChecker_Cfg.debug);
                                  FStar_TypeChecker_Cfg.delta_level =
-                                   (uu___1463_10434.FStar_TypeChecker_Cfg.delta_level);
+                                   (uu___1463_10419.FStar_TypeChecker_Cfg.delta_level);
                                  FStar_TypeChecker_Cfg.primitive_steps =
-                                   (uu___1463_10434.FStar_TypeChecker_Cfg.primitive_steps);
+                                   (uu___1463_10419.FStar_TypeChecker_Cfg.primitive_steps);
                                  FStar_TypeChecker_Cfg.strong = true;
                                  FStar_TypeChecker_Cfg.memoize_lazy =
-                                   (uu___1463_10434.FStar_TypeChecker_Cfg.memoize_lazy);
+                                   (uu___1463_10419.FStar_TypeChecker_Cfg.memoize_lazy);
                                  FStar_TypeChecker_Cfg.normalize_pure_lets =
-                                   (uu___1463_10434.FStar_TypeChecker_Cfg.normalize_pure_lets);
+                                   (uu___1463_10419.FStar_TypeChecker_Cfg.normalize_pure_lets);
                                  FStar_TypeChecker_Cfg.reifying =
-                                   (uu___1463_10434.FStar_TypeChecker_Cfg.reifying)
+                                   (uu___1463_10419.FStar_TypeChecker_Cfg.reifying)
                                } in
                              norm cfg1 env'
                                ((Abs
                                    (env1, bs1, env', lopt1,
                                      (t1.FStar_Syntax_Syntax.pos))) ::
                                stack2) body1)))
-                | (Abs uu____10437)::uu____10438 ->
+                | (Abs uu____10422)::uu____10423 ->
                     if
                       (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.weak
                     then
                       let t2 = closure_as_term cfg env1 t1 in
                       rebuild cfg env1 stack1 t2
                     else
-                      (let uu____10455 =
+                      (let uu____10440 =
                          FStar_Syntax_Subst.open_term' bs body in
-                       match uu____10455 with
+                       match uu____10440 with
                        | (bs1, body1, opening) ->
                            let env' =
                              FStar_All.pipe_right bs1
                                (FStar_List.fold_left
                                   (fun env2 ->
-                                     fun uu____10491 -> dummy :: env2) env1) in
+                                     fun uu____10476 -> dummy :: env2) env1) in
                            let lopt1 =
                              match lopt with
                              | FStar_Pervasives_Native.Some rc ->
@@ -3377,53 +3376,53 @@ let rec (norm :
                                      FStar_Util.map_opt
                                        rc.FStar_Syntax_Syntax.residual_typ
                                        (fun t2 ->
-                                          let uu____10534 =
+                                          let uu____10519 =
                                             FStar_Syntax_Subst.subst opening
                                               t2 in
-                                          norm cfg env' [] uu____10534)
+                                          norm cfg env' [] uu____10519)
                                    else
                                      FStar_Util.map_opt
                                        rc.FStar_Syntax_Syntax.residual_typ
                                        (FStar_Syntax_Subst.subst opening) in
                                  FStar_Pervasives_Native.Some
-                                   (let uu___1456_10541 = rc in
+                                   (let uu___1456_10526 = rc in
                                     {
                                       FStar_Syntax_Syntax.residual_effect =
-                                        (uu___1456_10541.FStar_Syntax_Syntax.residual_effect);
+                                        (uu___1456_10526.FStar_Syntax_Syntax.residual_effect);
                                       FStar_Syntax_Syntax.residual_typ = rct;
                                       FStar_Syntax_Syntax.residual_flags =
-                                        (uu___1456_10541.FStar_Syntax_Syntax.residual_flags)
+                                        (uu___1456_10526.FStar_Syntax_Syntax.residual_flags)
                                     })
-                             | uu____10542 -> lopt in
+                             | uu____10527 -> lopt in
                            (FStar_TypeChecker_Cfg.log cfg
-                              (fun uu____10548 ->
-                                 let uu____10549 =
+                              (fun uu____10533 ->
+                                 let uu____10534 =
                                    FStar_All.pipe_left
                                      FStar_Util.string_of_int
                                      (FStar_List.length bs1) in
                                  FStar_Util.print1 "\tShifted %s dummies\n"
-                                   uu____10549);
+                                   uu____10534);
                             (let stack2 = (Cfg cfg) :: stack1 in
                              let cfg1 =
-                               let uu___1463_10560 = cfg in
+                               let uu___1463_10545 = cfg in
                                {
                                  FStar_TypeChecker_Cfg.steps =
-                                   (uu___1463_10560.FStar_TypeChecker_Cfg.steps);
+                                   (uu___1463_10545.FStar_TypeChecker_Cfg.steps);
                                  FStar_TypeChecker_Cfg.tcenv =
-                                   (uu___1463_10560.FStar_TypeChecker_Cfg.tcenv);
+                                   (uu___1463_10545.FStar_TypeChecker_Cfg.tcenv);
                                  FStar_TypeChecker_Cfg.debug =
-                                   (uu___1463_10560.FStar_TypeChecker_Cfg.debug);
+                                   (uu___1463_10545.FStar_TypeChecker_Cfg.debug);
                                  FStar_TypeChecker_Cfg.delta_level =
-                                   (uu___1463_10560.FStar_TypeChecker_Cfg.delta_level);
+                                   (uu___1463_10545.FStar_TypeChecker_Cfg.delta_level);
                                  FStar_TypeChecker_Cfg.primitive_steps =
-                                   (uu___1463_10560.FStar_TypeChecker_Cfg.primitive_steps);
+                                   (uu___1463_10545.FStar_TypeChecker_Cfg.primitive_steps);
                                  FStar_TypeChecker_Cfg.strong = true;
                                  FStar_TypeChecker_Cfg.memoize_lazy =
-                                   (uu___1463_10560.FStar_TypeChecker_Cfg.memoize_lazy);
+                                   (uu___1463_10545.FStar_TypeChecker_Cfg.memoize_lazy);
                                  FStar_TypeChecker_Cfg.normalize_pure_lets =
-                                   (uu___1463_10560.FStar_TypeChecker_Cfg.normalize_pure_lets);
+                                   (uu___1463_10545.FStar_TypeChecker_Cfg.normalize_pure_lets);
                                  FStar_TypeChecker_Cfg.reifying =
-                                   (uu___1463_10560.FStar_TypeChecker_Cfg.reifying)
+                                   (uu___1463_10545.FStar_TypeChecker_Cfg.reifying)
                                } in
                              norm cfg1 env'
                                ((Abs
@@ -3437,15 +3436,15 @@ let rec (norm :
                       let t2 = closure_as_term cfg env1 t1 in
                       rebuild cfg env1 stack1 t2
                     else
-                      (let uu____10565 =
+                      (let uu____10550 =
                          FStar_Syntax_Subst.open_term' bs body in
-                       match uu____10565 with
+                       match uu____10550 with
                        | (bs1, body1, opening) ->
                            let env' =
                              FStar_All.pipe_right bs1
                                (FStar_List.fold_left
                                   (fun env2 ->
-                                     fun uu____10601 -> dummy :: env2) env1) in
+                                     fun uu____10586 -> dummy :: env2) env1) in
                            let lopt1 =
                              match lopt with
                              | FStar_Pervasives_Native.Some rc ->
@@ -3456,53 +3455,53 @@ let rec (norm :
                                      FStar_Util.map_opt
                                        rc.FStar_Syntax_Syntax.residual_typ
                                        (fun t2 ->
-                                          let uu____10644 =
+                                          let uu____10629 =
                                             FStar_Syntax_Subst.subst opening
                                               t2 in
-                                          norm cfg env' [] uu____10644)
+                                          norm cfg env' [] uu____10629)
                                    else
                                      FStar_Util.map_opt
                                        rc.FStar_Syntax_Syntax.residual_typ
                                        (FStar_Syntax_Subst.subst opening) in
                                  FStar_Pervasives_Native.Some
-                                   (let uu___1456_10651 = rc in
+                                   (let uu___1456_10636 = rc in
                                     {
                                       FStar_Syntax_Syntax.residual_effect =
-                                        (uu___1456_10651.FStar_Syntax_Syntax.residual_effect);
+                                        (uu___1456_10636.FStar_Syntax_Syntax.residual_effect);
                                       FStar_Syntax_Syntax.residual_typ = rct;
                                       FStar_Syntax_Syntax.residual_flags =
-                                        (uu___1456_10651.FStar_Syntax_Syntax.residual_flags)
+                                        (uu___1456_10636.FStar_Syntax_Syntax.residual_flags)
                                     })
-                             | uu____10652 -> lopt in
+                             | uu____10637 -> lopt in
                            (FStar_TypeChecker_Cfg.log cfg
-                              (fun uu____10658 ->
-                                 let uu____10659 =
+                              (fun uu____10643 ->
+                                 let uu____10644 =
                                    FStar_All.pipe_left
                                      FStar_Util.string_of_int
                                      (FStar_List.length bs1) in
                                  FStar_Util.print1 "\tShifted %s dummies\n"
-                                   uu____10659);
+                                   uu____10644);
                             (let stack2 = (Cfg cfg) :: stack1 in
                              let cfg1 =
-                               let uu___1463_10670 = cfg in
+                               let uu___1463_10655 = cfg in
                                {
                                  FStar_TypeChecker_Cfg.steps =
-                                   (uu___1463_10670.FStar_TypeChecker_Cfg.steps);
+                                   (uu___1463_10655.FStar_TypeChecker_Cfg.steps);
                                  FStar_TypeChecker_Cfg.tcenv =
-                                   (uu___1463_10670.FStar_TypeChecker_Cfg.tcenv);
+                                   (uu___1463_10655.FStar_TypeChecker_Cfg.tcenv);
                                  FStar_TypeChecker_Cfg.debug =
-                                   (uu___1463_10670.FStar_TypeChecker_Cfg.debug);
+                                   (uu___1463_10655.FStar_TypeChecker_Cfg.debug);
                                  FStar_TypeChecker_Cfg.delta_level =
-                                   (uu___1463_10670.FStar_TypeChecker_Cfg.delta_level);
+                                   (uu___1463_10655.FStar_TypeChecker_Cfg.delta_level);
                                  FStar_TypeChecker_Cfg.primitive_steps =
-                                   (uu___1463_10670.FStar_TypeChecker_Cfg.primitive_steps);
+                                   (uu___1463_10655.FStar_TypeChecker_Cfg.primitive_steps);
                                  FStar_TypeChecker_Cfg.strong = true;
                                  FStar_TypeChecker_Cfg.memoize_lazy =
-                                   (uu___1463_10670.FStar_TypeChecker_Cfg.memoize_lazy);
+                                   (uu___1463_10655.FStar_TypeChecker_Cfg.memoize_lazy);
                                  FStar_TypeChecker_Cfg.normalize_pure_lets =
-                                   (uu___1463_10670.FStar_TypeChecker_Cfg.normalize_pure_lets);
+                                   (uu___1463_10655.FStar_TypeChecker_Cfg.normalize_pure_lets);
                                  FStar_TypeChecker_Cfg.reifying =
-                                   (uu___1463_10670.FStar_TypeChecker_Cfg.reifying)
+                                   (uu___1463_10655.FStar_TypeChecker_Cfg.reifying)
                                } in
                              norm cfg1 env'
                                ((Abs
@@ -3511,115 +3510,115 @@ let rec (norm :
                                stack2) body1))))
            | FStar_Syntax_Syntax.Tm_app (head, args) ->
                let strict_args =
-                 let uu____10704 =
-                   let uu____10705 = FStar_Syntax_Util.un_uinst head in
-                   uu____10705.FStar_Syntax_Syntax.n in
-                 match uu____10704 with
+                 let uu____10689 =
+                   let uu____10690 = FStar_Syntax_Util.un_uinst head in
+                   uu____10690.FStar_Syntax_Syntax.n in
+                 match uu____10689 with
                  | FStar_Syntax_Syntax.Tm_fvar fv ->
                      FStar_TypeChecker_Env.fv_has_strict_args
                        cfg.FStar_TypeChecker_Cfg.tcenv fv
-                 | uu____10713 -> FStar_Pervasives_Native.None in
+                 | uu____10698 -> FStar_Pervasives_Native.None in
                (match strict_args with
                 | FStar_Pervasives_Native.None ->
                     let stack2 =
                       FStar_All.pipe_right stack1
                         (FStar_List.fold_right
-                           (fun uu____10732 ->
+                           (fun uu____10717 ->
                               fun stack2 ->
-                                match uu____10732 with
+                                match uu____10717 with
                                 | (a, aq) ->
-                                    let uu____10744 =
-                                      let uu____10745 =
-                                        let uu____10752 =
-                                          let uu____10753 =
-                                            let uu____10784 =
+                                    let uu____10729 =
+                                      let uu____10730 =
+                                        let uu____10737 =
+                                          let uu____10738 =
+                                            let uu____10769 =
                                               FStar_Util.mk_ref
                                                 FStar_Pervasives_Native.None in
-                                            (env1, a, uu____10784, false) in
-                                          Clos uu____10753 in
-                                        (uu____10752, aq,
+                                            (env1, a, uu____10769, false) in
+                                          Clos uu____10738 in
+                                        (uu____10737, aq,
                                           (t1.FStar_Syntax_Syntax.pos)) in
-                                      Arg uu____10745 in
-                                    uu____10744 :: stack2) args) in
+                                      Arg uu____10730 in
+                                    uu____10729 :: stack2) args) in
                     (FStar_TypeChecker_Cfg.log cfg
-                       (fun uu____10850 ->
-                          let uu____10851 =
+                       (fun uu____10835 ->
+                          let uu____10836 =
                             FStar_All.pipe_left FStar_Util.string_of_int
                               (FStar_List.length args) in
                           FStar_Util.print1 "\tPushed %s arguments\n"
-                            uu____10851);
+                            uu____10836);
                      norm cfg env1 stack2 head)
                 | FStar_Pervasives_Native.Some strict_args1 ->
                     let norm_args =
                       FStar_All.pipe_right args
                         (FStar_List.map
-                           (fun uu____10896 ->
-                              match uu____10896 with
+                           (fun uu____10881 ->
+                              match uu____10881 with
                               | (a, i) ->
-                                  let uu____10907 = norm cfg env1 [] a in
-                                  (uu____10907, i))) in
+                                  let uu____10892 = norm cfg env1 [] a in
+                                  (uu____10892, i))) in
                     let norm_args_len = FStar_List.length norm_args in
-                    let uu____10913 =
+                    let uu____10898 =
                       FStar_All.pipe_right strict_args1
                         (FStar_List.for_all
                            (fun i ->
                               if i >= norm_args_len
                               then false
                               else
-                                (let uu____10919 = FStar_List.nth norm_args i in
-                                 match uu____10919 with
-                                 | (arg_i, uu____10929) ->
-                                     let uu____10930 =
+                                (let uu____10904 = FStar_List.nth norm_args i in
+                                 match uu____10904 with
+                                 | (arg_i, uu____10914) ->
+                                     let uu____10915 =
                                        FStar_Syntax_Util.head_and_args arg_i in
-                                     (match uu____10930 with
-                                      | (head1, uu____10948) ->
-                                          let uu____10973 =
-                                            let uu____10974 =
+                                     (match uu____10915 with
+                                      | (head1, uu____10933) ->
+                                          let uu____10958 =
+                                            let uu____10959 =
                                               FStar_Syntax_Util.un_uinst
                                                 head1 in
-                                            uu____10974.FStar_Syntax_Syntax.n in
-                                          (match uu____10973 with
+                                            uu____10959.FStar_Syntax_Syntax.n in
+                                          (match uu____10958 with
                                            | FStar_Syntax_Syntax.Tm_constant
-                                               uu____10977 -> true
+                                               uu____10962 -> true
                                            | FStar_Syntax_Syntax.Tm_fvar fv
                                                ->
-                                               let uu____10979 =
+                                               let uu____10964 =
                                                  FStar_Syntax_Syntax.lid_of_fv
                                                    fv in
                                                FStar_TypeChecker_Env.is_datacon
                                                  cfg.FStar_TypeChecker_Cfg.tcenv
-                                                 uu____10979
-                                           | uu____10980 -> false))))) in
-                    if uu____10913
+                                                 uu____10964
+                                           | uu____10965 -> false))))) in
+                    if uu____10898
                     then
                       let stack2 =
                         FStar_All.pipe_right stack1
                           (FStar_List.fold_right
-                             (fun uu____10995 ->
+                             (fun uu____10980 ->
                                 fun stack2 ->
-                                  match uu____10995 with
+                                  match uu____10980 with
                                   | (a, aq) ->
-                                      let uu____11007 =
-                                        let uu____11008 =
-                                          let uu____11015 =
-                                            let uu____11016 =
-                                              let uu____11047 =
+                                      let uu____10992 =
+                                        let uu____10993 =
+                                          let uu____11000 =
+                                            let uu____11001 =
+                                              let uu____11032 =
                                                 FStar_Util.mk_ref
                                                   (FStar_Pervasives_Native.Some
                                                      ([], a)) in
-                                              (env1, a, uu____11047, false) in
-                                            Clos uu____11016 in
-                                          (uu____11015, aq,
+                                              (env1, a, uu____11032, false) in
+                                            Clos uu____11001 in
+                                          (uu____11000, aq,
                                             (t1.FStar_Syntax_Syntax.pos)) in
-                                        Arg uu____11008 in
-                                      uu____11007 :: stack2) norm_args) in
+                                        Arg uu____10993 in
+                                      uu____10992 :: stack2) norm_args) in
                       (FStar_TypeChecker_Cfg.log cfg
-                         (fun uu____11127 ->
-                            let uu____11128 =
+                         (fun uu____11112 ->
+                            let uu____11113 =
                               FStar_All.pipe_left FStar_Util.string_of_int
                                 (FStar_List.length args) in
                             FStar_Util.print1 "\tPushed %s arguments\n"
-                              uu____11128);
+                              uu____11113);
                        norm cfg env1 stack2 head)
                     else
                       (let head1 = closure_as_term cfg env1 head in
@@ -3627,7 +3626,7 @@ let rec (norm :
                          FStar_Syntax_Syntax.mk_Tm_app head1 norm_args
                            t1.FStar_Syntax_Syntax.pos in
                        rebuild cfg env1 stack1 term))
-           | FStar_Syntax_Syntax.Tm_refine (x, uu____11141) when
+           | FStar_Syntax_Syntax.Tm_refine (x, uu____11126) when
                (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.for_extraction
                -> norm cfg env1 stack1 x.FStar_Syntax_Syntax.sort
            | FStar_Syntax_Syntax.Tm_refine (x, f) ->
@@ -3640,152 +3639,152 @@ let rec (norm :
                       let t2 =
                         FStar_Syntax_Syntax.mk
                           (FStar_Syntax_Syntax.Tm_refine
-                             ((let uu___1525_11185 = x in
+                             ((let uu___1525_11170 = x in
                                {
                                  FStar_Syntax_Syntax.ppname =
-                                   (uu___1525_11185.FStar_Syntax_Syntax.ppname);
+                                   (uu___1525_11170.FStar_Syntax_Syntax.ppname);
                                  FStar_Syntax_Syntax.index =
-                                   (uu___1525_11185.FStar_Syntax_Syntax.index);
+                                   (uu___1525_11170.FStar_Syntax_Syntax.index);
                                  FStar_Syntax_Syntax.sort = t_x
                                }), f)) t1.FStar_Syntax_Syntax.pos in
                       rebuild cfg env1 stack1 t2
-                  | uu____11186 ->
-                      let uu____11201 = closure_as_term cfg env1 t1 in
-                      rebuild cfg env1 stack1 uu____11201)
+                  | uu____11171 ->
+                      let uu____11186 = closure_as_term cfg env1 t1 in
+                      rebuild cfg env1 stack1 uu____11186)
                else
                  (let t_x = norm cfg env1 [] x.FStar_Syntax_Syntax.sort in
-                  let uu____11204 =
+                  let uu____11189 =
                     FStar_Syntax_Subst.open_term
                       [(x, FStar_Pervasives_Native.None)] f in
-                  match uu____11204 with
+                  match uu____11189 with
                   | (closing, f1) ->
                       let f2 = norm cfg (dummy :: env1) [] f1 in
                       let t2 =
-                        let uu____11235 =
-                          let uu____11236 =
-                            let uu____11243 =
+                        let uu____11220 =
+                          let uu____11221 =
+                            let uu____11228 =
                               FStar_Syntax_Subst.close closing f2 in
-                            ((let uu___1534_11249 = x in
+                            ((let uu___1534_11234 = x in
                               {
                                 FStar_Syntax_Syntax.ppname =
-                                  (uu___1534_11249.FStar_Syntax_Syntax.ppname);
+                                  (uu___1534_11234.FStar_Syntax_Syntax.ppname);
                                 FStar_Syntax_Syntax.index =
-                                  (uu___1534_11249.FStar_Syntax_Syntax.index);
+                                  (uu___1534_11234.FStar_Syntax_Syntax.index);
                                 FStar_Syntax_Syntax.sort = t_x
-                              }), uu____11243) in
-                          FStar_Syntax_Syntax.Tm_refine uu____11236 in
-                        FStar_Syntax_Syntax.mk uu____11235
+                              }), uu____11228) in
+                          FStar_Syntax_Syntax.Tm_refine uu____11221 in
+                        FStar_Syntax_Syntax.mk uu____11220
                           t1.FStar_Syntax_Syntax.pos in
                       rebuild cfg env1 stack1 t2)
            | FStar_Syntax_Syntax.Tm_arrow (bs, c) ->
                if
                  (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.weak
                then
-                 let uu____11272 = closure_as_term cfg env1 t1 in
-                 rebuild cfg env1 stack1 uu____11272
+                 let uu____11257 = closure_as_term cfg env1 t1 in
+                 rebuild cfg env1 stack1 uu____11257
                else
-                 (let uu____11274 = FStar_Syntax_Subst.open_comp bs c in
-                  match uu____11274 with
+                 (let uu____11259 = FStar_Syntax_Subst.open_comp bs c in
+                  match uu____11259 with
                   | (bs1, c1) ->
                       let c2 =
-                        let uu____11282 =
+                        let uu____11267 =
                           FStar_All.pipe_right bs1
                             (FStar_List.fold_left
-                               (fun env2 -> fun uu____11308 -> dummy :: env2)
+                               (fun env2 -> fun uu____11293 -> dummy :: env2)
                                env1) in
-                        norm_comp cfg uu____11282 c1 in
+                        norm_comp cfg uu____11267 c1 in
                       let t2 =
-                        let uu____11332 = norm_binders cfg env1 bs1 in
-                        FStar_Syntax_Util.arrow uu____11332 c2 in
+                        let uu____11317 = norm_binders cfg env1 bs1 in
+                        FStar_Syntax_Util.arrow uu____11317 c2 in
                       rebuild cfg env1 stack1 t2)
            | FStar_Syntax_Syntax.Tm_ascribed (t11, (tc, tacopt), l) when
                (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.unascribe
                -> norm cfg env1 stack1 t11
            | FStar_Syntax_Syntax.Tm_ascribed (t11, (tc, tacopt), l) ->
                (match stack1 with
-                | (Match uu____11445)::uu____11446 when
+                | (Match uu____11430)::uu____11431 when
                     (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.beta
                     ->
                     (FStar_TypeChecker_Cfg.log cfg
-                       (fun uu____11459 ->
+                       (fun uu____11444 ->
                           FStar_Util.print_string
                             "+++ Dropping ascription \n");
                      norm cfg env1 stack1 t11)
-                | (Arg uu____11460)::uu____11461 when
+                | (Arg uu____11445)::uu____11446 when
                     (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.beta
                     ->
                     (FStar_TypeChecker_Cfg.log cfg
-                       (fun uu____11472 ->
+                       (fun uu____11457 ->
                           FStar_Util.print_string
                             "+++ Dropping ascription \n");
                      norm cfg env1 stack1 t11)
                 | (App
-                    (uu____11473,
+                    (uu____11458,
                      {
                        FStar_Syntax_Syntax.n =
                          FStar_Syntax_Syntax.Tm_constant
                          (FStar_Const.Const_reify);
-                       FStar_Syntax_Syntax.pos = uu____11474;
-                       FStar_Syntax_Syntax.vars = uu____11475;_},
-                     uu____11476, uu____11477))::uu____11478
+                       FStar_Syntax_Syntax.pos = uu____11459;
+                       FStar_Syntax_Syntax.vars = uu____11460;_},
+                     uu____11461, uu____11462))::uu____11463
                     when
                     (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.beta
                     ->
                     (FStar_TypeChecker_Cfg.log cfg
-                       (fun uu____11485 ->
+                       (fun uu____11470 ->
                           FStar_Util.print_string
                             "+++ Dropping ascription \n");
                      norm cfg env1 stack1 t11)
-                | (MemoLazy uu____11486)::uu____11487 when
+                | (MemoLazy uu____11471)::uu____11472 when
                     (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.beta
                     ->
                     (FStar_TypeChecker_Cfg.log cfg
-                       (fun uu____11498 ->
+                       (fun uu____11483 ->
                           FStar_Util.print_string
                             "+++ Dropping ascription \n");
                      norm cfg env1 stack1 t11)
-                | uu____11499 ->
+                | uu____11484 ->
                     (FStar_TypeChecker_Cfg.log cfg
-                       (fun uu____11502 ->
+                       (fun uu____11487 ->
                           FStar_Util.print_string "+++ Keeping ascription \n");
                      (let t12 = norm cfg env1 [] t11 in
                       FStar_TypeChecker_Cfg.log cfg
-                        (fun uu____11506 ->
+                        (fun uu____11491 ->
                            FStar_Util.print_string
                              "+++ Normalizing ascription \n");
                       (let tc1 =
                          match tc with
                          | FStar_Util.Inl t2 ->
-                             let uu____11531 = norm cfg env1 [] t2 in
-                             FStar_Util.Inl uu____11531
+                             let uu____11516 = norm cfg env1 [] t2 in
+                             FStar_Util.Inl uu____11516
                          | FStar_Util.Inr c ->
-                             let uu____11545 = norm_comp cfg env1 c in
-                             FStar_Util.Inr uu____11545 in
+                             let uu____11530 = norm_comp cfg env1 c in
+                             FStar_Util.Inr uu____11530 in
                        let tacopt1 =
                          FStar_Util.map_opt tacopt (norm cfg env1 []) in
                        match stack1 with
                        | (Cfg cfg1)::stack2 ->
                            let t2 =
-                             let uu____11568 =
-                               let uu____11569 =
-                                 let uu____11596 =
+                             let uu____11553 =
+                               let uu____11554 =
+                                 let uu____11581 =
                                    FStar_Syntax_Util.unascribe t12 in
-                                 (uu____11596, (tc1, tacopt1), l) in
-                               FStar_Syntax_Syntax.Tm_ascribed uu____11569 in
-                             FStar_Syntax_Syntax.mk uu____11568
+                                 (uu____11581, (tc1, tacopt1), l) in
+                               FStar_Syntax_Syntax.Tm_ascribed uu____11554 in
+                             FStar_Syntax_Syntax.mk uu____11553
                                t1.FStar_Syntax_Syntax.pos in
                            norm cfg1 env1 stack2 t2
-                       | uu____11631 ->
-                           let uu____11632 =
-                             let uu____11633 =
-                               let uu____11634 =
-                                 let uu____11661 =
+                       | uu____11616 ->
+                           let uu____11617 =
+                             let uu____11618 =
+                               let uu____11619 =
+                                 let uu____11646 =
                                    FStar_Syntax_Util.unascribe t12 in
-                                 (uu____11661, (tc1, tacopt1), l) in
-                               FStar_Syntax_Syntax.Tm_ascribed uu____11634 in
-                             FStar_Syntax_Syntax.mk uu____11633
+                                 (uu____11646, (tc1, tacopt1), l) in
+                               FStar_Syntax_Syntax.Tm_ascribed uu____11619 in
+                             FStar_Syntax_Syntax.mk uu____11618
                                t1.FStar_Syntax_Syntax.pos in
-                           rebuild cfg env1 stack1 uu____11632))))
+                           rebuild cfg env1 stack1 uu____11617))))
            | FStar_Syntax_Syntax.Tm_match (head, branches1) ->
                let stack2 =
                  (Match (env1, branches1, cfg, (t1.FStar_Syntax_Syntax.pos)))
@@ -3799,82 +3798,82 @@ let rec (norm :
                       (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.weak)
                then
                  let cfg' =
-                   let uu___1613_11738 = cfg in
+                   let uu___1613_11723 = cfg in
                    {
                      FStar_TypeChecker_Cfg.steps =
-                       (let uu___1615_11741 = cfg.FStar_TypeChecker_Cfg.steps in
+                       (let uu___1615_11726 = cfg.FStar_TypeChecker_Cfg.steps in
                         {
                           FStar_TypeChecker_Cfg.beta =
-                            (uu___1615_11741.FStar_TypeChecker_Cfg.beta);
+                            (uu___1615_11726.FStar_TypeChecker_Cfg.beta);
                           FStar_TypeChecker_Cfg.iota =
-                            (uu___1615_11741.FStar_TypeChecker_Cfg.iota);
+                            (uu___1615_11726.FStar_TypeChecker_Cfg.iota);
                           FStar_TypeChecker_Cfg.zeta =
-                            (uu___1615_11741.FStar_TypeChecker_Cfg.zeta);
+                            (uu___1615_11726.FStar_TypeChecker_Cfg.zeta);
                           FStar_TypeChecker_Cfg.zeta_full =
-                            (uu___1615_11741.FStar_TypeChecker_Cfg.zeta_full);
+                            (uu___1615_11726.FStar_TypeChecker_Cfg.zeta_full);
                           FStar_TypeChecker_Cfg.weak = true;
                           FStar_TypeChecker_Cfg.hnf =
-                            (uu___1615_11741.FStar_TypeChecker_Cfg.hnf);
+                            (uu___1615_11726.FStar_TypeChecker_Cfg.hnf);
                           FStar_TypeChecker_Cfg.primops =
-                            (uu___1615_11741.FStar_TypeChecker_Cfg.primops);
+                            (uu___1615_11726.FStar_TypeChecker_Cfg.primops);
                           FStar_TypeChecker_Cfg.do_not_unfold_pure_lets =
-                            (uu___1615_11741.FStar_TypeChecker_Cfg.do_not_unfold_pure_lets);
+                            (uu___1615_11726.FStar_TypeChecker_Cfg.do_not_unfold_pure_lets);
                           FStar_TypeChecker_Cfg.unfold_until =
-                            (uu___1615_11741.FStar_TypeChecker_Cfg.unfold_until);
+                            (uu___1615_11726.FStar_TypeChecker_Cfg.unfold_until);
                           FStar_TypeChecker_Cfg.unfold_only =
-                            (uu___1615_11741.FStar_TypeChecker_Cfg.unfold_only);
+                            (uu___1615_11726.FStar_TypeChecker_Cfg.unfold_only);
                           FStar_TypeChecker_Cfg.unfold_fully =
-                            (uu___1615_11741.FStar_TypeChecker_Cfg.unfold_fully);
+                            (uu___1615_11726.FStar_TypeChecker_Cfg.unfold_fully);
                           FStar_TypeChecker_Cfg.unfold_attr =
-                            (uu___1615_11741.FStar_TypeChecker_Cfg.unfold_attr);
+                            (uu___1615_11726.FStar_TypeChecker_Cfg.unfold_attr);
                           FStar_TypeChecker_Cfg.unfold_tac =
-                            (uu___1615_11741.FStar_TypeChecker_Cfg.unfold_tac);
+                            (uu___1615_11726.FStar_TypeChecker_Cfg.unfold_tac);
                           FStar_TypeChecker_Cfg.pure_subterms_within_computations
                             =
-                            (uu___1615_11741.FStar_TypeChecker_Cfg.pure_subterms_within_computations);
+                            (uu___1615_11726.FStar_TypeChecker_Cfg.pure_subterms_within_computations);
                           FStar_TypeChecker_Cfg.simplify =
-                            (uu___1615_11741.FStar_TypeChecker_Cfg.simplify);
+                            (uu___1615_11726.FStar_TypeChecker_Cfg.simplify);
                           FStar_TypeChecker_Cfg.erase_universes =
-                            (uu___1615_11741.FStar_TypeChecker_Cfg.erase_universes);
+                            (uu___1615_11726.FStar_TypeChecker_Cfg.erase_universes);
                           FStar_TypeChecker_Cfg.allow_unbound_universes =
-                            (uu___1615_11741.FStar_TypeChecker_Cfg.allow_unbound_universes);
+                            (uu___1615_11726.FStar_TypeChecker_Cfg.allow_unbound_universes);
                           FStar_TypeChecker_Cfg.reify_ =
-                            (uu___1615_11741.FStar_TypeChecker_Cfg.reify_);
+                            (uu___1615_11726.FStar_TypeChecker_Cfg.reify_);
                           FStar_TypeChecker_Cfg.compress_uvars =
-                            (uu___1615_11741.FStar_TypeChecker_Cfg.compress_uvars);
+                            (uu___1615_11726.FStar_TypeChecker_Cfg.compress_uvars);
                           FStar_TypeChecker_Cfg.no_full_norm =
-                            (uu___1615_11741.FStar_TypeChecker_Cfg.no_full_norm);
+                            (uu___1615_11726.FStar_TypeChecker_Cfg.no_full_norm);
                           FStar_TypeChecker_Cfg.check_no_uvars =
-                            (uu___1615_11741.FStar_TypeChecker_Cfg.check_no_uvars);
+                            (uu___1615_11726.FStar_TypeChecker_Cfg.check_no_uvars);
                           FStar_TypeChecker_Cfg.unmeta =
-                            (uu___1615_11741.FStar_TypeChecker_Cfg.unmeta);
+                            (uu___1615_11726.FStar_TypeChecker_Cfg.unmeta);
                           FStar_TypeChecker_Cfg.unascribe =
-                            (uu___1615_11741.FStar_TypeChecker_Cfg.unascribe);
+                            (uu___1615_11726.FStar_TypeChecker_Cfg.unascribe);
                           FStar_TypeChecker_Cfg.in_full_norm_request =
-                            (uu___1615_11741.FStar_TypeChecker_Cfg.in_full_norm_request);
+                            (uu___1615_11726.FStar_TypeChecker_Cfg.in_full_norm_request);
                           FStar_TypeChecker_Cfg.weakly_reduce_scrutinee =
-                            (uu___1615_11741.FStar_TypeChecker_Cfg.weakly_reduce_scrutinee);
+                            (uu___1615_11726.FStar_TypeChecker_Cfg.weakly_reduce_scrutinee);
                           FStar_TypeChecker_Cfg.nbe_step =
-                            (uu___1615_11741.FStar_TypeChecker_Cfg.nbe_step);
+                            (uu___1615_11726.FStar_TypeChecker_Cfg.nbe_step);
                           FStar_TypeChecker_Cfg.for_extraction =
-                            (uu___1615_11741.FStar_TypeChecker_Cfg.for_extraction)
+                            (uu___1615_11726.FStar_TypeChecker_Cfg.for_extraction)
                         });
                      FStar_TypeChecker_Cfg.tcenv =
-                       (uu___1613_11738.FStar_TypeChecker_Cfg.tcenv);
+                       (uu___1613_11723.FStar_TypeChecker_Cfg.tcenv);
                      FStar_TypeChecker_Cfg.debug =
-                       (uu___1613_11738.FStar_TypeChecker_Cfg.debug);
+                       (uu___1613_11723.FStar_TypeChecker_Cfg.debug);
                      FStar_TypeChecker_Cfg.delta_level =
-                       (uu___1613_11738.FStar_TypeChecker_Cfg.delta_level);
+                       (uu___1613_11723.FStar_TypeChecker_Cfg.delta_level);
                      FStar_TypeChecker_Cfg.primitive_steps =
-                       (uu___1613_11738.FStar_TypeChecker_Cfg.primitive_steps);
+                       (uu___1613_11723.FStar_TypeChecker_Cfg.primitive_steps);
                      FStar_TypeChecker_Cfg.strong =
-                       (uu___1613_11738.FStar_TypeChecker_Cfg.strong);
+                       (uu___1613_11723.FStar_TypeChecker_Cfg.strong);
                      FStar_TypeChecker_Cfg.memoize_lazy =
-                       (uu___1613_11738.FStar_TypeChecker_Cfg.memoize_lazy);
+                       (uu___1613_11723.FStar_TypeChecker_Cfg.memoize_lazy);
                      FStar_TypeChecker_Cfg.normalize_pure_lets =
-                       (uu___1613_11738.FStar_TypeChecker_Cfg.normalize_pure_lets);
+                       (uu___1613_11723.FStar_TypeChecker_Cfg.normalize_pure_lets);
                      FStar_TypeChecker_Cfg.reifying =
-                       (uu___1613_11738.FStar_TypeChecker_Cfg.reifying)
+                       (uu___1613_11723.FStar_TypeChecker_Cfg.reifying)
                    } in
                  norm cfg' env1 ((Cfg cfg) :: stack2) head
                else norm cfg env1 stack2 head
@@ -3886,124 +3885,124 @@ let rec (norm :
                  FStar_All.pipe_right lbs
                    (FStar_List.map
                       (fun lb ->
-                         let uu____11777 =
+                         let uu____11762 =
                            FStar_Syntax_Subst.univ_var_opening
                              lb.FStar_Syntax_Syntax.lbunivs in
-                         match uu____11777 with
+                         match uu____11762 with
                          | (openings, lbunivs) ->
                              let cfg1 =
-                               let uu___1628_11797 = cfg in
-                               let uu____11798 =
+                               let uu___1628_11782 = cfg in
+                               let uu____11783 =
                                  FStar_TypeChecker_Env.push_univ_vars
                                    cfg.FStar_TypeChecker_Cfg.tcenv lbunivs in
                                {
                                  FStar_TypeChecker_Cfg.steps =
-                                   (uu___1628_11797.FStar_TypeChecker_Cfg.steps);
-                                 FStar_TypeChecker_Cfg.tcenv = uu____11798;
+                                   (uu___1628_11782.FStar_TypeChecker_Cfg.steps);
+                                 FStar_TypeChecker_Cfg.tcenv = uu____11783;
                                  FStar_TypeChecker_Cfg.debug =
-                                   (uu___1628_11797.FStar_TypeChecker_Cfg.debug);
+                                   (uu___1628_11782.FStar_TypeChecker_Cfg.debug);
                                  FStar_TypeChecker_Cfg.delta_level =
-                                   (uu___1628_11797.FStar_TypeChecker_Cfg.delta_level);
+                                   (uu___1628_11782.FStar_TypeChecker_Cfg.delta_level);
                                  FStar_TypeChecker_Cfg.primitive_steps =
-                                   (uu___1628_11797.FStar_TypeChecker_Cfg.primitive_steps);
+                                   (uu___1628_11782.FStar_TypeChecker_Cfg.primitive_steps);
                                  FStar_TypeChecker_Cfg.strong =
-                                   (uu___1628_11797.FStar_TypeChecker_Cfg.strong);
+                                   (uu___1628_11782.FStar_TypeChecker_Cfg.strong);
                                  FStar_TypeChecker_Cfg.memoize_lazy =
-                                   (uu___1628_11797.FStar_TypeChecker_Cfg.memoize_lazy);
+                                   (uu___1628_11782.FStar_TypeChecker_Cfg.memoize_lazy);
                                  FStar_TypeChecker_Cfg.normalize_pure_lets =
-                                   (uu___1628_11797.FStar_TypeChecker_Cfg.normalize_pure_lets);
+                                   (uu___1628_11782.FStar_TypeChecker_Cfg.normalize_pure_lets);
                                  FStar_TypeChecker_Cfg.reifying =
-                                   (uu___1628_11797.FStar_TypeChecker_Cfg.reifying)
+                                   (uu___1628_11782.FStar_TypeChecker_Cfg.reifying)
                                } in
                              let norm1 t2 =
-                               let uu____11805 =
-                                 let uu____11806 =
+                               let uu____11790 =
+                                 let uu____11791 =
                                    FStar_Syntax_Subst.subst openings t2 in
-                                 norm cfg1 env1 [] uu____11806 in
+                                 norm cfg1 env1 [] uu____11791 in
                                FStar_Syntax_Subst.close_univ_vars lbunivs
-                                 uu____11805 in
+                                 uu____11790 in
                              let lbtyp = norm1 lb.FStar_Syntax_Syntax.lbtyp in
                              let lbdef = norm1 lb.FStar_Syntax_Syntax.lbdef in
-                             let uu___1635_11809 = lb in
+                             let uu___1635_11794 = lb in
                              {
                                FStar_Syntax_Syntax.lbname =
-                                 (uu___1635_11809.FStar_Syntax_Syntax.lbname);
+                                 (uu___1635_11794.FStar_Syntax_Syntax.lbname);
                                FStar_Syntax_Syntax.lbunivs = lbunivs;
                                FStar_Syntax_Syntax.lbtyp = lbtyp;
                                FStar_Syntax_Syntax.lbeff =
-                                 (uu___1635_11809.FStar_Syntax_Syntax.lbeff);
+                                 (uu___1635_11794.FStar_Syntax_Syntax.lbeff);
                                FStar_Syntax_Syntax.lbdef = lbdef;
                                FStar_Syntax_Syntax.lbattrs =
-                                 (uu___1635_11809.FStar_Syntax_Syntax.lbattrs);
+                                 (uu___1635_11794.FStar_Syntax_Syntax.lbattrs);
                                FStar_Syntax_Syntax.lbpos =
-                                 (uu___1635_11809.FStar_Syntax_Syntax.lbpos)
+                                 (uu___1635_11794.FStar_Syntax_Syntax.lbpos)
                              })) in
-               let uu____11810 =
+               let uu____11795 =
                  FStar_Syntax_Syntax.mk
                    (FStar_Syntax_Syntax.Tm_let ((b, lbs1), lbody))
                    t1.FStar_Syntax_Syntax.pos in
-               rebuild cfg env1 stack1 uu____11810
+               rebuild cfg env1 stack1 uu____11795
            | FStar_Syntax_Syntax.Tm_let
-               ((uu____11821,
-                 { FStar_Syntax_Syntax.lbname = FStar_Util.Inr uu____11822;
-                   FStar_Syntax_Syntax.lbunivs = uu____11823;
-                   FStar_Syntax_Syntax.lbtyp = uu____11824;
-                   FStar_Syntax_Syntax.lbeff = uu____11825;
-                   FStar_Syntax_Syntax.lbdef = uu____11826;
-                   FStar_Syntax_Syntax.lbattrs = uu____11827;
-                   FStar_Syntax_Syntax.lbpos = uu____11828;_}::uu____11829),
-                uu____11830)
+               ((uu____11806,
+                 { FStar_Syntax_Syntax.lbname = FStar_Util.Inr uu____11807;
+                   FStar_Syntax_Syntax.lbunivs = uu____11808;
+                   FStar_Syntax_Syntax.lbtyp = uu____11809;
+                   FStar_Syntax_Syntax.lbeff = uu____11810;
+                   FStar_Syntax_Syntax.lbdef = uu____11811;
+                   FStar_Syntax_Syntax.lbattrs = uu____11812;
+                   FStar_Syntax_Syntax.lbpos = uu____11813;_}::uu____11814),
+                uu____11815)
                -> rebuild cfg env1 stack1 t1
            | FStar_Syntax_Syntax.Tm_let ((false, lb::[]), body) ->
-               let uu____11869 =
+               let uu____11854 =
                  FStar_TypeChecker_Cfg.should_reduce_local_let cfg lb in
-               if uu____11869
+               if uu____11854
                then
                  let binder =
-                   let uu____11871 =
+                   let uu____11856 =
                      FStar_Util.left lb.FStar_Syntax_Syntax.lbname in
-                   FStar_Syntax_Syntax.mk_binder uu____11871 in
+                   FStar_Syntax_Syntax.mk_binder uu____11856 in
                  let def =
                    FStar_Syntax_Util.unmeta_lift lb.FStar_Syntax_Syntax.lbdef in
                  let env2 =
-                   let uu____11882 =
-                     let uu____11889 =
-                       let uu____11890 =
-                         let uu____11921 =
+                   let uu____11867 =
+                     let uu____11874 =
+                       let uu____11875 =
+                         let uu____11906 =
                            FStar_Util.mk_ref FStar_Pervasives_Native.None in
-                         (env1, def, uu____11921, false) in
-                       Clos uu____11890 in
-                     ((FStar_Pervasives_Native.Some binder), uu____11889) in
-                   uu____11882 :: env1 in
+                         (env1, def, uu____11906, false) in
+                       Clos uu____11875 in
+                     ((FStar_Pervasives_Native.Some binder), uu____11874) in
+                   uu____11867 :: env1 in
                  (FStar_TypeChecker_Cfg.log cfg
-                    (fun uu____11994 ->
+                    (fun uu____11979 ->
                        FStar_Util.print_string "+++ Reducing Tm_let\n");
                   norm cfg env2 stack1 body)
                else
-                 (let uu____11996 =
+                 (let uu____11981 =
                     (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.reify_
                       &&
-                      (let uu____11998 =
+                      (let uu____11983 =
                          FStar_TypeChecker_Env.norm_eff_name
                            cfg.FStar_TypeChecker_Cfg.tcenv
                            lb.FStar_Syntax_Syntax.lbeff in
-                       FStar_Syntax_Util.is_div_effect uu____11998) in
-                  if uu____11996
+                       FStar_Syntax_Util.is_div_effect uu____11983) in
+                  if uu____11981
                   then
                     let ffun =
-                      let uu____12002 =
-                        let uu____12003 =
-                          let uu____12022 =
-                            let uu____12031 =
-                              let uu____12038 =
+                      let uu____11987 =
+                        let uu____11988 =
+                          let uu____12007 =
+                            let uu____12016 =
+                              let uu____12023 =
                                 FStar_All.pipe_right
                                   lb.FStar_Syntax_Syntax.lbname
                                   FStar_Util.left in
-                              FStar_Syntax_Syntax.mk_binder uu____12038 in
-                            [uu____12031] in
-                          (uu____12022, body, FStar_Pervasives_Native.None) in
-                        FStar_Syntax_Syntax.Tm_abs uu____12003 in
-                      FStar_Syntax_Syntax.mk uu____12002
+                              FStar_Syntax_Syntax.mk_binder uu____12023 in
+                            [uu____12016] in
+                          (uu____12007, body, FStar_Pervasives_Native.None) in
+                        FStar_Syntax_Syntax.Tm_abs uu____11988 in
+                      FStar_Syntax_Syntax.mk uu____11987
                         t1.FStar_Syntax_Syntax.pos in
                     let stack2 =
                       (CBVApp
@@ -4011,7 +4010,7 @@ let rec (norm :
                            (t1.FStar_Syntax_Syntax.pos)))
                       :: stack1 in
                     (FStar_TypeChecker_Cfg.log cfg
-                       (fun uu____12072 ->
+                       (fun uu____12057 ->
                           FStar_Util.print_string
                             "+++ Evaluating DIV Tm_let\n");
                      norm cfg env1 stack2 lb.FStar_Syntax_Syntax.lbdef)
@@ -4020,98 +4019,98 @@ let rec (norm :
                       (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.weak
                     then
                       (FStar_TypeChecker_Cfg.log cfg
-                         (fun uu____12076 ->
+                         (fun uu____12061 ->
                             FStar_Util.print_string
                               "+++ Not touching Tm_let\n");
-                       (let uu____12077 = closure_as_term cfg env1 t1 in
-                        rebuild cfg env1 stack1 uu____12077))
+                       (let uu____12062 = closure_as_term cfg env1 t1 in
+                        rebuild cfg env1 stack1 uu____12062))
                     else
-                      (let uu____12079 =
-                         let uu____12084 =
-                           let uu____12085 =
-                             let uu____12092 =
+                      (let uu____12064 =
+                         let uu____12069 =
+                           let uu____12070 =
+                             let uu____12077 =
                                FStar_All.pipe_right
                                  lb.FStar_Syntax_Syntax.lbname
                                  FStar_Util.left in
-                             FStar_All.pipe_right uu____12092
+                             FStar_All.pipe_right uu____12077
                                FStar_Syntax_Syntax.mk_binder in
-                           [uu____12085] in
-                         FStar_Syntax_Subst.open_term uu____12084 body in
-                       match uu____12079 with
+                           [uu____12070] in
+                         FStar_Syntax_Subst.open_term uu____12069 body in
+                       match uu____12064 with
                        | (bs, body1) ->
                            (FStar_TypeChecker_Cfg.log cfg
-                              (fun uu____12119 ->
+                              (fun uu____12104 ->
                                  FStar_Util.print_string
                                    "+++ Normalizing Tm_let -- type");
                             (let ty =
                                norm cfg env1 [] lb.FStar_Syntax_Syntax.lbtyp in
                              let lbname =
                                let x =
-                                 let uu____12127 = FStar_List.hd bs in
-                                 FStar_Pervasives_Native.fst uu____12127 in
+                                 let uu____12112 = FStar_List.hd bs in
+                                 FStar_Pervasives_Native.fst uu____12112 in
                                FStar_Util.Inl
-                                 (let uu___1682_12143 = x in
+                                 (let uu___1682_12128 = x in
                                   {
                                     FStar_Syntax_Syntax.ppname =
-                                      (uu___1682_12143.FStar_Syntax_Syntax.ppname);
+                                      (uu___1682_12128.FStar_Syntax_Syntax.ppname);
                                     FStar_Syntax_Syntax.index =
-                                      (uu___1682_12143.FStar_Syntax_Syntax.index);
+                                      (uu___1682_12128.FStar_Syntax_Syntax.index);
                                     FStar_Syntax_Syntax.sort = ty
                                   }) in
                              FStar_TypeChecker_Cfg.log cfg
-                               (fun uu____12146 ->
+                               (fun uu____12131 ->
                                   FStar_Util.print_string
                                     "+++ Normalizing Tm_let -- definiens\n");
                              (let lb1 =
-                                let uu___1687_12148 = lb in
-                                let uu____12149 =
+                                let uu___1687_12133 = lb in
+                                let uu____12134 =
                                   norm cfg env1 []
                                     lb.FStar_Syntax_Syntax.lbdef in
-                                let uu____12152 =
+                                let uu____12137 =
                                   FStar_List.map (norm cfg env1 [])
                                     lb.FStar_Syntax_Syntax.lbattrs in
                                 {
                                   FStar_Syntax_Syntax.lbname = lbname;
                                   FStar_Syntax_Syntax.lbunivs =
-                                    (uu___1687_12148.FStar_Syntax_Syntax.lbunivs);
+                                    (uu___1687_12133.FStar_Syntax_Syntax.lbunivs);
                                   FStar_Syntax_Syntax.lbtyp = ty;
                                   FStar_Syntax_Syntax.lbeff =
-                                    (uu___1687_12148.FStar_Syntax_Syntax.lbeff);
-                                  FStar_Syntax_Syntax.lbdef = uu____12149;
-                                  FStar_Syntax_Syntax.lbattrs = uu____12152;
+                                    (uu___1687_12133.FStar_Syntax_Syntax.lbeff);
+                                  FStar_Syntax_Syntax.lbdef = uu____12134;
+                                  FStar_Syntax_Syntax.lbattrs = uu____12137;
                                   FStar_Syntax_Syntax.lbpos =
-                                    (uu___1687_12148.FStar_Syntax_Syntax.lbpos)
+                                    (uu___1687_12133.FStar_Syntax_Syntax.lbpos)
                                 } in
                               let env' =
                                 FStar_All.pipe_right bs
                                   (FStar_List.fold_left
                                      (fun env2 ->
-                                        fun uu____12187 -> dummy :: env2)
+                                        fun uu____12172 -> dummy :: env2)
                                      env1) in
                               let stack2 = (Cfg cfg) :: stack1 in
                               let cfg1 =
-                                let uu___1694_12212 = cfg in
+                                let uu___1694_12197 = cfg in
                                 {
                                   FStar_TypeChecker_Cfg.steps =
-                                    (uu___1694_12212.FStar_TypeChecker_Cfg.steps);
+                                    (uu___1694_12197.FStar_TypeChecker_Cfg.steps);
                                   FStar_TypeChecker_Cfg.tcenv =
-                                    (uu___1694_12212.FStar_TypeChecker_Cfg.tcenv);
+                                    (uu___1694_12197.FStar_TypeChecker_Cfg.tcenv);
                                   FStar_TypeChecker_Cfg.debug =
-                                    (uu___1694_12212.FStar_TypeChecker_Cfg.debug);
+                                    (uu___1694_12197.FStar_TypeChecker_Cfg.debug);
                                   FStar_TypeChecker_Cfg.delta_level =
-                                    (uu___1694_12212.FStar_TypeChecker_Cfg.delta_level);
+                                    (uu___1694_12197.FStar_TypeChecker_Cfg.delta_level);
                                   FStar_TypeChecker_Cfg.primitive_steps =
-                                    (uu___1694_12212.FStar_TypeChecker_Cfg.primitive_steps);
+                                    (uu___1694_12197.FStar_TypeChecker_Cfg.primitive_steps);
                                   FStar_TypeChecker_Cfg.strong = true;
                                   FStar_TypeChecker_Cfg.memoize_lazy =
-                                    (uu___1694_12212.FStar_TypeChecker_Cfg.memoize_lazy);
+                                    (uu___1694_12197.FStar_TypeChecker_Cfg.memoize_lazy);
                                   FStar_TypeChecker_Cfg.normalize_pure_lets =
-                                    (uu___1694_12212.FStar_TypeChecker_Cfg.normalize_pure_lets);
+                                    (uu___1694_12197.FStar_TypeChecker_Cfg.normalize_pure_lets);
                                   FStar_TypeChecker_Cfg.reifying =
-                                    (uu___1694_12212.FStar_TypeChecker_Cfg.reifying)
+                                    (uu___1694_12197.FStar_TypeChecker_Cfg.reifying)
                                 } in
                               FStar_TypeChecker_Cfg.log cfg1
-                                (fun uu____12215 ->
+                                (fun uu____12200 ->
                                    FStar_Util.print_string
                                      "+++ Normalizing Tm_let -- body\n");
                               norm cfg1 env'
@@ -4130,8 +4129,8 @@ let rec (norm :
                     &&
                     (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.pure_subterms_within_computations)
                ->
-               let uu____12232 = FStar_Syntax_Subst.open_let_rec lbs body in
-               (match uu____12232 with
+               let uu____12217 = FStar_Syntax_Subst.open_let_rec lbs body in
+               (match uu____12217 with
                 | (lbs1, body1) ->
                     let lbs2 =
                       FStar_List.map
@@ -4139,90 +4138,90 @@ let rec (norm :
                            let ty =
                              norm cfg env1 [] lb.FStar_Syntax_Syntax.lbtyp in
                            let lbname =
-                             let uu____12268 =
-                               let uu___1710_12269 =
+                             let uu____12253 =
+                               let uu___1710_12254 =
                                  FStar_Util.left
                                    lb.FStar_Syntax_Syntax.lbname in
                                {
                                  FStar_Syntax_Syntax.ppname =
-                                   (uu___1710_12269.FStar_Syntax_Syntax.ppname);
+                                   (uu___1710_12254.FStar_Syntax_Syntax.ppname);
                                  FStar_Syntax_Syntax.index =
-                                   (uu___1710_12269.FStar_Syntax_Syntax.index);
+                                   (uu___1710_12254.FStar_Syntax_Syntax.index);
                                  FStar_Syntax_Syntax.sort = ty
                                } in
-                             FStar_Util.Inl uu____12268 in
-                           let uu____12270 =
+                             FStar_Util.Inl uu____12253 in
+                           let uu____12255 =
                              FStar_Syntax_Util.abs_formals
                                lb.FStar_Syntax_Syntax.lbdef in
-                           match uu____12270 with
+                           match uu____12255 with
                            | (xs, def_body, lopt) ->
                                let xs1 = norm_binders cfg env1 xs in
                                let env2 =
-                                 let uu____12296 =
-                                   FStar_List.map (fun uu____12318 -> dummy)
+                                 let uu____12281 =
+                                   FStar_List.map (fun uu____12303 -> dummy)
                                      xs1 in
-                                 let uu____12325 =
-                                   let uu____12334 =
+                                 let uu____12310 =
+                                   let uu____12319 =
                                      FStar_List.map
-                                       (fun uu____12350 -> dummy) lbs1 in
-                                   FStar_List.append uu____12334 env1 in
-                                 FStar_List.append uu____12296 uu____12325 in
+                                       (fun uu____12335 -> dummy) lbs1 in
+                                   FStar_List.append uu____12319 env1 in
+                                 FStar_List.append uu____12281 uu____12310 in
                                let def_body1 = norm cfg env2 [] def_body in
                                let lopt1 =
                                  match lopt with
                                  | FStar_Pervasives_Native.Some rc ->
-                                     let uu____12370 =
-                                       let uu___1724_12371 = rc in
-                                       let uu____12372 =
+                                     let uu____12355 =
+                                       let uu___1724_12356 = rc in
+                                       let uu____12357 =
                                          FStar_Util.map_opt
                                            rc.FStar_Syntax_Syntax.residual_typ
                                            (norm cfg env2 []) in
                                        {
                                          FStar_Syntax_Syntax.residual_effect
                                            =
-                                           (uu___1724_12371.FStar_Syntax_Syntax.residual_effect);
+                                           (uu___1724_12356.FStar_Syntax_Syntax.residual_effect);
                                          FStar_Syntax_Syntax.residual_typ =
-                                           uu____12372;
+                                           uu____12357;
                                          FStar_Syntax_Syntax.residual_flags =
-                                           (uu___1724_12371.FStar_Syntax_Syntax.residual_flags)
+                                           (uu___1724_12356.FStar_Syntax_Syntax.residual_flags)
                                        } in
-                                     FStar_Pervasives_Native.Some uu____12370
-                                 | uu____12381 -> lopt in
+                                     FStar_Pervasives_Native.Some uu____12355
+                                 | uu____12366 -> lopt in
                                let def =
                                  FStar_Syntax_Util.abs xs1 def_body1 lopt1 in
-                               let uu___1729_12387 = lb in
+                               let uu___1729_12372 = lb in
                                {
                                  FStar_Syntax_Syntax.lbname = lbname;
                                  FStar_Syntax_Syntax.lbunivs =
-                                   (uu___1729_12387.FStar_Syntax_Syntax.lbunivs);
+                                   (uu___1729_12372.FStar_Syntax_Syntax.lbunivs);
                                  FStar_Syntax_Syntax.lbtyp = ty;
                                  FStar_Syntax_Syntax.lbeff =
-                                   (uu___1729_12387.FStar_Syntax_Syntax.lbeff);
+                                   (uu___1729_12372.FStar_Syntax_Syntax.lbeff);
                                  FStar_Syntax_Syntax.lbdef = def;
                                  FStar_Syntax_Syntax.lbattrs =
-                                   (uu___1729_12387.FStar_Syntax_Syntax.lbattrs);
+                                   (uu___1729_12372.FStar_Syntax_Syntax.lbattrs);
                                  FStar_Syntax_Syntax.lbpos =
-                                   (uu___1729_12387.FStar_Syntax_Syntax.lbpos)
+                                   (uu___1729_12372.FStar_Syntax_Syntax.lbpos)
                                }) lbs1 in
                     let env' =
-                      let uu____12397 =
-                        FStar_List.map (fun uu____12413 -> dummy) lbs2 in
-                      FStar_List.append uu____12397 env1 in
+                      let uu____12382 =
+                        FStar_List.map (fun uu____12398 -> dummy) lbs2 in
+                      FStar_List.append uu____12382 env1 in
                     let body2 = norm cfg env' [] body1 in
-                    let uu____12421 =
+                    let uu____12406 =
                       FStar_Syntax_Subst.close_let_rec lbs2 body2 in
-                    (match uu____12421 with
+                    (match uu____12406 with
                      | (lbs3, body3) ->
                          let t2 =
-                           let uu___1738_12437 = t1 in
+                           let uu___1738_12422 = t1 in
                            {
                              FStar_Syntax_Syntax.n =
                                (FStar_Syntax_Syntax.Tm_let
                                   ((true, lbs3), body3));
                              FStar_Syntax_Syntax.pos =
-                               (uu___1738_12437.FStar_Syntax_Syntax.pos);
+                               (uu___1738_12422.FStar_Syntax_Syntax.pos);
                              FStar_Syntax_Syntax.vars =
-                               (uu___1738_12437.FStar_Syntax_Syntax.vars)
+                               (uu___1738_12422.FStar_Syntax_Syntax.vars)
                            } in
                          rebuild cfg env1 stack1 t2))
            | FStar_Syntax_Syntax.Tm_let (lbs, body) when
@@ -4232,24 +4231,24 @@ let rec (norm :
                  (Prims.op_Negation
                     (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.zeta_full)
                ->
-               let uu____12466 = closure_as_term cfg env1 t1 in
-               rebuild cfg env1 stack1 uu____12466
+               let uu____12451 = closure_as_term cfg env1 t1 in
+               rebuild cfg env1 stack1 uu____12451
            | FStar_Syntax_Syntax.Tm_let (lbs, body) ->
-               let uu____12485 =
+               let uu____12470 =
                  FStar_List.fold_right
                    (fun lb ->
-                      fun uu____12561 ->
-                        match uu____12561 with
+                      fun uu____12546 ->
+                        match uu____12546 with
                         | (rec_env, memos, i) ->
                             let bv =
-                              let uu___1754_12682 =
+                              let uu___1754_12667 =
                                 FStar_Util.left lb.FStar_Syntax_Syntax.lbname in
                               {
                                 FStar_Syntax_Syntax.ppname =
-                                  (uu___1754_12682.FStar_Syntax_Syntax.ppname);
+                                  (uu___1754_12667.FStar_Syntax_Syntax.ppname);
                                 FStar_Syntax_Syntax.index = i;
                                 FStar_Syntax_Syntax.sort =
-                                  (uu___1754_12682.FStar_Syntax_Syntax.sort)
+                                  (uu___1754_12667.FStar_Syntax_Syntax.sort)
                               } in
                             let f_i = FStar_Syntax_Syntax.bv_to_tm bv in
                             let fix_f_i =
@@ -4265,9 +4264,9 @@ let rec (norm :
                             (rec_env1, (memo :: memos), (i + Prims.int_one)))
                    (FStar_Pervasives_Native.snd lbs)
                    (env1, [], Prims.int_zero) in
-               (match uu____12485 with
-                | (rec_env, memos, uu____12865) ->
-                    let uu____12918 =
+               (match uu____12470 with
+                | (rec_env, memos, uu____12850) ->
+                    let uu____12903 =
                       FStar_List.map2
                         (fun lb ->
                            fun memo ->
@@ -4279,25 +4278,25 @@ let rec (norm :
                       FStar_List.fold_right
                         (fun lb ->
                            fun env2 ->
-                             let uu____13101 =
-                               let uu____13108 =
-                                 let uu____13109 =
-                                   let uu____13140 =
+                             let uu____13086 =
+                               let uu____13093 =
+                                 let uu____13094 =
+                                   let uu____13125 =
                                      FStar_Util.mk_ref
                                        FStar_Pervasives_Native.None in
                                    (rec_env, (lb.FStar_Syntax_Syntax.lbdef),
-                                     uu____13140, false) in
-                                 Clos uu____13109 in
-                               (FStar_Pervasives_Native.None, uu____13108) in
-                             uu____13101 :: env2)
+                                     uu____13125, false) in
+                                 Clos uu____13094 in
+                               (FStar_Pervasives_Native.None, uu____13093) in
+                             uu____13086 :: env2)
                         (FStar_Pervasives_Native.snd lbs) env1 in
                     norm cfg body_env stack1 body)
            | FStar_Syntax_Syntax.Tm_meta (head, m) ->
                (FStar_TypeChecker_Cfg.log cfg
-                  (fun uu____13222 ->
-                     let uu____13223 =
+                  (fun uu____13207 ->
+                     let uu____13208 =
                        FStar_Syntax_Print.metadata_to_string m in
-                     FStar_Util.print1 ">> metadata = %s\n" uu____13223);
+                     FStar_Util.print1 ">> metadata = %s\n" uu____13208);
                 (match m with
                  | FStar_Syntax_Syntax.Meta_monadic (m1, t2) ->
                      reduce_impure_comp cfg env1 stack1 head
@@ -4305,16 +4304,16 @@ let rec (norm :
                  | FStar_Syntax_Syntax.Meta_monadic_lift (m1, m', t2) ->
                      reduce_impure_comp cfg env1 stack1 head
                        (FStar_Util.Inr (m1, m')) t2
-                 | uu____13245 ->
+                 | uu____13230 ->
                      if
                        (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.unmeta
                      then norm cfg env1 stack1 head
                      else
                        (match stack1 with
-                        | uu____13247::uu____13248 ->
+                        | uu____13232::uu____13233 ->
                             (match m with
                              | FStar_Syntax_Syntax.Meta_labeled
-                                 (l, r, uu____13253) ->
+                                 (l, r, uu____13238) ->
                                  norm cfg env1 ((Meta (env1, m, r)) ::
                                    stack1) head
                              | FStar_Syntax_Syntax.Meta_pattern (names, args)
@@ -4330,7 +4329,7 @@ let rec (norm :
                                             (names1, args1)),
                                          (t1.FStar_Syntax_Syntax.pos))) ::
                                    stack1) head
-                             | uu____13328 -> norm cfg env1 stack1 head)
+                             | uu____13313 -> norm cfg env1 stack1 head)
                         | [] ->
                             let head1 = norm cfg env1 [] head in
                             let m1 =
@@ -4340,42 +4339,42 @@ let rec (norm :
                                   let names1 =
                                     FStar_All.pipe_right names
                                       (FStar_List.map (norm cfg env1 [])) in
-                                  let uu____13376 =
-                                    let uu____13397 =
+                                  let uu____13361 =
+                                    let uu____13382 =
                                       norm_pattern_args cfg env1 args in
-                                    (names1, uu____13397) in
+                                    (names1, uu____13382) in
                                   FStar_Syntax_Syntax.Meta_pattern
-                                    uu____13376
-                              | uu____13426 -> m in
+                                    uu____13361
+                              | uu____13411 -> m in
                             let t2 =
                               FStar_Syntax_Syntax.mk
                                 (FStar_Syntax_Syntax.Tm_meta (head1, m1))
                                 t1.FStar_Syntax_Syntax.pos in
                             rebuild cfg env1 stack1 t2)))
-           | FStar_Syntax_Syntax.Tm_delayed uu____13432 ->
+           | FStar_Syntax_Syntax.Tm_delayed uu____13417 ->
                let t2 = FStar_Syntax_Subst.compress t1 in
                norm cfg env1 stack1 t2
-           | FStar_Syntax_Syntax.Tm_uvar uu____13448 ->
+           | FStar_Syntax_Syntax.Tm_uvar uu____13433 ->
                let t2 = FStar_Syntax_Subst.compress t1 in
                (match t2.FStar_Syntax_Syntax.n with
-                | FStar_Syntax_Syntax.Tm_uvar uu____13462 ->
+                | FStar_Syntax_Syntax.Tm_uvar uu____13447 ->
                     if
                       (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.check_no_uvars
                     then
-                      let uu____13475 =
-                        let uu____13476 =
+                      let uu____13460 =
+                        let uu____13461 =
                           FStar_Range.string_of_range
                             t2.FStar_Syntax_Syntax.pos in
-                        let uu____13477 =
+                        let uu____13462 =
                           FStar_Syntax_Print.term_to_string t2 in
                         FStar_Util.format2
                           "(%s) CheckNoUvars: Unexpected unification variable remains: %s"
-                          uu____13476 uu____13477 in
-                      failwith uu____13475
+                          uu____13461 uu____13462 in
+                      failwith uu____13460
                     else
-                      (let uu____13479 = inline_closure_env cfg env1 [] t2 in
-                       rebuild cfg env1 stack1 uu____13479)
-                | uu____13480 -> norm cfg env1 stack1 t2))
+                      (let uu____13464 = inline_closure_env cfg env1 [] t2 in
+                       rebuild cfg env1 stack1 uu____13464)
+                | uu____13465 -> norm cfg env1 stack1 t2))
 and (do_unfold_fv :
   FStar_TypeChecker_Cfg.cfg ->
     env ->
@@ -4390,27 +4389,27 @@ and (do_unfold_fv :
         fun t0 ->
           fun qninfo ->
             fun f ->
-              let uu____13489 =
+              let uu____13474 =
                 FStar_TypeChecker_Env.lookup_definition_qninfo
                   cfg.FStar_TypeChecker_Cfg.delta_level
                   (f.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
                   qninfo in
-              match uu____13489 with
+              match uu____13474 with
               | FStar_Pervasives_Native.None ->
                   (FStar_TypeChecker_Cfg.log_unfolding cfg
-                     (fun uu____13503 ->
-                        let uu____13504 = FStar_Syntax_Print.fv_to_string f in
+                     (fun uu____13488 ->
+                        let uu____13489 = FStar_Syntax_Print.fv_to_string f in
                         FStar_Util.print1 " >> Tm_fvar case 2 for %s\n"
-                          uu____13504);
+                          uu____13489);
                    rebuild cfg env1 stack1 t0)
               | FStar_Pervasives_Native.Some (us, t) ->
                   (FStar_TypeChecker_Cfg.log_unfolding cfg
-                     (fun uu____13515 ->
-                        let uu____13516 =
+                     (fun uu____13500 ->
+                        let uu____13501 =
                           FStar_Syntax_Print.term_to_string t0 in
-                        let uu____13517 = FStar_Syntax_Print.term_to_string t in
+                        let uu____13502 = FStar_Syntax_Print.term_to_string t in
                         FStar_Util.print2 " >> Unfolded %s to %s\n"
-                          uu____13516 uu____13517);
+                          uu____13501 uu____13502);
                    (let t1 =
                       if
                         (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.unfold_until
@@ -4425,20 +4424,20 @@ and (do_unfold_fv :
                     if n > Prims.int_zero
                     then
                       match stack1 with
-                      | (UnivArgs (us', uu____13524))::stack2 ->
-                          ((let uu____13533 =
+                      | (UnivArgs (us', uu____13509))::stack2 ->
+                          ((let uu____13518 =
                               FStar_All.pipe_left
                                 (FStar_TypeChecker_Env.debug
                                    cfg.FStar_TypeChecker_Cfg.tcenv)
                                 (FStar_Options.Other "univ_norm") in
-                            if uu____13533
+                            if uu____13518
                             then
                               FStar_List.iter
                                 (fun x ->
-                                   let uu____13537 =
+                                   let uu____13522 =
                                      FStar_Syntax_Print.univ_to_string x in
                                    FStar_Util.print1 "Univ (normalizer) %s\n"
-                                     uu____13537) us'
+                                     uu____13522) us'
                             else ());
                            (let env2 =
                               FStar_All.pipe_right us'
@@ -4449,20 +4448,20 @@ and (do_unfold_fv :
                                           (Univ u))
                                         :: env2) env1) in
                             norm cfg env2 stack2 t1))
-                      | uu____13570 when
+                      | uu____13555 when
                           (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.erase_universes
                             ||
                             (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.allow_unbound_universes
                           -> norm cfg env1 stack1 t1
-                      | uu____13573 ->
-                          let uu____13576 =
-                            let uu____13577 =
+                      | uu____13558 ->
+                          let uu____13561 =
+                            let uu____13562 =
                               FStar_Syntax_Print.lid_to_string
                                 (f.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
                             FStar_Util.format1
                               "Impossible: missing universe instantiation on %s"
-                              uu____13577 in
-                          failwith uu____13576
+                              uu____13562 in
+                          failwith uu____13561
                     else norm cfg env1 stack1 t1))
 and (reduce_impure_comp :
   FStar_TypeChecker_Cfg.cfg ->
@@ -4481,7 +4480,7 @@ and (reduce_impure_comp :
           fun m ->
             fun t ->
               let t1 = norm cfg env1 [] t in
-              let uu____13594 =
+              let uu____13579 =
                 if
                   (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.pure_subterms_within_computations
                 then
@@ -4493,34 +4492,34 @@ and (reduce_impure_comp :
                     FStar_TypeChecker_Env.Exclude FStar_TypeChecker_Env.Zeta;
                     FStar_TypeChecker_Env.Inlining] in
                   let cfg' =
-                    let uu___1865_13611 = cfg in
-                    let uu____13612 =
+                    let uu___1865_13596 = cfg in
+                    let uu____13597 =
                       FStar_List.fold_right
                         FStar_TypeChecker_Cfg.fstep_add_one new_steps
                         cfg.FStar_TypeChecker_Cfg.steps in
                     {
-                      FStar_TypeChecker_Cfg.steps = uu____13612;
+                      FStar_TypeChecker_Cfg.steps = uu____13597;
                       FStar_TypeChecker_Cfg.tcenv =
-                        (uu___1865_13611.FStar_TypeChecker_Cfg.tcenv);
+                        (uu___1865_13596.FStar_TypeChecker_Cfg.tcenv);
                       FStar_TypeChecker_Cfg.debug =
-                        (uu___1865_13611.FStar_TypeChecker_Cfg.debug);
+                        (uu___1865_13596.FStar_TypeChecker_Cfg.debug);
                       FStar_TypeChecker_Cfg.delta_level =
                         [FStar_TypeChecker_Env.InliningDelta;
                         FStar_TypeChecker_Env.Eager_unfolding_only];
                       FStar_TypeChecker_Cfg.primitive_steps =
-                        (uu___1865_13611.FStar_TypeChecker_Cfg.primitive_steps);
+                        (uu___1865_13596.FStar_TypeChecker_Cfg.primitive_steps);
                       FStar_TypeChecker_Cfg.strong =
-                        (uu___1865_13611.FStar_TypeChecker_Cfg.strong);
+                        (uu___1865_13596.FStar_TypeChecker_Cfg.strong);
                       FStar_TypeChecker_Cfg.memoize_lazy =
-                        (uu___1865_13611.FStar_TypeChecker_Cfg.memoize_lazy);
+                        (uu___1865_13596.FStar_TypeChecker_Cfg.memoize_lazy);
                       FStar_TypeChecker_Cfg.normalize_pure_lets =
-                        (uu___1865_13611.FStar_TypeChecker_Cfg.normalize_pure_lets);
+                        (uu___1865_13596.FStar_TypeChecker_Cfg.normalize_pure_lets);
                       FStar_TypeChecker_Cfg.reifying =
-                        (uu___1865_13611.FStar_TypeChecker_Cfg.reifying)
+                        (uu___1865_13596.FStar_TypeChecker_Cfg.reifying)
                     } in
                   (cfg', ((Cfg cfg) :: stack1))
                 else (cfg, stack1) in
-              match uu____13594 with
+              match uu____13579 with
               | (cfg1, stack2) ->
                   let metadata =
                     match m with
@@ -4549,36 +4548,36 @@ and (do_reify_monadic :
               fun t ->
                 (match stack1 with
                  | (App
-                     (uu____13652,
+                     (uu____13637,
                       {
                         FStar_Syntax_Syntax.n =
                           FStar_Syntax_Syntax.Tm_constant
                           (FStar_Const.Const_reify);
-                        FStar_Syntax_Syntax.pos = uu____13653;
-                        FStar_Syntax_Syntax.vars = uu____13654;_},
-                      uu____13655, uu____13656))::uu____13657
+                        FStar_Syntax_Syntax.pos = uu____13638;
+                        FStar_Syntax_Syntax.vars = uu____13639;_},
+                      uu____13640, uu____13641))::uu____13642
                      -> ()
-                 | uu____13662 ->
-                     let uu____13665 =
-                       let uu____13666 = stack_to_string stack1 in
+                 | uu____13647 ->
+                     let uu____13650 =
+                       let uu____13651 = stack_to_string stack1 in
                        FStar_Util.format1
                          "INTERNAL ERROR: do_reify_monadic: bad stack: %s"
-                         uu____13666 in
-                     failwith uu____13665);
+                         uu____13651 in
+                     failwith uu____13650);
                 (let top0 = top in
                  let top1 = FStar_Syntax_Util.unascribe top in
                  FStar_TypeChecker_Cfg.log cfg
-                   (fun uu____13673 ->
-                      let uu____13674 = FStar_Syntax_Print.tag_of_term top1 in
-                      let uu____13675 =
+                   (fun uu____13658 ->
+                      let uu____13659 = FStar_Syntax_Print.tag_of_term top1 in
+                      let uu____13660 =
                         FStar_Syntax_Print.term_to_string top1 in
-                      FStar_Util.print2 "Reifying: (%s) %s\n" uu____13674
-                        uu____13675);
+                      FStar_Util.print2 "Reifying: (%s) %s\n" uu____13659
+                        uu____13660);
                  (let top2 = FStar_Syntax_Util.unmeta_safe top1 in
-                  let uu____13677 =
-                    let uu____13678 = FStar_Syntax_Subst.compress top2 in
-                    uu____13678.FStar_Syntax_Syntax.n in
-                  match uu____13677 with
+                  let uu____13662 =
+                    let uu____13663 = FStar_Syntax_Subst.compress top2 in
+                    uu____13663.FStar_Syntax_Syntax.n in
+                  match uu____13662 with
                   | FStar_Syntax_Syntax.Tm_let ((false, lb::[]), body) ->
                       let eff_name =
                         FStar_TypeChecker_Env.norm_eff_name
@@ -4586,113 +4585,113 @@ and (do_reify_monadic :
                       let ed =
                         FStar_TypeChecker_Env.get_effect_decl
                           cfg.FStar_TypeChecker_Cfg.tcenv eff_name in
-                      let uu____13697 =
-                        let uu____13706 =
+                      let uu____13682 =
+                        let uu____13691 =
                           FStar_All.pipe_right ed
                             FStar_Syntax_Util.get_eff_repr in
-                        FStar_All.pipe_right uu____13706 FStar_Util.must in
-                      (match uu____13697 with
-                       | (uu____13721, repr) ->
-                           let uu____13731 =
-                             let uu____13738 =
+                        FStar_All.pipe_right uu____13691 FStar_Util.must in
+                      (match uu____13682 with
+                       | (uu____13706, repr) ->
+                           let uu____13716 =
+                             let uu____13723 =
                                FStar_All.pipe_right ed
                                  FStar_Syntax_Util.get_bind_repr in
-                             FStar_All.pipe_right uu____13738 FStar_Util.must in
-                           (match uu____13731 with
-                            | (uu____13775, bind_repr) ->
+                             FStar_All.pipe_right uu____13723 FStar_Util.must in
+                           (match uu____13716 with
+                            | (uu____13760, bind_repr) ->
                                 (match lb.FStar_Syntax_Syntax.lbname with
-                                 | FStar_Util.Inr uu____13781 ->
+                                 | FStar_Util.Inr uu____13766 ->
                                      failwith
                                        "Cannot reify a top-level let binding"
                                  | FStar_Util.Inl x ->
                                      let is_return e =
-                                       let uu____13791 =
-                                         let uu____13792 =
+                                       let uu____13776 =
+                                         let uu____13777 =
                                            FStar_Syntax_Subst.compress e in
-                                         uu____13792.FStar_Syntax_Syntax.n in
-                                       match uu____13791 with
+                                         uu____13777.FStar_Syntax_Syntax.n in
+                                       match uu____13776 with
                                        | FStar_Syntax_Syntax.Tm_meta
                                            (e1,
                                             FStar_Syntax_Syntax.Meta_monadic
-                                            (uu____13798, uu____13799))
+                                            (uu____13783, uu____13784))
                                            ->
-                                           let uu____13808 =
-                                             let uu____13809 =
+                                           let uu____13793 =
+                                             let uu____13794 =
                                                FStar_Syntax_Subst.compress e1 in
-                                             uu____13809.FStar_Syntax_Syntax.n in
-                                           (match uu____13808 with
+                                             uu____13794.FStar_Syntax_Syntax.n in
+                                           (match uu____13793 with
                                             | FStar_Syntax_Syntax.Tm_meta
                                                 (e2,
                                                  FStar_Syntax_Syntax.Meta_monadic_lift
-                                                 (uu____13815, msrc,
-                                                  uu____13817))
+                                                 (uu____13800, msrc,
+                                                  uu____13802))
                                                 when
                                                 FStar_Syntax_Util.is_pure_effect
                                                   msrc
                                                 ->
-                                                let uu____13826 =
+                                                let uu____13811 =
                                                   FStar_Syntax_Subst.compress
                                                     e2 in
                                                 FStar_Pervasives_Native.Some
-                                                  uu____13826
-                                            | uu____13827 ->
+                                                  uu____13811
+                                            | uu____13812 ->
                                                 FStar_Pervasives_Native.None)
-                                       | uu____13828 ->
+                                       | uu____13813 ->
                                            FStar_Pervasives_Native.None in
-                                     let uu____13829 =
+                                     let uu____13814 =
                                        is_return lb.FStar_Syntax_Syntax.lbdef in
-                                     (match uu____13829 with
+                                     (match uu____13814 with
                                       | FStar_Pervasives_Native.Some e ->
                                           let lb1 =
-                                            let uu___1944_13834 = lb in
+                                            let uu___1944_13819 = lb in
                                             {
                                               FStar_Syntax_Syntax.lbname =
-                                                (uu___1944_13834.FStar_Syntax_Syntax.lbname);
+                                                (uu___1944_13819.FStar_Syntax_Syntax.lbname);
                                               FStar_Syntax_Syntax.lbunivs =
-                                                (uu___1944_13834.FStar_Syntax_Syntax.lbunivs);
+                                                (uu___1944_13819.FStar_Syntax_Syntax.lbunivs);
                                               FStar_Syntax_Syntax.lbtyp =
-                                                (uu___1944_13834.FStar_Syntax_Syntax.lbtyp);
+                                                (uu___1944_13819.FStar_Syntax_Syntax.lbtyp);
                                               FStar_Syntax_Syntax.lbeff =
                                                 FStar_Parser_Const.effect_PURE_lid;
                                               FStar_Syntax_Syntax.lbdef = e;
                                               FStar_Syntax_Syntax.lbattrs =
-                                                (uu___1944_13834.FStar_Syntax_Syntax.lbattrs);
+                                                (uu___1944_13819.FStar_Syntax_Syntax.lbattrs);
                                               FStar_Syntax_Syntax.lbpos =
-                                                (uu___1944_13834.FStar_Syntax_Syntax.lbpos)
+                                                (uu___1944_13819.FStar_Syntax_Syntax.lbpos)
                                             } in
-                                          let uu____13835 =
+                                          let uu____13820 =
                                             FStar_List.tl stack1 in
-                                          let uu____13836 =
-                                            let uu____13837 =
-                                              let uu____13838 =
-                                                let uu____13851 =
+                                          let uu____13821 =
+                                            let uu____13822 =
+                                              let uu____13823 =
+                                                let uu____13836 =
                                                   FStar_Syntax_Util.mk_reify
                                                     body in
-                                                ((false, [lb1]), uu____13851) in
+                                                ((false, [lb1]), uu____13836) in
                                               FStar_Syntax_Syntax.Tm_let
-                                                uu____13838 in
+                                                uu____13823 in
                                             FStar_Syntax_Syntax.mk
-                                              uu____13837
+                                              uu____13822
                                               top2.FStar_Syntax_Syntax.pos in
-                                          norm cfg env1 uu____13835
-                                            uu____13836
+                                          norm cfg env1 uu____13820
+                                            uu____13821
                                       | FStar_Pervasives_Native.None ->
-                                          let uu____13864 =
-                                            let uu____13865 = is_return body in
-                                            match uu____13865 with
+                                          let uu____13849 =
+                                            let uu____13850 = is_return body in
+                                            match uu____13850 with
                                             | FStar_Pervasives_Native.Some
                                                 {
                                                   FStar_Syntax_Syntax.n =
                                                     FStar_Syntax_Syntax.Tm_bvar
                                                     y;
                                                   FStar_Syntax_Syntax.pos =
-                                                    uu____13869;
+                                                    uu____13854;
                                                   FStar_Syntax_Syntax.vars =
-                                                    uu____13870;_}
+                                                    uu____13855;_}
                                                 ->
                                                 FStar_Syntax_Syntax.bv_eq x y
-                                            | uu____13873 -> false in
-                                          if uu____13864
+                                            | uu____13858 -> false in
+                                          if uu____13849
                                           then
                                             norm cfg env1 stack1
                                               lb.FStar_Syntax_Syntax.lbdef
@@ -4719,94 +4718,94 @@ and (do_reify_monadic :
                                                    = []
                                                } in
                                              let body2 =
-                                               let uu____13898 =
-                                                 let uu____13899 =
-                                                   let uu____13918 =
-                                                     let uu____13927 =
+                                               let uu____13883 =
+                                                 let uu____13884 =
+                                                   let uu____13903 =
+                                                     let uu____13912 =
                                                        FStar_Syntax_Syntax.mk_binder
                                                          x in
-                                                     [uu____13927] in
-                                                   (uu____13918, body1,
+                                                     [uu____13912] in
+                                                   (uu____13903, body1,
                                                      (FStar_Pervasives_Native.Some
                                                         body_rc)) in
                                                  FStar_Syntax_Syntax.Tm_abs
-                                                   uu____13899 in
+                                                   uu____13884 in
                                                FStar_Syntax_Syntax.mk
-                                                 uu____13898
+                                                 uu____13883
                                                  body1.FStar_Syntax_Syntax.pos in
                                              let close =
                                                closure_as_term cfg env1 in
                                              let bind_inst =
-                                               let uu____13966 =
-                                                 let uu____13967 =
+                                               let uu____13951 =
+                                                 let uu____13952 =
                                                    FStar_Syntax_Subst.compress
                                                      bind_repr in
-                                                 uu____13967.FStar_Syntax_Syntax.n in
-                                               match uu____13966 with
+                                                 uu____13952.FStar_Syntax_Syntax.n in
+                                               match uu____13951 with
                                                | FStar_Syntax_Syntax.Tm_uinst
                                                    (bind,
-                                                    uu____13973::uu____13974::[])
+                                                    uu____13958::uu____13959::[])
                                                    ->
-                                                   let uu____13979 =
-                                                     let uu____13980 =
-                                                       let uu____13987 =
-                                                         let uu____13988 =
-                                                           let uu____13989 =
+                                                   let uu____13964 =
+                                                     let uu____13965 =
+                                                       let uu____13972 =
+                                                         let uu____13973 =
+                                                           let uu____13974 =
                                                              close
                                                                lb.FStar_Syntax_Syntax.lbtyp in
                                                            (cfg.FStar_TypeChecker_Cfg.tcenv).FStar_TypeChecker_Env.universe_of
                                                              cfg.FStar_TypeChecker_Cfg.tcenv
-                                                             uu____13989 in
-                                                         let uu____13990 =
-                                                           let uu____13993 =
-                                                             let uu____13994
+                                                             uu____13974 in
+                                                         let uu____13975 =
+                                                           let uu____13978 =
+                                                             let uu____13979
                                                                = close t in
                                                              (cfg.FStar_TypeChecker_Cfg.tcenv).FStar_TypeChecker_Env.universe_of
                                                                cfg.FStar_TypeChecker_Cfg.tcenv
-                                                               uu____13994 in
-                                                           [uu____13993] in
-                                                         uu____13988 ::
-                                                           uu____13990 in
-                                                       (bind, uu____13987) in
+                                                               uu____13979 in
+                                                           [uu____13978] in
+                                                         uu____13973 ::
+                                                           uu____13975 in
+                                                       (bind, uu____13972) in
                                                      FStar_Syntax_Syntax.Tm_uinst
-                                                       uu____13980 in
+                                                       uu____13965 in
                                                    FStar_Syntax_Syntax.mk
-                                                     uu____13979 rng
-                                               | uu____13997 ->
+                                                     uu____13964 rng
+                                               | uu____13982 ->
                                                    failwith
                                                      "NIY : Reification of indexed effects" in
                                              let bind_inst_args f_arg =
-                                               let uu____14008 =
+                                               let uu____13993 =
                                                  FStar_Syntax_Util.is_layered
                                                    ed in
-                                               if uu____14008
+                                               if uu____13993
                                                then
                                                  let unit_args =
-                                                   let uu____14014 =
-                                                     let uu____14015 =
-                                                       let uu____14018 =
-                                                         let uu____14019 =
+                                                   let uu____13999 =
+                                                     let uu____14000 =
+                                                       let uu____14003 =
+                                                         let uu____14004 =
                                                            FStar_All.pipe_right
                                                              ed
                                                              FStar_Syntax_Util.get_bind_vc_combinator in
                                                          FStar_All.pipe_right
-                                                           uu____14019
+                                                           uu____14004
                                                            FStar_Pervasives_Native.snd in
                                                        FStar_All.pipe_right
-                                                         uu____14018
+                                                         uu____14003
                                                          FStar_Syntax_Subst.compress in
-                                                     uu____14015.FStar_Syntax_Syntax.n in
-                                                   match uu____14014 with
+                                                     uu____14000.FStar_Syntax_Syntax.n in
+                                                   match uu____13999 with
                                                    | FStar_Syntax_Syntax.Tm_arrow
-                                                       (uu____14052::uu____14053::bs,
-                                                        uu____14055)
+                                                       (uu____14037::uu____14038::bs,
+                                                        uu____14040)
                                                        when
                                                        (FStar_List.length bs)
                                                          >=
                                                          (Prims.of_int (2))
                                                        ->
-                                                       let uu____14106 =
-                                                         let uu____14115 =
+                                                       let uu____14091 =
+                                                         let uu____14100 =
                                                            FStar_All.pipe_right
                                                              bs
                                                              (FStar_List.splitAt
@@ -4815,136 +4814,136 @@ and (do_reify_monadic :
                                                                    -
                                                                    (Prims.of_int (2)))) in
                                                          FStar_All.pipe_right
-                                                           uu____14115
+                                                           uu____14100
                                                            FStar_Pervasives_Native.fst in
                                                        FStar_All.pipe_right
-                                                         uu____14106
+                                                         uu____14091
                                                          (FStar_List.map
-                                                            (fun uu____14237
+                                                            (fun uu____14222
                                                                ->
                                                                FStar_Syntax_Syntax.as_arg
                                                                  FStar_Syntax_Syntax.unit_const))
-                                                   | uu____14244 ->
-                                                       let uu____14245 =
-                                                         let uu____14250 =
-                                                           let uu____14251 =
+                                                   | uu____14229 ->
+                                                       let uu____14230 =
+                                                         let uu____14235 =
+                                                           let uu____14236 =
                                                              FStar_Ident.string_of_lid
                                                                ed.FStar_Syntax_Syntax.mname in
-                                                           let uu____14252 =
-                                                             let uu____14253
+                                                           let uu____14237 =
+                                                             let uu____14238
                                                                =
-                                                               let uu____14254
+                                                               let uu____14239
                                                                  =
                                                                  FStar_All.pipe_right
                                                                    ed
                                                                    FStar_Syntax_Util.get_bind_vc_combinator in
                                                                FStar_All.pipe_right
-                                                                 uu____14254
+                                                                 uu____14239
                                                                  FStar_Pervasives_Native.snd in
                                                              FStar_All.pipe_right
-                                                               uu____14253
+                                                               uu____14238
                                                                FStar_Syntax_Print.term_to_string in
                                                            FStar_Util.format2
                                                              "bind_wp for layered effect %s is not an arrow with >= 4 arguments (%s)"
-                                                             uu____14251
-                                                             uu____14252 in
+                                                             uu____14236
+                                                             uu____14237 in
                                                          (FStar_Errors.Fatal_UnexpectedEffect,
-                                                           uu____14250) in
+                                                           uu____14235) in
                                                        FStar_Errors.raise_error
-                                                         uu____14245 rng in
-                                                 let uu____14277 =
+                                                         uu____14230 rng in
+                                                 let uu____14262 =
                                                    FStar_Syntax_Syntax.as_arg
                                                      lb.FStar_Syntax_Syntax.lbtyp in
-                                                 let uu____14278 =
-                                                   let uu____14281 =
+                                                 let uu____14263 =
+                                                   let uu____14266 =
                                                      FStar_Syntax_Syntax.as_arg
                                                        t in
-                                                   let uu____14282 =
-                                                     let uu____14285 =
-                                                       let uu____14288 =
+                                                   let uu____14267 =
+                                                     let uu____14270 =
+                                                       let uu____14273 =
                                                          FStar_Syntax_Syntax.as_arg
                                                            f_arg in
-                                                       let uu____14289 =
-                                                         let uu____14292 =
+                                                       let uu____14274 =
+                                                         let uu____14277 =
                                                            FStar_Syntax_Syntax.as_arg
                                                              body2 in
-                                                         [uu____14292] in
-                                                       uu____14288 ::
-                                                         uu____14289 in
+                                                         [uu____14277] in
+                                                       uu____14273 ::
+                                                         uu____14274 in
                                                      FStar_List.append
-                                                       unit_args uu____14285 in
-                                                   uu____14281 :: uu____14282 in
-                                                 uu____14277 :: uu____14278
+                                                       unit_args uu____14270 in
+                                                   uu____14266 :: uu____14267 in
+                                                 uu____14262 :: uu____14263
                                                else
                                                  (let maybe_range_arg =
-                                                    let uu____14297 =
+                                                    let uu____14282 =
                                                       FStar_Util.for_some
                                                         (FStar_Syntax_Util.attr_eq
                                                            FStar_Syntax_Util.dm4f_bind_range_attr)
                                                         ed.FStar_Syntax_Syntax.eff_attrs in
-                                                    if uu____14297
+                                                    if uu____14282
                                                     then
-                                                      let uu____14300 =
-                                                        let uu____14301 =
+                                                      let uu____14285 =
+                                                        let uu____14286 =
                                                           FStar_TypeChecker_Cfg.embed_simple
                                                             FStar_Syntax_Embeddings.e_range
                                                             lb.FStar_Syntax_Syntax.lbpos
                                                             lb.FStar_Syntax_Syntax.lbpos in
                                                         FStar_Syntax_Syntax.as_arg
-                                                          uu____14301 in
-                                                      let uu____14302 =
-                                                        let uu____14305 =
-                                                          let uu____14306 =
+                                                          uu____14286 in
+                                                      let uu____14287 =
+                                                        let uu____14290 =
+                                                          let uu____14291 =
                                                             FStar_TypeChecker_Cfg.embed_simple
                                                               FStar_Syntax_Embeddings.e_range
                                                               body2.FStar_Syntax_Syntax.pos
                                                               body2.FStar_Syntax_Syntax.pos in
                                                           FStar_Syntax_Syntax.as_arg
-                                                            uu____14306 in
-                                                        [uu____14305] in
-                                                      uu____14300 ::
-                                                        uu____14302
+                                                            uu____14291 in
+                                                        [uu____14290] in
+                                                      uu____14285 ::
+                                                        uu____14287
                                                     else [] in
-                                                  let uu____14308 =
-                                                    let uu____14311 =
+                                                  let uu____14293 =
+                                                    let uu____14296 =
                                                       FStar_Syntax_Syntax.as_arg
                                                         lb.FStar_Syntax_Syntax.lbtyp in
-                                                    let uu____14312 =
-                                                      let uu____14315 =
+                                                    let uu____14297 =
+                                                      let uu____14300 =
                                                         FStar_Syntax_Syntax.as_arg
                                                           t in
-                                                      [uu____14315] in
-                                                    uu____14311 ::
-                                                      uu____14312 in
-                                                  let uu____14316 =
-                                                    let uu____14319 =
-                                                      let uu____14322 =
+                                                      [uu____14300] in
+                                                    uu____14296 ::
+                                                      uu____14297 in
+                                                  let uu____14301 =
+                                                    let uu____14304 =
+                                                      let uu____14307 =
                                                         FStar_Syntax_Syntax.as_arg
                                                           FStar_Syntax_Syntax.tun in
-                                                      let uu____14323 =
-                                                        let uu____14326 =
+                                                      let uu____14308 =
+                                                        let uu____14311 =
                                                           FStar_Syntax_Syntax.as_arg
                                                             f_arg in
-                                                        let uu____14327 =
-                                                          let uu____14330 =
+                                                        let uu____14312 =
+                                                          let uu____14315 =
                                                             FStar_Syntax_Syntax.as_arg
                                                               FStar_Syntax_Syntax.tun in
-                                                          let uu____14331 =
-                                                            let uu____14334 =
+                                                          let uu____14316 =
+                                                            let uu____14319 =
                                                               FStar_Syntax_Syntax.as_arg
                                                                 body2 in
-                                                            [uu____14334] in
-                                                          uu____14330 ::
-                                                            uu____14331 in
-                                                        uu____14326 ::
-                                                          uu____14327 in
-                                                      uu____14322 ::
-                                                        uu____14323 in
+                                                            [uu____14319] in
+                                                          uu____14315 ::
+                                                            uu____14316 in
+                                                        uu____14311 ::
+                                                          uu____14312 in
+                                                      uu____14307 ::
+                                                        uu____14308 in
                                                     FStar_List.append
                                                       maybe_range_arg
-                                                      uu____14319 in
+                                                      uu____14304 in
                                                   FStar_List.append
-                                                    uu____14308 uu____14316) in
+                                                    uu____14293 uu____14301) in
                                              let reified =
                                                let is_total_effect =
                                                  FStar_TypeChecker_Env.is_total_effect
@@ -4952,30 +4951,30 @@ and (do_reify_monadic :
                                                    eff_name in
                                                if is_total_effect
                                                then
-                                                 let uu____14337 =
-                                                   let uu____14338 =
-                                                     let uu____14355 =
+                                                 let uu____14322 =
+                                                   let uu____14323 =
+                                                     let uu____14340 =
                                                        bind_inst_args head in
-                                                     (bind_inst, uu____14355) in
+                                                     (bind_inst, uu____14340) in
                                                    FStar_Syntax_Syntax.Tm_app
-                                                     uu____14338 in
+                                                     uu____14323 in
                                                  FStar_Syntax_Syntax.mk
-                                                   uu____14337 rng
+                                                   uu____14322 rng
                                                else
-                                                 (let uu____14379 =
+                                                 (let uu____14364 =
                                                     let bv =
                                                       FStar_Syntax_Syntax.new_bv
                                                         FStar_Pervasives_Native.None
                                                         x.FStar_Syntax_Syntax.sort in
                                                     let lb1 =
-                                                      let uu____14388 =
-                                                        let uu____14391 =
-                                                          let uu____14402 =
+                                                      let uu____14373 =
+                                                        let uu____14376 =
+                                                          let uu____14387 =
                                                             FStar_Syntax_Syntax.as_arg
                                                               x.FStar_Syntax_Syntax.sort in
-                                                          [uu____14402] in
+                                                          [uu____14387] in
                                                         FStar_Syntax_Util.mk_app
-                                                          repr uu____14391 in
+                                                          repr uu____14376 in
                                                       {
                                                         FStar_Syntax_Syntax.lbname
                                                           =
@@ -4983,7 +4982,7 @@ and (do_reify_monadic :
                                                         FStar_Syntax_Syntax.lbunivs
                                                           = [];
                                                         FStar_Syntax_Syntax.lbtyp
-                                                          = uu____14388;
+                                                          = uu____14373;
                                                         FStar_Syntax_Syntax.lbeff
                                                           =
                                                           (if is_total_effect
@@ -4999,202 +4998,202 @@ and (do_reify_monadic :
                                                           =
                                                           (head.FStar_Syntax_Syntax.pos)
                                                       } in
-                                                    let uu____14430 =
+                                                    let uu____14415 =
                                                       FStar_Syntax_Syntax.bv_to_name
                                                         bv in
-                                                    (lb1, bv, uu____14430) in
-                                                  match uu____14379 with
+                                                    (lb1, bv, uu____14415) in
+                                                  match uu____14364 with
                                                   | (lb_head, head_bv, head1)
                                                       ->
-                                                      let uu____14434 =
-                                                        let uu____14435 =
-                                                          let uu____14448 =
-                                                            let uu____14451 =
-                                                              let uu____14458
+                                                      let uu____14419 =
+                                                        let uu____14420 =
+                                                          let uu____14433 =
+                                                            let uu____14436 =
+                                                              let uu____14443
                                                                 =
-                                                                let uu____14459
+                                                                let uu____14444
                                                                   =
                                                                   FStar_Syntax_Syntax.mk_binder
                                                                     head_bv in
-                                                                [uu____14459] in
+                                                                [uu____14444] in
                                                               FStar_Syntax_Subst.close
-                                                                uu____14458 in
-                                                            let uu____14478 =
-                                                              let uu____14479
+                                                                uu____14443 in
+                                                            let uu____14463 =
+                                                              let uu____14464
                                                                 =
-                                                                let uu____14480
+                                                                let uu____14465
                                                                   =
-                                                                  let uu____14497
+                                                                  let uu____14482
                                                                     =
                                                                     bind_inst_args
                                                                     head1 in
                                                                   (bind_inst,
-                                                                    uu____14497) in
+                                                                    uu____14482) in
                                                                 FStar_Syntax_Syntax.Tm_app
-                                                                  uu____14480 in
+                                                                  uu____14465 in
                                                               FStar_Syntax_Syntax.mk
-                                                                uu____14479
+                                                                uu____14464
                                                                 rng in
                                                             FStar_All.pipe_left
-                                                              uu____14451
-                                                              uu____14478 in
+                                                              uu____14436
+                                                              uu____14463 in
                                                           ((false, [lb_head]),
-                                                            uu____14448) in
+                                                            uu____14433) in
                                                         FStar_Syntax_Syntax.Tm_let
-                                                          uu____14435 in
+                                                          uu____14420 in
                                                       FStar_Syntax_Syntax.mk
-                                                        uu____14434 rng) in
+                                                        uu____14419 rng) in
                                              FStar_TypeChecker_Cfg.log cfg
-                                               (fun uu____14536 ->
-                                                  let uu____14537 =
+                                               (fun uu____14521 ->
+                                                  let uu____14522 =
                                                     FStar_Syntax_Print.term_to_string
                                                       top0 in
-                                                  let uu____14538 =
+                                                  let uu____14523 =
                                                     FStar_Syntax_Print.term_to_string
                                                       reified in
                                                   FStar_Util.print2
                                                     "Reified (1) <%s> to %s\n"
-                                                    uu____14537 uu____14538);
-                                             (let uu____14539 =
+                                                    uu____14522 uu____14523);
+                                             (let uu____14524 =
                                                 FStar_List.tl stack1 in
-                                              norm cfg env1 uu____14539
+                                              norm cfg env1 uu____14524
                                                 reified))))))
                   | FStar_Syntax_Syntax.Tm_app (head, args) ->
-                      ((let uu____14567 = FStar_Options.defensive () in
-                        if uu____14567
+                      ((let uu____14552 = FStar_Options.defensive () in
+                        if uu____14552
                         then
-                          let is_arg_impure uu____14579 =
-                            match uu____14579 with
+                          let is_arg_impure uu____14564 =
+                            match uu____14564 with
                             | (e, q) ->
-                                let uu____14592 =
-                                  let uu____14593 =
+                                let uu____14577 =
+                                  let uu____14578 =
                                     FStar_Syntax_Subst.compress e in
-                                  uu____14593.FStar_Syntax_Syntax.n in
-                                (match uu____14592 with
+                                  uu____14578.FStar_Syntax_Syntax.n in
+                                (match uu____14577 with
                                  | FStar_Syntax_Syntax.Tm_meta
                                      (e0,
                                       FStar_Syntax_Syntax.Meta_monadic_lift
                                       (m1, m2, t'))
                                      ->
-                                     let uu____14608 =
+                                     let uu____14593 =
                                        FStar_Syntax_Util.is_pure_effect m1 in
-                                     Prims.op_Negation uu____14608
-                                 | uu____14609 -> false) in
-                          let uu____14610 =
-                            let uu____14611 =
-                              let uu____14622 =
+                                     Prims.op_Negation uu____14593
+                                 | uu____14594 -> false) in
+                          let uu____14595 =
+                            let uu____14596 =
+                              let uu____14607 =
                                 FStar_Syntax_Syntax.as_arg head in
-                              uu____14622 :: args in
-                            FStar_Util.for_some is_arg_impure uu____14611 in
-                          (if uu____14610
+                              uu____14607 :: args in
+                            FStar_Util.for_some is_arg_impure uu____14596 in
+                          (if uu____14595
                            then
-                             let uu____14647 =
-                               let uu____14652 =
-                                 let uu____14653 =
+                             let uu____14632 =
+                               let uu____14637 =
+                                 let uu____14638 =
                                    FStar_Syntax_Print.term_to_string top2 in
                                  FStar_Util.format1
                                    "Incompatibility between typechecker and normalizer; this monadic application contains impure terms %s\n"
-                                   uu____14653 in
-                               (FStar_Errors.Warning_Defensive, uu____14652) in
+                                   uu____14638 in
+                               (FStar_Errors.Warning_Defensive, uu____14637) in
                              FStar_Errors.log_issue
-                               top2.FStar_Syntax_Syntax.pos uu____14647
+                               top2.FStar_Syntax_Syntax.pos uu____14632
                            else ())
                         else ());
-                       (let fallback1 uu____14661 =
+                       (let fallback1 uu____14646 =
                           FStar_TypeChecker_Cfg.log cfg
-                            (fun uu____14665 ->
-                               let uu____14666 =
+                            (fun uu____14650 ->
+                               let uu____14651 =
                                  FStar_Syntax_Print.term_to_string top0 in
                                FStar_Util.print2 "Reified (2) <%s> to %s\n"
-                                 uu____14666 "");
-                          (let uu____14667 = FStar_List.tl stack1 in
-                           let uu____14668 = FStar_Syntax_Util.mk_reify top2 in
-                           norm cfg env1 uu____14667 uu____14668) in
-                        let fallback2 uu____14674 =
+                                 uu____14651 "");
+                          (let uu____14652 = FStar_List.tl stack1 in
+                           let uu____14653 = FStar_Syntax_Util.mk_reify top2 in
+                           norm cfg env1 uu____14652 uu____14653) in
+                        let fallback2 uu____14659 =
                           FStar_TypeChecker_Cfg.log cfg
-                            (fun uu____14678 ->
-                               let uu____14679 =
+                            (fun uu____14663 ->
+                               let uu____14664 =
                                  FStar_Syntax_Print.term_to_string top0 in
                                FStar_Util.print2 "Reified (3) <%s> to %s\n"
-                                 uu____14679 "");
-                          (let uu____14680 = FStar_List.tl stack1 in
-                           let uu____14681 =
+                                 uu____14664 "");
+                          (let uu____14665 = FStar_List.tl stack1 in
+                           let uu____14666 =
                              FStar_Syntax_Syntax.mk
                                (FStar_Syntax_Syntax.Tm_meta
                                   (top2,
                                     (FStar_Syntax_Syntax.Meta_monadic (m, t))))
                                top0.FStar_Syntax_Syntax.pos in
-                           norm cfg env1 uu____14680 uu____14681) in
-                        let uu____14686 =
-                          let uu____14687 = FStar_Syntax_Util.un_uinst head in
-                          uu____14687.FStar_Syntax_Syntax.n in
-                        match uu____14686 with
+                           norm cfg env1 uu____14665 uu____14666) in
+                        let uu____14671 =
+                          let uu____14672 = FStar_Syntax_Util.un_uinst head in
+                          uu____14672.FStar_Syntax_Syntax.n in
+                        match uu____14671 with
                         | FStar_Syntax_Syntax.Tm_fvar fv ->
                             let lid = FStar_Syntax_Syntax.lid_of_fv fv in
                             let qninfo =
                               FStar_TypeChecker_Env.lookup_qname
                                 cfg.FStar_TypeChecker_Cfg.tcenv lid in
-                            let uu____14693 =
-                              let uu____14694 =
+                            let uu____14678 =
+                              let uu____14679 =
                                 FStar_TypeChecker_Env.is_action
                                   cfg.FStar_TypeChecker_Cfg.tcenv lid in
-                              Prims.op_Negation uu____14694 in
-                            if uu____14693
+                              Prims.op_Negation uu____14679 in
+                            if uu____14678
                             then fallback1 ()
                             else
-                              (let uu____14696 =
-                                 let uu____14697 =
+                              (let uu____14681 =
+                                 let uu____14682 =
                                    FStar_TypeChecker_Env.lookup_definition_qninfo
                                      cfg.FStar_TypeChecker_Cfg.delta_level
                                      (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
                                      qninfo in
-                                 FStar_Option.isNone uu____14697 in
-                               if uu____14696
+                                 FStar_Option.isNone uu____14682 in
+                               if uu____14681
                                then fallback2 ()
                                else
                                  (let t1 =
-                                    let uu____14710 =
+                                    let uu____14695 =
                                       FStar_Syntax_Util.mk_reify head in
-                                    FStar_Syntax_Syntax.mk_Tm_app uu____14710
+                                    FStar_Syntax_Syntax.mk_Tm_app uu____14695
                                       args t.FStar_Syntax_Syntax.pos in
-                                  let uu____14711 = FStar_List.tl stack1 in
-                                  norm cfg env1 uu____14711 t1))
-                        | uu____14712 -> fallback1 ()))
+                                  let uu____14696 = FStar_List.tl stack1 in
+                                  norm cfg env1 uu____14696 t1))
+                        | uu____14697 -> fallback1 ()))
                   | FStar_Syntax_Syntax.Tm_meta
-                      (e, FStar_Syntax_Syntax.Meta_monadic uu____14714) ->
+                      (e, FStar_Syntax_Syntax.Meta_monadic uu____14699) ->
                       do_reify_monadic fallback cfg env1 stack1 e m t
                   | FStar_Syntax_Syntax.Tm_meta
                       (e, FStar_Syntax_Syntax.Meta_monadic_lift
                        (msrc, mtgt, t'))
                       ->
                       let lifted =
-                        let uu____14738 = closure_as_term cfg env1 t' in
-                        reify_lift cfg e msrc mtgt uu____14738 in
+                        let uu____14723 = closure_as_term cfg env1 t' in
+                        reify_lift cfg e msrc mtgt uu____14723 in
                       (FStar_TypeChecker_Cfg.log cfg
-                         (fun uu____14742 ->
-                            let uu____14743 =
+                         (fun uu____14727 ->
+                            let uu____14728 =
                               FStar_Syntax_Print.term_to_string lifted in
                             FStar_Util.print1 "Reified lift to (2): %s\n"
-                              uu____14743);
-                       (let uu____14744 = FStar_List.tl stack1 in
-                        norm cfg env1 uu____14744 lifted))
+                              uu____14728);
+                       (let uu____14729 = FStar_List.tl stack1 in
+                        norm cfg env1 uu____14729 lifted))
                   | FStar_Syntax_Syntax.Tm_match (e, branches1) ->
                       let branches2 =
                         FStar_All.pipe_right branches1
                           (FStar_List.map
-                             (fun uu____14865 ->
-                                match uu____14865 with
+                             (fun uu____14850 ->
+                                match uu____14850 with
                                 | (pat, wopt, tm) ->
-                                    let uu____14913 =
+                                    let uu____14898 =
                                       FStar_Syntax_Util.mk_reify tm in
-                                    (pat, wopt, uu____14913))) in
+                                    (pat, wopt, uu____14898))) in
                       let tm =
                         FStar_Syntax_Syntax.mk
                           (FStar_Syntax_Syntax.Tm_match (e, branches2))
                           top2.FStar_Syntax_Syntax.pos in
-                      let uu____14945 = FStar_List.tl stack1 in
-                      norm cfg env1 uu____14945 tm
-                  | uu____14946 -> fallback ()))
+                      let uu____14930 = FStar_List.tl stack1 in
+                      norm cfg env1 uu____14930 tm
+                  | uu____14931 -> fallback ()))
 and (reify_lift :
   FStar_TypeChecker_Cfg.cfg ->
     FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
@@ -5209,166 +5208,166 @@ and (reify_lift :
           fun t ->
             let env1 = cfg.FStar_TypeChecker_Cfg.tcenv in
             FStar_TypeChecker_Cfg.log cfg
-              (fun uu____14960 ->
-                 let uu____14961 = FStar_Ident.string_of_lid msrc in
-                 let uu____14962 = FStar_Ident.string_of_lid mtgt in
-                 let uu____14963 = FStar_Syntax_Print.term_to_string e in
-                 FStar_Util.print3 "Reifying lift %s -> %s: %s\n" uu____14961
-                   uu____14962 uu____14963);
-            (let uu____14964 =
+              (fun uu____14945 ->
+                 let uu____14946 = FStar_Ident.string_of_lid msrc in
+                 let uu____14947 = FStar_Ident.string_of_lid mtgt in
+                 let uu____14948 = FStar_Syntax_Print.term_to_string e in
+                 FStar_Util.print3 "Reifying lift %s -> %s: %s\n" uu____14946
+                   uu____14947 uu____14948);
+            (let uu____14949 =
                ((FStar_Syntax_Util.is_pure_effect msrc) ||
                   (FStar_Syntax_Util.is_div_effect msrc))
                  &&
-                 (let uu____14966 =
+                 (let uu____14951 =
                     FStar_All.pipe_right mtgt
                       (FStar_TypeChecker_Env.is_layered_effect env1) in
-                  Prims.op_Negation uu____14966) in
-             if uu____14964
+                  Prims.op_Negation uu____14951) in
+             if uu____14949
              then
                let ed =
-                 let uu____14968 =
+                 let uu____14953 =
                    FStar_TypeChecker_Env.norm_eff_name
                      cfg.FStar_TypeChecker_Cfg.tcenv mtgt in
-                 FStar_TypeChecker_Env.get_effect_decl env1 uu____14968 in
-               let uu____14969 =
-                 let uu____14978 =
+                 FStar_TypeChecker_Env.get_effect_decl env1 uu____14953 in
+               let uu____14954 =
+                 let uu____14963 =
                    FStar_All.pipe_right ed FStar_Syntax_Util.get_eff_repr in
-                 FStar_All.pipe_right uu____14978 FStar_Util.must in
-               match uu____14969 with
-               | (uu____15025, repr) ->
-                   let uu____15035 =
-                     let uu____15044 =
+                 FStar_All.pipe_right uu____14963 FStar_Util.must in
+               match uu____14954 with
+               | (uu____15010, repr) ->
+                   let uu____15020 =
+                     let uu____15029 =
                        FStar_All.pipe_right ed
                          FStar_Syntax_Util.get_return_repr in
-                     FStar_All.pipe_right uu____15044 FStar_Util.must in
-                   (match uu____15035 with
-                    | (uu____15091, return_repr) ->
+                     FStar_All.pipe_right uu____15029 FStar_Util.must in
+                   (match uu____15020 with
+                    | (uu____15076, return_repr) ->
                         let return_inst =
-                          let uu____15104 =
-                            let uu____15105 =
+                          let uu____15089 =
+                            let uu____15090 =
                               FStar_Syntax_Subst.compress return_repr in
-                            uu____15105.FStar_Syntax_Syntax.n in
-                          match uu____15104 with
+                            uu____15090.FStar_Syntax_Syntax.n in
+                          match uu____15089 with
                           | FStar_Syntax_Syntax.Tm_uinst
-                              (return_tm, uu____15111::[]) ->
-                              let uu____15116 =
-                                let uu____15117 =
-                                  let uu____15124 =
-                                    let uu____15125 =
+                              (return_tm, uu____15096::[]) ->
+                              let uu____15101 =
+                                let uu____15102 =
+                                  let uu____15109 =
+                                    let uu____15110 =
                                       env1.FStar_TypeChecker_Env.universe_of
                                         env1 t in
-                                    [uu____15125] in
-                                  (return_tm, uu____15124) in
-                                FStar_Syntax_Syntax.Tm_uinst uu____15117 in
-                              FStar_Syntax_Syntax.mk uu____15116
+                                    [uu____15110] in
+                                  (return_tm, uu____15109) in
+                                FStar_Syntax_Syntax.Tm_uinst uu____15102 in
+                              FStar_Syntax_Syntax.mk uu____15101
                                 e.FStar_Syntax_Syntax.pos
-                          | uu____15128 ->
+                          | uu____15113 ->
                               failwith "NIY : Reification of indexed effects" in
-                        let uu____15131 =
+                        let uu____15116 =
                           let bv =
                             FStar_Syntax_Syntax.new_bv
                               FStar_Pervasives_Native.None t in
                           let lb =
-                            let uu____15142 =
-                              let uu____15145 =
-                                let uu____15156 =
+                            let uu____15127 =
+                              let uu____15130 =
+                                let uu____15141 =
                                   FStar_Syntax_Syntax.as_arg t in
-                                [uu____15156] in
-                              FStar_Syntax_Util.mk_app repr uu____15145 in
+                                [uu____15141] in
+                              FStar_Syntax_Util.mk_app repr uu____15130 in
                             {
                               FStar_Syntax_Syntax.lbname =
                                 (FStar_Util.Inl bv);
                               FStar_Syntax_Syntax.lbunivs = [];
-                              FStar_Syntax_Syntax.lbtyp = uu____15142;
+                              FStar_Syntax_Syntax.lbtyp = uu____15127;
                               FStar_Syntax_Syntax.lbeff = msrc;
                               FStar_Syntax_Syntax.lbdef = e;
                               FStar_Syntax_Syntax.lbattrs = [];
                               FStar_Syntax_Syntax.lbpos =
                                 (e.FStar_Syntax_Syntax.pos)
                             } in
-                          let uu____15183 = FStar_Syntax_Syntax.bv_to_name bv in
-                          (lb, bv, uu____15183) in
-                        (match uu____15131 with
+                          let uu____15168 = FStar_Syntax_Syntax.bv_to_name bv in
+                          (lb, bv, uu____15168) in
+                        (match uu____15116 with
                          | (lb_e, e_bv, e1) ->
-                             let uu____15195 =
-                               let uu____15196 =
-                                 let uu____15209 =
-                                   let uu____15212 =
-                                     let uu____15219 =
-                                       let uu____15220 =
+                             let uu____15180 =
+                               let uu____15181 =
+                                 let uu____15194 =
+                                   let uu____15197 =
+                                     let uu____15204 =
+                                       let uu____15205 =
                                          FStar_Syntax_Syntax.mk_binder e_bv in
-                                       [uu____15220] in
-                                     FStar_Syntax_Subst.close uu____15219 in
-                                   let uu____15239 =
-                                     let uu____15240 =
-                                       let uu____15241 =
-                                         let uu____15258 =
-                                           let uu____15269 =
+                                       [uu____15205] in
+                                     FStar_Syntax_Subst.close uu____15204 in
+                                   let uu____15224 =
+                                     let uu____15225 =
+                                       let uu____15226 =
+                                         let uu____15243 =
+                                           let uu____15254 =
                                              FStar_Syntax_Syntax.as_arg t in
-                                           let uu____15278 =
-                                             let uu____15289 =
+                                           let uu____15263 =
+                                             let uu____15274 =
                                                FStar_Syntax_Syntax.as_arg e1 in
-                                             [uu____15289] in
-                                           uu____15269 :: uu____15278 in
-                                         (return_inst, uu____15258) in
-                                       FStar_Syntax_Syntax.Tm_app uu____15241 in
-                                     FStar_Syntax_Syntax.mk uu____15240
+                                             [uu____15274] in
+                                           uu____15254 :: uu____15263 in
+                                         (return_inst, uu____15243) in
+                                       FStar_Syntax_Syntax.Tm_app uu____15226 in
+                                     FStar_Syntax_Syntax.mk uu____15225
                                        e1.FStar_Syntax_Syntax.pos in
-                                   FStar_All.pipe_left uu____15212
-                                     uu____15239 in
-                                 ((false, [lb_e]), uu____15209) in
-                               FStar_Syntax_Syntax.Tm_let uu____15196 in
-                             FStar_Syntax_Syntax.mk uu____15195
+                                   FStar_All.pipe_left uu____15197
+                                     uu____15224 in
+                                 ((false, [lb_e]), uu____15194) in
+                               FStar_Syntax_Syntax.Tm_let uu____15181 in
+                             FStar_Syntax_Syntax.mk uu____15180
                                e1.FStar_Syntax_Syntax.pos))
              else
-               (let uu____15347 =
+               (let uu____15332 =
                   FStar_TypeChecker_Env.monad_leq env1 msrc mtgt in
-                match uu____15347 with
+                match uu____15332 with
                 | FStar_Pervasives_Native.None ->
-                    let uu____15350 =
-                      let uu____15351 = FStar_Ident.string_of_lid msrc in
-                      let uu____15352 = FStar_Ident.string_of_lid mtgt in
+                    let uu____15335 =
+                      let uu____15336 = FStar_Ident.string_of_lid msrc in
+                      let uu____15337 = FStar_Ident.string_of_lid mtgt in
                       FStar_Util.format2
                         "Impossible : trying to reify a lift between unrelated effects (%s and %s)"
-                        uu____15351 uu____15352 in
-                    failwith uu____15350
+                        uu____15336 uu____15337 in
+                    failwith uu____15335
                 | FStar_Pervasives_Native.Some
-                    { FStar_TypeChecker_Env.msource = uu____15353;
-                      FStar_TypeChecker_Env.mtarget = uu____15354;
+                    { FStar_TypeChecker_Env.msource = uu____15338;
+                      FStar_TypeChecker_Env.mtarget = uu____15339;
                       FStar_TypeChecker_Env.mlift =
-                        { FStar_TypeChecker_Env.mlift_wp = uu____15355;
+                        { FStar_TypeChecker_Env.mlift_wp = uu____15340;
                           FStar_TypeChecker_Env.mlift_term =
                             FStar_Pervasives_Native.None;_};_}
                     ->
-                    let uu____15375 =
-                      let uu____15376 = FStar_Ident.string_of_lid msrc in
-                      let uu____15377 = FStar_Ident.string_of_lid mtgt in
+                    let uu____15360 =
+                      let uu____15361 = FStar_Ident.string_of_lid msrc in
+                      let uu____15362 = FStar_Ident.string_of_lid mtgt in
                       FStar_Util.format2
                         "Impossible : trying to reify a non-reifiable lift (from %s to %s)"
-                        uu____15376 uu____15377 in
-                    failwith uu____15375
+                        uu____15361 uu____15362 in
+                    failwith uu____15360
                 | FStar_Pervasives_Native.Some
-                    { FStar_TypeChecker_Env.msource = uu____15378;
-                      FStar_TypeChecker_Env.mtarget = uu____15379;
+                    { FStar_TypeChecker_Env.msource = uu____15363;
+                      FStar_TypeChecker_Env.mtarget = uu____15364;
                       FStar_TypeChecker_Env.mlift =
-                        { FStar_TypeChecker_Env.mlift_wp = uu____15380;
+                        { FStar_TypeChecker_Env.mlift_wp = uu____15365;
                           FStar_TypeChecker_Env.mlift_term =
                             FStar_Pervasives_Native.Some lift;_};_}
                     ->
                     let e1 =
-                      let uu____15411 =
+                      let uu____15396 =
                         FStar_TypeChecker_Env.is_reifiable_effect env1 msrc in
-                      if uu____15411
+                      if uu____15396
                       then FStar_Syntax_Util.mk_reify e
                       else
-                        (let uu____15413 =
-                           let uu____15414 =
-                             let uu____15433 =
-                               let uu____15442 =
+                        (let uu____15398 =
+                           let uu____15399 =
+                             let uu____15418 =
+                               let uu____15427 =
                                  FStar_Syntax_Syntax.null_binder
                                    FStar_Syntax_Syntax.t_unit in
-                               [uu____15442] in
-                             (uu____15433, e,
+                               [uu____15427] in
+                             (uu____15418, e,
                                (FStar_Pervasives_Native.Some
                                   {
                                     FStar_Syntax_Syntax.residual_effect =
@@ -5377,12 +5376,12 @@ and (reify_lift :
                                       (FStar_Pervasives_Native.Some t);
                                     FStar_Syntax_Syntax.residual_flags = []
                                   })) in
-                           FStar_Syntax_Syntax.Tm_abs uu____15414 in
-                         FStar_Syntax_Syntax.mk uu____15413
+                           FStar_Syntax_Syntax.Tm_abs uu____15399 in
+                         FStar_Syntax_Syntax.mk uu____15398
                            e.FStar_Syntax_Syntax.pos) in
-                    let uu____15475 =
+                    let uu____15460 =
                       env1.FStar_TypeChecker_Env.universe_of env1 t in
-                    lift uu____15475 t e1))
+                    lift uu____15460 t e1))
 and (norm_pattern_args :
   FStar_TypeChecker_Cfg.cfg ->
     env ->
@@ -5399,11 +5398,11 @@ and (norm_pattern_args :
         FStar_All.pipe_right args
           (FStar_List.map
              (FStar_List.map
-                (fun uu____15545 ->
-                   match uu____15545 with
+                (fun uu____15530 ->
+                   match uu____15530 with
                    | (a, imp) ->
-                       let uu____15564 = norm cfg env1 [] a in
-                       (uu____15564, imp))))
+                       let uu____15549 = norm cfg env1 [] a in
+                       (uu____15549, imp))))
 and (norm_comp :
   FStar_TypeChecker_Cfg.cfg ->
     env -> FStar_Syntax_Syntax.comp -> FStar_Syntax_Syntax.comp)
@@ -5412,50 +5411,50 @@ and (norm_comp :
     fun env1 ->
       fun comp ->
         FStar_TypeChecker_Cfg.log cfg
-          (fun uu____15574 ->
-             let uu____15575 = FStar_Syntax_Print.comp_to_string comp in
-             let uu____15576 =
+          (fun uu____15559 ->
+             let uu____15560 = FStar_Syntax_Print.comp_to_string comp in
+             let uu____15561 =
                FStar_Util.string_of_int (FStar_List.length env1) in
              FStar_Util.print2 ">>> %s\nNormComp with with %s env elements\n"
-               uu____15575 uu____15576);
+               uu____15560 uu____15561);
         (match comp.FStar_Syntax_Syntax.n with
          | FStar_Syntax_Syntax.Total (t, uopt) ->
              let t1 = norm cfg env1 [] t in
              let uopt1 =
                match uopt with
                | FStar_Pervasives_Native.Some u ->
-                   let uu____15600 = norm_universe cfg env1 u in
+                   let uu____15585 = norm_universe cfg env1 u in
                    FStar_All.pipe_left
-                     (fun uu____15603 ->
-                        FStar_Pervasives_Native.Some uu____15603) uu____15600
+                     (fun uu____15588 ->
+                        FStar_Pervasives_Native.Some uu____15588) uu____15585
                | FStar_Pervasives_Native.None -> FStar_Pervasives_Native.None in
-             let uu___2128_15604 = comp in
+             let uu___2128_15589 = comp in
              {
                FStar_Syntax_Syntax.n =
                  (FStar_Syntax_Syntax.Total (t1, uopt1));
                FStar_Syntax_Syntax.pos =
-                 (uu___2128_15604.FStar_Syntax_Syntax.pos);
+                 (uu___2128_15589.FStar_Syntax_Syntax.pos);
                FStar_Syntax_Syntax.vars =
-                 (uu___2128_15604.FStar_Syntax_Syntax.vars)
+                 (uu___2128_15589.FStar_Syntax_Syntax.vars)
              }
          | FStar_Syntax_Syntax.GTotal (t, uopt) ->
              let t1 = norm cfg env1 [] t in
              let uopt1 =
                match uopt with
                | FStar_Pervasives_Native.Some u ->
-                   let uu____15626 = norm_universe cfg env1 u in
+                   let uu____15611 = norm_universe cfg env1 u in
                    FStar_All.pipe_left
-                     (fun uu____15629 ->
-                        FStar_Pervasives_Native.Some uu____15629) uu____15626
+                     (fun uu____15614 ->
+                        FStar_Pervasives_Native.Some uu____15614) uu____15611
                | FStar_Pervasives_Native.None -> FStar_Pervasives_Native.None in
-             let uu___2139_15630 = comp in
+             let uu___2139_15615 = comp in
              {
                FStar_Syntax_Syntax.n =
                  (FStar_Syntax_Syntax.GTotal (t1, uopt1));
                FStar_Syntax_Syntax.pos =
-                 (uu___2139_15630.FStar_Syntax_Syntax.pos);
+                 (uu___2139_15615.FStar_Syntax_Syntax.pos);
                FStar_Syntax_Syntax.vars =
-                 (uu___2139_15630.FStar_Syntax_Syntax.vars)
+                 (uu___2139_15615.FStar_Syntax_Syntax.vars)
              }
          | FStar_Syntax_Syntax.Comp ct ->
              let effect_args =
@@ -5464,48 +5463,48 @@ and (norm_comp :
                     (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.for_extraction
                   then
                     FStar_List.map
-                      (fun uu____15693 ->
+                      (fun uu____15678 ->
                          FStar_All.pipe_right FStar_Syntax_Syntax.unit_const
                            FStar_Syntax_Syntax.as_arg)
                   else
                     FStar_List.mapi
                       (fun idx ->
-                         fun uu____15719 ->
-                           match uu____15719 with
+                         fun uu____15704 ->
+                           match uu____15704 with
                            | (a, i) ->
-                               let uu____15738 = norm cfg env1 [] a in
-                               (uu____15738, i))) in
+                               let uu____15723 = norm cfg env1 [] a in
+                               (uu____15723, i))) in
              let flags =
                FStar_All.pipe_right ct.FStar_Syntax_Syntax.flags
                  (FStar_List.map
-                    (fun uu___14_15751 ->
-                       match uu___14_15751 with
+                    (fun uu___14_15736 ->
+                       match uu___14_15736 with
                        | FStar_Syntax_Syntax.DECREASES t ->
-                           let uu____15755 = norm cfg env1 [] t in
-                           FStar_Syntax_Syntax.DECREASES uu____15755
+                           let uu____15740 = norm cfg env1 [] t in
+                           FStar_Syntax_Syntax.DECREASES uu____15740
                        | f -> f)) in
              let comp_univs =
                FStar_List.map (norm_universe cfg env1)
                  ct.FStar_Syntax_Syntax.comp_univs in
              let result_typ =
                norm cfg env1 [] ct.FStar_Syntax_Syntax.result_typ in
-             let uu___2157_15763 = comp in
+             let uu___2157_15748 = comp in
              {
                FStar_Syntax_Syntax.n =
                  (FStar_Syntax_Syntax.Comp
-                    (let uu___2159_15766 = ct in
+                    (let uu___2159_15751 = ct in
                      {
                        FStar_Syntax_Syntax.comp_univs = comp_univs;
                        FStar_Syntax_Syntax.effect_name =
-                         (uu___2159_15766.FStar_Syntax_Syntax.effect_name);
+                         (uu___2159_15751.FStar_Syntax_Syntax.effect_name);
                        FStar_Syntax_Syntax.result_typ = result_typ;
                        FStar_Syntax_Syntax.effect_args = effect_args;
                        FStar_Syntax_Syntax.flags = flags
                      }));
                FStar_Syntax_Syntax.pos =
-                 (uu___2157_15763.FStar_Syntax_Syntax.pos);
+                 (uu___2157_15748.FStar_Syntax_Syntax.pos);
                FStar_Syntax_Syntax.vars =
-                 (uu___2157_15763.FStar_Syntax_Syntax.vars)
+                 (uu___2157_15748.FStar_Syntax_Syntax.vars)
              })
 and (norm_binder :
   FStar_TypeChecker_Cfg.cfg ->
@@ -5514,37 +5513,37 @@ and (norm_binder :
   fun cfg ->
     fun env1 ->
       fun b ->
-        let uu____15770 = b in
-        match uu____15770 with
+        let uu____15755 = b in
+        match uu____15755 with
         | (x, imp) ->
             let x1 =
-              let uu___2167_15778 = x in
-              let uu____15779 = norm cfg env1 [] x.FStar_Syntax_Syntax.sort in
+              let uu___2167_15763 = x in
+              let uu____15764 = norm cfg env1 [] x.FStar_Syntax_Syntax.sort in
               {
                 FStar_Syntax_Syntax.ppname =
-                  (uu___2167_15778.FStar_Syntax_Syntax.ppname);
+                  (uu___2167_15763.FStar_Syntax_Syntax.ppname);
                 FStar_Syntax_Syntax.index =
-                  (uu___2167_15778.FStar_Syntax_Syntax.index);
-                FStar_Syntax_Syntax.sort = uu____15779
+                  (uu___2167_15763.FStar_Syntax_Syntax.index);
+                FStar_Syntax_Syntax.sort = uu____15764
               } in
             let imp1 =
               match imp with
               | FStar_Pervasives_Native.Some (FStar_Syntax_Syntax.Meta
                   (FStar_Syntax_Syntax.Arg_qualifier_meta_tac t)) ->
-                  let uu____15790 =
-                    let uu____15791 =
-                      let uu____15792 = closure_as_term cfg env1 t in
-                      FStar_Syntax_Syntax.Arg_qualifier_meta_tac uu____15792 in
-                    FStar_Syntax_Syntax.Meta uu____15791 in
-                  FStar_Pervasives_Native.Some uu____15790
+                  let uu____15775 =
+                    let uu____15776 =
+                      let uu____15777 = closure_as_term cfg env1 t in
+                      FStar_Syntax_Syntax.Arg_qualifier_meta_tac uu____15777 in
+                    FStar_Syntax_Syntax.Meta uu____15776 in
+                  FStar_Pervasives_Native.Some uu____15775
               | FStar_Pervasives_Native.Some (FStar_Syntax_Syntax.Meta
                   (FStar_Syntax_Syntax.Arg_qualifier_meta_attr t)) ->
-                  let uu____15798 =
-                    let uu____15799 =
-                      let uu____15800 = closure_as_term cfg env1 t in
-                      FStar_Syntax_Syntax.Arg_qualifier_meta_attr uu____15800 in
-                    FStar_Syntax_Syntax.Meta uu____15799 in
-                  FStar_Pervasives_Native.Some uu____15798
+                  let uu____15783 =
+                    let uu____15784 =
+                      let uu____15785 = closure_as_term cfg env1 t in
+                      FStar_Syntax_Syntax.Arg_qualifier_meta_attr uu____15785 in
+                    FStar_Syntax_Syntax.Meta uu____15784 in
+                  FStar_Pervasives_Native.Some uu____15783
               | i -> i in
             (x1, imp1)
 and (norm_binders :
@@ -5554,15 +5553,15 @@ and (norm_binders :
   fun cfg ->
     fun env1 ->
       fun bs ->
-        let uu____15811 =
+        let uu____15796 =
           FStar_List.fold_left
-            (fun uu____15845 ->
+            (fun uu____15830 ->
                fun b ->
-                 match uu____15845 with
+                 match uu____15830 with
                  | (nbs', env2) ->
                      let b1 = norm_binder cfg env2 b in
                      ((b1 :: nbs'), (dummy :: env2))) ([], env1) bs in
-        match uu____15811 with | (nbs, uu____15925) -> FStar_List.rev nbs
+        match uu____15796 with | (nbs, uu____15910) -> FStar_List.rev nbs
 and (norm_lcomp_opt :
   FStar_TypeChecker_Cfg.cfg ->
     env ->
@@ -5576,9 +5575,9 @@ and (norm_lcomp_opt :
         | FStar_Pervasives_Native.Some rc ->
             let flags =
               filter_out_lcomp_cflags rc.FStar_Syntax_Syntax.residual_flags in
-            let uu____15957 =
-              let uu___2197_15958 = rc in
-              let uu____15959 =
+            let uu____15942 =
+              let uu___2197_15943 = rc in
+              let uu____15944 =
                 if
                   (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.for_extraction
                 then FStar_Pervasives_Native.None
@@ -5587,13 +5586,13 @@ and (norm_lcomp_opt :
                     (norm cfg env1 []) in
               {
                 FStar_Syntax_Syntax.residual_effect =
-                  (uu___2197_15958.FStar_Syntax_Syntax.residual_effect);
-                FStar_Syntax_Syntax.residual_typ = uu____15959;
+                  (uu___2197_15943.FStar_Syntax_Syntax.residual_effect);
+                FStar_Syntax_Syntax.residual_typ = uu____15944;
                 FStar_Syntax_Syntax.residual_flags =
-                  (uu___2197_15958.FStar_Syntax_Syntax.residual_flags)
+                  (uu___2197_15943.FStar_Syntax_Syntax.residual_flags)
               } in
-            FStar_Pervasives_Native.Some uu____15957
-        | uu____15975 -> lopt
+            FStar_Pervasives_Native.Some uu____15942
+        | uu____15960 -> lopt
 and (maybe_simplify :
   FStar_TypeChecker_Cfg.cfg ->
     env -> stack -> FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term)
@@ -5605,33 +5604,33 @@ and (maybe_simplify :
           let tm' = maybe_simplify_aux cfg env1 stack1 tm in
           if (cfg.FStar_TypeChecker_Cfg.debug).FStar_TypeChecker_Cfg.b380
           then
-            (let uu____15984 = FStar_Syntax_Print.term_to_string tm in
-             let uu____15985 = FStar_Syntax_Print.term_to_string tm' in
+            (let uu____15969 = FStar_Syntax_Print.term_to_string tm in
+             let uu____15970 = FStar_Syntax_Print.term_to_string tm' in
              FStar_Util.print3 "%sSimplified\n\t%s to\n\t%s\n"
                (if
                   (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.simplify
                 then ""
-                else "NOT ") uu____15984 uu____15985)
+                else "NOT ") uu____15969 uu____15970)
           else ();
           tm'
 and (norm_cb : FStar_TypeChecker_Cfg.cfg -> FStar_Syntax_Embeddings.norm_cb)
   =
   fun cfg ->
-    fun uu___15_15989 ->
-      match uu___15_15989 with
+    fun uu___15_15974 ->
+      match uu___15_15974 with
       | FStar_Util.Inr x -> norm cfg [] [] x
       | FStar_Util.Inl l ->
-          let uu____16002 =
+          let uu____15987 =
             FStar_Syntax_DsEnv.try_lookup_lid
               (cfg.FStar_TypeChecker_Cfg.tcenv).FStar_TypeChecker_Env.dsenv l in
-          (match uu____16002 with
+          (match uu____15987 with
            | FStar_Pervasives_Native.Some t -> t
            | FStar_Pervasives_Native.None ->
-               let uu____16006 =
+               let uu____15991 =
                  FStar_Syntax_Syntax.lid_as_fv l
                    FStar_Syntax_Syntax.delta_constant
                    FStar_Pervasives_Native.None in
-               FStar_Syntax_Syntax.fv_to_tm uu____16006)
+               FStar_Syntax_Syntax.fv_to_tm uu____15991)
 and (maybe_simplify_aux :
   FStar_TypeChecker_Cfg.cfg ->
     env -> stack -> FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term)
@@ -5641,28 +5640,28 @@ and (maybe_simplify_aux :
       fun stack1 ->
         fun tm ->
           let tm1 =
-            let uu____16014 = norm_cb cfg in
-            reduce_primops uu____16014 cfg env1 tm in
-          let uu____16019 =
+            let uu____15999 = norm_cb cfg in
+            reduce_primops uu____15999 cfg env1 tm in
+          let uu____16004 =
             FStar_All.pipe_left Prims.op_Negation
               (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.simplify in
-          if uu____16019
+          if uu____16004
           then tm1
           else
             (let w t =
-               let uu___2226_16033 = t in
+               let uu___2226_16018 = t in
                {
                  FStar_Syntax_Syntax.n =
-                   (uu___2226_16033.FStar_Syntax_Syntax.n);
+                   (uu___2226_16018.FStar_Syntax_Syntax.n);
                  FStar_Syntax_Syntax.pos = (tm1.FStar_Syntax_Syntax.pos);
                  FStar_Syntax_Syntax.vars =
-                   (uu___2226_16033.FStar_Syntax_Syntax.vars)
+                   (uu___2226_16018.FStar_Syntax_Syntax.vars)
                } in
              let simp_t t =
-               let uu____16044 =
-                 let uu____16045 = FStar_Syntax_Util.unmeta t in
-                 uu____16045.FStar_Syntax_Syntax.n in
-               match uu____16044 with
+               let uu____16029 =
+                 let uu____16030 = FStar_Syntax_Util.unmeta t in
+                 uu____16030.FStar_Syntax_Syntax.n in
+               match uu____16029 with
                | FStar_Syntax_Syntax.Tm_fvar fv when
                    FStar_Syntax_Syntax.fv_eq_lid fv
                      FStar_Parser_Const.true_lid
@@ -5671,137 +5670,137 @@ and (maybe_simplify_aux :
                    FStar_Syntax_Syntax.fv_eq_lid fv
                      FStar_Parser_Const.false_lid
                    -> FStar_Pervasives_Native.Some false
-               | uu____16052 -> FStar_Pervasives_Native.None in
+               | uu____16037 -> FStar_Pervasives_Native.None in
              let rec args_are_binders args bs =
                match (args, bs) with
-               | ((t, uu____16113)::args1, (bv, uu____16116)::bs1) ->
-                   let uu____16170 =
-                     let uu____16171 = FStar_Syntax_Subst.compress t in
-                     uu____16171.FStar_Syntax_Syntax.n in
-                   (match uu____16170 with
+               | ((t, uu____16098)::args1, (bv, uu____16101)::bs1) ->
+                   let uu____16155 =
+                     let uu____16156 = FStar_Syntax_Subst.compress t in
+                     uu____16156.FStar_Syntax_Syntax.n in
+                   (match uu____16155 with
                     | FStar_Syntax_Syntax.Tm_name bv' ->
                         (FStar_Syntax_Syntax.bv_eq bv bv') &&
                           (args_are_binders args1 bs1)
-                    | uu____16175 -> false)
+                    | uu____16160 -> false)
                | ([], []) -> true
-               | (uu____16204, uu____16205) -> false in
+               | (uu____16189, uu____16190) -> false in
              let is_applied bs t =
                if (cfg.FStar_TypeChecker_Cfg.debug).FStar_TypeChecker_Cfg.wpe
                then
-                 (let uu____16254 = FStar_Syntax_Print.term_to_string t in
-                  let uu____16255 = FStar_Syntax_Print.tag_of_term t in
-                  FStar_Util.print2 "WPE> is_applied %s -- %s\n" uu____16254
-                    uu____16255)
+                 (let uu____16239 = FStar_Syntax_Print.term_to_string t in
+                  let uu____16240 = FStar_Syntax_Print.tag_of_term t in
+                  FStar_Util.print2 "WPE> is_applied %s -- %s\n" uu____16239
+                    uu____16240)
                else ();
-               (let uu____16257 = FStar_Syntax_Util.head_and_args' t in
-                match uu____16257 with
+               (let uu____16242 = FStar_Syntax_Util.head_and_args' t in
+                match uu____16242 with
                 | (hd, args) ->
-                    let uu____16296 =
-                      let uu____16297 = FStar_Syntax_Subst.compress hd in
-                      uu____16297.FStar_Syntax_Syntax.n in
-                    (match uu____16296 with
+                    let uu____16281 =
+                      let uu____16282 = FStar_Syntax_Subst.compress hd in
+                      uu____16282.FStar_Syntax_Syntax.n in
+                    (match uu____16281 with
                      | FStar_Syntax_Syntax.Tm_name bv when
                          args_are_binders args bs ->
                          (if
                             (cfg.FStar_TypeChecker_Cfg.debug).FStar_TypeChecker_Cfg.wpe
                           then
-                            (let uu____16304 =
+                            (let uu____16289 =
                                FStar_Syntax_Print.term_to_string t in
-                             let uu____16305 =
+                             let uu____16290 =
                                FStar_Syntax_Print.bv_to_string bv in
-                             let uu____16306 =
+                             let uu____16291 =
                                FStar_Syntax_Print.term_to_string hd in
                              FStar_Util.print3
                                "WPE> got it\n>>>>top = %s\n>>>>b = %s\n>>>>hd = %s\n"
-                               uu____16304 uu____16305 uu____16306)
+                               uu____16289 uu____16290 uu____16291)
                           else ();
                           FStar_Pervasives_Native.Some bv)
-                     | uu____16308 -> FStar_Pervasives_Native.None)) in
+                     | uu____16293 -> FStar_Pervasives_Native.None)) in
              let is_applied_maybe_squashed bs t =
                if (cfg.FStar_TypeChecker_Cfg.debug).FStar_TypeChecker_Cfg.wpe
                then
-                 (let uu____16325 = FStar_Syntax_Print.term_to_string t in
-                  let uu____16326 = FStar_Syntax_Print.tag_of_term t in
+                 (let uu____16310 = FStar_Syntax_Print.term_to_string t in
+                  let uu____16311 = FStar_Syntax_Print.tag_of_term t in
                   FStar_Util.print2
-                    "WPE> is_applied_maybe_squashed %s -- %s\n" uu____16325
-                    uu____16326)
+                    "WPE> is_applied_maybe_squashed %s -- %s\n" uu____16310
+                    uu____16311)
                else ();
-               (let uu____16328 = FStar_Syntax_Util.is_squash t in
-                match uu____16328 with
-                | FStar_Pervasives_Native.Some (uu____16339, t') ->
+               (let uu____16313 = FStar_Syntax_Util.is_squash t in
+                match uu____16313 with
+                | FStar_Pervasives_Native.Some (uu____16324, t') ->
                     is_applied bs t'
-                | uu____16351 ->
-                    let uu____16360 = FStar_Syntax_Util.is_auto_squash t in
-                    (match uu____16360 with
-                     | FStar_Pervasives_Native.Some (uu____16371, t') ->
+                | uu____16336 ->
+                    let uu____16345 = FStar_Syntax_Util.is_auto_squash t in
+                    (match uu____16345 with
+                     | FStar_Pervasives_Native.Some (uu____16356, t') ->
                          is_applied bs t'
-                     | uu____16383 -> is_applied bs t)) in
+                     | uu____16368 -> is_applied bs t)) in
              let is_quantified_const bv phi =
-               let uu____16407 =
+               let uu____16392 =
                  FStar_Syntax_Util.destruct_typ_as_formula phi in
-               match uu____16407 with
+               match uu____16392 with
                | FStar_Pervasives_Native.Some (FStar_Syntax_Util.BaseConn
-                   (lid, (p, uu____16414)::(q, uu____16416)::[])) when
+                   (lid, (p, uu____16399)::(q, uu____16401)::[])) when
                    FStar_Ident.lid_equals lid FStar_Parser_Const.imp_lid ->
                    (if
                       (cfg.FStar_TypeChecker_Cfg.debug).FStar_TypeChecker_Cfg.wpe
                     then
-                      (let uu____16458 = FStar_Syntax_Print.term_to_string p in
-                       let uu____16459 = FStar_Syntax_Print.term_to_string q in
+                      (let uu____16443 = FStar_Syntax_Print.term_to_string p in
+                       let uu____16444 = FStar_Syntax_Print.term_to_string q in
                        FStar_Util.print2 "WPE> p = (%s); q = (%s)\n"
-                         uu____16458 uu____16459)
+                         uu____16443 uu____16444)
                     else ();
-                    (let uu____16461 =
+                    (let uu____16446 =
                        FStar_Syntax_Util.destruct_typ_as_formula p in
-                     match uu____16461 with
+                     match uu____16446 with
                      | FStar_Pervasives_Native.None ->
-                         let uu____16466 =
-                           let uu____16467 = FStar_Syntax_Subst.compress p in
-                           uu____16467.FStar_Syntax_Syntax.n in
-                         (match uu____16466 with
+                         let uu____16451 =
+                           let uu____16452 = FStar_Syntax_Subst.compress p in
+                           uu____16452.FStar_Syntax_Syntax.n in
+                         (match uu____16451 with
                           | FStar_Syntax_Syntax.Tm_bvar bv' when
                               FStar_Syntax_Syntax.bv_eq bv bv' ->
                               (if
                                  (cfg.FStar_TypeChecker_Cfg.debug).FStar_TypeChecker_Cfg.wpe
                                then FStar_Util.print_string "WPE> Case 1\n"
                                else ();
-                               (let uu____16475 =
+                               (let uu____16460 =
                                   FStar_Syntax_Subst.subst
                                     [FStar_Syntax_Syntax.NT
                                        (bv, FStar_Syntax_Util.t_true)] q in
-                                FStar_Pervasives_Native.Some uu____16475))
-                          | uu____16478 -> FStar_Pervasives_Native.None)
+                                FStar_Pervasives_Native.Some uu____16460))
+                          | uu____16463 -> FStar_Pervasives_Native.None)
                      | FStar_Pervasives_Native.Some
                          (FStar_Syntax_Util.BaseConn
-                         (lid1, (p1, uu____16481)::[])) when
+                         (lid1, (p1, uu____16466)::[])) when
                          FStar_Ident.lid_equals lid1
                            FStar_Parser_Const.not_lid
                          ->
-                         let uu____16506 =
-                           let uu____16507 = FStar_Syntax_Subst.compress p1 in
-                           uu____16507.FStar_Syntax_Syntax.n in
-                         (match uu____16506 with
+                         let uu____16491 =
+                           let uu____16492 = FStar_Syntax_Subst.compress p1 in
+                           uu____16492.FStar_Syntax_Syntax.n in
+                         (match uu____16491 with
                           | FStar_Syntax_Syntax.Tm_bvar bv' when
                               FStar_Syntax_Syntax.bv_eq bv bv' ->
                               (if
                                  (cfg.FStar_TypeChecker_Cfg.debug).FStar_TypeChecker_Cfg.wpe
                                then FStar_Util.print_string "WPE> Case 2\n"
                                else ();
-                               (let uu____16515 =
+                               (let uu____16500 =
                                   FStar_Syntax_Subst.subst
                                     [FStar_Syntax_Syntax.NT
                                        (bv, FStar_Syntax_Util.t_false)] q in
-                                FStar_Pervasives_Native.Some uu____16515))
-                          | uu____16518 -> FStar_Pervasives_Native.None)
+                                FStar_Pervasives_Native.Some uu____16500))
+                          | uu____16503 -> FStar_Pervasives_Native.None)
                      | FStar_Pervasives_Native.Some (FStar_Syntax_Util.QAll
                          (bs, pats, phi1)) ->
-                         let uu____16522 =
+                         let uu____16507 =
                            FStar_Syntax_Util.destruct_typ_as_formula phi1 in
-                         (match uu____16522 with
+                         (match uu____16507 with
                           | FStar_Pervasives_Native.None ->
-                              let uu____16527 =
+                              let uu____16512 =
                                 is_applied_maybe_squashed bs phi1 in
-                              (match uu____16527 with
+                              (match uu____16512 with
                                | FStar_Pervasives_Native.Some bv' when
                                    FStar_Syntax_Syntax.bv_eq bv bv' ->
                                    (if
@@ -5815,21 +5814,21 @@ and (maybe_simplify_aux :
                                          (FStar_Pervasives_Native.Some
                                             (FStar_Syntax_Util.residual_tot
                                                FStar_Syntax_Util.ktype0)) in
-                                     let uu____16538 =
+                                     let uu____16523 =
                                        FStar_Syntax_Subst.subst
                                          [FStar_Syntax_Syntax.NT (bv, ftrue)]
                                          q in
-                                     FStar_Pervasives_Native.Some uu____16538))
-                               | uu____16541 -> FStar_Pervasives_Native.None)
+                                     FStar_Pervasives_Native.Some uu____16523))
+                               | uu____16526 -> FStar_Pervasives_Native.None)
                           | FStar_Pervasives_Native.Some
                               (FStar_Syntax_Util.BaseConn
-                              (lid1, (p1, uu____16546)::[])) when
+                              (lid1, (p1, uu____16531)::[])) when
                               FStar_Ident.lid_equals lid1
                                 FStar_Parser_Const.not_lid
                               ->
-                              let uu____16571 =
+                              let uu____16556 =
                                 is_applied_maybe_squashed bs p1 in
-                              (match uu____16571 with
+                              (match uu____16556 with
                                | FStar_Pervasives_Native.Some bv' when
                                    FStar_Syntax_Syntax.bv_eq bv bv' ->
                                    (if
@@ -5843,91 +5842,91 @@ and (maybe_simplify_aux :
                                          (FStar_Pervasives_Native.Some
                                             (FStar_Syntax_Util.residual_tot
                                                FStar_Syntax_Util.ktype0)) in
-                                     let uu____16582 =
+                                     let uu____16567 =
                                        FStar_Syntax_Subst.subst
                                          [FStar_Syntax_Syntax.NT (bv, ffalse)]
                                          q in
-                                     FStar_Pervasives_Native.Some uu____16582))
-                               | uu____16585 -> FStar_Pervasives_Native.None)
-                          | uu____16588 -> FStar_Pervasives_Native.None)
-                     | uu____16591 -> FStar_Pervasives_Native.None))
-               | uu____16594 -> FStar_Pervasives_Native.None in
+                                     FStar_Pervasives_Native.Some uu____16567))
+                               | uu____16570 -> FStar_Pervasives_Native.None)
+                          | uu____16573 -> FStar_Pervasives_Native.None)
+                     | uu____16576 -> FStar_Pervasives_Native.None))
+               | uu____16579 -> FStar_Pervasives_Native.None in
              let is_forall_const phi =
-               let uu____16607 =
+               let uu____16592 =
                  FStar_Syntax_Util.destruct_typ_as_formula phi in
-               match uu____16607 with
+               match uu____16592 with
                | FStar_Pervasives_Native.Some (FStar_Syntax_Util.QAll
-                   ((bv, uu____16613)::[], uu____16614, phi')) ->
+                   ((bv, uu____16598)::[], uu____16599, phi')) ->
                    (if
                       (cfg.FStar_TypeChecker_Cfg.debug).FStar_TypeChecker_Cfg.wpe
                     then
-                      (let uu____16633 = FStar_Syntax_Print.bv_to_string bv in
-                       let uu____16634 =
+                      (let uu____16618 = FStar_Syntax_Print.bv_to_string bv in
+                       let uu____16619 =
                          FStar_Syntax_Print.term_to_string phi' in
-                       FStar_Util.print2 "WPE> QAll [%s] %s\n" uu____16633
-                         uu____16634)
+                       FStar_Util.print2 "WPE> QAll [%s] %s\n" uu____16618
+                         uu____16619)
                     else ();
                     is_quantified_const bv phi')
-               | uu____16636 -> FStar_Pervasives_Native.None in
+               | uu____16621 -> FStar_Pervasives_Native.None in
              let is_const_match phi =
-               let uu____16649 =
-                 let uu____16650 = FStar_Syntax_Subst.compress phi in
-                 uu____16650.FStar_Syntax_Syntax.n in
-               match uu____16649 with
-               | FStar_Syntax_Syntax.Tm_match (uu____16655, br::brs) ->
-                   let uu____16722 = br in
-                   (match uu____16722 with
-                    | (uu____16739, uu____16740, e) ->
+               let uu____16634 =
+                 let uu____16635 = FStar_Syntax_Subst.compress phi in
+                 uu____16635.FStar_Syntax_Syntax.n in
+               match uu____16634 with
+               | FStar_Syntax_Syntax.Tm_match (uu____16640, br::brs) ->
+                   let uu____16707 = br in
+                   (match uu____16707 with
+                    | (uu____16724, uu____16725, e) ->
                         let r =
-                          let uu____16761 = simp_t e in
-                          match uu____16761 with
+                          let uu____16746 = simp_t e in
+                          match uu____16746 with
                           | FStar_Pervasives_Native.None ->
                               FStar_Pervasives_Native.None
                           | FStar_Pervasives_Native.Some b ->
-                              let uu____16767 =
+                              let uu____16752 =
                                 FStar_List.for_all
-                                  (fun uu____16785 ->
-                                     match uu____16785 with
-                                     | (uu____16798, uu____16799, e') ->
-                                         let uu____16813 = simp_t e' in
-                                         uu____16813 =
+                                  (fun uu____16770 ->
+                                     match uu____16770 with
+                                     | (uu____16783, uu____16784, e') ->
+                                         let uu____16798 = simp_t e' in
+                                         uu____16798 =
                                            (FStar_Pervasives_Native.Some b))
                                   brs in
-                              if uu____16767
+                              if uu____16752
                               then FStar_Pervasives_Native.Some b
                               else FStar_Pervasives_Native.None in
                         r)
-               | uu____16821 -> FStar_Pervasives_Native.None in
+               | uu____16806 -> FStar_Pervasives_Native.None in
              let maybe_auto_squash t =
-               let uu____16830 = FStar_Syntax_Util.is_sub_singleton t in
-               if uu____16830
+               let uu____16815 = FStar_Syntax_Util.is_sub_singleton t in
+               if uu____16815
                then t
                else
                  FStar_Syntax_Util.mk_auto_squash FStar_Syntax_Syntax.U_zero
                    t in
              let squashed_head_un_auto_squash_args t =
-               let maybe_un_auto_squash_arg uu____16863 =
-                 match uu____16863 with
+               let maybe_un_auto_squash_arg uu____16848 =
+                 match uu____16848 with
                  | (t1, q) ->
-                     let uu____16884 = FStar_Syntax_Util.is_auto_squash t1 in
-                     (match uu____16884 with
+                     let uu____16869 = FStar_Syntax_Util.is_auto_squash t1 in
+                     (match uu____16869 with
                       | FStar_Pervasives_Native.Some
                           (FStar_Syntax_Syntax.U_zero, t2) -> (t2, q)
-                      | uu____16916 -> (t1, q)) in
-               let uu____16929 = FStar_Syntax_Util.head_and_args t in
-               match uu____16929 with
+                      | uu____16901 -> (t1, q)) in
+               let uu____16914 = FStar_Syntax_Util.head_and_args t in
+               match uu____16914 with
                | (head, args) ->
                    let args1 = FStar_List.map maybe_un_auto_squash_arg args in
                    FStar_Syntax_Syntax.mk_Tm_app head args1
                      t.FStar_Syntax_Syntax.pos in
              let rec clearly_inhabited ty =
-               let uu____17005 =
-                 let uu____17006 = FStar_Syntax_Util.unmeta ty in
-                 uu____17006.FStar_Syntax_Syntax.n in
-               match uu____17005 with
-               | FStar_Syntax_Syntax.Tm_uinst (t, uu____17010) ->
+               let uu____16990 =
+                 let uu____16991 = FStar_Syntax_Util.unmeta ty in
+                 uu____16991.FStar_Syntax_Syntax.n in
+               match uu____16990 with
+               | FStar_Syntax_Syntax.Tm_uinst (t, uu____16995) ->
                    clearly_inhabited t
-               | FStar_Syntax_Syntax.Tm_arrow (uu____17015, c) ->
+               | FStar_Syntax_Syntax.Tm_arrow (uu____17000, c) ->
                    clearly_inhabited (FStar_Syntax_Util.comp_result c)
                | FStar_Syntax_Syntax.Tm_fvar fv ->
                    let l = FStar_Syntax_Syntax.lid_of_fv fv in
@@ -5936,238 +5935,238 @@ and (maybe_simplify_aux :
                       ||
                       (FStar_Ident.lid_equals l FStar_Parser_Const.string_lid))
                      || (FStar_Ident.lid_equals l FStar_Parser_Const.exn_lid)
-               | uu____17039 -> false in
+               | uu____17024 -> false in
              let simplify arg =
-               let uu____17070 = simp_t (FStar_Pervasives_Native.fst arg) in
-               (uu____17070, arg) in
-             let uu____17083 = is_forall_const tm1 in
-             match uu____17083 with
+               let uu____17055 = simp_t (FStar_Pervasives_Native.fst arg) in
+               (uu____17055, arg) in
+             let uu____17068 = is_forall_const tm1 in
+             match uu____17068 with
              | FStar_Pervasives_Native.Some tm' ->
                  (if
                     (cfg.FStar_TypeChecker_Cfg.debug).FStar_TypeChecker_Cfg.wpe
                   then
-                    (let uu____17088 = FStar_Syntax_Print.term_to_string tm1 in
-                     let uu____17089 = FStar_Syntax_Print.term_to_string tm' in
-                     FStar_Util.print2 "WPE> %s ~> %s\n" uu____17088
-                       uu____17089)
+                    (let uu____17073 = FStar_Syntax_Print.term_to_string tm1 in
+                     let uu____17074 = FStar_Syntax_Print.term_to_string tm' in
+                     FStar_Util.print2 "WPE> %s ~> %s\n" uu____17073
+                       uu____17074)
                   else ();
-                  (let uu____17091 = norm cfg env1 [] tm' in
-                   maybe_simplify_aux cfg env1 stack1 uu____17091))
+                  (let uu____17076 = norm cfg env1 [] tm' in
+                   maybe_simplify_aux cfg env1 stack1 uu____17076))
              | FStar_Pervasives_Native.None ->
-                 let uu____17092 =
-                   let uu____17093 = FStar_Syntax_Subst.compress tm1 in
-                   uu____17093.FStar_Syntax_Syntax.n in
-                 (match uu____17092 with
+                 let uu____17077 =
+                   let uu____17078 = FStar_Syntax_Subst.compress tm1 in
+                   uu____17078.FStar_Syntax_Syntax.n in
+                 (match uu____17077 with
                   | FStar_Syntax_Syntax.Tm_app
                       ({
                          FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_uinst
                            ({
                               FStar_Syntax_Syntax.n =
                                 FStar_Syntax_Syntax.Tm_fvar fv;
-                              FStar_Syntax_Syntax.pos = uu____17097;
-                              FStar_Syntax_Syntax.vars = uu____17098;_},
-                            uu____17099);
-                         FStar_Syntax_Syntax.pos = uu____17100;
-                         FStar_Syntax_Syntax.vars = uu____17101;_},
+                              FStar_Syntax_Syntax.pos = uu____17082;
+                              FStar_Syntax_Syntax.vars = uu____17083;_},
+                            uu____17084);
+                         FStar_Syntax_Syntax.pos = uu____17085;
+                         FStar_Syntax_Syntax.vars = uu____17086;_},
                        args)
                       ->
-                      let uu____17131 =
+                      let uu____17116 =
                         FStar_Syntax_Syntax.fv_eq_lid fv
                           FStar_Parser_Const.and_lid in
-                      if uu____17131
+                      if uu____17116
                       then
-                        let uu____17132 =
+                        let uu____17117 =
                           FStar_All.pipe_right args (FStar_List.map simplify) in
-                        (match uu____17132 with
-                         | (FStar_Pervasives_Native.Some (true), uu____17187)::
-                             (uu____17188, (arg, uu____17190))::[] ->
+                        (match uu____17117 with
+                         | (FStar_Pervasives_Native.Some (true), uu____17172)::
+                             (uu____17173, (arg, uu____17175))::[] ->
                              maybe_auto_squash arg
-                         | (uu____17255, (arg, uu____17257))::(FStar_Pervasives_Native.Some
+                         | (uu____17240, (arg, uu____17242))::(FStar_Pervasives_Native.Some
                                                                (true),
-                                                               uu____17258)::[]
+                                                               uu____17243)::[]
                              -> maybe_auto_squash arg
                          | (FStar_Pervasives_Native.Some (false),
-                            uu____17323)::uu____17324::[] ->
+                            uu____17308)::uu____17309::[] ->
                              w FStar_Syntax_Util.t_false
-                         | uu____17387::(FStar_Pervasives_Native.Some
-                                         (false), uu____17388)::[]
+                         | uu____17372::(FStar_Pervasives_Native.Some
+                                         (false), uu____17373)::[]
                              -> w FStar_Syntax_Util.t_false
-                         | uu____17451 ->
+                         | uu____17436 ->
                              squashed_head_un_auto_squash_args tm1)
                       else
-                        (let uu____17467 =
+                        (let uu____17452 =
                            FStar_Syntax_Syntax.fv_eq_lid fv
                              FStar_Parser_Const.or_lid in
-                         if uu____17467
+                         if uu____17452
                          then
-                           let uu____17468 =
+                           let uu____17453 =
                              FStar_All.pipe_right args
                                (FStar_List.map simplify) in
-                           match uu____17468 with
+                           match uu____17453 with
                            | (FStar_Pervasives_Native.Some (true),
-                              uu____17523)::uu____17524::[] ->
+                              uu____17508)::uu____17509::[] ->
                                w FStar_Syntax_Util.t_true
-                           | uu____17587::(FStar_Pervasives_Native.Some
-                                           (true), uu____17588)::[]
+                           | uu____17572::(FStar_Pervasives_Native.Some
+                                           (true), uu____17573)::[]
                                -> w FStar_Syntax_Util.t_true
                            | (FStar_Pervasives_Native.Some (false),
-                              uu____17651)::(uu____17652, (arg, uu____17654))::[]
+                              uu____17636)::(uu____17637, (arg, uu____17639))::[]
                                -> maybe_auto_squash arg
-                           | (uu____17719, (arg, uu____17721))::(FStar_Pervasives_Native.Some
+                           | (uu____17704, (arg, uu____17706))::(FStar_Pervasives_Native.Some
                                                                  (false),
-                                                                 uu____17722)::[]
+                                                                 uu____17707)::[]
                                -> maybe_auto_squash arg
-                           | uu____17787 ->
+                           | uu____17772 ->
                                squashed_head_un_auto_squash_args tm1
                          else
-                           (let uu____17803 =
+                           (let uu____17788 =
                               FStar_Syntax_Syntax.fv_eq_lid fv
                                 FStar_Parser_Const.imp_lid in
-                            if uu____17803
+                            if uu____17788
                             then
-                              let uu____17804 =
+                              let uu____17789 =
                                 FStar_All.pipe_right args
                                   (FStar_List.map simplify) in
-                              match uu____17804 with
-                              | uu____17859::(FStar_Pervasives_Native.Some
-                                              (true), uu____17860)::[]
+                              match uu____17789 with
+                              | uu____17844::(FStar_Pervasives_Native.Some
+                                              (true), uu____17845)::[]
                                   -> w FStar_Syntax_Util.t_true
                               | (FStar_Pervasives_Native.Some (false),
-                                 uu____17923)::uu____17924::[] ->
+                                 uu____17908)::uu____17909::[] ->
                                   w FStar_Syntax_Util.t_true
                               | (FStar_Pervasives_Native.Some (true),
-                                 uu____17987)::(uu____17988,
-                                                (arg, uu____17990))::[]
+                                 uu____17972)::(uu____17973,
+                                                (arg, uu____17975))::[]
                                   -> maybe_auto_squash arg
-                              | (uu____18055, (p, uu____18057))::(uu____18058,
+                              | (uu____18040, (p, uu____18042))::(uu____18043,
                                                                   (q,
-                                                                   uu____18060))::[]
+                                                                   uu____18045))::[]
                                   ->
-                                  let uu____18125 =
+                                  let uu____18110 =
                                     FStar_Syntax_Util.term_eq p q in
-                                  (if uu____18125
+                                  (if uu____18110
                                    then w FStar_Syntax_Util.t_true
                                    else squashed_head_un_auto_squash_args tm1)
-                              | uu____18127 ->
+                              | uu____18112 ->
                                   squashed_head_un_auto_squash_args tm1
                             else
-                              (let uu____18143 =
+                              (let uu____18128 =
                                  FStar_Syntax_Syntax.fv_eq_lid fv
                                    FStar_Parser_Const.iff_lid in
-                               if uu____18143
+                               if uu____18128
                                then
-                                 let uu____18144 =
+                                 let uu____18129 =
                                    FStar_All.pipe_right args
                                      (FStar_List.map simplify) in
-                                 match uu____18144 with
+                                 match uu____18129 with
                                  | (FStar_Pervasives_Native.Some (true),
-                                    uu____18199)::(FStar_Pervasives_Native.Some
-                                                   (true), uu____18200)::[]
+                                    uu____18184)::(FStar_Pervasives_Native.Some
+                                                   (true), uu____18185)::[]
                                      -> w FStar_Syntax_Util.t_true
                                  | (FStar_Pervasives_Native.Some (false),
-                                    uu____18265)::(FStar_Pervasives_Native.Some
-                                                   (false), uu____18266)::[]
+                                    uu____18250)::(FStar_Pervasives_Native.Some
+                                                   (false), uu____18251)::[]
                                      -> w FStar_Syntax_Util.t_true
                                  | (FStar_Pervasives_Native.Some (true),
-                                    uu____18331)::(FStar_Pervasives_Native.Some
-                                                   (false), uu____18332)::[]
+                                    uu____18316)::(FStar_Pervasives_Native.Some
+                                                   (false), uu____18317)::[]
                                      -> w FStar_Syntax_Util.t_false
                                  | (FStar_Pervasives_Native.Some (false),
-                                    uu____18397)::(FStar_Pervasives_Native.Some
-                                                   (true), uu____18398)::[]
+                                    uu____18382)::(FStar_Pervasives_Native.Some
+                                                   (true), uu____18383)::[]
                                      -> w FStar_Syntax_Util.t_false
-                                 | (uu____18463, (arg, uu____18465))::
+                                 | (uu____18448, (arg, uu____18450))::
                                      (FStar_Pervasives_Native.Some (true),
-                                      uu____18466)::[]
+                                      uu____18451)::[]
                                      -> maybe_auto_squash arg
                                  | (FStar_Pervasives_Native.Some (true),
-                                    uu____18531)::(uu____18532,
-                                                   (arg, uu____18534))::[]
+                                    uu____18516)::(uu____18517,
+                                                   (arg, uu____18519))::[]
                                      -> maybe_auto_squash arg
-                                 | (uu____18599, (arg, uu____18601))::
+                                 | (uu____18584, (arg, uu____18586))::
                                      (FStar_Pervasives_Native.Some (false),
-                                      uu____18602)::[]
+                                      uu____18587)::[]
                                      ->
-                                     let uu____18667 =
+                                     let uu____18652 =
                                        FStar_Syntax_Util.mk_neg arg in
-                                     maybe_auto_squash uu____18667
+                                     maybe_auto_squash uu____18652
                                  | (FStar_Pervasives_Native.Some (false),
-                                    uu____18668)::(uu____18669,
-                                                   (arg, uu____18671))::[]
+                                    uu____18653)::(uu____18654,
+                                                   (arg, uu____18656))::[]
                                      ->
-                                     let uu____18736 =
+                                     let uu____18721 =
                                        FStar_Syntax_Util.mk_neg arg in
-                                     maybe_auto_squash uu____18736
-                                 | (uu____18737, (p, uu____18739))::(uu____18740,
+                                     maybe_auto_squash uu____18721
+                                 | (uu____18722, (p, uu____18724))::(uu____18725,
                                                                     (q,
-                                                                    uu____18742))::[]
+                                                                    uu____18727))::[]
                                      ->
-                                     let uu____18807 =
+                                     let uu____18792 =
                                        FStar_Syntax_Util.term_eq p q in
-                                     (if uu____18807
+                                     (if uu____18792
                                       then w FStar_Syntax_Util.t_true
                                       else
                                         squashed_head_un_auto_squash_args tm1)
-                                 | uu____18809 ->
+                                 | uu____18794 ->
                                      squashed_head_un_auto_squash_args tm1
                                else
-                                 (let uu____18825 =
+                                 (let uu____18810 =
                                     FStar_Syntax_Syntax.fv_eq_lid fv
                                       FStar_Parser_Const.not_lid in
-                                  if uu____18825
+                                  if uu____18810
                                   then
-                                    let uu____18826 =
+                                    let uu____18811 =
                                       FStar_All.pipe_right args
                                         (FStar_List.map simplify) in
-                                    match uu____18826 with
+                                    match uu____18811 with
                                     | (FStar_Pervasives_Native.Some (true),
-                                       uu____18881)::[] ->
+                                       uu____18866)::[] ->
                                         w FStar_Syntax_Util.t_false
                                     | (FStar_Pervasives_Native.Some (false),
-                                       uu____18920)::[] ->
+                                       uu____18905)::[] ->
                                         w FStar_Syntax_Util.t_true
-                                    | uu____18959 ->
+                                    | uu____18944 ->
                                         squashed_head_un_auto_squash_args tm1
                                   else
-                                    (let uu____18975 =
+                                    (let uu____18960 =
                                        FStar_Syntax_Syntax.fv_eq_lid fv
                                          FStar_Parser_Const.forall_lid in
-                                     if uu____18975
+                                     if uu____18960
                                      then
                                        match args with
-                                       | (t, uu____18977)::[] ->
-                                           let uu____19002 =
-                                             let uu____19003 =
+                                       | (t, uu____18962)::[] ->
+                                           let uu____18987 =
+                                             let uu____18988 =
                                                FStar_Syntax_Subst.compress t in
-                                             uu____19003.FStar_Syntax_Syntax.n in
-                                           (match uu____19002 with
+                                             uu____18988.FStar_Syntax_Syntax.n in
+                                           (match uu____18987 with
                                             | FStar_Syntax_Syntax.Tm_abs
-                                                (uu____19006::[], body,
-                                                 uu____19008)
+                                                (uu____18991::[], body,
+                                                 uu____18993)
                                                 ->
-                                                let uu____19043 = simp_t body in
-                                                (match uu____19043 with
+                                                let uu____19028 = simp_t body in
+                                                (match uu____19028 with
                                                  | FStar_Pervasives_Native.Some
                                                      (true) ->
                                                      w
                                                        FStar_Syntax_Util.t_true
-                                                 | uu____19046 -> tm1)
-                                            | uu____19049 -> tm1)
+                                                 | uu____19031 -> tm1)
+                                            | uu____19034 -> tm1)
                                        | (ty, FStar_Pervasives_Native.Some
                                           (FStar_Syntax_Syntax.Implicit
-                                          uu____19051))::(t, uu____19053)::[]
+                                          uu____19036))::(t, uu____19038)::[]
                                            ->
-                                           let uu____19092 =
-                                             let uu____19093 =
+                                           let uu____19077 =
+                                             let uu____19078 =
                                                FStar_Syntax_Subst.compress t in
-                                             uu____19093.FStar_Syntax_Syntax.n in
-                                           (match uu____19092 with
+                                             uu____19078.FStar_Syntax_Syntax.n in
+                                           (match uu____19077 with
                                             | FStar_Syntax_Syntax.Tm_abs
-                                                (uu____19096::[], body,
-                                                 uu____19098)
+                                                (uu____19081::[], body,
+                                                 uu____19083)
                                                 ->
-                                                let uu____19133 = simp_t body in
-                                                (match uu____19133 with
+                                                let uu____19118 = simp_t body in
+                                                (match uu____19118 with
                                                  | FStar_Pervasives_Native.Some
                                                      (true) ->
                                                      w
@@ -6177,53 +6176,53 @@ and (maybe_simplify_aux :
                                                      clearly_inhabited ty ->
                                                      w
                                                        FStar_Syntax_Util.t_false
-                                                 | uu____19136 -> tm1)
-                                            | uu____19139 -> tm1)
-                                       | uu____19140 -> tm1
+                                                 | uu____19121 -> tm1)
+                                            | uu____19124 -> tm1)
+                                       | uu____19125 -> tm1
                                      else
-                                       (let uu____19152 =
+                                       (let uu____19137 =
                                           FStar_Syntax_Syntax.fv_eq_lid fv
                                             FStar_Parser_Const.exists_lid in
-                                        if uu____19152
+                                        if uu____19137
                                         then
                                           match args with
-                                          | (t, uu____19154)::[] ->
-                                              let uu____19179 =
-                                                let uu____19180 =
+                                          | (t, uu____19139)::[] ->
+                                              let uu____19164 =
+                                                let uu____19165 =
                                                   FStar_Syntax_Subst.compress
                                                     t in
-                                                uu____19180.FStar_Syntax_Syntax.n in
-                                              (match uu____19179 with
+                                                uu____19165.FStar_Syntax_Syntax.n in
+                                              (match uu____19164 with
                                                | FStar_Syntax_Syntax.Tm_abs
-                                                   (uu____19183::[], body,
-                                                    uu____19185)
+                                                   (uu____19168::[], body,
+                                                    uu____19170)
                                                    ->
-                                                   let uu____19220 =
+                                                   let uu____19205 =
                                                      simp_t body in
-                                                   (match uu____19220 with
+                                                   (match uu____19205 with
                                                     | FStar_Pervasives_Native.Some
                                                         (false) ->
                                                         w
                                                           FStar_Syntax_Util.t_false
-                                                    | uu____19223 -> tm1)
-                                               | uu____19226 -> tm1)
+                                                    | uu____19208 -> tm1)
+                                               | uu____19211 -> tm1)
                                           | (ty, FStar_Pervasives_Native.Some
                                              (FStar_Syntax_Syntax.Implicit
-                                             uu____19228))::(t, uu____19230)::[]
+                                             uu____19213))::(t, uu____19215)::[]
                                               ->
-                                              let uu____19269 =
-                                                let uu____19270 =
+                                              let uu____19254 =
+                                                let uu____19255 =
                                                   FStar_Syntax_Subst.compress
                                                     t in
-                                                uu____19270.FStar_Syntax_Syntax.n in
-                                              (match uu____19269 with
+                                                uu____19255.FStar_Syntax_Syntax.n in
+                                              (match uu____19254 with
                                                | FStar_Syntax_Syntax.Tm_abs
-                                                   (uu____19273::[], body,
-                                                    uu____19275)
+                                                   (uu____19258::[], body,
+                                                    uu____19260)
                                                    ->
-                                                   let uu____19310 =
+                                                   let uu____19295 =
                                                      simp_t body in
-                                                   (match uu____19310 with
+                                                   (match uu____19295 with
                                                     | FStar_Pervasives_Native.Some
                                                         (false) ->
                                                         w
@@ -6234,14 +6233,14 @@ and (maybe_simplify_aux :
                                                         ->
                                                         w
                                                           FStar_Syntax_Util.t_true
-                                                    | uu____19313 -> tm1)
-                                               | uu____19316 -> tm1)
-                                          | uu____19317 -> tm1
+                                                    | uu____19298 -> tm1)
+                                               | uu____19301 -> tm1)
+                                          | uu____19302 -> tm1
                                         else
-                                          (let uu____19329 =
+                                          (let uu____19314 =
                                              FStar_Syntax_Syntax.fv_eq_lid fv
                                                FStar_Parser_Const.b2t_lid in
-                                           if uu____19329
+                                           if uu____19314
                                            then
                                              match args with
                                              | ({
@@ -6250,10 +6249,10 @@ and (maybe_simplify_aux :
                                                     (FStar_Const.Const_bool
                                                     (true));
                                                   FStar_Syntax_Syntax.pos =
-                                                    uu____19330;
+                                                    uu____19315;
                                                   FStar_Syntax_Syntax.vars =
-                                                    uu____19331;_},
-                                                uu____19332)::[] ->
+                                                    uu____19316;_},
+                                                uu____19317)::[] ->
                                                  w FStar_Syntax_Util.t_true
                                              | ({
                                                   FStar_Syntax_Syntax.n =
@@ -6261,18 +6260,18 @@ and (maybe_simplify_aux :
                                                     (FStar_Const.Const_bool
                                                     (false));
                                                   FStar_Syntax_Syntax.pos =
-                                                    uu____19357;
+                                                    uu____19342;
                                                   FStar_Syntax_Syntax.vars =
-                                                    uu____19358;_},
-                                                uu____19359)::[] ->
+                                                    uu____19343;_},
+                                                uu____19344)::[] ->
                                                  w FStar_Syntax_Util.t_false
-                                             | uu____19384 -> tm1
+                                             | uu____19369 -> tm1
                                            else
-                                             (let uu____19396 =
+                                             (let uu____19381 =
                                                 FStar_Syntax_Syntax.fv_eq_lid
                                                   fv
                                                   FStar_Parser_Const.haseq_lid in
-                                              if uu____19396
+                                              if uu____19381
                                               then
                                                 let t_has_eq_for_sure t =
                                                   let haseq_lids =
@@ -6280,12 +6279,12 @@ and (maybe_simplify_aux :
                                                     FStar_Parser_Const.bool_lid;
                                                     FStar_Parser_Const.unit_lid;
                                                     FStar_Parser_Const.string_lid] in
-                                                  let uu____19406 =
-                                                    let uu____19407 =
+                                                  let uu____19391 =
+                                                    let uu____19392 =
                                                       FStar_Syntax_Subst.compress
                                                         t in
-                                                    uu____19407.FStar_Syntax_Syntax.n in
-                                                  match uu____19406 with
+                                                    uu____19392.FStar_Syntax_Syntax.n in
+                                                  match uu____19391 with
                                                   | FStar_Syntax_Syntax.Tm_fvar
                                                       fv1 when
                                                       FStar_All.pipe_right
@@ -6295,82 +6294,82 @@ and (maybe_simplify_aux :
                                                               FStar_Syntax_Syntax.fv_eq_lid
                                                                 fv1 l))
                                                       -> true
-                                                  | uu____19415 -> false in
+                                                  | uu____19400 -> false in
                                                 (if
                                                    (FStar_List.length args) =
                                                      Prims.int_one
                                                  then
                                                    let t =
-                                                     let uu____19425 =
+                                                     let uu____19410 =
                                                        FStar_All.pipe_right
                                                          args FStar_List.hd in
                                                      FStar_All.pipe_right
-                                                       uu____19425
+                                                       uu____19410
                                                        FStar_Pervasives_Native.fst in
-                                                   let uu____19464 =
+                                                   let uu____19445 =
                                                      FStar_All.pipe_right t
                                                        t_has_eq_for_sure in
-                                                   (if uu____19464
+                                                   (if uu____19445
                                                     then
                                                       w
                                                         FStar_Syntax_Util.t_true
                                                     else
-                                                      (let uu____19466 =
-                                                         let uu____19467 =
+                                                      (let uu____19447 =
+                                                         let uu____19448 =
                                                            FStar_Syntax_Subst.compress
                                                              t in
-                                                         uu____19467.FStar_Syntax_Syntax.n in
-                                                       match uu____19466 with
+                                                         uu____19448.FStar_Syntax_Syntax.n in
+                                                       match uu____19447 with
                                                        | FStar_Syntax_Syntax.Tm_refine
-                                                           uu____19470 ->
+                                                           uu____19451 ->
                                                            let t1 =
                                                              FStar_Syntax_Util.unrefine
                                                                t in
-                                                           let uu____19478 =
+                                                           let uu____19459 =
                                                              FStar_All.pipe_right
                                                                t1
                                                                t_has_eq_for_sure in
-                                                           if uu____19478
+                                                           if uu____19459
                                                            then
                                                              w
                                                                FStar_Syntax_Util.t_true
                                                            else
                                                              (let haseq_tm =
-                                                                let uu____19483
+                                                                let uu____19464
                                                                   =
-                                                                  let uu____19484
+                                                                  let uu____19465
                                                                     =
                                                                     FStar_Syntax_Subst.compress
                                                                     tm1 in
-                                                                  uu____19484.FStar_Syntax_Syntax.n in
-                                                                match uu____19483
+                                                                  uu____19465.FStar_Syntax_Syntax.n in
+                                                                match uu____19464
                                                                 with
                                                                 | FStar_Syntax_Syntax.Tm_app
                                                                     (hd,
-                                                                    uu____19490)
+                                                                    uu____19471)
                                                                     -> hd
-                                                                | uu____19515
+                                                                | uu____19496
                                                                     ->
                                                                     failwith
                                                                     "Impossible! We have already checked that this is a Tm_app" in
-                                                              let uu____19518
+                                                              let uu____19499
                                                                 =
-                                                                let uu____19529
+                                                                let uu____19510
                                                                   =
                                                                   FStar_All.pipe_right
                                                                     t1
                                                                     FStar_Syntax_Syntax.as_arg in
-                                                                [uu____19529] in
+                                                                [uu____19510] in
                                                               FStar_Syntax_Util.mk_app
                                                                 haseq_tm
-                                                                uu____19518)
-                                                       | uu____19562 -> tm1))
+                                                                uu____19499)
+                                                       | uu____19543 -> tm1))
                                                  else tm1)
                                               else
-                                                (let uu____19565 =
+                                                (let uu____19546 =
                                                    FStar_Syntax_Util.is_auto_squash
                                                      tm1 in
-                                                 match uu____19565 with
+                                                 match uu____19546 with
                                                  | FStar_Pervasives_Native.Some
                                                      (FStar_Syntax_Syntax.U_zero,
                                                       t)
@@ -6378,217 +6377,217 @@ and (maybe_simplify_aux :
                                                      FStar_Syntax_Util.is_sub_singleton
                                                        t
                                                      -> t
-                                                 | uu____19585 ->
-                                                     let uu____19594 =
+                                                 | uu____19566 ->
+                                                     let uu____19575 =
                                                        norm_cb cfg in
                                                      reduce_equality
-                                                       uu____19594 cfg env1
+                                                       uu____19575 cfg env1
                                                        tm1)))))))))
                   | FStar_Syntax_Syntax.Tm_app
                       ({
                          FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar
                            fv;
-                         FStar_Syntax_Syntax.pos = uu____19600;
-                         FStar_Syntax_Syntax.vars = uu____19601;_},
+                         FStar_Syntax_Syntax.pos = uu____19581;
+                         FStar_Syntax_Syntax.vars = uu____19582;_},
                        args)
                       ->
-                      let uu____19627 =
+                      let uu____19608 =
                         FStar_Syntax_Syntax.fv_eq_lid fv
                           FStar_Parser_Const.and_lid in
-                      if uu____19627
+                      if uu____19608
                       then
-                        let uu____19628 =
+                        let uu____19609 =
                           FStar_All.pipe_right args (FStar_List.map simplify) in
-                        (match uu____19628 with
-                         | (FStar_Pervasives_Native.Some (true), uu____19683)::
-                             (uu____19684, (arg, uu____19686))::[] ->
+                        (match uu____19609 with
+                         | (FStar_Pervasives_Native.Some (true), uu____19664)::
+                             (uu____19665, (arg, uu____19667))::[] ->
                              maybe_auto_squash arg
-                         | (uu____19751, (arg, uu____19753))::(FStar_Pervasives_Native.Some
+                         | (uu____19732, (arg, uu____19734))::(FStar_Pervasives_Native.Some
                                                                (true),
-                                                               uu____19754)::[]
+                                                               uu____19735)::[]
                              -> maybe_auto_squash arg
                          | (FStar_Pervasives_Native.Some (false),
-                            uu____19819)::uu____19820::[] ->
+                            uu____19800)::uu____19801::[] ->
                              w FStar_Syntax_Util.t_false
-                         | uu____19883::(FStar_Pervasives_Native.Some
-                                         (false), uu____19884)::[]
+                         | uu____19864::(FStar_Pervasives_Native.Some
+                                         (false), uu____19865)::[]
                              -> w FStar_Syntax_Util.t_false
-                         | uu____19947 ->
+                         | uu____19928 ->
                              squashed_head_un_auto_squash_args tm1)
                       else
-                        (let uu____19963 =
+                        (let uu____19944 =
                            FStar_Syntax_Syntax.fv_eq_lid fv
                              FStar_Parser_Const.or_lid in
-                         if uu____19963
+                         if uu____19944
                          then
-                           let uu____19964 =
+                           let uu____19945 =
                              FStar_All.pipe_right args
                                (FStar_List.map simplify) in
-                           match uu____19964 with
+                           match uu____19945 with
                            | (FStar_Pervasives_Native.Some (true),
-                              uu____20019)::uu____20020::[] ->
+                              uu____20000)::uu____20001::[] ->
                                w FStar_Syntax_Util.t_true
-                           | uu____20083::(FStar_Pervasives_Native.Some
-                                           (true), uu____20084)::[]
+                           | uu____20064::(FStar_Pervasives_Native.Some
+                                           (true), uu____20065)::[]
                                -> w FStar_Syntax_Util.t_true
                            | (FStar_Pervasives_Native.Some (false),
-                              uu____20147)::(uu____20148, (arg, uu____20150))::[]
+                              uu____20128)::(uu____20129, (arg, uu____20131))::[]
                                -> maybe_auto_squash arg
-                           | (uu____20215, (arg, uu____20217))::(FStar_Pervasives_Native.Some
+                           | (uu____20196, (arg, uu____20198))::(FStar_Pervasives_Native.Some
                                                                  (false),
-                                                                 uu____20218)::[]
+                                                                 uu____20199)::[]
                                -> maybe_auto_squash arg
-                           | uu____20283 ->
+                           | uu____20264 ->
                                squashed_head_un_auto_squash_args tm1
                          else
-                           (let uu____20299 =
+                           (let uu____20280 =
                               FStar_Syntax_Syntax.fv_eq_lid fv
                                 FStar_Parser_Const.imp_lid in
-                            if uu____20299
+                            if uu____20280
                             then
-                              let uu____20300 =
+                              let uu____20281 =
                                 FStar_All.pipe_right args
                                   (FStar_List.map simplify) in
-                              match uu____20300 with
-                              | uu____20355::(FStar_Pervasives_Native.Some
-                                              (true), uu____20356)::[]
+                              match uu____20281 with
+                              | uu____20336::(FStar_Pervasives_Native.Some
+                                              (true), uu____20337)::[]
                                   -> w FStar_Syntax_Util.t_true
                               | (FStar_Pervasives_Native.Some (false),
-                                 uu____20419)::uu____20420::[] ->
+                                 uu____20400)::uu____20401::[] ->
                                   w FStar_Syntax_Util.t_true
                               | (FStar_Pervasives_Native.Some (true),
-                                 uu____20483)::(uu____20484,
-                                                (arg, uu____20486))::[]
+                                 uu____20464)::(uu____20465,
+                                                (arg, uu____20467))::[]
                                   -> maybe_auto_squash arg
-                              | (uu____20551, (p, uu____20553))::(uu____20554,
+                              | (uu____20532, (p, uu____20534))::(uu____20535,
                                                                   (q,
-                                                                   uu____20556))::[]
+                                                                   uu____20537))::[]
                                   ->
-                                  let uu____20621 =
+                                  let uu____20602 =
                                     FStar_Syntax_Util.term_eq p q in
-                                  (if uu____20621
+                                  (if uu____20602
                                    then w FStar_Syntax_Util.t_true
                                    else squashed_head_un_auto_squash_args tm1)
-                              | uu____20623 ->
+                              | uu____20604 ->
                                   squashed_head_un_auto_squash_args tm1
                             else
-                              (let uu____20639 =
+                              (let uu____20620 =
                                  FStar_Syntax_Syntax.fv_eq_lid fv
                                    FStar_Parser_Const.iff_lid in
-                               if uu____20639
+                               if uu____20620
                                then
-                                 let uu____20640 =
+                                 let uu____20621 =
                                    FStar_All.pipe_right args
                                      (FStar_List.map simplify) in
-                                 match uu____20640 with
+                                 match uu____20621 with
                                  | (FStar_Pervasives_Native.Some (true),
-                                    uu____20695)::(FStar_Pervasives_Native.Some
-                                                   (true), uu____20696)::[]
+                                    uu____20676)::(FStar_Pervasives_Native.Some
+                                                   (true), uu____20677)::[]
                                      -> w FStar_Syntax_Util.t_true
                                  | (FStar_Pervasives_Native.Some (false),
-                                    uu____20761)::(FStar_Pervasives_Native.Some
-                                                   (false), uu____20762)::[]
+                                    uu____20742)::(FStar_Pervasives_Native.Some
+                                                   (false), uu____20743)::[]
                                      -> w FStar_Syntax_Util.t_true
                                  | (FStar_Pervasives_Native.Some (true),
-                                    uu____20827)::(FStar_Pervasives_Native.Some
-                                                   (false), uu____20828)::[]
+                                    uu____20808)::(FStar_Pervasives_Native.Some
+                                                   (false), uu____20809)::[]
                                      -> w FStar_Syntax_Util.t_false
                                  | (FStar_Pervasives_Native.Some (false),
-                                    uu____20893)::(FStar_Pervasives_Native.Some
-                                                   (true), uu____20894)::[]
+                                    uu____20874)::(FStar_Pervasives_Native.Some
+                                                   (true), uu____20875)::[]
                                      -> w FStar_Syntax_Util.t_false
-                                 | (uu____20959, (arg, uu____20961))::
+                                 | (uu____20940, (arg, uu____20942))::
                                      (FStar_Pervasives_Native.Some (true),
-                                      uu____20962)::[]
+                                      uu____20943)::[]
                                      -> maybe_auto_squash arg
                                  | (FStar_Pervasives_Native.Some (true),
-                                    uu____21027)::(uu____21028,
-                                                   (arg, uu____21030))::[]
+                                    uu____21008)::(uu____21009,
+                                                   (arg, uu____21011))::[]
                                      -> maybe_auto_squash arg
-                                 | (uu____21095, (arg, uu____21097))::
+                                 | (uu____21076, (arg, uu____21078))::
                                      (FStar_Pervasives_Native.Some (false),
-                                      uu____21098)::[]
+                                      uu____21079)::[]
                                      ->
-                                     let uu____21163 =
+                                     let uu____21144 =
                                        FStar_Syntax_Util.mk_neg arg in
-                                     maybe_auto_squash uu____21163
+                                     maybe_auto_squash uu____21144
                                  | (FStar_Pervasives_Native.Some (false),
-                                    uu____21164)::(uu____21165,
-                                                   (arg, uu____21167))::[]
+                                    uu____21145)::(uu____21146,
+                                                   (arg, uu____21148))::[]
                                      ->
-                                     let uu____21232 =
+                                     let uu____21213 =
                                        FStar_Syntax_Util.mk_neg arg in
-                                     maybe_auto_squash uu____21232
-                                 | (uu____21233, (p, uu____21235))::(uu____21236,
+                                     maybe_auto_squash uu____21213
+                                 | (uu____21214, (p, uu____21216))::(uu____21217,
                                                                     (q,
-                                                                    uu____21238))::[]
+                                                                    uu____21219))::[]
                                      ->
-                                     let uu____21303 =
+                                     let uu____21284 =
                                        FStar_Syntax_Util.term_eq p q in
-                                     (if uu____21303
+                                     (if uu____21284
                                       then w FStar_Syntax_Util.t_true
                                       else
                                         squashed_head_un_auto_squash_args tm1)
-                                 | uu____21305 ->
+                                 | uu____21286 ->
                                      squashed_head_un_auto_squash_args tm1
                                else
-                                 (let uu____21321 =
+                                 (let uu____21302 =
                                     FStar_Syntax_Syntax.fv_eq_lid fv
                                       FStar_Parser_Const.not_lid in
-                                  if uu____21321
+                                  if uu____21302
                                   then
-                                    let uu____21322 =
+                                    let uu____21303 =
                                       FStar_All.pipe_right args
                                         (FStar_List.map simplify) in
-                                    match uu____21322 with
+                                    match uu____21303 with
                                     | (FStar_Pervasives_Native.Some (true),
-                                       uu____21377)::[] ->
+                                       uu____21358)::[] ->
                                         w FStar_Syntax_Util.t_false
                                     | (FStar_Pervasives_Native.Some (false),
-                                       uu____21416)::[] ->
+                                       uu____21397)::[] ->
                                         w FStar_Syntax_Util.t_true
-                                    | uu____21455 ->
+                                    | uu____21436 ->
                                         squashed_head_un_auto_squash_args tm1
                                   else
-                                    (let uu____21471 =
+                                    (let uu____21452 =
                                        FStar_Syntax_Syntax.fv_eq_lid fv
                                          FStar_Parser_Const.forall_lid in
-                                     if uu____21471
+                                     if uu____21452
                                      then
                                        match args with
-                                       | (t, uu____21473)::[] ->
-                                           let uu____21498 =
-                                             let uu____21499 =
+                                       | (t, uu____21454)::[] ->
+                                           let uu____21479 =
+                                             let uu____21480 =
                                                FStar_Syntax_Subst.compress t in
-                                             uu____21499.FStar_Syntax_Syntax.n in
-                                           (match uu____21498 with
+                                             uu____21480.FStar_Syntax_Syntax.n in
+                                           (match uu____21479 with
                                             | FStar_Syntax_Syntax.Tm_abs
-                                                (uu____21502::[], body,
-                                                 uu____21504)
+                                                (uu____21483::[], body,
+                                                 uu____21485)
                                                 ->
-                                                let uu____21539 = simp_t body in
-                                                (match uu____21539 with
+                                                let uu____21520 = simp_t body in
+                                                (match uu____21520 with
                                                  | FStar_Pervasives_Native.Some
                                                      (true) ->
                                                      w
                                                        FStar_Syntax_Util.t_true
-                                                 | uu____21542 -> tm1)
-                                            | uu____21545 -> tm1)
+                                                 | uu____21523 -> tm1)
+                                            | uu____21526 -> tm1)
                                        | (ty, FStar_Pervasives_Native.Some
                                           (FStar_Syntax_Syntax.Implicit
-                                          uu____21547))::(t, uu____21549)::[]
+                                          uu____21528))::(t, uu____21530)::[]
                                            ->
-                                           let uu____21588 =
-                                             let uu____21589 =
+                                           let uu____21569 =
+                                             let uu____21570 =
                                                FStar_Syntax_Subst.compress t in
-                                             uu____21589.FStar_Syntax_Syntax.n in
-                                           (match uu____21588 with
+                                             uu____21570.FStar_Syntax_Syntax.n in
+                                           (match uu____21569 with
                                             | FStar_Syntax_Syntax.Tm_abs
-                                                (uu____21592::[], body,
-                                                 uu____21594)
+                                                (uu____21573::[], body,
+                                                 uu____21575)
                                                 ->
-                                                let uu____21629 = simp_t body in
-                                                (match uu____21629 with
+                                                let uu____21610 = simp_t body in
+                                                (match uu____21610 with
                                                  | FStar_Pervasives_Native.Some
                                                      (true) ->
                                                      w
@@ -6598,53 +6597,53 @@ and (maybe_simplify_aux :
                                                      clearly_inhabited ty ->
                                                      w
                                                        FStar_Syntax_Util.t_false
-                                                 | uu____21632 -> tm1)
-                                            | uu____21635 -> tm1)
-                                       | uu____21636 -> tm1
+                                                 | uu____21613 -> tm1)
+                                            | uu____21616 -> tm1)
+                                       | uu____21617 -> tm1
                                      else
-                                       (let uu____21648 =
+                                       (let uu____21629 =
                                           FStar_Syntax_Syntax.fv_eq_lid fv
                                             FStar_Parser_Const.exists_lid in
-                                        if uu____21648
+                                        if uu____21629
                                         then
                                           match args with
-                                          | (t, uu____21650)::[] ->
-                                              let uu____21675 =
-                                                let uu____21676 =
+                                          | (t, uu____21631)::[] ->
+                                              let uu____21656 =
+                                                let uu____21657 =
                                                   FStar_Syntax_Subst.compress
                                                     t in
-                                                uu____21676.FStar_Syntax_Syntax.n in
-                                              (match uu____21675 with
+                                                uu____21657.FStar_Syntax_Syntax.n in
+                                              (match uu____21656 with
                                                | FStar_Syntax_Syntax.Tm_abs
-                                                   (uu____21679::[], body,
-                                                    uu____21681)
+                                                   (uu____21660::[], body,
+                                                    uu____21662)
                                                    ->
-                                                   let uu____21716 =
+                                                   let uu____21697 =
                                                      simp_t body in
-                                                   (match uu____21716 with
+                                                   (match uu____21697 with
                                                     | FStar_Pervasives_Native.Some
                                                         (false) ->
                                                         w
                                                           FStar_Syntax_Util.t_false
-                                                    | uu____21719 -> tm1)
-                                               | uu____21722 -> tm1)
+                                                    | uu____21700 -> tm1)
+                                               | uu____21703 -> tm1)
                                           | (ty, FStar_Pervasives_Native.Some
                                              (FStar_Syntax_Syntax.Implicit
-                                             uu____21724))::(t, uu____21726)::[]
+                                             uu____21705))::(t, uu____21707)::[]
                                               ->
-                                              let uu____21765 =
-                                                let uu____21766 =
+                                              let uu____21746 =
+                                                let uu____21747 =
                                                   FStar_Syntax_Subst.compress
                                                     t in
-                                                uu____21766.FStar_Syntax_Syntax.n in
-                                              (match uu____21765 with
+                                                uu____21747.FStar_Syntax_Syntax.n in
+                                              (match uu____21746 with
                                                | FStar_Syntax_Syntax.Tm_abs
-                                                   (uu____21769::[], body,
-                                                    uu____21771)
+                                                   (uu____21750::[], body,
+                                                    uu____21752)
                                                    ->
-                                                   let uu____21806 =
+                                                   let uu____21787 =
                                                      simp_t body in
-                                                   (match uu____21806 with
+                                                   (match uu____21787 with
                                                     | FStar_Pervasives_Native.Some
                                                         (false) ->
                                                         w
@@ -6655,14 +6654,14 @@ and (maybe_simplify_aux :
                                                         ->
                                                         w
                                                           FStar_Syntax_Util.t_true
-                                                    | uu____21809 -> tm1)
-                                               | uu____21812 -> tm1)
-                                          | uu____21813 -> tm1
+                                                    | uu____21790 -> tm1)
+                                               | uu____21793 -> tm1)
+                                          | uu____21794 -> tm1
                                         else
-                                          (let uu____21825 =
+                                          (let uu____21806 =
                                              FStar_Syntax_Syntax.fv_eq_lid fv
                                                FStar_Parser_Const.b2t_lid in
-                                           if uu____21825
+                                           if uu____21806
                                            then
                                              match args with
                                              | ({
@@ -6671,10 +6670,10 @@ and (maybe_simplify_aux :
                                                     (FStar_Const.Const_bool
                                                     (true));
                                                   FStar_Syntax_Syntax.pos =
-                                                    uu____21826;
+                                                    uu____21807;
                                                   FStar_Syntax_Syntax.vars =
-                                                    uu____21827;_},
-                                                uu____21828)::[] ->
+                                                    uu____21808;_},
+                                                uu____21809)::[] ->
                                                  w FStar_Syntax_Util.t_true
                                              | ({
                                                   FStar_Syntax_Syntax.n =
@@ -6682,18 +6681,18 @@ and (maybe_simplify_aux :
                                                     (FStar_Const.Const_bool
                                                     (false));
                                                   FStar_Syntax_Syntax.pos =
-                                                    uu____21853;
+                                                    uu____21834;
                                                   FStar_Syntax_Syntax.vars =
-                                                    uu____21854;_},
-                                                uu____21855)::[] ->
+                                                    uu____21835;_},
+                                                uu____21836)::[] ->
                                                  w FStar_Syntax_Util.t_false
-                                             | uu____21880 -> tm1
+                                             | uu____21861 -> tm1
                                            else
-                                             (let uu____21892 =
+                                             (let uu____21873 =
                                                 FStar_Syntax_Syntax.fv_eq_lid
                                                   fv
                                                   FStar_Parser_Const.haseq_lid in
-                                              if uu____21892
+                                              if uu____21873
                                               then
                                                 let t_has_eq_for_sure t =
                                                   let haseq_lids =
@@ -6701,12 +6700,12 @@ and (maybe_simplify_aux :
                                                     FStar_Parser_Const.bool_lid;
                                                     FStar_Parser_Const.unit_lid;
                                                     FStar_Parser_Const.string_lid] in
-                                                  let uu____21902 =
-                                                    let uu____21903 =
+                                                  let uu____21883 =
+                                                    let uu____21884 =
                                                       FStar_Syntax_Subst.compress
                                                         t in
-                                                    uu____21903.FStar_Syntax_Syntax.n in
-                                                  match uu____21902 with
+                                                    uu____21884.FStar_Syntax_Syntax.n in
+                                                  match uu____21883 with
                                                   | FStar_Syntax_Syntax.Tm_fvar
                                                       fv1 when
                                                       FStar_All.pipe_right
@@ -6716,82 +6715,82 @@ and (maybe_simplify_aux :
                                                               FStar_Syntax_Syntax.fv_eq_lid
                                                                 fv1 l))
                                                       -> true
-                                                  | uu____21911 -> false in
+                                                  | uu____21892 -> false in
                                                 (if
                                                    (FStar_List.length args) =
                                                      Prims.int_one
                                                  then
                                                    let t =
-                                                     let uu____21921 =
+                                                     let uu____21902 =
                                                        FStar_All.pipe_right
                                                          args FStar_List.hd in
                                                      FStar_All.pipe_right
-                                                       uu____21921
+                                                       uu____21902
                                                        FStar_Pervasives_Native.fst in
-                                                   let uu____21956 =
+                                                   let uu____21941 =
                                                      FStar_All.pipe_right t
                                                        t_has_eq_for_sure in
-                                                   (if uu____21956
+                                                   (if uu____21941
                                                     then
                                                       w
                                                         FStar_Syntax_Util.t_true
                                                     else
-                                                      (let uu____21958 =
-                                                         let uu____21959 =
+                                                      (let uu____21943 =
+                                                         let uu____21944 =
                                                            FStar_Syntax_Subst.compress
                                                              t in
-                                                         uu____21959.FStar_Syntax_Syntax.n in
-                                                       match uu____21958 with
+                                                         uu____21944.FStar_Syntax_Syntax.n in
+                                                       match uu____21943 with
                                                        | FStar_Syntax_Syntax.Tm_refine
-                                                           uu____21962 ->
+                                                           uu____21947 ->
                                                            let t1 =
                                                              FStar_Syntax_Util.unrefine
                                                                t in
-                                                           let uu____21970 =
+                                                           let uu____21955 =
                                                              FStar_All.pipe_right
                                                                t1
                                                                t_has_eq_for_sure in
-                                                           if uu____21970
+                                                           if uu____21955
                                                            then
                                                              w
                                                                FStar_Syntax_Util.t_true
                                                            else
                                                              (let haseq_tm =
-                                                                let uu____21975
+                                                                let uu____21960
                                                                   =
-                                                                  let uu____21976
+                                                                  let uu____21961
                                                                     =
                                                                     FStar_Syntax_Subst.compress
                                                                     tm1 in
-                                                                  uu____21976.FStar_Syntax_Syntax.n in
-                                                                match uu____21975
+                                                                  uu____21961.FStar_Syntax_Syntax.n in
+                                                                match uu____21960
                                                                 with
                                                                 | FStar_Syntax_Syntax.Tm_app
                                                                     (hd,
-                                                                    uu____21982)
+                                                                    uu____21967)
                                                                     -> hd
-                                                                | uu____22007
+                                                                | uu____21992
                                                                     ->
                                                                     failwith
                                                                     "Impossible! We have already checked that this is a Tm_app" in
-                                                              let uu____22010
+                                                              let uu____21995
                                                                 =
-                                                                let uu____22021
+                                                                let uu____22006
                                                                   =
                                                                   FStar_All.pipe_right
                                                                     t1
                                                                     FStar_Syntax_Syntax.as_arg in
-                                                                [uu____22021] in
+                                                                [uu____22006] in
                                                               FStar_Syntax_Util.mk_app
                                                                 haseq_tm
-                                                                uu____22010)
-                                                       | uu____22054 -> tm1))
+                                                                uu____21995)
+                                                       | uu____22039 -> tm1))
                                                  else tm1)
                                               else
-                                                (let uu____22057 =
+                                                (let uu____22042 =
                                                    FStar_Syntax_Util.is_auto_squash
                                                      tm1 in
-                                                 match uu____22057 with
+                                                 match uu____22042 with
                                                  | FStar_Pervasives_Native.Some
                                                      (FStar_Syntax_Syntax.U_zero,
                                                       t)
@@ -6799,28 +6798,28 @@ and (maybe_simplify_aux :
                                                      FStar_Syntax_Util.is_sub_singleton
                                                        t
                                                      -> t
-                                                 | uu____22077 ->
-                                                     let uu____22086 =
+                                                 | uu____22062 ->
+                                                     let uu____22071 =
                                                        norm_cb cfg in
                                                      reduce_equality
-                                                       uu____22086 cfg env1
+                                                       uu____22071 cfg env1
                                                        tm1)))))))))
                   | FStar_Syntax_Syntax.Tm_refine (bv, t) ->
-                      let uu____22097 = simp_t t in
-                      (match uu____22097 with
+                      let uu____22082 = simp_t t in
+                      (match uu____22082 with
                        | FStar_Pervasives_Native.Some (true) ->
                            bv.FStar_Syntax_Syntax.sort
                        | FStar_Pervasives_Native.Some (false) -> tm1
                        | FStar_Pervasives_Native.None -> tm1)
-                  | FStar_Syntax_Syntax.Tm_match uu____22100 ->
-                      let uu____22123 = is_const_match tm1 in
-                      (match uu____22123 with
+                  | FStar_Syntax_Syntax.Tm_match uu____22085 ->
+                      let uu____22108 = is_const_match tm1 in
+                      (match uu____22108 with
                        | FStar_Pervasives_Native.Some (true) ->
                            w FStar_Syntax_Util.t_true
                        | FStar_Pervasives_Native.Some (false) ->
                            w FStar_Syntax_Util.t_false
                        | FStar_Pervasives_Native.None -> tm1)
-                  | uu____22126 -> tm1))
+                  | uu____22111 -> tm1))
 and (rebuild :
   FStar_TypeChecker_Cfg.cfg ->
     env -> stack -> FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term)
@@ -6830,52 +6829,52 @@ and (rebuild :
       fun stack1 ->
         fun t ->
           FStar_TypeChecker_Cfg.log cfg
-            (fun uu____22136 ->
-               (let uu____22138 = FStar_Syntax_Print.tag_of_term t in
-                let uu____22139 = FStar_Syntax_Print.term_to_string t in
-                let uu____22140 =
+            (fun uu____22121 ->
+               (let uu____22123 = FStar_Syntax_Print.tag_of_term t in
+                let uu____22124 = FStar_Syntax_Print.term_to_string t in
+                let uu____22125 =
                   FStar_Util.string_of_int (FStar_List.length env1) in
-                let uu____22147 =
-                  let uu____22148 =
-                    let uu____22151 = firstn (Prims.of_int (4)) stack1 in
+                let uu____22132 =
+                  let uu____22133 =
+                    let uu____22136 = firstn (Prims.of_int (4)) stack1 in
                     FStar_All.pipe_left FStar_Pervasives_Native.fst
-                      uu____22151 in
-                  stack_to_string uu____22148 in
+                      uu____22136 in
+                  stack_to_string uu____22133 in
                 FStar_Util.print4
                   ">>> %s\nRebuild %s with %s env elements and top of the stack %s \n"
-                  uu____22138 uu____22139 uu____22140 uu____22147);
-               (let uu____22174 =
+                  uu____22123 uu____22124 uu____22125 uu____22132);
+               (let uu____22159 =
                   FStar_TypeChecker_Env.debug cfg.FStar_TypeChecker_Cfg.tcenv
                     (FStar_Options.Other "NormRebuild") in
-                if uu____22174
+                if uu____22159
                 then
-                  let uu____22175 = FStar_Syntax_Util.unbound_variables t in
-                  match uu____22175 with
+                  let uu____22160 = FStar_Syntax_Util.unbound_variables t in
+                  match uu____22160 with
                   | [] -> ()
                   | bvs ->
-                      ((let uu____22182 = FStar_Syntax_Print.tag_of_term t in
-                        let uu____22183 = FStar_Syntax_Print.term_to_string t in
-                        let uu____22184 =
-                          let uu____22185 =
+                      ((let uu____22167 = FStar_Syntax_Print.tag_of_term t in
+                        let uu____22168 = FStar_Syntax_Print.term_to_string t in
+                        let uu____22169 =
+                          let uu____22170 =
                             FStar_All.pipe_right bvs
                               (FStar_List.map FStar_Syntax_Print.bv_to_string) in
-                          FStar_All.pipe_right uu____22185
+                          FStar_All.pipe_right uu____22170
                             (FStar_String.concat ", ") in
                         FStar_Util.print3
-                          "!!! Rebuild (%s) %s, free vars=%s\n" uu____22182
-                          uu____22183 uu____22184);
+                          "!!! Rebuild (%s) %s, free vars=%s\n" uu____22167
+                          uu____22168 uu____22169);
                        failwith "DIE!")
                 else ()));
           (let f_opt = is_fext_on_domain t in
-           let uu____22198 =
+           let uu____22183 =
              (FStar_All.pipe_right f_opt FStar_Util.is_some) &&
                (match stack1 with
-                | (Arg uu____22203)::uu____22204 -> true
-                | uu____22213 -> false) in
-           if uu____22198
+                | (Arg uu____22188)::uu____22189 -> true
+                | uu____22198 -> false) in
+           if uu____22183
            then
-             let uu____22214 = FStar_All.pipe_right f_opt FStar_Util.must in
-             FStar_All.pipe_right uu____22214 (norm cfg env1 stack1)
+             let uu____22199 = FStar_All.pipe_right f_opt FStar_Util.must in
+             FStar_All.pipe_right uu____22199 (norm cfg env1 stack1)
            else
              (let t1 = maybe_simplify cfg env1 stack1 t in
               match stack1 with
@@ -6885,23 +6884,23 @@ and (rebuild :
                      (cfg.FStar_TypeChecker_Cfg.debug).FStar_TypeChecker_Cfg.print_normalized
                    then
                      (let time_now = FStar_Util.now () in
-                      let uu____22226 =
-                        let uu____22227 =
-                          let uu____22228 =
+                      let uu____22211 =
+                        let uu____22212 =
+                          let uu____22213 =
                             FStar_Util.time_diff time_then time_now in
-                          FStar_Pervasives_Native.snd uu____22228 in
-                        FStar_Util.string_of_int uu____22227 in
-                      let uu____22233 = FStar_Syntax_Print.term_to_string tm in
-                      let uu____22234 =
+                          FStar_Pervasives_Native.snd uu____22213 in
+                        FStar_Util.string_of_int uu____22212 in
+                      let uu____22218 = FStar_Syntax_Print.term_to_string tm in
+                      let uu____22219 =
                         FStar_TypeChecker_Cfg.cfg_to_string cfg in
-                      let uu____22235 = FStar_Syntax_Print.term_to_string t1 in
+                      let uu____22220 = FStar_Syntax_Print.term_to_string t1 in
                       FStar_Util.print4
                         "Normalizer result timing (%s ms){\nOn term {\n%s\n}\nwith steps {%s}\nresult is{\n\n%s\n}\n}\n"
-                        uu____22226 uu____22233 uu____22234 uu____22235)
+                        uu____22211 uu____22218 uu____22219 uu____22220)
                    else ();
                    rebuild cfg env1 stack2 t1)
               | (Cfg cfg1)::stack2 -> rebuild cfg1 env1 stack2 t1
-              | (Meta (uu____22241, m, r))::stack2 ->
+              | (Meta (uu____22226, m, r))::stack2 ->
                   let t2 =
                     FStar_Syntax_Syntax.mk
                       (FStar_Syntax_Syntax.Tm_meta (t1, m)) r in
@@ -6909,10 +6908,10 @@ and (rebuild :
               | (MemoLazy r)::stack2 ->
                   (set_memo cfg r (env1, t1);
                    FStar_TypeChecker_Cfg.log cfg
-                     (fun uu____22270 ->
-                        let uu____22271 =
+                     (fun uu____22255 ->
+                        let uu____22256 =
                           FStar_Syntax_Print.term_to_string t1 in
-                        FStar_Util.print1 "\tSet memo %s\n" uu____22271);
+                        FStar_Util.print1 "\tSet memo %s\n" uu____22256);
                    rebuild cfg env1 stack2 t1)
               | (Let (env', bs, lb, r))::stack2 ->
                   let body = FStar_Syntax_Subst.close bs t1 in
@@ -6923,52 +6922,52 @@ and (rebuild :
               | (Abs (env', bs, env'', lopt, r))::stack2 ->
                   let bs1 = norm_binders cfg env' bs in
                   let lopt1 = norm_lcomp_opt cfg env'' lopt in
-                  let uu____22309 =
-                    let uu___2855_22310 = FStar_Syntax_Util.abs bs1 t1 lopt1 in
+                  let uu____22294 =
+                    let uu___2855_22295 = FStar_Syntax_Util.abs bs1 t1 lopt1 in
                     {
                       FStar_Syntax_Syntax.n =
-                        (uu___2855_22310.FStar_Syntax_Syntax.n);
+                        (uu___2855_22295.FStar_Syntax_Syntax.n);
                       FStar_Syntax_Syntax.pos = r;
                       FStar_Syntax_Syntax.vars =
-                        (uu___2855_22310.FStar_Syntax_Syntax.vars)
+                        (uu___2855_22295.FStar_Syntax_Syntax.vars)
                     } in
-                  rebuild cfg env1 stack2 uu____22309
+                  rebuild cfg env1 stack2 uu____22294
               | (Arg
-                  (Univ uu____22313, uu____22314, uu____22315))::uu____22316
+                  (Univ uu____22298, uu____22299, uu____22300))::uu____22301
                   -> failwith "Impossible"
-              | (Arg (Dummy, uu____22319, uu____22320))::uu____22321 ->
+              | (Arg (Dummy, uu____22304, uu____22305))::uu____22306 ->
                   failwith "Impossible"
               | (UnivArgs (us, r))::stack2 ->
                   let t2 = FStar_Syntax_Syntax.mk_Tm_uinst t1 us in
                   rebuild cfg env1 stack2 t2
               | (Arg
-                  (Clos (env_arg, tm, uu____22336, uu____22337), aq, r))::stack2
+                  (Clos (env_arg, tm, uu____22321, uu____22322), aq, r))::stack2
                   when
-                  let uu____22387 = head_of t1 in
-                  FStar_Syntax_Util.is_fstar_tactics_by_tactic uu____22387 ->
+                  let uu____22372 = head_of t1 in
+                  FStar_Syntax_Util.is_fstar_tactics_by_tactic uu____22372 ->
                   let t2 =
-                    let uu____22389 =
-                      let uu____22390 = closure_as_term cfg env_arg tm in
-                      (uu____22390, aq) in
-                    FStar_Syntax_Syntax.extend_app t1 uu____22389 r in
+                    let uu____22374 =
+                      let uu____22375 = closure_as_term cfg env_arg tm in
+                      (uu____22375, aq) in
+                    FStar_Syntax_Syntax.extend_app t1 uu____22374 r in
                   rebuild cfg env1 stack2 t2
-              | (Arg (Clos (env_arg, tm, m, uu____22400), aq, r))::stack2 ->
+              | (Arg (Clos (env_arg, tm, m, uu____22385), aq, r))::stack2 ->
                   (FStar_TypeChecker_Cfg.log cfg
-                     (fun uu____22453 ->
-                        let uu____22454 =
+                     (fun uu____22438 ->
+                        let uu____22439 =
                           FStar_Syntax_Print.term_to_string tm in
                         FStar_Util.print1 "Rebuilding with arg %s\n"
-                          uu____22454);
+                          uu____22439);
                    if
                      Prims.op_Negation
                        (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.iota
                    then
-                     (let uu____22455 =
+                     (let uu____22440 =
                         (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.hnf
                           &&
-                          (let uu____22457 = is_partial_primop_app cfg t1 in
-                           Prims.op_Negation uu____22457) in
-                      if uu____22455
+                          (let uu____22442 = is_partial_primop_app cfg t1 in
+                           Prims.op_Negation uu____22442) in
+                      if uu____22440
                       then
                         let arg = closure_as_term cfg env_arg tm in
                         let t2 =
@@ -6978,15 +6977,15 @@ and (rebuild :
                         (let stack3 = (App (env1, t1, aq, r)) :: stack2 in
                          norm cfg env_arg stack3 tm))
                    else
-                     (let uu____22469 = FStar_ST.op_Bang m in
-                      match uu____22469 with
+                     (let uu____22454 = FStar_ST.op_Bang m in
+                      match uu____22454 with
                       | FStar_Pervasives_Native.None ->
-                          let uu____22530 =
+                          let uu____22515 =
                             (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.hnf
                               &&
-                              (let uu____22532 = is_partial_primop_app cfg t1 in
-                               Prims.op_Negation uu____22532) in
-                          if uu____22530
+                              (let uu____22517 = is_partial_primop_app cfg t1 in
+                               Prims.op_Negation uu____22517) in
+                          if uu____22515
                           then
                             let arg = closure_as_term cfg env_arg tm in
                             let t2 =
@@ -6996,64 +6995,64 @@ and (rebuild :
                             (let stack3 = (MemoLazy m) ::
                                (App (env1, t1, aq, r)) :: stack2 in
                              norm cfg env_arg stack3 tm)
-                      | FStar_Pervasives_Native.Some (uu____22543, a) ->
+                      | FStar_Pervasives_Native.Some (uu____22528, a) ->
                           let t2 =
                             FStar_Syntax_Syntax.extend_app t1 (a, aq) r in
                           rebuild cfg env_arg stack2 t2))
               | (App (env2, head, aq, r))::stack' when
                   should_reify cfg stack1 ->
                   let t0 = t1 in
-                  let fallback msg uu____22596 =
+                  let fallback msg uu____22581 =
                     FStar_TypeChecker_Cfg.log cfg
-                      (fun uu____22600 ->
-                         let uu____22601 =
+                      (fun uu____22585 ->
+                         let uu____22586 =
                            FStar_Syntax_Print.term_to_string t1 in
                          FStar_Util.print2 "Not reifying%s: %s\n" msg
-                           uu____22601);
+                           uu____22586);
                     (let t2 = FStar_Syntax_Syntax.extend_app head (t1, aq) r in
                      rebuild cfg env2 stack' t2) in
                   let is_layered_effect m =
-                    let uu____22613 =
+                    let uu____22598 =
                       FStar_All.pipe_right m
                         (FStar_TypeChecker_Env.norm_eff_name
                            cfg.FStar_TypeChecker_Cfg.tcenv) in
-                    FStar_All.pipe_right uu____22613
+                    FStar_All.pipe_right uu____22598
                       (FStar_TypeChecker_Env.is_layered_effect
                          cfg.FStar_TypeChecker_Cfg.tcenv) in
-                  let uu____22614 =
-                    let uu____22615 = FStar_Syntax_Subst.compress t1 in
-                    uu____22615.FStar_Syntax_Syntax.n in
-                  (match uu____22614 with
+                  let uu____22599 =
+                    let uu____22600 = FStar_Syntax_Subst.compress t1 in
+                    uu____22600.FStar_Syntax_Syntax.n in
+                  (match uu____22599 with
                    | FStar_Syntax_Syntax.Tm_meta
-                       (uu____22618, FStar_Syntax_Syntax.Meta_monadic
-                        (m, uu____22620))
+                       (uu____22603, FStar_Syntax_Syntax.Meta_monadic
+                        (m, uu____22605))
                        when
                        (FStar_All.pipe_right m is_layered_effect) &&
                          (Prims.op_Negation
                             (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.for_extraction)
                        ->
-                       let uu____22629 =
-                         let uu____22630 = FStar_Ident.string_of_lid m in
+                       let uu____22614 =
+                         let uu____22615 = FStar_Ident.string_of_lid m in
                          FStar_Util.format1
                            "Meta_monadic for a layered effect %s in non-extraction mode"
-                           uu____22630 in
-                       fallback uu____22629 ()
+                           uu____22615 in
+                       fallback uu____22614 ()
                    | FStar_Syntax_Syntax.Tm_meta
-                       (uu____22631, FStar_Syntax_Syntax.Meta_monadic_lift
-                        (msrc, mtgt, uu____22634))
+                       (uu____22616, FStar_Syntax_Syntax.Meta_monadic_lift
+                        (msrc, mtgt, uu____22619))
                        when
                        ((is_layered_effect msrc) || (is_layered_effect mtgt))
                          &&
                          (Prims.op_Negation
                             (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.for_extraction)
                        ->
-                       let uu____22643 =
-                         let uu____22644 = FStar_Ident.string_of_lid msrc in
-                         let uu____22645 = FStar_Ident.string_of_lid mtgt in
+                       let uu____22628 =
+                         let uu____22629 = FStar_Ident.string_of_lid msrc in
+                         let uu____22630 = FStar_Ident.string_of_lid mtgt in
                          FStar_Util.format2
                            "Meta_monadic_lift for layered effect %s ~> %s in non extraction mode"
-                           uu____22644 uu____22645 in
-                       fallback uu____22643 ()
+                           uu____22629 uu____22630 in
+                       fallback uu____22628 ()
                    | FStar_Syntax_Syntax.Tm_meta
                        (t2, FStar_Syntax_Syntax.Meta_monadic (m, ty)) ->
                        do_reify_monadic (fallback " (1)") cfg env2 stack1 t2
@@ -7063,109 +7062,109 @@ and (rebuild :
                         (msrc, mtgt, ty))
                        ->
                        let lifted =
-                         let uu____22670 = closure_as_term cfg env2 ty in
-                         reify_lift cfg t2 msrc mtgt uu____22670 in
+                         let uu____22655 = closure_as_term cfg env2 ty in
+                         reify_lift cfg t2 msrc mtgt uu____22655 in
                        (FStar_TypeChecker_Cfg.log cfg
-                          (fun uu____22674 ->
-                             let uu____22675 =
+                          (fun uu____22659 ->
+                             let uu____22660 =
                                FStar_Syntax_Print.term_to_string lifted in
                              FStar_Util.print1 "Reified lift to (1): %s\n"
-                               uu____22675);
-                        (let uu____22676 = FStar_List.tl stack1 in
-                         norm cfg env2 uu____22676 lifted))
+                               uu____22660);
+                        (let uu____22661 = FStar_List.tl stack1 in
+                         norm cfg env2 uu____22661 lifted))
                    | FStar_Syntax_Syntax.Tm_app
                        ({
                           FStar_Syntax_Syntax.n =
                             FStar_Syntax_Syntax.Tm_constant
-                            (FStar_Const.Const_reflect uu____22677);
-                          FStar_Syntax_Syntax.pos = uu____22678;
-                          FStar_Syntax_Syntax.vars = uu____22679;_},
-                        (e, uu____22681)::[])
+                            (FStar_Const.Const_reflect uu____22662);
+                          FStar_Syntax_Syntax.pos = uu____22663;
+                          FStar_Syntax_Syntax.vars = uu____22664;_},
+                        (e, uu____22666)::[])
                        -> norm cfg env2 stack' e
-                   | FStar_Syntax_Syntax.Tm_app uu____22720 when
+                   | FStar_Syntax_Syntax.Tm_app uu____22705 when
                        (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.primops
                        ->
-                       let uu____22737 = FStar_Syntax_Util.head_and_args t1 in
-                       (match uu____22737 with
+                       let uu____22722 = FStar_Syntax_Util.head_and_args t1 in
+                       (match uu____22722 with
                         | (hd, args) ->
-                            let uu____22780 =
-                              let uu____22781 = FStar_Syntax_Util.un_uinst hd in
-                              uu____22781.FStar_Syntax_Syntax.n in
-                            (match uu____22780 with
+                            let uu____22765 =
+                              let uu____22766 = FStar_Syntax_Util.un_uinst hd in
+                              uu____22766.FStar_Syntax_Syntax.n in
+                            (match uu____22765 with
                              | FStar_Syntax_Syntax.Tm_fvar fv ->
-                                 let uu____22785 =
+                                 let uu____22770 =
                                    FStar_TypeChecker_Cfg.find_prim_step cfg
                                      fv in
-                                 (match uu____22785 with
+                                 (match uu____22770 with
                                   | FStar_Pervasives_Native.Some
                                       {
                                         FStar_TypeChecker_Cfg.name =
-                                          uu____22788;
+                                          uu____22773;
                                         FStar_TypeChecker_Cfg.arity =
-                                          uu____22789;
+                                          uu____22774;
                                         FStar_TypeChecker_Cfg.univ_arity =
-                                          uu____22790;
+                                          uu____22775;
                                         FStar_TypeChecker_Cfg.auto_reflect =
                                           FStar_Pervasives_Native.Some n;
                                         FStar_TypeChecker_Cfg.strong_reduction_ok
-                                          = uu____22792;
+                                          = uu____22777;
                                         FStar_TypeChecker_Cfg.requires_binder_substitution
-                                          = uu____22793;
+                                          = uu____22778;
                                         FStar_TypeChecker_Cfg.interpretation
-                                          = uu____22794;
+                                          = uu____22779;
                                         FStar_TypeChecker_Cfg.interpretation_nbe
-                                          = uu____22795;_}
+                                          = uu____22780;_}
                                       when (FStar_List.length args) = n ->
                                       norm cfg env2 stack' t1
-                                  | uu____22824 -> fallback " (3)" ())
-                             | uu____22827 -> fallback " (4)" ()))
-                   | uu____22828 -> fallback " (2)" ())
+                                  | uu____22809 -> fallback " (3)" ())
+                             | uu____22812 -> fallback " (4)" ()))
+                   | uu____22813 -> fallback " (2)" ())
               | (App (env2, head, aq, r))::stack2 ->
                   let t2 = FStar_Syntax_Syntax.extend_app head (t1, aq) r in
                   rebuild cfg env2 stack2 t2
               | (CBVApp (env', head, aq, r))::stack2 ->
-                  let uu____22848 =
-                    let uu____22849 =
-                      let uu____22850 =
-                        let uu____22857 =
-                          let uu____22858 =
-                            let uu____22889 =
+                  let uu____22833 =
+                    let uu____22834 =
+                      let uu____22835 =
+                        let uu____22842 =
+                          let uu____22843 =
+                            let uu____22874 =
                               FStar_Util.mk_ref FStar_Pervasives_Native.None in
-                            (env1, t1, uu____22889, false) in
-                          Clos uu____22858 in
-                        (uu____22857, aq, (t1.FStar_Syntax_Syntax.pos)) in
-                      Arg uu____22850 in
-                    uu____22849 :: stack2 in
-                  norm cfg env' uu____22848 head
+                            (env1, t1, uu____22874, false) in
+                          Clos uu____22843 in
+                        (uu____22842, aq, (t1.FStar_Syntax_Syntax.pos)) in
+                      Arg uu____22835 in
+                    uu____22834 :: stack2 in
+                  norm cfg env' uu____22833 head
               | (Match (env', branches1, cfg1, r))::stack2 ->
                   (FStar_TypeChecker_Cfg.log cfg1
-                     (fun uu____22962 ->
-                        let uu____22963 =
+                     (fun uu____22947 ->
+                        let uu____22948 =
                           FStar_Syntax_Print.term_to_string t1 in
                         FStar_Util.print1
                           "Rebuilding with match, scrutinee is %s ...\n"
-                          uu____22963);
+                          uu____22948);
                    (let scrutinee_env = env1 in
                     let env2 = env' in
                     let scrutinee = t1 in
-                    let norm_and_rebuild_match uu____22972 =
+                    let norm_and_rebuild_match uu____22957 =
                       FStar_TypeChecker_Cfg.log cfg1
-                        (fun uu____22977 ->
-                           let uu____22978 =
+                        (fun uu____22962 ->
+                           let uu____22963 =
                              FStar_Syntax_Print.term_to_string scrutinee in
-                           let uu____22979 =
-                             let uu____22980 =
+                           let uu____22964 =
+                             let uu____22965 =
                                FStar_All.pipe_right branches1
                                  (FStar_List.map
-                                    (fun uu____23007 ->
-                                       match uu____23007 with
-                                       | (p, uu____23017, uu____23018) ->
+                                    (fun uu____22992 ->
+                                       match uu____22992 with
+                                       | (p, uu____23002, uu____23003) ->
                                            FStar_Syntax_Print.pat_to_string p)) in
-                             FStar_All.pipe_right uu____22980
+                             FStar_All.pipe_right uu____22965
                                (FStar_String.concat "\n\t") in
                            FStar_Util.print2
                              "match is irreducible: scrutinee=%s\nbranches=%s\n"
-                             uu____22978 uu____22979);
+                             uu____22963 uu____22964);
                       (let whnf =
                          (cfg1.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.weak
                            ||
@@ -7179,91 +7178,91 @@ and (rebuild :
                               FStar_All.pipe_right
                                 cfg1.FStar_TypeChecker_Cfg.delta_level
                                 (FStar_List.filter
-                                   (fun uu___16_23036 ->
-                                      match uu___16_23036 with
+                                   (fun uu___16_23021 ->
+                                      match uu___16_23021 with
                                       | FStar_TypeChecker_Env.InliningDelta
                                           -> true
                                       | FStar_TypeChecker_Env.Eager_unfolding_only
                                           -> true
-                                      | uu____23037 -> false)) in
+                                      | uu____23022 -> false)) in
                             let steps =
-                              let uu___3049_23039 =
+                              let uu___3049_23024 =
                                 cfg1.FStar_TypeChecker_Cfg.steps in
                               {
                                 FStar_TypeChecker_Cfg.beta =
-                                  (uu___3049_23039.FStar_TypeChecker_Cfg.beta);
+                                  (uu___3049_23024.FStar_TypeChecker_Cfg.beta);
                                 FStar_TypeChecker_Cfg.iota =
-                                  (uu___3049_23039.FStar_TypeChecker_Cfg.iota);
+                                  (uu___3049_23024.FStar_TypeChecker_Cfg.iota);
                                 FStar_TypeChecker_Cfg.zeta = false;
                                 FStar_TypeChecker_Cfg.zeta_full =
-                                  (uu___3049_23039.FStar_TypeChecker_Cfg.zeta_full);
+                                  (uu___3049_23024.FStar_TypeChecker_Cfg.zeta_full);
                                 FStar_TypeChecker_Cfg.weak =
-                                  (uu___3049_23039.FStar_TypeChecker_Cfg.weak);
+                                  (uu___3049_23024.FStar_TypeChecker_Cfg.weak);
                                 FStar_TypeChecker_Cfg.hnf =
-                                  (uu___3049_23039.FStar_TypeChecker_Cfg.hnf);
+                                  (uu___3049_23024.FStar_TypeChecker_Cfg.hnf);
                                 FStar_TypeChecker_Cfg.primops =
-                                  (uu___3049_23039.FStar_TypeChecker_Cfg.primops);
+                                  (uu___3049_23024.FStar_TypeChecker_Cfg.primops);
                                 FStar_TypeChecker_Cfg.do_not_unfold_pure_lets
                                   =
-                                  (uu___3049_23039.FStar_TypeChecker_Cfg.do_not_unfold_pure_lets);
+                                  (uu___3049_23024.FStar_TypeChecker_Cfg.do_not_unfold_pure_lets);
                                 FStar_TypeChecker_Cfg.unfold_until =
                                   FStar_Pervasives_Native.None;
                                 FStar_TypeChecker_Cfg.unfold_only =
                                   FStar_Pervasives_Native.None;
                                 FStar_TypeChecker_Cfg.unfold_fully =
-                                  (uu___3049_23039.FStar_TypeChecker_Cfg.unfold_fully);
+                                  (uu___3049_23024.FStar_TypeChecker_Cfg.unfold_fully);
                                 FStar_TypeChecker_Cfg.unfold_attr =
                                   FStar_Pervasives_Native.None;
                                 FStar_TypeChecker_Cfg.unfold_tac = false;
                                 FStar_TypeChecker_Cfg.pure_subterms_within_computations
                                   =
-                                  (uu___3049_23039.FStar_TypeChecker_Cfg.pure_subterms_within_computations);
+                                  (uu___3049_23024.FStar_TypeChecker_Cfg.pure_subterms_within_computations);
                                 FStar_TypeChecker_Cfg.simplify =
-                                  (uu___3049_23039.FStar_TypeChecker_Cfg.simplify);
+                                  (uu___3049_23024.FStar_TypeChecker_Cfg.simplify);
                                 FStar_TypeChecker_Cfg.erase_universes =
-                                  (uu___3049_23039.FStar_TypeChecker_Cfg.erase_universes);
+                                  (uu___3049_23024.FStar_TypeChecker_Cfg.erase_universes);
                                 FStar_TypeChecker_Cfg.allow_unbound_universes
                                   =
-                                  (uu___3049_23039.FStar_TypeChecker_Cfg.allow_unbound_universes);
+                                  (uu___3049_23024.FStar_TypeChecker_Cfg.allow_unbound_universes);
                                 FStar_TypeChecker_Cfg.reify_ =
-                                  (uu___3049_23039.FStar_TypeChecker_Cfg.reify_);
+                                  (uu___3049_23024.FStar_TypeChecker_Cfg.reify_);
                                 FStar_TypeChecker_Cfg.compress_uvars =
-                                  (uu___3049_23039.FStar_TypeChecker_Cfg.compress_uvars);
+                                  (uu___3049_23024.FStar_TypeChecker_Cfg.compress_uvars);
                                 FStar_TypeChecker_Cfg.no_full_norm =
-                                  (uu___3049_23039.FStar_TypeChecker_Cfg.no_full_norm);
+                                  (uu___3049_23024.FStar_TypeChecker_Cfg.no_full_norm);
                                 FStar_TypeChecker_Cfg.check_no_uvars =
-                                  (uu___3049_23039.FStar_TypeChecker_Cfg.check_no_uvars);
+                                  (uu___3049_23024.FStar_TypeChecker_Cfg.check_no_uvars);
                                 FStar_TypeChecker_Cfg.unmeta =
-                                  (uu___3049_23039.FStar_TypeChecker_Cfg.unmeta);
+                                  (uu___3049_23024.FStar_TypeChecker_Cfg.unmeta);
                                 FStar_TypeChecker_Cfg.unascribe =
-                                  (uu___3049_23039.FStar_TypeChecker_Cfg.unascribe);
+                                  (uu___3049_23024.FStar_TypeChecker_Cfg.unascribe);
                                 FStar_TypeChecker_Cfg.in_full_norm_request =
-                                  (uu___3049_23039.FStar_TypeChecker_Cfg.in_full_norm_request);
+                                  (uu___3049_23024.FStar_TypeChecker_Cfg.in_full_norm_request);
                                 FStar_TypeChecker_Cfg.weakly_reduce_scrutinee
                                   =
-                                  (uu___3049_23039.FStar_TypeChecker_Cfg.weakly_reduce_scrutinee);
+                                  (uu___3049_23024.FStar_TypeChecker_Cfg.weakly_reduce_scrutinee);
                                 FStar_TypeChecker_Cfg.nbe_step =
-                                  (uu___3049_23039.FStar_TypeChecker_Cfg.nbe_step);
+                                  (uu___3049_23024.FStar_TypeChecker_Cfg.nbe_step);
                                 FStar_TypeChecker_Cfg.for_extraction =
-                                  (uu___3049_23039.FStar_TypeChecker_Cfg.for_extraction)
+                                  (uu___3049_23024.FStar_TypeChecker_Cfg.for_extraction)
                               } in
-                            let uu___3052_23044 = cfg1 in
+                            let uu___3052_23029 = cfg1 in
                             {
                               FStar_TypeChecker_Cfg.steps = steps;
                               FStar_TypeChecker_Cfg.tcenv =
-                                (uu___3052_23044.FStar_TypeChecker_Cfg.tcenv);
+                                (uu___3052_23029.FStar_TypeChecker_Cfg.tcenv);
                               FStar_TypeChecker_Cfg.debug =
-                                (uu___3052_23044.FStar_TypeChecker_Cfg.debug);
+                                (uu___3052_23029.FStar_TypeChecker_Cfg.debug);
                               FStar_TypeChecker_Cfg.delta_level = new_delta;
                               FStar_TypeChecker_Cfg.primitive_steps =
-                                (uu___3052_23044.FStar_TypeChecker_Cfg.primitive_steps);
+                                (uu___3052_23029.FStar_TypeChecker_Cfg.primitive_steps);
                               FStar_TypeChecker_Cfg.strong = true;
                               FStar_TypeChecker_Cfg.memoize_lazy =
-                                (uu___3052_23044.FStar_TypeChecker_Cfg.memoize_lazy);
+                                (uu___3052_23029.FStar_TypeChecker_Cfg.memoize_lazy);
                               FStar_TypeChecker_Cfg.normalize_pure_lets =
-                                (uu___3052_23044.FStar_TypeChecker_Cfg.normalize_pure_lets);
+                                (uu___3052_23029.FStar_TypeChecker_Cfg.normalize_pure_lets);
                               FStar_TypeChecker_Cfg.reifying =
-                                (uu___3052_23044.FStar_TypeChecker_Cfg.reifying)
+                                (uu___3052_23029.FStar_TypeChecker_Cfg.reifying)
                             }) in
                        let norm_or_whnf env3 t2 =
                          if whnf
@@ -7271,104 +7270,104 @@ and (rebuild :
                          else norm cfg_exclude_zeta env3 [] t2 in
                        let rec norm_pat env3 p =
                          match p.FStar_Syntax_Syntax.v with
-                         | FStar_Syntax_Syntax.Pat_constant uu____23116 ->
+                         | FStar_Syntax_Syntax.Pat_constant uu____23101 ->
                              (p, env3)
                          | FStar_Syntax_Syntax.Pat_cons (fv, pats) ->
-                             let uu____23145 =
+                             let uu____23130 =
                                FStar_All.pipe_right pats
                                  (FStar_List.fold_left
-                                    (fun uu____23229 ->
-                                       fun uu____23230 ->
-                                         match (uu____23229, uu____23230)
+                                    (fun uu____23214 ->
+                                       fun uu____23215 ->
+                                         match (uu____23214, uu____23215)
                                          with
                                          | ((pats1, env4), (p1, b)) ->
-                                             let uu____23369 =
+                                             let uu____23354 =
                                                norm_pat env4 p1 in
-                                             (match uu____23369 with
+                                             (match uu____23354 with
                                               | (p2, env5) ->
                                                   (((p2, b) :: pats1), env5)))
                                     ([], env3)) in
-                             (match uu____23145 with
+                             (match uu____23130 with
                               | (pats1, env4) ->
-                                  ((let uu___3080_23531 = p in
+                                  ((let uu___3080_23516 = p in
                                     {
                                       FStar_Syntax_Syntax.v =
                                         (FStar_Syntax_Syntax.Pat_cons
                                            (fv, (FStar_List.rev pats1)));
                                       FStar_Syntax_Syntax.p =
-                                        (uu___3080_23531.FStar_Syntax_Syntax.p)
+                                        (uu___3080_23516.FStar_Syntax_Syntax.p)
                                     }), env4))
                          | FStar_Syntax_Syntax.Pat_var x ->
                              let x1 =
-                               let uu___3084_23550 = x in
-                               let uu____23551 =
+                               let uu___3084_23535 = x in
+                               let uu____23536 =
                                  norm_or_whnf env3 x.FStar_Syntax_Syntax.sort in
                                {
                                  FStar_Syntax_Syntax.ppname =
-                                   (uu___3084_23550.FStar_Syntax_Syntax.ppname);
+                                   (uu___3084_23535.FStar_Syntax_Syntax.ppname);
                                  FStar_Syntax_Syntax.index =
-                                   (uu___3084_23550.FStar_Syntax_Syntax.index);
-                                 FStar_Syntax_Syntax.sort = uu____23551
+                                   (uu___3084_23535.FStar_Syntax_Syntax.index);
+                                 FStar_Syntax_Syntax.sort = uu____23536
                                } in
-                             ((let uu___3087_23565 = p in
+                             ((let uu___3087_23550 = p in
                                {
                                  FStar_Syntax_Syntax.v =
                                    (FStar_Syntax_Syntax.Pat_var x1);
                                  FStar_Syntax_Syntax.p =
-                                   (uu___3087_23565.FStar_Syntax_Syntax.p)
+                                   (uu___3087_23550.FStar_Syntax_Syntax.p)
                                }), (dummy :: env3))
                          | FStar_Syntax_Syntax.Pat_wild x ->
                              let x1 =
-                               let uu___3091_23576 = x in
-                               let uu____23577 =
+                               let uu___3091_23561 = x in
+                               let uu____23562 =
                                  norm_or_whnf env3 x.FStar_Syntax_Syntax.sort in
                                {
                                  FStar_Syntax_Syntax.ppname =
-                                   (uu___3091_23576.FStar_Syntax_Syntax.ppname);
+                                   (uu___3091_23561.FStar_Syntax_Syntax.ppname);
                                  FStar_Syntax_Syntax.index =
-                                   (uu___3091_23576.FStar_Syntax_Syntax.index);
-                                 FStar_Syntax_Syntax.sort = uu____23577
+                                   (uu___3091_23561.FStar_Syntax_Syntax.index);
+                                 FStar_Syntax_Syntax.sort = uu____23562
                                } in
-                             ((let uu___3094_23591 = p in
+                             ((let uu___3094_23576 = p in
                                {
                                  FStar_Syntax_Syntax.v =
                                    (FStar_Syntax_Syntax.Pat_wild x1);
                                  FStar_Syntax_Syntax.p =
-                                   (uu___3094_23591.FStar_Syntax_Syntax.p)
+                                   (uu___3094_23576.FStar_Syntax_Syntax.p)
                                }), (dummy :: env3))
                          | FStar_Syntax_Syntax.Pat_dot_term (x, t2) ->
                              let x1 =
-                               let uu___3100_23607 = x in
-                               let uu____23608 =
+                               let uu___3100_23592 = x in
+                               let uu____23593 =
                                  norm_or_whnf env3 x.FStar_Syntax_Syntax.sort in
                                {
                                  FStar_Syntax_Syntax.ppname =
-                                   (uu___3100_23607.FStar_Syntax_Syntax.ppname);
+                                   (uu___3100_23592.FStar_Syntax_Syntax.ppname);
                                  FStar_Syntax_Syntax.index =
-                                   (uu___3100_23607.FStar_Syntax_Syntax.index);
-                                 FStar_Syntax_Syntax.sort = uu____23608
+                                   (uu___3100_23592.FStar_Syntax_Syntax.index);
+                                 FStar_Syntax_Syntax.sort = uu____23593
                                } in
                              let t3 = norm_or_whnf env3 t2 in
-                             ((let uu___3104_23623 = p in
+                             ((let uu___3104_23608 = p in
                                {
                                  FStar_Syntax_Syntax.v =
                                    (FStar_Syntax_Syntax.Pat_dot_term (x1, t3));
                                  FStar_Syntax_Syntax.p =
-                                   (uu___3104_23623.FStar_Syntax_Syntax.p)
+                                   (uu___3104_23608.FStar_Syntax_Syntax.p)
                                }), env3) in
-                       let norm_branches uu____23643 =
+                       let norm_branches uu____23628 =
                          match env2 with
                          | [] when whnf -> branches1
-                         | uu____23660 ->
+                         | uu____23645 ->
                              FStar_All.pipe_right branches1
                                (FStar_List.map
                                   (fun branch ->
-                                     let uu____23676 =
+                                     let uu____23661 =
                                        FStar_Syntax_Subst.open_branch branch in
-                                     match uu____23676 with
+                                     match uu____23661 with
                                      | (p, wopt, e) ->
-                                         let uu____23696 = norm_pat env2 p in
-                                         (match uu____23696 with
+                                         let uu____23681 = norm_pat env2 p in
+                                         (match uu____23681 with
                                           | (p1, env3) ->
                                               let wopt1 =
                                                 match wopt with
@@ -7377,66 +7376,66 @@ and (rebuild :
                                                     FStar_Pervasives_Native.None
                                                 | FStar_Pervasives_Native.Some
                                                     w ->
-                                                    let uu____23751 =
+                                                    let uu____23736 =
                                                       norm_or_whnf env3 w in
                                                     FStar_Pervasives_Native.Some
-                                                      uu____23751 in
+                                                      uu____23736 in
                                               let e1 = norm_or_whnf env3 e in
                                               FStar_Syntax_Util.branch
                                                 (p1, wopt1, e1)))) in
-                       let maybe_commute_matches uu____23770 =
+                       let maybe_commute_matches uu____23755 =
                          let can_commute =
                            match branches1 with
                            | ({
                                 FStar_Syntax_Syntax.v =
                                   FStar_Syntax_Syntax.Pat_cons
-                                  (fv, uu____23773);
-                                FStar_Syntax_Syntax.p = uu____23774;_},
-                              uu____23775, uu____23776)::uu____23777 ->
+                                  (fv, uu____23758);
+                                FStar_Syntax_Syntax.p = uu____23759;_},
+                              uu____23760, uu____23761)::uu____23762 ->
                                FStar_TypeChecker_Env.fv_has_attr
                                  cfg1.FStar_TypeChecker_Cfg.tcenv fv
                                  FStar_Parser_Const.commute_nested_matches_lid
-                           | uu____23816 -> false in
-                         let uu____23817 =
-                           let uu____23818 =
+                           | uu____23801 -> false in
+                         let uu____23802 =
+                           let uu____23803 =
                              FStar_Syntax_Util.unascribe scrutinee in
-                           uu____23818.FStar_Syntax_Syntax.n in
-                         match uu____23817 with
+                           uu____23803.FStar_Syntax_Syntax.n in
+                         match uu____23802 with
                          | FStar_Syntax_Syntax.Tm_match (sc0, branches0) when
                              can_commute ->
                              let reduce_branch b =
                                let stack3 =
                                  [Match (env', branches1, cfg1, r)] in
-                               let uu____23868 =
+                               let uu____23853 =
                                  FStar_Syntax_Subst.open_branch b in
-                               match uu____23868 with
+                               match uu____23853 with
                                | (p, wopt, e) ->
-                                   let uu____23888 = norm_pat scrutinee_env p in
-                                   (match uu____23888 with
+                                   let uu____23873 = norm_pat scrutinee_env p in
+                                   (match uu____23873 with
                                     | (p1, branch_env) ->
                                         let wopt1 =
                                           match wopt with
                                           | FStar_Pervasives_Native.None ->
                                               FStar_Pervasives_Native.None
                                           | FStar_Pervasives_Native.Some w ->
-                                              let uu____23943 =
+                                              let uu____23928 =
                                                 norm_or_whnf branch_env w in
                                               FStar_Pervasives_Native.Some
-                                                uu____23943 in
+                                                uu____23928 in
                                         let e1 =
                                           norm cfg1 branch_env stack3 e in
                                         FStar_Syntax_Util.branch
                                           (p1, wopt1, e1)) in
                              let branches01 =
                                FStar_List.map reduce_branch branches0 in
-                             let uu____24002 =
+                             let uu____23987 =
                                FStar_Syntax_Syntax.mk
                                  (FStar_Syntax_Syntax.Tm_match
                                     (sc0, branches01)) r in
-                             rebuild cfg1 env2 stack2 uu____24002
-                         | uu____24021 ->
+                             rebuild cfg1 env2 stack2 uu____23987
+                         | uu____24006 ->
                              let scrutinee1 =
-                               let uu____24025 =
+                               let uu____24010 =
                                  ((((cfg1.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.iota
                                       &&
                                       (Prims.op_Negation
@@ -7447,132 +7446,132 @@ and (rebuild :
                                     &&
                                     (cfg1.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.weakly_reduce_scrutinee)
                                    && (maybe_weakly_reduced scrutinee) in
-                               if uu____24025
+                               if uu____24010
                                then
                                  norm
-                                   (let uu___3160_24030 = cfg1 in
+                                   (let uu___3160_24015 = cfg1 in
                                     {
                                       FStar_TypeChecker_Cfg.steps =
-                                        (let uu___3162_24033 =
+                                        (let uu___3162_24018 =
                                            cfg1.FStar_TypeChecker_Cfg.steps in
                                          {
                                            FStar_TypeChecker_Cfg.beta =
-                                             (uu___3162_24033.FStar_TypeChecker_Cfg.beta);
+                                             (uu___3162_24018.FStar_TypeChecker_Cfg.beta);
                                            FStar_TypeChecker_Cfg.iota =
-                                             (uu___3162_24033.FStar_TypeChecker_Cfg.iota);
+                                             (uu___3162_24018.FStar_TypeChecker_Cfg.iota);
                                            FStar_TypeChecker_Cfg.zeta =
-                                             (uu___3162_24033.FStar_TypeChecker_Cfg.zeta);
+                                             (uu___3162_24018.FStar_TypeChecker_Cfg.zeta);
                                            FStar_TypeChecker_Cfg.zeta_full =
-                                             (uu___3162_24033.FStar_TypeChecker_Cfg.zeta_full);
+                                             (uu___3162_24018.FStar_TypeChecker_Cfg.zeta_full);
                                            FStar_TypeChecker_Cfg.weak =
-                                             (uu___3162_24033.FStar_TypeChecker_Cfg.weak);
+                                             (uu___3162_24018.FStar_TypeChecker_Cfg.weak);
                                            FStar_TypeChecker_Cfg.hnf =
-                                             (uu___3162_24033.FStar_TypeChecker_Cfg.hnf);
+                                             (uu___3162_24018.FStar_TypeChecker_Cfg.hnf);
                                            FStar_TypeChecker_Cfg.primops =
-                                             (uu___3162_24033.FStar_TypeChecker_Cfg.primops);
+                                             (uu___3162_24018.FStar_TypeChecker_Cfg.primops);
                                            FStar_TypeChecker_Cfg.do_not_unfold_pure_lets
                                              =
-                                             (uu___3162_24033.FStar_TypeChecker_Cfg.do_not_unfold_pure_lets);
+                                             (uu___3162_24018.FStar_TypeChecker_Cfg.do_not_unfold_pure_lets);
                                            FStar_TypeChecker_Cfg.unfold_until
                                              =
-                                             (uu___3162_24033.FStar_TypeChecker_Cfg.unfold_until);
+                                             (uu___3162_24018.FStar_TypeChecker_Cfg.unfold_until);
                                            FStar_TypeChecker_Cfg.unfold_only
                                              =
-                                             (uu___3162_24033.FStar_TypeChecker_Cfg.unfold_only);
+                                             (uu___3162_24018.FStar_TypeChecker_Cfg.unfold_only);
                                            FStar_TypeChecker_Cfg.unfold_fully
                                              =
-                                             (uu___3162_24033.FStar_TypeChecker_Cfg.unfold_fully);
+                                             (uu___3162_24018.FStar_TypeChecker_Cfg.unfold_fully);
                                            FStar_TypeChecker_Cfg.unfold_attr
                                              =
-                                             (uu___3162_24033.FStar_TypeChecker_Cfg.unfold_attr);
+                                             (uu___3162_24018.FStar_TypeChecker_Cfg.unfold_attr);
                                            FStar_TypeChecker_Cfg.unfold_tac =
-                                             (uu___3162_24033.FStar_TypeChecker_Cfg.unfold_tac);
+                                             (uu___3162_24018.FStar_TypeChecker_Cfg.unfold_tac);
                                            FStar_TypeChecker_Cfg.pure_subterms_within_computations
                                              =
-                                             (uu___3162_24033.FStar_TypeChecker_Cfg.pure_subterms_within_computations);
+                                             (uu___3162_24018.FStar_TypeChecker_Cfg.pure_subterms_within_computations);
                                            FStar_TypeChecker_Cfg.simplify =
-                                             (uu___3162_24033.FStar_TypeChecker_Cfg.simplify);
+                                             (uu___3162_24018.FStar_TypeChecker_Cfg.simplify);
                                            FStar_TypeChecker_Cfg.erase_universes
                                              =
-                                             (uu___3162_24033.FStar_TypeChecker_Cfg.erase_universes);
+                                             (uu___3162_24018.FStar_TypeChecker_Cfg.erase_universes);
                                            FStar_TypeChecker_Cfg.allow_unbound_universes
                                              =
-                                             (uu___3162_24033.FStar_TypeChecker_Cfg.allow_unbound_universes);
+                                             (uu___3162_24018.FStar_TypeChecker_Cfg.allow_unbound_universes);
                                            FStar_TypeChecker_Cfg.reify_ =
-                                             (uu___3162_24033.FStar_TypeChecker_Cfg.reify_);
+                                             (uu___3162_24018.FStar_TypeChecker_Cfg.reify_);
                                            FStar_TypeChecker_Cfg.compress_uvars
                                              =
-                                             (uu___3162_24033.FStar_TypeChecker_Cfg.compress_uvars);
+                                             (uu___3162_24018.FStar_TypeChecker_Cfg.compress_uvars);
                                            FStar_TypeChecker_Cfg.no_full_norm
                                              =
-                                             (uu___3162_24033.FStar_TypeChecker_Cfg.no_full_norm);
+                                             (uu___3162_24018.FStar_TypeChecker_Cfg.no_full_norm);
                                            FStar_TypeChecker_Cfg.check_no_uvars
                                              =
-                                             (uu___3162_24033.FStar_TypeChecker_Cfg.check_no_uvars);
+                                             (uu___3162_24018.FStar_TypeChecker_Cfg.check_no_uvars);
                                            FStar_TypeChecker_Cfg.unmeta =
-                                             (uu___3162_24033.FStar_TypeChecker_Cfg.unmeta);
+                                             (uu___3162_24018.FStar_TypeChecker_Cfg.unmeta);
                                            FStar_TypeChecker_Cfg.unascribe =
-                                             (uu___3162_24033.FStar_TypeChecker_Cfg.unascribe);
+                                             (uu___3162_24018.FStar_TypeChecker_Cfg.unascribe);
                                            FStar_TypeChecker_Cfg.in_full_norm_request
                                              =
-                                             (uu___3162_24033.FStar_TypeChecker_Cfg.in_full_norm_request);
+                                             (uu___3162_24018.FStar_TypeChecker_Cfg.in_full_norm_request);
                                            FStar_TypeChecker_Cfg.weakly_reduce_scrutinee
                                              = false;
                                            FStar_TypeChecker_Cfg.nbe_step =
-                                             (uu___3162_24033.FStar_TypeChecker_Cfg.nbe_step);
+                                             (uu___3162_24018.FStar_TypeChecker_Cfg.nbe_step);
                                            FStar_TypeChecker_Cfg.for_extraction
                                              =
-                                             (uu___3162_24033.FStar_TypeChecker_Cfg.for_extraction)
+                                             (uu___3162_24018.FStar_TypeChecker_Cfg.for_extraction)
                                          });
                                       FStar_TypeChecker_Cfg.tcenv =
-                                        (uu___3160_24030.FStar_TypeChecker_Cfg.tcenv);
+                                        (uu___3160_24015.FStar_TypeChecker_Cfg.tcenv);
                                       FStar_TypeChecker_Cfg.debug =
-                                        (uu___3160_24030.FStar_TypeChecker_Cfg.debug);
+                                        (uu___3160_24015.FStar_TypeChecker_Cfg.debug);
                                       FStar_TypeChecker_Cfg.delta_level =
-                                        (uu___3160_24030.FStar_TypeChecker_Cfg.delta_level);
+                                        (uu___3160_24015.FStar_TypeChecker_Cfg.delta_level);
                                       FStar_TypeChecker_Cfg.primitive_steps =
-                                        (uu___3160_24030.FStar_TypeChecker_Cfg.primitive_steps);
+                                        (uu___3160_24015.FStar_TypeChecker_Cfg.primitive_steps);
                                       FStar_TypeChecker_Cfg.strong =
-                                        (uu___3160_24030.FStar_TypeChecker_Cfg.strong);
+                                        (uu___3160_24015.FStar_TypeChecker_Cfg.strong);
                                       FStar_TypeChecker_Cfg.memoize_lazy =
-                                        (uu___3160_24030.FStar_TypeChecker_Cfg.memoize_lazy);
+                                        (uu___3160_24015.FStar_TypeChecker_Cfg.memoize_lazy);
                                       FStar_TypeChecker_Cfg.normalize_pure_lets
                                         =
-                                        (uu___3160_24030.FStar_TypeChecker_Cfg.normalize_pure_lets);
+                                        (uu___3160_24015.FStar_TypeChecker_Cfg.normalize_pure_lets);
                                       FStar_TypeChecker_Cfg.reifying =
-                                        (uu___3160_24030.FStar_TypeChecker_Cfg.reifying)
+                                        (uu___3160_24015.FStar_TypeChecker_Cfg.reifying)
                                     }) scrutinee_env [] scrutinee
                                else scrutinee in
                              let branches2 = norm_branches () in
-                             let uu____24046 =
+                             let uu____24031 =
                                FStar_Syntax_Syntax.mk
                                  (FStar_Syntax_Syntax.Tm_match
                                     (scrutinee1, branches2)) r in
-                             rebuild cfg1 env2 stack2 uu____24046 in
+                             rebuild cfg1 env2 stack2 uu____24031 in
                        maybe_commute_matches ()) in
                     let rec is_cons head =
-                      let uu____24071 =
-                        let uu____24072 = FStar_Syntax_Subst.compress head in
-                        uu____24072.FStar_Syntax_Syntax.n in
-                      match uu____24071 with
-                      | FStar_Syntax_Syntax.Tm_uinst (h, uu____24076) ->
+                      let uu____24056 =
+                        let uu____24057 = FStar_Syntax_Subst.compress head in
+                        uu____24057.FStar_Syntax_Syntax.n in
+                      match uu____24056 with
+                      | FStar_Syntax_Syntax.Tm_uinst (h, uu____24061) ->
                           is_cons h
-                      | FStar_Syntax_Syntax.Tm_constant uu____24081 -> true
+                      | FStar_Syntax_Syntax.Tm_constant uu____24066 -> true
                       | FStar_Syntax_Syntax.Tm_fvar
-                          { FStar_Syntax_Syntax.fv_name = uu____24082;
-                            FStar_Syntax_Syntax.fv_delta = uu____24083;
+                          { FStar_Syntax_Syntax.fv_name = uu____24067;
+                            FStar_Syntax_Syntax.fv_delta = uu____24068;
                             FStar_Syntax_Syntax.fv_qual =
                               FStar_Pervasives_Native.Some
                               (FStar_Syntax_Syntax.Data_ctor);_}
                           -> true
                       | FStar_Syntax_Syntax.Tm_fvar
-                          { FStar_Syntax_Syntax.fv_name = uu____24084;
-                            FStar_Syntax_Syntax.fv_delta = uu____24085;
+                          { FStar_Syntax_Syntax.fv_name = uu____24069;
+                            FStar_Syntax_Syntax.fv_delta = uu____24070;
                             FStar_Syntax_Syntax.fv_qual =
                               FStar_Pervasives_Native.Some
-                              (FStar_Syntax_Syntax.Record_ctor uu____24086);_}
+                              (FStar_Syntax_Syntax.Record_ctor uu____24071);_}
                           -> true
-                      | uu____24093 -> false in
+                      | uu____24078 -> false in
                     let guard_when_clause wopt b rest =
                       match wopt with
                       | FStar_Pervasives_Native.None -> b
@@ -7588,109 +7587,109 @@ and (rebuild :
                       let scrutinee1 =
                         FStar_Syntax_Util.unmeta scrutinee_orig in
                       let scrutinee2 = FStar_Syntax_Util.unlazy scrutinee1 in
-                      let uu____24257 =
+                      let uu____24242 =
                         FStar_Syntax_Util.head_and_args scrutinee2 in
-                      match uu____24257 with
+                      match uu____24242 with
                       | (head, args) ->
                           (match p.FStar_Syntax_Syntax.v with
                            | FStar_Syntax_Syntax.Pat_var bv ->
                                FStar_Util.Inl [(bv, scrutinee_orig)]
                            | FStar_Syntax_Syntax.Pat_wild bv ->
                                FStar_Util.Inl [(bv, scrutinee_orig)]
-                           | FStar_Syntax_Syntax.Pat_dot_term uu____24350 ->
+                           | FStar_Syntax_Syntax.Pat_dot_term uu____24335 ->
                                FStar_Util.Inl []
                            | FStar_Syntax_Syntax.Pat_constant s ->
                                (match scrutinee2.FStar_Syntax_Syntax.n with
                                 | FStar_Syntax_Syntax.Tm_constant s' when
                                     FStar_Const.eq_const s s' ->
                                     FStar_Util.Inl []
-                                | uu____24389 ->
-                                    let uu____24390 =
-                                      let uu____24391 = is_cons head in
-                                      Prims.op_Negation uu____24391 in
-                                    FStar_Util.Inr uu____24390)
+                                | uu____24374 ->
+                                    let uu____24375 =
+                                      let uu____24376 = is_cons head in
+                                      Prims.op_Negation uu____24376 in
+                                    FStar_Util.Inr uu____24375)
                            | FStar_Syntax_Syntax.Pat_cons (fv, arg_pats) ->
-                               let uu____24416 =
-                                 let uu____24417 =
+                               let uu____24401 =
+                                 let uu____24402 =
                                    FStar_Syntax_Util.un_uinst head in
-                                 uu____24417.FStar_Syntax_Syntax.n in
-                               (match uu____24416 with
+                                 uu____24402.FStar_Syntax_Syntax.n in
+                               (match uu____24401 with
                                 | FStar_Syntax_Syntax.Tm_fvar fv' when
                                     FStar_Syntax_Syntax.fv_eq fv fv' ->
                                     matches_args [] args arg_pats
-                                | uu____24435 ->
-                                    let uu____24436 =
-                                      let uu____24437 = is_cons head in
-                                      Prims.op_Negation uu____24437 in
-                                    FStar_Util.Inr uu____24436))
+                                | uu____24420 ->
+                                    let uu____24421 =
+                                      let uu____24422 = is_cons head in
+                                      Prims.op_Negation uu____24422 in
+                                    FStar_Util.Inr uu____24421))
                     and matches_args out a p =
                       match (a, p) with
                       | ([], []) -> FStar_Util.Inl out
-                      | ((t2, uu____24520)::rest_a,
-                         (p1, uu____24523)::rest_p) ->
-                          let uu____24577 = matches_pat t2 p1 in
-                          (match uu____24577 with
+                      | ((t2, uu____24505)::rest_a,
+                         (p1, uu____24508)::rest_p) ->
+                          let uu____24562 = matches_pat t2 p1 in
+                          (match uu____24562 with
                            | FStar_Util.Inl s ->
                                matches_args (FStar_List.append out s) rest_a
                                  rest_p
                            | m -> m)
-                      | uu____24626 -> FStar_Util.Inr false in
+                      | uu____24611 -> FStar_Util.Inr false in
                     let rec matches scrutinee1 p =
                       match p with
                       | [] -> norm_and_rebuild_match ()
                       | (p1, wopt, b)::rest ->
-                          let uu____24746 = matches_pat scrutinee1 p1 in
-                          (match uu____24746 with
+                          let uu____24731 = matches_pat scrutinee1 p1 in
+                          (match uu____24731 with
                            | FStar_Util.Inr (false) ->
                                matches scrutinee1 rest
                            | FStar_Util.Inr (true) ->
                                norm_and_rebuild_match ()
                            | FStar_Util.Inl s ->
                                (FStar_TypeChecker_Cfg.log cfg1
-                                  (fun uu____24786 ->
-                                     let uu____24787 =
+                                  (fun uu____24771 ->
+                                     let uu____24772 =
                                        FStar_Syntax_Print.pat_to_string p1 in
-                                     let uu____24788 =
-                                       let uu____24789 =
+                                     let uu____24773 =
+                                       let uu____24774 =
                                          FStar_List.map
-                                           (fun uu____24799 ->
-                                              match uu____24799 with
-                                              | (uu____24804, t2) ->
+                                           (fun uu____24784 ->
+                                              match uu____24784 with
+                                              | (uu____24789, t2) ->
                                                   FStar_Syntax_Print.term_to_string
                                                     t2) s in
-                                       FStar_All.pipe_right uu____24789
+                                       FStar_All.pipe_right uu____24774
                                          (FStar_String.concat "; ") in
                                      FStar_Util.print2
                                        "Matches pattern %s with subst = %s\n"
-                                       uu____24787 uu____24788);
+                                       uu____24772 uu____24773);
                                 (let env0 = env2 in
                                  let env3 =
                                    FStar_List.fold_left
                                      (fun env3 ->
-                                        fun uu____24836 ->
-                                          match uu____24836 with
+                                        fun uu____24821 ->
+                                          match uu____24821 with
                                           | (bv, t2) ->
-                                              let uu____24859 =
-                                                let uu____24866 =
-                                                  let uu____24869 =
+                                              let uu____24844 =
+                                                let uu____24851 =
+                                                  let uu____24854 =
                                                     FStar_Syntax_Syntax.mk_binder
                                                       bv in
                                                   FStar_Pervasives_Native.Some
-                                                    uu____24869 in
-                                                let uu____24870 =
-                                                  let uu____24871 =
-                                                    let uu____24902 =
+                                                    uu____24854 in
+                                                let uu____24855 =
+                                                  let uu____24856 =
+                                                    let uu____24887 =
                                                       FStar_Util.mk_ref
                                                         (FStar_Pervasives_Native.Some
                                                            ([], t2)) in
-                                                    ([], t2, uu____24902,
+                                                    ([], t2, uu____24887,
                                                       false) in
-                                                  Clos uu____24871 in
-                                                (uu____24866, uu____24870) in
-                                              uu____24859 :: env3) env2 s in
-                                 let uu____24993 =
+                                                  Clos uu____24856 in
+                                                (uu____24851, uu____24855) in
+                                              uu____24844 :: env3) env2 s in
+                                 let uu____24978 =
                                    guard_when_clause wopt b rest in
-                                 norm cfg1 env3 stack2 uu____24993))) in
+                                 norm cfg1 env3 stack2 uu____24978))) in
                     if
                       (cfg1.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.iota
                     then matches scrutinee branches1
@@ -7712,55 +7711,55 @@ let (normalize_with_primitive_steps :
           FStar_ST.op_Colon_Equals reflection_env_hook
             (FStar_Pervasives_Native.Some e);
           FStar_TypeChecker_Cfg.log_cfg c
-            (fun uu____25040 ->
-               let uu____25041 = FStar_TypeChecker_Cfg.cfg_to_string c in
-               FStar_Util.print1 "Cfg = %s\n" uu____25041);
-          (let uu____25042 = is_nbe_request s in
-           if uu____25042
+            (fun uu____25025 ->
+               let uu____25026 = FStar_TypeChecker_Cfg.cfg_to_string c in
+               FStar_Util.print1 "Cfg = %s\n" uu____25026);
+          (let uu____25027 = is_nbe_request s in
+           if uu____25027
            then
              (FStar_TypeChecker_Cfg.log_top c
-                (fun uu____25046 ->
-                   let uu____25047 = FStar_Syntax_Print.term_to_string t in
-                   FStar_Util.print1 "Starting NBE for (%s) {\n" uu____25047);
+                (fun uu____25031 ->
+                   let uu____25032 = FStar_Syntax_Print.term_to_string t in
+                   FStar_Util.print1 "Starting NBE for (%s) {\n" uu____25032);
               FStar_TypeChecker_Cfg.log_top c
-                (fun uu____25051 ->
-                   let uu____25052 = FStar_TypeChecker_Cfg.cfg_to_string c in
-                   FStar_Util.print1 ">>> cfg = %s\n" uu____25052);
-              (let uu____25053 =
-                 FStar_Util.record_time (fun uu____25059 -> nbe_eval c s t) in
-               match uu____25053 with
+                (fun uu____25036 ->
+                   let uu____25037 = FStar_TypeChecker_Cfg.cfg_to_string c in
+                   FStar_Util.print1 ">>> cfg = %s\n" uu____25037);
+              (let uu____25038 =
+                 FStar_Util.record_time (fun uu____25044 -> nbe_eval c s t) in
+               match uu____25038 with
                | (r, ms) ->
                    (FStar_TypeChecker_Cfg.log_top c
-                      (fun uu____25066 ->
-                         let uu____25067 =
+                      (fun uu____25051 ->
+                         let uu____25052 =
                            FStar_Syntax_Print.term_to_string r in
-                         let uu____25068 = FStar_Util.string_of_int ms in
+                         let uu____25053 = FStar_Util.string_of_int ms in
                          FStar_Util.print2
                            "}\nNormalization result = (%s) in %s ms\n"
-                           uu____25067 uu____25068);
+                           uu____25052 uu____25053);
                     r)))
            else
              (FStar_TypeChecker_Cfg.log_top c
-                (fun uu____25073 ->
-                   let uu____25074 = FStar_Syntax_Print.term_to_string t in
+                (fun uu____25058 ->
+                   let uu____25059 = FStar_Syntax_Print.term_to_string t in
                    FStar_Util.print1 "Starting normalizer for (%s) {\n"
-                     uu____25074);
+                     uu____25059);
               FStar_TypeChecker_Cfg.log_top c
-                (fun uu____25078 ->
-                   let uu____25079 = FStar_TypeChecker_Cfg.cfg_to_string c in
-                   FStar_Util.print1 ">>> cfg = %s\n" uu____25079);
-              (let uu____25080 =
-                 FStar_Util.record_time (fun uu____25086 -> norm c [] [] t) in
-               match uu____25080 with
+                (fun uu____25063 ->
+                   let uu____25064 = FStar_TypeChecker_Cfg.cfg_to_string c in
+                   FStar_Util.print1 ">>> cfg = %s\n" uu____25064);
+              (let uu____25065 =
+                 FStar_Util.record_time (fun uu____25071 -> norm c [] [] t) in
+               match uu____25065 with
                | (r, ms) ->
                    (FStar_TypeChecker_Cfg.log_top c
-                      (fun uu____25099 ->
-                         let uu____25100 =
+                      (fun uu____25084 ->
+                         let uu____25085 =
                            FStar_Syntax_Print.term_to_string r in
-                         let uu____25101 = FStar_Util.string_of_int ms in
+                         let uu____25086 = FStar_Util.string_of_int ms in
                          FStar_Util.print2
                            "}\nNormalization result = (%s) in %s ms\n"
-                           uu____25100 uu____25101);
+                           uu____25085 uu____25086);
                     r))))
 let (normalize :
   FStar_TypeChecker_Env.steps ->
@@ -7770,14 +7769,14 @@ let (normalize :
   fun s ->
     fun e ->
       fun t ->
-        let uu____25117 =
-          let uu____25120 =
-            let uu____25121 = FStar_TypeChecker_Env.current_module e in
-            FStar_Ident.string_of_lid uu____25121 in
-          FStar_Pervasives_Native.Some uu____25120 in
+        let uu____25102 =
+          let uu____25105 =
+            let uu____25106 = FStar_TypeChecker_Env.current_module e in
+            FStar_Ident.string_of_lid uu____25106 in
+          FStar_Pervasives_Native.Some uu____25105 in
         FStar_Profiling.profile
-          (fun uu____25123 -> normalize_with_primitive_steps [] s e t)
-          uu____25117 "FStar.TypeChecker.Normalize"
+          (fun uu____25108 -> normalize_with_primitive_steps [] s e t)
+          uu____25102 "FStar.TypeChecker.Normalize"
 let (normalize_comp :
   FStar_TypeChecker_Env.steps ->
     FStar_TypeChecker_Env.env ->
@@ -7790,25 +7789,25 @@ let (normalize_comp :
         FStar_ST.op_Colon_Equals reflection_env_hook
           (FStar_Pervasives_Native.Some e);
         FStar_TypeChecker_Cfg.log_top cfg
-          (fun uu____25154 ->
-             let uu____25155 = FStar_Syntax_Print.comp_to_string c in
+          (fun uu____25139 ->
+             let uu____25140 = FStar_Syntax_Print.comp_to_string c in
              FStar_Util.print1 "Starting normalizer for computation (%s) {\n"
-               uu____25155);
+               uu____25140);
         FStar_TypeChecker_Cfg.log_top cfg
-          (fun uu____25159 ->
-             let uu____25160 = FStar_TypeChecker_Cfg.cfg_to_string cfg in
-             FStar_Util.print1 ">>> cfg = %s\n" uu____25160);
-        (let uu____25161 =
-           FStar_Util.record_time (fun uu____25167 -> norm_comp cfg [] c) in
-         match uu____25161 with
+          (fun uu____25144 ->
+             let uu____25145 = FStar_TypeChecker_Cfg.cfg_to_string cfg in
+             FStar_Util.print1 ">>> cfg = %s\n" uu____25145);
+        (let uu____25146 =
+           FStar_Util.record_time (fun uu____25152 -> norm_comp cfg [] c) in
+         match uu____25146 with
          | (c1, ms) ->
              (FStar_TypeChecker_Cfg.log_top cfg
-                (fun uu____25180 ->
-                   let uu____25181 = FStar_Syntax_Print.comp_to_string c1 in
-                   let uu____25182 = FStar_Util.string_of_int ms in
+                (fun uu____25165 ->
+                   let uu____25166 = FStar_Syntax_Print.comp_to_string c1 in
+                   let uu____25167 = FStar_Util.string_of_int ms in
                    FStar_Util.print2
-                     "}\nNormalization result = (%s) in %s ms\n" uu____25181
-                     uu____25182);
+                     "}\nNormalization result = (%s) in %s ms\n" uu____25166
+                     uu____25167);
               c1))
 let (normalize_universe :
   FStar_TypeChecker_Env.env ->
@@ -7816,8 +7815,8 @@ let (normalize_universe :
   =
   fun env1 ->
     fun u ->
-      let uu____25193 = FStar_TypeChecker_Cfg.config [] env1 in
-      norm_universe uu____25193 [] u
+      let uu____25178 = FStar_TypeChecker_Cfg.config [] env1 in
+      norm_universe uu____25178 [] u
 let (non_info_norm :
   FStar_TypeChecker_Env.env -> FStar_Syntax_Syntax.term -> Prims.bool) =
   fun env1 ->
@@ -7829,8 +7828,8 @@ let (non_info_norm :
         FStar_TypeChecker_Env.HNF;
         FStar_TypeChecker_Env.Unascribe;
         FStar_TypeChecker_Env.ForExtraction] in
-      let uu____25213 = normalize steps env1 t in
-      FStar_TypeChecker_Env.non_informative env1 uu____25213
+      let uu____25198 = normalize steps env1 t in
+      FStar_TypeChecker_Env.non_informative env1 uu____25198
 let (ghost_to_pure :
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.comp -> FStar_Syntax_Syntax.comp)
@@ -7838,102 +7837,102 @@ let (ghost_to_pure :
   fun env1 ->
     fun c ->
       match c.FStar_Syntax_Syntax.n with
-      | FStar_Syntax_Syntax.Total uu____25224 -> c
+      | FStar_Syntax_Syntax.Total uu____25209 -> c
       | FStar_Syntax_Syntax.GTotal (t, uopt) when non_info_norm env1 t ->
-          let uu___3333_25243 = c in
+          let uu___3333_25228 = c in
           {
             FStar_Syntax_Syntax.n = (FStar_Syntax_Syntax.Total (t, uopt));
             FStar_Syntax_Syntax.pos =
-              (uu___3333_25243.FStar_Syntax_Syntax.pos);
+              (uu___3333_25228.FStar_Syntax_Syntax.pos);
             FStar_Syntax_Syntax.vars =
-              (uu___3333_25243.FStar_Syntax_Syntax.vars)
+              (uu___3333_25228.FStar_Syntax_Syntax.vars)
           }
       | FStar_Syntax_Syntax.Comp ct ->
           let l =
             FStar_TypeChecker_Env.norm_eff_name env1
               ct.FStar_Syntax_Syntax.effect_name in
-          let uu____25250 =
+          let uu____25235 =
             (FStar_Syntax_Util.is_ghost_effect l) &&
               (non_info_norm env1 ct.FStar_Syntax_Syntax.result_typ) in
-          if uu____25250
+          if uu____25235
           then
             let ct1 =
-              let uu____25252 =
+              let uu____25237 =
                 downgrade_ghost_effect_name
                   ct.FStar_Syntax_Syntax.effect_name in
-              match uu____25252 with
+              match uu____25237 with
               | FStar_Pervasives_Native.Some pure_eff ->
                   let flags =
-                    let uu____25259 =
+                    let uu____25244 =
                       FStar_Ident.lid_equals pure_eff
                         FStar_Parser_Const.effect_Tot_lid in
-                    if uu____25259
+                    if uu____25244
                     then FStar_Syntax_Syntax.TOTAL ::
                       (ct.FStar_Syntax_Syntax.flags)
                     else ct.FStar_Syntax_Syntax.flags in
-                  let uu___3343_25263 = ct in
+                  let uu___3343_25248 = ct in
                   {
                     FStar_Syntax_Syntax.comp_univs =
-                      (uu___3343_25263.FStar_Syntax_Syntax.comp_univs);
+                      (uu___3343_25248.FStar_Syntax_Syntax.comp_univs);
                     FStar_Syntax_Syntax.effect_name = pure_eff;
                     FStar_Syntax_Syntax.result_typ =
-                      (uu___3343_25263.FStar_Syntax_Syntax.result_typ);
+                      (uu___3343_25248.FStar_Syntax_Syntax.result_typ);
                     FStar_Syntax_Syntax.effect_args =
-                      (uu___3343_25263.FStar_Syntax_Syntax.effect_args);
+                      (uu___3343_25248.FStar_Syntax_Syntax.effect_args);
                     FStar_Syntax_Syntax.flags = flags
                   }
               | FStar_Pervasives_Native.None ->
                   let ct1 = FStar_TypeChecker_Env.unfold_effect_abbrev env1 c in
-                  let uu___3347_25265 = ct1 in
+                  let uu___3347_25250 = ct1 in
                   {
                     FStar_Syntax_Syntax.comp_univs =
-                      (uu___3347_25265.FStar_Syntax_Syntax.comp_univs);
+                      (uu___3347_25250.FStar_Syntax_Syntax.comp_univs);
                     FStar_Syntax_Syntax.effect_name =
                       FStar_Parser_Const.effect_PURE_lid;
                     FStar_Syntax_Syntax.result_typ =
-                      (uu___3347_25265.FStar_Syntax_Syntax.result_typ);
+                      (uu___3347_25250.FStar_Syntax_Syntax.result_typ);
                     FStar_Syntax_Syntax.effect_args =
-                      (uu___3347_25265.FStar_Syntax_Syntax.effect_args);
+                      (uu___3347_25250.FStar_Syntax_Syntax.effect_args);
                     FStar_Syntax_Syntax.flags =
-                      (uu___3347_25265.FStar_Syntax_Syntax.flags)
+                      (uu___3347_25250.FStar_Syntax_Syntax.flags)
                   } in
-            let uu___3350_25266 = c in
+            let uu___3350_25251 = c in
             {
               FStar_Syntax_Syntax.n = (FStar_Syntax_Syntax.Comp ct1);
               FStar_Syntax_Syntax.pos =
-                (uu___3350_25266.FStar_Syntax_Syntax.pos);
+                (uu___3350_25251.FStar_Syntax_Syntax.pos);
               FStar_Syntax_Syntax.vars =
-                (uu___3350_25266.FStar_Syntax_Syntax.vars)
+                (uu___3350_25251.FStar_Syntax_Syntax.vars)
             }
           else c
-      | uu____25268 -> c
+      | uu____25253 -> c
 let (ghost_to_pure_lcomp :
   FStar_TypeChecker_Env.env ->
     FStar_TypeChecker_Common.lcomp -> FStar_TypeChecker_Common.lcomp)
   =
   fun env1 ->
     fun lc ->
-      let uu____25279 =
+      let uu____25264 =
         (FStar_Syntax_Util.is_ghost_effect
            lc.FStar_TypeChecker_Common.eff_name)
           && (non_info_norm env1 lc.FStar_TypeChecker_Common.res_typ) in
-      if uu____25279
+      if uu____25264
       then
-        let uu____25280 =
+        let uu____25265 =
           downgrade_ghost_effect_name lc.FStar_TypeChecker_Common.eff_name in
-        match uu____25280 with
+        match uu____25265 with
         | FStar_Pervasives_Native.Some pure_eff ->
-            let uu___3358_25284 =
+            let uu___3358_25269 =
               FStar_TypeChecker_Common.apply_lcomp (ghost_to_pure env1)
                 (fun g -> g) lc in
             {
               FStar_TypeChecker_Common.eff_name = pure_eff;
               FStar_TypeChecker_Common.res_typ =
-                (uu___3358_25284.FStar_TypeChecker_Common.res_typ);
+                (uu___3358_25269.FStar_TypeChecker_Common.res_typ);
               FStar_TypeChecker_Common.cflags =
-                (uu___3358_25284.FStar_TypeChecker_Common.cflags);
+                (uu___3358_25269.FStar_TypeChecker_Common.cflags);
               FStar_TypeChecker_Common.comp_thunk =
-                (uu___3358_25284.FStar_TypeChecker_Common.comp_thunk)
+                (uu___3358_25269.FStar_TypeChecker_Common.comp_thunk)
             }
         | FStar_Pervasives_Native.None -> lc
       else lc
@@ -7943,20 +7942,20 @@ let (term_to_string :
     fun t ->
       let t1 =
         try
-          (fun uu___3365_25300 ->
+          (fun uu___3365_25285 ->
              match () with
              | () ->
                  normalize [FStar_TypeChecker_Env.AllowUnboundUniverses] env1
                    t) ()
         with
-        | uu___3364_25303 ->
-            ((let uu____25305 =
-                let uu____25310 =
-                  let uu____25311 = FStar_Util.message_of_exn uu___3364_25303 in
+        | uu___3364_25288 ->
+            ((let uu____25290 =
+                let uu____25295 =
+                  let uu____25296 = FStar_Util.message_of_exn uu___3364_25288 in
                   FStar_Util.format1 "Normalization failed with error %s\n"
-                    uu____25311 in
-                (FStar_Errors.Warning_NormalizationFailure, uu____25310) in
-              FStar_Errors.log_issue t.FStar_Syntax_Syntax.pos uu____25305);
+                    uu____25296 in
+                (FStar_Errors.Warning_NormalizationFailure, uu____25295) in
+              FStar_Errors.log_issue t.FStar_Syntax_Syntax.pos uu____25290);
              t) in
       FStar_Syntax_Print.term_to_string' env1.FStar_TypeChecker_Env.dsenv t1
 let (comp_to_string :
@@ -7965,22 +7964,22 @@ let (comp_to_string :
     fun c ->
       let c1 =
         try
-          (fun uu___3375_25325 ->
+          (fun uu___3375_25310 ->
              match () with
              | () ->
-                 let uu____25326 =
+                 let uu____25311 =
                    FStar_TypeChecker_Cfg.config
                      [FStar_TypeChecker_Env.AllowUnboundUniverses] env1 in
-                 norm_comp uu____25326 [] c) ()
+                 norm_comp uu____25311 [] c) ()
         with
-        | uu___3374_25335 ->
-            ((let uu____25337 =
-                let uu____25342 =
-                  let uu____25343 = FStar_Util.message_of_exn uu___3374_25335 in
+        | uu___3374_25320 ->
+            ((let uu____25322 =
+                let uu____25327 =
+                  let uu____25328 = FStar_Util.message_of_exn uu___3374_25320 in
                   FStar_Util.format1 "Normalization failed with error %s\n"
-                    uu____25343 in
-                (FStar_Errors.Warning_NormalizationFailure, uu____25342) in
-              FStar_Errors.log_issue c.FStar_Syntax_Syntax.pos uu____25337);
+                    uu____25328 in
+                (FStar_Errors.Warning_NormalizationFailure, uu____25327) in
+              FStar_Errors.log_issue c.FStar_Syntax_Syntax.pos uu____25322);
              c) in
       FStar_Syntax_Print.comp_to_string' env1.FStar_TypeChecker_Env.dsenv c1
 let (normalize_refinement :
@@ -8001,16 +8000,16 @@ let (normalize_refinement :
               let t01 = aux x.FStar_Syntax_Syntax.sort in
               (match t01.FStar_Syntax_Syntax.n with
                | FStar_Syntax_Syntax.Tm_refine (y, phi1) ->
-                   let uu____25388 =
-                     let uu____25389 =
-                       let uu____25396 =
+                   let uu____25373 =
+                     let uu____25374 =
+                       let uu____25381 =
                          FStar_Syntax_Util.mk_conj_simp phi1 phi in
-                       (y, uu____25396) in
-                     FStar_Syntax_Syntax.Tm_refine uu____25389 in
-                   FStar_Syntax_Syntax.mk uu____25388
+                       (y, uu____25381) in
+                     FStar_Syntax_Syntax.Tm_refine uu____25374 in
+                   FStar_Syntax_Syntax.mk uu____25373
                      t01.FStar_Syntax_Syntax.pos
-               | uu____25401 -> t2)
-          | uu____25402 -> t2 in
+               | uu____25386 -> t2)
+          | uu____25387 -> t2 in
         aux t
 let (whnf_steps : FStar_TypeChecker_Env.step Prims.list) =
   [FStar_TypeChecker_Env.Primops;
@@ -8063,29 +8062,29 @@ let (eta_expand_with_type :
   fun env1 ->
     fun e ->
       fun t_e ->
-        let uu____25483 = FStar_Syntax_Util.arrow_formals_comp t_e in
-        match uu____25483 with
+        let uu____25468 = FStar_Syntax_Util.arrow_formals_comp t_e in
+        match uu____25468 with
         | (formals, c) ->
             (match formals with
              | [] -> e
-             | uu____25496 ->
-                 let uu____25497 = FStar_Syntax_Util.abs_formals e in
-                 (match uu____25497 with
-                  | (actuals, uu____25507, uu____25508) ->
+             | uu____25481 ->
+                 let uu____25482 = FStar_Syntax_Util.abs_formals e in
+                 (match uu____25482 with
+                  | (actuals, uu____25492, uu____25493) ->
                       if
                         (FStar_List.length actuals) =
                           (FStar_List.length formals)
                       then e
                       else
-                        (let uu____25526 =
+                        (let uu____25511 =
                            FStar_All.pipe_right formals
                              FStar_Syntax_Util.args_of_binders in
-                         match uu____25526 with
+                         match uu____25511 with
                          | (binders, args) ->
-                             let uu____25537 =
+                             let uu____25522 =
                                FStar_Syntax_Syntax.mk_Tm_app e args
                                  e.FStar_Syntax_Syntax.pos in
-                             FStar_Syntax_Util.abs binders uu____25537
+                             FStar_Syntax_Util.abs binders uu____25522
                                (FStar_Pervasives_Native.Some
                                   (FStar_Syntax_Util.residual_comp_of_comp c)))))
 let (eta_expand :
@@ -8097,231 +8096,231 @@ let (eta_expand :
       match t.FStar_Syntax_Syntax.n with
       | FStar_Syntax_Syntax.Tm_name x ->
           eta_expand_with_type env1 t x.FStar_Syntax_Syntax.sort
-      | uu____25551 ->
-          let uu____25552 = FStar_Syntax_Util.head_and_args t in
-          (match uu____25552 with
+      | uu____25536 ->
+          let uu____25537 = FStar_Syntax_Util.head_and_args t in
+          (match uu____25537 with
            | (head, args) ->
-               let uu____25595 =
-                 let uu____25596 = FStar_Syntax_Subst.compress head in
-                 uu____25596.FStar_Syntax_Syntax.n in
-               (match uu____25595 with
+               let uu____25580 =
+                 let uu____25581 = FStar_Syntax_Subst.compress head in
+                 uu____25581.FStar_Syntax_Syntax.n in
+               (match uu____25580 with
                 | FStar_Syntax_Syntax.Tm_uvar (u, s) ->
-                    let uu____25617 =
-                      let uu____25624 =
+                    let uu____25602 =
+                      let uu____25609 =
                         FStar_Syntax_Subst.subst' s
                           u.FStar_Syntax_Syntax.ctx_uvar_typ in
-                      FStar_Syntax_Util.arrow_formals uu____25624 in
-                    (match uu____25617 with
+                      FStar_Syntax_Util.arrow_formals uu____25609 in
+                    (match uu____25602 with
                      | (formals, _tres) ->
                          if
                            (FStar_List.length formals) =
                              (FStar_List.length args)
                          then t
                          else
-                           (let uu____25646 =
+                           (let uu____25631 =
                               env1.FStar_TypeChecker_Env.type_of
-                                (let uu___3445_25654 = env1 in
+                                (let uu___3445_25639 = env1 in
                                  {
                                    FStar_TypeChecker_Env.solver =
-                                     (uu___3445_25654.FStar_TypeChecker_Env.solver);
+                                     (uu___3445_25639.FStar_TypeChecker_Env.solver);
                                    FStar_TypeChecker_Env.range =
-                                     (uu___3445_25654.FStar_TypeChecker_Env.range);
+                                     (uu___3445_25639.FStar_TypeChecker_Env.range);
                                    FStar_TypeChecker_Env.curmodule =
-                                     (uu___3445_25654.FStar_TypeChecker_Env.curmodule);
+                                     (uu___3445_25639.FStar_TypeChecker_Env.curmodule);
                                    FStar_TypeChecker_Env.gamma =
-                                     (uu___3445_25654.FStar_TypeChecker_Env.gamma);
+                                     (uu___3445_25639.FStar_TypeChecker_Env.gamma);
                                    FStar_TypeChecker_Env.gamma_sig =
-                                     (uu___3445_25654.FStar_TypeChecker_Env.gamma_sig);
+                                     (uu___3445_25639.FStar_TypeChecker_Env.gamma_sig);
                                    FStar_TypeChecker_Env.gamma_cache =
-                                     (uu___3445_25654.FStar_TypeChecker_Env.gamma_cache);
+                                     (uu___3445_25639.FStar_TypeChecker_Env.gamma_cache);
                                    FStar_TypeChecker_Env.modules =
-                                     (uu___3445_25654.FStar_TypeChecker_Env.modules);
+                                     (uu___3445_25639.FStar_TypeChecker_Env.modules);
                                    FStar_TypeChecker_Env.expected_typ =
                                      FStar_Pervasives_Native.None;
                                    FStar_TypeChecker_Env.sigtab =
-                                     (uu___3445_25654.FStar_TypeChecker_Env.sigtab);
+                                     (uu___3445_25639.FStar_TypeChecker_Env.sigtab);
                                    FStar_TypeChecker_Env.attrtab =
-                                     (uu___3445_25654.FStar_TypeChecker_Env.attrtab);
+                                     (uu___3445_25639.FStar_TypeChecker_Env.attrtab);
                                    FStar_TypeChecker_Env.instantiate_imp =
-                                     (uu___3445_25654.FStar_TypeChecker_Env.instantiate_imp);
+                                     (uu___3445_25639.FStar_TypeChecker_Env.instantiate_imp);
                                    FStar_TypeChecker_Env.effects =
-                                     (uu___3445_25654.FStar_TypeChecker_Env.effects);
+                                     (uu___3445_25639.FStar_TypeChecker_Env.effects);
                                    FStar_TypeChecker_Env.generalize =
-                                     (uu___3445_25654.FStar_TypeChecker_Env.generalize);
+                                     (uu___3445_25639.FStar_TypeChecker_Env.generalize);
                                    FStar_TypeChecker_Env.letrecs =
-                                     (uu___3445_25654.FStar_TypeChecker_Env.letrecs);
+                                     (uu___3445_25639.FStar_TypeChecker_Env.letrecs);
                                    FStar_TypeChecker_Env.top_level =
-                                     (uu___3445_25654.FStar_TypeChecker_Env.top_level);
+                                     (uu___3445_25639.FStar_TypeChecker_Env.top_level);
                                    FStar_TypeChecker_Env.check_uvars =
-                                     (uu___3445_25654.FStar_TypeChecker_Env.check_uvars);
+                                     (uu___3445_25639.FStar_TypeChecker_Env.check_uvars);
                                    FStar_TypeChecker_Env.use_eq =
-                                     (uu___3445_25654.FStar_TypeChecker_Env.use_eq);
+                                     (uu___3445_25639.FStar_TypeChecker_Env.use_eq);
                                    FStar_TypeChecker_Env.use_eq_strict =
-                                     (uu___3445_25654.FStar_TypeChecker_Env.use_eq_strict);
+                                     (uu___3445_25639.FStar_TypeChecker_Env.use_eq_strict);
                                    FStar_TypeChecker_Env.is_iface =
-                                     (uu___3445_25654.FStar_TypeChecker_Env.is_iface);
+                                     (uu___3445_25639.FStar_TypeChecker_Env.is_iface);
                                    FStar_TypeChecker_Env.admit =
-                                     (uu___3445_25654.FStar_TypeChecker_Env.admit);
+                                     (uu___3445_25639.FStar_TypeChecker_Env.admit);
                                    FStar_TypeChecker_Env.lax = true;
                                    FStar_TypeChecker_Env.lax_universes =
-                                     (uu___3445_25654.FStar_TypeChecker_Env.lax_universes);
+                                     (uu___3445_25639.FStar_TypeChecker_Env.lax_universes);
                                    FStar_TypeChecker_Env.phase1 =
-                                     (uu___3445_25654.FStar_TypeChecker_Env.phase1);
+                                     (uu___3445_25639.FStar_TypeChecker_Env.phase1);
                                    FStar_TypeChecker_Env.failhard =
-                                     (uu___3445_25654.FStar_TypeChecker_Env.failhard);
+                                     (uu___3445_25639.FStar_TypeChecker_Env.failhard);
                                    FStar_TypeChecker_Env.nosynth =
-                                     (uu___3445_25654.FStar_TypeChecker_Env.nosynth);
+                                     (uu___3445_25639.FStar_TypeChecker_Env.nosynth);
                                    FStar_TypeChecker_Env.uvar_subtyping =
-                                     (uu___3445_25654.FStar_TypeChecker_Env.uvar_subtyping);
+                                     (uu___3445_25639.FStar_TypeChecker_Env.uvar_subtyping);
                                    FStar_TypeChecker_Env.tc_term =
-                                     (uu___3445_25654.FStar_TypeChecker_Env.tc_term);
+                                     (uu___3445_25639.FStar_TypeChecker_Env.tc_term);
                                    FStar_TypeChecker_Env.type_of =
-                                     (uu___3445_25654.FStar_TypeChecker_Env.type_of);
+                                     (uu___3445_25639.FStar_TypeChecker_Env.type_of);
                                    FStar_TypeChecker_Env.universe_of =
-                                     (uu___3445_25654.FStar_TypeChecker_Env.universe_of);
+                                     (uu___3445_25639.FStar_TypeChecker_Env.universe_of);
                                    FStar_TypeChecker_Env.check_type_of =
-                                     (uu___3445_25654.FStar_TypeChecker_Env.check_type_of);
+                                     (uu___3445_25639.FStar_TypeChecker_Env.check_type_of);
                                    FStar_TypeChecker_Env.use_bv_sorts = true;
                                    FStar_TypeChecker_Env.qtbl_name_and_index
                                      =
-                                     (uu___3445_25654.FStar_TypeChecker_Env.qtbl_name_and_index);
+                                     (uu___3445_25639.FStar_TypeChecker_Env.qtbl_name_and_index);
                                    FStar_TypeChecker_Env.normalized_eff_names
                                      =
-                                     (uu___3445_25654.FStar_TypeChecker_Env.normalized_eff_names);
+                                     (uu___3445_25639.FStar_TypeChecker_Env.normalized_eff_names);
                                    FStar_TypeChecker_Env.fv_delta_depths =
-                                     (uu___3445_25654.FStar_TypeChecker_Env.fv_delta_depths);
+                                     (uu___3445_25639.FStar_TypeChecker_Env.fv_delta_depths);
                                    FStar_TypeChecker_Env.proof_ns =
-                                     (uu___3445_25654.FStar_TypeChecker_Env.proof_ns);
+                                     (uu___3445_25639.FStar_TypeChecker_Env.proof_ns);
                                    FStar_TypeChecker_Env.synth_hook =
-                                     (uu___3445_25654.FStar_TypeChecker_Env.synth_hook);
+                                     (uu___3445_25639.FStar_TypeChecker_Env.synth_hook);
                                    FStar_TypeChecker_Env.try_solve_implicits_hook
                                      =
-                                     (uu___3445_25654.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                                     (uu___3445_25639.FStar_TypeChecker_Env.try_solve_implicits_hook);
                                    FStar_TypeChecker_Env.splice =
-                                     (uu___3445_25654.FStar_TypeChecker_Env.splice);
+                                     (uu___3445_25639.FStar_TypeChecker_Env.splice);
                                    FStar_TypeChecker_Env.mpreprocess =
-                                     (uu___3445_25654.FStar_TypeChecker_Env.mpreprocess);
+                                     (uu___3445_25639.FStar_TypeChecker_Env.mpreprocess);
                                    FStar_TypeChecker_Env.postprocess =
-                                     (uu___3445_25654.FStar_TypeChecker_Env.postprocess);
+                                     (uu___3445_25639.FStar_TypeChecker_Env.postprocess);
                                    FStar_TypeChecker_Env.identifier_info =
-                                     (uu___3445_25654.FStar_TypeChecker_Env.identifier_info);
+                                     (uu___3445_25639.FStar_TypeChecker_Env.identifier_info);
                                    FStar_TypeChecker_Env.tc_hooks =
-                                     (uu___3445_25654.FStar_TypeChecker_Env.tc_hooks);
+                                     (uu___3445_25639.FStar_TypeChecker_Env.tc_hooks);
                                    FStar_TypeChecker_Env.dsenv =
-                                     (uu___3445_25654.FStar_TypeChecker_Env.dsenv);
+                                     (uu___3445_25639.FStar_TypeChecker_Env.dsenv);
                                    FStar_TypeChecker_Env.nbe =
-                                     (uu___3445_25654.FStar_TypeChecker_Env.nbe);
+                                     (uu___3445_25639.FStar_TypeChecker_Env.nbe);
                                    FStar_TypeChecker_Env.strict_args_tab =
-                                     (uu___3445_25654.FStar_TypeChecker_Env.strict_args_tab);
+                                     (uu___3445_25639.FStar_TypeChecker_Env.strict_args_tab);
                                    FStar_TypeChecker_Env.erasable_types_tab =
-                                     (uu___3445_25654.FStar_TypeChecker_Env.erasable_types_tab);
+                                     (uu___3445_25639.FStar_TypeChecker_Env.erasable_types_tab);
                                    FStar_TypeChecker_Env.enable_defer_to_tac
                                      =
-                                     (uu___3445_25654.FStar_TypeChecker_Env.enable_defer_to_tac)
+                                     (uu___3445_25639.FStar_TypeChecker_Env.enable_defer_to_tac)
                                  }) t in
-                            match uu____25646 with
-                            | (uu____25655, ty, uu____25657) ->
+                            match uu____25631 with
+                            | (uu____25640, ty, uu____25642) ->
                                 eta_expand_with_type env1 t ty))
-                | uu____25658 ->
-                    let uu____25659 =
+                | uu____25643 ->
+                    let uu____25644 =
                       env1.FStar_TypeChecker_Env.type_of
-                        (let uu___3452_25667 = env1 in
+                        (let uu___3452_25652 = env1 in
                          {
                            FStar_TypeChecker_Env.solver =
-                             (uu___3452_25667.FStar_TypeChecker_Env.solver);
+                             (uu___3452_25652.FStar_TypeChecker_Env.solver);
                            FStar_TypeChecker_Env.range =
-                             (uu___3452_25667.FStar_TypeChecker_Env.range);
+                             (uu___3452_25652.FStar_TypeChecker_Env.range);
                            FStar_TypeChecker_Env.curmodule =
-                             (uu___3452_25667.FStar_TypeChecker_Env.curmodule);
+                             (uu___3452_25652.FStar_TypeChecker_Env.curmodule);
                            FStar_TypeChecker_Env.gamma =
-                             (uu___3452_25667.FStar_TypeChecker_Env.gamma);
+                             (uu___3452_25652.FStar_TypeChecker_Env.gamma);
                            FStar_TypeChecker_Env.gamma_sig =
-                             (uu___3452_25667.FStar_TypeChecker_Env.gamma_sig);
+                             (uu___3452_25652.FStar_TypeChecker_Env.gamma_sig);
                            FStar_TypeChecker_Env.gamma_cache =
-                             (uu___3452_25667.FStar_TypeChecker_Env.gamma_cache);
+                             (uu___3452_25652.FStar_TypeChecker_Env.gamma_cache);
                            FStar_TypeChecker_Env.modules =
-                             (uu___3452_25667.FStar_TypeChecker_Env.modules);
+                             (uu___3452_25652.FStar_TypeChecker_Env.modules);
                            FStar_TypeChecker_Env.expected_typ =
                              FStar_Pervasives_Native.None;
                            FStar_TypeChecker_Env.sigtab =
-                             (uu___3452_25667.FStar_TypeChecker_Env.sigtab);
+                             (uu___3452_25652.FStar_TypeChecker_Env.sigtab);
                            FStar_TypeChecker_Env.attrtab =
-                             (uu___3452_25667.FStar_TypeChecker_Env.attrtab);
+                             (uu___3452_25652.FStar_TypeChecker_Env.attrtab);
                            FStar_TypeChecker_Env.instantiate_imp =
-                             (uu___3452_25667.FStar_TypeChecker_Env.instantiate_imp);
+                             (uu___3452_25652.FStar_TypeChecker_Env.instantiate_imp);
                            FStar_TypeChecker_Env.effects =
-                             (uu___3452_25667.FStar_TypeChecker_Env.effects);
+                             (uu___3452_25652.FStar_TypeChecker_Env.effects);
                            FStar_TypeChecker_Env.generalize =
-                             (uu___3452_25667.FStar_TypeChecker_Env.generalize);
+                             (uu___3452_25652.FStar_TypeChecker_Env.generalize);
                            FStar_TypeChecker_Env.letrecs =
-                             (uu___3452_25667.FStar_TypeChecker_Env.letrecs);
+                             (uu___3452_25652.FStar_TypeChecker_Env.letrecs);
                            FStar_TypeChecker_Env.top_level =
-                             (uu___3452_25667.FStar_TypeChecker_Env.top_level);
+                             (uu___3452_25652.FStar_TypeChecker_Env.top_level);
                            FStar_TypeChecker_Env.check_uvars =
-                             (uu___3452_25667.FStar_TypeChecker_Env.check_uvars);
+                             (uu___3452_25652.FStar_TypeChecker_Env.check_uvars);
                            FStar_TypeChecker_Env.use_eq =
-                             (uu___3452_25667.FStar_TypeChecker_Env.use_eq);
+                             (uu___3452_25652.FStar_TypeChecker_Env.use_eq);
                            FStar_TypeChecker_Env.use_eq_strict =
-                             (uu___3452_25667.FStar_TypeChecker_Env.use_eq_strict);
+                             (uu___3452_25652.FStar_TypeChecker_Env.use_eq_strict);
                            FStar_TypeChecker_Env.is_iface =
-                             (uu___3452_25667.FStar_TypeChecker_Env.is_iface);
+                             (uu___3452_25652.FStar_TypeChecker_Env.is_iface);
                            FStar_TypeChecker_Env.admit =
-                             (uu___3452_25667.FStar_TypeChecker_Env.admit);
+                             (uu___3452_25652.FStar_TypeChecker_Env.admit);
                            FStar_TypeChecker_Env.lax = true;
                            FStar_TypeChecker_Env.lax_universes =
-                             (uu___3452_25667.FStar_TypeChecker_Env.lax_universes);
+                             (uu___3452_25652.FStar_TypeChecker_Env.lax_universes);
                            FStar_TypeChecker_Env.phase1 =
-                             (uu___3452_25667.FStar_TypeChecker_Env.phase1);
+                             (uu___3452_25652.FStar_TypeChecker_Env.phase1);
                            FStar_TypeChecker_Env.failhard =
-                             (uu___3452_25667.FStar_TypeChecker_Env.failhard);
+                             (uu___3452_25652.FStar_TypeChecker_Env.failhard);
                            FStar_TypeChecker_Env.nosynth =
-                             (uu___3452_25667.FStar_TypeChecker_Env.nosynth);
+                             (uu___3452_25652.FStar_TypeChecker_Env.nosynth);
                            FStar_TypeChecker_Env.uvar_subtyping =
-                             (uu___3452_25667.FStar_TypeChecker_Env.uvar_subtyping);
+                             (uu___3452_25652.FStar_TypeChecker_Env.uvar_subtyping);
                            FStar_TypeChecker_Env.tc_term =
-                             (uu___3452_25667.FStar_TypeChecker_Env.tc_term);
+                             (uu___3452_25652.FStar_TypeChecker_Env.tc_term);
                            FStar_TypeChecker_Env.type_of =
-                             (uu___3452_25667.FStar_TypeChecker_Env.type_of);
+                             (uu___3452_25652.FStar_TypeChecker_Env.type_of);
                            FStar_TypeChecker_Env.universe_of =
-                             (uu___3452_25667.FStar_TypeChecker_Env.universe_of);
+                             (uu___3452_25652.FStar_TypeChecker_Env.universe_of);
                            FStar_TypeChecker_Env.check_type_of =
-                             (uu___3452_25667.FStar_TypeChecker_Env.check_type_of);
+                             (uu___3452_25652.FStar_TypeChecker_Env.check_type_of);
                            FStar_TypeChecker_Env.use_bv_sorts = true;
                            FStar_TypeChecker_Env.qtbl_name_and_index =
-                             (uu___3452_25667.FStar_TypeChecker_Env.qtbl_name_and_index);
+                             (uu___3452_25652.FStar_TypeChecker_Env.qtbl_name_and_index);
                            FStar_TypeChecker_Env.normalized_eff_names =
-                             (uu___3452_25667.FStar_TypeChecker_Env.normalized_eff_names);
+                             (uu___3452_25652.FStar_TypeChecker_Env.normalized_eff_names);
                            FStar_TypeChecker_Env.fv_delta_depths =
-                             (uu___3452_25667.FStar_TypeChecker_Env.fv_delta_depths);
+                             (uu___3452_25652.FStar_TypeChecker_Env.fv_delta_depths);
                            FStar_TypeChecker_Env.proof_ns =
-                             (uu___3452_25667.FStar_TypeChecker_Env.proof_ns);
+                             (uu___3452_25652.FStar_TypeChecker_Env.proof_ns);
                            FStar_TypeChecker_Env.synth_hook =
-                             (uu___3452_25667.FStar_TypeChecker_Env.synth_hook);
+                             (uu___3452_25652.FStar_TypeChecker_Env.synth_hook);
                            FStar_TypeChecker_Env.try_solve_implicits_hook =
-                             (uu___3452_25667.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                             (uu___3452_25652.FStar_TypeChecker_Env.try_solve_implicits_hook);
                            FStar_TypeChecker_Env.splice =
-                             (uu___3452_25667.FStar_TypeChecker_Env.splice);
+                             (uu___3452_25652.FStar_TypeChecker_Env.splice);
                            FStar_TypeChecker_Env.mpreprocess =
-                             (uu___3452_25667.FStar_TypeChecker_Env.mpreprocess);
+                             (uu___3452_25652.FStar_TypeChecker_Env.mpreprocess);
                            FStar_TypeChecker_Env.postprocess =
-                             (uu___3452_25667.FStar_TypeChecker_Env.postprocess);
+                             (uu___3452_25652.FStar_TypeChecker_Env.postprocess);
                            FStar_TypeChecker_Env.identifier_info =
-                             (uu___3452_25667.FStar_TypeChecker_Env.identifier_info);
+                             (uu___3452_25652.FStar_TypeChecker_Env.identifier_info);
                            FStar_TypeChecker_Env.tc_hooks =
-                             (uu___3452_25667.FStar_TypeChecker_Env.tc_hooks);
+                             (uu___3452_25652.FStar_TypeChecker_Env.tc_hooks);
                            FStar_TypeChecker_Env.dsenv =
-                             (uu___3452_25667.FStar_TypeChecker_Env.dsenv);
+                             (uu___3452_25652.FStar_TypeChecker_Env.dsenv);
                            FStar_TypeChecker_Env.nbe =
-                             (uu___3452_25667.FStar_TypeChecker_Env.nbe);
+                             (uu___3452_25652.FStar_TypeChecker_Env.nbe);
                            FStar_TypeChecker_Env.strict_args_tab =
-                             (uu___3452_25667.FStar_TypeChecker_Env.strict_args_tab);
+                             (uu___3452_25652.FStar_TypeChecker_Env.strict_args_tab);
                            FStar_TypeChecker_Env.erasable_types_tab =
-                             (uu___3452_25667.FStar_TypeChecker_Env.erasable_types_tab);
+                             (uu___3452_25652.FStar_TypeChecker_Env.erasable_types_tab);
                            FStar_TypeChecker_Env.enable_defer_to_tac =
-                             (uu___3452_25667.FStar_TypeChecker_Env.enable_defer_to_tac)
+                             (uu___3452_25652.FStar_TypeChecker_Env.enable_defer_to_tac)
                          }) t in
-                    (match uu____25659 with
-                     | (uu____25668, ty, uu____25670) ->
+                    (match uu____25644 with
+                     | (uu____25653, ty, uu____25655) ->
                          eta_expand_with_type env1 t ty)))
 let rec (elim_delayed_subst_term :
   FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term) =
@@ -8329,224 +8328,224 @@ let rec (elim_delayed_subst_term :
     let mk x = FStar_Syntax_Syntax.mk x t.FStar_Syntax_Syntax.pos in
     let t1 = FStar_Syntax_Subst.compress t in
     let elim_bv x =
-      let uu___3464_25751 = x in
-      let uu____25752 = elim_delayed_subst_term x.FStar_Syntax_Syntax.sort in
+      let uu___3464_25736 = x in
+      let uu____25737 = elim_delayed_subst_term x.FStar_Syntax_Syntax.sort in
       {
         FStar_Syntax_Syntax.ppname =
-          (uu___3464_25751.FStar_Syntax_Syntax.ppname);
+          (uu___3464_25736.FStar_Syntax_Syntax.ppname);
         FStar_Syntax_Syntax.index =
-          (uu___3464_25751.FStar_Syntax_Syntax.index);
-        FStar_Syntax_Syntax.sort = uu____25752
+          (uu___3464_25736.FStar_Syntax_Syntax.index);
+        FStar_Syntax_Syntax.sort = uu____25737
       } in
     match t1.FStar_Syntax_Syntax.n with
-    | FStar_Syntax_Syntax.Tm_delayed uu____25755 -> failwith "Impossible"
-    | FStar_Syntax_Syntax.Tm_bvar uu____25770 -> t1
-    | FStar_Syntax_Syntax.Tm_name uu____25771 -> t1
-    | FStar_Syntax_Syntax.Tm_fvar uu____25772 -> t1
-    | FStar_Syntax_Syntax.Tm_uinst uu____25773 -> t1
-    | FStar_Syntax_Syntax.Tm_constant uu____25780 -> t1
-    | FStar_Syntax_Syntax.Tm_type uu____25781 -> t1
-    | FStar_Syntax_Syntax.Tm_lazy uu____25782 -> t1
+    | FStar_Syntax_Syntax.Tm_delayed uu____25740 -> failwith "Impossible"
+    | FStar_Syntax_Syntax.Tm_bvar uu____25755 -> t1
+    | FStar_Syntax_Syntax.Tm_name uu____25756 -> t1
+    | FStar_Syntax_Syntax.Tm_fvar uu____25757 -> t1
+    | FStar_Syntax_Syntax.Tm_uinst uu____25758 -> t1
+    | FStar_Syntax_Syntax.Tm_constant uu____25765 -> t1
+    | FStar_Syntax_Syntax.Tm_type uu____25766 -> t1
+    | FStar_Syntax_Syntax.Tm_lazy uu____25767 -> t1
     | FStar_Syntax_Syntax.Tm_unknown -> t1
     | FStar_Syntax_Syntax.Tm_abs (bs, t2, rc_opt) ->
         let elim_rc rc =
-          let uu___3490_25816 = rc in
-          let uu____25817 =
+          let uu___3490_25801 = rc in
+          let uu____25802 =
             FStar_Util.map_opt rc.FStar_Syntax_Syntax.residual_typ
               elim_delayed_subst_term in
-          let uu____25826 =
+          let uu____25811 =
             elim_delayed_subst_cflags rc.FStar_Syntax_Syntax.residual_flags in
           {
             FStar_Syntax_Syntax.residual_effect =
-              (uu___3490_25816.FStar_Syntax_Syntax.residual_effect);
-            FStar_Syntax_Syntax.residual_typ = uu____25817;
-            FStar_Syntax_Syntax.residual_flags = uu____25826
+              (uu___3490_25801.FStar_Syntax_Syntax.residual_effect);
+            FStar_Syntax_Syntax.residual_typ = uu____25802;
+            FStar_Syntax_Syntax.residual_flags = uu____25811
           } in
-        let uu____25829 =
-          let uu____25830 =
-            let uu____25849 = elim_delayed_subst_binders bs in
-            let uu____25858 = elim_delayed_subst_term t2 in
-            let uu____25861 = FStar_Util.map_opt rc_opt elim_rc in
-            (uu____25849, uu____25858, uu____25861) in
-          FStar_Syntax_Syntax.Tm_abs uu____25830 in
-        mk uu____25829
+        let uu____25814 =
+          let uu____25815 =
+            let uu____25834 = elim_delayed_subst_binders bs in
+            let uu____25843 = elim_delayed_subst_term t2 in
+            let uu____25846 = FStar_Util.map_opt rc_opt elim_rc in
+            (uu____25834, uu____25843, uu____25846) in
+          FStar_Syntax_Syntax.Tm_abs uu____25815 in
+        mk uu____25814
     | FStar_Syntax_Syntax.Tm_arrow (bs, c) ->
-        let uu____25898 =
-          let uu____25899 =
-            let uu____25914 = elim_delayed_subst_binders bs in
-            let uu____25923 = elim_delayed_subst_comp c in
-            (uu____25914, uu____25923) in
-          FStar_Syntax_Syntax.Tm_arrow uu____25899 in
-        mk uu____25898
+        let uu____25883 =
+          let uu____25884 =
+            let uu____25899 = elim_delayed_subst_binders bs in
+            let uu____25908 = elim_delayed_subst_comp c in
+            (uu____25899, uu____25908) in
+          FStar_Syntax_Syntax.Tm_arrow uu____25884 in
+        mk uu____25883
     | FStar_Syntax_Syntax.Tm_refine (bv, phi) ->
-        let uu____25942 =
-          let uu____25943 =
-            let uu____25950 = elim_bv bv in
-            let uu____25951 = elim_delayed_subst_term phi in
-            (uu____25950, uu____25951) in
-          FStar_Syntax_Syntax.Tm_refine uu____25943 in
-        mk uu____25942
+        let uu____25927 =
+          let uu____25928 =
+            let uu____25935 = elim_bv bv in
+            let uu____25936 = elim_delayed_subst_term phi in
+            (uu____25935, uu____25936) in
+          FStar_Syntax_Syntax.Tm_refine uu____25928 in
+        mk uu____25927
     | FStar_Syntax_Syntax.Tm_app (t2, args) ->
-        let uu____25982 =
-          let uu____25983 =
-            let uu____26000 = elim_delayed_subst_term t2 in
-            let uu____26003 = elim_delayed_subst_args args in
-            (uu____26000, uu____26003) in
-          FStar_Syntax_Syntax.Tm_app uu____25983 in
-        mk uu____25982
+        let uu____25967 =
+          let uu____25968 =
+            let uu____25985 = elim_delayed_subst_term t2 in
+            let uu____25988 = elim_delayed_subst_args args in
+            (uu____25985, uu____25988) in
+          FStar_Syntax_Syntax.Tm_app uu____25968 in
+        mk uu____25967
     | FStar_Syntax_Syntax.Tm_match (t2, branches1) ->
         let rec elim_pat p =
           match p.FStar_Syntax_Syntax.v with
           | FStar_Syntax_Syntax.Pat_var x ->
-              let uu___3512_26075 = p in
-              let uu____26076 =
-                let uu____26077 = elim_bv x in
-                FStar_Syntax_Syntax.Pat_var uu____26077 in
+              let uu___3512_26060 = p in
+              let uu____26061 =
+                let uu____26062 = elim_bv x in
+                FStar_Syntax_Syntax.Pat_var uu____26062 in
               {
-                FStar_Syntax_Syntax.v = uu____26076;
+                FStar_Syntax_Syntax.v = uu____26061;
                 FStar_Syntax_Syntax.p =
-                  (uu___3512_26075.FStar_Syntax_Syntax.p)
+                  (uu___3512_26060.FStar_Syntax_Syntax.p)
               }
           | FStar_Syntax_Syntax.Pat_wild x ->
-              let uu___3516_26079 = p in
-              let uu____26080 =
-                let uu____26081 = elim_bv x in
-                FStar_Syntax_Syntax.Pat_wild uu____26081 in
+              let uu___3516_26064 = p in
+              let uu____26065 =
+                let uu____26066 = elim_bv x in
+                FStar_Syntax_Syntax.Pat_wild uu____26066 in
               {
-                FStar_Syntax_Syntax.v = uu____26080;
+                FStar_Syntax_Syntax.v = uu____26065;
                 FStar_Syntax_Syntax.p =
-                  (uu___3516_26079.FStar_Syntax_Syntax.p)
+                  (uu___3516_26064.FStar_Syntax_Syntax.p)
               }
           | FStar_Syntax_Syntax.Pat_dot_term (x, t0) ->
-              let uu___3522_26088 = p in
-              let uu____26089 =
-                let uu____26090 =
-                  let uu____26097 = elim_bv x in
-                  let uu____26098 = elim_delayed_subst_term t0 in
-                  (uu____26097, uu____26098) in
-                FStar_Syntax_Syntax.Pat_dot_term uu____26090 in
+              let uu___3522_26073 = p in
+              let uu____26074 =
+                let uu____26075 =
+                  let uu____26082 = elim_bv x in
+                  let uu____26083 = elim_delayed_subst_term t0 in
+                  (uu____26082, uu____26083) in
+                FStar_Syntax_Syntax.Pat_dot_term uu____26075 in
               {
-                FStar_Syntax_Syntax.v = uu____26089;
+                FStar_Syntax_Syntax.v = uu____26074;
                 FStar_Syntax_Syntax.p =
-                  (uu___3522_26088.FStar_Syntax_Syntax.p)
+                  (uu___3522_26073.FStar_Syntax_Syntax.p)
               }
           | FStar_Syntax_Syntax.Pat_cons (fv, pats) ->
-              let uu___3528_26121 = p in
-              let uu____26122 =
-                let uu____26123 =
-                  let uu____26136 =
+              let uu___3528_26106 = p in
+              let uu____26107 =
+                let uu____26108 =
+                  let uu____26121 =
                     FStar_List.map
-                      (fun uu____26159 ->
-                         match uu____26159 with
+                      (fun uu____26144 ->
+                         match uu____26144 with
                          | (x, b) ->
-                             let uu____26172 = elim_pat x in (uu____26172, b))
+                             let uu____26157 = elim_pat x in (uu____26157, b))
                       pats in
-                  (fv, uu____26136) in
-                FStar_Syntax_Syntax.Pat_cons uu____26123 in
+                  (fv, uu____26121) in
+                FStar_Syntax_Syntax.Pat_cons uu____26108 in
               {
-                FStar_Syntax_Syntax.v = uu____26122;
+                FStar_Syntax_Syntax.v = uu____26107;
                 FStar_Syntax_Syntax.p =
-                  (uu___3528_26121.FStar_Syntax_Syntax.p)
+                  (uu___3528_26106.FStar_Syntax_Syntax.p)
               }
-          | uu____26185 -> p in
-        let elim_branch uu____26209 =
-          match uu____26209 with
+          | uu____26170 -> p in
+        let elim_branch uu____26194 =
+          match uu____26194 with
           | (pat, wopt, t3) ->
-              let uu____26235 = elim_pat pat in
-              let uu____26238 =
+              let uu____26220 = elim_pat pat in
+              let uu____26223 =
                 FStar_Util.map_opt wopt elim_delayed_subst_term in
-              let uu____26241 = elim_delayed_subst_term t3 in
-              (uu____26235, uu____26238, uu____26241) in
-        let uu____26246 =
-          let uu____26247 =
-            let uu____26270 = elim_delayed_subst_term t2 in
-            let uu____26273 = FStar_List.map elim_branch branches1 in
-            (uu____26270, uu____26273) in
-          FStar_Syntax_Syntax.Tm_match uu____26247 in
-        mk uu____26246
+              let uu____26226 = elim_delayed_subst_term t3 in
+              (uu____26220, uu____26223, uu____26226) in
+        let uu____26231 =
+          let uu____26232 =
+            let uu____26255 = elim_delayed_subst_term t2 in
+            let uu____26258 = FStar_List.map elim_branch branches1 in
+            (uu____26255, uu____26258) in
+          FStar_Syntax_Syntax.Tm_match uu____26232 in
+        mk uu____26231
     | FStar_Syntax_Syntax.Tm_ascribed (t2, a, lopt) ->
-        let elim_ascription uu____26404 =
-          match uu____26404 with
+        let elim_ascription uu____26389 =
+          match uu____26389 with
           | (tc, topt) ->
-              let uu____26439 =
+              let uu____26424 =
                 match tc with
                 | FStar_Util.Inl t3 ->
-                    let uu____26449 = elim_delayed_subst_term t3 in
-                    FStar_Util.Inl uu____26449
+                    let uu____26434 = elim_delayed_subst_term t3 in
+                    FStar_Util.Inl uu____26434
                 | FStar_Util.Inr c ->
-                    let uu____26451 = elim_delayed_subst_comp c in
-                    FStar_Util.Inr uu____26451 in
-              let uu____26452 =
+                    let uu____26436 = elim_delayed_subst_comp c in
+                    FStar_Util.Inr uu____26436 in
+              let uu____26437 =
                 FStar_Util.map_opt topt elim_delayed_subst_term in
-              (uu____26439, uu____26452) in
-        let uu____26461 =
-          let uu____26462 =
-            let uu____26489 = elim_delayed_subst_term t2 in
-            let uu____26492 = elim_ascription a in
-            (uu____26489, uu____26492, lopt) in
-          FStar_Syntax_Syntax.Tm_ascribed uu____26462 in
-        mk uu____26461
+              (uu____26424, uu____26437) in
+        let uu____26446 =
+          let uu____26447 =
+            let uu____26474 = elim_delayed_subst_term t2 in
+            let uu____26477 = elim_ascription a in
+            (uu____26474, uu____26477, lopt) in
+          FStar_Syntax_Syntax.Tm_ascribed uu____26447 in
+        mk uu____26446
     | FStar_Syntax_Syntax.Tm_let (lbs, t2) ->
         let elim_lb lb =
-          let uu___3558_26553 = lb in
-          let uu____26554 =
+          let uu___3558_26538 = lb in
+          let uu____26539 =
             elim_delayed_subst_term lb.FStar_Syntax_Syntax.lbtyp in
-          let uu____26557 =
+          let uu____26542 =
             elim_delayed_subst_term lb.FStar_Syntax_Syntax.lbdef in
           {
             FStar_Syntax_Syntax.lbname =
-              (uu___3558_26553.FStar_Syntax_Syntax.lbname);
+              (uu___3558_26538.FStar_Syntax_Syntax.lbname);
             FStar_Syntax_Syntax.lbunivs =
-              (uu___3558_26553.FStar_Syntax_Syntax.lbunivs);
-            FStar_Syntax_Syntax.lbtyp = uu____26554;
+              (uu___3558_26538.FStar_Syntax_Syntax.lbunivs);
+            FStar_Syntax_Syntax.lbtyp = uu____26539;
             FStar_Syntax_Syntax.lbeff =
-              (uu___3558_26553.FStar_Syntax_Syntax.lbeff);
-            FStar_Syntax_Syntax.lbdef = uu____26557;
+              (uu___3558_26538.FStar_Syntax_Syntax.lbeff);
+            FStar_Syntax_Syntax.lbdef = uu____26542;
             FStar_Syntax_Syntax.lbattrs =
-              (uu___3558_26553.FStar_Syntax_Syntax.lbattrs);
+              (uu___3558_26538.FStar_Syntax_Syntax.lbattrs);
             FStar_Syntax_Syntax.lbpos =
-              (uu___3558_26553.FStar_Syntax_Syntax.lbpos)
+              (uu___3558_26538.FStar_Syntax_Syntax.lbpos)
           } in
-        let uu____26560 =
-          let uu____26561 =
-            let uu____26574 =
-              let uu____26581 =
+        let uu____26545 =
+          let uu____26546 =
+            let uu____26559 =
+              let uu____26566 =
                 FStar_List.map elim_lb (FStar_Pervasives_Native.snd lbs) in
-              ((FStar_Pervasives_Native.fst lbs), uu____26581) in
-            let uu____26590 = elim_delayed_subst_term t2 in
-            (uu____26574, uu____26590) in
-          FStar_Syntax_Syntax.Tm_let uu____26561 in
-        mk uu____26560
+              ((FStar_Pervasives_Native.fst lbs), uu____26566) in
+            let uu____26575 = elim_delayed_subst_term t2 in
+            (uu____26559, uu____26575) in
+          FStar_Syntax_Syntax.Tm_let uu____26546 in
+        mk uu____26545
     | FStar_Syntax_Syntax.Tm_uvar (u, s) ->
         mk (FStar_Syntax_Syntax.Tm_uvar (u, s))
     | FStar_Syntax_Syntax.Tm_quoted (tm, qi) ->
         let qi1 =
           FStar_Syntax_Syntax.on_antiquoted elim_delayed_subst_term qi in
-        let uu____26634 =
-          let uu____26635 =
-            let uu____26642 = elim_delayed_subst_term tm in
-            (uu____26642, qi1) in
-          FStar_Syntax_Syntax.Tm_quoted uu____26635 in
-        mk uu____26634
+        let uu____26619 =
+          let uu____26620 =
+            let uu____26627 = elim_delayed_subst_term tm in
+            (uu____26627, qi1) in
+          FStar_Syntax_Syntax.Tm_quoted uu____26620 in
+        mk uu____26619
     | FStar_Syntax_Syntax.Tm_meta (t2, md) ->
-        let uu____26653 =
-          let uu____26654 =
-            let uu____26661 = elim_delayed_subst_term t2 in
-            let uu____26664 = elim_delayed_subst_meta md in
-            (uu____26661, uu____26664) in
-          FStar_Syntax_Syntax.Tm_meta uu____26654 in
-        mk uu____26653
+        let uu____26638 =
+          let uu____26639 =
+            let uu____26646 = elim_delayed_subst_term t2 in
+            let uu____26649 = elim_delayed_subst_meta md in
+            (uu____26646, uu____26649) in
+          FStar_Syntax_Syntax.Tm_meta uu____26639 in
+        mk uu____26638
 and (elim_delayed_subst_cflags :
   FStar_Syntax_Syntax.cflag Prims.list ->
     FStar_Syntax_Syntax.cflag Prims.list)
   =
   fun flags ->
     FStar_List.map
-      (fun uu___17_26673 ->
-         match uu___17_26673 with
+      (fun uu___17_26658 ->
+         match uu___17_26658 with
          | FStar_Syntax_Syntax.DECREASES t ->
-             let uu____26677 = elim_delayed_subst_term t in
-             FStar_Syntax_Syntax.DECREASES uu____26677
+             let uu____26662 = elim_delayed_subst_term t in
+             FStar_Syntax_Syntax.DECREASES uu____26662
          | f -> f) flags
 and (elim_delayed_subst_comp :
   FStar_Syntax_Syntax.comp -> FStar_Syntax_Syntax.comp) =
@@ -8554,57 +8553,57 @@ and (elim_delayed_subst_comp :
     let mk x = FStar_Syntax_Syntax.mk x c.FStar_Syntax_Syntax.pos in
     match c.FStar_Syntax_Syntax.n with
     | FStar_Syntax_Syntax.Total (t, uopt) ->
-        let uu____26700 =
-          let uu____26701 =
-            let uu____26710 = elim_delayed_subst_term t in
-            (uu____26710, uopt) in
-          FStar_Syntax_Syntax.Total uu____26701 in
-        mk uu____26700
+        let uu____26685 =
+          let uu____26686 =
+            let uu____26695 = elim_delayed_subst_term t in
+            (uu____26695, uopt) in
+          FStar_Syntax_Syntax.Total uu____26686 in
+        mk uu____26685
     | FStar_Syntax_Syntax.GTotal (t, uopt) ->
-        let uu____26727 =
-          let uu____26728 =
-            let uu____26737 = elim_delayed_subst_term t in
-            (uu____26737, uopt) in
-          FStar_Syntax_Syntax.GTotal uu____26728 in
-        mk uu____26727
+        let uu____26712 =
+          let uu____26713 =
+            let uu____26722 = elim_delayed_subst_term t in
+            (uu____26722, uopt) in
+          FStar_Syntax_Syntax.GTotal uu____26713 in
+        mk uu____26712
     | FStar_Syntax_Syntax.Comp ct ->
         let ct1 =
-          let uu___3591_26746 = ct in
-          let uu____26747 =
+          let uu___3591_26731 = ct in
+          let uu____26732 =
             elim_delayed_subst_term ct.FStar_Syntax_Syntax.result_typ in
-          let uu____26750 =
+          let uu____26735 =
             elim_delayed_subst_args ct.FStar_Syntax_Syntax.effect_args in
-          let uu____26761 =
+          let uu____26746 =
             elim_delayed_subst_cflags ct.FStar_Syntax_Syntax.flags in
           {
             FStar_Syntax_Syntax.comp_univs =
-              (uu___3591_26746.FStar_Syntax_Syntax.comp_univs);
+              (uu___3591_26731.FStar_Syntax_Syntax.comp_univs);
             FStar_Syntax_Syntax.effect_name =
-              (uu___3591_26746.FStar_Syntax_Syntax.effect_name);
-            FStar_Syntax_Syntax.result_typ = uu____26747;
-            FStar_Syntax_Syntax.effect_args = uu____26750;
-            FStar_Syntax_Syntax.flags = uu____26761
+              (uu___3591_26731.FStar_Syntax_Syntax.effect_name);
+            FStar_Syntax_Syntax.result_typ = uu____26732;
+            FStar_Syntax_Syntax.effect_args = uu____26735;
+            FStar_Syntax_Syntax.flags = uu____26746
           } in
         mk (FStar_Syntax_Syntax.Comp ct1)
 and (elim_delayed_subst_meta :
   FStar_Syntax_Syntax.metadata -> FStar_Syntax_Syntax.metadata) =
-  fun uu___18_26764 ->
-    match uu___18_26764 with
+  fun uu___18_26749 ->
+    match uu___18_26749 with
     | FStar_Syntax_Syntax.Meta_pattern (names, args) ->
-        let uu____26799 =
-          let uu____26820 = FStar_List.map elim_delayed_subst_term names in
-          let uu____26829 = FStar_List.map elim_delayed_subst_args args in
-          (uu____26820, uu____26829) in
-        FStar_Syntax_Syntax.Meta_pattern uu____26799
+        let uu____26784 =
+          let uu____26805 = FStar_List.map elim_delayed_subst_term names in
+          let uu____26814 = FStar_List.map elim_delayed_subst_args args in
+          (uu____26805, uu____26814) in
+        FStar_Syntax_Syntax.Meta_pattern uu____26784
     | FStar_Syntax_Syntax.Meta_monadic (m, t) ->
-        let uu____26884 =
-          let uu____26891 = elim_delayed_subst_term t in (m, uu____26891) in
-        FStar_Syntax_Syntax.Meta_monadic uu____26884
+        let uu____26869 =
+          let uu____26876 = elim_delayed_subst_term t in (m, uu____26876) in
+        FStar_Syntax_Syntax.Meta_monadic uu____26869
     | FStar_Syntax_Syntax.Meta_monadic_lift (m1, m2, t) ->
-        let uu____26903 =
-          let uu____26912 = elim_delayed_subst_term t in
-          (m1, m2, uu____26912) in
-        FStar_Syntax_Syntax.Meta_monadic_lift uu____26903
+        let uu____26888 =
+          let uu____26897 = elim_delayed_subst_term t in
+          (m1, m2, uu____26897) in
+        FStar_Syntax_Syntax.Meta_monadic_lift uu____26888
     | m -> m
 and (elim_delayed_subst_args :
   (FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax *
@@ -8616,10 +8615,10 @@ and (elim_delayed_subst_args :
   =
   fun args ->
     FStar_List.map
-      (fun uu____26945 ->
-         match uu____26945 with
+      (fun uu____26930 ->
+         match uu____26930 with
          | (t, q) ->
-             let uu____26964 = elim_delayed_subst_term t in (uu____26964, q))
+             let uu____26949 = elim_delayed_subst_term t in (uu____26949, q))
       args
 and (elim_delayed_subst_binders :
   (FStar_Syntax_Syntax.bv * FStar_Syntax_Syntax.arg_qualifier
@@ -8629,21 +8628,21 @@ and (elim_delayed_subst_binders :
   =
   fun bs ->
     FStar_List.map
-      (fun uu____26992 ->
-         match uu____26992 with
+      (fun uu____26977 ->
+         match uu____26977 with
          | (x, q) ->
-             let uu____27011 =
-               let uu___3617_27012 = x in
-               let uu____27013 =
+             let uu____26996 =
+               let uu___3617_26997 = x in
+               let uu____26998 =
                  elim_delayed_subst_term x.FStar_Syntax_Syntax.sort in
                {
                  FStar_Syntax_Syntax.ppname =
-                   (uu___3617_27012.FStar_Syntax_Syntax.ppname);
+                   (uu___3617_26997.FStar_Syntax_Syntax.ppname);
                  FStar_Syntax_Syntax.index =
-                   (uu___3617_27012.FStar_Syntax_Syntax.index);
-                 FStar_Syntax_Syntax.sort = uu____27013
+                   (uu___3617_26997.FStar_Syntax_Syntax.index);
+                 FStar_Syntax_Syntax.sort = uu____26998
                } in
-             (uu____27011, q)) bs
+             (uu____26996, q)) bs
 let (elim_uvars_aux_tc :
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.univ_names ->
@@ -8666,44 +8665,44 @@ let (elim_uvars_aux_tc :
             | ([], FStar_Util.Inl t) -> t
             | ([], FStar_Util.Inr c) ->
                 failwith "Impossible: empty bindes with a comp"
-            | (uu____27119, FStar_Util.Inr c) ->
+            | (uu____27104, FStar_Util.Inr c) ->
                 FStar_Syntax_Syntax.mk
                   (FStar_Syntax_Syntax.Tm_arrow (binders, c))
                   c.FStar_Syntax_Syntax.pos
-            | (uu____27151, FStar_Util.Inl t) ->
-                let uu____27173 =
-                  let uu____27174 =
-                    let uu____27189 = FStar_Syntax_Syntax.mk_Total t in
-                    (binders, uu____27189) in
-                  FStar_Syntax_Syntax.Tm_arrow uu____27174 in
-                FStar_Syntax_Syntax.mk uu____27173 t.FStar_Syntax_Syntax.pos in
-          let uu____27202 = FStar_Syntax_Subst.open_univ_vars univ_names t in
-          match uu____27202 with
+            | (uu____27136, FStar_Util.Inl t) ->
+                let uu____27158 =
+                  let uu____27159 =
+                    let uu____27174 = FStar_Syntax_Syntax.mk_Total t in
+                    (binders, uu____27174) in
+                  FStar_Syntax_Syntax.Tm_arrow uu____27159 in
+                FStar_Syntax_Syntax.mk uu____27158 t.FStar_Syntax_Syntax.pos in
+          let uu____27187 = FStar_Syntax_Subst.open_univ_vars univ_names t in
+          match uu____27187 with
           | (univ_names1, t1) ->
               let t2 = remove_uvar_solutions env1 t1 in
               let t3 = FStar_Syntax_Subst.close_univ_vars univ_names1 t2 in
               let t4 = elim_delayed_subst_term t3 in
-              let uu____27234 =
+              let uu____27219 =
                 match binders with
                 | [] -> ([], (FStar_Util.Inl t4))
-                | uu____27307 ->
-                    let uu____27308 =
-                      let uu____27317 =
-                        let uu____27318 = FStar_Syntax_Subst.compress t4 in
-                        uu____27318.FStar_Syntax_Syntax.n in
-                      (uu____27317, tc) in
-                    (match uu____27308 with
+                | uu____27292 ->
+                    let uu____27293 =
+                      let uu____27302 =
+                        let uu____27303 = FStar_Syntax_Subst.compress t4 in
+                        uu____27303.FStar_Syntax_Syntax.n in
+                      (uu____27302, tc) in
+                    (match uu____27293 with
                      | (FStar_Syntax_Syntax.Tm_arrow (binders1, c),
-                        FStar_Util.Inr uu____27347) ->
+                        FStar_Util.Inr uu____27332) ->
                          (binders1, (FStar_Util.Inr c))
                      | (FStar_Syntax_Syntax.Tm_arrow (binders1, c),
-                        FStar_Util.Inl uu____27394) ->
+                        FStar_Util.Inl uu____27379) ->
                          (binders1,
                            (FStar_Util.Inl (FStar_Syntax_Util.comp_result c)))
-                     | (uu____27439, FStar_Util.Inl uu____27440) ->
+                     | (uu____27424, FStar_Util.Inl uu____27425) ->
                          ([], (FStar_Util.Inl t4))
-                     | uu____27471 -> failwith "Impossible") in
-              (match uu____27234 with
+                     | uu____27456 -> failwith "Impossible") in
+              (match uu____27219 with
                | (binders1, tc1) -> (univ_names1, binders1, tc1))
 let (elim_uvars_aux_t :
   FStar_TypeChecker_Env.env ->
@@ -8719,12 +8718,12 @@ let (elim_uvars_aux_t :
     fun univ_names ->
       fun binders ->
         fun t ->
-          let uu____27608 =
+          let uu____27593 =
             elim_uvars_aux_tc env1 univ_names binders (FStar_Util.Inl t) in
-          match uu____27608 with
+          match uu____27593 with
           | (univ_names1, binders1, tc) ->
-              let uu____27682 = FStar_Util.left tc in
-              (univ_names1, binders1, uu____27682)
+              let uu____27667 = FStar_Util.left tc in
+              (univ_names1, binders1, uu____27667)
 let (elim_uvars_aux_c :
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.univ_names ->
@@ -8739,12 +8738,12 @@ let (elim_uvars_aux_c :
     fun univ_names ->
       fun binders ->
         fun c ->
-          let uu____27735 =
+          let uu____27720 =
             elim_uvars_aux_tc env1 univ_names binders (FStar_Util.Inr c) in
-          match uu____27735 with
+          match uu____27720 with
           | (univ_names1, binders1, tc) ->
-              let uu____27809 = FStar_Util.right tc in
-              (univ_names1, binders1, uu____27809)
+              let uu____27794 = FStar_Util.right tc in
+              (univ_names1, binders1, uu____27794)
 let rec (elim_uvars :
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.sigelt -> FStar_Syntax_Syntax.sigelt)
@@ -8754,245 +8753,245 @@ let rec (elim_uvars :
       match s.FStar_Syntax_Syntax.sigel with
       | FStar_Syntax_Syntax.Sig_inductive_typ
           (lid, univ_names, binders, typ, lids, lids') ->
-          let uu____27850 = elim_uvars_aux_t env1 univ_names binders typ in
-          (match uu____27850 with
+          let uu____27835 = elim_uvars_aux_t env1 univ_names binders typ in
+          (match uu____27835 with
            | (univ_names1, binders1, typ1) ->
-               let uu___3700_27890 = s in
+               let uu___3700_27875 = s in
                {
                  FStar_Syntax_Syntax.sigel =
                    (FStar_Syntax_Syntax.Sig_inductive_typ
                       (lid, univ_names1, binders1, typ1, lids, lids'));
                  FStar_Syntax_Syntax.sigrng =
-                   (uu___3700_27890.FStar_Syntax_Syntax.sigrng);
+                   (uu___3700_27875.FStar_Syntax_Syntax.sigrng);
                  FStar_Syntax_Syntax.sigquals =
-                   (uu___3700_27890.FStar_Syntax_Syntax.sigquals);
+                   (uu___3700_27875.FStar_Syntax_Syntax.sigquals);
                  FStar_Syntax_Syntax.sigmeta =
-                   (uu___3700_27890.FStar_Syntax_Syntax.sigmeta);
+                   (uu___3700_27875.FStar_Syntax_Syntax.sigmeta);
                  FStar_Syntax_Syntax.sigattrs =
-                   (uu___3700_27890.FStar_Syntax_Syntax.sigattrs);
+                   (uu___3700_27875.FStar_Syntax_Syntax.sigattrs);
                  FStar_Syntax_Syntax.sigopts =
-                   (uu___3700_27890.FStar_Syntax_Syntax.sigopts)
+                   (uu___3700_27875.FStar_Syntax_Syntax.sigopts)
                })
       | FStar_Syntax_Syntax.Sig_bundle (sigs, lids) ->
-          let uu___3706_27905 = s in
-          let uu____27906 =
-            let uu____27907 =
-              let uu____27916 = FStar_List.map (elim_uvars env1) sigs in
-              (uu____27916, lids) in
-            FStar_Syntax_Syntax.Sig_bundle uu____27907 in
+          let uu___3706_27890 = s in
+          let uu____27891 =
+            let uu____27892 =
+              let uu____27901 = FStar_List.map (elim_uvars env1) sigs in
+              (uu____27901, lids) in
+            FStar_Syntax_Syntax.Sig_bundle uu____27892 in
           {
-            FStar_Syntax_Syntax.sigel = uu____27906;
+            FStar_Syntax_Syntax.sigel = uu____27891;
             FStar_Syntax_Syntax.sigrng =
-              (uu___3706_27905.FStar_Syntax_Syntax.sigrng);
+              (uu___3706_27890.FStar_Syntax_Syntax.sigrng);
             FStar_Syntax_Syntax.sigquals =
-              (uu___3706_27905.FStar_Syntax_Syntax.sigquals);
+              (uu___3706_27890.FStar_Syntax_Syntax.sigquals);
             FStar_Syntax_Syntax.sigmeta =
-              (uu___3706_27905.FStar_Syntax_Syntax.sigmeta);
+              (uu___3706_27890.FStar_Syntax_Syntax.sigmeta);
             FStar_Syntax_Syntax.sigattrs =
-              (uu___3706_27905.FStar_Syntax_Syntax.sigattrs);
+              (uu___3706_27890.FStar_Syntax_Syntax.sigattrs);
             FStar_Syntax_Syntax.sigopts =
-              (uu___3706_27905.FStar_Syntax_Syntax.sigopts)
+              (uu___3706_27890.FStar_Syntax_Syntax.sigopts)
           }
       | FStar_Syntax_Syntax.Sig_datacon
           (lid, univ_names, typ, lident, i, lids) ->
-          let uu____27933 = elim_uvars_aux_t env1 univ_names [] typ in
-          (match uu____27933 with
-           | (univ_names1, uu____27957, typ1) ->
-               let uu___3720_27979 = s in
+          let uu____27918 = elim_uvars_aux_t env1 univ_names [] typ in
+          (match uu____27918 with
+           | (univ_names1, uu____27942, typ1) ->
+               let uu___3720_27964 = s in
                {
                  FStar_Syntax_Syntax.sigel =
                    (FStar_Syntax_Syntax.Sig_datacon
                       (lid, univ_names1, typ1, lident, i, lids));
                  FStar_Syntax_Syntax.sigrng =
-                   (uu___3720_27979.FStar_Syntax_Syntax.sigrng);
+                   (uu___3720_27964.FStar_Syntax_Syntax.sigrng);
                  FStar_Syntax_Syntax.sigquals =
-                   (uu___3720_27979.FStar_Syntax_Syntax.sigquals);
+                   (uu___3720_27964.FStar_Syntax_Syntax.sigquals);
                  FStar_Syntax_Syntax.sigmeta =
-                   (uu___3720_27979.FStar_Syntax_Syntax.sigmeta);
+                   (uu___3720_27964.FStar_Syntax_Syntax.sigmeta);
                  FStar_Syntax_Syntax.sigattrs =
-                   (uu___3720_27979.FStar_Syntax_Syntax.sigattrs);
+                   (uu___3720_27964.FStar_Syntax_Syntax.sigattrs);
                  FStar_Syntax_Syntax.sigopts =
-                   (uu___3720_27979.FStar_Syntax_Syntax.sigopts)
+                   (uu___3720_27964.FStar_Syntax_Syntax.sigopts)
                })
       | FStar_Syntax_Syntax.Sig_declare_typ (lid, univ_names, typ) ->
-          let uu____27985 = elim_uvars_aux_t env1 univ_names [] typ in
-          (match uu____27985 with
-           | (univ_names1, uu____28009, typ1) ->
-               let uu___3731_28031 = s in
+          let uu____27970 = elim_uvars_aux_t env1 univ_names [] typ in
+          (match uu____27970 with
+           | (univ_names1, uu____27994, typ1) ->
+               let uu___3731_28016 = s in
                {
                  FStar_Syntax_Syntax.sigel =
                    (FStar_Syntax_Syntax.Sig_declare_typ
                       (lid, univ_names1, typ1));
                  FStar_Syntax_Syntax.sigrng =
-                   (uu___3731_28031.FStar_Syntax_Syntax.sigrng);
+                   (uu___3731_28016.FStar_Syntax_Syntax.sigrng);
                  FStar_Syntax_Syntax.sigquals =
-                   (uu___3731_28031.FStar_Syntax_Syntax.sigquals);
+                   (uu___3731_28016.FStar_Syntax_Syntax.sigquals);
                  FStar_Syntax_Syntax.sigmeta =
-                   (uu___3731_28031.FStar_Syntax_Syntax.sigmeta);
+                   (uu___3731_28016.FStar_Syntax_Syntax.sigmeta);
                  FStar_Syntax_Syntax.sigattrs =
-                   (uu___3731_28031.FStar_Syntax_Syntax.sigattrs);
+                   (uu___3731_28016.FStar_Syntax_Syntax.sigattrs);
                  FStar_Syntax_Syntax.sigopts =
-                   (uu___3731_28031.FStar_Syntax_Syntax.sigopts)
+                   (uu___3731_28016.FStar_Syntax_Syntax.sigopts)
                })
       | FStar_Syntax_Syntax.Sig_let ((b, lbs), lids) ->
           let lbs1 =
             FStar_All.pipe_right lbs
               (FStar_List.map
                  (fun lb ->
-                    let uu____28059 =
+                    let uu____28044 =
                       FStar_Syntax_Subst.univ_var_opening
                         lb.FStar_Syntax_Syntax.lbunivs in
-                    match uu____28059 with
+                    match uu____28044 with
                     | (opening, lbunivs) ->
                         let elim t =
-                          let uu____28084 =
-                            let uu____28085 =
-                              let uu____28086 =
+                          let uu____28069 =
+                            let uu____28070 =
+                              let uu____28071 =
                                 FStar_Syntax_Subst.subst opening t in
-                              remove_uvar_solutions env1 uu____28086 in
+                              remove_uvar_solutions env1 uu____28071 in
                             FStar_Syntax_Subst.close_univ_vars lbunivs
-                              uu____28085 in
-                          elim_delayed_subst_term uu____28084 in
+                              uu____28070 in
+                          elim_delayed_subst_term uu____28069 in
                         let lbtyp = elim lb.FStar_Syntax_Syntax.lbtyp in
                         let lbdef = elim lb.FStar_Syntax_Syntax.lbdef in
-                        let uu___3747_28089 = lb in
+                        let uu___3747_28074 = lb in
                         {
                           FStar_Syntax_Syntax.lbname =
-                            (uu___3747_28089.FStar_Syntax_Syntax.lbname);
+                            (uu___3747_28074.FStar_Syntax_Syntax.lbname);
                           FStar_Syntax_Syntax.lbunivs = lbunivs;
                           FStar_Syntax_Syntax.lbtyp = lbtyp;
                           FStar_Syntax_Syntax.lbeff =
-                            (uu___3747_28089.FStar_Syntax_Syntax.lbeff);
+                            (uu___3747_28074.FStar_Syntax_Syntax.lbeff);
                           FStar_Syntax_Syntax.lbdef = lbdef;
                           FStar_Syntax_Syntax.lbattrs =
-                            (uu___3747_28089.FStar_Syntax_Syntax.lbattrs);
+                            (uu___3747_28074.FStar_Syntax_Syntax.lbattrs);
                           FStar_Syntax_Syntax.lbpos =
-                            (uu___3747_28089.FStar_Syntax_Syntax.lbpos)
+                            (uu___3747_28074.FStar_Syntax_Syntax.lbpos)
                         })) in
-          let uu___3750_28090 = s in
+          let uu___3750_28075 = s in
           {
             FStar_Syntax_Syntax.sigel =
               (FStar_Syntax_Syntax.Sig_let ((b, lbs1), lids));
             FStar_Syntax_Syntax.sigrng =
-              (uu___3750_28090.FStar_Syntax_Syntax.sigrng);
+              (uu___3750_28075.FStar_Syntax_Syntax.sigrng);
             FStar_Syntax_Syntax.sigquals =
-              (uu___3750_28090.FStar_Syntax_Syntax.sigquals);
+              (uu___3750_28075.FStar_Syntax_Syntax.sigquals);
             FStar_Syntax_Syntax.sigmeta =
-              (uu___3750_28090.FStar_Syntax_Syntax.sigmeta);
+              (uu___3750_28075.FStar_Syntax_Syntax.sigmeta);
             FStar_Syntax_Syntax.sigattrs =
-              (uu___3750_28090.FStar_Syntax_Syntax.sigattrs);
+              (uu___3750_28075.FStar_Syntax_Syntax.sigattrs);
             FStar_Syntax_Syntax.sigopts =
-              (uu___3750_28090.FStar_Syntax_Syntax.sigopts)
+              (uu___3750_28075.FStar_Syntax_Syntax.sigopts)
           }
       | FStar_Syntax_Syntax.Sig_assume (l, us, t) ->
-          let uu____28098 = elim_uvars_aux_t env1 us [] t in
-          (match uu____28098 with
-           | (us1, uu____28122, t1) ->
-               let uu___3761_28144 = s in
+          let uu____28083 = elim_uvars_aux_t env1 us [] t in
+          (match uu____28083 with
+           | (us1, uu____28107, t1) ->
+               let uu___3761_28129 = s in
                {
                  FStar_Syntax_Syntax.sigel =
                    (FStar_Syntax_Syntax.Sig_assume (l, us1, t1));
                  FStar_Syntax_Syntax.sigrng =
-                   (uu___3761_28144.FStar_Syntax_Syntax.sigrng);
+                   (uu___3761_28129.FStar_Syntax_Syntax.sigrng);
                  FStar_Syntax_Syntax.sigquals =
-                   (uu___3761_28144.FStar_Syntax_Syntax.sigquals);
+                   (uu___3761_28129.FStar_Syntax_Syntax.sigquals);
                  FStar_Syntax_Syntax.sigmeta =
-                   (uu___3761_28144.FStar_Syntax_Syntax.sigmeta);
+                   (uu___3761_28129.FStar_Syntax_Syntax.sigmeta);
                  FStar_Syntax_Syntax.sigattrs =
-                   (uu___3761_28144.FStar_Syntax_Syntax.sigattrs);
+                   (uu___3761_28129.FStar_Syntax_Syntax.sigattrs);
                  FStar_Syntax_Syntax.sigopts =
-                   (uu___3761_28144.FStar_Syntax_Syntax.sigopts)
+                   (uu___3761_28129.FStar_Syntax_Syntax.sigopts)
                })
       | FStar_Syntax_Syntax.Sig_new_effect ed ->
-          let uu____28146 =
+          let uu____28131 =
             elim_uvars_aux_t env1 ed.FStar_Syntax_Syntax.univs
               ed.FStar_Syntax_Syntax.binders FStar_Syntax_Syntax.t_unit in
-          (match uu____28146 with
-           | (univs, binders, uu____28165) ->
-               let uu____28186 =
-                 let uu____28191 = FStar_Syntax_Subst.univ_var_opening univs in
-                 match uu____28191 with
+          (match uu____28131 with
+           | (univs, binders, uu____28150) ->
+               let uu____28171 =
+                 let uu____28176 = FStar_Syntax_Subst.univ_var_opening univs in
+                 match uu____28176 with
                  | (univs_opening, univs1) ->
-                     let uu____28214 =
+                     let uu____28199 =
                        FStar_Syntax_Subst.univ_var_closing univs1 in
-                     (univs_opening, uu____28214) in
-               (match uu____28186 with
+                     (univs_opening, uu____28199) in
+               (match uu____28171 with
                 | (univs_opening, univs_closing) ->
-                    let uu____28217 =
+                    let uu____28202 =
                       let binders1 = FStar_Syntax_Subst.open_binders binders in
-                      let uu____28223 =
+                      let uu____28208 =
                         FStar_Syntax_Subst.opening_of_binders binders1 in
-                      let uu____28224 =
+                      let uu____28209 =
                         FStar_Syntax_Subst.closing_of_binders binders1 in
-                      (uu____28223, uu____28224) in
-                    (match uu____28217 with
+                      (uu____28208, uu____28209) in
+                    (match uu____28202 with
                      | (b_opening, b_closing) ->
                          let n = FStar_List.length univs in
                          let n_binders = FStar_List.length binders in
-                         let elim_tscheme uu____28250 =
-                           match uu____28250 with
+                         let elim_tscheme uu____28235 =
+                           match uu____28235 with
                            | (us, t) ->
                                let n_us = FStar_List.length us in
-                               let uu____28268 =
+                               let uu____28253 =
                                  FStar_Syntax_Subst.open_univ_vars us t in
-                               (match uu____28268 with
+                               (match uu____28253 with
                                 | (us1, t1) ->
-                                    let uu____28279 =
-                                      let uu____28288 =
+                                    let uu____28264 =
+                                      let uu____28273 =
                                         FStar_All.pipe_right b_opening
                                           (FStar_Syntax_Subst.shift_subst
                                              n_us) in
-                                      let uu____28293 =
+                                      let uu____28278 =
                                         FStar_All.pipe_right b_closing
                                           (FStar_Syntax_Subst.shift_subst
                                              n_us) in
-                                      (uu____28288, uu____28293) in
-                                    (match uu____28279 with
+                                      (uu____28273, uu____28278) in
+                                    (match uu____28264 with
                                      | (b_opening1, b_closing1) ->
-                                         let uu____28316 =
-                                           let uu____28325 =
+                                         let uu____28301 =
+                                           let uu____28310 =
                                              FStar_All.pipe_right
                                                univs_opening
                                                (FStar_Syntax_Subst.shift_subst
                                                   (n_us + n_binders)) in
-                                           let uu____28330 =
+                                           let uu____28315 =
                                              FStar_All.pipe_right
                                                univs_closing
                                                (FStar_Syntax_Subst.shift_subst
                                                   (n_us + n_binders)) in
-                                           (uu____28325, uu____28330) in
-                                         (match uu____28316 with
+                                           (uu____28310, uu____28315) in
+                                         (match uu____28301 with
                                           | (univs_opening1, univs_closing1)
                                               ->
                                               let t2 =
-                                                let uu____28354 =
+                                                let uu____28339 =
                                                   FStar_Syntax_Subst.subst
                                                     b_opening1 t1 in
                                                 FStar_Syntax_Subst.subst
-                                                  univs_opening1 uu____28354 in
-                                              let uu____28355 =
+                                                  univs_opening1 uu____28339 in
+                                              let uu____28340 =
                                                 elim_uvars_aux_t env1 [] []
                                                   t2 in
-                                              (match uu____28355 with
-                                               | (uu____28382, uu____28383,
+                                              (match uu____28340 with
+                                               | (uu____28367, uu____28368,
                                                   t3) ->
                                                    let t4 =
-                                                     let uu____28406 =
-                                                       let uu____28407 =
+                                                     let uu____28391 =
+                                                       let uu____28392 =
                                                          FStar_Syntax_Subst.close_univ_vars
                                                            us1 t3 in
                                                        FStar_Syntax_Subst.subst
                                                          b_closing1
-                                                         uu____28407 in
+                                                         uu____28392 in
                                                      FStar_Syntax_Subst.subst
                                                        univs_closing1
-                                                       uu____28406 in
+                                                       uu____28391 in
                                                    (us1, t4))))) in
                          let elim_term t =
-                           let uu____28416 =
+                           let uu____28401 =
                              elim_uvars_aux_t env1 univs binders t in
-                           match uu____28416 with
-                           | (uu____28435, uu____28436, t1) -> t1 in
+                           match uu____28401 with
+                           | (uu____28420, uu____28421, t1) -> t1 in
                          let elim_action a =
                            let action_typ_templ =
                              let body =
@@ -9006,57 +9005,57 @@ let rec (elim_uvars :
                                  (a.FStar_Syntax_Syntax.action_defn).FStar_Syntax_Syntax.pos in
                              match a.FStar_Syntax_Syntax.action_params with
                              | [] -> body
-                             | uu____28512 ->
+                             | uu____28497 ->
                                  FStar_Syntax_Syntax.mk
                                    (FStar_Syntax_Syntax.Tm_abs
                                       ((a.FStar_Syntax_Syntax.action_params),
                                         body, FStar_Pervasives_Native.None))
                                    (a.FStar_Syntax_Syntax.action_defn).FStar_Syntax_Syntax.pos in
                            let destruct_action_body body =
-                             let uu____28539 =
-                               let uu____28540 =
+                             let uu____28524 =
+                               let uu____28525 =
                                  FStar_Syntax_Subst.compress body in
-                               uu____28540.FStar_Syntax_Syntax.n in
-                             match uu____28539 with
+                               uu____28525.FStar_Syntax_Syntax.n in
+                             match uu____28524 with
                              | FStar_Syntax_Syntax.Tm_ascribed
                                  (defn,
                                   (FStar_Util.Inl typ,
                                    FStar_Pervasives_Native.None),
                                   FStar_Pervasives_Native.None)
                                  -> (defn, typ)
-                             | uu____28599 -> failwith "Impossible" in
+                             | uu____28584 -> failwith "Impossible" in
                            let destruct_action_typ_templ t =
-                             let uu____28632 =
-                               let uu____28633 =
+                             let uu____28617 =
+                               let uu____28618 =
                                  FStar_Syntax_Subst.compress t in
-                               uu____28633.FStar_Syntax_Syntax.n in
-                             match uu____28632 with
+                               uu____28618.FStar_Syntax_Syntax.n in
+                             match uu____28617 with
                              | FStar_Syntax_Syntax.Tm_abs
-                                 (pars, body, uu____28656) ->
-                                 let uu____28681 = destruct_action_body body in
-                                 (match uu____28681 with
+                                 (pars, body, uu____28641) ->
+                                 let uu____28666 = destruct_action_body body in
+                                 (match uu____28666 with
                                   | (defn, typ) -> (pars, defn, typ))
-                             | uu____28730 ->
-                                 let uu____28731 = destruct_action_body t in
-                                 (match uu____28731 with
+                             | uu____28715 ->
+                                 let uu____28716 = destruct_action_body t in
+                                 (match uu____28716 with
                                   | (defn, typ) -> ([], defn, typ)) in
-                           let uu____28786 =
+                           let uu____28771 =
                              elim_tscheme
                                ((a.FStar_Syntax_Syntax.action_univs),
                                  action_typ_templ) in
-                           match uu____28786 with
+                           match uu____28771 with
                            | (action_univs, t) ->
-                               let uu____28795 = destruct_action_typ_templ t in
-                               (match uu____28795 with
+                               let uu____28780 = destruct_action_typ_templ t in
+                               (match uu____28780 with
                                 | (action_params, action_defn, action_typ) ->
                                     let a' =
-                                      let uu___3845_28842 = a in
+                                      let uu___3845_28827 = a in
                                       {
                                         FStar_Syntax_Syntax.action_name =
-                                          (uu___3845_28842.FStar_Syntax_Syntax.action_name);
+                                          (uu___3845_28827.FStar_Syntax_Syntax.action_name);
                                         FStar_Syntax_Syntax.action_unqualified_name
                                           =
-                                          (uu___3845_28842.FStar_Syntax_Syntax.action_unqualified_name);
+                                          (uu___3845_28827.FStar_Syntax_Syntax.action_unqualified_name);
                                         FStar_Syntax_Syntax.action_univs =
                                           action_univs;
                                         FStar_Syntax_Syntax.action_params =
@@ -9068,153 +9067,153 @@ let rec (elim_uvars :
                                       } in
                                     a') in
                          let ed1 =
-                           let uu___3848_28844 = ed in
-                           let uu____28845 =
+                           let uu___3848_28829 = ed in
+                           let uu____28830 =
                              elim_tscheme ed.FStar_Syntax_Syntax.signature in
-                           let uu____28846 =
+                           let uu____28831 =
                              FStar_Syntax_Util.apply_eff_combinators
                                elim_tscheme
                                ed.FStar_Syntax_Syntax.combinators in
-                           let uu____28847 =
+                           let uu____28832 =
                              FStar_List.map elim_action
                                ed.FStar_Syntax_Syntax.actions in
                            {
                              FStar_Syntax_Syntax.mname =
-                               (uu___3848_28844.FStar_Syntax_Syntax.mname);
+                               (uu___3848_28829.FStar_Syntax_Syntax.mname);
                              FStar_Syntax_Syntax.cattributes =
-                               (uu___3848_28844.FStar_Syntax_Syntax.cattributes);
+                               (uu___3848_28829.FStar_Syntax_Syntax.cattributes);
                              FStar_Syntax_Syntax.univs = univs;
                              FStar_Syntax_Syntax.binders = binders;
-                             FStar_Syntax_Syntax.signature = uu____28845;
-                             FStar_Syntax_Syntax.combinators = uu____28846;
-                             FStar_Syntax_Syntax.actions = uu____28847;
+                             FStar_Syntax_Syntax.signature = uu____28830;
+                             FStar_Syntax_Syntax.combinators = uu____28831;
+                             FStar_Syntax_Syntax.actions = uu____28832;
                              FStar_Syntax_Syntax.eff_attrs =
-                               (uu___3848_28844.FStar_Syntax_Syntax.eff_attrs)
+                               (uu___3848_28829.FStar_Syntax_Syntax.eff_attrs)
                            } in
-                         let uu___3851_28850 = s in
+                         let uu___3851_28835 = s in
                          {
                            FStar_Syntax_Syntax.sigel =
                              (FStar_Syntax_Syntax.Sig_new_effect ed1);
                            FStar_Syntax_Syntax.sigrng =
-                             (uu___3851_28850.FStar_Syntax_Syntax.sigrng);
+                             (uu___3851_28835.FStar_Syntax_Syntax.sigrng);
                            FStar_Syntax_Syntax.sigquals =
-                             (uu___3851_28850.FStar_Syntax_Syntax.sigquals);
+                             (uu___3851_28835.FStar_Syntax_Syntax.sigquals);
                            FStar_Syntax_Syntax.sigmeta =
-                             (uu___3851_28850.FStar_Syntax_Syntax.sigmeta);
+                             (uu___3851_28835.FStar_Syntax_Syntax.sigmeta);
                            FStar_Syntax_Syntax.sigattrs =
-                             (uu___3851_28850.FStar_Syntax_Syntax.sigattrs);
+                             (uu___3851_28835.FStar_Syntax_Syntax.sigattrs);
                            FStar_Syntax_Syntax.sigopts =
-                             (uu___3851_28850.FStar_Syntax_Syntax.sigopts)
+                             (uu___3851_28835.FStar_Syntax_Syntax.sigopts)
                          })))
       | FStar_Syntax_Syntax.Sig_sub_effect sub_eff ->
-          let elim_tscheme_opt uu___19_28871 =
-            match uu___19_28871 with
+          let elim_tscheme_opt uu___19_28856 =
+            match uu___19_28856 with
             | FStar_Pervasives_Native.None -> FStar_Pervasives_Native.None
             | FStar_Pervasives_Native.Some (us, t) ->
-                let uu____28902 = elim_uvars_aux_t env1 us [] t in
-                (match uu____28902 with
-                 | (us1, uu____28934, t1) ->
+                let uu____28887 = elim_uvars_aux_t env1 us [] t in
+                (match uu____28887 with
+                 | (us1, uu____28919, t1) ->
                      FStar_Pervasives_Native.Some (us1, t1)) in
           let sub_eff1 =
-            let uu___3866_28965 = sub_eff in
-            let uu____28966 =
+            let uu___3866_28950 = sub_eff in
+            let uu____28951 =
               elim_tscheme_opt sub_eff.FStar_Syntax_Syntax.lift_wp in
-            let uu____28969 =
+            let uu____28954 =
               elim_tscheme_opt sub_eff.FStar_Syntax_Syntax.lift in
             {
               FStar_Syntax_Syntax.source =
-                (uu___3866_28965.FStar_Syntax_Syntax.source);
+                (uu___3866_28950.FStar_Syntax_Syntax.source);
               FStar_Syntax_Syntax.target =
-                (uu___3866_28965.FStar_Syntax_Syntax.target);
-              FStar_Syntax_Syntax.lift_wp = uu____28966;
-              FStar_Syntax_Syntax.lift = uu____28969
+                (uu___3866_28950.FStar_Syntax_Syntax.target);
+              FStar_Syntax_Syntax.lift_wp = uu____28951;
+              FStar_Syntax_Syntax.lift = uu____28954
             } in
-          let uu___3869_28972 = s in
+          let uu___3869_28957 = s in
           {
             FStar_Syntax_Syntax.sigel =
               (FStar_Syntax_Syntax.Sig_sub_effect sub_eff1);
             FStar_Syntax_Syntax.sigrng =
-              (uu___3869_28972.FStar_Syntax_Syntax.sigrng);
+              (uu___3869_28957.FStar_Syntax_Syntax.sigrng);
             FStar_Syntax_Syntax.sigquals =
-              (uu___3869_28972.FStar_Syntax_Syntax.sigquals);
+              (uu___3869_28957.FStar_Syntax_Syntax.sigquals);
             FStar_Syntax_Syntax.sigmeta =
-              (uu___3869_28972.FStar_Syntax_Syntax.sigmeta);
+              (uu___3869_28957.FStar_Syntax_Syntax.sigmeta);
             FStar_Syntax_Syntax.sigattrs =
-              (uu___3869_28972.FStar_Syntax_Syntax.sigattrs);
+              (uu___3869_28957.FStar_Syntax_Syntax.sigattrs);
             FStar_Syntax_Syntax.sigopts =
-              (uu___3869_28972.FStar_Syntax_Syntax.sigopts)
+              (uu___3869_28957.FStar_Syntax_Syntax.sigopts)
           }
       | FStar_Syntax_Syntax.Sig_effect_abbrev
           (lid, univ_names, binders, comp, flags) ->
-          let uu____28982 = elim_uvars_aux_c env1 univ_names binders comp in
-          (match uu____28982 with
+          let uu____28967 = elim_uvars_aux_c env1 univ_names binders comp in
+          (match uu____28967 with
            | (univ_names1, binders1, comp1) ->
-               let uu___3882_29022 = s in
+               let uu___3882_29007 = s in
                {
                  FStar_Syntax_Syntax.sigel =
                    (FStar_Syntax_Syntax.Sig_effect_abbrev
                       (lid, univ_names1, binders1, comp1, flags));
                  FStar_Syntax_Syntax.sigrng =
-                   (uu___3882_29022.FStar_Syntax_Syntax.sigrng);
+                   (uu___3882_29007.FStar_Syntax_Syntax.sigrng);
                  FStar_Syntax_Syntax.sigquals =
-                   (uu___3882_29022.FStar_Syntax_Syntax.sigquals);
+                   (uu___3882_29007.FStar_Syntax_Syntax.sigquals);
                  FStar_Syntax_Syntax.sigmeta =
-                   (uu___3882_29022.FStar_Syntax_Syntax.sigmeta);
+                   (uu___3882_29007.FStar_Syntax_Syntax.sigmeta);
                  FStar_Syntax_Syntax.sigattrs =
-                   (uu___3882_29022.FStar_Syntax_Syntax.sigattrs);
+                   (uu___3882_29007.FStar_Syntax_Syntax.sigattrs);
                  FStar_Syntax_Syntax.sigopts =
-                   (uu___3882_29022.FStar_Syntax_Syntax.sigopts)
+                   (uu___3882_29007.FStar_Syntax_Syntax.sigopts)
                })
-      | FStar_Syntax_Syntax.Sig_pragma uu____29025 -> s
-      | FStar_Syntax_Syntax.Sig_fail uu____29026 -> s
-      | FStar_Syntax_Syntax.Sig_splice uu____29037 -> s
+      | FStar_Syntax_Syntax.Sig_pragma uu____29010 -> s
+      | FStar_Syntax_Syntax.Sig_fail uu____29011 -> s
+      | FStar_Syntax_Syntax.Sig_splice uu____29022 -> s
       | FStar_Syntax_Syntax.Sig_polymonadic_bind
           (m, n, p, (us_t, t), (us_ty, ty)) ->
-          let uu____29067 = elim_uvars_aux_t env1 us_t [] t in
-          (match uu____29067 with
-           | (us_t1, uu____29091, t1) ->
-               let uu____29113 = elim_uvars_aux_t env1 us_ty [] ty in
-               (match uu____29113 with
-                | (us_ty1, uu____29137, ty1) ->
-                    let uu___3909_29159 = s in
+          let uu____29052 = elim_uvars_aux_t env1 us_t [] t in
+          (match uu____29052 with
+           | (us_t1, uu____29076, t1) ->
+               let uu____29098 = elim_uvars_aux_t env1 us_ty [] ty in
+               (match uu____29098 with
+                | (us_ty1, uu____29122, ty1) ->
+                    let uu___3909_29144 = s in
                     {
                       FStar_Syntax_Syntax.sigel =
                         (FStar_Syntax_Syntax.Sig_polymonadic_bind
                            (m, n, p, (us_t1, t1), (us_ty1, ty1)));
                       FStar_Syntax_Syntax.sigrng =
-                        (uu___3909_29159.FStar_Syntax_Syntax.sigrng);
+                        (uu___3909_29144.FStar_Syntax_Syntax.sigrng);
                       FStar_Syntax_Syntax.sigquals =
-                        (uu___3909_29159.FStar_Syntax_Syntax.sigquals);
+                        (uu___3909_29144.FStar_Syntax_Syntax.sigquals);
                       FStar_Syntax_Syntax.sigmeta =
-                        (uu___3909_29159.FStar_Syntax_Syntax.sigmeta);
+                        (uu___3909_29144.FStar_Syntax_Syntax.sigmeta);
                       FStar_Syntax_Syntax.sigattrs =
-                        (uu___3909_29159.FStar_Syntax_Syntax.sigattrs);
+                        (uu___3909_29144.FStar_Syntax_Syntax.sigattrs);
                       FStar_Syntax_Syntax.sigopts =
-                        (uu___3909_29159.FStar_Syntax_Syntax.sigopts)
+                        (uu___3909_29144.FStar_Syntax_Syntax.sigopts)
                     }))
       | FStar_Syntax_Syntax.Sig_polymonadic_subcomp
           (m, n, (us_t, t), (us_ty, ty)) ->
-          let uu____29190 = elim_uvars_aux_t env1 us_t [] t in
-          (match uu____29190 with
-           | (us_t1, uu____29214, t1) ->
-               let uu____29236 = elim_uvars_aux_t env1 us_ty [] ty in
-               (match uu____29236 with
-                | (us_ty1, uu____29260, ty1) ->
-                    let uu___3929_29282 = s in
+          let uu____29175 = elim_uvars_aux_t env1 us_t [] t in
+          (match uu____29175 with
+           | (us_t1, uu____29199, t1) ->
+               let uu____29221 = elim_uvars_aux_t env1 us_ty [] ty in
+               (match uu____29221 with
+                | (us_ty1, uu____29245, ty1) ->
+                    let uu___3929_29267 = s in
                     {
                       FStar_Syntax_Syntax.sigel =
                         (FStar_Syntax_Syntax.Sig_polymonadic_subcomp
                            (m, n, (us_t1, t1), (us_ty1, ty1)));
                       FStar_Syntax_Syntax.sigrng =
-                        (uu___3929_29282.FStar_Syntax_Syntax.sigrng);
+                        (uu___3929_29267.FStar_Syntax_Syntax.sigrng);
                       FStar_Syntax_Syntax.sigquals =
-                        (uu___3929_29282.FStar_Syntax_Syntax.sigquals);
+                        (uu___3929_29267.FStar_Syntax_Syntax.sigquals);
                       FStar_Syntax_Syntax.sigmeta =
-                        (uu___3929_29282.FStar_Syntax_Syntax.sigmeta);
+                        (uu___3929_29267.FStar_Syntax_Syntax.sigmeta);
                       FStar_Syntax_Syntax.sigattrs =
-                        (uu___3929_29282.FStar_Syntax_Syntax.sigattrs);
+                        (uu___3929_29267.FStar_Syntax_Syntax.sigattrs);
                       FStar_Syntax_Syntax.sigopts =
-                        (uu___3929_29282.FStar_Syntax_Syntax.sigopts)
+                        (uu___3929_29267.FStar_Syntax_Syntax.sigopts)
                     }))
 let (erase_universes :
   FStar_TypeChecker_Env.env ->
@@ -9233,17 +9232,17 @@ let (unfold_head_once :
   fun env1 ->
     fun t ->
       let aux f us args =
-        let uu____29331 =
+        let uu____29316 =
           FStar_TypeChecker_Env.lookup_nonrec_definition
             [FStar_TypeChecker_Env.Unfold FStar_Syntax_Syntax.delta_constant]
             env1 (f.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-        match uu____29331 with
+        match uu____29316 with
         | FStar_Pervasives_Native.None -> FStar_Pervasives_Native.None
         | FStar_Pervasives_Native.Some head_def_ts ->
-            let uu____29353 =
+            let uu____29338 =
               FStar_TypeChecker_Env.inst_tscheme_with head_def_ts us in
-            (match uu____29353 with
-             | (uu____29360, head_def) ->
+            (match uu____29338 with
+             | (uu____29345, head_def) ->
                  let t' =
                    FStar_Syntax_Syntax.mk_Tm_app head_def args
                      t.FStar_Syntax_Syntax.pos in
@@ -9252,21 +9251,21 @@ let (unfold_head_once :
                      [FStar_TypeChecker_Env.Beta; FStar_TypeChecker_Env.Iota]
                      env1 t' in
                  FStar_Pervasives_Native.Some t'1) in
-      let uu____29364 = FStar_Syntax_Util.head_and_args t in
-      match uu____29364 with
+      let uu____29349 = FStar_Syntax_Util.head_and_args t in
+      match uu____29349 with
       | (head, args) ->
-          let uu____29409 =
-            let uu____29410 = FStar_Syntax_Subst.compress head in
-            uu____29410.FStar_Syntax_Syntax.n in
-          (match uu____29409 with
+          let uu____29394 =
+            let uu____29395 = FStar_Syntax_Subst.compress head in
+            uu____29395.FStar_Syntax_Syntax.n in
+          (match uu____29394 with
            | FStar_Syntax_Syntax.Tm_fvar fv -> aux fv [] args
            | FStar_Syntax_Syntax.Tm_uinst
                ({ FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar fv;
-                  FStar_Syntax_Syntax.pos = uu____29417;
-                  FStar_Syntax_Syntax.vars = uu____29418;_},
+                  FStar_Syntax_Syntax.pos = uu____29402;
+                  FStar_Syntax_Syntax.vars = uu____29403;_},
                 us)
                -> aux fv us args
-           | uu____29424 -> FStar_Pervasives_Native.None)
+           | uu____29409 -> FStar_Pervasives_Native.None)
 let (get_n_binders :
   FStar_TypeChecker_Env.env ->
     Prims.int ->
@@ -9277,32 +9276,32 @@ let (get_n_binders :
     fun n ->
       fun t ->
         let rec aux retry n1 t1 =
-          let uu____29480 = FStar_Syntax_Util.arrow_formals_comp t1 in
-          match uu____29480 with
+          let uu____29465 = FStar_Syntax_Util.arrow_formals_comp t1 in
+          match uu____29465 with
           | (bs, c) ->
               let len = FStar_List.length bs in
               (match (bs, c) with
-               | ([], uu____29516) when retry ->
-                   let uu____29535 = unfold_whnf env1 t1 in
-                   aux false n1 uu____29535
-               | ([], uu____29536) when Prims.op_Negation retry -> (bs, c)
+               | ([], uu____29501) when retry ->
+                   let uu____29520 = unfold_whnf env1 t1 in
+                   aux false n1 uu____29520
+               | ([], uu____29521) when Prims.op_Negation retry -> (bs, c)
                | (bs1, c1) when len = n1 -> (bs1, c1)
                | (bs1, c1) when len > n1 ->
-                   let uu____29603 = FStar_List.splitAt n1 bs1 in
-                   (match uu____29603 with
+                   let uu____29588 = FStar_List.splitAt n1 bs1 in
+                   (match uu____29588 with
                     | (bs_l, bs_r) ->
-                        let uu____29670 =
-                          let uu____29671 = FStar_Syntax_Util.arrow bs_r c1 in
-                          FStar_Syntax_Syntax.mk_Total uu____29671 in
-                        (bs_l, uu____29670))
+                        let uu____29655 =
+                          let uu____29656 = FStar_Syntax_Util.arrow bs_r c1 in
+                          FStar_Syntax_Syntax.mk_Total uu____29656 in
+                        (bs_l, uu____29655))
                | (bs1, c1) when
                    ((len < n1) && (FStar_Syntax_Util.is_total_comp c1)) &&
-                     (let uu____29697 = FStar_Syntax_Util.has_decreases c1 in
-                      Prims.op_Negation uu____29697)
+                     (let uu____29682 = FStar_Syntax_Util.has_decreases c1 in
+                      Prims.op_Negation uu____29682)
                    ->
-                   let uu____29698 =
+                   let uu____29683 =
                      aux true (n1 - len) (FStar_Syntax_Util.comp_result c1) in
-                   (match uu____29698 with
+                   (match uu____29683 with
                     | (bs', c') -> ((FStar_List.append bs1 bs'), c'))
                | (bs1, c1) -> (bs1, c1)) in
         aux true n t

--- a/src/ocaml-output/FStar_TypeChecker_Rel.ml
+++ b/src/ocaml-output/FStar_TypeChecker_Rel.ml
@@ -1496,107 +1496,107 @@ let (base_and_refinement_maybe_delta :
                 ((x.FStar_Syntax_Syntax.sort),
                   (FStar_Pervasives_Native.Some (x, phi)))
               else
-                (let uu____3204 = norm_refinement env t12 in
-                 match uu____3204 with
+                (let uu____3202 = norm_refinement env t12 in
+                 match uu____3202 with
                  | {
                      FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_refine
                        (x1, phi1);
-                     FStar_Syntax_Syntax.pos = uu____3219;
-                     FStar_Syntax_Syntax.vars = uu____3220;_} ->
+                     FStar_Syntax_Syntax.pos = uu____3217;
+                     FStar_Syntax_Syntax.vars = uu____3218;_} ->
                      ((x1.FStar_Syntax_Syntax.sort),
                        (FStar_Pervasives_Native.Some (x1, phi1)))
                  | tt ->
-                     let uu____3244 =
-                       let uu____3245 = FStar_Syntax_Print.term_to_string tt in
-                       let uu____3246 = FStar_Syntax_Print.tag_of_term tt in
+                     let uu____3242 =
+                       let uu____3243 = FStar_Syntax_Print.term_to_string tt in
+                       let uu____3244 = FStar_Syntax_Print.tag_of_term tt in
                        FStar_Util.format2 "impossible: Got %s ... %s\n"
-                         uu____3245 uu____3246 in
-                     failwith uu____3244)
+                         uu____3243 uu____3244 in
+                     failwith uu____3242)
           | FStar_Syntax_Syntax.Tm_lazy i ->
-              let uu____3260 = FStar_Syntax_Util.unfold_lazy i in
-              aux norm uu____3260
-          | FStar_Syntax_Syntax.Tm_uinst uu____3261 ->
+              let uu____3258 = FStar_Syntax_Util.unfold_lazy i in
+              aux norm uu____3258
+          | FStar_Syntax_Syntax.Tm_uinst uu____3259 ->
               if norm
               then (t12, FStar_Pervasives_Native.None)
               else
                 (let t1' = norm_refinement env t12 in
-                 let uu____3296 =
-                   let uu____3297 = FStar_Syntax_Subst.compress t1' in
-                   uu____3297.FStar_Syntax_Syntax.n in
-                 match uu____3296 with
-                 | FStar_Syntax_Syntax.Tm_refine uu____3312 -> aux true t1'
-                 | uu____3319 -> (t12, FStar_Pervasives_Native.None))
-          | FStar_Syntax_Syntax.Tm_fvar uu____3334 ->
+                 let uu____3294 =
+                   let uu____3295 = FStar_Syntax_Subst.compress t1' in
+                   uu____3295.FStar_Syntax_Syntax.n in
+                 match uu____3294 with
+                 | FStar_Syntax_Syntax.Tm_refine uu____3310 -> aux true t1'
+                 | uu____3317 -> (t12, FStar_Pervasives_Native.None))
+          | FStar_Syntax_Syntax.Tm_fvar uu____3332 ->
               if norm
               then (t12, FStar_Pervasives_Native.None)
               else
                 (let t1' = norm_refinement env t12 in
-                 let uu____3363 =
-                   let uu____3364 = FStar_Syntax_Subst.compress t1' in
-                   uu____3364.FStar_Syntax_Syntax.n in
-                 match uu____3363 with
-                 | FStar_Syntax_Syntax.Tm_refine uu____3379 -> aux true t1'
-                 | uu____3386 -> (t12, FStar_Pervasives_Native.None))
-          | FStar_Syntax_Syntax.Tm_app uu____3401 ->
+                 let uu____3361 =
+                   let uu____3362 = FStar_Syntax_Subst.compress t1' in
+                   uu____3362.FStar_Syntax_Syntax.n in
+                 match uu____3361 with
+                 | FStar_Syntax_Syntax.Tm_refine uu____3377 -> aux true t1'
+                 | uu____3384 -> (t12, FStar_Pervasives_Native.None))
+          | FStar_Syntax_Syntax.Tm_app uu____3399 ->
               if norm
               then (t12, FStar_Pervasives_Native.None)
               else
                 (let t1' = norm_refinement env t12 in
-                 let uu____3446 =
-                   let uu____3447 = FStar_Syntax_Subst.compress t1' in
-                   uu____3447.FStar_Syntax_Syntax.n in
-                 match uu____3446 with
-                 | FStar_Syntax_Syntax.Tm_refine uu____3462 -> aux true t1'
-                 | uu____3469 -> (t12, FStar_Pervasives_Native.None))
-          | FStar_Syntax_Syntax.Tm_type uu____3484 ->
+                 let uu____3444 =
+                   let uu____3445 = FStar_Syntax_Subst.compress t1' in
+                   uu____3445.FStar_Syntax_Syntax.n in
+                 match uu____3444 with
+                 | FStar_Syntax_Syntax.Tm_refine uu____3460 -> aux true t1'
+                 | uu____3467 -> (t12, FStar_Pervasives_Native.None))
+          | FStar_Syntax_Syntax.Tm_type uu____3482 ->
               (t12, FStar_Pervasives_Native.None)
-          | FStar_Syntax_Syntax.Tm_constant uu____3499 ->
+          | FStar_Syntax_Syntax.Tm_constant uu____3497 ->
               (t12, FStar_Pervasives_Native.None)
-          | FStar_Syntax_Syntax.Tm_name uu____3514 ->
+          | FStar_Syntax_Syntax.Tm_name uu____3512 ->
               (t12, FStar_Pervasives_Native.None)
-          | FStar_Syntax_Syntax.Tm_bvar uu____3529 ->
+          | FStar_Syntax_Syntax.Tm_bvar uu____3527 ->
               (t12, FStar_Pervasives_Native.None)
-          | FStar_Syntax_Syntax.Tm_arrow uu____3544 ->
+          | FStar_Syntax_Syntax.Tm_arrow uu____3542 ->
               (t12, FStar_Pervasives_Native.None)
-          | FStar_Syntax_Syntax.Tm_abs uu____3573 ->
+          | FStar_Syntax_Syntax.Tm_abs uu____3571 ->
               (t12, FStar_Pervasives_Native.None)
-          | FStar_Syntax_Syntax.Tm_quoted uu____3606 ->
+          | FStar_Syntax_Syntax.Tm_quoted uu____3604 ->
               (t12, FStar_Pervasives_Native.None)
-          | FStar_Syntax_Syntax.Tm_uvar uu____3627 ->
+          | FStar_Syntax_Syntax.Tm_uvar uu____3625 ->
               (t12, FStar_Pervasives_Native.None)
-          | FStar_Syntax_Syntax.Tm_let uu____3654 ->
+          | FStar_Syntax_Syntax.Tm_let uu____3652 ->
               (t12, FStar_Pervasives_Native.None)
-          | FStar_Syntax_Syntax.Tm_match uu____3681 ->
+          | FStar_Syntax_Syntax.Tm_match uu____3679 ->
               (t12, FStar_Pervasives_Native.None)
-          | FStar_Syntax_Syntax.Tm_meta uu____3718 ->
-              let uu____3725 =
-                let uu____3726 = FStar_Syntax_Print.term_to_string t12 in
-                let uu____3727 = FStar_Syntax_Print.tag_of_term t12 in
+          | FStar_Syntax_Syntax.Tm_meta uu____3716 ->
+              let uu____3723 =
+                let uu____3724 = FStar_Syntax_Print.term_to_string t12 in
+                let uu____3725 = FStar_Syntax_Print.tag_of_term t12 in
                 FStar_Util.format2 "impossible (outer): Got %s ... %s\n"
-                  uu____3726 uu____3727 in
-              failwith uu____3725
-          | FStar_Syntax_Syntax.Tm_ascribed uu____3740 ->
-              let uu____3767 =
-                let uu____3768 = FStar_Syntax_Print.term_to_string t12 in
-                let uu____3769 = FStar_Syntax_Print.tag_of_term t12 in
+                  uu____3724 uu____3725 in
+              failwith uu____3723
+          | FStar_Syntax_Syntax.Tm_ascribed uu____3738 ->
+              let uu____3765 =
+                let uu____3766 = FStar_Syntax_Print.term_to_string t12 in
+                let uu____3767 = FStar_Syntax_Print.tag_of_term t12 in
                 FStar_Util.format2 "impossible (outer): Got %s ... %s\n"
-                  uu____3768 uu____3769 in
-              failwith uu____3767
-          | FStar_Syntax_Syntax.Tm_delayed uu____3782 ->
-              let uu____3797 =
-                let uu____3798 = FStar_Syntax_Print.term_to_string t12 in
-                let uu____3799 = FStar_Syntax_Print.tag_of_term t12 in
+                  uu____3766 uu____3767 in
+              failwith uu____3765
+          | FStar_Syntax_Syntax.Tm_delayed uu____3780 ->
+              let uu____3795 =
+                let uu____3796 = FStar_Syntax_Print.term_to_string t12 in
+                let uu____3797 = FStar_Syntax_Print.tag_of_term t12 in
                 FStar_Util.format2 "impossible (outer): Got %s ... %s\n"
-                  uu____3798 uu____3799 in
-              failwith uu____3797
+                  uu____3796 uu____3797 in
+              failwith uu____3795
           | FStar_Syntax_Syntax.Tm_unknown ->
-              let uu____3812 =
-                let uu____3813 = FStar_Syntax_Print.term_to_string t12 in
-                let uu____3814 = FStar_Syntax_Print.tag_of_term t12 in
+              let uu____3810 =
+                let uu____3811 = FStar_Syntax_Print.term_to_string t12 in
+                let uu____3812 = FStar_Syntax_Print.tag_of_term t12 in
                 FStar_Util.format2 "impossible (outer): Got %s ... %s\n"
-                  uu____3813 uu____3814 in
-              failwith uu____3812 in
-        let uu____3827 = whnf env t1 in aux false uu____3827
+                  uu____3811 uu____3812 in
+              failwith uu____3810 in
+        let uu____3825 = whnf env t1 in aux false uu____3825
 let (base_and_refinement :
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.term ->
@@ -1609,15 +1609,15 @@ let (unrefine :
   =
   fun env ->
     fun t ->
-      let uu____3868 = base_and_refinement env t in
-      FStar_All.pipe_right uu____3868 FStar_Pervasives_Native.fst
+      let uu____3866 = base_and_refinement env t in
+      FStar_All.pipe_right uu____3866 FStar_Pervasives_Native.fst
 let (trivial_refinement :
   FStar_Syntax_Syntax.term ->
     (FStar_Syntax_Syntax.bv * FStar_Syntax_Syntax.term))
   =
   fun t ->
-    let uu____3908 = FStar_Syntax_Syntax.null_bv t in
-    (uu____3908, FStar_Syntax_Util.t_true)
+    let uu____3906 = FStar_Syntax_Syntax.null_bv t in
+    (uu____3906, FStar_Syntax_Util.t_true)
 let (as_refinement :
   Prims.bool ->
     FStar_TypeChecker_Env.env ->
@@ -1627,8 +1627,8 @@ let (as_refinement :
   fun delta ->
     fun env ->
       fun t ->
-        let uu____3932 = base_and_refinement_maybe_delta delta env t in
-        match uu____3932 with
+        let uu____3930 = base_and_refinement_maybe_delta delta env t in
+        match uu____3930 with
         | (t_base, refinement) ->
             (match refinement with
              | FStar_Pervasives_Native.None -> trivial_refinement t_base
@@ -1638,14 +1638,14 @@ let (force_refinement :
     (FStar_Syntax_Syntax.bv * FStar_Syntax_Syntax.term)
     FStar_Pervasives_Native.option) -> FStar_Syntax_Syntax.term)
   =
-  fun uu____3991 ->
-    match uu____3991 with
+  fun uu____3989 ->
+    match uu____3989 with
     | (t_base, refopt) ->
-        let uu____4022 =
+        let uu____4020 =
           match refopt with
           | FStar_Pervasives_Native.Some (y, phi) -> (y, phi)
           | FStar_Pervasives_Native.None -> trivial_refinement t_base in
-        (match uu____4022 with
+        (match uu____4020 with
          | (y, phi) ->
              FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_refine (y, phi))
                t_base.FStar_Syntax_Syntax.pos)
@@ -1654,16 +1654,16 @@ let (wl_prob_to_string :
   fun wl -> fun prob -> prob_to_string wl.tcenv prob
 let (wl_to_string : worklist -> Prims.string) =
   fun wl ->
-    let uu____4060 =
-      let uu____4063 =
-        let uu____4066 =
+    let uu____4058 =
+      let uu____4061 =
+        let uu____4064 =
           FStar_All.pipe_right wl.wl_deferred
             (FStar_List.map
-               (fun uu____4089 ->
-                  match uu____4089 with | (uu____4096, uu____4097, x) -> x)) in
-        FStar_List.append wl.attempting uu____4066 in
-      FStar_List.map (wl_prob_to_string wl) uu____4063 in
-    FStar_All.pipe_right uu____4060 (FStar_String.concat "\n\t")
+               (fun uu____4087 ->
+                  match uu____4087 with | (uu____4094, uu____4095, x) -> x)) in
+        FStar_List.append wl.attempting uu____4064 in
+      FStar_List.map (wl_prob_to_string wl) uu____4061 in
+    FStar_All.pipe_right uu____4058 (FStar_String.concat "\n\t")
 type flex_t =
   | Flex of (FStar_Syntax_Syntax.term * FStar_Syntax_Syntax.ctx_uvar *
   FStar_Syntax_Syntax.args) 
@@ -1674,40 +1674,40 @@ let (__proj__Flex__item___0 :
       FStar_Syntax_Syntax.args))
   = fun projectee -> match projectee with | Flex _0 -> _0
 let (flex_reason : flex_t -> Prims.string) =
-  fun uu____4145 ->
-    match uu____4145 with
-    | Flex (uu____4146, u, uu____4148) ->
+  fun uu____4143 ->
+    match uu____4143 with
+    | Flex (uu____4144, u, uu____4146) ->
         u.FStar_Syntax_Syntax.ctx_uvar_reason
 let (flex_t_to_string : flex_t -> Prims.string) =
-  fun uu____4153 ->
-    match uu____4153 with
-    | Flex (uu____4154, c, args) ->
-        let uu____4157 = print_ctx_uvar c in
-        let uu____4158 = FStar_Syntax_Print.args_to_string args in
-        FStar_Util.format2 "%s [%s]" uu____4157 uu____4158
+  fun uu____4151 ->
+    match uu____4151 with
+    | Flex (uu____4152, c, args) ->
+        let uu____4155 = print_ctx_uvar c in
+        let uu____4156 = FStar_Syntax_Print.args_to_string args in
+        FStar_Util.format2 "%s [%s]" uu____4155 uu____4156
 let (is_flex : FStar_Syntax_Syntax.term -> Prims.bool) =
   fun t ->
-    let uu____4164 = FStar_Syntax_Util.head_and_args t in
-    match uu____4164 with
+    let uu____4162 = FStar_Syntax_Util.head_and_args t in
+    match uu____4162 with
     | (head, _args) ->
-        let uu____4207 =
-          let uu____4208 = FStar_Syntax_Subst.compress head in
-          uu____4208.FStar_Syntax_Syntax.n in
-        (match uu____4207 with
-         | FStar_Syntax_Syntax.Tm_uvar uu____4211 -> true
-         | uu____4224 -> false)
+        let uu____4205 =
+          let uu____4206 = FStar_Syntax_Subst.compress head in
+          uu____4206.FStar_Syntax_Syntax.n in
+        (match uu____4205 with
+         | FStar_Syntax_Syntax.Tm_uvar uu____4209 -> true
+         | uu____4222 -> false)
 let (flex_uvar_head :
   FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.ctx_uvar) =
   fun t ->
-    let uu____4230 = FStar_Syntax_Util.head_and_args t in
-    match uu____4230 with
+    let uu____4228 = FStar_Syntax_Util.head_and_args t in
+    match uu____4228 with
     | (head, _args) ->
-        let uu____4273 =
-          let uu____4274 = FStar_Syntax_Subst.compress head in
-          uu____4274.FStar_Syntax_Syntax.n in
-        (match uu____4273 with
-         | FStar_Syntax_Syntax.Tm_uvar (u, uu____4278) -> u
-         | uu____4295 -> failwith "Not a flex-uvar")
+        let uu____4271 =
+          let uu____4272 = FStar_Syntax_Subst.compress head in
+          uu____4272.FStar_Syntax_Syntax.n in
+        (match uu____4271 with
+         | FStar_Syntax_Syntax.Tm_uvar (u, uu____4276) -> u
+         | uu____4293 -> failwith "Not a flex-uvar")
 let (ensure_no_uvar_subst :
   FStar_Syntax_Syntax.term ->
     worklist -> (FStar_Syntax_Syntax.term * worklist))
@@ -1717,66 +1717,66 @@ let (ensure_no_uvar_subst :
       let bv_not_affected_by s x =
         let t_x = FStar_Syntax_Syntax.bv_to_name x in
         let t_x' = FStar_Syntax_Subst.subst' s t_x in
-        let uu____4327 =
-          let uu____4328 = FStar_Syntax_Subst.compress t_x' in
-          uu____4328.FStar_Syntax_Syntax.n in
-        match uu____4327 with
+        let uu____4325 =
+          let uu____4326 = FStar_Syntax_Subst.compress t_x' in
+          uu____4326.FStar_Syntax_Syntax.n in
+        match uu____4325 with
         | FStar_Syntax_Syntax.Tm_name y -> FStar_Syntax_Syntax.bv_eq x y
-        | uu____4332 -> false in
+        | uu____4330 -> false in
       let binding_not_affected_by s b =
         match b with
         | FStar_Syntax_Syntax.Binding_var x -> bv_not_affected_by s x
-        | uu____4345 -> true in
-      let uu____4346 = FStar_Syntax_Util.head_and_args t0 in
-      match uu____4346 with
+        | uu____4343 -> true in
+      let uu____4344 = FStar_Syntax_Util.head_and_args t0 in
+      match uu____4344 with
       | (head, args) ->
-          let uu____4393 =
-            let uu____4394 = FStar_Syntax_Subst.compress head in
-            uu____4394.FStar_Syntax_Syntax.n in
-          (match uu____4393 with
-           | FStar_Syntax_Syntax.Tm_uvar (uv, ([], uu____4402)) -> (t0, wl)
-           | FStar_Syntax_Syntax.Tm_uvar (uv, uu____4418) when
+          let uu____4391 =
+            let uu____4392 = FStar_Syntax_Subst.compress head in
+            uu____4392.FStar_Syntax_Syntax.n in
+          (match uu____4391 with
+           | FStar_Syntax_Syntax.Tm_uvar (uv, ([], uu____4400)) -> (t0, wl)
+           | FStar_Syntax_Syntax.Tm_uvar (uv, uu____4416) when
                FStar_List.isEmpty uv.FStar_Syntax_Syntax.ctx_uvar_binders ->
                (t0, wl)
            | FStar_Syntax_Syntax.Tm_uvar (uv, s) ->
-               let uu____4459 =
+               let uu____4457 =
                  FStar_Common.max_suffix (binding_not_affected_by s)
                    uv.FStar_Syntax_Syntax.ctx_uvar_gamma in
-               (match uu____4459 with
+               (match uu____4457 with
                 | (gamma_aff, new_gamma) ->
                     (match gamma_aff with
                      | [] -> (t0, wl)
-                     | uu____4486 ->
+                     | uu____4484 ->
                          let dom_binders =
                            FStar_TypeChecker_Env.binders_of_bindings
                              gamma_aff in
-                         let uu____4490 =
-                           let uu____4497 =
+                         let uu____4488 =
+                           let uu____4495 =
                              FStar_TypeChecker_Env.binders_of_bindings
                                new_gamma in
-                           let uu____4506 =
-                             let uu____4509 =
+                           let uu____4504 =
+                             let uu____4507 =
                                FStar_Syntax_Syntax.mk_Total
                                  uv.FStar_Syntax_Syntax.ctx_uvar_typ in
-                             FStar_Syntax_Util.arrow dom_binders uu____4509 in
+                             FStar_Syntax_Util.arrow dom_binders uu____4507 in
                            new_uvar
                              (Prims.op_Hat
                                 uv.FStar_Syntax_Syntax.ctx_uvar_reason
                                 "; force delayed") wl
-                             t0.FStar_Syntax_Syntax.pos new_gamma uu____4497
-                             uu____4506
+                             t0.FStar_Syntax_Syntax.pos new_gamma uu____4495
+                             uu____4504
                              uv.FStar_Syntax_Syntax.ctx_uvar_should_check
                              uv.FStar_Syntax_Syntax.ctx_uvar_meta in
-                         (match uu____4490 with
+                         (match uu____4488 with
                           | (v, t_v, wl1) ->
                               let args_sol =
                                 FStar_List.map
-                                  (fun uu____4544 ->
-                                     match uu____4544 with
+                                  (fun uu____4542 ->
+                                     match uu____4542 with
                                      | (x, i) ->
-                                         let uu____4563 =
+                                         let uu____4561 =
                                            FStar_Syntax_Syntax.bv_to_name x in
-                                         (uu____4563, i)) dom_binders in
+                                         (uu____4561, i)) dom_binders in
                               let sol =
                                 FStar_Syntax_Syntax.mk_Tm_app t_v args_sol
                                   t0.FStar_Syntax_Syntax.pos in
@@ -1784,38 +1784,38 @@ let (ensure_no_uvar_subst :
                                  uv.FStar_Syntax_Syntax.ctx_uvar_head sol;
                                (let args_sol_s =
                                   FStar_List.map
-                                    (fun uu____4593 ->
-                                       match uu____4593 with
+                                    (fun uu____4591 ->
+                                       match uu____4591 with
                                        | (a, i) ->
-                                           let uu____4612 =
+                                           let uu____4610 =
                                              FStar_Syntax_Subst.subst' s a in
-                                           (uu____4612, i)) args_sol in
+                                           (uu____4610, i)) args_sol in
                                 let t =
                                   FStar_Syntax_Syntax.mk_Tm_app t_v
                                     (FStar_List.append args_sol_s args)
                                     t0.FStar_Syntax_Syntax.pos in
                                 (t, wl1))))))
-           | uu____4622 ->
+           | uu____4620 ->
                failwith "ensure_no_uvar_subst: expected a uvar at the head")
 let (destruct_flex_t' : FStar_Syntax_Syntax.term -> flex_t) =
   fun t ->
-    let uu____4632 = FStar_Syntax_Util.head_and_args t in
-    match uu____4632 with
+    let uu____4630 = FStar_Syntax_Util.head_and_args t in
+    match uu____4630 with
     | (head, args) ->
-        let uu____4675 =
-          let uu____4676 = FStar_Syntax_Subst.compress head in
-          uu____4676.FStar_Syntax_Syntax.n in
-        (match uu____4675 with
+        let uu____4673 =
+          let uu____4674 = FStar_Syntax_Subst.compress head in
+          uu____4674.FStar_Syntax_Syntax.n in
+        (match uu____4673 with
          | FStar_Syntax_Syntax.Tm_uvar (uv, s) -> Flex (t, uv, args)
-         | uu____4697 -> failwith "Not a flex-uvar")
+         | uu____4695 -> failwith "Not a flex-uvar")
 let (destruct_flex_t :
   FStar_Syntax_Syntax.term -> worklist -> (flex_t * worklist)) =
   fun t ->
     fun wl ->
-      let uu____4716 = ensure_no_uvar_subst t wl in
-      match uu____4716 with
+      let uu____4714 = ensure_no_uvar_subst t wl in
+      match uu____4714 with
       | (t1, wl1) ->
-          let uu____4727 = destruct_flex_t' t1 in (uu____4727, wl1)
+          let uu____4725 = destruct_flex_t' t1 in (uu____4725, wl1)
 let (u_abs :
   FStar_Syntax_Syntax.typ ->
     FStar_Syntax_Syntax.binders ->
@@ -1824,28 +1824,28 @@ let (u_abs :
   fun k ->
     fun ys ->
       fun t ->
-        let uu____4743 =
-          let uu____4766 =
-            let uu____4767 = FStar_Syntax_Subst.compress k in
-            uu____4767.FStar_Syntax_Syntax.n in
-          match uu____4766 with
+        let uu____4741 =
+          let uu____4764 =
+            let uu____4765 = FStar_Syntax_Subst.compress k in
+            uu____4765.FStar_Syntax_Syntax.n in
+          match uu____4764 with
           | FStar_Syntax_Syntax.Tm_arrow (bs, c) ->
               if (FStar_List.length bs) = (FStar_List.length ys)
               then
-                let uu____4848 = FStar_Syntax_Subst.open_comp bs c in
-                ((ys, t), uu____4848)
+                let uu____4846 = FStar_Syntax_Subst.open_comp bs c in
+                ((ys, t), uu____4846)
               else
-                (let uu____4882 = FStar_Syntax_Util.abs_formals t in
-                 match uu____4882 with
-                 | (ys', t1, uu____4915) ->
-                     let uu____4920 = FStar_Syntax_Util.arrow_formals_comp k in
-                     (((FStar_List.append ys ys'), t1), uu____4920))
-          | uu____4959 ->
-              let uu____4960 =
-                let uu____4965 = FStar_Syntax_Syntax.mk_Total k in
-                ([], uu____4965) in
-              ((ys, t), uu____4960) in
-        match uu____4743 with
+                (let uu____4880 = FStar_Syntax_Util.abs_formals t in
+                 match uu____4880 with
+                 | (ys', t1, uu____4913) ->
+                     let uu____4918 = FStar_Syntax_Util.arrow_formals_comp k in
+                     (((FStar_List.append ys ys'), t1), uu____4918))
+          | uu____4957 ->
+              let uu____4958 =
+                let uu____4963 = FStar_Syntax_Syntax.mk_Total k in
+                ([], uu____4963) in
+              ((ys, t), uu____4958) in
+        match uu____4741 with
         | ((ys1, t1), (xs, c)) ->
             if (FStar_List.length xs) <> (FStar_List.length ys1)
             then
@@ -1856,8 +1856,8 @@ let (u_abs :
                       FStar_Pervasives_Native.None []))
             else
               (let c1 =
-                 let uu____5058 = FStar_Syntax_Util.rename_binders xs ys1 in
-                 FStar_Syntax_Subst.subst_comp uu____5058 c in
+                 let uu____5056 = FStar_Syntax_Util.rename_binders xs ys1 in
+                 FStar_Syntax_Subst.subst_comp uu____5056 c in
                FStar_Syntax_Util.abs ys1 t1
                  (FStar_Pervasives_Native.Some
                     (FStar_Syntax_Util.residual_comp_of_comp c1)))
@@ -1879,108 +1879,108 @@ let (solve_prob' :
                | FStar_Pervasives_Native.None -> FStar_Syntax_Util.t_true
                | FStar_Pervasives_Native.Some phi -> phi in
              let assign_solution xs uv phi1 =
-               (let uu____5132 =
+               (let uu____5130 =
                   FStar_All.pipe_left (FStar_TypeChecker_Env.debug wl.tcenv)
                     (FStar_Options.Other "Rel") in
-                if uu____5132
+                if uu____5130
                 then
-                  let uu____5133 = FStar_Util.string_of_int (p_pid prob) in
-                  let uu____5134 = print_ctx_uvar uv in
-                  let uu____5135 = FStar_Syntax_Print.term_to_string phi1 in
+                  let uu____5131 = FStar_Util.string_of_int (p_pid prob) in
+                  let uu____5132 = print_ctx_uvar uv in
+                  let uu____5133 = FStar_Syntax_Print.term_to_string phi1 in
                   FStar_Util.print3 "Solving %s (%s) with formula %s\n"
-                    uu____5133 uu____5134 uu____5135
+                    uu____5131 uu____5132 uu____5133
                 else ());
                (let phi2 =
                   FStar_Syntax_Util.abs xs phi1
                     (FStar_Pervasives_Native.Some
                        (FStar_Syntax_Util.residual_tot
                           FStar_Syntax_Util.ktype0)) in
-                (let uu____5141 =
-                   let uu____5142 = FStar_Util.string_of_int (p_pid prob) in
-                   Prims.op_Hat "solve_prob'.sol." uu____5142 in
-                 let uu____5143 =
-                   let uu____5146 = p_scope prob in
+                (let uu____5139 =
+                   let uu____5140 = FStar_Util.string_of_int (p_pid prob) in
+                   Prims.op_Hat "solve_prob'.sol." uu____5140 in
+                 let uu____5141 =
+                   let uu____5144 = p_scope prob in
                    FStar_All.pipe_left
-                     (FStar_List.map FStar_Pervasives_Native.fst) uu____5146 in
+                     (FStar_List.map FStar_Pervasives_Native.fst) uu____5144 in
                  FStar_TypeChecker_Env.def_check_closed_in (p_loc prob)
-                   uu____5141 uu____5143 phi2);
+                   uu____5139 uu____5141 phi2);
                 FStar_Syntax_Util.set_uvar
                   uv.FStar_Syntax_Syntax.ctx_uvar_head phi2) in
              let uv = p_guard_uvar prob in
-             let fail uu____5179 =
-               let uu____5180 =
-                 let uu____5181 = FStar_Syntax_Print.ctx_uvar_to_string uv in
-                 let uu____5182 =
+             let fail uu____5177 =
+               let uu____5178 =
+                 let uu____5179 = FStar_Syntax_Print.ctx_uvar_to_string uv in
+                 let uu____5180 =
                    FStar_Syntax_Print.term_to_string (p_guard prob) in
                  FStar_Util.format2
                    "Impossible: this instance %s has already been assigned a solution\n%s\n"
-                   uu____5181 uu____5182 in
-               failwith uu____5180 in
+                   uu____5179 uu____5180 in
+               failwith uu____5178 in
              let args_as_binders args =
                FStar_All.pipe_right args
                  (FStar_List.collect
-                    (fun uu____5246 ->
-                       match uu____5246 with
+                    (fun uu____5244 ->
+                       match uu____5244 with
                        | (a, i) ->
-                           let uu____5267 =
-                             let uu____5268 = FStar_Syntax_Subst.compress a in
-                             uu____5268.FStar_Syntax_Syntax.n in
-                           (match uu____5267 with
+                           let uu____5265 =
+                             let uu____5266 = FStar_Syntax_Subst.compress a in
+                             uu____5266.FStar_Syntax_Syntax.n in
+                           (match uu____5265 with
                             | FStar_Syntax_Syntax.Tm_name x -> [(x, i)]
-                            | uu____5294 -> (fail (); [])))) in
+                            | uu____5292 -> (fail (); [])))) in
              let wl1 =
                let g = whnf wl.tcenv (p_guard prob) in
-               let uu____5304 =
-                 let uu____5305 = is_flex g in Prims.op_Negation uu____5305 in
-               if uu____5304
+               let uu____5302 =
+                 let uu____5303 = is_flex g in Prims.op_Negation uu____5303 in
+               if uu____5302
                then (if resolve_ok then wl else (fail (); wl))
                else
-                 (let uu____5309 = destruct_flex_t g wl in
-                  match uu____5309 with
-                  | (Flex (uu____5314, uv1, args), wl1) ->
-                      ((let uu____5319 = args_as_binders args in
-                        assign_solution uu____5319 uv1 phi);
+                 (let uu____5307 = destruct_flex_t g wl in
+                  match uu____5307 with
+                  | (Flex (uu____5312, uv1, args), wl1) ->
+                      ((let uu____5317 = args_as_binders args in
+                        assign_solution uu____5317 uv1 phi);
                        wl1)) in
              commit uvis;
-             (let uu___762_5321 = wl1 in
+             (let uu___762_5319 = wl1 in
               {
-                attempting = (uu___762_5321.attempting);
-                wl_deferred = (uu___762_5321.wl_deferred);
-                wl_deferred_to_tac = (uu___762_5321.wl_deferred_to_tac);
+                attempting = (uu___762_5319.attempting);
+                wl_deferred = (uu___762_5319.wl_deferred);
+                wl_deferred_to_tac = (uu___762_5319.wl_deferred_to_tac);
                 ctr = (wl1.ctr + Prims.int_one);
-                defer_ok = (uu___762_5321.defer_ok);
-                smt_ok = (uu___762_5321.smt_ok);
-                umax_heuristic_ok = (uu___762_5321.umax_heuristic_ok);
-                tcenv = (uu___762_5321.tcenv);
-                wl_implicits = (uu___762_5321.wl_implicits);
-                repr_subcomp_allowed = (uu___762_5321.repr_subcomp_allowed)
+                defer_ok = (uu___762_5319.defer_ok);
+                smt_ok = (uu___762_5319.smt_ok);
+                umax_heuristic_ok = (uu___762_5319.umax_heuristic_ok);
+                tcenv = (uu___762_5319.tcenv);
+                wl_implicits = (uu___762_5319.wl_implicits);
+                repr_subcomp_allowed = (uu___762_5319.repr_subcomp_allowed)
               }))
 let (extend_solution : Prims.int -> uvi Prims.list -> worklist -> worklist) =
   fun pid ->
     fun sol ->
       fun wl ->
-        (let uu____5342 =
+        (let uu____5340 =
            FStar_All.pipe_left (FStar_TypeChecker_Env.debug wl.tcenv)
              (FStar_Options.Other "Rel") in
-         if uu____5342
+         if uu____5340
          then
-           let uu____5343 = FStar_Util.string_of_int pid in
-           let uu____5344 = uvis_to_string wl.tcenv sol in
-           FStar_Util.print2 "Solving %s: with [%s]\n" uu____5343 uu____5344
+           let uu____5341 = FStar_Util.string_of_int pid in
+           let uu____5342 = uvis_to_string wl.tcenv sol in
+           FStar_Util.print2 "Solving %s: with [%s]\n" uu____5341 uu____5342
          else ());
         commit sol;
-        (let uu___770_5347 = wl in
+        (let uu___770_5345 = wl in
          {
-           attempting = (uu___770_5347.attempting);
-           wl_deferred = (uu___770_5347.wl_deferred);
-           wl_deferred_to_tac = (uu___770_5347.wl_deferred_to_tac);
+           attempting = (uu___770_5345.attempting);
+           wl_deferred = (uu___770_5345.wl_deferred);
+           wl_deferred_to_tac = (uu___770_5345.wl_deferred_to_tac);
            ctr = (wl.ctr + Prims.int_one);
-           defer_ok = (uu___770_5347.defer_ok);
-           smt_ok = (uu___770_5347.smt_ok);
-           umax_heuristic_ok = (uu___770_5347.umax_heuristic_ok);
-           tcenv = (uu___770_5347.tcenv);
-           wl_implicits = (uu___770_5347.wl_implicits);
-           repr_subcomp_allowed = (uu___770_5347.repr_subcomp_allowed)
+           defer_ok = (uu___770_5345.defer_ok);
+           smt_ok = (uu___770_5345.smt_ok);
+           umax_heuristic_ok = (uu___770_5345.umax_heuristic_ok);
+           tcenv = (uu___770_5345.tcenv);
+           wl_implicits = (uu___770_5345.wl_implicits);
+           repr_subcomp_allowed = (uu___770_5345.repr_subcomp_allowed)
          })
 let (solve_prob :
   FStar_TypeChecker_Common.prob ->
@@ -1994,15 +1994,15 @@ let (solve_prob :
           def_check_prob "solve_prob.prob" prob;
           FStar_Util.iter_opt logical_guard
             (def_check_scoped "solve_prob.guard" prob);
-          (let uu____5379 =
+          (let uu____5377 =
              FStar_All.pipe_left (FStar_TypeChecker_Env.debug wl.tcenv)
                (FStar_Options.Other "Rel") in
-           if uu____5379
+           if uu____5377
            then
-             let uu____5380 =
+             let uu____5378 =
                FStar_All.pipe_left FStar_Util.string_of_int (p_pid prob) in
-             let uu____5381 = uvis_to_string wl.tcenv uvis in
-             FStar_Util.print2 "Solving %s: with %s\n" uu____5380 uu____5381
+             let uu____5379 = uvis_to_string wl.tcenv uvis in
+             FStar_Util.print2 "Solving %s: with %s\n" uu____5378 uu____5379
            else ());
           solve_prob' false prob logical_guard uvis wl
 let (occurs :
@@ -2013,8 +2013,8 @@ let (occurs :
   fun uk ->
     fun t ->
       let uvars =
-        let uu____5402 = FStar_Syntax_Free.uvars t in
-        FStar_All.pipe_right uu____5402 FStar_Util.set_elements in
+        let uu____5400 = FStar_Syntax_Free.uvars t in
+        FStar_All.pipe_right uu____5400 FStar_Util.set_elements in
       let occurs =
         FStar_All.pipe_right uvars
           (FStar_Util.for_some
@@ -2031,21 +2031,21 @@ let (occurs_check :
   =
   fun uk ->
     fun t ->
-      let uu____5436 = occurs uk t in
-      match uu____5436 with
+      let uu____5434 = occurs uk t in
+      match uu____5434 with
       | (uvars, occurs1) ->
           let msg =
             if Prims.op_Negation occurs1
             then FStar_Pervasives_Native.None
             else
-              (let uu____5465 =
-                 let uu____5466 =
+              (let uu____5463 =
+                 let uu____5464 =
                    FStar_Syntax_Print.uvar_to_string
                      uk.FStar_Syntax_Syntax.ctx_uvar_head in
-                 let uu____5467 = FStar_Syntax_Print.term_to_string t in
+                 let uu____5465 = FStar_Syntax_Print.term_to_string t in
                  FStar_Util.format2 "occurs-check failed (%s occurs in %s)"
-                   uu____5466 uu____5467 in
-               FStar_Pervasives_Native.Some uu____5465) in
+                   uu____5464 uu____5465 in
+               FStar_Pervasives_Native.Some uu____5463) in
           (uvars, (Prims.op_Negation occurs1), msg)
 let rec (maximal_prefix :
   FStar_Syntax_Syntax.binders ->
@@ -2057,13 +2057,13 @@ let rec (maximal_prefix :
     fun bs' ->
       match (bs, bs') with
       | ((b, i)::bs_tail, (b', i')::bs'_tail) ->
-          let uu____5572 = FStar_Syntax_Syntax.bv_eq b b' in
-          if uu____5572
+          let uu____5570 = FStar_Syntax_Syntax.bv_eq b b' in
+          if uu____5570
           then
-            let uu____5581 = maximal_prefix bs_tail bs'_tail in
-            (match uu____5581 with | (pfx, rest) -> (((b, i) :: pfx), rest))
+            let uu____5579 = maximal_prefix bs_tail bs'_tail in
+            (match uu____5579 with | (pfx, rest) -> (((b, i) :: pfx), rest))
           else ([], (bs, bs'))
-      | uu____5631 -> ([], (bs, bs'))
+      | uu____5629 -> ([], (bs, bs'))
 let (extend_gamma :
   FStar_Syntax_Syntax.gamma ->
     FStar_Syntax_Syntax.binders -> FStar_Syntax_Syntax.binding Prims.list)
@@ -2072,9 +2072,9 @@ let (extend_gamma :
     fun bs ->
       FStar_List.fold_left
         (fun g1 ->
-           fun uu____5687 ->
-             match uu____5687 with
-             | (x, uu____5699) -> (FStar_Syntax_Syntax.Binding_var x) :: g1)
+           fun uu____5685 ->
+             match uu____5685 with
+             | (x, uu____5697) -> (FStar_Syntax_Syntax.Binding_var x) :: g1)
         g bs
 let (gamma_until :
   FStar_Syntax_Syntax.gamma ->
@@ -2082,20 +2082,20 @@ let (gamma_until :
   =
   fun g ->
     fun bs ->
-      let uu____5716 = FStar_List.last bs in
-      match uu____5716 with
+      let uu____5714 = FStar_List.last bs in
+      match uu____5714 with
       | FStar_Pervasives_Native.None -> []
-      | FStar_Pervasives_Native.Some (x, uu____5740) ->
-          let uu____5751 =
+      | FStar_Pervasives_Native.Some (x, uu____5738) ->
+          let uu____5749 =
             FStar_Util.prefix_until
-              (fun uu___18_5766 ->
-                 match uu___18_5766 with
+              (fun uu___18_5764 ->
+                 match uu___18_5764 with
                  | FStar_Syntax_Syntax.Binding_var x' ->
                      FStar_Syntax_Syntax.bv_eq x x'
-                 | uu____5768 -> false) g in
-          (match uu____5751 with
+                 | uu____5766 -> false) g in
+          (match uu____5749 with
            | FStar_Pervasives_Native.None -> []
-           | FStar_Pervasives_Native.Some (uu____5781, bx, rest) -> bx ::
+           | FStar_Pervasives_Native.Some (uu____5779, bx, rest) -> bx ::
                rest)
 let (restrict_ctx :
   FStar_TypeChecker_Env.env ->
@@ -2108,81 +2108,81 @@ let (restrict_ctx :
       fun bs ->
         fun src ->
           fun wl ->
-            let uu____5827 =
+            let uu____5825 =
               maximal_prefix tgt.FStar_Syntax_Syntax.ctx_uvar_binders
                 src.FStar_Syntax_Syntax.ctx_uvar_binders in
-            match uu____5827 with
-            | (pfx, uu____5837) ->
+            match uu____5825 with
+            | (pfx, uu____5835) ->
                 let g =
                   gamma_until src.FStar_Syntax_Syntax.ctx_uvar_gamma pfx in
                 let aux t f =
-                  let uu____5865 =
-                    let uu____5872 =
-                      let uu____5873 =
+                  let uu____5863 =
+                    let uu____5870 =
+                      let uu____5871 =
                         FStar_Syntax_Print.uvar_to_string
                           src.FStar_Syntax_Syntax.ctx_uvar_head in
-                      Prims.op_Hat "restricted " uu____5873 in
-                    new_uvar uu____5872 wl
+                      Prims.op_Hat "restricted " uu____5871 in
+                    new_uvar uu____5870 wl
                       src.FStar_Syntax_Syntax.ctx_uvar_range g pfx t
                       src.FStar_Syntax_Syntax.ctx_uvar_should_check
                       src.FStar_Syntax_Syntax.ctx_uvar_meta in
-                  match uu____5865 with
-                  | (uu____5874, src', wl1) ->
-                      ((let uu____5878 = f src' in
+                  match uu____5863 with
+                  | (uu____5872, src', wl1) ->
+                      ((let uu____5876 = f src' in
                         FStar_Syntax_Util.set_uvar
-                          src.FStar_Syntax_Syntax.ctx_uvar_head uu____5878);
+                          src.FStar_Syntax_Syntax.ctx_uvar_head uu____5876);
                        wl1) in
                 let bs1 =
                   FStar_All.pipe_right bs
                     (FStar_List.filter
-                       (fun uu____5913 ->
-                          match uu____5913 with
-                          | (bv1, uu____5921) ->
+                       (fun uu____5911 ->
+                          match uu____5911 with
+                          | (bv1, uu____5919) ->
                               (FStar_All.pipe_right
                                  src.FStar_Syntax_Syntax.ctx_uvar_binders
                                  (FStar_List.existsb
-                                    (fun uu____5943 ->
-                                       match uu____5943 with
-                                       | (bv2, uu____5951) ->
+                                    (fun uu____5941 ->
+                                       match uu____5941 with
+                                       | (bv2, uu____5949) ->
                                            FStar_Syntax_Syntax.bv_eq bv1 bv2)))
                                 &&
-                                (let uu____5957 =
+                                (let uu____5955 =
                                    FStar_All.pipe_right pfx
                                      (FStar_List.existsb
-                                        (fun uu____5975 ->
-                                           match uu____5975 with
-                                           | (bv2, uu____5983) ->
+                                        (fun uu____5973 ->
+                                           match uu____5973 with
+                                           | (bv2, uu____5981) ->
                                                FStar_Syntax_Syntax.bv_eq bv1
                                                  bv2)) in
-                                 Prims.op_Negation uu____5957))) in
+                                 Prims.op_Negation uu____5955))) in
                 if (FStar_List.length bs1) = Prims.int_zero
                 then
                   aux src.FStar_Syntax_Syntax.ctx_uvar_typ (fun src' -> src')
                 else
-                  (let uu____5997 =
-                     let uu____5998 =
-                       let uu____6001 =
-                         let uu____6004 =
+                  (let uu____5995 =
+                     let uu____5996 =
+                       let uu____5999 =
+                         let uu____6002 =
                            FStar_All.pipe_right
                              src.FStar_Syntax_Syntax.ctx_uvar_typ
                              (env.FStar_TypeChecker_Env.universe_of env) in
-                         FStar_All.pipe_right uu____6004
-                           (fun uu____6007 ->
-                              FStar_Pervasives_Native.Some uu____6007) in
-                       FStar_All.pipe_right uu____6001
+                         FStar_All.pipe_right uu____6002
+                           (fun uu____6005 ->
+                              FStar_Pervasives_Native.Some uu____6005) in
+                       FStar_All.pipe_right uu____5999
                          (FStar_Syntax_Syntax.mk_Total'
                             src.FStar_Syntax_Syntax.ctx_uvar_typ) in
-                     FStar_All.pipe_right uu____5998
+                     FStar_All.pipe_right uu____5996
                        (FStar_Syntax_Util.arrow bs1) in
-                   aux uu____5997
+                   aux uu____5995
                      (fun src' ->
-                        let uu____6017 =
-                          let uu____6018 =
+                        let uu____6015 =
+                          let uu____6016 =
                             FStar_All.pipe_right bs1
                               FStar_Syntax_Syntax.binders_to_names in
-                          FStar_All.pipe_right uu____6018
+                          FStar_All.pipe_right uu____6016
                             (FStar_List.map FStar_Syntax_Syntax.as_arg) in
-                        FStar_Syntax_Syntax.mk_Tm_app src' uu____6017
+                        FStar_Syntax_Syntax.mk_Tm_app src' uu____6015
                           src.FStar_Syntax_Syntax.ctx_uvar_range))
 let (restrict_all_uvars :
   FStar_TypeChecker_Env.env ->
@@ -2219,60 +2219,60 @@ let (intersect_binders :
                  match b with
                  | FStar_Syntax_Syntax.Binding_var x ->
                      FStar_Util.set_add x out
-                 | uu____6143 -> out) FStar_Syntax_Syntax.no_names g in
-        let uu____6144 =
+                 | uu____6141 -> out) FStar_Syntax_Syntax.no_names g in
+        let uu____6142 =
           FStar_All.pipe_right v2
             (FStar_List.fold_left
-               (fun uu____6208 ->
-                  fun uu____6209 ->
-                    match (uu____6208, uu____6209) with
+               (fun uu____6206 ->
+                  fun uu____6207 ->
+                    match (uu____6206, uu____6207) with
                     | ((isect, isect_set), (x, imp)) ->
-                        let uu____6312 =
-                          let uu____6313 = FStar_Util.set_mem x v1_set in
-                          FStar_All.pipe_left Prims.op_Negation uu____6313 in
-                        if uu____6312
+                        let uu____6310 =
+                          let uu____6311 = FStar_Util.set_mem x v1_set in
+                          FStar_All.pipe_left Prims.op_Negation uu____6311 in
+                        if uu____6310
                         then (isect, isect_set)
                         else
                           (let fvs =
                              FStar_Syntax_Free.names
                                x.FStar_Syntax_Syntax.sort in
-                           let uu____6342 =
+                           let uu____6340 =
                              FStar_Util.set_is_subset_of fvs isect_set in
-                           if uu____6342
+                           if uu____6340
                            then
-                             let uu____6357 = FStar_Util.set_add x isect_set in
-                             (((x, imp) :: isect), uu____6357)
+                             let uu____6355 = FStar_Util.set_add x isect_set in
+                             (((x, imp) :: isect), uu____6355)
                            else (isect, isect_set))) ([], ctx_binders)) in
-        match uu____6144 with | (isect, uu____6406) -> FStar_List.rev isect
+        match uu____6142 with | (isect, uu____6404) -> FStar_List.rev isect
 let binders_eq :
-  'uuuuuu6441 'uuuuuu6442 .
-    (FStar_Syntax_Syntax.bv * 'uuuuuu6441) Prims.list ->
-      (FStar_Syntax_Syntax.bv * 'uuuuuu6442) Prims.list -> Prims.bool
+  'uuuuuu6439 'uuuuuu6440 .
+    (FStar_Syntax_Syntax.bv * 'uuuuuu6439) Prims.list ->
+      (FStar_Syntax_Syntax.bv * 'uuuuuu6440) Prims.list -> Prims.bool
   =
   fun v1 ->
     fun v2 ->
       ((FStar_List.length v1) = (FStar_List.length v2)) &&
         (FStar_List.forall2
-           (fun uu____6499 ->
-              fun uu____6500 ->
-                match (uu____6499, uu____6500) with
-                | ((a, uu____6518), (b, uu____6520)) ->
+           (fun uu____6497 ->
+              fun uu____6498 ->
+                match (uu____6497, uu____6498) with
+                | ((a, uu____6516), (b, uu____6518)) ->
                     FStar_Syntax_Syntax.bv_eq a b) v1 v2)
 let name_exists_in_binders :
-  'uuuuuu6535 .
+  'uuuuuu6533 .
     FStar_Syntax_Syntax.bv ->
-      (FStar_Syntax_Syntax.bv * 'uuuuuu6535) Prims.list -> Prims.bool
+      (FStar_Syntax_Syntax.bv * 'uuuuuu6533) Prims.list -> Prims.bool
   =
   fun x ->
     fun bs ->
       FStar_Util.for_some
-        (fun uu____6565 ->
-           match uu____6565 with
-           | (y, uu____6571) -> FStar_Syntax_Syntax.bv_eq x y) bs
+        (fun uu____6563 ->
+           match uu____6563 with
+           | (y, uu____6569) -> FStar_Syntax_Syntax.bv_eq x y) bs
 let pat_vars :
-  'uuuuuu6580 .
+  'uuuuuu6578 .
     FStar_TypeChecker_Env.env ->
-      (FStar_Syntax_Syntax.bv * 'uuuuuu6580) Prims.list ->
+      (FStar_Syntax_Syntax.bv * 'uuuuuu6578) Prims.list ->
         (FStar_Syntax_Syntax.term * FStar_Syntax_Syntax.arg_qualifier
           FStar_Pervasives_Native.option) Prims.list ->
           FStar_Syntax_Syntax.binders FStar_Pervasives_Native.option
@@ -2287,13 +2287,13 @@ let pat_vars :
               let hd = sn env arg in
               (match hd.FStar_Syntax_Syntax.n with
                | FStar_Syntax_Syntax.Tm_name a ->
-                   let uu____6742 =
+                   let uu____6740 =
                      (name_exists_in_binders a seen) ||
                        (name_exists_in_binders a ctx) in
-                   if uu____6742
+                   if uu____6740
                    then FStar_Pervasives_Native.None
                    else aux ((a, i) :: seen) args2
-               | uu____6772 -> FStar_Pervasives_Native.None) in
+               | uu____6770 -> FStar_Pervasives_Native.None) in
         aux [] args
 type match_result =
   | MisMatch of (FStar_Syntax_Syntax.delta_depth
@@ -2303,7 +2303,7 @@ type match_result =
   | FullMatch 
 let (uu___is_MisMatch : match_result -> Prims.bool) =
   fun projectee ->
-    match projectee with | MisMatch _0 -> true | uu____6819 -> false
+    match projectee with | MisMatch _0 -> true | uu____6817 -> false
 let (__proj__MisMatch__item___0 :
   match_result ->
     (FStar_Syntax_Syntax.delta_depth FStar_Pervasives_Native.option *
@@ -2311,39 +2311,39 @@ let (__proj__MisMatch__item___0 :
   = fun projectee -> match projectee with | MisMatch _0 -> _0
 let (uu___is_HeadMatch : match_result -> Prims.bool) =
   fun projectee ->
-    match projectee with | HeadMatch _0 -> true | uu____6856 -> false
+    match projectee with | HeadMatch _0 -> true | uu____6854 -> false
 let (__proj__HeadMatch__item___0 : match_result -> Prims.bool) =
   fun projectee -> match projectee with | HeadMatch _0 -> _0
 let (uu___is_FullMatch : match_result -> Prims.bool) =
   fun projectee ->
-    match projectee with | FullMatch -> true | uu____6868 -> false
+    match projectee with | FullMatch -> true | uu____6866 -> false
 let (string_of_match_result : match_result -> Prims.string) =
-  fun uu___19_6873 ->
-    match uu___19_6873 with
+  fun uu___19_6871 ->
+    match uu___19_6871 with
     | MisMatch (d1, d2) ->
-        let uu____6884 =
-          let uu____6885 =
+        let uu____6882 =
+          let uu____6883 =
             FStar_Common.string_of_option
               FStar_Syntax_Print.delta_depth_to_string d1 in
-          let uu____6886 =
-            let uu____6887 =
-              let uu____6888 =
+          let uu____6884 =
+            let uu____6885 =
+              let uu____6886 =
                 FStar_Common.string_of_option
                   FStar_Syntax_Print.delta_depth_to_string d2 in
-              Prims.op_Hat uu____6888 ")" in
-            Prims.op_Hat ") (" uu____6887 in
-          Prims.op_Hat uu____6885 uu____6886 in
-        Prims.op_Hat "MisMatch (" uu____6884
+              Prims.op_Hat uu____6886 ")" in
+            Prims.op_Hat ") (" uu____6885 in
+          Prims.op_Hat uu____6883 uu____6884 in
+        Prims.op_Hat "MisMatch (" uu____6882
     | HeadMatch u ->
-        let uu____6890 = FStar_Util.string_of_bool u in
-        Prims.op_Hat "HeadMatch " uu____6890
+        let uu____6888 = FStar_Util.string_of_bool u in
+        Prims.op_Hat "HeadMatch " uu____6888
     | FullMatch -> "FullMatch"
 let (head_match : match_result -> match_result) =
-  fun uu___20_6895 ->
-    match uu___20_6895 with
+  fun uu___20_6893 ->
+    match uu___20_6893 with
     | MisMatch (i, j) -> MisMatch (i, j)
     | HeadMatch (true) -> HeadMatch true
-    | uu____6910 -> HeadMatch false
+    | uu____6908 -> HeadMatch false
 let (fv_delta_depth :
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.fv -> FStar_Syntax_Syntax.delta_depth)
@@ -2353,26 +2353,26 @@ let (fv_delta_depth :
       let d = FStar_TypeChecker_Env.delta_depth_of_fv env fv in
       match d with
       | FStar_Syntax_Syntax.Delta_abstract d1 ->
-          let uu____6923 =
-            (let uu____6928 =
+          let uu____6921 =
+            (let uu____6926 =
                FStar_Ident.string_of_lid env.FStar_TypeChecker_Env.curmodule in
-             let uu____6929 =
+             let uu____6927 =
                FStar_Ident.nsstr
                  (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-             uu____6928 = uu____6929) &&
+             uu____6926 = uu____6927) &&
               (Prims.op_Negation env.FStar_TypeChecker_Env.is_iface) in
-          if uu____6923 then d1 else FStar_Syntax_Syntax.delta_constant
+          if uu____6921 then d1 else FStar_Syntax_Syntax.delta_constant
       | FStar_Syntax_Syntax.Delta_constant_at_level i when i > Prims.int_zero
           ->
-          let uu____6932 =
+          let uu____6930 =
             FStar_TypeChecker_Env.lookup_definition
               [FStar_TypeChecker_Env.Unfold
                  FStar_Syntax_Syntax.delta_constant] env
               (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-          (match uu____6932 with
+          (match uu____6930 with
            | FStar_Pervasives_Native.None ->
                FStar_Syntax_Syntax.delta_constant
-           | uu____6943 -> d)
+           | uu____6941 -> d)
       | d1 -> d1
 let rec (delta_depth_of_term :
   FStar_TypeChecker_Env.env ->
@@ -2383,46 +2383,46 @@ let rec (delta_depth_of_term :
     fun t ->
       let t1 = FStar_Syntax_Util.unmeta t in
       match t1.FStar_Syntax_Syntax.n with
-      | FStar_Syntax_Syntax.Tm_meta uu____6966 -> failwith "Impossible"
-      | FStar_Syntax_Syntax.Tm_delayed uu____6975 -> failwith "Impossible"
+      | FStar_Syntax_Syntax.Tm_meta uu____6964 -> failwith "Impossible"
+      | FStar_Syntax_Syntax.Tm_delayed uu____6973 -> failwith "Impossible"
       | FStar_Syntax_Syntax.Tm_lazy i ->
-          let uu____6993 = FStar_Syntax_Util.unfold_lazy i in
-          delta_depth_of_term env uu____6993
+          let uu____6991 = FStar_Syntax_Util.unfold_lazy i in
+          delta_depth_of_term env uu____6991
       | FStar_Syntax_Syntax.Tm_unknown -> FStar_Pervasives_Native.None
-      | FStar_Syntax_Syntax.Tm_bvar uu____6994 ->
+      | FStar_Syntax_Syntax.Tm_bvar uu____6992 ->
           FStar_Pervasives_Native.None
-      | FStar_Syntax_Syntax.Tm_name uu____6995 ->
+      | FStar_Syntax_Syntax.Tm_name uu____6993 ->
           FStar_Pervasives_Native.None
-      | FStar_Syntax_Syntax.Tm_uvar uu____6996 ->
+      | FStar_Syntax_Syntax.Tm_uvar uu____6994 ->
           FStar_Pervasives_Native.None
-      | FStar_Syntax_Syntax.Tm_let uu____7009 -> FStar_Pervasives_Native.None
-      | FStar_Syntax_Syntax.Tm_match uu____7022 ->
+      | FStar_Syntax_Syntax.Tm_let uu____7007 -> FStar_Pervasives_Native.None
+      | FStar_Syntax_Syntax.Tm_match uu____7020 ->
           FStar_Pervasives_Native.None
-      | FStar_Syntax_Syntax.Tm_uinst (t2, uu____7046) ->
+      | FStar_Syntax_Syntax.Tm_uinst (t2, uu____7044) ->
           delta_depth_of_term env t2
-      | FStar_Syntax_Syntax.Tm_ascribed (t2, uu____7052, uu____7053) ->
+      | FStar_Syntax_Syntax.Tm_ascribed (t2, uu____7050, uu____7051) ->
           delta_depth_of_term env t2
-      | FStar_Syntax_Syntax.Tm_app (t2, uu____7095) ->
+      | FStar_Syntax_Syntax.Tm_app (t2, uu____7093) ->
           delta_depth_of_term env t2
       | FStar_Syntax_Syntax.Tm_refine
-          ({ FStar_Syntax_Syntax.ppname = uu____7120;
-             FStar_Syntax_Syntax.index = uu____7121;
+          ({ FStar_Syntax_Syntax.ppname = uu____7118;
+             FStar_Syntax_Syntax.index = uu____7119;
              FStar_Syntax_Syntax.sort = t2;_},
-           uu____7123)
+           uu____7121)
           -> delta_depth_of_term env t2
-      | FStar_Syntax_Syntax.Tm_constant uu____7130 ->
+      | FStar_Syntax_Syntax.Tm_constant uu____7128 ->
           FStar_Pervasives_Native.Some FStar_Syntax_Syntax.delta_constant
-      | FStar_Syntax_Syntax.Tm_type uu____7131 ->
+      | FStar_Syntax_Syntax.Tm_type uu____7129 ->
           FStar_Pervasives_Native.Some FStar_Syntax_Syntax.delta_constant
-      | FStar_Syntax_Syntax.Tm_arrow uu____7132 ->
+      | FStar_Syntax_Syntax.Tm_arrow uu____7130 ->
           FStar_Pervasives_Native.Some FStar_Syntax_Syntax.delta_constant
-      | FStar_Syntax_Syntax.Tm_quoted uu____7147 ->
+      | FStar_Syntax_Syntax.Tm_quoted uu____7145 ->
           FStar_Pervasives_Native.Some FStar_Syntax_Syntax.delta_constant
-      | FStar_Syntax_Syntax.Tm_abs uu____7154 ->
+      | FStar_Syntax_Syntax.Tm_abs uu____7152 ->
           FStar_Pervasives_Native.Some FStar_Syntax_Syntax.delta_constant
       | FStar_Syntax_Syntax.Tm_fvar fv ->
-          let uu____7174 = fv_delta_depth env fv in
-          FStar_Pervasives_Native.Some uu____7174
+          let uu____7172 = fv_delta_depth env fv in
+          FStar_Pervasives_Native.Some uu____7172
 let rec (head_matches :
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term -> match_result)
@@ -2434,112 +2434,112 @@ let rec (head_matches :
         let t21 = FStar_Syntax_Util.unmeta t2 in
         match ((t11.FStar_Syntax_Syntax.n), (t21.FStar_Syntax_Syntax.n)) with
         | (FStar_Syntax_Syntax.Tm_lazy
-           { FStar_Syntax_Syntax.blob = uu____7192;
+           { FStar_Syntax_Syntax.blob = uu____7190;
              FStar_Syntax_Syntax.lkind = FStar_Syntax_Syntax.Lazy_embedding
-               uu____7193;
-             FStar_Syntax_Syntax.ltyp = uu____7194;
-             FStar_Syntax_Syntax.rng = uu____7195;_},
-           uu____7196) ->
-            let uu____7207 = FStar_Syntax_Util.unlazy t11 in
-            head_matches env uu____7207 t21
-        | (uu____7208, FStar_Syntax_Syntax.Tm_lazy
-           { FStar_Syntax_Syntax.blob = uu____7209;
+               uu____7191;
+             FStar_Syntax_Syntax.ltyp = uu____7192;
+             FStar_Syntax_Syntax.rng = uu____7193;_},
+           uu____7194) ->
+            let uu____7205 = FStar_Syntax_Util.unlazy t11 in
+            head_matches env uu____7205 t21
+        | (uu____7206, FStar_Syntax_Syntax.Tm_lazy
+           { FStar_Syntax_Syntax.blob = uu____7207;
              FStar_Syntax_Syntax.lkind = FStar_Syntax_Syntax.Lazy_embedding
-               uu____7210;
-             FStar_Syntax_Syntax.ltyp = uu____7211;
-             FStar_Syntax_Syntax.rng = uu____7212;_})
+               uu____7208;
+             FStar_Syntax_Syntax.ltyp = uu____7209;
+             FStar_Syntax_Syntax.rng = uu____7210;_})
             ->
-            let uu____7223 = FStar_Syntax_Util.unlazy t21 in
-            head_matches env t11 uu____7223
+            let uu____7221 = FStar_Syntax_Util.unlazy t21 in
+            head_matches env t11 uu____7221
         | (FStar_Syntax_Syntax.Tm_name x, FStar_Syntax_Syntax.Tm_name y) ->
-            let uu____7226 = FStar_Syntax_Syntax.bv_eq x y in
-            if uu____7226
+            let uu____7224 = FStar_Syntax_Syntax.bv_eq x y in
+            if uu____7224
             then FullMatch
             else
               MisMatch
                 (FStar_Pervasives_Native.None, FStar_Pervasives_Native.None)
         | (FStar_Syntax_Syntax.Tm_fvar f, FStar_Syntax_Syntax.Tm_fvar g) ->
-            let uu____7234 = FStar_Syntax_Syntax.fv_eq f g in
-            if uu____7234
+            let uu____7232 = FStar_Syntax_Syntax.fv_eq f g in
+            if uu____7232
             then FullMatch
             else
-              (let uu____7236 =
-                 let uu____7245 =
-                   let uu____7248 = fv_delta_depth env f in
-                   FStar_Pervasives_Native.Some uu____7248 in
-                 let uu____7249 =
-                   let uu____7252 = fv_delta_depth env g in
-                   FStar_Pervasives_Native.Some uu____7252 in
-                 (uu____7245, uu____7249) in
-               MisMatch uu____7236)
-        | (FStar_Syntax_Syntax.Tm_uinst (f, uu____7258),
-           FStar_Syntax_Syntax.Tm_uinst (g, uu____7260)) ->
-            let uu____7269 = head_matches env f g in
-            FStar_All.pipe_right uu____7269 head_match
+              (let uu____7234 =
+                 let uu____7243 =
+                   let uu____7246 = fv_delta_depth env f in
+                   FStar_Pervasives_Native.Some uu____7246 in
+                 let uu____7247 =
+                   let uu____7250 = fv_delta_depth env g in
+                   FStar_Pervasives_Native.Some uu____7250 in
+                 (uu____7243, uu____7247) in
+               MisMatch uu____7234)
+        | (FStar_Syntax_Syntax.Tm_uinst (f, uu____7256),
+           FStar_Syntax_Syntax.Tm_uinst (g, uu____7258)) ->
+            let uu____7267 = head_matches env f g in
+            FStar_All.pipe_right uu____7267 head_match
         | (FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_reify),
            FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_reify)) ->
             FullMatch
         | (FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_reify),
-           uu____7270) -> HeadMatch true
-        | (uu____7271, FStar_Syntax_Syntax.Tm_constant
+           uu____7268) -> HeadMatch true
+        | (uu____7269, FStar_Syntax_Syntax.Tm_constant
            (FStar_Const.Const_reify)) -> HeadMatch true
         | (FStar_Syntax_Syntax.Tm_constant c, FStar_Syntax_Syntax.Tm_constant
            d) ->
-            let uu____7274 = FStar_Const.eq_const c d in
-            if uu____7274
+            let uu____7272 = FStar_Const.eq_const c d in
+            if uu____7272
             then FullMatch
             else
               MisMatch
                 (FStar_Pervasives_Native.None, FStar_Pervasives_Native.None)
-        | (FStar_Syntax_Syntax.Tm_uvar (uv, uu____7281),
-           FStar_Syntax_Syntax.Tm_uvar (uv', uu____7283)) ->
-            let uu____7316 =
+        | (FStar_Syntax_Syntax.Tm_uvar (uv, uu____7279),
+           FStar_Syntax_Syntax.Tm_uvar (uv', uu____7281)) ->
+            let uu____7314 =
               FStar_Syntax_Unionfind.equiv
                 uv.FStar_Syntax_Syntax.ctx_uvar_head
                 uv'.FStar_Syntax_Syntax.ctx_uvar_head in
-            if uu____7316
+            if uu____7314
             then FullMatch
             else
               MisMatch
                 (FStar_Pervasives_Native.None, FStar_Pervasives_Native.None)
-        | (FStar_Syntax_Syntax.Tm_refine (x, uu____7323),
-           FStar_Syntax_Syntax.Tm_refine (y, uu____7325)) ->
-            let uu____7334 =
+        | (FStar_Syntax_Syntax.Tm_refine (x, uu____7321),
+           FStar_Syntax_Syntax.Tm_refine (y, uu____7323)) ->
+            let uu____7332 =
               head_matches env x.FStar_Syntax_Syntax.sort
                 y.FStar_Syntax_Syntax.sort in
-            FStar_All.pipe_right uu____7334 head_match
-        | (FStar_Syntax_Syntax.Tm_refine (x, uu____7336), uu____7337) ->
-            let uu____7342 = head_matches env x.FStar_Syntax_Syntax.sort t21 in
-            FStar_All.pipe_right uu____7342 head_match
-        | (uu____7343, FStar_Syntax_Syntax.Tm_refine (x, uu____7345)) ->
-            let uu____7350 = head_matches env t11 x.FStar_Syntax_Syntax.sort in
-            FStar_All.pipe_right uu____7350 head_match
-        | (FStar_Syntax_Syntax.Tm_type uu____7351,
-           FStar_Syntax_Syntax.Tm_type uu____7352) -> HeadMatch false
-        | (FStar_Syntax_Syntax.Tm_arrow uu____7353,
-           FStar_Syntax_Syntax.Tm_arrow uu____7354) -> HeadMatch false
-        | (FStar_Syntax_Syntax.Tm_app (head, uu____7384),
-           FStar_Syntax_Syntax.Tm_app (head', uu____7386)) ->
-            let uu____7435 = head_matches env head head' in
-            FStar_All.pipe_right uu____7435 head_match
-        | (FStar_Syntax_Syntax.Tm_app (head, uu____7437), uu____7438) ->
-            let uu____7463 = head_matches env head t21 in
-            FStar_All.pipe_right uu____7463 head_match
-        | (uu____7464, FStar_Syntax_Syntax.Tm_app (head, uu____7466)) ->
-            let uu____7491 = head_matches env t11 head in
-            FStar_All.pipe_right uu____7491 head_match
-        | (FStar_Syntax_Syntax.Tm_let uu____7492, FStar_Syntax_Syntax.Tm_let
-           uu____7493) -> HeadMatch true
-        | (FStar_Syntax_Syntax.Tm_match uu____7518,
-           FStar_Syntax_Syntax.Tm_match uu____7519) -> HeadMatch true
-        | (FStar_Syntax_Syntax.Tm_abs uu____7564, FStar_Syntax_Syntax.Tm_abs
-           uu____7565) -> HeadMatch true
-        | uu____7602 ->
-            let uu____7607 =
-              let uu____7616 = delta_depth_of_term env t11 in
-              let uu____7619 = delta_depth_of_term env t21 in
-              (uu____7616, uu____7619) in
-            MisMatch uu____7607
+            FStar_All.pipe_right uu____7332 head_match
+        | (FStar_Syntax_Syntax.Tm_refine (x, uu____7334), uu____7335) ->
+            let uu____7340 = head_matches env x.FStar_Syntax_Syntax.sort t21 in
+            FStar_All.pipe_right uu____7340 head_match
+        | (uu____7341, FStar_Syntax_Syntax.Tm_refine (x, uu____7343)) ->
+            let uu____7348 = head_matches env t11 x.FStar_Syntax_Syntax.sort in
+            FStar_All.pipe_right uu____7348 head_match
+        | (FStar_Syntax_Syntax.Tm_type uu____7349,
+           FStar_Syntax_Syntax.Tm_type uu____7350) -> HeadMatch false
+        | (FStar_Syntax_Syntax.Tm_arrow uu____7351,
+           FStar_Syntax_Syntax.Tm_arrow uu____7352) -> HeadMatch false
+        | (FStar_Syntax_Syntax.Tm_app (head, uu____7382),
+           FStar_Syntax_Syntax.Tm_app (head', uu____7384)) ->
+            let uu____7433 = head_matches env head head' in
+            FStar_All.pipe_right uu____7433 head_match
+        | (FStar_Syntax_Syntax.Tm_app (head, uu____7435), uu____7436) ->
+            let uu____7461 = head_matches env head t21 in
+            FStar_All.pipe_right uu____7461 head_match
+        | (uu____7462, FStar_Syntax_Syntax.Tm_app (head, uu____7464)) ->
+            let uu____7489 = head_matches env t11 head in
+            FStar_All.pipe_right uu____7489 head_match
+        | (FStar_Syntax_Syntax.Tm_let uu____7490, FStar_Syntax_Syntax.Tm_let
+           uu____7491) -> HeadMatch true
+        | (FStar_Syntax_Syntax.Tm_match uu____7516,
+           FStar_Syntax_Syntax.Tm_match uu____7517) -> HeadMatch true
+        | (FStar_Syntax_Syntax.Tm_abs uu____7562, FStar_Syntax_Syntax.Tm_abs
+           uu____7563) -> HeadMatch true
+        | uu____7600 ->
+            let uu____7605 =
+              let uu____7614 = delta_depth_of_term env t11 in
+              let uu____7617 = delta_depth_of_term env t21 in
+              (uu____7614, uu____7617) in
+            MisMatch uu____7605
 let (head_matches_delta :
   FStar_TypeChecker_Env.env ->
     worklist ->
@@ -2554,43 +2554,43 @@ let (head_matches_delta :
         fun t2 ->
           let maybe_inline t =
             let head =
-              let uu____7687 = unrefine env t in
-              FStar_Syntax_Util.head_of uu____7687 in
-            (let uu____7689 =
+              let uu____7685 = unrefine env t in
+              FStar_Syntax_Util.head_of uu____7685 in
+            (let uu____7687 =
                FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
                  (FStar_Options.Other "RelDelta") in
-             if uu____7689
+             if uu____7687
              then
-               let uu____7690 = FStar_Syntax_Print.term_to_string t in
-               let uu____7691 = FStar_Syntax_Print.term_to_string head in
-               FStar_Util.print2 "Head of %s is %s\n" uu____7690 uu____7691
+               let uu____7688 = FStar_Syntax_Print.term_to_string t in
+               let uu____7689 = FStar_Syntax_Print.term_to_string head in
+               FStar_Util.print2 "Head of %s is %s\n" uu____7688 uu____7689
              else ());
-            (let uu____7693 =
-               let uu____7694 = FStar_Syntax_Util.un_uinst head in
-               uu____7694.FStar_Syntax_Syntax.n in
-             match uu____7693 with
+            (let uu____7691 =
+               let uu____7692 = FStar_Syntax_Util.un_uinst head in
+               uu____7692.FStar_Syntax_Syntax.n in
+             match uu____7691 with
              | FStar_Syntax_Syntax.Tm_fvar fv ->
-                 let uu____7700 =
+                 let uu____7698 =
                    FStar_TypeChecker_Env.lookup_definition
                      [FStar_TypeChecker_Env.Unfold
                         FStar_Syntax_Syntax.delta_constant;
                      FStar_TypeChecker_Env.Eager_unfolding_only] env
                      (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-                 (match uu____7700 with
+                 (match uu____7698 with
                   | FStar_Pervasives_Native.None ->
-                      ((let uu____7714 =
+                      ((let uu____7712 =
                           FStar_All.pipe_left
                             (FStar_TypeChecker_Env.debug env)
                             (FStar_Options.Other "RelDelta") in
-                        if uu____7714
+                        if uu____7712
                         then
-                          let uu____7715 =
+                          let uu____7713 =
                             FStar_Syntax_Print.term_to_string head in
                           FStar_Util.print1 "No definition found for %s\n"
-                            uu____7715
+                            uu____7713
                         else ());
                        FStar_Pervasives_Native.None)
-                  | FStar_Pervasives_Native.Some uu____7717 ->
+                  | FStar_Pervasives_Native.Some uu____7715 ->
                       let basic_steps =
                         [FStar_TypeChecker_Env.UnfoldUntil
                            FStar_Syntax_Syntax.delta_constant;
@@ -2611,27 +2611,27 @@ let (head_matches_delta :
                         norm_with_steps
                           "FStar.TypeChecker.Rel.norm_with_steps.1" steps env
                           t in
-                      let uu____7732 =
-                        let uu____7733 = FStar_Syntax_Util.eq_tm t t' in
-                        uu____7733 = FStar_Syntax_Util.Equal in
-                      if uu____7732
+                      let uu____7730 =
+                        let uu____7731 = FStar_Syntax_Util.eq_tm t t' in
+                        uu____7731 = FStar_Syntax_Util.Equal in
+                      if uu____7730
                       then FStar_Pervasives_Native.None
                       else
-                        ((let uu____7738 =
+                        ((let uu____7736 =
                             FStar_All.pipe_left
                               (FStar_TypeChecker_Env.debug env)
                               (FStar_Options.Other "RelDelta") in
-                          if uu____7738
+                          if uu____7736
                           then
-                            let uu____7739 =
+                            let uu____7737 =
                               FStar_Syntax_Print.term_to_string t in
-                            let uu____7740 =
+                            let uu____7738 =
                               FStar_Syntax_Print.term_to_string t' in
-                            FStar_Util.print2 "Inlined %s to %s\n" uu____7739
-                              uu____7740
+                            FStar_Util.print2 "Inlined %s to %s\n" uu____7737
+                              uu____7738
                           else ());
                          FStar_Pervasives_Native.Some t'))
-             | uu____7742 -> FStar_Pervasives_Native.None) in
+             | uu____7740 -> FStar_Pervasives_Native.None) in
           let success d r t11 t21 =
             (r,
               (if d > Prims.int_zero
@@ -2644,21 +2644,21 @@ let (head_matches_delta :
                else FStar_Pervasives_Native.None)) in
           let rec aux retry n_delta t11 t21 =
             let r = head_matches env t11 t21 in
-            (let uu____7880 =
+            (let uu____7878 =
                FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
                  (FStar_Options.Other "RelDelta") in
-             if uu____7880
+             if uu____7878
              then
-               let uu____7881 = FStar_Syntax_Print.term_to_string t11 in
-               let uu____7882 = FStar_Syntax_Print.term_to_string t21 in
-               let uu____7883 = string_of_match_result r in
-               FStar_Util.print3 "head_matches (%s, %s) = %s\n" uu____7881
-                 uu____7882 uu____7883
+               let uu____7879 = FStar_Syntax_Print.term_to_string t11 in
+               let uu____7880 = FStar_Syntax_Print.term_to_string t21 in
+               let uu____7881 = string_of_match_result r in
+               FStar_Util.print3 "head_matches (%s, %s) = %s\n" uu____7879
+                 uu____7880 uu____7881
              else ());
             (let reduce_one_and_try_again d1 d2 =
                let d1_greater_than_d2 =
                  FStar_TypeChecker_Common.delta_depth_greater_than d1 d2 in
-               let uu____7907 =
+               let uu____7905 =
                  if d1_greater_than_d2
                  then
                    let t1' =
@@ -2674,11 +2674,11 @@ let (head_matches_delta :
                         FStar_TypeChecker_Env.Weak;
                         FStar_TypeChecker_Env.HNF] env t21 in
                     (t11, t2')) in
-               match uu____7907 with
+               match uu____7905 with
                | (t12, t22) -> aux retry (n_delta + Prims.int_one) t12 t22 in
              let reduce_both_and_try_again d r1 =
-               let uu____7952 = FStar_TypeChecker_Common.decr_delta_depth d in
-               match uu____7952 with
+               let uu____7950 = FStar_TypeChecker_Common.decr_delta_depth d in
+               match uu____7950 with
                | FStar_Pervasives_Native.None -> fail n_delta r1 t11 t21
                | FStar_Pervasives_Native.Some d1 ->
                    let t12 =
@@ -2706,17 +2706,17 @@ let (head_matches_delta :
                    (FStar_Syntax_Syntax.Delta_equational_at_level j)
              | MisMatch
                  (FStar_Pervasives_Native.Some
-                  (FStar_Syntax_Syntax.Delta_equational_at_level uu____7984),
-                  uu____7985)
+                  (FStar_Syntax_Syntax.Delta_equational_at_level uu____7982),
+                  uu____7983)
                  ->
                  if Prims.op_Negation retry
                  then fail n_delta r t11 t21
                  else
-                   (let uu____8003 =
-                      let uu____8012 = maybe_inline t11 in
-                      let uu____8015 = maybe_inline t21 in
-                      (uu____8012, uu____8015) in
-                    match uu____8003 with
+                   (let uu____8001 =
+                      let uu____8010 = maybe_inline t11 in
+                      let uu____8013 = maybe_inline t21 in
+                      (uu____8010, uu____8013) in
+                    match uu____8001 with
                     | (FStar_Pervasives_Native.None,
                        FStar_Pervasives_Native.None) ->
                         fail n_delta r t11 t21
@@ -2730,17 +2730,17 @@ let (head_matches_delta :
                        FStar_Pervasives_Native.Some t22) ->
                         aux false (n_delta + Prims.int_one) t12 t22)
              | MisMatch
-                 (uu____8052, FStar_Pervasives_Native.Some
-                  (FStar_Syntax_Syntax.Delta_equational_at_level uu____8053))
+                 (uu____8050, FStar_Pervasives_Native.Some
+                  (FStar_Syntax_Syntax.Delta_equational_at_level uu____8051))
                  ->
                  if Prims.op_Negation retry
                  then fail n_delta r t11 t21
                  else
-                   (let uu____8071 =
-                      let uu____8080 = maybe_inline t11 in
-                      let uu____8083 = maybe_inline t21 in
-                      (uu____8080, uu____8083) in
-                    match uu____8071 with
+                   (let uu____8069 =
+                      let uu____8078 = maybe_inline t11 in
+                      let uu____8081 = maybe_inline t21 in
+                      (uu____8078, uu____8081) in
+                    match uu____8069 with
                     | (FStar_Pervasives_Native.None,
                        FStar_Pervasives_Native.None) ->
                         fail n_delta r t11 t21
@@ -2761,38 +2761,38 @@ let (head_matches_delta :
                  (FStar_Pervasives_Native.Some d1,
                   FStar_Pervasives_Native.Some d2)
                  -> reduce_one_and_try_again d1 d2
-             | MisMatch uu____8132 -> fail n_delta r t11 t21
-             | uu____8141 -> success n_delta r t11 t21) in
+             | MisMatch uu____8130 -> fail n_delta r t11 t21
+             | uu____8139 -> success n_delta r t11 t21) in
           let r = aux true Prims.int_zero t1 t2 in
-          (let uu____8154 =
+          (let uu____8152 =
              FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
                (FStar_Options.Other "RelDelta") in
-           if uu____8154
+           if uu____8152
            then
-             let uu____8155 = FStar_Syntax_Print.term_to_string t1 in
-             let uu____8156 = FStar_Syntax_Print.term_to_string t2 in
-             let uu____8157 =
+             let uu____8153 = FStar_Syntax_Print.term_to_string t1 in
+             let uu____8154 = FStar_Syntax_Print.term_to_string t2 in
+             let uu____8155 =
                string_of_match_result (FStar_Pervasives_Native.fst r) in
-             let uu____8164 =
+             let uu____8162 =
                if FStar_Option.isNone (FStar_Pervasives_Native.snd r)
                then "None"
                else
-                 (let uu____8176 =
+                 (let uu____8174 =
                     FStar_All.pipe_right (FStar_Pervasives_Native.snd r)
                       FStar_Util.must in
-                  FStar_All.pipe_right uu____8176
-                    (fun uu____8210 ->
-                       match uu____8210 with
+                  FStar_All.pipe_right uu____8174
+                    (fun uu____8208 ->
+                       match uu____8208 with
                        | (t11, t21) ->
-                           let uu____8217 =
+                           let uu____8215 =
                              FStar_Syntax_Print.term_to_string t11 in
-                           let uu____8218 =
-                             let uu____8219 =
+                           let uu____8216 =
+                             let uu____8217 =
                                FStar_Syntax_Print.term_to_string t21 in
-                             Prims.op_Hat "; " uu____8219 in
-                           Prims.op_Hat uu____8217 uu____8218)) in
+                             Prims.op_Hat "; " uu____8217 in
+                           Prims.op_Hat uu____8215 uu____8216)) in
              FStar_Util.print4 "head_matches_delta (%s, %s) = %s (%s)\n"
-               uu____8155 uu____8156 uu____8157 uu____8164
+               uu____8153 uu____8154 uu____8155 uu____8162
            else ());
           r
 let (kind_type :
@@ -2800,11 +2800,11 @@ let (kind_type :
   =
   fun binders ->
     fun r ->
-      let uu____8231 = FStar_Syntax_Util.type_u () in
-      FStar_All.pipe_right uu____8231 FStar_Pervasives_Native.fst
+      let uu____8229 = FStar_Syntax_Util.type_u () in
+      FStar_All.pipe_right uu____8229 FStar_Pervasives_Native.fst
 let (rank_t_num : FStar_TypeChecker_Common.rank_t -> Prims.int) =
-  fun uu___21_8244 ->
-    match uu___21_8244 with
+  fun uu___21_8242 ->
+    match uu___21_8242 with
     | FStar_TypeChecker_Common.Rigid_rigid -> Prims.int_zero
     | FStar_TypeChecker_Common.Flex_rigid_eq -> Prims.int_one
     | FStar_TypeChecker_Common.Flex_flex_pattern_eq -> (Prims.of_int (2))
@@ -2826,28 +2826,28 @@ let (compress_tprob :
   =
   fun tcenv ->
     fun p ->
-      let uu___1279_8281 = p in
-      let uu____8284 = whnf tcenv p.FStar_TypeChecker_Common.lhs in
-      let uu____8285 = whnf tcenv p.FStar_TypeChecker_Common.rhs in
+      let uu___1279_8279 = p in
+      let uu____8282 = whnf tcenv p.FStar_TypeChecker_Common.lhs in
+      let uu____8283 = whnf tcenv p.FStar_TypeChecker_Common.rhs in
       {
         FStar_TypeChecker_Common.pid =
-          (uu___1279_8281.FStar_TypeChecker_Common.pid);
-        FStar_TypeChecker_Common.lhs = uu____8284;
+          (uu___1279_8279.FStar_TypeChecker_Common.pid);
+        FStar_TypeChecker_Common.lhs = uu____8282;
         FStar_TypeChecker_Common.relation =
-          (uu___1279_8281.FStar_TypeChecker_Common.relation);
-        FStar_TypeChecker_Common.rhs = uu____8285;
+          (uu___1279_8279.FStar_TypeChecker_Common.relation);
+        FStar_TypeChecker_Common.rhs = uu____8283;
         FStar_TypeChecker_Common.element =
-          (uu___1279_8281.FStar_TypeChecker_Common.element);
+          (uu___1279_8279.FStar_TypeChecker_Common.element);
         FStar_TypeChecker_Common.logical_guard =
-          (uu___1279_8281.FStar_TypeChecker_Common.logical_guard);
+          (uu___1279_8279.FStar_TypeChecker_Common.logical_guard);
         FStar_TypeChecker_Common.logical_guard_uvar =
-          (uu___1279_8281.FStar_TypeChecker_Common.logical_guard_uvar);
+          (uu___1279_8279.FStar_TypeChecker_Common.logical_guard_uvar);
         FStar_TypeChecker_Common.reason =
-          (uu___1279_8281.FStar_TypeChecker_Common.reason);
+          (uu___1279_8279.FStar_TypeChecker_Common.reason);
         FStar_TypeChecker_Common.loc =
-          (uu___1279_8281.FStar_TypeChecker_Common.loc);
+          (uu___1279_8279.FStar_TypeChecker_Common.loc);
         FStar_TypeChecker_Common.rank =
-          (uu___1279_8281.FStar_TypeChecker_Common.rank)
+          (uu___1279_8279.FStar_TypeChecker_Common.rank)
       }
 let (compress_prob :
   FStar_TypeChecker_Env.env ->
@@ -2857,10 +2857,10 @@ let (compress_prob :
     fun p ->
       match p with
       | FStar_TypeChecker_Common.TProb p1 ->
-          let uu____8299 = compress_tprob tcenv p1 in
-          FStar_All.pipe_right uu____8299
-            (fun uu____8304 -> FStar_TypeChecker_Common.TProb uu____8304)
-      | FStar_TypeChecker_Common.CProb uu____8305 -> p
+          let uu____8297 = compress_tprob tcenv p1 in
+          FStar_All.pipe_right uu____8297
+            (fun uu____8302 -> FStar_TypeChecker_Common.TProb uu____8302)
+      | FStar_TypeChecker_Common.CProb uu____8303 -> p
 let (rank :
   FStar_TypeChecker_Env.env ->
     FStar_TypeChecker_Common.prob ->
@@ -2869,25 +2869,25 @@ let (rank :
   fun tcenv ->
     fun pr ->
       let prob =
-        let uu____8327 = compress_prob tcenv pr in
-        FStar_All.pipe_right uu____8327 maybe_invert_p in
+        let uu____8325 = compress_prob tcenv pr in
+        FStar_All.pipe_right uu____8325 maybe_invert_p in
       match prob with
       | FStar_TypeChecker_Common.TProb tp ->
-          let uu____8335 =
+          let uu____8333 =
             FStar_Syntax_Util.head_and_args tp.FStar_TypeChecker_Common.lhs in
-          (match uu____8335 with
+          (match uu____8333 with
            | (lh, lhs_args) ->
-               let uu____8382 =
+               let uu____8380 =
                  FStar_Syntax_Util.head_and_args
                    tp.FStar_TypeChecker_Common.rhs in
-               (match uu____8382 with
+               (match uu____8380 with
                 | (rh, rhs_args) ->
-                    let uu____8429 =
+                    let uu____8427 =
                       match ((lh.FStar_Syntax_Syntax.n),
                               (rh.FStar_Syntax_Syntax.n))
                       with
-                      | (FStar_Syntax_Syntax.Tm_uvar uu____8442,
-                         FStar_Syntax_Syntax.Tm_uvar uu____8443) ->
+                      | (FStar_Syntax_Syntax.Tm_uvar uu____8440,
+                         FStar_Syntax_Syntax.Tm_uvar uu____8441) ->
                           (match (lhs_args, rhs_args) with
                            | ([], []) when
                                tp.FStar_TypeChecker_Common.relation =
@@ -2895,171 +2895,171 @@ let (rank :
                                ->
                                (FStar_TypeChecker_Common.Flex_flex_pattern_eq,
                                  tp)
-                           | uu____8532 ->
+                           | uu____8530 ->
                                (FStar_TypeChecker_Common.Flex_flex, tp))
-                      | (FStar_Syntax_Syntax.Tm_uvar uu____8559, uu____8560)
+                      | (FStar_Syntax_Syntax.Tm_uvar uu____8557, uu____8558)
                           when
                           tp.FStar_TypeChecker_Common.relation =
                             FStar_TypeChecker_Common.EQ
                           -> (FStar_TypeChecker_Common.Flex_rigid_eq, tp)
-                      | (uu____8575, FStar_Syntax_Syntax.Tm_uvar uu____8576)
+                      | (uu____8573, FStar_Syntax_Syntax.Tm_uvar uu____8574)
                           when
                           tp.FStar_TypeChecker_Common.relation =
                             FStar_TypeChecker_Common.EQ
                           -> (FStar_TypeChecker_Common.Flex_rigid_eq, tp)
-                      | (FStar_Syntax_Syntax.Tm_uvar uu____8591,
-                         FStar_Syntax_Syntax.Tm_arrow uu____8592) ->
+                      | (FStar_Syntax_Syntax.Tm_uvar uu____8589,
+                         FStar_Syntax_Syntax.Tm_arrow uu____8590) ->
                           (FStar_TypeChecker_Common.Flex_rigid_eq,
-                            (let uu___1330_8622 = tp in
+                            (let uu___1330_8620 = tp in
                              {
                                FStar_TypeChecker_Common.pid =
-                                 (uu___1330_8622.FStar_TypeChecker_Common.pid);
+                                 (uu___1330_8620.FStar_TypeChecker_Common.pid);
                                FStar_TypeChecker_Common.lhs =
-                                 (uu___1330_8622.FStar_TypeChecker_Common.lhs);
+                                 (uu___1330_8620.FStar_TypeChecker_Common.lhs);
                                FStar_TypeChecker_Common.relation =
                                  FStar_TypeChecker_Common.EQ;
                                FStar_TypeChecker_Common.rhs =
-                                 (uu___1330_8622.FStar_TypeChecker_Common.rhs);
+                                 (uu___1330_8620.FStar_TypeChecker_Common.rhs);
                                FStar_TypeChecker_Common.element =
-                                 (uu___1330_8622.FStar_TypeChecker_Common.element);
+                                 (uu___1330_8620.FStar_TypeChecker_Common.element);
                                FStar_TypeChecker_Common.logical_guard =
-                                 (uu___1330_8622.FStar_TypeChecker_Common.logical_guard);
+                                 (uu___1330_8620.FStar_TypeChecker_Common.logical_guard);
                                FStar_TypeChecker_Common.logical_guard_uvar =
-                                 (uu___1330_8622.FStar_TypeChecker_Common.logical_guard_uvar);
+                                 (uu___1330_8620.FStar_TypeChecker_Common.logical_guard_uvar);
                                FStar_TypeChecker_Common.reason =
-                                 (uu___1330_8622.FStar_TypeChecker_Common.reason);
+                                 (uu___1330_8620.FStar_TypeChecker_Common.reason);
                                FStar_TypeChecker_Common.loc =
-                                 (uu___1330_8622.FStar_TypeChecker_Common.loc);
+                                 (uu___1330_8620.FStar_TypeChecker_Common.loc);
                                FStar_TypeChecker_Common.rank =
-                                 (uu___1330_8622.FStar_TypeChecker_Common.rank)
+                                 (uu___1330_8620.FStar_TypeChecker_Common.rank)
                              }))
-                      | (FStar_Syntax_Syntax.Tm_uvar uu____8625,
-                         FStar_Syntax_Syntax.Tm_type uu____8626) ->
+                      | (FStar_Syntax_Syntax.Tm_uvar uu____8623,
+                         FStar_Syntax_Syntax.Tm_type uu____8624) ->
                           (FStar_TypeChecker_Common.Flex_rigid_eq,
-                            (let uu___1330_8642 = tp in
+                            (let uu___1330_8640 = tp in
                              {
                                FStar_TypeChecker_Common.pid =
-                                 (uu___1330_8642.FStar_TypeChecker_Common.pid);
+                                 (uu___1330_8640.FStar_TypeChecker_Common.pid);
                                FStar_TypeChecker_Common.lhs =
-                                 (uu___1330_8642.FStar_TypeChecker_Common.lhs);
+                                 (uu___1330_8640.FStar_TypeChecker_Common.lhs);
                                FStar_TypeChecker_Common.relation =
                                  FStar_TypeChecker_Common.EQ;
                                FStar_TypeChecker_Common.rhs =
-                                 (uu___1330_8642.FStar_TypeChecker_Common.rhs);
+                                 (uu___1330_8640.FStar_TypeChecker_Common.rhs);
                                FStar_TypeChecker_Common.element =
-                                 (uu___1330_8642.FStar_TypeChecker_Common.element);
+                                 (uu___1330_8640.FStar_TypeChecker_Common.element);
                                FStar_TypeChecker_Common.logical_guard =
-                                 (uu___1330_8642.FStar_TypeChecker_Common.logical_guard);
+                                 (uu___1330_8640.FStar_TypeChecker_Common.logical_guard);
                                FStar_TypeChecker_Common.logical_guard_uvar =
-                                 (uu___1330_8642.FStar_TypeChecker_Common.logical_guard_uvar);
+                                 (uu___1330_8640.FStar_TypeChecker_Common.logical_guard_uvar);
                                FStar_TypeChecker_Common.reason =
-                                 (uu___1330_8642.FStar_TypeChecker_Common.reason);
+                                 (uu___1330_8640.FStar_TypeChecker_Common.reason);
                                FStar_TypeChecker_Common.loc =
-                                 (uu___1330_8642.FStar_TypeChecker_Common.loc);
+                                 (uu___1330_8640.FStar_TypeChecker_Common.loc);
                                FStar_TypeChecker_Common.rank =
-                                 (uu___1330_8642.FStar_TypeChecker_Common.rank)
+                                 (uu___1330_8640.FStar_TypeChecker_Common.rank)
                              }))
-                      | (FStar_Syntax_Syntax.Tm_type uu____8645,
-                         FStar_Syntax_Syntax.Tm_uvar uu____8646) ->
+                      | (FStar_Syntax_Syntax.Tm_type uu____8643,
+                         FStar_Syntax_Syntax.Tm_uvar uu____8644) ->
                           (FStar_TypeChecker_Common.Flex_rigid_eq,
-                            (let uu___1330_8662 = tp in
+                            (let uu___1330_8660 = tp in
                              {
                                FStar_TypeChecker_Common.pid =
-                                 (uu___1330_8662.FStar_TypeChecker_Common.pid);
+                                 (uu___1330_8660.FStar_TypeChecker_Common.pid);
                                FStar_TypeChecker_Common.lhs =
-                                 (uu___1330_8662.FStar_TypeChecker_Common.lhs);
+                                 (uu___1330_8660.FStar_TypeChecker_Common.lhs);
                                FStar_TypeChecker_Common.relation =
                                  FStar_TypeChecker_Common.EQ;
                                FStar_TypeChecker_Common.rhs =
-                                 (uu___1330_8662.FStar_TypeChecker_Common.rhs);
+                                 (uu___1330_8660.FStar_TypeChecker_Common.rhs);
                                FStar_TypeChecker_Common.element =
-                                 (uu___1330_8662.FStar_TypeChecker_Common.element);
+                                 (uu___1330_8660.FStar_TypeChecker_Common.element);
                                FStar_TypeChecker_Common.logical_guard =
-                                 (uu___1330_8662.FStar_TypeChecker_Common.logical_guard);
+                                 (uu___1330_8660.FStar_TypeChecker_Common.logical_guard);
                                FStar_TypeChecker_Common.logical_guard_uvar =
-                                 (uu___1330_8662.FStar_TypeChecker_Common.logical_guard_uvar);
+                                 (uu___1330_8660.FStar_TypeChecker_Common.logical_guard_uvar);
                                FStar_TypeChecker_Common.reason =
-                                 (uu___1330_8662.FStar_TypeChecker_Common.reason);
+                                 (uu___1330_8660.FStar_TypeChecker_Common.reason);
                                FStar_TypeChecker_Common.loc =
-                                 (uu___1330_8662.FStar_TypeChecker_Common.loc);
+                                 (uu___1330_8660.FStar_TypeChecker_Common.loc);
                                FStar_TypeChecker_Common.rank =
-                                 (uu___1330_8662.FStar_TypeChecker_Common.rank)
+                                 (uu___1330_8660.FStar_TypeChecker_Common.rank)
                              }))
-                      | (uu____8665, FStar_Syntax_Syntax.Tm_uvar uu____8666)
+                      | (uu____8663, FStar_Syntax_Syntax.Tm_uvar uu____8664)
                           -> (FStar_TypeChecker_Common.Rigid_flex, tp)
-                      | (FStar_Syntax_Syntax.Tm_uvar uu____8681, uu____8682)
+                      | (FStar_Syntax_Syntax.Tm_uvar uu____8679, uu____8680)
                           -> (FStar_TypeChecker_Common.Flex_rigid, tp)
-                      | (uu____8697, FStar_Syntax_Syntax.Tm_uvar uu____8698)
+                      | (uu____8695, FStar_Syntax_Syntax.Tm_uvar uu____8696)
                           -> (FStar_TypeChecker_Common.Rigid_flex, tp)
-                      | (uu____8713, uu____8714) ->
+                      | (uu____8711, uu____8712) ->
                           (FStar_TypeChecker_Common.Rigid_rigid, tp) in
-                    (match uu____8429 with
+                    (match uu____8427 with
                      | (rank, tp1) ->
-                         let uu____8727 =
+                         let uu____8725 =
                            FStar_All.pipe_right
-                             (let uu___1350_8731 = tp1 in
+                             (let uu___1350_8729 = tp1 in
                               {
                                 FStar_TypeChecker_Common.pid =
-                                  (uu___1350_8731.FStar_TypeChecker_Common.pid);
+                                  (uu___1350_8729.FStar_TypeChecker_Common.pid);
                                 FStar_TypeChecker_Common.lhs =
-                                  (uu___1350_8731.FStar_TypeChecker_Common.lhs);
+                                  (uu___1350_8729.FStar_TypeChecker_Common.lhs);
                                 FStar_TypeChecker_Common.relation =
-                                  (uu___1350_8731.FStar_TypeChecker_Common.relation);
+                                  (uu___1350_8729.FStar_TypeChecker_Common.relation);
                                 FStar_TypeChecker_Common.rhs =
-                                  (uu___1350_8731.FStar_TypeChecker_Common.rhs);
+                                  (uu___1350_8729.FStar_TypeChecker_Common.rhs);
                                 FStar_TypeChecker_Common.element =
-                                  (uu___1350_8731.FStar_TypeChecker_Common.element);
+                                  (uu___1350_8729.FStar_TypeChecker_Common.element);
                                 FStar_TypeChecker_Common.logical_guard =
-                                  (uu___1350_8731.FStar_TypeChecker_Common.logical_guard);
+                                  (uu___1350_8729.FStar_TypeChecker_Common.logical_guard);
                                 FStar_TypeChecker_Common.logical_guard_uvar =
-                                  (uu___1350_8731.FStar_TypeChecker_Common.logical_guard_uvar);
+                                  (uu___1350_8729.FStar_TypeChecker_Common.logical_guard_uvar);
                                 FStar_TypeChecker_Common.reason =
-                                  (uu___1350_8731.FStar_TypeChecker_Common.reason);
+                                  (uu___1350_8729.FStar_TypeChecker_Common.reason);
                                 FStar_TypeChecker_Common.loc =
-                                  (uu___1350_8731.FStar_TypeChecker_Common.loc);
+                                  (uu___1350_8729.FStar_TypeChecker_Common.loc);
                                 FStar_TypeChecker_Common.rank =
                                   (FStar_Pervasives_Native.Some rank)
                               })
-                             (fun uu____8734 ->
-                                FStar_TypeChecker_Common.TProb uu____8734) in
-                         (rank, uu____8727))))
+                             (fun uu____8732 ->
+                                FStar_TypeChecker_Common.TProb uu____8732) in
+                         (rank, uu____8725))))
       | FStar_TypeChecker_Common.CProb cp ->
-          let uu____8738 =
+          let uu____8736 =
             FStar_All.pipe_right
-              (let uu___1354_8742 = cp in
+              (let uu___1354_8740 = cp in
                {
                  FStar_TypeChecker_Common.pid =
-                   (uu___1354_8742.FStar_TypeChecker_Common.pid);
+                   (uu___1354_8740.FStar_TypeChecker_Common.pid);
                  FStar_TypeChecker_Common.lhs =
-                   (uu___1354_8742.FStar_TypeChecker_Common.lhs);
+                   (uu___1354_8740.FStar_TypeChecker_Common.lhs);
                  FStar_TypeChecker_Common.relation =
-                   (uu___1354_8742.FStar_TypeChecker_Common.relation);
+                   (uu___1354_8740.FStar_TypeChecker_Common.relation);
                  FStar_TypeChecker_Common.rhs =
-                   (uu___1354_8742.FStar_TypeChecker_Common.rhs);
+                   (uu___1354_8740.FStar_TypeChecker_Common.rhs);
                  FStar_TypeChecker_Common.element =
-                   (uu___1354_8742.FStar_TypeChecker_Common.element);
+                   (uu___1354_8740.FStar_TypeChecker_Common.element);
                  FStar_TypeChecker_Common.logical_guard =
-                   (uu___1354_8742.FStar_TypeChecker_Common.logical_guard);
+                   (uu___1354_8740.FStar_TypeChecker_Common.logical_guard);
                  FStar_TypeChecker_Common.logical_guard_uvar =
-                   (uu___1354_8742.FStar_TypeChecker_Common.logical_guard_uvar);
+                   (uu___1354_8740.FStar_TypeChecker_Common.logical_guard_uvar);
                  FStar_TypeChecker_Common.reason =
-                   (uu___1354_8742.FStar_TypeChecker_Common.reason);
+                   (uu___1354_8740.FStar_TypeChecker_Common.reason);
                  FStar_TypeChecker_Common.loc =
-                   (uu___1354_8742.FStar_TypeChecker_Common.loc);
+                   (uu___1354_8740.FStar_TypeChecker_Common.loc);
                  FStar_TypeChecker_Common.rank =
                    (FStar_Pervasives_Native.Some
                       FStar_TypeChecker_Common.Rigid_rigid)
                })
-              (fun uu____8745 -> FStar_TypeChecker_Common.CProb uu____8745) in
-          (FStar_TypeChecker_Common.Rigid_rigid, uu____8738)
+              (fun uu____8743 -> FStar_TypeChecker_Common.CProb uu____8743) in
+          (FStar_TypeChecker_Common.Rigid_rigid, uu____8736)
 let (next_prob :
   worklist ->
     (FStar_TypeChecker_Common.prob * FStar_TypeChecker_Common.prob Prims.list
       * FStar_TypeChecker_Common.rank_t) FStar_Pervasives_Native.option)
   =
   fun wl ->
-    let rec aux uu____8804 probs =
-      match uu____8804 with
+    let rec aux uu____8802 probs =
+      match uu____8802 with
       | (min_rank, min, out) ->
           (match probs with
            | [] ->
@@ -3067,10 +3067,10 @@ let (next_prob :
                 | (FStar_Pervasives_Native.Some p,
                    FStar_Pervasives_Native.Some r) ->
                     FStar_Pervasives_Native.Some (p, out, r)
-                | uu____8885 -> FStar_Pervasives_Native.None)
+                | uu____8883 -> FStar_Pervasives_Native.None)
            | hd::tl ->
-               let uu____8906 = rank wl.tcenv hd in
-               (match uu____8906 with
+               let uu____8904 = rank wl.tcenv hd in
+               (match uu____8904 with
                 | (rank1, hd1) ->
                     if rank_leq rank1 FStar_TypeChecker_Common.Flex_rigid_eq
                     then
@@ -3082,11 +3082,11 @@ let (next_prob :
                            FStar_Pervasives_Native.Some
                              (hd1, (FStar_List.append out (m :: tl)), rank1))
                     else
-                      (let uu____8965 =
+                      (let uu____8963 =
                          (min_rank = FStar_Pervasives_Native.None) ||
-                           (let uu____8969 = FStar_Option.get min_rank in
-                            rank_less_than rank1 uu____8969) in
-                       if uu____8965
+                           (let uu____8967 = FStar_Option.get min_rank in
+                            rank_less_than rank1 uu____8967) in
+                       if uu____8963
                        then
                          match min with
                          | FStar_Pervasives_Native.None ->
@@ -3110,32 +3110,32 @@ let (flex_prob_closing :
     fun bs ->
       fun p ->
         let flex_will_be_closed t =
-          let uu____9037 = FStar_Syntax_Util.head_and_args t in
-          match uu____9037 with
-          | (hd, uu____9055) ->
-              let uu____9080 =
-                let uu____9081 = FStar_Syntax_Subst.compress hd in
-                uu____9081.FStar_Syntax_Syntax.n in
-              (match uu____9080 with
-               | FStar_Syntax_Syntax.Tm_uvar (u, uu____9085) ->
+          let uu____9035 = FStar_Syntax_Util.head_and_args t in
+          match uu____9035 with
+          | (hd, uu____9053) ->
+              let uu____9078 =
+                let uu____9079 = FStar_Syntax_Subst.compress hd in
+                uu____9079.FStar_Syntax_Syntax.n in
+              (match uu____9078 with
+               | FStar_Syntax_Syntax.Tm_uvar (u, uu____9083) ->
                    FStar_All.pipe_right
                      u.FStar_Syntax_Syntax.ctx_uvar_binders
                      (FStar_Util.for_some
-                        (fun uu____9119 ->
-                           match uu____9119 with
-                           | (y, uu____9127) ->
+                        (fun uu____9117 ->
+                           match uu____9117 with
+                           | (y, uu____9125) ->
                                FStar_All.pipe_right bs
                                  (FStar_Util.for_some
-                                    (fun uu____9149 ->
-                                       match uu____9149 with
-                                       | (x, uu____9157) ->
+                                    (fun uu____9147 ->
+                                       match uu____9147 with
+                                       | (x, uu____9155) ->
                                            FStar_Syntax_Syntax.bv_eq x y))))
-               | uu____9162 -> false) in
-        let uu____9163 = rank tcenv p in
-        match uu____9163 with
+               | uu____9160 -> false) in
+        let uu____9161 = rank tcenv p in
+        match uu____9161 with
         | (r, p1) ->
             (match p1 with
-             | FStar_TypeChecker_Common.CProb uu____9170 -> true
+             | FStar_TypeChecker_Common.CProb uu____9168 -> true
              | FStar_TypeChecker_Common.TProb p2 ->
                  (match r with
                   | FStar_TypeChecker_Common.Rigid_rigid -> true
@@ -3159,23 +3159,23 @@ type univ_eq_sol =
   | UFailed of lstring 
 let (uu___is_UDeferred : univ_eq_sol -> Prims.bool) =
   fun projectee ->
-    match projectee with | UDeferred _0 -> true | uu____9202 -> false
+    match projectee with | UDeferred _0 -> true | uu____9200 -> false
 let (__proj__UDeferred__item___0 : univ_eq_sol -> worklist) =
   fun projectee -> match projectee with | UDeferred _0 -> _0
 let (uu___is_USolved : univ_eq_sol -> Prims.bool) =
   fun projectee ->
-    match projectee with | USolved _0 -> true | uu____9215 -> false
+    match projectee with | USolved _0 -> true | uu____9213 -> false
 let (__proj__USolved__item___0 : univ_eq_sol -> worklist) =
   fun projectee -> match projectee with | USolved _0 -> _0
 let (uu___is_UFailed : univ_eq_sol -> Prims.bool) =
   fun projectee ->
-    match projectee with | UFailed _0 -> true | uu____9228 -> false
+    match projectee with | UFailed _0 -> true | uu____9226 -> false
 let (__proj__UFailed__item___0 : univ_eq_sol -> lstring) =
   fun projectee -> match projectee with | UFailed _0 -> _0
 let (ufailed_simple : Prims.string -> univ_eq_sol) =
-  fun s -> let uu____9240 = FStar_Thunk.mkv s in UFailed uu____9240
+  fun s -> let uu____9238 = FStar_Thunk.mkv s in UFailed uu____9238
 let (ufailed_thunk : (unit -> Prims.string) -> univ_eq_sol) =
-  fun s -> let uu____9251 = mklstr s in UFailed uu____9251
+  fun s -> let uu____9249 = mklstr s in UFailed uu____9249
 let rec (really_solve_universe_eq :
   Prims.int ->
     worklist ->
@@ -3196,35 +3196,35 @@ let rec (really_solve_universe_eq :
                 FStar_All.pipe_right us
                   (FStar_Util.for_some
                      (fun u3 ->
-                        let uu____9296 = FStar_Syntax_Util.univ_kernel u3 in
-                        match uu____9296 with
-                        | (k, uu____9302) ->
+                        let uu____9294 = FStar_Syntax_Util.univ_kernel u3 in
+                        match uu____9294 with
+                        | (k, uu____9300) ->
                             (match k with
                              | FStar_Syntax_Syntax.U_unif v2 ->
                                  FStar_Syntax_Unionfind.univ_equiv v1 v2
-                             | uu____9314 -> false)))
-            | uu____9315 -> occurs_univ v1 (FStar_Syntax_Syntax.U_max [u]) in
+                             | uu____9312 -> false)))
+            | uu____9313 -> occurs_univ v1 (FStar_Syntax_Syntax.U_max [u]) in
           let rec filter_out_common_univs u12 u22 =
             let common_elts =
               FStar_All.pipe_right u12
                 (FStar_List.fold_left
                    (fun uvs ->
                       fun uv1 ->
-                        let uu____9367 =
+                        let uu____9365 =
                           FStar_All.pipe_right u22
                             (FStar_List.existsML
                                (fun uv2 -> FStar_Syntax_Util.eq_univs uv1 uv2)) in
-                        if uu____9367 then uv1 :: uvs else uvs) []) in
+                        if uu____9365 then uv1 :: uvs else uvs) []) in
             let filter =
               FStar_List.filter
                 (fun u ->
-                   let uu____9387 =
+                   let uu____9385 =
                      FStar_All.pipe_right common_elts
                        (FStar_List.existsML
                           (fun u' -> FStar_Syntax_Util.eq_univs u u')) in
-                   Prims.op_Negation uu____9387) in
-            let uu____9392 = filter u12 in
-            let uu____9395 = filter u22 in (uu____9392, uu____9395) in
+                   Prims.op_Negation uu____9385) in
+            let uu____9390 = filter u12 in
+            let uu____9393 = filter u22 in (uu____9390, uu____9393) in
           let try_umax_components u12 u22 msg =
             if Prims.op_Negation wl.umax_heuristic_ok
             then ufailed_simple "Unable to unify universe terms with umax"
@@ -3232,8 +3232,8 @@ let rec (really_solve_universe_eq :
               (match (u12, u22) with
                | (FStar_Syntax_Syntax.U_max us1, FStar_Syntax_Syntax.U_max
                   us2) ->
-                   let uu____9425 = filter_out_common_univs us1 us2 in
-                   (match uu____9425 with
+                   let uu____9423 = filter_out_common_univs us1 us2 in
+                   (match uu____9423 with
                     | (us11, us21) ->
                         if
                           (FStar_List.length us11) = (FStar_List.length us21)
@@ -3241,32 +3241,32 @@ let rec (really_solve_universe_eq :
                           let rec aux wl1 us12 us22 =
                             match (us12, us22) with
                             | (u13::us13, u23::us23) ->
-                                let uu____9484 =
+                                let uu____9482 =
                                   really_solve_universe_eq pid_orig wl1 u13
                                     u23 in
-                                (match uu____9484 with
+                                (match uu____9482 with
                                  | USolved wl2 -> aux wl2 us13 us23
                                  | failed -> failed)
-                            | uu____9487 -> USolved wl1 in
+                            | uu____9485 -> USolved wl1 in
                           aux wl us11 us21
                         else
                           ufailed_thunk
-                            (fun uu____9503 ->
-                               let uu____9504 =
+                            (fun uu____9501 ->
+                               let uu____9502 =
                                  FStar_Syntax_Print.univ_to_string u12 in
-                               let uu____9505 =
+                               let uu____9503 =
                                  FStar_Syntax_Print.univ_to_string u22 in
                                FStar_Util.format2
                                  "Unable to unify universes: %s and %s"
-                                 uu____9504 uu____9505))
+                                 uu____9502 uu____9503))
                | (FStar_Syntax_Syntax.U_max us, u') ->
                    let rec aux wl1 us1 =
                      match us1 with
                      | [] -> USolved wl1
                      | u::us2 ->
-                         let uu____9529 =
+                         let uu____9527 =
                            really_solve_universe_eq pid_orig wl1 u u' in
-                         (match uu____9529 with
+                         (match uu____9527 with
                           | USolved wl2 -> aux wl2 us2
                           | failed -> failed) in
                    aux wl us
@@ -3275,61 +3275,61 @@ let rec (really_solve_universe_eq :
                      match us1 with
                      | [] -> USolved wl1
                      | u::us2 ->
-                         let uu____9555 =
+                         let uu____9553 =
                            really_solve_universe_eq pid_orig wl1 u u' in
-                         (match uu____9555 with
+                         (match uu____9553 with
                           | USolved wl2 -> aux wl2 us2
                           | failed -> failed) in
                    aux wl us
-               | uu____9558 ->
+               | uu____9556 ->
                    ufailed_thunk
-                     (fun uu____9569 ->
-                        let uu____9570 =
+                     (fun uu____9567 ->
+                        let uu____9568 =
                           FStar_Syntax_Print.univ_to_string u12 in
-                        let uu____9571 =
+                        let uu____9569 =
                           FStar_Syntax_Print.univ_to_string u22 in
                         FStar_Util.format3
                           "Unable to unify universes: %s and %s (%s)"
-                          uu____9570 uu____9571 msg)) in
+                          uu____9568 uu____9569 msg)) in
           match (u11, u21) with
-          | (FStar_Syntax_Syntax.U_bvar uu____9572, uu____9573) ->
-              let uu____9574 =
-                let uu____9575 = FStar_Syntax_Print.univ_to_string u11 in
-                let uu____9576 = FStar_Syntax_Print.univ_to_string u21 in
+          | (FStar_Syntax_Syntax.U_bvar uu____9570, uu____9571) ->
+              let uu____9572 =
+                let uu____9573 = FStar_Syntax_Print.univ_to_string u11 in
+                let uu____9574 = FStar_Syntax_Print.univ_to_string u21 in
                 FStar_Util.format2
                   "Impossible: found an de Bruijn universe variable or unknown universe: %s, %s"
-                  uu____9575 uu____9576 in
-              failwith uu____9574
-          | (FStar_Syntax_Syntax.U_unknown, uu____9577) ->
-              let uu____9578 =
-                let uu____9579 = FStar_Syntax_Print.univ_to_string u11 in
-                let uu____9580 = FStar_Syntax_Print.univ_to_string u21 in
+                  uu____9573 uu____9574 in
+              failwith uu____9572
+          | (FStar_Syntax_Syntax.U_unknown, uu____9575) ->
+              let uu____9576 =
+                let uu____9577 = FStar_Syntax_Print.univ_to_string u11 in
+                let uu____9578 = FStar_Syntax_Print.univ_to_string u21 in
                 FStar_Util.format2
                   "Impossible: found an de Bruijn universe variable or unknown universe: %s, %s"
-                  uu____9579 uu____9580 in
-              failwith uu____9578
-          | (uu____9581, FStar_Syntax_Syntax.U_bvar uu____9582) ->
-              let uu____9583 =
-                let uu____9584 = FStar_Syntax_Print.univ_to_string u11 in
-                let uu____9585 = FStar_Syntax_Print.univ_to_string u21 in
+                  uu____9577 uu____9578 in
+              failwith uu____9576
+          | (uu____9579, FStar_Syntax_Syntax.U_bvar uu____9580) ->
+              let uu____9581 =
+                let uu____9582 = FStar_Syntax_Print.univ_to_string u11 in
+                let uu____9583 = FStar_Syntax_Print.univ_to_string u21 in
                 FStar_Util.format2
                   "Impossible: found an de Bruijn universe variable or unknown universe: %s, %s"
-                  uu____9584 uu____9585 in
-              failwith uu____9583
-          | (uu____9586, FStar_Syntax_Syntax.U_unknown) ->
-              let uu____9587 =
-                let uu____9588 = FStar_Syntax_Print.univ_to_string u11 in
-                let uu____9589 = FStar_Syntax_Print.univ_to_string u21 in
+                  uu____9582 uu____9583 in
+              failwith uu____9581
+          | (uu____9584, FStar_Syntax_Syntax.U_unknown) ->
+              let uu____9585 =
+                let uu____9586 = FStar_Syntax_Print.univ_to_string u11 in
+                let uu____9587 = FStar_Syntax_Print.univ_to_string u21 in
                 FStar_Util.format2
                   "Impossible: found an de Bruijn universe variable or unknown universe: %s, %s"
-                  uu____9588 uu____9589 in
-              failwith uu____9587
+                  uu____9586 uu____9587 in
+              failwith uu____9585
           | (FStar_Syntax_Syntax.U_name x, FStar_Syntax_Syntax.U_name y) ->
-              let uu____9592 =
-                let uu____9593 = FStar_Ident.string_of_id x in
-                let uu____9594 = FStar_Ident.string_of_id y in
-                uu____9593 = uu____9594 in
-              if uu____9592
+              let uu____9590 =
+                let uu____9591 = FStar_Ident.string_of_id x in
+                let uu____9592 = FStar_Ident.string_of_id y in
+                uu____9591 = uu____9592 in
+              if uu____9590
               then USolved wl
               else ufailed_simple "Incompatible universes"
           | (FStar_Syntax_Syntax.U_zero, FStar_Syntax_Syntax.U_zero) ->
@@ -3337,78 +3337,78 @@ let rec (really_solve_universe_eq :
           | (FStar_Syntax_Syntax.U_succ u12, FStar_Syntax_Syntax.U_succ u22)
               -> really_solve_universe_eq pid_orig wl u12 u22
           | (FStar_Syntax_Syntax.U_unif v1, FStar_Syntax_Syntax.U_unif v2) ->
-              let uu____9620 = FStar_Syntax_Unionfind.univ_equiv v1 v2 in
-              if uu____9620
+              let uu____9618 = FStar_Syntax_Unionfind.univ_equiv v1 v2 in
+              if uu____9618
               then USolved wl
               else
                 (let wl1 = extend_solution pid_orig [UNIV (v1, u21)] wl in
                  USolved wl1)
           | (FStar_Syntax_Syntax.U_unif v1, u) ->
               let u3 = norm_univ wl u in
-              let uu____9636 = occurs_univ v1 u3 in
-              if uu____9636
+              let uu____9634 = occurs_univ v1 u3 in
+              if uu____9634
               then
-                let uu____9637 =
-                  let uu____9638 =
+                let uu____9635 =
+                  let uu____9636 =
                     FStar_Syntax_Print.univ_to_string
                       (FStar_Syntax_Syntax.U_unif v1) in
-                  let uu____9639 = FStar_Syntax_Print.univ_to_string u3 in
+                  let uu____9637 = FStar_Syntax_Print.univ_to_string u3 in
                   FStar_Util.format2 "Failed occurs check: %s occurs in %s"
-                    uu____9638 uu____9639 in
-                try_umax_components u11 u21 uu____9637
+                    uu____9636 uu____9637 in
+                try_umax_components u11 u21 uu____9635
               else
-                (let uu____9641 = extend_solution pid_orig [UNIV (v1, u3)] wl in
-                 USolved uu____9641)
+                (let uu____9639 = extend_solution pid_orig [UNIV (v1, u3)] wl in
+                 USolved uu____9639)
           | (u, FStar_Syntax_Syntax.U_unif v1) ->
               let u3 = norm_univ wl u in
-              let uu____9655 = occurs_univ v1 u3 in
-              if uu____9655
+              let uu____9653 = occurs_univ v1 u3 in
+              if uu____9653
               then
-                let uu____9656 =
-                  let uu____9657 =
+                let uu____9654 =
+                  let uu____9655 =
                     FStar_Syntax_Print.univ_to_string
                       (FStar_Syntax_Syntax.U_unif v1) in
-                  let uu____9658 = FStar_Syntax_Print.univ_to_string u3 in
+                  let uu____9656 = FStar_Syntax_Print.univ_to_string u3 in
                   FStar_Util.format2 "Failed occurs check: %s occurs in %s"
-                    uu____9657 uu____9658 in
-                try_umax_components u11 u21 uu____9656
+                    uu____9655 uu____9656 in
+                try_umax_components u11 u21 uu____9654
               else
-                (let uu____9660 = extend_solution pid_orig [UNIV (v1, u3)] wl in
-                 USolved uu____9660)
-          | (FStar_Syntax_Syntax.U_max uu____9661, uu____9662) ->
+                (let uu____9658 = extend_solution pid_orig [UNIV (v1, u3)] wl in
+                 USolved uu____9658)
+          | (FStar_Syntax_Syntax.U_max uu____9659, uu____9660) ->
               if wl.defer_ok
               then UDeferred wl
               else
                 (let u12 = norm_univ wl u11 in
                  let u22 = norm_univ wl u21 in
-                 let uu____9668 = FStar_Syntax_Util.eq_univs u12 u22 in
-                 if uu____9668
+                 let uu____9666 = FStar_Syntax_Util.eq_univs u12 u22 in
+                 if uu____9666
                  then USolved wl
                  else try_umax_components u12 u22 "")
-          | (uu____9670, FStar_Syntax_Syntax.U_max uu____9671) ->
+          | (uu____9668, FStar_Syntax_Syntax.U_max uu____9669) ->
               if wl.defer_ok
               then UDeferred wl
               else
                 (let u12 = norm_univ wl u11 in
                  let u22 = norm_univ wl u21 in
-                 let uu____9677 = FStar_Syntax_Util.eq_univs u12 u22 in
-                 if uu____9677
+                 let uu____9675 = FStar_Syntax_Util.eq_univs u12 u22 in
+                 if uu____9675
                  then USolved wl
                  else try_umax_components u12 u22 "")
-          | (FStar_Syntax_Syntax.U_succ uu____9679,
+          | (FStar_Syntax_Syntax.U_succ uu____9677,
              FStar_Syntax_Syntax.U_zero) ->
               ufailed_simple "Incompatible universes"
-          | (FStar_Syntax_Syntax.U_succ uu____9680,
-             FStar_Syntax_Syntax.U_name uu____9681) ->
+          | (FStar_Syntax_Syntax.U_succ uu____9678,
+             FStar_Syntax_Syntax.U_name uu____9679) ->
               ufailed_simple "Incompatible universes"
           | (FStar_Syntax_Syntax.U_zero, FStar_Syntax_Syntax.U_succ
-             uu____9682) -> ufailed_simple "Incompatible universes"
+             uu____9680) -> ufailed_simple "Incompatible universes"
           | (FStar_Syntax_Syntax.U_zero, FStar_Syntax_Syntax.U_name
-             uu____9683) -> ufailed_simple "Incompatible universes"
-          | (FStar_Syntax_Syntax.U_name uu____9684,
-             FStar_Syntax_Syntax.U_succ uu____9685) ->
+             uu____9681) -> ufailed_simple "Incompatible universes"
+          | (FStar_Syntax_Syntax.U_name uu____9682,
+             FStar_Syntax_Syntax.U_succ uu____9683) ->
               ufailed_simple "Incompatible universes"
-          | (FStar_Syntax_Syntax.U_name uu____9686,
+          | (FStar_Syntax_Syntax.U_name uu____9684,
              FStar_Syntax_Syntax.U_zero) ->
               ufailed_simple "Incompatible universes"
 let (solve_universe_eq :
@@ -3432,25 +3432,25 @@ let match_num_binders :
   =
   fun bc1 ->
     fun bc2 ->
-      let uu____9786 = bc1 in
-      match uu____9786 with
+      let uu____9784 = bc1 in
+      match uu____9784 with
       | (bs1, mk_cod1) ->
-          let uu____9830 = bc2 in
-          (match uu____9830 with
+          let uu____9828 = bc2 in
+          (match uu____9828 with
            | (bs2, mk_cod2) ->
                let rec aux bs11 bs21 =
                  match (bs11, bs21) with
                  | (x::xs, y::ys) ->
-                     let uu____9941 = aux xs ys in
-                     (match uu____9941 with
+                     let uu____9939 = aux xs ys in
+                     (match uu____9939 with
                       | ((xs1, xr), (ys1, yr)) ->
                           (((x :: xs1), xr), ((y :: ys1), yr)))
                  | (xs, ys) ->
-                     let uu____10024 =
-                       let uu____10031 = mk_cod1 xs in ([], uu____10031) in
-                     let uu____10034 =
-                       let uu____10041 = mk_cod2 ys in ([], uu____10041) in
-                     (uu____10024, uu____10034) in
+                     let uu____10022 =
+                       let uu____10029 = mk_cod1 xs in ([], uu____10029) in
+                     let uu____10032 =
+                       let uu____10039 = mk_cod2 ys in ([], uu____10039) in
+                     (uu____10022, uu____10032) in
                aux bs1 bs2)
 let (guard_of_prob :
   FStar_TypeChecker_Env.env ->
@@ -3467,51 +3467,51 @@ let (guard_of_prob :
             let has_type_guard t11 t21 =
               match problem.FStar_TypeChecker_Common.element with
               | FStar_Pervasives_Native.Some t ->
-                  let uu____10109 = FStar_Syntax_Syntax.bv_to_name t in
-                  FStar_Syntax_Util.mk_has_type t11 uu____10109 t21
+                  let uu____10107 = FStar_Syntax_Syntax.bv_to_name t in
+                  FStar_Syntax_Util.mk_has_type t11 uu____10107 t21
               | FStar_Pervasives_Native.None ->
                   let x =
                     FStar_Syntax_Syntax.new_bv FStar_Pervasives_Native.None
                       t11 in
                   let u_x = env.FStar_TypeChecker_Env.universe_of env t11 in
-                  let uu____10112 =
-                    let uu____10113 = FStar_Syntax_Syntax.bv_to_name x in
-                    FStar_Syntax_Util.mk_has_type t11 uu____10113 t21 in
-                  FStar_Syntax_Util.mk_forall u_x x uu____10112 in
+                  let uu____10110 =
+                    let uu____10111 = FStar_Syntax_Syntax.bv_to_name x in
+                    FStar_Syntax_Util.mk_has_type t11 uu____10111 t21 in
+                  FStar_Syntax_Util.mk_forall u_x x uu____10110 in
             match problem.FStar_TypeChecker_Common.relation with
             | FStar_TypeChecker_Common.EQ ->
                 mk_eq2 wl env (FStar_TypeChecker_Common.TProb problem) t1 t2
             | FStar_TypeChecker_Common.SUB ->
-                let uu____10118 = has_type_guard t1 t2 in (uu____10118, wl)
+                let uu____10116 = has_type_guard t1 t2 in (uu____10116, wl)
             | FStar_TypeChecker_Common.SUBINV ->
-                let uu____10119 = has_type_guard t2 t1 in (uu____10119, wl)
+                let uu____10117 = has_type_guard t2 t1 in (uu____10117, wl)
 let (is_flex_pat : flex_t -> Prims.bool) =
-  fun uu___22_10124 ->
-    match uu___22_10124 with
-    | Flex (uu____10125, uu____10126, []) -> true
-    | uu____10135 -> false
+  fun uu___22_10122 ->
+    match uu___22_10122 with
+    | Flex (uu____10123, uu____10124, []) -> true
+    | uu____10133 -> false
 let (should_defer_flex_to_user_tac :
   FStar_TypeChecker_Env.env -> worklist -> flex_t -> Prims.bool) =
   fun env ->
     fun wl ->
       fun f ->
-        let uu____10151 = f in
-        match uu____10151 with
-        | Flex (uu____10152, u, uu____10154) ->
+        let uu____10149 = f in
+        match uu____10149 with
+        | Flex (uu____10150, u, uu____10152) ->
             let b =
               FStar_TypeChecker_DeferredImplicits.should_defer_uvar_to_user_tac
                 wl.tcenv u in
-            ((let uu____10157 =
+            ((let uu____10155 =
                 FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
                   (FStar_Options.Other "ResolveImplicitsHook") in
-              if uu____10157
+              if uu____10155
               then
-                let uu____10158 =
+                let uu____10156 =
                   FStar_Syntax_Print.ctx_uvar_to_string_no_reason u in
-                let uu____10159 = FStar_Util.string_of_bool b in
+                let uu____10157 = FStar_Util.string_of_bool b in
                 FStar_Util.print2
                   "Rel.should_defer_flex_to_user_tac for %s returning %s\n"
-                  uu____10158 uu____10159
+                  uu____10156 uu____10157
               else ());
              b)
 let (quasi_pattern :
@@ -3522,157 +3522,157 @@ let (quasi_pattern :
   =
   fun env ->
     fun f ->
-      let uu____10183 = f in
-      match uu____10183 with
+      let uu____10181 = f in
+      match uu____10181 with
       | Flex
-          (uu____10190,
-           { FStar_Syntax_Syntax.ctx_uvar_head = uu____10191;
-             FStar_Syntax_Syntax.ctx_uvar_gamma = uu____10192;
+          (uu____10188,
+           { FStar_Syntax_Syntax.ctx_uvar_head = uu____10189;
+             FStar_Syntax_Syntax.ctx_uvar_gamma = uu____10190;
              FStar_Syntax_Syntax.ctx_uvar_binders = ctx;
              FStar_Syntax_Syntax.ctx_uvar_typ = t_hd;
-             FStar_Syntax_Syntax.ctx_uvar_reason = uu____10195;
-             FStar_Syntax_Syntax.ctx_uvar_should_check = uu____10196;
-             FStar_Syntax_Syntax.ctx_uvar_range = uu____10197;
-             FStar_Syntax_Syntax.ctx_uvar_meta = uu____10198;_},
+             FStar_Syntax_Syntax.ctx_uvar_reason = uu____10193;
+             FStar_Syntax_Syntax.ctx_uvar_should_check = uu____10194;
+             FStar_Syntax_Syntax.ctx_uvar_range = uu____10195;
+             FStar_Syntax_Syntax.ctx_uvar_meta = uu____10196;_},
            args)
           ->
           let name_exists_in x bs =
             FStar_Util.for_some
-              (fun uu____10262 ->
-                 match uu____10262 with
-                 | (y, uu____10270) -> FStar_Syntax_Syntax.bv_eq x y) bs in
+              (fun uu____10260 ->
+                 match uu____10260 with
+                 | (y, uu____10268) -> FStar_Syntax_Syntax.bv_eq x y) bs in
           let rec aux pat_binders formals t_res args1 =
             match (formals, args1) with
             | ([], []) ->
-                let uu____10424 =
-                  let uu____10439 =
-                    let uu____10442 = FStar_Syntax_Syntax.mk_Total t_res in
-                    FStar_Syntax_Util.arrow formals uu____10442 in
-                  ((FStar_List.rev pat_binders), uu____10439) in
-                FStar_Pervasives_Native.Some uu____10424
-            | (uu____10475, []) ->
-                let uu____10506 =
-                  let uu____10521 =
-                    let uu____10524 = FStar_Syntax_Syntax.mk_Total t_res in
-                    FStar_Syntax_Util.arrow formals uu____10524 in
-                  ((FStar_List.rev pat_binders), uu____10521) in
-                FStar_Pervasives_Native.Some uu____10506
+                let uu____10422 =
+                  let uu____10437 =
+                    let uu____10440 = FStar_Syntax_Syntax.mk_Total t_res in
+                    FStar_Syntax_Util.arrow formals uu____10440 in
+                  ((FStar_List.rev pat_binders), uu____10437) in
+                FStar_Pervasives_Native.Some uu____10422
+            | (uu____10473, []) ->
+                let uu____10504 =
+                  let uu____10519 =
+                    let uu____10522 = FStar_Syntax_Syntax.mk_Total t_res in
+                    FStar_Syntax_Util.arrow formals uu____10522 in
+                  ((FStar_List.rev pat_binders), uu____10519) in
+                FStar_Pervasives_Native.Some uu____10504
             | ((formal, formal_imp)::formals1, (a, a_imp)::args2) ->
-                let uu____10615 =
-                  let uu____10616 = FStar_Syntax_Subst.compress a in
-                  uu____10616.FStar_Syntax_Syntax.n in
-                (match uu____10615 with
+                let uu____10613 =
+                  let uu____10614 = FStar_Syntax_Subst.compress a in
+                  uu____10614.FStar_Syntax_Syntax.n in
+                (match uu____10613 with
                  | FStar_Syntax_Syntax.Tm_name x ->
-                     let uu____10636 =
+                     let uu____10634 =
                        (name_exists_in x ctx) ||
                          (name_exists_in x pat_binders) in
-                     if uu____10636
+                     if uu____10634
                      then
                        aux ((formal, formal_imp) :: pat_binders) formals1
                          t_res args2
                      else
                        (let x1 =
-                          let uu___1695_10663 = x in
+                          let uu___1695_10661 = x in
                           {
                             FStar_Syntax_Syntax.ppname =
-                              (uu___1695_10663.FStar_Syntax_Syntax.ppname);
+                              (uu___1695_10661.FStar_Syntax_Syntax.ppname);
                             FStar_Syntax_Syntax.index =
-                              (uu___1695_10663.FStar_Syntax_Syntax.index);
+                              (uu___1695_10661.FStar_Syntax_Syntax.index);
                             FStar_Syntax_Syntax.sort =
                               (formal.FStar_Syntax_Syntax.sort)
                           } in
                         let subst =
-                          let uu____10667 =
-                            let uu____10668 =
-                              let uu____10675 =
+                          let uu____10665 =
+                            let uu____10666 =
+                              let uu____10673 =
                                 FStar_Syntax_Syntax.bv_to_name x1 in
-                              (formal, uu____10675) in
-                            FStar_Syntax_Syntax.NT uu____10668 in
-                          [uu____10667] in
+                              (formal, uu____10673) in
+                            FStar_Syntax_Syntax.NT uu____10666 in
+                          [uu____10665] in
                         let formals2 =
                           FStar_Syntax_Subst.subst_binders subst formals1 in
                         let t_res1 = FStar_Syntax_Subst.subst subst t_res in
                         aux
-                          (((let uu___1701_10691 = x1 in
+                          (((let uu___1701_10689 = x1 in
                              {
                                FStar_Syntax_Syntax.ppname =
-                                 (uu___1701_10691.FStar_Syntax_Syntax.ppname);
+                                 (uu___1701_10689.FStar_Syntax_Syntax.ppname);
                                FStar_Syntax_Syntax.index =
-                                 (uu___1701_10691.FStar_Syntax_Syntax.index);
+                                 (uu___1701_10689.FStar_Syntax_Syntax.index);
                                FStar_Syntax_Syntax.sort =
                                  (formal.FStar_Syntax_Syntax.sort)
                              }), a_imp) :: pat_binders) formals2 t_res1 args2)
-                 | uu____10692 ->
+                 | uu____10690 ->
                      aux ((formal, formal_imp) :: pat_binders) formals1 t_res
                        args2)
             | ([], args2) ->
-                let uu____10732 =
-                  let uu____10739 =
+                let uu____10730 =
+                  let uu____10737 =
                     FStar_TypeChecker_Normalize.unfold_whnf env t_res in
-                  FStar_Syntax_Util.arrow_formals uu____10739 in
-                (match uu____10732 with
+                  FStar_Syntax_Util.arrow_formals uu____10737 in
+                (match uu____10730 with
                  | (more_formals, t_res1) ->
                      (match more_formals with
                       | [] -> FStar_Pervasives_Native.None
-                      | uu____10798 ->
+                      | uu____10796 ->
                           aux pat_binders more_formals t_res1 args2)) in
           (match args with
            | [] -> FStar_Pervasives_Native.Some ([], t_hd)
-           | uu____10823 ->
-               let uu____10824 = FStar_Syntax_Util.arrow_formals t_hd in
-               (match uu____10824 with
+           | uu____10821 ->
+               let uu____10822 = FStar_Syntax_Util.arrow_formals t_hd in
+               (match uu____10822 with
                 | (formals, t_res) -> aux [] formals t_res args))
 let rec (solve : FStar_TypeChecker_Env.env -> worklist -> solution) =
   fun env ->
     fun probs ->
-      (let uu____11153 =
+      (let uu____11151 =
          FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
            (FStar_Options.Other "Rel") in
-       if uu____11153
+       if uu____11151
        then
-         let uu____11154 = wl_to_string probs in
-         FStar_Util.print1 "solve:\n\t%s\n" uu____11154
+         let uu____11152 = wl_to_string probs in
+         FStar_Util.print1 "solve:\n\t%s\n" uu____11152
        else ());
-      (let uu____11157 =
+      (let uu____11155 =
          FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
            (FStar_Options.Other "ImplicitTrace") in
-       if uu____11157
+       if uu____11155
        then
-         let uu____11158 =
+         let uu____11156 =
            FStar_TypeChecker_Common.implicits_to_string probs.wl_implicits in
-         FStar_Util.print1 "solve: wl_implicits = %s\n" uu____11158
+         FStar_Util.print1 "solve: wl_implicits = %s\n" uu____11156
        else ());
-      (let uu____11160 = next_prob probs in
-       match uu____11160 with
+      (let uu____11158 = next_prob probs in
+       match uu____11158 with
        | FStar_Pervasives_Native.Some (hd, tl, rank1) ->
            let probs1 =
-             let uu___1728_11187 = probs in
+             let uu___1728_11185 = probs in
              {
                attempting = tl;
-               wl_deferred = (uu___1728_11187.wl_deferred);
-               wl_deferred_to_tac = (uu___1728_11187.wl_deferred_to_tac);
-               ctr = (uu___1728_11187.ctr);
-               defer_ok = (uu___1728_11187.defer_ok);
-               smt_ok = (uu___1728_11187.smt_ok);
-               umax_heuristic_ok = (uu___1728_11187.umax_heuristic_ok);
-               tcenv = (uu___1728_11187.tcenv);
-               wl_implicits = (uu___1728_11187.wl_implicits);
-               repr_subcomp_allowed = (uu___1728_11187.repr_subcomp_allowed)
+               wl_deferred = (uu___1728_11185.wl_deferred);
+               wl_deferred_to_tac = (uu___1728_11185.wl_deferred_to_tac);
+               ctr = (uu___1728_11185.ctr);
+               defer_ok = (uu___1728_11185.defer_ok);
+               smt_ok = (uu___1728_11185.smt_ok);
+               umax_heuristic_ok = (uu___1728_11185.umax_heuristic_ok);
+               tcenv = (uu___1728_11185.tcenv);
+               wl_implicits = (uu___1728_11185.wl_implicits);
+               repr_subcomp_allowed = (uu___1728_11185.repr_subcomp_allowed)
              } in
            (def_check_prob "solve,hd" hd;
             (match hd with
              | FStar_TypeChecker_Common.CProb cp ->
                  solve_c env (maybe_invert cp) probs1
              | FStar_TypeChecker_Common.TProb tp ->
-                 let uu____11195 =
+                 let uu____11193 =
                    FStar_Util.physical_equality
                      tp.FStar_TypeChecker_Common.lhs
                      tp.FStar_TypeChecker_Common.rhs in
-                 if uu____11195
+                 if uu____11193
                  then
-                   let uu____11196 =
+                   let uu____11194 =
                      solve_prob hd FStar_Pervasives_Native.None [] probs1 in
-                   solve env uu____11196
+                   solve env uu____11194
                  else
                    if
                      (rank1 = FStar_TypeChecker_Common.Rigid_rigid) ||
@@ -3689,28 +3689,28 @@ let rec (solve : FStar_TypeChecker_Env.env -> worklist -> solution) =
                        if rank1 = FStar_TypeChecker_Common.Flex_flex
                        then
                          solve_t env
-                           (let uu___1740_11201 = tp in
+                           (let uu___1740_11199 = tp in
                             {
                               FStar_TypeChecker_Common.pid =
-                                (uu___1740_11201.FStar_TypeChecker_Common.pid);
+                                (uu___1740_11199.FStar_TypeChecker_Common.pid);
                               FStar_TypeChecker_Common.lhs =
-                                (uu___1740_11201.FStar_TypeChecker_Common.lhs);
+                                (uu___1740_11199.FStar_TypeChecker_Common.lhs);
                               FStar_TypeChecker_Common.relation =
                                 FStar_TypeChecker_Common.EQ;
                               FStar_TypeChecker_Common.rhs =
-                                (uu___1740_11201.FStar_TypeChecker_Common.rhs);
+                                (uu___1740_11199.FStar_TypeChecker_Common.rhs);
                               FStar_TypeChecker_Common.element =
-                                (uu___1740_11201.FStar_TypeChecker_Common.element);
+                                (uu___1740_11199.FStar_TypeChecker_Common.element);
                               FStar_TypeChecker_Common.logical_guard =
-                                (uu___1740_11201.FStar_TypeChecker_Common.logical_guard);
+                                (uu___1740_11199.FStar_TypeChecker_Common.logical_guard);
                               FStar_TypeChecker_Common.logical_guard_uvar =
-                                (uu___1740_11201.FStar_TypeChecker_Common.logical_guard_uvar);
+                                (uu___1740_11199.FStar_TypeChecker_Common.logical_guard_uvar);
                               FStar_TypeChecker_Common.reason =
-                                (uu___1740_11201.FStar_TypeChecker_Common.reason);
+                                (uu___1740_11199.FStar_TypeChecker_Common.reason);
                               FStar_TypeChecker_Common.loc =
-                                (uu___1740_11201.FStar_TypeChecker_Common.loc);
+                                (uu___1740_11199.FStar_TypeChecker_Common.loc);
                               FStar_TypeChecker_Common.rank =
-                                (uu___1740_11201.FStar_TypeChecker_Common.rank)
+                                (uu___1740_11199.FStar_TypeChecker_Common.rank)
                             }) probs1
                        else
                          solve_rigid_flex_or_flex_rigid_subtyping rank1 env
@@ -3718,52 +3718,52 @@ let rec (solve : FStar_TypeChecker_Env.env -> worklist -> solution) =
        | FStar_Pervasives_Native.None ->
            (match probs.wl_deferred with
             | [] ->
-                let uu____11219 =
-                  let uu____11226 = as_deferred probs.wl_deferred_to_tac in
-                  ([], uu____11226, (probs.wl_implicits)) in
-                Success uu____11219
-            | uu____11231 ->
-                let uu____11240 =
+                let uu____11217 =
+                  let uu____11224 = as_deferred probs.wl_deferred_to_tac in
+                  ([], uu____11224, (probs.wl_implicits)) in
+                Success uu____11217
+            | uu____11229 ->
+                let uu____11238 =
                   FStar_All.pipe_right probs.wl_deferred
                     (FStar_List.partition
-                       (fun uu____11299 ->
-                          match uu____11299 with
-                          | (c, uu____11307, uu____11308) -> c < probs.ctr)) in
-                (match uu____11240 with
+                       (fun uu____11297 ->
+                          match uu____11297 with
+                          | (c, uu____11305, uu____11306) -> c < probs.ctr)) in
+                (match uu____11238 with
                  | (attempt1, rest) ->
                      (match attempt1 with
                       | [] ->
-                          let uu____11349 =
-                            let uu____11356 = as_deferred probs.wl_deferred in
-                            let uu____11357 =
+                          let uu____11347 =
+                            let uu____11354 = as_deferred probs.wl_deferred in
+                            let uu____11355 =
                               as_deferred probs.wl_deferred_to_tac in
-                            (uu____11356, uu____11357, (probs.wl_implicits)) in
-                          Success uu____11349
-                      | uu____11358 ->
-                          let uu____11367 =
-                            let uu___1754_11368 = probs in
-                            let uu____11369 =
+                            (uu____11354, uu____11355, (probs.wl_implicits)) in
+                          Success uu____11347
+                      | uu____11356 ->
+                          let uu____11365 =
+                            let uu___1754_11366 = probs in
+                            let uu____11367 =
                               FStar_All.pipe_right attempt1
                                 (FStar_List.map
-                                   (fun uu____11388 ->
-                                      match uu____11388 with
-                                      | (uu____11395, uu____11396, y) -> y)) in
+                                   (fun uu____11386 ->
+                                      match uu____11386 with
+                                      | (uu____11393, uu____11394, y) -> y)) in
                             {
-                              attempting = uu____11369;
+                              attempting = uu____11367;
                               wl_deferred = rest;
                               wl_deferred_to_tac =
-                                (uu___1754_11368.wl_deferred_to_tac);
-                              ctr = (uu___1754_11368.ctr);
-                              defer_ok = (uu___1754_11368.defer_ok);
-                              smt_ok = (uu___1754_11368.smt_ok);
+                                (uu___1754_11366.wl_deferred_to_tac);
+                              ctr = (uu___1754_11366.ctr);
+                              defer_ok = (uu___1754_11366.defer_ok);
+                              smt_ok = (uu___1754_11366.smt_ok);
                               umax_heuristic_ok =
-                                (uu___1754_11368.umax_heuristic_ok);
-                              tcenv = (uu___1754_11368.tcenv);
-                              wl_implicits = (uu___1754_11368.wl_implicits);
+                                (uu___1754_11366.umax_heuristic_ok);
+                              tcenv = (uu___1754_11366.tcenv);
+                              wl_implicits = (uu___1754_11366.wl_implicits);
                               repr_subcomp_allowed =
-                                (uu___1754_11368.repr_subcomp_allowed)
+                                (uu___1754_11366.repr_subcomp_allowed)
                             } in
-                          solve env uu____11367))))
+                          solve env uu____11365))))
 and (solve_one_universe_eq :
   FStar_TypeChecker_Env.env ->
     FStar_TypeChecker_Common.prob ->
@@ -3775,16 +3775,16 @@ and (solve_one_universe_eq :
       fun u1 ->
         fun u2 ->
           fun wl ->
-            let uu____11403 = solve_universe_eq (p_pid orig) wl u1 u2 in
-            match uu____11403 with
+            let uu____11401 = solve_universe_eq (p_pid orig) wl u1 u2 in
+            match uu____11401 with
             | USolved wl1 ->
-                let uu____11405 =
+                let uu____11403 =
                   solve_prob orig FStar_Pervasives_Native.None [] wl1 in
-                solve env uu____11405
+                solve env uu____11403
             | UFailed msg -> giveup env msg orig
             | UDeferred wl1 ->
-                let uu____11408 = defer_lit "" orig wl1 in
-                solve env uu____11408
+                let uu____11406 = defer_lit "" orig wl1 in
+                solve env uu____11406
 and (solve_maybe_uinsts :
   FStar_TypeChecker_Env.env ->
     FStar_TypeChecker_Common.prob ->
@@ -3800,31 +3800,31 @@ and (solve_maybe_uinsts :
               match (us1, us2) with
               | ([], []) -> USolved wl1
               | (u1::us11, u2::us21) ->
-                  let uu____11458 = solve_universe_eq (p_pid orig) wl1 u1 u2 in
-                  (match uu____11458 with
+                  let uu____11456 = solve_universe_eq (p_pid orig) wl1 u1 u2 in
+                  (match uu____11456 with
                    | USolved wl2 -> aux wl2 us11 us21
                    | failed_or_deferred -> failed_or_deferred)
-              | uu____11461 -> ufailed_simple "Unequal number of universes" in
+              | uu____11459 -> ufailed_simple "Unequal number of universes" in
             let t11 = whnf env t1 in
             let t21 = whnf env t2 in
             match ((t11.FStar_Syntax_Syntax.n), (t21.FStar_Syntax_Syntax.n))
             with
             | (FStar_Syntax_Syntax.Tm_uinst
                ({ FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar f;
-                  FStar_Syntax_Syntax.pos = uu____11473;
-                  FStar_Syntax_Syntax.vars = uu____11474;_},
+                  FStar_Syntax_Syntax.pos = uu____11471;
+                  FStar_Syntax_Syntax.vars = uu____11472;_},
                 us1),
                FStar_Syntax_Syntax.Tm_uinst
                ({ FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar g;
-                  FStar_Syntax_Syntax.pos = uu____11477;
-                  FStar_Syntax_Syntax.vars = uu____11478;_},
+                  FStar_Syntax_Syntax.pos = uu____11475;
+                  FStar_Syntax_Syntax.vars = uu____11476;_},
                 us2)) ->
                 let b = FStar_Syntax_Syntax.fv_eq f g in aux wl us1 us2
-            | (FStar_Syntax_Syntax.Tm_uinst uu____11490, uu____11491) ->
+            | (FStar_Syntax_Syntax.Tm_uinst uu____11488, uu____11489) ->
                 failwith "Impossible: expect head symbols to match"
-            | (uu____11498, FStar_Syntax_Syntax.Tm_uinst uu____11499) ->
+            | (uu____11496, FStar_Syntax_Syntax.Tm_uinst uu____11497) ->
                 failwith "Impossible: expect head symbols to match"
-            | uu____11506 -> USolved wl
+            | uu____11504 -> USolved wl
 and (giveup_or_defer :
   FStar_TypeChecker_Env.env ->
     FStar_TypeChecker_Common.prob -> worklist -> lstring -> solution)
@@ -3835,15 +3835,15 @@ and (giveup_or_defer :
         fun msg ->
           if wl.defer_ok
           then
-            ((let uu____11516 =
+            ((let uu____11514 =
                 FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
                   (FStar_Options.Other "Rel") in
-              if uu____11516
+              if uu____11514
               then
-                let uu____11517 = prob_to_string env orig in
-                let uu____11518 = FStar_Thunk.force msg in
+                let uu____11515 = prob_to_string env orig in
+                let uu____11516 = FStar_Thunk.force msg in
                 FStar_Util.print2 "\n\t\tDeferring %s\n\t\tBecause %s\n"
-                  uu____11517 uu____11518
+                  uu____11515 uu____11516
               else ());
              solve env (defer msg orig wl))
           else giveup env msg orig
@@ -3855,33 +3855,33 @@ and (defer_to_user_tac :
     fun orig ->
       fun reason ->
         fun wl ->
-          (let uu____11526 =
+          (let uu____11524 =
              FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
                (FStar_Options.Other "Rel") in
-           if uu____11526
+           if uu____11524
            then
-             let uu____11527 = prob_to_string env orig in
-             FStar_Util.print1 "\n\t\tDeferring %s to a tactic\n" uu____11527
+             let uu____11525 = prob_to_string env orig in
+             FStar_Util.print1 "\n\t\tDeferring %s to a tactic\n" uu____11525
            else ());
           (let wl1 = solve_prob orig FStar_Pervasives_Native.None [] wl in
            let wl2 =
-             let uu___1838_11531 = wl1 in
-             let uu____11532 =
-               let uu____11541 =
-                 let uu____11548 = FStar_Thunk.mkv reason in
-                 ((wl1.ctr), uu____11548, orig) in
-               uu____11541 :: (wl1.wl_deferred_to_tac) in
+             let uu___1838_11529 = wl1 in
+             let uu____11530 =
+               let uu____11539 =
+                 let uu____11546 = FStar_Thunk.mkv reason in
+                 ((wl1.ctr), uu____11546, orig) in
+               uu____11539 :: (wl1.wl_deferred_to_tac) in
              {
-               attempting = (uu___1838_11531.attempting);
-               wl_deferred = (uu___1838_11531.wl_deferred);
-               wl_deferred_to_tac = uu____11532;
-               ctr = (uu___1838_11531.ctr);
-               defer_ok = (uu___1838_11531.defer_ok);
-               smt_ok = (uu___1838_11531.smt_ok);
-               umax_heuristic_ok = (uu___1838_11531.umax_heuristic_ok);
-               tcenv = (uu___1838_11531.tcenv);
-               wl_implicits = (uu___1838_11531.wl_implicits);
-               repr_subcomp_allowed = (uu___1838_11531.repr_subcomp_allowed)
+               attempting = (uu___1838_11529.attempting);
+               wl_deferred = (uu___1838_11529.wl_deferred);
+               wl_deferred_to_tac = uu____11530;
+               ctr = (uu___1838_11529.ctr);
+               defer_ok = (uu___1838_11529.defer_ok);
+               smt_ok = (uu___1838_11529.smt_ok);
+               umax_heuristic_ok = (uu___1838_11529.umax_heuristic_ok);
+               tcenv = (uu___1838_11529.tcenv);
+               wl_implicits = (uu___1838_11529.wl_implicits);
+               repr_subcomp_allowed = (uu___1838_11529.repr_subcomp_allowed)
              } in
            solve env wl2)
 and (maybe_defer_to_user_tac :
@@ -3896,27 +3896,27 @@ and (maybe_defer_to_user_tac :
           match prob.FStar_TypeChecker_Common.relation with
           | FStar_TypeChecker_Common.EQ ->
               let should_defer_tac t =
-                let uu____11571 = FStar_Syntax_Util.head_and_args t in
-                match uu____11571 with
-                | (head, uu____11593) ->
-                    let uu____11618 =
-                      let uu____11619 = FStar_Syntax_Subst.compress head in
-                      uu____11619.FStar_Syntax_Syntax.n in
-                    (match uu____11618 with
-                     | FStar_Syntax_Syntax.Tm_uvar (uv, uu____11627) ->
-                         let uu____11644 =
+                let uu____11569 = FStar_Syntax_Util.head_and_args t in
+                match uu____11569 with
+                | (head, uu____11591) ->
+                    let uu____11616 =
+                      let uu____11617 = FStar_Syntax_Subst.compress head in
+                      uu____11617.FStar_Syntax_Syntax.n in
+                    (match uu____11616 with
+                     | FStar_Syntax_Syntax.Tm_uvar (uv, uu____11625) ->
+                         let uu____11642 =
                            FStar_TypeChecker_DeferredImplicits.should_defer_uvar_to_user_tac
                              wl.tcenv uv in
-                         (uu____11644,
+                         (uu____11642,
                            (uv.FStar_Syntax_Syntax.ctx_uvar_reason))
-                     | uu____11645 -> (false, "")) in
-              let uu____11646 =
+                     | uu____11643 -> (false, "")) in
+              let uu____11644 =
                 should_defer_tac prob.FStar_TypeChecker_Common.lhs in
-              (match uu____11646 with
+              (match uu____11644 with
                | (l1, r1) ->
-                   let uu____11653 =
+                   let uu____11651 =
                      should_defer_tac prob.FStar_TypeChecker_Common.rhs in
-                   (match uu____11653 with
+                   (match uu____11651 with
                     | (l2, r2) ->
                         if l1 || l2
                         then
@@ -3924,14 +3924,14 @@ and (maybe_defer_to_user_tac :
                             (FStar_TypeChecker_Common.TProb prob)
                             (Prims.op_Hat r1 (Prims.op_Hat ", " r2)) wl
                         else
-                          (let uu____11661 =
+                          (let uu____11659 =
                              defer_lit reason
                                (FStar_TypeChecker_Common.TProb prob) wl in
-                           solve env uu____11661)))
-          | uu____11662 ->
-              let uu____11663 =
+                           solve env uu____11659)))
+          | uu____11660 ->
+              let uu____11661 =
                 defer_lit reason (FStar_TypeChecker_Common.TProb prob) wl in
-              solve env uu____11663
+              solve env uu____11661
 and (solve_rigid_flex_or_flex_rigid_subtyping :
   FStar_TypeChecker_Common.rank_t ->
     FStar_TypeChecker_Env.env -> tprob -> worklist -> solution)
@@ -3945,165 +3945,165 @@ and (solve_rigid_flex_or_flex_rigid_subtyping :
           (let flip = rank1 = FStar_TypeChecker_Common.Flex_rigid in
            let meet_or_join op ts env1 wl1 =
              let eq_prob t1 t2 wl2 =
-               let uu____11747 =
+               let uu____11745 =
                  new_problem wl2 env1 t1 FStar_TypeChecker_Common.EQ t2
                    FStar_Pervasives_Native.None t1.FStar_Syntax_Syntax.pos
                    "join/meet refinements" in
-               match uu____11747 with
+               match uu____11745 with
                | (p, wl3) ->
                    (def_check_prob "meet_or_join"
                       (FStar_TypeChecker_Common.TProb p);
                     ((FStar_TypeChecker_Common.TProb p), wl3)) in
              let pairwise t1 t2 wl2 =
-               (let uu____11800 =
+               (let uu____11798 =
                   FStar_All.pipe_left (FStar_TypeChecker_Env.debug env1)
                     (FStar_Options.Other "Rel") in
-                if uu____11800
+                if uu____11798
                 then
-                  let uu____11801 = FStar_Syntax_Print.term_to_string t1 in
-                  let uu____11802 = FStar_Syntax_Print.term_to_string t2 in
+                  let uu____11799 = FStar_Syntax_Print.term_to_string t1 in
+                  let uu____11800 = FStar_Syntax_Print.term_to_string t2 in
                   FStar_Util.print2 "[meet/join]: pairwise: %s and %s\n"
-                    uu____11801 uu____11802
+                    uu____11799 uu____11800
                 else ());
-               (let uu____11804 = head_matches_delta env1 wl2 t1 t2 in
-                match uu____11804 with
+               (let uu____11802 = head_matches_delta env1 wl2 t1 t2 in
+                match uu____11802 with
                 | (mr, ts1) ->
                     (match mr with
                      | HeadMatch (true) ->
-                         let uu____11849 = eq_prob t1 t2 wl2 in
-                         (match uu____11849 with | (p, wl3) -> (t1, [p], wl3))
-                     | MisMatch uu____11870 ->
-                         let uu____11879 = eq_prob t1 t2 wl2 in
-                         (match uu____11879 with | (p, wl3) -> (t1, [p], wl3))
+                         let uu____11847 = eq_prob t1 t2 wl2 in
+                         (match uu____11847 with | (p, wl3) -> (t1, [p], wl3))
+                     | MisMatch uu____11868 ->
+                         let uu____11877 = eq_prob t1 t2 wl2 in
+                         (match uu____11877 with | (p, wl3) -> (t1, [p], wl3))
                      | FullMatch ->
                          (match ts1 with
                           | FStar_Pervasives_Native.None -> (t1, [], wl2)
                           | FStar_Pervasives_Native.Some (t11, t21) ->
                               (t11, [], wl2))
                      | HeadMatch (false) ->
-                         let uu____11928 =
+                         let uu____11926 =
                            match ts1 with
                            | FStar_Pervasives_Native.Some (t11, t21) ->
-                               let uu____11943 =
+                               let uu____11941 =
                                  FStar_Syntax_Subst.compress t11 in
-                               let uu____11944 =
+                               let uu____11942 =
                                  FStar_Syntax_Subst.compress t21 in
-                               (uu____11943, uu____11944)
+                               (uu____11941, uu____11942)
                            | FStar_Pervasives_Native.None ->
-                               let uu____11949 =
+                               let uu____11947 =
                                  FStar_Syntax_Subst.compress t1 in
-                               let uu____11950 =
+                               let uu____11948 =
                                  FStar_Syntax_Subst.compress t2 in
-                               (uu____11949, uu____11950) in
-                         (match uu____11928 with
+                               (uu____11947, uu____11948) in
+                         (match uu____11926 with
                           | (t11, t21) ->
                               let try_eq t12 t22 wl3 =
-                                let uu____11981 =
+                                let uu____11979 =
                                   FStar_Syntax_Util.head_and_args t12 in
-                                match uu____11981 with
+                                match uu____11979 with
                                 | (t1_hd, t1_args) ->
-                                    let uu____12026 =
+                                    let uu____12024 =
                                       FStar_Syntax_Util.head_and_args t22 in
-                                    (match uu____12026 with
+                                    (match uu____12024 with
                                      | (t2_hd, t2_args) ->
                                          if
                                            (FStar_List.length t1_args) <>
                                              (FStar_List.length t2_args)
                                          then FStar_Pervasives_Native.None
                                          else
-                                           (let uu____12090 =
-                                              let uu____12097 =
-                                                let uu____12108 =
+                                           (let uu____12088 =
+                                              let uu____12095 =
+                                                let uu____12106 =
                                                   FStar_Syntax_Syntax.as_arg
                                                     t1_hd in
-                                                uu____12108 :: t1_args in
-                                              let uu____12125 =
-                                                let uu____12134 =
+                                                uu____12106 :: t1_args in
+                                              let uu____12123 =
+                                                let uu____12132 =
                                                   FStar_Syntax_Syntax.as_arg
                                                     t2_hd in
-                                                uu____12134 :: t2_args in
+                                                uu____12132 :: t2_args in
                                               FStar_List.fold_left2
-                                                (fun uu____12183 ->
-                                                   fun uu____12184 ->
-                                                     fun uu____12185 ->
-                                                       match (uu____12183,
-                                                               uu____12184,
-                                                               uu____12185)
+                                                (fun uu____12181 ->
+                                                   fun uu____12182 ->
+                                                     fun uu____12183 ->
+                                                       match (uu____12181,
+                                                               uu____12182,
+                                                               uu____12183)
                                                        with
                                                        | ((probs, wl4),
-                                                          (a1, uu____12235),
-                                                          (a2, uu____12237))
+                                                          (a1, uu____12233),
+                                                          (a2, uu____12235))
                                                            ->
-                                                           let uu____12274 =
+                                                           let uu____12272 =
                                                              eq_prob a1 a2
                                                                wl4 in
-                                                           (match uu____12274
+                                                           (match uu____12272
                                                             with
                                                             | (p, wl5) ->
                                                                 ((p ::
                                                                   probs),
                                                                   wl5)))
-                                                ([], wl3) uu____12097
-                                                uu____12125 in
-                                            match uu____12090 with
+                                                ([], wl3) uu____12095
+                                                uu____12123 in
+                                            match uu____12088 with
                                             | (probs, wl4) ->
                                                 let wl' =
-                                                  let uu___1941_12300 = wl4 in
+                                                  let uu___1941_12298 = wl4 in
                                                   {
                                                     attempting = probs;
                                                     wl_deferred = [];
                                                     wl_deferred_to_tac =
-                                                      (uu___1941_12300.wl_deferred_to_tac);
+                                                      (uu___1941_12298.wl_deferred_to_tac);
                                                     ctr =
-                                                      (uu___1941_12300.ctr);
+                                                      (uu___1941_12298.ctr);
                                                     defer_ok = false;
                                                     smt_ok = false;
                                                     umax_heuristic_ok =
-                                                      (uu___1941_12300.umax_heuristic_ok);
+                                                      (uu___1941_12298.umax_heuristic_ok);
                                                     tcenv =
-                                                      (uu___1941_12300.tcenv);
+                                                      (uu___1941_12298.tcenv);
                                                     wl_implicits = [];
                                                     repr_subcomp_allowed =
-                                                      (uu___1941_12300.repr_subcomp_allowed)
+                                                      (uu___1941_12298.repr_subcomp_allowed)
                                                   } in
                                                 let tx =
                                                   FStar_Syntax_Unionfind.new_transaction
                                                     () in
-                                                let uu____12308 =
+                                                let uu____12306 =
                                                   solve env1 wl' in
-                                                (match uu____12308 with
+                                                (match uu____12306 with
                                                  | Success
-                                                     (uu____12311,
+                                                     (uu____12309,
                                                       defer_to_tac, imps)
                                                      ->
                                                      (FStar_Syntax_Unionfind.commit
                                                         tx;
-                                                      (let uu____12315 =
+                                                      (let uu____12313 =
                                                          extend_wl wl4
                                                            defer_to_tac imps in
                                                        FStar_Pervasives_Native.Some
-                                                         uu____12315))
-                                                 | Failed uu____12316 ->
+                                                         uu____12313))
+                                                 | Failed uu____12314 ->
                                                      (FStar_Syntax_Unionfind.rollback
                                                         tx;
                                                       FStar_Pervasives_Native.None)))) in
                               let combine t12 t22 wl3 =
-                                let uu____12348 =
+                                let uu____12346 =
                                   base_and_refinement_maybe_delta false env1
                                     t12 in
-                                match uu____12348 with
+                                match uu____12346 with
                                 | (t1_base, p1_opt) ->
-                                    let uu____12383 =
+                                    let uu____12381 =
                                       base_and_refinement_maybe_delta false
                                         env1 t22 in
-                                    (match uu____12383 with
+                                    (match uu____12381 with
                                      | (t2_base, p2_opt) ->
                                          let combine_refinements t_base
                                            p1_opt1 p2_opt1 =
                                            let refine x t =
-                                             let uu____12481 =
+                                             let uu____12479 =
                                                FStar_Syntax_Util.is_t_true t in
-                                             if uu____12481
+                                             if uu____12479
                                              then x.FStar_Syntax_Syntax.sort
                                              else
                                                FStar_Syntax_Util.refine x t in
@@ -4124,9 +4124,9 @@ and (solve_rigid_flex_or_flex_rigid_subtyping :
                                                let phi21 =
                                                  FStar_Syntax_Subst.subst
                                                    subst phi2 in
-                                               let uu____12529 =
+                                               let uu____12527 =
                                                  op phi11 phi21 in
-                                               refine x1 uu____12529
+                                               refine x1 uu____12527
                                            | (FStar_Pervasives_Native.None,
                                               FStar_Pervasives_Native.Some
                                               (x, phi)) ->
@@ -4139,10 +4139,10 @@ and (solve_rigid_flex_or_flex_rigid_subtyping :
                                                let phi1 =
                                                  FStar_Syntax_Subst.subst
                                                    subst phi in
-                                               let uu____12559 =
+                                               let uu____12557 =
                                                  op FStar_Syntax_Util.t_true
                                                    phi1 in
-                                               refine x1 uu____12559
+                                               refine x1 uu____12557
                                            | (FStar_Pervasives_Native.Some
                                               (x, phi),
                                               FStar_Pervasives_Native.None)
@@ -4156,35 +4156,35 @@ and (solve_rigid_flex_or_flex_rigid_subtyping :
                                                let phi1 =
                                                  FStar_Syntax_Subst.subst
                                                    subst phi in
-                                               let uu____12589 =
+                                               let uu____12587 =
                                                  op FStar_Syntax_Util.t_true
                                                    phi1 in
-                                               refine x1 uu____12589
-                                           | uu____12592 -> t_base in
-                                         let uu____12609 =
+                                               refine x1 uu____12587
+                                           | uu____12590 -> t_base in
+                                         let uu____12607 =
                                            try_eq t1_base t2_base wl3 in
-                                         (match uu____12609 with
+                                         (match uu____12607 with
                                           | FStar_Pervasives_Native.Some wl4
                                               ->
-                                              let uu____12623 =
+                                              let uu____12621 =
                                                 combine_refinements t1_base
                                                   p1_opt p2_opt in
-                                              (uu____12623, [], wl4)
+                                              (uu____12621, [], wl4)
                                           | FStar_Pervasives_Native.None ->
-                                              let uu____12630 =
+                                              let uu____12628 =
                                                 base_and_refinement_maybe_delta
                                                   true env1 t12 in
-                                              (match uu____12630 with
+                                              (match uu____12628 with
                                                | (t1_base1, p1_opt1) ->
-                                                   let uu____12665 =
+                                                   let uu____12663 =
                                                      base_and_refinement_maybe_delta
                                                        true env1 t22 in
-                                                   (match uu____12665 with
+                                                   (match uu____12663 with
                                                     | (t2_base1, p2_opt1) ->
-                                                        let uu____12700 =
+                                                        let uu____12698 =
                                                           eq_prob t1_base1
                                                             t2_base1 wl3 in
-                                                        (match uu____12700
+                                                        (match uu____12698
                                                          with
                                                          | (p, wl4) ->
                                                              let t =
@@ -4193,40 +4193,40 @@ and (solve_rigid_flex_or_flex_rigid_subtyping :
                                                                  p1_opt1
                                                                  p2_opt1 in
                                                              (t, [p], wl4)))))) in
-                              let uu____12724 = combine t11 t21 wl2 in
-                              (match uu____12724 with
+                              let uu____12722 = combine t11 t21 wl2 in
+                              (match uu____12722 with
                                | (t12, ps, wl3) ->
-                                   ((let uu____12757 =
+                                   ((let uu____12755 =
                                        FStar_All.pipe_left
                                          (FStar_TypeChecker_Env.debug env1)
                                          (FStar_Options.Other "Rel") in
-                                     if uu____12757
+                                     if uu____12755
                                      then
-                                       let uu____12758 =
+                                       let uu____12756 =
                                          FStar_Syntax_Print.term_to_string
                                            t12 in
                                        FStar_Util.print1
                                          "pairwise fallback2 succeeded: %s"
-                                         uu____12758
+                                         uu____12756
                                      else ());
                                     (t12, ps, wl3)))))) in
-             let rec aux uu____12797 ts1 =
-               match uu____12797 with
+             let rec aux uu____12795 ts1 =
+               match uu____12795 with
                | (out, probs, wl2) ->
                    (match ts1 with
                     | [] -> (out, probs, wl2)
                     | t::ts2 ->
-                        let uu____12860 = pairwise out t wl2 in
-                        (match uu____12860 with
+                        let uu____12858 = pairwise out t wl2 in
+                        (match uu____12858 with
                          | (out1, probs', wl3) ->
                              aux
                                (out1, (FStar_List.append probs probs'), wl3)
                                ts2)) in
-             let uu____12896 =
-               let uu____12907 = FStar_List.hd ts in (uu____12907, [], wl1) in
-             let uu____12916 = FStar_List.tl ts in
-             aux uu____12896 uu____12916 in
-           let uu____12923 =
+             let uu____12894 =
+               let uu____12905 = FStar_List.hd ts in (uu____12905, [], wl1) in
+             let uu____12914 = FStar_List.tl ts in
+             aux uu____12894 uu____12914 in
+           let uu____12921 =
              if flip
              then
                ((tp.FStar_TypeChecker_Common.lhs),
@@ -4234,40 +4234,40 @@ and (solve_rigid_flex_or_flex_rigid_subtyping :
              else
                ((tp.FStar_TypeChecker_Common.rhs),
                  (tp.FStar_TypeChecker_Common.lhs)) in
-           match uu____12923 with
+           match uu____12921 with
            | (this_flex, this_rigid) ->
-               let uu____12947 =
-                 let uu____12948 = FStar_Syntax_Subst.compress this_rigid in
-                 uu____12948.FStar_Syntax_Syntax.n in
-               (match uu____12947 with
+               let uu____12945 =
+                 let uu____12946 = FStar_Syntax_Subst.compress this_rigid in
+                 uu____12946.FStar_Syntax_Syntax.n in
+               (match uu____12945 with
                 | FStar_Syntax_Syntax.Tm_arrow (_bs, comp) ->
-                    let uu____12973 =
+                    let uu____12971 =
                       FStar_Syntax_Util.is_tot_or_gtot_comp comp in
-                    if uu____12973
+                    if uu____12971
                     then
-                      let uu____12974 = destruct_flex_t this_flex wl in
-                      (match uu____12974 with
+                      let uu____12972 = destruct_flex_t this_flex wl in
+                      (match uu____12972 with
                        | (flex, wl1) ->
-                           let uu____12981 = quasi_pattern env flex in
-                           (match uu____12981 with
+                           let uu____12979 = quasi_pattern env flex in
+                           (match uu____12979 with
                             | FStar_Pervasives_Native.None ->
                                 giveup_lit env
                                   "flex-arrow subtyping, not a quasi pattern"
                                   (FStar_TypeChecker_Common.TProb tp)
                             | FStar_Pervasives_Native.Some (flex_bs, flex_t1)
                                 ->
-                                ((let uu____12999 =
+                                ((let uu____12997 =
                                     FStar_All.pipe_left
                                       (FStar_TypeChecker_Env.debug env)
                                       (FStar_Options.Other "Rel") in
-                                  if uu____12999
+                                  if uu____12997
                                   then
-                                    let uu____13000 =
+                                    let uu____12998 =
                                       FStar_Util.string_of_int
                                         tp.FStar_TypeChecker_Common.pid in
                                     FStar_Util.print1
                                       "Trying to solve by imitating arrow:%s\n"
-                                      uu____13000
+                                      uu____12998
                                   else ());
                                  imitate_arrow
                                    (FStar_TypeChecker_Common.TProb tp) env
@@ -4275,77 +4275,77 @@ and (solve_rigid_flex_or_flex_rigid_subtyping :
                                    tp.FStar_TypeChecker_Common.relation
                                    this_rigid)))
                     else
-                      (let uu____13003 =
+                      (let uu____13001 =
                          attempt
                            [FStar_TypeChecker_Common.TProb
-                              ((let uu___2051_13006 = tp in
+                              ((let uu___2051_13004 = tp in
                                 {
                                   FStar_TypeChecker_Common.pid =
-                                    (uu___2051_13006.FStar_TypeChecker_Common.pid);
+                                    (uu___2051_13004.FStar_TypeChecker_Common.pid);
                                   FStar_TypeChecker_Common.lhs =
-                                    (uu___2051_13006.FStar_TypeChecker_Common.lhs);
+                                    (uu___2051_13004.FStar_TypeChecker_Common.lhs);
                                   FStar_TypeChecker_Common.relation =
                                     FStar_TypeChecker_Common.EQ;
                                   FStar_TypeChecker_Common.rhs =
-                                    (uu___2051_13006.FStar_TypeChecker_Common.rhs);
+                                    (uu___2051_13004.FStar_TypeChecker_Common.rhs);
                                   FStar_TypeChecker_Common.element =
-                                    (uu___2051_13006.FStar_TypeChecker_Common.element);
+                                    (uu___2051_13004.FStar_TypeChecker_Common.element);
                                   FStar_TypeChecker_Common.logical_guard =
-                                    (uu___2051_13006.FStar_TypeChecker_Common.logical_guard);
+                                    (uu___2051_13004.FStar_TypeChecker_Common.logical_guard);
                                   FStar_TypeChecker_Common.logical_guard_uvar
                                     =
-                                    (uu___2051_13006.FStar_TypeChecker_Common.logical_guard_uvar);
+                                    (uu___2051_13004.FStar_TypeChecker_Common.logical_guard_uvar);
                                   FStar_TypeChecker_Common.reason =
-                                    (uu___2051_13006.FStar_TypeChecker_Common.reason);
+                                    (uu___2051_13004.FStar_TypeChecker_Common.reason);
                                   FStar_TypeChecker_Common.loc =
-                                    (uu___2051_13006.FStar_TypeChecker_Common.loc);
+                                    (uu___2051_13004.FStar_TypeChecker_Common.loc);
                                   FStar_TypeChecker_Common.rank =
-                                    (uu___2051_13006.FStar_TypeChecker_Common.rank)
+                                    (uu___2051_13004.FStar_TypeChecker_Common.rank)
                                 }))] wl in
-                       solve env uu____13003)
-                | uu____13007 ->
-                    ((let uu____13009 =
+                       solve env uu____13001)
+                | uu____13005 ->
+                    ((let uu____13007 =
                         FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
                           (FStar_Options.Other "Rel") in
-                      if uu____13009
+                      if uu____13007
                       then
-                        let uu____13010 =
+                        let uu____13008 =
                           FStar_Util.string_of_int
                             tp.FStar_TypeChecker_Common.pid in
                         FStar_Util.print1
                           "Trying to solve by meeting refinements:%s\n"
-                          uu____13010
+                          uu____13008
                       else ());
-                     (let uu____13012 =
+                     (let uu____13010 =
                         FStar_Syntax_Util.head_and_args this_flex in
-                      match uu____13012 with
+                      match uu____13010 with
                       | (u, _args) ->
-                          let uu____13055 =
-                            let uu____13056 = FStar_Syntax_Subst.compress u in
-                            uu____13056.FStar_Syntax_Syntax.n in
-                          (match uu____13055 with
+                          let uu____13053 =
+                            let uu____13054 = FStar_Syntax_Subst.compress u in
+                            uu____13054.FStar_Syntax_Syntax.n in
+                          (match uu____13053 with
                            | FStar_Syntax_Syntax.Tm_uvar (ctx_uvar, _subst)
                                ->
                                let equiv t =
-                                 let uu____13083 =
+                                 let uu____13081 =
                                    FStar_Syntax_Util.head_and_args t in
-                                 match uu____13083 with
-                                 | (u', uu____13101) ->
-                                     let uu____13126 =
-                                       let uu____13127 = whnf env u' in
-                                       uu____13127.FStar_Syntax_Syntax.n in
-                                     (match uu____13126 with
+                                 match uu____13081 with
+                                 | (u', uu____13099) ->
+                                     let uu____13124 =
+                                       let uu____13125 = whnf env u' in
+                                       uu____13125.FStar_Syntax_Syntax.n in
+                                     (match uu____13124 with
                                       | FStar_Syntax_Syntax.Tm_uvar
                                           (ctx_uvar', _subst') ->
                                           FStar_Syntax_Unionfind.equiv
                                             ctx_uvar.FStar_Syntax_Syntax.ctx_uvar_head
                                             ctx_uvar'.FStar_Syntax_Syntax.ctx_uvar_head
-                                      | uu____13148 -> false) in
-                               let uu____13149 =
+                                      | uu____13146 -> false) in
+                               let uu____13147 =
                                  FStar_All.pipe_right wl.attempting
                                    (FStar_List.partition
-                                      (fun uu___23_13172 ->
-                                         match uu___23_13172 with
+                                      (fun uu___23_13170 ->
+                                         match uu___23_13170 with
                                          | FStar_TypeChecker_Common.TProb tp1
                                              ->
                                              let tp2 = maybe_invert tp1 in
@@ -4360,19 +4360,19 @@ and (solve_rigid_flex_or_flex_rigid_subtyping :
                                                   else
                                                     equiv
                                                       tp2.FStar_TypeChecker_Common.rhs
-                                              | uu____13181 -> false)
-                                         | uu____13184 -> false)) in
-                               (match uu____13149 with
+                                              | uu____13179 -> false)
+                                         | uu____13182 -> false)) in
+                               (match uu____13147 with
                                 | (bounds_probs, rest) ->
                                     let bounds_typs =
-                                      let uu____13198 = whnf env this_rigid in
-                                      let uu____13199 =
+                                      let uu____13196 = whnf env this_rigid in
+                                      let uu____13197 =
                                         FStar_List.collect
-                                          (fun uu___24_13205 ->
-                                             match uu___24_13205 with
+                                          (fun uu___24_13203 ->
+                                             match uu___24_13203 with
                                              | FStar_TypeChecker_Common.TProb
                                                  p ->
-                                                 let uu____13211 =
+                                                 let uu____13209 =
                                                    if flip
                                                    then
                                                      whnf env
@@ -4380,43 +4380,43 @@ and (solve_rigid_flex_or_flex_rigid_subtyping :
                                                    else
                                                      whnf env
                                                        (maybe_invert p).FStar_TypeChecker_Common.lhs in
-                                                 [uu____13211]
-                                             | uu____13213 -> [])
+                                                 [uu____13209]
+                                             | uu____13211 -> [])
                                           bounds_probs in
-                                      uu____13198 :: uu____13199 in
-                                    let uu____13214 =
+                                      uu____13196 :: uu____13197 in
+                                    let uu____13212 =
                                       meet_or_join
                                         (if flip
                                          then FStar_Syntax_Util.mk_conj_simp
                                          else FStar_Syntax_Util.mk_disj_simp)
                                         bounds_typs env wl in
-                                    (match uu____13214 with
+                                    (match uu____13212 with
                                      | (bound, sub_probs, wl1) ->
-                                         let uu____13245 =
+                                         let uu____13243 =
                                            let flex_u =
                                              flex_uvar_head this_flex in
                                            let bound1 =
-                                             let uu____13260 =
-                                               let uu____13261 =
+                                             let uu____13258 =
+                                               let uu____13259 =
                                                  FStar_Syntax_Subst.compress
                                                    bound in
-                                               uu____13261.FStar_Syntax_Syntax.n in
-                                             match uu____13260 with
+                                               uu____13259.FStar_Syntax_Syntax.n in
+                                             match uu____13258 with
                                              | FStar_Syntax_Syntax.Tm_refine
                                                  (x, phi) when
                                                  (tp.FStar_TypeChecker_Common.relation
                                                     =
                                                     FStar_TypeChecker_Common.SUB)
                                                    &&
-                                                   (let uu____13273 =
+                                                   (let uu____13271 =
                                                       occurs flex_u
                                                         x.FStar_Syntax_Syntax.sort in
                                                     FStar_Pervasives_Native.snd
-                                                      uu____13273)
+                                                      uu____13271)
                                                  ->
                                                  x.FStar_Syntax_Syntax.sort
-                                             | uu____13282 -> bound in
-                                           let uu____13283 =
+                                             | uu____13280 -> bound in
+                                           let uu____13281 =
                                              new_problem wl1 env bound1
                                                FStar_TypeChecker_Common.EQ
                                                this_flex
@@ -4425,107 +4425,107 @@ and (solve_rigid_flex_or_flex_rigid_subtyping :
                                                (if flip
                                                 then "joining refinements"
                                                 else "meeting refinements") in
-                                           (bound1, uu____13283) in
-                                         (match uu____13245 with
+                                           (bound1, uu____13281) in
+                                         (match uu____13243 with
                                           | (bound_typ, (eq_prob, wl')) ->
                                               (def_check_prob "meet_or_join2"
                                                  (FStar_TypeChecker_Common.TProb
                                                     eq_prob);
-                                               (let uu____13312 =
+                                               (let uu____13310 =
                                                   FStar_All.pipe_left
                                                     (FStar_TypeChecker_Env.debug
                                                        env)
                                                     (FStar_Options.Other
                                                        "Rel") in
-                                                if uu____13312
+                                                if uu____13310
                                                 then
                                                   let wl'1 =
-                                                    let uu___2111_13314 = wl1 in
+                                                    let uu___2111_13312 = wl1 in
                                                     {
                                                       attempting =
                                                         ((FStar_TypeChecker_Common.TProb
                                                             eq_prob) ::
                                                         sub_probs);
                                                       wl_deferred =
-                                                        (uu___2111_13314.wl_deferred);
+                                                        (uu___2111_13312.wl_deferred);
                                                       wl_deferred_to_tac =
-                                                        (uu___2111_13314.wl_deferred_to_tac);
+                                                        (uu___2111_13312.wl_deferred_to_tac);
                                                       ctr =
-                                                        (uu___2111_13314.ctr);
+                                                        (uu___2111_13312.ctr);
                                                       defer_ok =
-                                                        (uu___2111_13314.defer_ok);
+                                                        (uu___2111_13312.defer_ok);
                                                       smt_ok =
-                                                        (uu___2111_13314.smt_ok);
+                                                        (uu___2111_13312.smt_ok);
                                                       umax_heuristic_ok =
-                                                        (uu___2111_13314.umax_heuristic_ok);
+                                                        (uu___2111_13312.umax_heuristic_ok);
                                                       tcenv =
-                                                        (uu___2111_13314.tcenv);
+                                                        (uu___2111_13312.tcenv);
                                                       wl_implicits =
-                                                        (uu___2111_13314.wl_implicits);
+                                                        (uu___2111_13312.wl_implicits);
                                                       repr_subcomp_allowed =
-                                                        (uu___2111_13314.repr_subcomp_allowed)
+                                                        (uu___2111_13312.repr_subcomp_allowed)
                                                     } in
-                                                  let uu____13315 =
+                                                  let uu____13313 =
                                                     wl_to_string wl'1 in
                                                   FStar_Util.print1
                                                     "After meet/join refinements: %s\n"
-                                                    uu____13315
+                                                    uu____13313
                                                 else ());
                                                (let tx =
                                                   FStar_Syntax_Unionfind.new_transaction
                                                     () in
-                                                let uu____13318 =
+                                                let uu____13316 =
                                                   solve_t env eq_prob
-                                                    (let uu___2116_13320 =
+                                                    (let uu___2116_13318 =
                                                        wl' in
                                                      {
                                                        attempting = sub_probs;
                                                        wl_deferred =
-                                                         (uu___2116_13320.wl_deferred);
+                                                         (uu___2116_13318.wl_deferred);
                                                        wl_deferred_to_tac =
-                                                         (uu___2116_13320.wl_deferred_to_tac);
+                                                         (uu___2116_13318.wl_deferred_to_tac);
                                                        ctr =
-                                                         (uu___2116_13320.ctr);
+                                                         (uu___2116_13318.ctr);
                                                        defer_ok = false;
                                                        smt_ok =
-                                                         (uu___2116_13320.smt_ok);
+                                                         (uu___2116_13318.smt_ok);
                                                        umax_heuristic_ok =
-                                                         (uu___2116_13320.umax_heuristic_ok);
+                                                         (uu___2116_13318.umax_heuristic_ok);
                                                        tcenv =
-                                                         (uu___2116_13320.tcenv);
+                                                         (uu___2116_13318.tcenv);
                                                        wl_implicits = [];
                                                        repr_subcomp_allowed =
-                                                         (uu___2116_13320.repr_subcomp_allowed)
+                                                         (uu___2116_13318.repr_subcomp_allowed)
                                                      }) in
-                                                match uu____13318 with
+                                                match uu____13316 with
                                                 | Success
-                                                    (uu____13321,
+                                                    (uu____13319,
                                                      defer_to_tac, imps)
                                                     ->
                                                     let wl2 =
-                                                      let uu___2123_13325 =
+                                                      let uu___2123_13323 =
                                                         wl' in
                                                       {
                                                         attempting = rest;
                                                         wl_deferred =
-                                                          (uu___2123_13325.wl_deferred);
+                                                          (uu___2123_13323.wl_deferred);
                                                         wl_deferred_to_tac =
-                                                          (uu___2123_13325.wl_deferred_to_tac);
+                                                          (uu___2123_13323.wl_deferred_to_tac);
                                                         ctr =
-                                                          (uu___2123_13325.ctr);
+                                                          (uu___2123_13323.ctr);
                                                         defer_ok =
-                                                          (uu___2123_13325.defer_ok);
+                                                          (uu___2123_13323.defer_ok);
                                                         smt_ok =
-                                                          (uu___2123_13325.smt_ok);
+                                                          (uu___2123_13323.smt_ok);
                                                         umax_heuristic_ok =
-                                                          (uu___2123_13325.umax_heuristic_ok);
+                                                          (uu___2123_13323.umax_heuristic_ok);
                                                         tcenv =
-                                                          (uu___2123_13325.tcenv);
+                                                          (uu___2123_13323.tcenv);
                                                         wl_implicits =
-                                                          (uu___2123_13325.wl_implicits);
+                                                          (uu___2123_13323.wl_implicits);
                                                         repr_subcomp_allowed
                                                           =
-                                                          (uu___2123_13325.repr_subcomp_allowed)
+                                                          (uu___2123_13323.repr_subcomp_allowed)
                                                       } in
                                                     let wl3 =
                                                       extend_wl wl2
@@ -4544,7 +4544,7 @@ and (solve_rigid_flex_or_flex_rigid_subtyping :
                                                            tp)
                                                         (FStar_Pervasives_Native.Some
                                                            g) [] wl3 in
-                                                    let uu____13341 =
+                                                    let uu____13339 =
                                                       FStar_List.fold_left
                                                         (fun wl5 ->
                                                            fun p ->
@@ -4557,16 +4557,16 @@ and (solve_rigid_flex_or_flex_rigid_subtyping :
                                                        tx;
                                                      solve env wl4)
                                                 | Failed (p, msg) ->
-                                                    ((let uu____13352 =
+                                                    ((let uu____13350 =
                                                         FStar_All.pipe_left
                                                           (FStar_TypeChecker_Env.debug
                                                              env)
                                                           (FStar_Options.Other
                                                              "Rel") in
-                                                      if uu____13352
+                                                      if uu____13350
                                                       then
-                                                        let uu____13353 =
-                                                          let uu____13354 =
+                                                        let uu____13351 =
+                                                          let uu____13352 =
                                                             FStar_List.map
                                                               (prob_to_string
                                                                  env)
@@ -4574,26 +4574,26 @@ and (solve_rigid_flex_or_flex_rigid_subtyping :
                                                                   eq_prob) ::
                                                               sub_probs) in
                                                           FStar_All.pipe_right
-                                                            uu____13354
+                                                            uu____13352
                                                             (FStar_String.concat
                                                                "\n") in
                                                         FStar_Util.print1
                                                           "meet/join attempted and failed to solve problems:\n%s\n"
-                                                          uu____13353
+                                                          uu____13351
                                                       else ());
-                                                     (let uu____13360 =
-                                                        let uu____13375 =
+                                                     (let uu____13358 =
+                                                        let uu____13373 =
                                                           base_and_refinement
                                                             env bound_typ in
-                                                        (rank1, uu____13375) in
-                                                      match uu____13360 with
+                                                        (rank1, uu____13373) in
+                                                      match uu____13358 with
                                                       | (FStar_TypeChecker_Common.Rigid_flex,
                                                          (t_base,
                                                           FStar_Pervasives_Native.Some
-                                                          uu____13397)) ->
+                                                          uu____13395)) ->
                                                           (FStar_Syntax_Unionfind.rollback
                                                              tx;
-                                                           (let uu____13423 =
+                                                           (let uu____13421 =
                                                               new_problem wl1
                                                                 env t_base
                                                                 FStar_TypeChecker_Common.EQ
@@ -4601,7 +4601,7 @@ and (solve_rigid_flex_or_flex_rigid_subtyping :
                                                                 FStar_Pervasives_Native.None
                                                                 tp.FStar_TypeChecker_Common.loc
                                                                 "widened subtyping" in
-                                                            match uu____13423
+                                                            match uu____13421
                                                             with
                                                             | (eq_prob1, wl2)
                                                                 ->
@@ -4619,7 +4619,7 @@ and (solve_rigid_flex_or_flex_rigid_subtyping :
                                                                     (FStar_TypeChecker_Common.TProb
                                                                     eq_prob1)))
                                                                     [] wl2 in
-                                                                  let uu____13440
+                                                                  let uu____13438
                                                                     =
                                                                     attempt
                                                                     [
@@ -4627,14 +4627,14 @@ and (solve_rigid_flex_or_flex_rigid_subtyping :
                                                                     eq_prob1]
                                                                     wl3 in
                                                                   solve env
-                                                                    uu____13440))))
+                                                                    uu____13438))))
                                                       | (FStar_TypeChecker_Common.Flex_rigid,
                                                          (t_base,
                                                           FStar_Pervasives_Native.Some
                                                           (x, phi))) ->
                                                           (FStar_Syntax_Unionfind.rollback
                                                              tx;
-                                                           (let uu____13465 =
+                                                           (let uu____13463 =
                                                               new_problem wl1
                                                                 env t_base
                                                                 FStar_TypeChecker_Common.EQ
@@ -4642,7 +4642,7 @@ and (solve_rigid_flex_or_flex_rigid_subtyping :
                                                                 FStar_Pervasives_Native.None
                                                                 tp.FStar_TypeChecker_Common.loc
                                                                 "widened subtyping" in
-                                                            match uu____13465
+                                                            match uu____13463
                                                             with
                                                             | (eq_prob1, wl2)
                                                                 ->
@@ -4655,9 +4655,9 @@ and (solve_rigid_flex_or_flex_rigid_subtyping :
                                                                     wl2 tp x
                                                                     phi in
                                                                   let wl3 =
-                                                                    let uu____13483
+                                                                    let uu____13481
                                                                     =
-                                                                    let uu____13488
+                                                                    let uu____13486
                                                                     =
                                                                     FStar_Syntax_Util.mk_conj
                                                                     phi1
@@ -4665,14 +4665,14 @@ and (solve_rigid_flex_or_flex_rigid_subtyping :
                                                                     (FStar_TypeChecker_Common.TProb
                                                                     eq_prob1)) in
                                                                     FStar_Pervasives_Native.Some
-                                                                    uu____13488 in
+                                                                    uu____13486 in
                                                                     solve_prob'
                                                                     false
                                                                     (FStar_TypeChecker_Common.TProb
                                                                     tp)
-                                                                    uu____13483
+                                                                    uu____13481
                                                                     [] wl2 in
-                                                                  let uu____13493
+                                                                  let uu____13491
                                                                     =
                                                                     attempt
                                                                     [
@@ -4680,40 +4680,40 @@ and (solve_rigid_flex_or_flex_rigid_subtyping :
                                                                     eq_prob1]
                                                                     wl3 in
                                                                   solve env
-                                                                    uu____13493))))
-                                                      | uu____13494 ->
-                                                          let uu____13509 =
+                                                                    uu____13491))))
+                                                      | uu____13492 ->
+                                                          let uu____13507 =
                                                             FStar_Thunk.map
                                                               (fun s ->
                                                                  Prims.op_Hat
                                                                    "failed to solve the sub-problems: "
                                                                    s) msg in
                                                           giveup env
-                                                            uu____13509 p)))))))
-                           | uu____13512 when flip ->
-                               let uu____13513 =
-                                 let uu____13514 =
+                                                            uu____13507 p)))))))
+                           | uu____13510 when flip ->
+                               let uu____13511 =
+                                 let uu____13512 =
                                    FStar_Util.string_of_int
                                      (rank_t_num rank1) in
-                                 let uu____13515 =
+                                 let uu____13513 =
                                    prob_to_string env
                                      (FStar_TypeChecker_Common.TProb tp) in
                                  FStar_Util.format2
                                    "Impossible: (rank=%s) Not a flex-rigid: %s"
-                                   uu____13514 uu____13515 in
-                               failwith uu____13513
-                           | uu____13516 ->
-                               let uu____13517 =
-                                 let uu____13518 =
+                                   uu____13512 uu____13513 in
+                               failwith uu____13511
+                           | uu____13514 ->
+                               let uu____13515 =
+                                 let uu____13516 =
                                    FStar_Util.string_of_int
                                      (rank_t_num rank1) in
-                                 let uu____13519 =
+                                 let uu____13517 =
                                    prob_to_string env
                                      (FStar_TypeChecker_Common.TProb tp) in
                                  FStar_Util.format2
                                    "Impossible: (rank=%s) Not a rigid-flex: %s"
-                                   uu____13518 uu____13519 in
-                               failwith uu____13517)))))
+                                   uu____13516 uu____13517 in
+                               failwith uu____13515)))))
 and (imitate_arrow :
   FStar_TypeChecker_Common.prob ->
     FStar_TypeChecker_Env.env ->
@@ -4734,37 +4734,37 @@ and (imitate_arrow :
                 fun arrow ->
                   let bs_lhs_args =
                     FStar_List.map
-                      (fun uu____13553 ->
-                         match uu____13553 with
+                      (fun uu____13551 ->
+                         match uu____13551 with
                          | (x, i) ->
-                             let uu____13572 =
+                             let uu____13570 =
                                FStar_Syntax_Syntax.bv_to_name x in
-                             (uu____13572, i)) bs_lhs in
-                  let uu____13575 = lhs in
-                  match uu____13575 with
-                  | Flex (uu____13576, u_lhs, uu____13578) ->
+                             (uu____13570, i)) bs_lhs in
+                  let uu____13573 = lhs in
+                  match uu____13573 with
+                  | Flex (uu____13574, u_lhs, uu____13576) ->
                       let imitate_comp bs bs_terms c wl1 =
                         let imitate_tot_or_gtot t uopt f wl2 =
-                          let uu____13675 =
+                          let uu____13673 =
                             match uopt with
                             | FStar_Pervasives_Native.None ->
                                 FStar_Syntax_Util.type_u ()
                             | FStar_Pervasives_Native.Some univ ->
-                                let uu____13685 =
+                                let uu____13683 =
                                   FStar_Syntax_Syntax.mk
                                     (FStar_Syntax_Syntax.Tm_type univ)
                                     t.FStar_Syntax_Syntax.pos in
-                                (uu____13685, univ) in
-                          match uu____13675 with
+                                (uu____13683, univ) in
+                          match uu____13673 with
                           | (k, univ) ->
-                              let uu____13692 =
+                              let uu____13690 =
                                 copy_uvar u_lhs (FStar_List.append bs_lhs bs)
                                   k wl2 in
-                              (match uu____13692 with
-                               | (uu____13709, u, wl3) ->
-                                   let uu____13712 =
+                              (match uu____13690 with
+                               | (uu____13707, u, wl3) ->
+                                   let uu____13710 =
                                      f u (FStar_Pervasives_Native.Some univ) in
-                                   (uu____13712, wl3)) in
+                                   (uu____13710, wl3)) in
                         match c.FStar_Syntax_Syntax.n with
                         | FStar_Syntax_Syntax.Total (t, uopt) ->
                             imitate_tot_or_gtot t uopt
@@ -4773,152 +4773,152 @@ and (imitate_arrow :
                             imitate_tot_or_gtot t uopt
                               FStar_Syntax_Syntax.mk_GTotal' wl1
                         | FStar_Syntax_Syntax.Comp ct ->
-                            let uu____13738 =
-                              let uu____13751 =
-                                let uu____13762 =
+                            let uu____13736 =
+                              let uu____13749 =
+                                let uu____13760 =
                                   FStar_Syntax_Syntax.as_arg
                                     ct.FStar_Syntax_Syntax.result_typ in
-                                uu____13762 ::
+                                uu____13760 ::
                                   (ct.FStar_Syntax_Syntax.effect_args) in
                               FStar_List.fold_right
-                                (fun uu____13813 ->
-                                   fun uu____13814 ->
-                                     match (uu____13813, uu____13814) with
+                                (fun uu____13811 ->
+                                   fun uu____13812 ->
+                                     match (uu____13811, uu____13812) with
                                      | ((a, i), (out_args, wl2)) ->
-                                         let uu____13915 =
-                                           let uu____13922 =
-                                             let uu____13925 =
+                                         let uu____13913 =
+                                           let uu____13920 =
+                                             let uu____13923 =
                                                FStar_Syntax_Util.type_u () in
                                              FStar_All.pipe_left
                                                FStar_Pervasives_Native.fst
-                                               uu____13925 in
-                                           copy_uvar u_lhs [] uu____13922 wl2 in
-                                         (match uu____13915 with
-                                          | (uu____13954, t_a, wl3) ->
-                                              let uu____13957 =
+                                               uu____13923 in
+                                           copy_uvar u_lhs [] uu____13920 wl2 in
+                                         (match uu____13913 with
+                                          | (uu____13952, t_a, wl3) ->
+                                              let uu____13955 =
                                                 copy_uvar u_lhs bs t_a wl3 in
-                                              (match uu____13957 with
-                                               | (uu____13976, a', wl4) ->
+                                              (match uu____13955 with
+                                               | (uu____13974, a', wl4) ->
                                                    (((a', i) :: out_args),
-                                                     wl4)))) uu____13751
+                                                     wl4)))) uu____13749
                                 ([], wl1) in
-                            (match uu____13738 with
+                            (match uu____13736 with
                              | (out_args, wl2) ->
                                  let nodec flags =
                                    FStar_List.filter
-                                     (fun uu___25_14045 ->
-                                        match uu___25_14045 with
+                                     (fun uu___25_14043 ->
+                                        match uu___25_14043 with
                                         | FStar_Syntax_Syntax.DECREASES
-                                            uu____14046 -> false
-                                        | uu____14049 -> true) flags in
+                                            uu____14044 -> false
+                                        | uu____14047 -> true) flags in
                                  let ct' =
-                                   let uu___2242_14051 = ct in
-                                   let uu____14052 =
-                                     let uu____14055 = FStar_List.hd out_args in
-                                     FStar_Pervasives_Native.fst uu____14055 in
-                                   let uu____14070 = FStar_List.tl out_args in
-                                   let uu____14087 =
+                                   let uu___2242_14049 = ct in
+                                   let uu____14050 =
+                                     let uu____14053 = FStar_List.hd out_args in
+                                     FStar_Pervasives_Native.fst uu____14053 in
+                                   let uu____14068 = FStar_List.tl out_args in
+                                   let uu____14085 =
                                      nodec ct.FStar_Syntax_Syntax.flags in
                                    {
                                      FStar_Syntax_Syntax.comp_univs =
-                                       (uu___2242_14051.FStar_Syntax_Syntax.comp_univs);
+                                       (uu___2242_14049.FStar_Syntax_Syntax.comp_univs);
                                      FStar_Syntax_Syntax.effect_name =
-                                       (uu___2242_14051.FStar_Syntax_Syntax.effect_name);
+                                       (uu___2242_14049.FStar_Syntax_Syntax.effect_name);
                                      FStar_Syntax_Syntax.result_typ =
-                                       uu____14052;
+                                       uu____14050;
                                      FStar_Syntax_Syntax.effect_args =
-                                       uu____14070;
-                                     FStar_Syntax_Syntax.flags = uu____14087
+                                       uu____14068;
+                                     FStar_Syntax_Syntax.flags = uu____14085
                                    } in
-                                 ((let uu___2245_14091 = c in
+                                 ((let uu___2245_14089 = c in
                                    {
                                      FStar_Syntax_Syntax.n =
                                        (FStar_Syntax_Syntax.Comp ct');
                                      FStar_Syntax_Syntax.pos =
-                                       (uu___2245_14091.FStar_Syntax_Syntax.pos);
+                                       (uu___2245_14089.FStar_Syntax_Syntax.pos);
                                      FStar_Syntax_Syntax.vars =
-                                       (uu___2245_14091.FStar_Syntax_Syntax.vars)
+                                       (uu___2245_14089.FStar_Syntax_Syntax.vars)
                                    }), wl2)) in
-                      let uu____14094 =
+                      let uu____14092 =
                         FStar_Syntax_Util.arrow_formals_comp arrow in
-                      (match uu____14094 with
+                      (match uu____14092 with
                        | (formals, c) ->
                            let rec aux bs bs_terms formals1 wl1 =
                              match formals1 with
                              | [] ->
-                                 let uu____14132 =
+                                 let uu____14130 =
                                    imitate_comp bs bs_terms c wl1 in
-                                 (match uu____14132 with
+                                 (match uu____14130 with
                                   | (c', wl2) ->
                                       let lhs' =
                                         FStar_Syntax_Util.arrow bs c' in
                                       let sol =
-                                        let uu____14143 =
-                                          let uu____14148 =
+                                        let uu____14141 =
+                                          let uu____14146 =
                                             FStar_Syntax_Util.abs bs_lhs lhs'
                                               (FStar_Pervasives_Native.Some
                                                  (FStar_Syntax_Util.residual_tot
                                                     t_res_lhs)) in
-                                          (u_lhs, uu____14148) in
-                                        TERM uu____14143 in
-                                      let uu____14149 =
+                                          (u_lhs, uu____14146) in
+                                        TERM uu____14141 in
+                                      let uu____14147 =
                                         mk_t_problem wl2 [] orig lhs' rel
                                           arrow FStar_Pervasives_Native.None
                                           "arrow imitation" in
-                                      (match uu____14149 with
+                                      (match uu____14147 with
                                        | (sub_prob, wl3) ->
-                                           let uu____14162 =
-                                             let uu____14163 =
+                                           let uu____14160 =
+                                             let uu____14161 =
                                                solve_prob orig
                                                  FStar_Pervasives_Native.None
                                                  [sol] wl3 in
-                                             attempt [sub_prob] uu____14163 in
-                                           solve env uu____14162))
+                                             attempt [sub_prob] uu____14161 in
+                                           solve env uu____14160))
                              | (x, imp)::formals2 ->
-                                 let uu____14185 =
-                                   let uu____14192 =
-                                     let uu____14195 =
+                                 let uu____14183 =
+                                   let uu____14190 =
+                                     let uu____14193 =
                                        FStar_Syntax_Util.type_u () in
-                                     FStar_All.pipe_right uu____14195
+                                     FStar_All.pipe_right uu____14193
                                        FStar_Pervasives_Native.fst in
                                    copy_uvar u_lhs
                                      (FStar_List.append bs_lhs bs)
-                                     uu____14192 wl1 in
-                                 (match uu____14185 with
+                                     uu____14190 wl1 in
+                                 (match uu____14183 with
                                   | (_ctx_u_x, u_x, wl2) ->
                                       let y =
-                                        let uu____14216 =
-                                          let uu____14219 =
+                                        let uu____14214 =
+                                          let uu____14217 =
                                             FStar_Syntax_Syntax.range_of_bv x in
                                           FStar_Pervasives_Native.Some
-                                            uu____14219 in
+                                            uu____14217 in
                                         FStar_Syntax_Syntax.new_bv
-                                          uu____14216 u_x in
-                                      let uu____14220 =
-                                        let uu____14223 =
-                                          let uu____14226 =
-                                            let uu____14227 =
+                                          uu____14214 u_x in
+                                      let uu____14218 =
+                                        let uu____14221 =
+                                          let uu____14224 =
+                                            let uu____14225 =
                                               FStar_Syntax_Syntax.bv_to_name
                                                 y in
-                                            (uu____14227, imp) in
-                                          [uu____14226] in
+                                            (uu____14225, imp) in
+                                          [uu____14224] in
                                         FStar_List.append bs_terms
-                                          uu____14223 in
+                                          uu____14221 in
                                       aux (FStar_List.append bs [(y, imp)])
-                                        uu____14220 formals2 wl2) in
-                           let uu____14254 = occurs_check u_lhs arrow in
-                           (match uu____14254 with
-                            | (uu____14265, occurs_ok, msg) ->
+                                        uu____14218 formals2 wl2) in
+                           let uu____14252 = occurs_check u_lhs arrow in
+                           (match uu____14252 with
+                            | (uu____14263, occurs_ok, msg) ->
                                 if Prims.op_Negation occurs_ok
                                 then
-                                  let uu____14276 =
+                                  let uu____14274 =
                                     mklstr
-                                      (fun uu____14281 ->
-                                         let uu____14282 =
+                                      (fun uu____14279 ->
+                                         let uu____14280 =
                                            FStar_Option.get msg in
                                          Prims.op_Hat "occurs-check failed: "
-                                           uu____14282) in
-                                  giveup_or_defer env orig wl uu____14276
+                                           uu____14280) in
+                                  giveup_or_defer env orig wl uu____14274
                                 else aux [] [] formals wl))
 and (solve_binders :
   FStar_TypeChecker_Env.env ->
@@ -4939,122 +4939,122 @@ and (solve_binders :
         fun orig ->
           fun wl ->
             fun rhs ->
-              (let uu____14311 =
+              (let uu____14309 =
                  FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
                    (FStar_Options.Other "Rel") in
-               if uu____14311
+               if uu____14309
                then
-                 let uu____14312 =
+                 let uu____14310 =
                    FStar_Syntax_Print.binders_to_string ", " bs1 in
-                 let uu____14313 =
+                 let uu____14311 =
                    FStar_Syntax_Print.binders_to_string ", " bs2 in
                  FStar_Util.print3 "solve_binders\n\t%s\n%s\n\t%s\n"
-                   uu____14312 (rel_to_string (p_rel orig)) uu____14313
+                   uu____14310 (rel_to_string (p_rel orig)) uu____14311
                else ());
               (let rec aux wl1 scope env1 subst xs ys =
                  match (xs, ys) with
                  | ([], []) ->
-                     let uu____14438 = rhs wl1 scope env1 subst in
-                     (match uu____14438 with
+                     let uu____14436 = rhs wl1 scope env1 subst in
+                     (match uu____14436 with
                       | (rhs_prob, wl2) ->
-                          ((let uu____14460 =
+                          ((let uu____14458 =
                               FStar_All.pipe_left
                                 (FStar_TypeChecker_Env.debug env1)
                                 (FStar_Options.Other "Rel") in
-                            if uu____14460
+                            if uu____14458
                             then
-                              let uu____14461 = prob_to_string env1 rhs_prob in
-                              FStar_Util.print1 "rhs_prob = %s\n" uu____14461
+                              let uu____14459 = prob_to_string env1 rhs_prob in
+                              FStar_Util.print1 "rhs_prob = %s\n" uu____14459
                             else ());
                            (let formula = p_guard rhs_prob in
                             (env1, (FStar_Util.Inl ([rhs_prob], formula)),
                               wl2))))
                  | ((hd1, imp)::xs1, (hd2, imp')::ys1) when
-                     let uu____14534 = FStar_Syntax_Util.eq_aqual imp imp' in
-                     uu____14534 = FStar_Syntax_Util.Equal ->
+                     let uu____14532 = FStar_Syntax_Util.eq_aqual imp imp' in
+                     uu____14532 = FStar_Syntax_Util.Equal ->
                      let hd11 =
-                       let uu___2315_14536 = hd1 in
-                       let uu____14537 =
+                       let uu___2315_14534 = hd1 in
+                       let uu____14535 =
                          FStar_Syntax_Subst.subst subst
                            hd1.FStar_Syntax_Syntax.sort in
                        {
                          FStar_Syntax_Syntax.ppname =
-                           (uu___2315_14536.FStar_Syntax_Syntax.ppname);
+                           (uu___2315_14534.FStar_Syntax_Syntax.ppname);
                          FStar_Syntax_Syntax.index =
-                           (uu___2315_14536.FStar_Syntax_Syntax.index);
-                         FStar_Syntax_Syntax.sort = uu____14537
+                           (uu___2315_14534.FStar_Syntax_Syntax.index);
+                         FStar_Syntax_Syntax.sort = uu____14535
                        } in
                      let hd21 =
-                       let uu___2318_14541 = hd2 in
-                       let uu____14542 =
+                       let uu___2318_14539 = hd2 in
+                       let uu____14540 =
                          FStar_Syntax_Subst.subst subst
                            hd2.FStar_Syntax_Syntax.sort in
                        {
                          FStar_Syntax_Syntax.ppname =
-                           (uu___2318_14541.FStar_Syntax_Syntax.ppname);
+                           (uu___2318_14539.FStar_Syntax_Syntax.ppname);
                          FStar_Syntax_Syntax.index =
-                           (uu___2318_14541.FStar_Syntax_Syntax.index);
-                         FStar_Syntax_Syntax.sort = uu____14542
+                           (uu___2318_14539.FStar_Syntax_Syntax.index);
+                         FStar_Syntax_Syntax.sort = uu____14540
                        } in
-                     let uu____14545 =
-                       let uu____14550 =
+                     let uu____14543 =
+                       let uu____14548 =
                          FStar_All.pipe_left invert_rel (p_rel orig) in
                        mk_t_problem wl1 scope orig
-                         hd11.FStar_Syntax_Syntax.sort uu____14550
+                         hd11.FStar_Syntax_Syntax.sort uu____14548
                          hd21.FStar_Syntax_Syntax.sort
                          FStar_Pervasives_Native.None "Formal parameter" in
-                     (match uu____14545 with
+                     (match uu____14543 with
                       | (prob, wl2) ->
                           let hd12 = FStar_Syntax_Syntax.freshen_bv hd11 in
                           let subst1 =
-                            let uu____14571 =
+                            let uu____14569 =
                               FStar_Syntax_Subst.shift_subst Prims.int_one
                                 subst in
                             (FStar_Syntax_Syntax.DB (Prims.int_zero, hd12))
-                              :: uu____14571 in
+                              :: uu____14569 in
                           let env2 = FStar_TypeChecker_Env.push_bv env1 hd12 in
-                          let uu____14575 =
+                          let uu____14573 =
                             aux wl2 (FStar_List.append scope [(hd12, imp)])
                               env2 subst1 xs1 ys1 in
-                          (match uu____14575 with
+                          (match uu____14573 with
                            | (env3, FStar_Util.Inl (sub_probs, phi), wl3) ->
                                let phi1 =
-                                 let uu____14643 =
+                                 let uu____14641 =
                                    FStar_TypeChecker_Env.close_forall env3
                                      [(hd12, imp)] phi in
                                  FStar_Syntax_Util.mk_conj (p_guard prob)
-                                   uu____14643 in
-                               ((let uu____14661 =
+                                   uu____14641 in
+                               ((let uu____14659 =
                                    FStar_All.pipe_left
                                      (FStar_TypeChecker_Env.debug env3)
                                      (FStar_Options.Other "Rel") in
-                                 if uu____14661
+                                 if uu____14659
                                  then
-                                   let uu____14662 =
+                                   let uu____14660 =
                                      FStar_Syntax_Print.term_to_string phi1 in
-                                   let uu____14663 =
+                                   let uu____14661 =
                                      FStar_Syntax_Print.bv_to_string hd12 in
                                    FStar_Util.print2
-                                     "Formula is %s\n\thd1=%s\n" uu____14662
-                                     uu____14663
+                                     "Formula is %s\n\thd1=%s\n" uu____14660
+                                     uu____14661
                                  else ());
                                 (env3,
                                   (FStar_Util.Inl ((prob :: sub_probs), phi1)),
                                   wl3))
                            | fail -> fail))
-                 | uu____14692 ->
+                 | uu____14690 ->
                      (env1,
                        (FStar_Util.Inr "arity or argument-qualifier mismatch"),
                        wl1) in
-               let uu____14725 = aux wl [] env [] bs1 bs2 in
-               match uu____14725 with
+               let uu____14723 = aux wl [] env [] bs1 bs2 in
+               match uu____14723 with
                | (env1, FStar_Util.Inr msg, wl1) -> giveup_lit env1 msg orig
                | (env1, FStar_Util.Inl (sub_probs, phi), wl1) ->
                    let wl2 =
                      solve_prob orig (FStar_Pervasives_Native.Some phi) []
                        wl1 in
-                   let uu____14778 = attempt sub_probs wl2 in
-                   solve env1 uu____14778)
+                   let uu____14776 = attempt sub_probs wl2 in
+                   solve env1 uu____14776)
 and (try_solve_without_smt_or_else :
   FStar_TypeChecker_Env.env ->
     worklist ->
@@ -5068,23 +5068,23 @@ and (try_solve_without_smt_or_else :
       fun try_solve ->
         fun else_solve ->
           let wl' =
-            let uu___2356_14798 = wl in
+            let uu___2356_14796 = wl in
             {
               attempting = [];
               wl_deferred = [];
-              wl_deferred_to_tac = (uu___2356_14798.wl_deferred_to_tac);
-              ctr = (uu___2356_14798.ctr);
+              wl_deferred_to_tac = (uu___2356_14796.wl_deferred_to_tac);
+              ctr = (uu___2356_14796.ctr);
               defer_ok = false;
               smt_ok = false;
               umax_heuristic_ok = false;
-              tcenv = (uu___2356_14798.tcenv);
+              tcenv = (uu___2356_14796.tcenv);
               wl_implicits = [];
-              repr_subcomp_allowed = (uu___2356_14798.repr_subcomp_allowed)
+              repr_subcomp_allowed = (uu___2356_14796.repr_subcomp_allowed)
             } in
           let tx = FStar_Syntax_Unionfind.new_transaction () in
-          let uu____14806 = try_solve env wl' in
-          match uu____14806 with
-          | Success (uu____14807, defer_to_tac, imps) ->
+          let uu____14804 = try_solve env wl' in
+          match uu____14804 with
+          | Success (uu____14805, defer_to_tac, imps) ->
               (FStar_Syntax_Unionfind.commit tx;
                (let wl1 = extend_wl wl defer_to_tac imps in solve env wl1))
           | Failed (p, s) ->
@@ -5094,8 +5094,8 @@ and (solve_t : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
     fun problem ->
       fun wl ->
         def_check_prob "solve_t" (FStar_TypeChecker_Common.TProb problem);
-        (let uu____14819 = compress_tprob wl.tcenv problem in
-         solve_t' env uu____14819 wl)
+        (let uu____14817 = compress_tprob wl.tcenv problem in
+         solve_t' env uu____14817 wl)
 and (solve_t_flex_rigid_eq :
   FStar_TypeChecker_Env.env ->
     FStar_TypeChecker_Common.prob ->
@@ -5106,60 +5106,60 @@ and (solve_t_flex_rigid_eq :
       fun wl ->
         fun lhs ->
           fun rhs ->
-            (let uu____14826 =
+            (let uu____14824 =
                FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
                  (FStar_Options.Other "Rel") in
-             if uu____14826
+             if uu____14824
              then FStar_Util.print_string "solve_t_flex_rigid_eq\n"
              else ());
-            (let uu____14828 = should_defer_flex_to_user_tac env wl lhs in
-             if uu____14828
+            (let uu____14826 = should_defer_flex_to_user_tac env wl lhs in
+             if uu____14826
              then defer_to_user_tac env orig (flex_reason lhs) wl
              else
                (let binders_as_bv_set bs =
-                  let uu____14838 =
+                  let uu____14836 =
                     FStar_List.map FStar_Pervasives_Native.fst bs in
-                  FStar_Util.as_set uu____14838 FStar_Syntax_Syntax.order_bv in
+                  FStar_Util.as_set uu____14836 FStar_Syntax_Syntax.order_bv in
                 let mk_solution env1 lhs1 bs rhs1 =
-                  let uu____14872 = lhs1 in
-                  match uu____14872 with
-                  | Flex (uu____14875, ctx_u, uu____14877) ->
+                  let uu____14870 = lhs1 in
+                  match uu____14870 with
+                  | Flex (uu____14873, ctx_u, uu____14875) ->
                       let sol =
                         match bs with
                         | [] -> rhs1
-                        | uu____14885 ->
-                            let uu____14886 = sn_binders env1 bs in
+                        | uu____14883 ->
+                            let uu____14884 = sn_binders env1 bs in
                             u_abs ctx_u.FStar_Syntax_Syntax.ctx_uvar_typ
-                              uu____14886 rhs1 in
+                              uu____14884 rhs1 in
                       [TERM (ctx_u, sol)] in
                 let try_quasi_pattern orig1 env1 wl1 lhs1 rhs1 =
-                  (let uu____14934 =
+                  (let uu____14932 =
                      FStar_All.pipe_left (FStar_TypeChecker_Env.debug env1)
                        (FStar_Options.Other "Rel") in
-                   if uu____14934
+                   if uu____14932
                    then FStar_Util.print_string "try_quasi_pattern\n"
                    else ());
-                  (let uu____14936 = quasi_pattern env1 lhs1 in
-                   match uu____14936 with
+                  (let uu____14934 = quasi_pattern env1 lhs1 in
+                   match uu____14934 with
                    | FStar_Pervasives_Native.None ->
                        ((FStar_Util.Inl "Not a quasi-pattern"), wl1)
-                   | FStar_Pervasives_Native.Some (bs, uu____14966) ->
-                       let uu____14971 = lhs1 in
-                       (match uu____14971 with
+                   | FStar_Pervasives_Native.Some (bs, uu____14964) ->
+                       let uu____14969 = lhs1 in
+                       (match uu____14969 with
                         | Flex (t_lhs, ctx_u, args) ->
-                            let uu____14985 = occurs_check ctx_u rhs1 in
-                            (match uu____14985 with
+                            let uu____14983 = occurs_check ctx_u rhs1 in
+                            (match uu____14983 with
                              | (uvars, occurs_ok, msg) ->
                                  if Prims.op_Negation occurs_ok
                                  then
-                                   let uu____15027 =
-                                     let uu____15034 =
-                                       let uu____15035 = FStar_Option.get msg in
+                                   let uu____15025 =
+                                     let uu____15032 =
+                                       let uu____15033 = FStar_Option.get msg in
                                        Prims.op_Hat
                                          "quasi-pattern, occurs-check failed: "
-                                         uu____15035 in
-                                     FStar_Util.Inl uu____15034 in
-                                   (uu____15027, wl1)
+                                         uu____15033 in
+                                     FStar_Util.Inl uu____15032 in
+                                   (uu____15025, wl1)
                                  else
                                    (let fvs_lhs =
                                       binders_as_bv_set
@@ -5168,115 +5168,115 @@ and (solve_t_flex_rigid_eq :
                                            bs) in
                                     let fvs_rhs =
                                       FStar_Syntax_Free.names rhs1 in
-                                    let uu____15057 =
-                                      let uu____15058 =
+                                    let uu____15055 =
+                                      let uu____15056 =
                                         FStar_Util.set_is_subset_of fvs_rhs
                                           fvs_lhs in
-                                      Prims.op_Negation uu____15058 in
-                                    if uu____15057
+                                      Prims.op_Negation uu____15056 in
+                                    if uu____15055
                                     then
                                       ((FStar_Util.Inl
                                           "quasi-pattern, free names on the RHS are not included in the LHS"),
                                         wl1)
                                     else
-                                      (let uu____15078 =
-                                         let uu____15085 =
+                                      (let uu____15076 =
+                                         let uu____15083 =
                                            mk_solution env1 lhs1 bs rhs1 in
-                                         FStar_Util.Inr uu____15085 in
-                                       let uu____15090 =
+                                         FStar_Util.Inr uu____15083 in
+                                       let uu____15088 =
                                          restrict_all_uvars env1 ctx_u []
                                            uvars wl1 in
-                                       (uu____15078, uu____15090)))))) in
+                                       (uu____15076, uu____15088)))))) in
                 let imitate_app orig1 env1 wl1 lhs1 bs_lhs t_res_lhs rhs1 =
-                  let uu____15139 = FStar_Syntax_Util.head_and_args rhs1 in
-                  match uu____15139 with
+                  let uu____15137 = FStar_Syntax_Util.head_and_args rhs1 in
+                  match uu____15137 with
                   | (rhs_hd, args) ->
-                      let uu____15182 = FStar_Util.prefix args in
-                      (match uu____15182 with
+                      let uu____15180 = FStar_Util.prefix args in
+                      (match uu____15180 with
                        | (args_rhs, last_arg_rhs) ->
                            let rhs' =
                              FStar_Syntax_Syntax.mk_Tm_app rhs_hd args_rhs
                                rhs1.FStar_Syntax_Syntax.pos in
-                           let uu____15252 = lhs1 in
-                           (match uu____15252 with
+                           let uu____15250 = lhs1 in
+                           (match uu____15250 with
                             | Flex (t_lhs, u_lhs, _lhs_args) ->
-                                let uu____15256 =
-                                  let uu____15267 =
-                                    let uu____15274 =
-                                      let uu____15277 =
+                                let uu____15254 =
+                                  let uu____15265 =
+                                    let uu____15272 =
+                                      let uu____15275 =
                                         FStar_Syntax_Util.type_u () in
                                       FStar_All.pipe_left
                                         FStar_Pervasives_Native.fst
-                                        uu____15277 in
-                                    copy_uvar u_lhs [] uu____15274 wl1 in
-                                  match uu____15267 with
-                                  | (uu____15304, t_last_arg, wl2) ->
-                                      let uu____15307 =
+                                        uu____15275 in
+                                    copy_uvar u_lhs [] uu____15272 wl1 in
+                                  match uu____15265 with
+                                  | (uu____15302, t_last_arg, wl2) ->
+                                      let uu____15305 =
                                         let b =
                                           FStar_Syntax_Syntax.null_binder
                                             t_last_arg in
-                                        let uu____15315 =
-                                          let uu____15318 =
-                                            let uu____15321 =
-                                              let uu____15324 =
+                                        let uu____15313 =
+                                          let uu____15316 =
+                                            let uu____15319 =
+                                              let uu____15322 =
                                                 FStar_All.pipe_right
                                                   t_res_lhs
                                                   (env1.FStar_TypeChecker_Env.universe_of
                                                      env1) in
                                               FStar_All.pipe_right
-                                                uu____15324
-                                                (fun uu____15327 ->
+                                                uu____15322
+                                                (fun uu____15325 ->
                                                    FStar_Pervasives_Native.Some
-                                                     uu____15327) in
-                                            FStar_All.pipe_right uu____15321
+                                                     uu____15325) in
+                                            FStar_All.pipe_right uu____15319
                                               (FStar_Syntax_Syntax.mk_Total'
                                                  t_res_lhs) in
-                                          FStar_All.pipe_right uu____15318
+                                          FStar_All.pipe_right uu____15316
                                             (FStar_Syntax_Util.arrow [b]) in
                                         copy_uvar u_lhs
                                           (FStar_List.append bs_lhs [b])
-                                          uu____15315 wl2 in
-                                      (match uu____15307 with
-                                       | (uu____15376, lhs', wl3) ->
-                                           let uu____15379 =
+                                          uu____15313 wl2 in
+                                      (match uu____15305 with
+                                       | (uu____15374, lhs', wl3) ->
+                                           let uu____15377 =
                                              copy_uvar u_lhs bs_lhs
                                                t_last_arg wl3 in
-                                           (match uu____15379 with
-                                            | (uu____15396, lhs'_last_arg,
+                                           (match uu____15377 with
+                                            | (uu____15394, lhs'_last_arg,
                                                wl4) ->
                                                 (lhs', lhs'_last_arg, wl4))) in
-                                (match uu____15256 with
+                                (match uu____15254 with
                                  | (lhs', lhs'_last_arg, wl2) ->
                                      let sol =
-                                       let uu____15417 =
-                                         let uu____15418 =
-                                           let uu____15423 =
-                                             let uu____15424 =
-                                               let uu____15427 =
-                                                 let uu____15428 =
+                                       let uu____15415 =
+                                         let uu____15416 =
+                                           let uu____15421 =
+                                             let uu____15422 =
+                                               let uu____15425 =
+                                                 let uu____15426 =
                                                    FStar_Syntax_Syntax.as_arg
                                                      lhs'_last_arg in
-                                                 [uu____15428] in
+                                                 [uu____15426] in
                                                FStar_Syntax_Syntax.mk_Tm_app
-                                                 lhs' uu____15427
+                                                 lhs' uu____15425
                                                  t_lhs.FStar_Syntax_Syntax.pos in
                                              FStar_Syntax_Util.abs bs_lhs
-                                               uu____15424
+                                               uu____15422
                                                (FStar_Pervasives_Native.Some
                                                   (FStar_Syntax_Util.residual_tot
                                                      t_res_lhs)) in
-                                           (u_lhs, uu____15423) in
-                                         TERM uu____15418 in
-                                       [uu____15417] in
-                                     let uu____15453 =
-                                       let uu____15460 =
+                                           (u_lhs, uu____15421) in
+                                         TERM uu____15416 in
+                                       [uu____15415] in
+                                     let uu____15451 =
+                                       let uu____15458 =
                                          mk_t_problem wl2 [] orig1 lhs'
                                            FStar_TypeChecker_Common.EQ rhs'
                                            FStar_Pervasives_Native.None
                                            "first-order lhs" in
-                                       match uu____15460 with
+                                       match uu____15458 with
                                        | (p1, wl3) ->
-                                           let uu____15479 =
+                                           let uu____15477 =
                                              mk_t_problem wl3 [] orig1
                                                lhs'_last_arg
                                                FStar_TypeChecker_Common.EQ
@@ -5284,71 +5284,80 @@ and (solve_t_flex_rigid_eq :
                                                   last_arg_rhs)
                                                FStar_Pervasives_Native.None
                                                "first-order rhs" in
-                                           (match uu____15479 with
+                                           (match uu____15477 with
                                             | (p2, wl4) -> ([p1; p2], wl4)) in
-                                     (match uu____15453 with
+                                     (match uu____15451 with
                                       | (sub_probs, wl3) ->
-                                          let uu____15510 =
-                                            let uu____15511 =
+                                          let uu____15508 =
+                                            let uu____15509 =
                                               solve_prob orig1
                                                 FStar_Pervasives_Native.None
                                                 sol wl3 in
-                                            attempt sub_probs uu____15511 in
-                                          solve env1 uu____15510)))) in
+                                            attempt sub_probs uu____15509 in
+                                          solve env1 uu____15508)))) in
                 let first_order orig1 env1 wl1 lhs1 rhs1 =
-                  (let uu____15539 =
+                  (let uu____15537 =
                      FStar_All.pipe_left (FStar_TypeChecker_Env.debug env1)
                        (FStar_Options.Other "Rel") in
-                   if uu____15539
+                   if uu____15537
                    then FStar_Util.print_string "first_order\n"
                    else ());
                   (let is_app rhs2 =
-                     let uu____15547 = FStar_Syntax_Util.head_and_args rhs2 in
-                     match uu____15547 with
-                     | (uu____15564, args) ->
-                         (match args with | [] -> false | uu____15598 -> true) in
+                     let uu____15545 = FStar_Syntax_Util.head_and_args rhs2 in
+                     match uu____15545 with
+                     | (uu____15562, args) ->
+                         (match args with | [] -> false | uu____15596 -> true) in
                    let is_arrow rhs2 =
-                     let uu____15615 =
-                       let uu____15616 = FStar_Syntax_Subst.compress rhs2 in
-                       uu____15616.FStar_Syntax_Syntax.n in
-                     match uu____15615 with
-                     | FStar_Syntax_Syntax.Tm_arrow uu____15619 -> true
-                     | uu____15634 -> false in
-                   let uu____15635 = quasi_pattern env1 lhs1 in
-                   match uu____15635 with
+                     let uu____15613 =
+                       let uu____15614 = FStar_Syntax_Subst.compress rhs2 in
+                       uu____15614.FStar_Syntax_Syntax.n in
+                     match uu____15613 with
+                     | FStar_Syntax_Syntax.Tm_arrow uu____15617 -> true
+                     | uu____15632 -> false in
+                   let uu____15633 = quasi_pattern env1 lhs1 in
+                   match uu____15633 with
                    | FStar_Pervasives_Native.None ->
                        let msg =
                          mklstr
-                           (fun uu____15653 ->
-                              let uu____15654 = prob_to_string env1 orig1 in
+                           (fun uu____15651 ->
+                              let uu____15652 = prob_to_string env1 orig1 in
                               FStar_Util.format1
                                 "first_order heuristic cannot solve %s; lhs not a quasi-pattern"
-                                uu____15654) in
+                                uu____15652) in
                        giveup_or_defer env1 orig1 wl1 msg
                    | FStar_Pervasives_Native.Some (bs_lhs, t_res_lhs) ->
-                       let uu____15661 = is_app rhs1 in
-                       if uu____15661
+                       let uu____15659 = is_app rhs1 in
+                       if uu____15659
                        then
                          imitate_app orig1 env1 wl1 lhs1 bs_lhs t_res_lhs
                            rhs1
                        else
-                         (let uu____15663 = is_arrow rhs1 in
-                          if uu____15663
+                         (let uu____15661 = is_arrow rhs1 in
+                          if uu____15661
                           then
                             imitate_arrow orig1 env1 wl1 lhs1 bs_lhs
                               t_res_lhs FStar_TypeChecker_Common.EQ rhs1
                           else
                             (let msg =
                                mklstr
-                                 (fun uu____15672 ->
-                                    let uu____15673 =
+                                 (fun uu____15670 ->
+                                    let uu____15671 =
                                       prob_to_string env1 orig1 in
                                     FStar_Util.format1
                                       "first_order heuristic cannot solve %s; rhs not an app or arrow"
-                                      uu____15673) in
+                                      uu____15671) in
                              giveup_or_defer env1 orig1 wl1 msg))) in
                 match p_rel orig with
                 | FStar_TypeChecker_Common.SUB ->
+                    if wl.defer_ok
+                    then
+                      let uu____15672 =
+                        FStar_Thunk.mkv "flex-rigid subtyping" in
+                      giveup_or_defer env orig wl uu____15672
+                    else
+                      solve_t_flex_rigid_eq env (make_prob_eq orig) wl lhs
+                        rhs
+                | FStar_TypeChecker_Common.SUBINV ->
                     if wl.defer_ok
                     then
                       let uu____15674 =
@@ -5357,42 +5366,33 @@ and (solve_t_flex_rigid_eq :
                     else
                       solve_t_flex_rigid_eq env (make_prob_eq orig) wl lhs
                         rhs
-                | FStar_TypeChecker_Common.SUBINV ->
-                    if wl.defer_ok
-                    then
-                      let uu____15676 =
-                        FStar_Thunk.mkv "flex-rigid subtyping" in
-                      giveup_or_defer env orig wl uu____15676
-                    else
-                      solve_t_flex_rigid_eq env (make_prob_eq orig) wl lhs
-                        rhs
                 | FStar_TypeChecker_Common.EQ ->
-                    let uu____15678 = lhs in
-                    (match uu____15678 with
+                    let uu____15676 = lhs in
+                    (match uu____15676 with
                      | Flex (_t1, ctx_uv, args_lhs) ->
-                         let uu____15682 =
+                         let uu____15680 =
                            pat_vars env
                              ctx_uv.FStar_Syntax_Syntax.ctx_uvar_binders
                              args_lhs in
-                         (match uu____15682 with
+                         (match uu____15680 with
                           | FStar_Pervasives_Native.Some lhs_binders ->
-                              ((let uu____15689 =
+                              ((let uu____15687 =
                                   FStar_All.pipe_left
                                     (FStar_TypeChecker_Env.debug env)
                                     (FStar_Options.Other "Rel") in
-                                if uu____15689
+                                if uu____15687
                                 then
                                   FStar_Util.print_string "it's a pattern\n"
                                 else ());
                                (let rhs1 = sn env rhs in
                                 let names_to_string1 fvs =
-                                  let uu____15702 =
-                                    let uu____15705 =
+                                  let uu____15700 =
+                                    let uu____15703 =
                                       FStar_Util.set_elements fvs in
                                     FStar_List.map
                                       FStar_Syntax_Print.bv_to_string
-                                      uu____15705 in
-                                  FStar_All.pipe_right uu____15702
+                                      uu____15703 in
+                                  FStar_All.pipe_right uu____15700
                                     (FStar_String.concat ", ") in
                                 let fvs1 =
                                   binders_as_bv_set
@@ -5400,26 +5400,26 @@ and (solve_t_flex_rigid_eq :
                                        ctx_uv.FStar_Syntax_Syntax.ctx_uvar_binders
                                        lhs_binders) in
                                 let fvs2 = FStar_Syntax_Free.names rhs1 in
-                                let uu____15722 = occurs_check ctx_uv rhs1 in
-                                match uu____15722 with
+                                let uu____15720 = occurs_check ctx_uv rhs1 in
+                                match uu____15720 with
                                 | (uvars, occurs_ok, msg) ->
                                     if Prims.op_Negation occurs_ok
                                     then
-                                      let uu____15744 =
-                                        let uu____15745 =
-                                          let uu____15746 =
+                                      let uu____15742 =
+                                        let uu____15743 =
+                                          let uu____15744 =
                                             FStar_Option.get msg in
                                           Prims.op_Hat
                                             "occurs-check failed: "
-                                            uu____15746 in
+                                            uu____15744 in
                                         FStar_All.pipe_left FStar_Thunk.mkv
-                                          uu____15745 in
-                                      giveup_or_defer env orig wl uu____15744
+                                          uu____15743 in
+                                      giveup_or_defer env orig wl uu____15742
                                     else
-                                      (let uu____15748 =
+                                      (let uu____15746 =
                                          FStar_Util.set_is_subset_of fvs2
                                            fvs1 in
-                                       if uu____15748
+                                       if uu____15746
                                        then
                                          let sol =
                                            mk_solution env lhs lhs_binders
@@ -5427,22 +5427,22 @@ and (solve_t_flex_rigid_eq :
                                          let wl1 =
                                            restrict_all_uvars env ctx_uv
                                              lhs_binders uvars wl in
-                                         let uu____15753 =
+                                         let uu____15751 =
                                            solve_prob orig
                                              FStar_Pervasives_Native.None sol
                                              wl1 in
-                                         solve env uu____15753
+                                         solve env uu____15751
                                        else
                                          if wl.defer_ok
                                          then
                                            (let msg1 =
                                               mklstr
-                                                (fun uu____15766 ->
-                                                   let uu____15767 =
+                                                (fun uu____15764 ->
+                                                   let uu____15765 =
                                                      names_to_string1 fvs2 in
-                                                   let uu____15768 =
+                                                   let uu____15766 =
                                                      names_to_string1 fvs1 in
-                                                   let uu____15769 =
+                                                   let uu____15767 =
                                                      FStar_Syntax_Print.binders_to_string
                                                        ", "
                                                        (FStar_List.append
@@ -5450,27 +5450,27 @@ and (solve_t_flex_rigid_eq :
                                                           lhs_binders) in
                                                    FStar_Util.format3
                                                      "free names in the RHS {%s} are out of scope for the LHS: {%s}, {%s}"
-                                                     uu____15767 uu____15768
-                                                     uu____15769) in
+                                                     uu____15765 uu____15766
+                                                     uu____15767) in
                                             giveup_or_defer env orig wl msg1)
                                          else
                                            first_order orig env wl lhs rhs1)))
-                          | uu____15777 ->
+                          | uu____15775 ->
                               if wl.defer_ok
                               then
-                                let uu____15780 =
+                                let uu____15778 =
                                   FStar_Thunk.mkv "Not a pattern" in
-                                giveup_or_defer env orig wl uu____15780
+                                giveup_or_defer env orig wl uu____15778
                               else
-                                (let uu____15782 =
+                                (let uu____15780 =
                                    try_quasi_pattern orig env wl lhs rhs in
-                                 match uu____15782 with
+                                 match uu____15780 with
                                  | (FStar_Util.Inr sol, wl1) ->
-                                     let uu____15805 =
+                                     let uu____15803 =
                                        solve_prob orig
                                          FStar_Pervasives_Native.None sol wl1 in
-                                     solve env uu____15805
-                                 | (FStar_Util.Inl msg, uu____15807) ->
+                                     solve env uu____15803
+                                 | (FStar_Util.Inl msg, uu____15805) ->
                                      first_order orig env wl lhs rhs)))))
 and (solve_t_flex_flex :
   FStar_TypeChecker_Env.env ->
@@ -5485,20 +5485,20 @@ and (solve_t_flex_flex :
             | FStar_TypeChecker_Common.SUB ->
                 if wl.defer_ok
                 then
-                  let uu____15821 = FStar_Thunk.mkv "flex-flex subtyping" in
-                  giveup_or_defer env orig wl uu____15821
+                  let uu____15819 = FStar_Thunk.mkv "flex-flex subtyping" in
+                  giveup_or_defer env orig wl uu____15819
                 else solve_t_flex_flex env (make_prob_eq orig) wl lhs rhs
             | FStar_TypeChecker_Common.SUBINV ->
                 if wl.defer_ok
                 then
-                  let uu____15823 = FStar_Thunk.mkv "flex-flex subtyping" in
-                  giveup_or_defer env orig wl uu____15823
+                  let uu____15821 = FStar_Thunk.mkv "flex-flex subtyping" in
+                  giveup_or_defer env orig wl uu____15821
                 else solve_t_flex_flex env (make_prob_eq orig) wl lhs rhs
             | FStar_TypeChecker_Common.EQ ->
-                let uu____15825 =
+                let uu____15823 =
                   (should_defer_flex_to_user_tac env wl lhs) ||
                     (should_defer_flex_to_user_tac env wl rhs) in
-                if uu____15825
+                if uu____15823
                 then
                   defer_to_user_tac env orig
                     (Prims.op_Hat (flex_reason lhs)
@@ -5509,48 +5509,48 @@ and (solve_t_flex_flex :
                       ((Prims.op_Negation (is_flex_pat lhs)) ||
                          (Prims.op_Negation (is_flex_pat rhs)))
                   then
-                    (let uu____15827 =
+                    (let uu____15825 =
                        FStar_Thunk.mkv "flex-flex non-pattern" in
-                     giveup_or_defer env orig wl uu____15827)
+                     giveup_or_defer env orig wl uu____15825)
                   else
-                    (let uu____15829 =
-                       let uu____15846 = quasi_pattern env lhs in
-                       let uu____15853 = quasi_pattern env rhs in
-                       (uu____15846, uu____15853) in
-                     match uu____15829 with
+                    (let uu____15827 =
+                       let uu____15844 = quasi_pattern env lhs in
+                       let uu____15851 = quasi_pattern env rhs in
+                       (uu____15844, uu____15851) in
+                     match uu____15827 with
                      | (FStar_Pervasives_Native.Some
                         (binders_lhs, t_res_lhs),
                         FStar_Pervasives_Native.Some
                         (binders_rhs, t_res_rhs)) ->
-                         let uu____15896 = lhs in
-                         (match uu____15896 with
+                         let uu____15894 = lhs in
+                         (match uu____15894 with
                           | Flex
-                              ({ FStar_Syntax_Syntax.n = uu____15897;
+                              ({ FStar_Syntax_Syntax.n = uu____15895;
                                  FStar_Syntax_Syntax.pos = range;
-                                 FStar_Syntax_Syntax.vars = uu____15899;_},
-                               u_lhs, uu____15901)
+                                 FStar_Syntax_Syntax.vars = uu____15897;_},
+                               u_lhs, uu____15899)
                               ->
-                              let uu____15904 = rhs in
-                              (match uu____15904 with
-                               | Flex (uu____15905, u_rhs, uu____15907) ->
-                                   let uu____15908 =
+                              let uu____15902 = rhs in
+                              (match uu____15902 with
+                               | Flex (uu____15903, u_rhs, uu____15905) ->
+                                   let uu____15906 =
                                      (FStar_Syntax_Unionfind.equiv
                                         u_lhs.FStar_Syntax_Syntax.ctx_uvar_head
                                         u_rhs.FStar_Syntax_Syntax.ctx_uvar_head)
                                        &&
                                        (binders_eq binders_lhs binders_rhs) in
-                                   if uu____15908
+                                   if uu____15906
                                    then
-                                     let uu____15913 =
+                                     let uu____15911 =
                                        solve_prob orig
                                          FStar_Pervasives_Native.None [] wl in
-                                     solve env uu____15913
+                                     solve env uu____15911
                                    else
-                                     (let uu____15915 =
+                                     (let uu____15913 =
                                         maximal_prefix
                                           u_lhs.FStar_Syntax_Syntax.ctx_uvar_binders
                                           u_rhs.FStar_Syntax_Syntax.ctx_uvar_binders in
-                                      match uu____15915 with
+                                      match uu____15913 with
                                       | (ctx_w, (ctx_l, ctx_r)) ->
                                           let gamma_w =
                                             gamma_until
@@ -5562,13 +5562,13 @@ and (solve_t_flex_flex :
                                                  binders_lhs)
                                               (FStar_List.append ctx_r
                                                  binders_rhs) in
-                                          let uu____15947 =
-                                            let uu____15954 =
-                                              let uu____15957 =
+                                          let uu____15945 =
+                                            let uu____15952 =
+                                              let uu____15955 =
                                                 FStar_Syntax_Syntax.mk_Total
                                                   t_res_lhs in
                                               FStar_Syntax_Util.arrow zs
-                                                uu____15957 in
+                                                uu____15955 in
                                             new_uvar
                                               (Prims.op_Hat
                                                  "flex-flex quasi:"
@@ -5578,7 +5578,7 @@ and (solve_t_flex_flex :
                                                        (Prims.op_Hat "\trhs="
                                                           u_rhs.FStar_Syntax_Syntax.ctx_uvar_reason))))
                                               wl range gamma_w ctx_w
-                                              uu____15954
+                                              uu____15952
                                               (if
                                                  (u_lhs.FStar_Syntax_Syntax.ctx_uvar_should_check
                                                     =
@@ -5592,97 +5592,97 @@ and (solve_t_flex_flex :
                                                else
                                                  FStar_Syntax_Syntax.Strict)
                                               FStar_Pervasives_Native.None in
-                                          (match uu____15947 with
-                                           | (uu____15961, w, wl1) ->
+                                          (match uu____15945 with
+                                           | (uu____15959, w, wl1) ->
                                                let w_app =
-                                                 let uu____15965 =
+                                                 let uu____15963 =
                                                    FStar_List.map
-                                                     (fun uu____15976 ->
-                                                        match uu____15976
+                                                     (fun uu____15974 ->
+                                                        match uu____15974
                                                         with
-                                                        | (z, uu____15984) ->
-                                                            let uu____15989 =
+                                                        | (z, uu____15982) ->
+                                                            let uu____15987 =
                                                               FStar_Syntax_Syntax.bv_to_name
                                                                 z in
                                                             FStar_Syntax_Syntax.as_arg
-                                                              uu____15989) zs in
+                                                              uu____15987) zs in
                                                  FStar_Syntax_Syntax.mk_Tm_app
-                                                   w uu____15965
+                                                   w uu____15963
                                                    w.FStar_Syntax_Syntax.pos in
-                                               ((let uu____15991 =
+                                               ((let uu____15989 =
                                                    FStar_All.pipe_left
                                                      (FStar_TypeChecker_Env.debug
                                                         env)
                                                      (FStar_Options.Other
                                                         "Rel") in
-                                                 if uu____15991
+                                                 if uu____15989
                                                  then
-                                                   let uu____15992 =
-                                                     let uu____15995 =
+                                                   let uu____15990 =
+                                                     let uu____15993 =
                                                        flex_t_to_string lhs in
-                                                     let uu____15996 =
-                                                       let uu____15999 =
+                                                     let uu____15994 =
+                                                       let uu____15997 =
                                                          flex_t_to_string rhs in
-                                                       let uu____16000 =
-                                                         let uu____16003 =
+                                                       let uu____15998 =
+                                                         let uu____16001 =
                                                            term_to_string w in
-                                                         let uu____16004 =
-                                                           let uu____16007 =
+                                                         let uu____16002 =
+                                                           let uu____16005 =
                                                              FStar_Syntax_Print.binders_to_string
                                                                ", "
                                                                (FStar_List.append
                                                                   ctx_l
                                                                   binders_lhs) in
-                                                           let uu____16014 =
-                                                             let uu____16017
+                                                           let uu____16012 =
+                                                             let uu____16015
                                                                =
                                                                FStar_Syntax_Print.binders_to_string
                                                                  ", "
                                                                  (FStar_List.append
                                                                     ctx_r
                                                                     binders_rhs) in
-                                                             let uu____16024
+                                                             let uu____16022
                                                                =
-                                                               let uu____16027
+                                                               let uu____16025
                                                                  =
                                                                  FStar_Syntax_Print.binders_to_string
                                                                    ", " zs in
-                                                               [uu____16027] in
-                                                             uu____16017 ::
-                                                               uu____16024 in
-                                                           uu____16007 ::
-                                                             uu____16014 in
-                                                         uu____16003 ::
-                                                           uu____16004 in
-                                                       uu____15999 ::
-                                                         uu____16000 in
-                                                     uu____15995 ::
-                                                       uu____15996 in
+                                                               [uu____16025] in
+                                                             uu____16015 ::
+                                                               uu____16022 in
+                                                           uu____16005 ::
+                                                             uu____16012 in
+                                                         uu____16001 ::
+                                                           uu____16002 in
+                                                       uu____15997 ::
+                                                         uu____15998 in
+                                                     uu____15993 ::
+                                                       uu____15994 in
                                                    FStar_Util.print
                                                      "flex-flex quasi:\n\tlhs=%s\n\trhs=%s\n\tsol=%s\n\tctx_l@binders_lhs=%s\n\tctx_r@binders_rhs=%s\n\tzs=%s\n"
-                                                     uu____15992
+                                                     uu____15990
                                                  else ());
                                                 (let sol =
                                                    let s1 =
-                                                     let uu____16033 =
-                                                       let uu____16038 =
+                                                     let uu____16031 =
+                                                       let uu____16036 =
                                                          FStar_Syntax_Util.abs
                                                            binders_lhs w_app
                                                            (FStar_Pervasives_Native.Some
                                                               (FStar_Syntax_Util.residual_tot
                                                                  t_res_lhs)) in
-                                                       (u_lhs, uu____16038) in
-                                                     TERM uu____16033 in
-                                                   let uu____16039 =
+                                                       (u_lhs, uu____16036) in
+                                                     TERM uu____16031 in
+                                                   let uu____16037 =
                                                      FStar_Syntax_Unionfind.equiv
                                                        u_lhs.FStar_Syntax_Syntax.ctx_uvar_head
                                                        u_rhs.FStar_Syntax_Syntax.ctx_uvar_head in
-                                                   if uu____16039
+                                                   if uu____16037
                                                    then [s1]
                                                    else
                                                      (let s2 =
-                                                        let uu____16044 =
-                                                          let uu____16049 =
+                                                        let uu____16042 =
+                                                          let uu____16047 =
                                                             FStar_Syntax_Util.abs
                                                               binders_rhs
                                                               w_app
@@ -5690,18 +5690,18 @@ and (solve_t_flex_flex :
                                                                  (FStar_Syntax_Util.residual_tot
                                                                     t_res_lhs)) in
                                                           (u_rhs,
-                                                            uu____16049) in
-                                                        TERM uu____16044 in
+                                                            uu____16047) in
+                                                        TERM uu____16042 in
                                                       [s1; s2]) in
-                                                 let uu____16050 =
+                                                 let uu____16048 =
                                                    solve_prob orig
                                                      FStar_Pervasives_Native.None
                                                      sol wl1 in
-                                                 solve env uu____16050))))))
-                     | uu____16051 ->
-                         let uu____16068 =
+                                                 solve env uu____16048))))))
+                     | uu____16049 ->
+                         let uu____16066 =
                            FStar_Thunk.mkv "flex-flex: non-patterns" in
-                         giveup_or_defer env orig wl uu____16068)
+                         giveup_or_defer env orig wl uu____16066)
 and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
   fun env ->
     fun problem ->
@@ -5710,87 +5710,87 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
         (let giveup_or_defer1 orig msg = giveup_or_defer env orig wl msg in
          let rigid_heads_match env1 need_unif torig wl1 t1 t2 =
            let orig = FStar_TypeChecker_Common.TProb torig in
-           (let uu____16117 =
+           (let uu____16115 =
               FStar_All.pipe_left (FStar_TypeChecker_Env.debug env1)
                 (FStar_Options.Other "Rel") in
-            if uu____16117
+            if uu____16115
             then
-              let uu____16118 = FStar_Syntax_Print.term_to_string t1 in
-              let uu____16119 = FStar_Syntax_Print.tag_of_term t1 in
-              let uu____16120 = FStar_Syntax_Print.term_to_string t2 in
-              let uu____16121 = FStar_Syntax_Print.tag_of_term t2 in
+              let uu____16116 = FStar_Syntax_Print.term_to_string t1 in
+              let uu____16117 = FStar_Syntax_Print.tag_of_term t1 in
+              let uu____16118 = FStar_Syntax_Print.term_to_string t2 in
+              let uu____16119 = FStar_Syntax_Print.tag_of_term t2 in
               FStar_Util.print5 "Heads %s: %s (%s) and %s (%s)\n"
                 (if need_unif then "need unification" else "match")
-                uu____16118 uu____16119 uu____16120 uu____16121
+                uu____16116 uu____16117 uu____16118 uu____16119
             else ());
-           (let uu____16124 = FStar_Syntax_Util.head_and_args t1 in
-            match uu____16124 with
+           (let uu____16122 = FStar_Syntax_Util.head_and_args t1 in
+            match uu____16122 with
             | (head1, args1) ->
-                let uu____16167 = FStar_Syntax_Util.head_and_args t2 in
-                (match uu____16167 with
+                let uu____16165 = FStar_Syntax_Util.head_and_args t2 in
+                (match uu____16165 with
                  | (head2, args2) ->
                      let solve_head_then wl2 k =
                        if need_unif
                        then k true wl2
                        else
-                         (let uu____16232 =
+                         (let uu____16230 =
                             solve_maybe_uinsts env1 orig head1 head2 wl2 in
-                          match uu____16232 with
+                          match uu____16230 with
                           | USolved wl3 -> k true wl3
                           | UFailed msg -> giveup env1 msg orig
                           | UDeferred wl3 ->
-                              let uu____16236 =
+                              let uu____16234 =
                                 defer_lit "universe constraints" orig wl3 in
-                              k false uu____16236) in
+                              k false uu____16234) in
                      let nargs = FStar_List.length args1 in
                      if nargs <> (FStar_List.length args2)
                      then
-                       let uu____16254 =
+                       let uu____16252 =
                          mklstr
-                           (fun uu____16265 ->
-                              let uu____16266 =
+                           (fun uu____16263 ->
+                              let uu____16264 =
                                 FStar_Syntax_Print.term_to_string head1 in
-                              let uu____16267 = args_to_string args1 in
-                              let uu____16270 =
+                              let uu____16265 = args_to_string args1 in
+                              let uu____16268 =
                                 FStar_Syntax_Print.term_to_string head2 in
-                              let uu____16271 = args_to_string args2 in
+                              let uu____16269 = args_to_string args2 in
                               FStar_Util.format4
                                 "unequal number of arguments: %s[%s] and %s[%s]"
-                                uu____16266 uu____16267 uu____16270
-                                uu____16271) in
-                       giveup env1 uu____16254 orig
+                                uu____16264 uu____16265 uu____16268
+                                uu____16269) in
+                       giveup env1 uu____16252 orig
                      else
-                       (let uu____16275 =
+                       (let uu____16273 =
                           (nargs = Prims.int_zero) ||
-                            (let uu____16277 =
+                            (let uu____16275 =
                                FStar_Syntax_Util.eq_args args1 args2 in
-                             uu____16277 = FStar_Syntax_Util.Equal) in
-                        if uu____16275
+                             uu____16275 = FStar_Syntax_Util.Equal) in
+                        if uu____16273
                         then
                           (if need_unif
                            then
                              solve_t env1
-                               (let uu___2638_16279 = problem in
+                               (let uu___2638_16277 = problem in
                                 {
                                   FStar_TypeChecker_Common.pid =
-                                    (uu___2638_16279.FStar_TypeChecker_Common.pid);
+                                    (uu___2638_16277.FStar_TypeChecker_Common.pid);
                                   FStar_TypeChecker_Common.lhs = head1;
                                   FStar_TypeChecker_Common.relation =
-                                    (uu___2638_16279.FStar_TypeChecker_Common.relation);
+                                    (uu___2638_16277.FStar_TypeChecker_Common.relation);
                                   FStar_TypeChecker_Common.rhs = head2;
                                   FStar_TypeChecker_Common.element =
-                                    (uu___2638_16279.FStar_TypeChecker_Common.element);
+                                    (uu___2638_16277.FStar_TypeChecker_Common.element);
                                   FStar_TypeChecker_Common.logical_guard =
-                                    (uu___2638_16279.FStar_TypeChecker_Common.logical_guard);
+                                    (uu___2638_16277.FStar_TypeChecker_Common.logical_guard);
                                   FStar_TypeChecker_Common.logical_guard_uvar
                                     =
-                                    (uu___2638_16279.FStar_TypeChecker_Common.logical_guard_uvar);
+                                    (uu___2638_16277.FStar_TypeChecker_Common.logical_guard_uvar);
                                   FStar_TypeChecker_Common.reason =
-                                    (uu___2638_16279.FStar_TypeChecker_Common.reason);
+                                    (uu___2638_16277.FStar_TypeChecker_Common.reason);
                                   FStar_TypeChecker_Common.loc =
-                                    (uu___2638_16279.FStar_TypeChecker_Common.loc);
+                                    (uu___2638_16277.FStar_TypeChecker_Common.loc);
                                   FStar_TypeChecker_Common.rank =
-                                    (uu___2638_16279.FStar_TypeChecker_Common.rank)
+                                    (uu___2638_16277.FStar_TypeChecker_Common.rank)
                                 }) wl1
                            else
                              solve_head_then wl1
@@ -5798,17 +5798,17 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                                   fun wl2 ->
                                     if ok
                                     then
-                                      let uu____16286 =
+                                      let uu____16284 =
                                         solve_prob orig
                                           FStar_Pervasives_Native.None [] wl2 in
-                                      solve env1 uu____16286
+                                      solve env1 uu____16284
                                     else solve env1 wl2))
                         else
-                          (let uu____16289 = base_and_refinement env1 t1 in
-                           match uu____16289 with
+                          (let uu____16287 = base_and_refinement env1 t1 in
+                           match uu____16287 with
                            | (base1, refinement1) ->
-                               let uu____16314 = base_and_refinement env1 t2 in
-                               (match uu____16314 with
+                               let uu____16312 = base_and_refinement env1 t2 in
+                               (match uu____16312 with
                                 | (base2, refinement2) ->
                                     (match (refinement1, refinement2) with
                                      | (FStar_Pervasives_Native.None,
@@ -5825,51 +5825,51 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                                                     FStar_Pervasives_Native.None)
                                                  :: args2)
                                              else FStar_List.zip args1 args2 in
-                                           let uu____16477 =
+                                           let uu____16475 =
                                              FStar_List.fold_right
-                                               (fun uu____16517 ->
-                                                  fun uu____16518 ->
-                                                    match (uu____16517,
-                                                            uu____16518)
+                                               (fun uu____16515 ->
+                                                  fun uu____16516 ->
+                                                    match (uu____16515,
+                                                            uu____16516)
                                                     with
-                                                    | (((a1, uu____16570),
-                                                        (a2, uu____16572)),
+                                                    | (((a1, uu____16568),
+                                                        (a2, uu____16570)),
                                                        (probs, wl3)) ->
-                                                        let uu____16621 =
+                                                        let uu____16619 =
                                                           mk_problem wl3 []
                                                             orig a1
                                                             FStar_TypeChecker_Common.EQ
                                                             a2
                                                             FStar_Pervasives_Native.None
                                                             "index" in
-                                                        (match uu____16621
+                                                        (match uu____16619
                                                          with
                                                          | (prob', wl4) ->
                                                              (((FStar_TypeChecker_Common.TProb
                                                                   prob') ::
                                                                probs), wl4)))
                                                argp ([], wl2) in
-                                           match uu____16477 with
+                                           match uu____16475 with
                                            | (subprobs, wl3) ->
-                                               ((let uu____16663 =
+                                               ((let uu____16661 =
                                                    FStar_All.pipe_left
                                                      (FStar_TypeChecker_Env.debug
                                                         env1)
                                                      (FStar_Options.Other
                                                         "Rel") in
-                                                 if uu____16663
+                                                 if uu____16661
                                                  then
-                                                   let uu____16664 =
+                                                   let uu____16662 =
                                                      FStar_Syntax_Print.list_to_string
                                                        (prob_to_string env1)
                                                        subprobs in
                                                    FStar_Util.print1
                                                      "Adding subproblems for arguments: %s"
-                                                     uu____16664
+                                                     uu____16662
                                                  else ());
-                                                (let uu____16667 =
+                                                (let uu____16665 =
                                                    FStar_Options.defensive () in
-                                                 if uu____16667
+                                                 if uu____16665
                                                  then
                                                    FStar_List.iter
                                                      (def_check_prob
@@ -5884,120 +5884,120 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                                                   if Prims.op_Negation ok
                                                   then solve env2 wl3
                                                   else
-                                                    (let uu____16687 =
+                                                    (let uu____16685 =
                                                        mk_sub_probs wl3 in
-                                                     match uu____16687 with
+                                                     match uu____16685 with
                                                      | (subprobs, wl4) ->
                                                          let formula =
-                                                           let uu____16703 =
+                                                           let uu____16701 =
                                                              FStar_List.map
                                                                (fun p ->
                                                                   p_guard p)
                                                                subprobs in
                                                            FStar_Syntax_Util.mk_conj_l
-                                                             uu____16703 in
+                                                             uu____16701 in
                                                          let wl5 =
                                                            solve_prob orig
                                                              (FStar_Pervasives_Native.Some
                                                                 formula) []
                                                              wl4 in
-                                                         let uu____16711 =
+                                                         let uu____16709 =
                                                            attempt subprobs
                                                              wl5 in
                                                          solve env2
-                                                           uu____16711)) in
+                                                           uu____16709)) in
                                          let solve_sub_probs_no_smt env2 wl2
                                            =
                                            solve_head_then wl2
                                              (fun ok ->
                                                 fun wl3 ->
-                                                  let uu____16735 =
+                                                  let uu____16733 =
                                                     mk_sub_probs wl3 in
-                                                  match uu____16735 with
+                                                  match uu____16733 with
                                                   | (subprobs, wl4) ->
                                                       let formula =
-                                                        let uu____16751 =
+                                                        let uu____16749 =
                                                           FStar_List.map
                                                             (fun p ->
                                                                p_guard p)
                                                             subprobs in
                                                         FStar_Syntax_Util.mk_conj_l
-                                                          uu____16751 in
+                                                          uu____16749 in
                                                       let wl5 =
                                                         solve_prob orig
                                                           (FStar_Pervasives_Native.Some
                                                              formula) [] wl4 in
-                                                      let uu____16759 =
+                                                      let uu____16757 =
                                                         attempt subprobs wl5 in
-                                                      solve env2 uu____16759) in
+                                                      solve env2 uu____16757) in
                                          let unfold_and_retry d env2 wl2
-                                           uu____16786 =
-                                           match uu____16786 with
+                                           uu____16784 =
+                                           match uu____16784 with
                                            | (prob, reason) ->
-                                               ((let uu____16800 =
+                                               ((let uu____16798 =
                                                    FStar_All.pipe_left
                                                      (FStar_TypeChecker_Env.debug
                                                         env2)
                                                      (FStar_Options.Other
                                                         "Rel") in
-                                                 if uu____16800
+                                                 if uu____16798
                                                  then
-                                                   let uu____16801 =
+                                                   let uu____16799 =
                                                      prob_to_string env2 orig in
-                                                   let uu____16802 =
+                                                   let uu____16800 =
                                                      FStar_Thunk.force reason in
                                                    FStar_Util.print2
                                                      "Failed to solve %s because a sub-problem is not solvable without SMT because %s"
-                                                     uu____16801 uu____16802
+                                                     uu____16799 uu____16800
                                                  else ());
-                                                (let uu____16804 =
-                                                   let uu____16813 =
+                                                (let uu____16802 =
+                                                   let uu____16811 =
                                                      FStar_TypeChecker_Normalize.unfold_head_once
                                                        env2 t1 in
-                                                   let uu____16816 =
+                                                   let uu____16814 =
                                                      FStar_TypeChecker_Normalize.unfold_head_once
                                                        env2 t2 in
-                                                   (uu____16813, uu____16816) in
-                                                 match uu____16804 with
+                                                   (uu____16811, uu____16814) in
+                                                 match uu____16802 with
                                                  | (FStar_Pervasives_Native.Some
                                                     t1',
                                                     FStar_Pervasives_Native.Some
                                                     t2') ->
-                                                     let uu____16829 =
+                                                     let uu____16827 =
                                                        FStar_Syntax_Util.head_and_args
                                                          t1' in
-                                                     (match uu____16829 with
-                                                      | (head1', uu____16847)
+                                                     (match uu____16827 with
+                                                      | (head1', uu____16845)
                                                           ->
-                                                          let uu____16872 =
+                                                          let uu____16870 =
                                                             FStar_Syntax_Util.head_and_args
                                                               t2' in
-                                                          (match uu____16872
+                                                          (match uu____16870
                                                            with
                                                            | (head2',
-                                                              uu____16890) ->
-                                                               let uu____16915
+                                                              uu____16888) ->
+                                                               let uu____16913
                                                                  =
-                                                                 let uu____16920
+                                                                 let uu____16918
                                                                    =
                                                                    FStar_Syntax_Util.eq_tm
                                                                     head1'
                                                                     head1 in
-                                                                 let uu____16921
+                                                                 let uu____16919
                                                                    =
                                                                    FStar_Syntax_Util.eq_tm
                                                                     head2'
                                                                     head2 in
-                                                                 (uu____16920,
-                                                                   uu____16921) in
-                                                               (match uu____16915
+                                                                 (uu____16918,
+                                                                   uu____16919) in
+                                                               (match uu____16913
                                                                 with
                                                                 | (FStar_Syntax_Util.Equal,
                                                                    FStar_Syntax_Util.Equal)
                                                                     ->
                                                                     (
                                                                     (
-                                                                    let uu____16923
+                                                                    let uu____16921
                                                                     =
                                                                     FStar_All.pipe_left
                                                                     (FStar_TypeChecker_Env.debug
@@ -6005,71 +6005,71 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                                                                     (FStar_Options.Other
                                                                     "Rel") in
                                                                     if
-                                                                    uu____16923
+                                                                    uu____16921
                                                                     then
-                                                                    let uu____16924
+                                                                    let uu____16922
                                                                     =
                                                                     FStar_Syntax_Print.term_to_string
                                                                     t1 in
-                                                                    let uu____16925
+                                                                    let uu____16923
                                                                     =
                                                                     FStar_Syntax_Print.term_to_string
                                                                     t1' in
-                                                                    let uu____16926
+                                                                    let uu____16924
                                                                     =
                                                                     FStar_Syntax_Print.term_to_string
                                                                     t2 in
-                                                                    let uu____16927
+                                                                    let uu____16925
                                                                     =
                                                                     FStar_Syntax_Print.term_to_string
                                                                     t2' in
                                                                     FStar_Util.print4
                                                                     "Unfolding didn't make progress ... got %s ~> %s;\nand %s ~> %s\n"
+                                                                    uu____16922
+                                                                    uu____16923
                                                                     uu____16924
                                                                     uu____16925
-                                                                    uu____16926
-                                                                    uu____16927
                                                                     else ());
                                                                     solve_sub_probs
                                                                     env2 wl2)
-                                                                | uu____16929
+                                                                | uu____16927
                                                                     ->
                                                                     let torig'
                                                                     =
-                                                                    let uu___2726_16937
+                                                                    let uu___2726_16935
                                                                     = torig in
                                                                     {
                                                                     FStar_TypeChecker_Common.pid
                                                                     =
-                                                                    (uu___2726_16937.FStar_TypeChecker_Common.pid);
+                                                                    (uu___2726_16935.FStar_TypeChecker_Common.pid);
                                                                     FStar_TypeChecker_Common.lhs
                                                                     = t1';
                                                                     FStar_TypeChecker_Common.relation
                                                                     =
-                                                                    (uu___2726_16937.FStar_TypeChecker_Common.relation);
+                                                                    (uu___2726_16935.FStar_TypeChecker_Common.relation);
                                                                     FStar_TypeChecker_Common.rhs
                                                                     = t2';
                                                                     FStar_TypeChecker_Common.element
                                                                     =
-                                                                    (uu___2726_16937.FStar_TypeChecker_Common.element);
+                                                                    (uu___2726_16935.FStar_TypeChecker_Common.element);
                                                                     FStar_TypeChecker_Common.logical_guard
                                                                     =
-                                                                    (uu___2726_16937.FStar_TypeChecker_Common.logical_guard);
+                                                                    (uu___2726_16935.FStar_TypeChecker_Common.logical_guard);
                                                                     FStar_TypeChecker_Common.logical_guard_uvar
                                                                     =
-                                                                    (uu___2726_16937.FStar_TypeChecker_Common.logical_guard_uvar);
+                                                                    (uu___2726_16935.FStar_TypeChecker_Common.logical_guard_uvar);
                                                                     FStar_TypeChecker_Common.reason
                                                                     =
-                                                                    (uu___2726_16937.FStar_TypeChecker_Common.reason);
+                                                                    (uu___2726_16935.FStar_TypeChecker_Common.reason);
                                                                     FStar_TypeChecker_Common.loc
                                                                     =
-                                                                    (uu___2726_16937.FStar_TypeChecker_Common.loc);
+                                                                    (uu___2726_16935.FStar_TypeChecker_Common.loc);
                                                                     FStar_TypeChecker_Common.rank
                                                                     =
-                                                                    (uu___2726_16937.FStar_TypeChecker_Common.rank)
+                                                                    (uu___2726_16935.FStar_TypeChecker_Common.rank)
                                                                     } in
                                                                     ((
-                                                                    let uu____16939
+                                                                    let uu____16937
                                                                     =
                                                                     FStar_All.pipe_left
                                                                     (FStar_TypeChecker_Env.debug
@@ -6077,9 +6077,9 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                                                                     (FStar_Options.Other
                                                                     "Rel") in
                                                                     if
-                                                                    uu____16939
+                                                                    uu____16937
                                                                     then
-                                                                    let uu____16940
+                                                                    let uu____16938
                                                                     =
                                                                     prob_to_string
                                                                     env2
@@ -6087,18 +6087,18 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                                                                     torig') in
                                                                     FStar_Util.print1
                                                                     "Unfolded and now trying %s\n"
-                                                                    uu____16940
+                                                                    uu____16938
                                                                     else ());
                                                                     solve_t
                                                                     env2
                                                                     torig'
                                                                     wl2))))
-                                                 | uu____16942 ->
+                                                 | uu____16940 ->
                                                      solve_sub_probs env2 wl2)) in
                                          let d =
-                                           let uu____16954 =
+                                           let uu____16952 =
                                              delta_depth_of_term env1 head1 in
-                                           match uu____16954 with
+                                           match uu____16952 with
                                            | FStar_Pervasives_Native.None ->
                                                FStar_Pervasives_Native.None
                                            | FStar_Pervasives_Native.Some d
@@ -6106,18 +6106,18 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                                                FStar_TypeChecker_Common.decr_delta_depth
                                                  d in
                                          let treat_as_injective =
-                                           let uu____16961 =
-                                             let uu____16962 =
+                                           let uu____16959 =
+                                             let uu____16960 =
                                                FStar_Syntax_Util.un_uinst
                                                  head1 in
-                                             uu____16962.FStar_Syntax_Syntax.n in
-                                           match uu____16961 with
+                                             uu____16960.FStar_Syntax_Syntax.n in
+                                           match uu____16959 with
                                            | FStar_Syntax_Syntax.Tm_fvar fv
                                                ->
                                                FStar_TypeChecker_Env.fv_has_attr
                                                  env1 fv
                                                  FStar_Parser_Const.unifier_hint_injective_lid
-                                           | uu____16966 -> false in
+                                           | uu____16964 -> false in
                                          (match d with
                                           | FStar_Pervasives_Native.Some d1
                                               when
@@ -6129,9 +6129,9 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                                                 env1 wl1
                                                 solve_sub_probs_no_smt
                                                 (unfold_and_retry d1)
-                                          | uu____16968 ->
+                                          | uu____16966 ->
                                               solve_sub_probs env1 wl1)
-                                     | uu____16971 ->
+                                     | uu____16969 ->
                                          let lhs =
                                            force_refinement
                                              (base1, refinement1) in
@@ -6139,610 +6139,610 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                                            force_refinement
                                              (base2, refinement2) in
                                          solve_t env1
-                                           (let uu___2746_17007 = problem in
+                                           (let uu___2746_17005 = problem in
                                             {
                                               FStar_TypeChecker_Common.pid =
-                                                (uu___2746_17007.FStar_TypeChecker_Common.pid);
+                                                (uu___2746_17005.FStar_TypeChecker_Common.pid);
                                               FStar_TypeChecker_Common.lhs =
                                                 lhs;
                                               FStar_TypeChecker_Common.relation
                                                 =
-                                                (uu___2746_17007.FStar_TypeChecker_Common.relation);
+                                                (uu___2746_17005.FStar_TypeChecker_Common.relation);
                                               FStar_TypeChecker_Common.rhs =
                                                 rhs;
                                               FStar_TypeChecker_Common.element
                                                 =
-                                                (uu___2746_17007.FStar_TypeChecker_Common.element);
+                                                (uu___2746_17005.FStar_TypeChecker_Common.element);
                                               FStar_TypeChecker_Common.logical_guard
                                                 =
-                                                (uu___2746_17007.FStar_TypeChecker_Common.logical_guard);
+                                                (uu___2746_17005.FStar_TypeChecker_Common.logical_guard);
                                               FStar_TypeChecker_Common.logical_guard_uvar
                                                 =
-                                                (uu___2746_17007.FStar_TypeChecker_Common.logical_guard_uvar);
+                                                (uu___2746_17005.FStar_TypeChecker_Common.logical_guard_uvar);
                                               FStar_TypeChecker_Common.reason
                                                 =
-                                                (uu___2746_17007.FStar_TypeChecker_Common.reason);
+                                                (uu___2746_17005.FStar_TypeChecker_Common.reason);
                                               FStar_TypeChecker_Common.loc =
-                                                (uu___2746_17007.FStar_TypeChecker_Common.loc);
+                                                (uu___2746_17005.FStar_TypeChecker_Common.loc);
                                               FStar_TypeChecker_Common.rank =
-                                                (uu___2746_17007.FStar_TypeChecker_Common.rank)
+                                                (uu___2746_17005.FStar_TypeChecker_Common.rank)
                                             }) wl1)))))) in
          let try_match_heuristic env1 orig wl1 s1 s2 t1t2_opt =
            let try_solve_branch scrutinee p =
-             let uu____17082 = destruct_flex_t scrutinee wl1 in
-             match uu____17082 with
+             let uu____17080 = destruct_flex_t scrutinee wl1 in
+             match uu____17080 with
              | (Flex (_t, uv, _args), wl2) ->
-                 let uu____17093 =
+                 let uu____17091 =
                    FStar_TypeChecker_PatternUtils.pat_as_exp true env1 p in
-                 (match uu____17093 with
-                  | (xs, pat_term, uu____17108, uu____17109) ->
-                      let uu____17114 =
+                 (match uu____17091 with
+                  | (xs, pat_term, uu____17106, uu____17107) ->
+                      let uu____17112 =
                         FStar_List.fold_left
-                          (fun uu____17137 ->
+                          (fun uu____17135 ->
                              fun x ->
-                               match uu____17137 with
+                               match uu____17135 with
                                | (subst, wl3) ->
                                    let t_x =
                                      FStar_Syntax_Subst.subst subst
                                        x.FStar_Syntax_Syntax.sort in
-                                   let uu____17158 = copy_uvar uv [] t_x wl3 in
-                                   (match uu____17158 with
-                                    | (uu____17177, u, wl4) ->
+                                   let uu____17156 = copy_uvar uv [] t_x wl3 in
+                                   (match uu____17156 with
+                                    | (uu____17175, u, wl4) ->
                                         let subst1 =
                                           (FStar_Syntax_Syntax.NT (x, u)) ::
                                           subst in
                                         (subst1, wl4))) ([], wl2) xs in
-                      (match uu____17114 with
+                      (match uu____17112 with
                        | (subst, wl3) ->
                            let pat_term1 =
                              FStar_Syntax_Subst.subst subst pat_term in
-                           let uu____17198 =
+                           let uu____17196 =
                              new_problem wl3 env1 scrutinee
                                FStar_TypeChecker_Common.EQ pat_term1
                                FStar_Pervasives_Native.None
                                scrutinee.FStar_Syntax_Syntax.pos
                                "match heuristic" in
-                           (match uu____17198 with
+                           (match uu____17196 with
                             | (prob, wl4) ->
                                 let wl' =
-                                  let uu___2787_17214 = wl4 in
+                                  let uu___2787_17212 = wl4 in
                                   {
                                     attempting =
                                       [FStar_TypeChecker_Common.TProb prob];
                                     wl_deferred = [];
                                     wl_deferred_to_tac =
-                                      (uu___2787_17214.wl_deferred_to_tac);
-                                    ctr = (uu___2787_17214.ctr);
+                                      (uu___2787_17212.wl_deferred_to_tac);
+                                    ctr = (uu___2787_17212.ctr);
                                     defer_ok = false;
                                     smt_ok = false;
                                     umax_heuristic_ok =
-                                      (uu___2787_17214.umax_heuristic_ok);
-                                    tcenv = (uu___2787_17214.tcenv);
+                                      (uu___2787_17212.umax_heuristic_ok);
+                                    tcenv = (uu___2787_17212.tcenv);
                                     wl_implicits = [];
                                     repr_subcomp_allowed =
-                                      (uu___2787_17214.repr_subcomp_allowed)
+                                      (uu___2787_17212.repr_subcomp_allowed)
                                   } in
                                 let tx =
                                   FStar_Syntax_Unionfind.new_transaction () in
-                                let uu____17222 = solve env1 wl' in
-                                (match uu____17222 with
-                                 | Success (uu____17225, defer_to_tac, imps)
+                                let uu____17220 = solve env1 wl' in
+                                (match uu____17220 with
+                                 | Success (uu____17223, defer_to_tac, imps)
                                      ->
                                      let wl'1 =
-                                       let uu___2796_17229 = wl' in
+                                       let uu___2796_17227 = wl' in
                                        {
                                          attempting = [orig];
                                          wl_deferred =
-                                           (uu___2796_17229.wl_deferred);
+                                           (uu___2796_17227.wl_deferred);
                                          wl_deferred_to_tac =
-                                           (uu___2796_17229.wl_deferred_to_tac);
-                                         ctr = (uu___2796_17229.ctr);
+                                           (uu___2796_17227.wl_deferred_to_tac);
+                                         ctr = (uu___2796_17227.ctr);
                                          defer_ok =
-                                           (uu___2796_17229.defer_ok);
-                                         smt_ok = (uu___2796_17229.smt_ok);
+                                           (uu___2796_17227.defer_ok);
+                                         smt_ok = (uu___2796_17227.smt_ok);
                                          umax_heuristic_ok =
-                                           (uu___2796_17229.umax_heuristic_ok);
-                                         tcenv = (uu___2796_17229.tcenv);
+                                           (uu___2796_17227.umax_heuristic_ok);
+                                         tcenv = (uu___2796_17227.tcenv);
                                          wl_implicits =
-                                           (uu___2796_17229.wl_implicits);
+                                           (uu___2796_17227.wl_implicits);
                                          repr_subcomp_allowed =
-                                           (uu___2796_17229.repr_subcomp_allowed)
+                                           (uu___2796_17227.repr_subcomp_allowed)
                                        } in
-                                     let uu____17230 = solve env1 wl'1 in
-                                     (match uu____17230 with
+                                     let uu____17228 = solve env1 wl'1 in
+                                     (match uu____17228 with
                                       | Success
-                                          (uu____17233, defer_to_tac', imps')
+                                          (uu____17231, defer_to_tac', imps')
                                           ->
                                           (FStar_Syntax_Unionfind.commit tx;
-                                           (let uu____17237 =
+                                           (let uu____17235 =
                                               extend_wl wl4
                                                 (FStar_List.append
                                                    defer_to_tac defer_to_tac')
                                                 (FStar_List.append imps imps') in
                                             FStar_Pervasives_Native.Some
-                                              uu____17237))
-                                      | Failed uu____17242 ->
+                                              uu____17235))
+                                      | Failed uu____17240 ->
                                           (FStar_Syntax_Unionfind.rollback tx;
                                            FStar_Pervasives_Native.None))
-                                 | uu____17248 ->
+                                 | uu____17246 ->
                                      (FStar_Syntax_Unionfind.rollback tx;
                                       FStar_Pervasives_Native.None))))) in
            match t1t2_opt with
            | FStar_Pervasives_Native.None ->
                FStar_Util.Inr FStar_Pervasives_Native.None
            | FStar_Pervasives_Native.Some (t1, t2) ->
-               ((let uu____17269 =
+               ((let uu____17267 =
                    FStar_All.pipe_left (FStar_TypeChecker_Env.debug env1)
                      (FStar_Options.Other "Rel") in
-                 if uu____17269
+                 if uu____17267
                  then
-                   let uu____17270 = FStar_Syntax_Print.term_to_string t1 in
-                   let uu____17271 = FStar_Syntax_Print.term_to_string t2 in
+                   let uu____17268 = FStar_Syntax_Print.term_to_string t1 in
+                   let uu____17269 = FStar_Syntax_Print.term_to_string t2 in
                    FStar_Util.print2 "Trying match heuristic for %s vs. %s\n"
-                     uu____17270 uu____17271
+                     uu____17268 uu____17269
                  else ());
-                (let uu____17273 =
-                   let uu____17294 =
-                     let uu____17303 = FStar_Syntax_Util.unmeta t1 in
-                     (s1, uu____17303) in
-                   let uu____17310 =
-                     let uu____17319 = FStar_Syntax_Util.unmeta t2 in
-                     (s2, uu____17319) in
-                   (uu____17294, uu____17310) in
-                 match uu____17273 with
-                 | ((uu____17348,
+                (let uu____17271 =
+                   let uu____17292 =
+                     let uu____17301 = FStar_Syntax_Util.unmeta t1 in
+                     (s1, uu____17301) in
+                   let uu____17308 =
+                     let uu____17317 = FStar_Syntax_Util.unmeta t2 in
+                     (s2, uu____17317) in
+                   (uu____17292, uu____17308) in
+                 match uu____17271 with
+                 | ((uu____17346,
                      {
                        FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_match
                          (scrutinee, branches);
-                       FStar_Syntax_Syntax.pos = uu____17351;
-                       FStar_Syntax_Syntax.vars = uu____17352;_}),
+                       FStar_Syntax_Syntax.pos = uu____17349;
+                       FStar_Syntax_Syntax.vars = uu____17350;_}),
                     (s, t)) ->
-                     let uu____17423 =
-                       let uu____17424 = is_flex scrutinee in
-                       Prims.op_Negation uu____17424 in
-                     if uu____17423
+                     let uu____17421 =
+                       let uu____17422 = is_flex scrutinee in
+                       Prims.op_Negation uu____17422 in
+                     if uu____17421
                      then
-                       ((let uu____17432 =
+                       ((let uu____17430 =
                            FStar_All.pipe_left
                              (FStar_TypeChecker_Env.debug env1)
                              (FStar_Options.Other "Rel") in
-                         if uu____17432
+                         if uu____17430
                          then
-                           let uu____17433 =
+                           let uu____17431 =
                              FStar_Syntax_Print.term_to_string scrutinee in
                            FStar_Util.print1
-                             "match head %s is not a flex term\n" uu____17433
+                             "match head %s is not a flex term\n" uu____17431
                          else ());
                         FStar_Util.Inr FStar_Pervasives_Native.None)
                      else
                        if wl1.defer_ok
                        then
-                         ((let uu____17445 =
+                         ((let uu____17443 =
                              FStar_All.pipe_left
                                (FStar_TypeChecker_Env.debug env1)
                                (FStar_Options.Other "Rel") in
-                           if uu____17445
+                           if uu____17443
                            then FStar_Util.print_string "Deferring ... \n"
                            else ());
                           FStar_Util.Inl "defer")
                        else
-                         ((let uu____17451 =
+                         ((let uu____17449 =
                              FStar_All.pipe_left
                                (FStar_TypeChecker_Env.debug env1)
                                (FStar_Options.Other "Rel") in
-                           if uu____17451
+                           if uu____17449
                            then
-                             let uu____17452 =
+                             let uu____17450 =
                                FStar_Syntax_Print.term_to_string scrutinee in
-                             let uu____17453 =
+                             let uu____17451 =
                                FStar_Syntax_Print.term_to_string t in
                              FStar_Util.print2
                                "Heuristic applicable with scrutinee %s and other side = %s\n"
-                               uu____17452 uu____17453
+                               uu____17450 uu____17451
                            else ());
-                          (let pat_discriminates uu___26_17474 =
-                             match uu___26_17474 with
+                          (let pat_discriminates uu___26_17472 =
+                             match uu___26_17472 with
                              | ({
                                   FStar_Syntax_Syntax.v =
                                     FStar_Syntax_Syntax.Pat_constant
-                                    uu____17489;
-                                  FStar_Syntax_Syntax.p = uu____17490;_},
-                                FStar_Pervasives_Native.None, uu____17491) ->
+                                    uu____17487;
+                                  FStar_Syntax_Syntax.p = uu____17488;_},
+                                FStar_Pervasives_Native.None, uu____17489) ->
                                  true
                              | ({
                                   FStar_Syntax_Syntax.v =
-                                    FStar_Syntax_Syntax.Pat_cons uu____17504;
-                                  FStar_Syntax_Syntax.p = uu____17505;_},
-                                FStar_Pervasives_Native.None, uu____17506) ->
+                                    FStar_Syntax_Syntax.Pat_cons uu____17502;
+                                  FStar_Syntax_Syntax.p = uu____17503;_},
+                                FStar_Pervasives_Native.None, uu____17504) ->
                                  true
-                             | uu____17531 -> false in
+                             | uu____17529 -> false in
                            let head_matching_branch =
                              FStar_All.pipe_right branches
                                (FStar_Util.try_find
                                   (fun b ->
                                      if pat_discriminates b
                                      then
-                                       let uu____17631 =
+                                       let uu____17629 =
                                          FStar_Syntax_Subst.open_branch b in
-                                       match uu____17631 with
-                                       | (uu____17632, uu____17633, t') ->
-                                           let uu____17651 =
+                                       match uu____17629 with
+                                       | (uu____17630, uu____17631, t') ->
+                                           let uu____17649 =
                                              head_matches_delta env1 wl1 s t' in
-                                           (match uu____17651 with
-                                            | (FullMatch, uu____17662) ->
+                                           (match uu____17649 with
+                                            | (FullMatch, uu____17660) ->
                                                 true
-                                            | (HeadMatch uu____17675,
-                                               uu____17676) -> true
-                                            | uu____17689 -> false)
+                                            | (HeadMatch uu____17673,
+                                               uu____17674) -> true
+                                            | uu____17687 -> false)
                                      else false)) in
                            match head_matching_branch with
                            | FStar_Pervasives_Native.None ->
-                               ((let uu____17722 =
+                               ((let uu____17720 =
                                    FStar_All.pipe_left
                                      (FStar_TypeChecker_Env.debug env1)
                                      (FStar_Options.Other "Rel") in
-                                 if uu____17722
+                                 if uu____17720
                                  then
                                    FStar_Util.print_string
                                      "No head_matching branch\n"
                                  else ());
                                 (let try_branches =
-                                   let uu____17727 =
+                                   let uu____17725 =
                                      FStar_Util.prefix_until
                                        (fun b ->
                                           Prims.op_Negation
                                             (pat_discriminates b)) branches in
-                                   match uu____17727 with
+                                   match uu____17725 with
                                    | FStar_Pervasives_Native.Some
-                                       (branches1, uu____17815, uu____17816)
+                                       (branches1, uu____17813, uu____17814)
                                        -> branches1
-                                   | uu____17961 -> branches in
-                                 let uu____18016 =
+                                   | uu____17959 -> branches in
+                                 let uu____18014 =
                                    FStar_Util.find_map try_branches
                                      (fun b ->
-                                        let uu____18025 =
+                                        let uu____18023 =
                                           FStar_Syntax_Subst.open_branch b in
-                                        match uu____18025 with
-                                        | (p, uu____18029, uu____18030) ->
+                                        match uu____18023 with
+                                        | (p, uu____18027, uu____18028) ->
                                             try_solve_branch scrutinee p) in
                                  FStar_All.pipe_left
-                                   (fun uu____18057 ->
-                                      FStar_Util.Inr uu____18057) uu____18016))
+                                   (fun uu____18055 ->
+                                      FStar_Util.Inr uu____18055) uu____18014))
                            | FStar_Pervasives_Native.Some b ->
-                               let uu____18087 =
+                               let uu____18085 =
                                  FStar_Syntax_Subst.open_branch b in
-                               (match uu____18087 with
-                                | (p, uu____18095, e) ->
-                                    ((let uu____18114 =
+                               (match uu____18085 with
+                                | (p, uu____18093, e) ->
+                                    ((let uu____18112 =
                                         FStar_All.pipe_left
                                           (FStar_TypeChecker_Env.debug env1)
                                           (FStar_Options.Other "Rel") in
-                                      if uu____18114
+                                      if uu____18112
                                       then
-                                        let uu____18115 =
+                                        let uu____18113 =
                                           FStar_Syntax_Print.pat_to_string p in
-                                        let uu____18116 =
+                                        let uu____18114 =
                                           FStar_Syntax_Print.term_to_string e in
                                         FStar_Util.print2
                                           "Found head matching branch %s -> %s\n"
-                                          uu____18115 uu____18116
+                                          uu____18113 uu____18114
                                       else ());
-                                     (let uu____18118 =
+                                     (let uu____18116 =
                                         try_solve_branch scrutinee p in
                                       FStar_All.pipe_left
-                                        (fun uu____18131 ->
-                                           FStar_Util.Inr uu____18131)
-                                        uu____18118)))))
+                                        (fun uu____18129 ->
+                                           FStar_Util.Inr uu____18129)
+                                        uu____18116)))))
                  | ((s, t),
-                    (uu____18134,
+                    (uu____18132,
                      {
                        FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_match
                          (scrutinee, branches);
-                       FStar_Syntax_Syntax.pos = uu____18137;
-                       FStar_Syntax_Syntax.vars = uu____18138;_}))
+                       FStar_Syntax_Syntax.pos = uu____18135;
+                       FStar_Syntax_Syntax.vars = uu____18136;_}))
                      ->
-                     let uu____18207 =
-                       let uu____18208 = is_flex scrutinee in
-                       Prims.op_Negation uu____18208 in
-                     if uu____18207
+                     let uu____18205 =
+                       let uu____18206 = is_flex scrutinee in
+                       Prims.op_Negation uu____18206 in
+                     if uu____18205
                      then
-                       ((let uu____18216 =
+                       ((let uu____18214 =
                            FStar_All.pipe_left
                              (FStar_TypeChecker_Env.debug env1)
                              (FStar_Options.Other "Rel") in
-                         if uu____18216
+                         if uu____18214
                          then
-                           let uu____18217 =
+                           let uu____18215 =
                              FStar_Syntax_Print.term_to_string scrutinee in
                            FStar_Util.print1
-                             "match head %s is not a flex term\n" uu____18217
+                             "match head %s is not a flex term\n" uu____18215
                          else ());
                         FStar_Util.Inr FStar_Pervasives_Native.None)
                      else
                        if wl1.defer_ok
                        then
-                         ((let uu____18229 =
+                         ((let uu____18227 =
                              FStar_All.pipe_left
                                (FStar_TypeChecker_Env.debug env1)
                                (FStar_Options.Other "Rel") in
-                           if uu____18229
+                           if uu____18227
                            then FStar_Util.print_string "Deferring ... \n"
                            else ());
                           FStar_Util.Inl "defer")
                        else
-                         ((let uu____18235 =
+                         ((let uu____18233 =
                              FStar_All.pipe_left
                                (FStar_TypeChecker_Env.debug env1)
                                (FStar_Options.Other "Rel") in
-                           if uu____18235
+                           if uu____18233
                            then
-                             let uu____18236 =
+                             let uu____18234 =
                                FStar_Syntax_Print.term_to_string scrutinee in
-                             let uu____18237 =
+                             let uu____18235 =
                                FStar_Syntax_Print.term_to_string t in
                              FStar_Util.print2
                                "Heuristic applicable with scrutinee %s and other side = %s\n"
-                               uu____18236 uu____18237
+                               uu____18234 uu____18235
                            else ());
-                          (let pat_discriminates uu___26_18258 =
-                             match uu___26_18258 with
+                          (let pat_discriminates uu___26_18256 =
+                             match uu___26_18256 with
                              | ({
                                   FStar_Syntax_Syntax.v =
                                     FStar_Syntax_Syntax.Pat_constant
-                                    uu____18273;
-                                  FStar_Syntax_Syntax.p = uu____18274;_},
-                                FStar_Pervasives_Native.None, uu____18275) ->
+                                    uu____18271;
+                                  FStar_Syntax_Syntax.p = uu____18272;_},
+                                FStar_Pervasives_Native.None, uu____18273) ->
                                  true
                              | ({
                                   FStar_Syntax_Syntax.v =
-                                    FStar_Syntax_Syntax.Pat_cons uu____18288;
-                                  FStar_Syntax_Syntax.p = uu____18289;_},
-                                FStar_Pervasives_Native.None, uu____18290) ->
+                                    FStar_Syntax_Syntax.Pat_cons uu____18286;
+                                  FStar_Syntax_Syntax.p = uu____18287;_},
+                                FStar_Pervasives_Native.None, uu____18288) ->
                                  true
-                             | uu____18315 -> false in
+                             | uu____18313 -> false in
                            let head_matching_branch =
                              FStar_All.pipe_right branches
                                (FStar_Util.try_find
                                   (fun b ->
                                      if pat_discriminates b
                                      then
-                                       let uu____18415 =
+                                       let uu____18413 =
                                          FStar_Syntax_Subst.open_branch b in
-                                       match uu____18415 with
-                                       | (uu____18416, uu____18417, t') ->
-                                           let uu____18435 =
+                                       match uu____18413 with
+                                       | (uu____18414, uu____18415, t') ->
+                                           let uu____18433 =
                                              head_matches_delta env1 wl1 s t' in
-                                           (match uu____18435 with
-                                            | (FullMatch, uu____18446) ->
+                                           (match uu____18433 with
+                                            | (FullMatch, uu____18444) ->
                                                 true
-                                            | (HeadMatch uu____18459,
-                                               uu____18460) -> true
-                                            | uu____18473 -> false)
+                                            | (HeadMatch uu____18457,
+                                               uu____18458) -> true
+                                            | uu____18471 -> false)
                                      else false)) in
                            match head_matching_branch with
                            | FStar_Pervasives_Native.None ->
-                               ((let uu____18506 =
+                               ((let uu____18504 =
                                    FStar_All.pipe_left
                                      (FStar_TypeChecker_Env.debug env1)
                                      (FStar_Options.Other "Rel") in
-                                 if uu____18506
+                                 if uu____18504
                                  then
                                    FStar_Util.print_string
                                      "No head_matching branch\n"
                                  else ());
                                 (let try_branches =
-                                   let uu____18511 =
+                                   let uu____18509 =
                                      FStar_Util.prefix_until
                                        (fun b ->
                                           Prims.op_Negation
                                             (pat_discriminates b)) branches in
-                                   match uu____18511 with
+                                   match uu____18509 with
                                    | FStar_Pervasives_Native.Some
-                                       (branches1, uu____18599, uu____18600)
+                                       (branches1, uu____18597, uu____18598)
                                        -> branches1
-                                   | uu____18745 -> branches in
-                                 let uu____18800 =
+                                   | uu____18743 -> branches in
+                                 let uu____18798 =
                                    FStar_Util.find_map try_branches
                                      (fun b ->
-                                        let uu____18809 =
+                                        let uu____18807 =
                                           FStar_Syntax_Subst.open_branch b in
-                                        match uu____18809 with
-                                        | (p, uu____18813, uu____18814) ->
+                                        match uu____18807 with
+                                        | (p, uu____18811, uu____18812) ->
                                             try_solve_branch scrutinee p) in
                                  FStar_All.pipe_left
-                                   (fun uu____18841 ->
-                                      FStar_Util.Inr uu____18841) uu____18800))
+                                   (fun uu____18839 ->
+                                      FStar_Util.Inr uu____18839) uu____18798))
                            | FStar_Pervasives_Native.Some b ->
-                               let uu____18871 =
+                               let uu____18869 =
                                  FStar_Syntax_Subst.open_branch b in
-                               (match uu____18871 with
-                                | (p, uu____18879, e) ->
-                                    ((let uu____18898 =
+                               (match uu____18869 with
+                                | (p, uu____18877, e) ->
+                                    ((let uu____18896 =
                                         FStar_All.pipe_left
                                           (FStar_TypeChecker_Env.debug env1)
                                           (FStar_Options.Other "Rel") in
-                                      if uu____18898
+                                      if uu____18896
                                       then
-                                        let uu____18899 =
+                                        let uu____18897 =
                                           FStar_Syntax_Print.pat_to_string p in
-                                        let uu____18900 =
+                                        let uu____18898 =
                                           FStar_Syntax_Print.term_to_string e in
                                         FStar_Util.print2
                                           "Found head matching branch %s -> %s\n"
-                                          uu____18899 uu____18900
+                                          uu____18897 uu____18898
                                       else ());
-                                     (let uu____18902 =
+                                     (let uu____18900 =
                                         try_solve_branch scrutinee p in
                                       FStar_All.pipe_left
-                                        (fun uu____18915 ->
-                                           FStar_Util.Inr uu____18915)
-                                        uu____18902)))))
-                 | uu____18916 ->
-                     ((let uu____18938 =
+                                        (fun uu____18913 ->
+                                           FStar_Util.Inr uu____18913)
+                                        uu____18900)))))
+                 | uu____18914 ->
+                     ((let uu____18936 =
                          FStar_All.pipe_left
                            (FStar_TypeChecker_Env.debug env1)
                            (FStar_Options.Other "Rel") in
-                       if uu____18938
+                       if uu____18936
                        then
-                         let uu____18939 = FStar_Syntax_Print.tag_of_term t1 in
-                         let uu____18940 = FStar_Syntax_Print.tag_of_term t2 in
+                         let uu____18937 = FStar_Syntax_Print.tag_of_term t1 in
+                         let uu____18938 = FStar_Syntax_Print.tag_of_term t2 in
                          FStar_Util.print2
                            "Heuristic not applicable: tag lhs=%s, rhs=%s\n"
-                           uu____18939 uu____18940
+                           uu____18937 uu____18938
                        else ());
                       FStar_Util.Inr FStar_Pervasives_Native.None))) in
          let rigid_rigid_delta env1 torig wl1 head1 head2 t1 t2 =
            let orig = FStar_TypeChecker_Common.TProb torig in
-           (let uu____18982 =
+           (let uu____18980 =
               FStar_All.pipe_left (FStar_TypeChecker_Env.debug env1)
                 (FStar_Options.Other "RelDelta") in
-            if uu____18982
+            if uu____18980
             then
-              let uu____18983 = FStar_Syntax_Print.tag_of_term t1 in
-              let uu____18984 = FStar_Syntax_Print.tag_of_term t2 in
-              let uu____18985 = FStar_Syntax_Print.term_to_string t1 in
-              let uu____18986 = FStar_Syntax_Print.term_to_string t2 in
+              let uu____18981 = FStar_Syntax_Print.tag_of_term t1 in
+              let uu____18982 = FStar_Syntax_Print.tag_of_term t2 in
+              let uu____18983 = FStar_Syntax_Print.term_to_string t1 in
+              let uu____18984 = FStar_Syntax_Print.term_to_string t2 in
               FStar_Util.print4 "rigid_rigid_delta of %s-%s (%s, %s)\n"
-                uu____18983 uu____18984 uu____18985 uu____18986
+                uu____18981 uu____18982 uu____18983 uu____18984
             else ());
-           (let uu____18988 = head_matches_delta env1 wl1 t1 t2 in
-            match uu____18988 with
+           (let uu____18986 = head_matches_delta env1 wl1 t1 t2 in
+            match uu____18986 with
             | (m, o) ->
                 (match (m, o) with
-                 | (MisMatch uu____19019, uu____19020) ->
+                 | (MisMatch uu____19017, uu____19018) ->
                      let rec may_relate head =
-                       let uu____19047 =
-                         let uu____19048 = FStar_Syntax_Subst.compress head in
-                         uu____19048.FStar_Syntax_Syntax.n in
-                       match uu____19047 with
-                       | FStar_Syntax_Syntax.Tm_name uu____19051 -> true
-                       | FStar_Syntax_Syntax.Tm_match uu____19052 -> true
+                       let uu____19045 =
+                         let uu____19046 = FStar_Syntax_Subst.compress head in
+                         uu____19046.FStar_Syntax_Syntax.n in
+                       match uu____19045 with
+                       | FStar_Syntax_Syntax.Tm_name uu____19049 -> true
+                       | FStar_Syntax_Syntax.Tm_match uu____19050 -> true
                        | FStar_Syntax_Syntax.Tm_fvar fv ->
-                           let uu____19076 =
+                           let uu____19074 =
                              FStar_TypeChecker_Env.delta_depth_of_fv env1 fv in
-                           (match uu____19076 with
+                           (match uu____19074 with
                             | FStar_Syntax_Syntax.Delta_equational_at_level
-                                uu____19077 -> true
-                            | FStar_Syntax_Syntax.Delta_abstract uu____19078
+                                uu____19075 -> true
+                            | FStar_Syntax_Syntax.Delta_abstract uu____19076
                                 ->
                                 problem.FStar_TypeChecker_Common.relation =
                                   FStar_TypeChecker_Common.EQ
-                            | uu____19079 -> false)
+                            | uu____19077 -> false)
                        | FStar_Syntax_Syntax.Tm_ascribed
-                           (t, uu____19081, uu____19082) -> may_relate t
-                       | FStar_Syntax_Syntax.Tm_uinst (t, uu____19124) ->
+                           (t, uu____19079, uu____19080) -> may_relate t
+                       | FStar_Syntax_Syntax.Tm_uinst (t, uu____19122) ->
                            may_relate t
-                       | FStar_Syntax_Syntax.Tm_meta (t, uu____19130) ->
+                       | FStar_Syntax_Syntax.Tm_meta (t, uu____19128) ->
                            may_relate t
-                       | uu____19135 -> false in
-                     let uu____19136 =
+                       | uu____19133 -> false in
+                     let uu____19134 =
                        try_match_heuristic env1 orig wl1 t1 t2 o in
-                     (match uu____19136 with
+                     (match uu____19134 with
                       | FStar_Util.Inl _defer_ok ->
-                          let uu____19146 =
+                          let uu____19144 =
                             FStar_Thunk.mkv "delaying match heuristic" in
-                          giveup_or_defer1 orig uu____19146
+                          giveup_or_defer1 orig uu____19144
                       | FStar_Util.Inr (FStar_Pervasives_Native.Some wl2) ->
                           solve env1 wl2
                       | FStar_Util.Inr (FStar_Pervasives_Native.None) ->
-                          let uu____19152 =
+                          let uu____19150 =
                             ((may_relate head1) || (may_relate head2)) &&
                               wl1.smt_ok in
-                          if uu____19152
+                          if uu____19150
                           then
-                            let uu____19153 =
+                            let uu____19151 =
                               guard_of_prob env1 wl1 problem t1 t2 in
-                            (match uu____19153 with
+                            (match uu____19151 with
                              | (guard, wl2) ->
-                                 let uu____19160 =
+                                 let uu____19158 =
                                    solve_prob orig
                                      (FStar_Pervasives_Native.Some guard) []
                                      wl2 in
-                                 solve env1 uu____19160)
+                                 solve env1 uu____19158)
                           else
-                            (let uu____19162 =
+                            (let uu____19160 =
                                mklstr
-                                 (fun uu____19173 ->
-                                    let uu____19174 =
+                                 (fun uu____19171 ->
+                                    let uu____19172 =
                                       FStar_Syntax_Print.term_to_string head1 in
-                                    let uu____19175 =
-                                      let uu____19176 =
-                                        let uu____19179 =
+                                    let uu____19173 =
+                                      let uu____19174 =
+                                        let uu____19177 =
                                           delta_depth_of_term env1 head1 in
-                                        FStar_Util.bind_opt uu____19179
+                                        FStar_Util.bind_opt uu____19177
                                           (fun x ->
-                                             let uu____19185 =
+                                             let uu____19183 =
                                                FStar_Syntax_Print.delta_depth_to_string
                                                  x in
                                              FStar_Pervasives_Native.Some
-                                               uu____19185) in
-                                      FStar_Util.dflt "" uu____19176 in
-                                    let uu____19186 =
+                                               uu____19183) in
+                                      FStar_Util.dflt "" uu____19174 in
+                                    let uu____19184 =
                                       FStar_Syntax_Print.term_to_string head2 in
-                                    let uu____19187 =
-                                      let uu____19188 =
-                                        let uu____19191 =
+                                    let uu____19185 =
+                                      let uu____19186 =
+                                        let uu____19189 =
                                           delta_depth_of_term env1 head2 in
-                                        FStar_Util.bind_opt uu____19191
+                                        FStar_Util.bind_opt uu____19189
                                           (fun x ->
-                                             let uu____19197 =
+                                             let uu____19195 =
                                                FStar_Syntax_Print.delta_depth_to_string
                                                  x in
                                              FStar_Pervasives_Native.Some
-                                               uu____19197) in
-                                      FStar_Util.dflt "" uu____19188 in
+                                               uu____19195) in
+                                      FStar_Util.dflt "" uu____19186 in
                                     FStar_Util.format4
                                       "head mismatch (%s (%s) vs %s (%s))"
-                                      uu____19174 uu____19175 uu____19186
-                                      uu____19187) in
-                             giveup env1 uu____19162 orig))
-                 | (HeadMatch (true), uu____19198) when
+                                      uu____19172 uu____19173 uu____19184
+                                      uu____19185) in
+                             giveup env1 uu____19160 orig))
+                 | (HeadMatch (true), uu____19196) when
                      problem.FStar_TypeChecker_Common.relation <>
                        FStar_TypeChecker_Common.EQ
                      ->
                      if wl1.smt_ok
                      then
-                       let uu____19211 = guard_of_prob env1 wl1 problem t1 t2 in
-                       (match uu____19211 with
+                       let uu____19209 = guard_of_prob env1 wl1 problem t1 t2 in
+                       (match uu____19209 with
                         | (guard, wl2) ->
-                            let uu____19218 =
+                            let uu____19216 =
                               solve_prob orig
                                 (FStar_Pervasives_Native.Some guard) [] wl2 in
-                            solve env1 uu____19218)
+                            solve env1 uu____19216)
                      else
-                       (let uu____19220 =
+                       (let uu____19218 =
                           mklstr
-                            (fun uu____19227 ->
-                               let uu____19228 =
+                            (fun uu____19225 ->
+                               let uu____19226 =
                                  FStar_Syntax_Print.term_to_string t1 in
-                               let uu____19229 =
+                               let uu____19227 =
                                  FStar_Syntax_Print.term_to_string t2 in
                                FStar_Util.format2
                                  "head mismatch for subtyping (%s vs %s)"
-                                 uu____19228 uu____19229) in
-                        giveup env1 uu____19220 orig)
-                 | (uu____19230, FStar_Pervasives_Native.Some (t11, t21)) ->
+                                 uu____19226 uu____19227) in
+                        giveup env1 uu____19218 orig)
+                 | (uu____19228, FStar_Pervasives_Native.Some (t11, t21)) ->
                      solve_t env1
-                       (let uu___2978_19244 = problem in
+                       (let uu___2978_19242 = problem in
                         {
                           FStar_TypeChecker_Common.pid =
-                            (uu___2978_19244.FStar_TypeChecker_Common.pid);
+                            (uu___2978_19242.FStar_TypeChecker_Common.pid);
                           FStar_TypeChecker_Common.lhs = t11;
                           FStar_TypeChecker_Common.relation =
-                            (uu___2978_19244.FStar_TypeChecker_Common.relation);
+                            (uu___2978_19242.FStar_TypeChecker_Common.relation);
                           FStar_TypeChecker_Common.rhs = t21;
                           FStar_TypeChecker_Common.element =
-                            (uu___2978_19244.FStar_TypeChecker_Common.element);
+                            (uu___2978_19242.FStar_TypeChecker_Common.element);
                           FStar_TypeChecker_Common.logical_guard =
-                            (uu___2978_19244.FStar_TypeChecker_Common.logical_guard);
+                            (uu___2978_19242.FStar_TypeChecker_Common.logical_guard);
                           FStar_TypeChecker_Common.logical_guard_uvar =
-                            (uu___2978_19244.FStar_TypeChecker_Common.logical_guard_uvar);
+                            (uu___2978_19242.FStar_TypeChecker_Common.logical_guard_uvar);
                           FStar_TypeChecker_Common.reason =
-                            (uu___2978_19244.FStar_TypeChecker_Common.reason);
+                            (uu___2978_19242.FStar_TypeChecker_Common.reason);
                           FStar_TypeChecker_Common.loc =
-                            (uu___2978_19244.FStar_TypeChecker_Common.loc);
+                            (uu___2978_19242.FStar_TypeChecker_Common.loc);
                           FStar_TypeChecker_Common.rank =
-                            (uu___2978_19244.FStar_TypeChecker_Common.rank)
+                            (uu___2978_19242.FStar_TypeChecker_Common.rank)
                         }) wl1
                  | (HeadMatch need_unif, FStar_Pervasives_Native.None) ->
                      rigid_heads_match env1 need_unif torig wl1 t1 t2
@@ -6750,188 +6750,188 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                      rigid_heads_match env1 false torig wl1 t1 t2)) in
          let orig = FStar_TypeChecker_Common.TProb problem in
          def_check_prob "solve_t'.2" orig;
-         (let uu____19268 =
+         (let uu____19266 =
             FStar_Util.physical_equality problem.FStar_TypeChecker_Common.lhs
               problem.FStar_TypeChecker_Common.rhs in
-          if uu____19268
+          if uu____19266
           then
-            let uu____19269 =
+            let uu____19267 =
               solve_prob orig FStar_Pervasives_Native.None [] wl in
-            solve env uu____19269
+            solve env uu____19267
           else
             (let t1 = problem.FStar_TypeChecker_Common.lhs in
              let t2 = problem.FStar_TypeChecker_Common.rhs in
-             (let uu____19274 =
-                let uu____19277 = p_scope orig in
-                FStar_List.map FStar_Pervasives_Native.fst uu____19277 in
+             (let uu____19272 =
+                let uu____19275 = p_scope orig in
+                FStar_List.map FStar_Pervasives_Native.fst uu____19275 in
               FStar_TypeChecker_Env.def_check_closed_in (p_loc orig) "ref.t1"
-                uu____19274 t1);
-             (let uu____19295 =
-                let uu____19298 = p_scope orig in
-                FStar_List.map FStar_Pervasives_Native.fst uu____19298 in
+                uu____19272 t1);
+             (let uu____19293 =
+                let uu____19296 = p_scope orig in
+                FStar_List.map FStar_Pervasives_Native.fst uu____19296 in
               FStar_TypeChecker_Env.def_check_closed_in (p_loc orig) "ref.t2"
-                uu____19295 t2);
-             (let uu____19316 =
+                uu____19293 t2);
+             (let uu____19314 =
                 FStar_TypeChecker_Env.debug env (FStar_Options.Other "Rel") in
-              if uu____19316
+              if uu____19314
               then
-                let uu____19317 =
+                let uu____19315 =
                   FStar_Util.string_of_int
                     problem.FStar_TypeChecker_Common.pid in
-                let uu____19318 =
-                  let uu____19319 = FStar_Syntax_Print.tag_of_term t1 in
-                  let uu____19320 =
-                    let uu____19321 = FStar_Syntax_Print.term_to_string t1 in
-                    Prims.op_Hat "::" uu____19321 in
-                  Prims.op_Hat uu____19319 uu____19320 in
-                let uu____19322 =
-                  let uu____19323 = FStar_Syntax_Print.tag_of_term t2 in
-                  let uu____19324 =
-                    let uu____19325 = FStar_Syntax_Print.term_to_string t2 in
-                    Prims.op_Hat "::" uu____19325 in
-                  Prims.op_Hat uu____19323 uu____19324 in
+                let uu____19316 =
+                  let uu____19317 = FStar_Syntax_Print.tag_of_term t1 in
+                  let uu____19318 =
+                    let uu____19319 = FStar_Syntax_Print.term_to_string t1 in
+                    Prims.op_Hat "::" uu____19319 in
+                  Prims.op_Hat uu____19317 uu____19318 in
+                let uu____19320 =
+                  let uu____19321 = FStar_Syntax_Print.tag_of_term t2 in
+                  let uu____19322 =
+                    let uu____19323 = FStar_Syntax_Print.term_to_string t2 in
+                    Prims.op_Hat "::" uu____19323 in
+                  Prims.op_Hat uu____19321 uu____19322 in
                 FStar_Util.print4 "Attempting %s (%s vs %s); rel = (%s)\n"
-                  uu____19317 uu____19318 uu____19322
+                  uu____19315 uu____19316 uu____19320
                   (rel_to_string problem.FStar_TypeChecker_Common.relation)
               else ());
              (let r = FStar_TypeChecker_Env.get_range env in
               match ((t1.FStar_Syntax_Syntax.n), (t2.FStar_Syntax_Syntax.n))
               with
-              | (FStar_Syntax_Syntax.Tm_delayed uu____19328, uu____19329) ->
+              | (FStar_Syntax_Syntax.Tm_delayed uu____19326, uu____19327) ->
                   failwith "Impossible: terms were not compressed"
-              | (uu____19344, FStar_Syntax_Syntax.Tm_delayed uu____19345) ->
+              | (uu____19342, FStar_Syntax_Syntax.Tm_delayed uu____19343) ->
                   failwith "Impossible: terms were not compressed"
-              | (FStar_Syntax_Syntax.Tm_ascribed uu____19360, uu____19361) ->
-                  let uu____19388 =
-                    let uu___3009_19389 = problem in
-                    let uu____19390 = FStar_Syntax_Util.unascribe t1 in
+              | (FStar_Syntax_Syntax.Tm_ascribed uu____19358, uu____19359) ->
+                  let uu____19386 =
+                    let uu___3009_19387 = problem in
+                    let uu____19388 = FStar_Syntax_Util.unascribe t1 in
                     {
                       FStar_TypeChecker_Common.pid =
-                        (uu___3009_19389.FStar_TypeChecker_Common.pid);
-                      FStar_TypeChecker_Common.lhs = uu____19390;
+                        (uu___3009_19387.FStar_TypeChecker_Common.pid);
+                      FStar_TypeChecker_Common.lhs = uu____19388;
                       FStar_TypeChecker_Common.relation =
-                        (uu___3009_19389.FStar_TypeChecker_Common.relation);
+                        (uu___3009_19387.FStar_TypeChecker_Common.relation);
                       FStar_TypeChecker_Common.rhs =
-                        (uu___3009_19389.FStar_TypeChecker_Common.rhs);
+                        (uu___3009_19387.FStar_TypeChecker_Common.rhs);
                       FStar_TypeChecker_Common.element =
-                        (uu___3009_19389.FStar_TypeChecker_Common.element);
+                        (uu___3009_19387.FStar_TypeChecker_Common.element);
                       FStar_TypeChecker_Common.logical_guard =
-                        (uu___3009_19389.FStar_TypeChecker_Common.logical_guard);
+                        (uu___3009_19387.FStar_TypeChecker_Common.logical_guard);
                       FStar_TypeChecker_Common.logical_guard_uvar =
-                        (uu___3009_19389.FStar_TypeChecker_Common.logical_guard_uvar);
+                        (uu___3009_19387.FStar_TypeChecker_Common.logical_guard_uvar);
                       FStar_TypeChecker_Common.reason =
-                        (uu___3009_19389.FStar_TypeChecker_Common.reason);
+                        (uu___3009_19387.FStar_TypeChecker_Common.reason);
                       FStar_TypeChecker_Common.loc =
-                        (uu___3009_19389.FStar_TypeChecker_Common.loc);
+                        (uu___3009_19387.FStar_TypeChecker_Common.loc);
                       FStar_TypeChecker_Common.rank =
-                        (uu___3009_19389.FStar_TypeChecker_Common.rank)
+                        (uu___3009_19387.FStar_TypeChecker_Common.rank)
                     } in
-                  solve_t' env uu____19388 wl
-              | (FStar_Syntax_Syntax.Tm_meta uu____19391, uu____19392) ->
-                  let uu____19399 =
-                    let uu___3015_19400 = problem in
-                    let uu____19401 = FStar_Syntax_Util.unmeta t1 in
+                  solve_t' env uu____19386 wl
+              | (FStar_Syntax_Syntax.Tm_meta uu____19389, uu____19390) ->
+                  let uu____19397 =
+                    let uu___3015_19398 = problem in
+                    let uu____19399 = FStar_Syntax_Util.unmeta t1 in
                     {
                       FStar_TypeChecker_Common.pid =
-                        (uu___3015_19400.FStar_TypeChecker_Common.pid);
-                      FStar_TypeChecker_Common.lhs = uu____19401;
+                        (uu___3015_19398.FStar_TypeChecker_Common.pid);
+                      FStar_TypeChecker_Common.lhs = uu____19399;
                       FStar_TypeChecker_Common.relation =
-                        (uu___3015_19400.FStar_TypeChecker_Common.relation);
+                        (uu___3015_19398.FStar_TypeChecker_Common.relation);
                       FStar_TypeChecker_Common.rhs =
-                        (uu___3015_19400.FStar_TypeChecker_Common.rhs);
+                        (uu___3015_19398.FStar_TypeChecker_Common.rhs);
                       FStar_TypeChecker_Common.element =
-                        (uu___3015_19400.FStar_TypeChecker_Common.element);
+                        (uu___3015_19398.FStar_TypeChecker_Common.element);
                       FStar_TypeChecker_Common.logical_guard =
-                        (uu___3015_19400.FStar_TypeChecker_Common.logical_guard);
+                        (uu___3015_19398.FStar_TypeChecker_Common.logical_guard);
                       FStar_TypeChecker_Common.logical_guard_uvar =
-                        (uu___3015_19400.FStar_TypeChecker_Common.logical_guard_uvar);
+                        (uu___3015_19398.FStar_TypeChecker_Common.logical_guard_uvar);
                       FStar_TypeChecker_Common.reason =
-                        (uu___3015_19400.FStar_TypeChecker_Common.reason);
+                        (uu___3015_19398.FStar_TypeChecker_Common.reason);
                       FStar_TypeChecker_Common.loc =
-                        (uu___3015_19400.FStar_TypeChecker_Common.loc);
+                        (uu___3015_19398.FStar_TypeChecker_Common.loc);
                       FStar_TypeChecker_Common.rank =
-                        (uu___3015_19400.FStar_TypeChecker_Common.rank)
+                        (uu___3015_19398.FStar_TypeChecker_Common.rank)
                     } in
-                  solve_t' env uu____19399 wl
-              | (uu____19402, FStar_Syntax_Syntax.Tm_ascribed uu____19403) ->
-                  let uu____19430 =
-                    let uu___3021_19431 = problem in
-                    let uu____19432 = FStar_Syntax_Util.unascribe t2 in
+                  solve_t' env uu____19397 wl
+              | (uu____19400, FStar_Syntax_Syntax.Tm_ascribed uu____19401) ->
+                  let uu____19428 =
+                    let uu___3021_19429 = problem in
+                    let uu____19430 = FStar_Syntax_Util.unascribe t2 in
                     {
                       FStar_TypeChecker_Common.pid =
-                        (uu___3021_19431.FStar_TypeChecker_Common.pid);
+                        (uu___3021_19429.FStar_TypeChecker_Common.pid);
                       FStar_TypeChecker_Common.lhs =
-                        (uu___3021_19431.FStar_TypeChecker_Common.lhs);
+                        (uu___3021_19429.FStar_TypeChecker_Common.lhs);
                       FStar_TypeChecker_Common.relation =
-                        (uu___3021_19431.FStar_TypeChecker_Common.relation);
-                      FStar_TypeChecker_Common.rhs = uu____19432;
+                        (uu___3021_19429.FStar_TypeChecker_Common.relation);
+                      FStar_TypeChecker_Common.rhs = uu____19430;
                       FStar_TypeChecker_Common.element =
-                        (uu___3021_19431.FStar_TypeChecker_Common.element);
+                        (uu___3021_19429.FStar_TypeChecker_Common.element);
                       FStar_TypeChecker_Common.logical_guard =
-                        (uu___3021_19431.FStar_TypeChecker_Common.logical_guard);
+                        (uu___3021_19429.FStar_TypeChecker_Common.logical_guard);
                       FStar_TypeChecker_Common.logical_guard_uvar =
-                        (uu___3021_19431.FStar_TypeChecker_Common.logical_guard_uvar);
+                        (uu___3021_19429.FStar_TypeChecker_Common.logical_guard_uvar);
                       FStar_TypeChecker_Common.reason =
-                        (uu___3021_19431.FStar_TypeChecker_Common.reason);
+                        (uu___3021_19429.FStar_TypeChecker_Common.reason);
                       FStar_TypeChecker_Common.loc =
-                        (uu___3021_19431.FStar_TypeChecker_Common.loc);
+                        (uu___3021_19429.FStar_TypeChecker_Common.loc);
                       FStar_TypeChecker_Common.rank =
-                        (uu___3021_19431.FStar_TypeChecker_Common.rank)
+                        (uu___3021_19429.FStar_TypeChecker_Common.rank)
                     } in
-                  solve_t' env uu____19430 wl
-              | (uu____19433, FStar_Syntax_Syntax.Tm_meta uu____19434) ->
-                  let uu____19441 =
-                    let uu___3027_19442 = problem in
-                    let uu____19443 = FStar_Syntax_Util.unmeta t2 in
+                  solve_t' env uu____19428 wl
+              | (uu____19431, FStar_Syntax_Syntax.Tm_meta uu____19432) ->
+                  let uu____19439 =
+                    let uu___3027_19440 = problem in
+                    let uu____19441 = FStar_Syntax_Util.unmeta t2 in
                     {
                       FStar_TypeChecker_Common.pid =
-                        (uu___3027_19442.FStar_TypeChecker_Common.pid);
+                        (uu___3027_19440.FStar_TypeChecker_Common.pid);
                       FStar_TypeChecker_Common.lhs =
-                        (uu___3027_19442.FStar_TypeChecker_Common.lhs);
+                        (uu___3027_19440.FStar_TypeChecker_Common.lhs);
                       FStar_TypeChecker_Common.relation =
-                        (uu___3027_19442.FStar_TypeChecker_Common.relation);
-                      FStar_TypeChecker_Common.rhs = uu____19443;
+                        (uu___3027_19440.FStar_TypeChecker_Common.relation);
+                      FStar_TypeChecker_Common.rhs = uu____19441;
                       FStar_TypeChecker_Common.element =
-                        (uu___3027_19442.FStar_TypeChecker_Common.element);
+                        (uu___3027_19440.FStar_TypeChecker_Common.element);
                       FStar_TypeChecker_Common.logical_guard =
-                        (uu___3027_19442.FStar_TypeChecker_Common.logical_guard);
+                        (uu___3027_19440.FStar_TypeChecker_Common.logical_guard);
                       FStar_TypeChecker_Common.logical_guard_uvar =
-                        (uu___3027_19442.FStar_TypeChecker_Common.logical_guard_uvar);
+                        (uu___3027_19440.FStar_TypeChecker_Common.logical_guard_uvar);
                       FStar_TypeChecker_Common.reason =
-                        (uu___3027_19442.FStar_TypeChecker_Common.reason);
+                        (uu___3027_19440.FStar_TypeChecker_Common.reason);
                       FStar_TypeChecker_Common.loc =
-                        (uu___3027_19442.FStar_TypeChecker_Common.loc);
+                        (uu___3027_19440.FStar_TypeChecker_Common.loc);
                       FStar_TypeChecker_Common.rank =
-                        (uu___3027_19442.FStar_TypeChecker_Common.rank)
+                        (uu___3027_19440.FStar_TypeChecker_Common.rank)
                     } in
-                  solve_t' env uu____19441 wl
-              | (FStar_Syntax_Syntax.Tm_quoted (t11, uu____19445),
-                 FStar_Syntax_Syntax.Tm_quoted (t21, uu____19447)) ->
-                  let uu____19456 =
+                  solve_t' env uu____19439 wl
+              | (FStar_Syntax_Syntax.Tm_quoted (t11, uu____19443),
+                 FStar_Syntax_Syntax.Tm_quoted (t21, uu____19445)) ->
+                  let uu____19454 =
                     solve_prob orig FStar_Pervasives_Native.None [] wl in
-                  solve env uu____19456
-              | (FStar_Syntax_Syntax.Tm_bvar uu____19457, uu____19458) ->
+                  solve env uu____19454
+              | (FStar_Syntax_Syntax.Tm_bvar uu____19455, uu____19456) ->
                   failwith
                     "Only locally nameless! We should never see a de Bruijn variable"
-              | (uu____19459, FStar_Syntax_Syntax.Tm_bvar uu____19460) ->
+              | (uu____19457, FStar_Syntax_Syntax.Tm_bvar uu____19458) ->
                   failwith
                     "Only locally nameless! We should never see a de Bruijn variable"
               | (FStar_Syntax_Syntax.Tm_type u1, FStar_Syntax_Syntax.Tm_type
                  u2) -> solve_one_universe_eq env orig u1 u2 wl
               | (FStar_Syntax_Syntax.Tm_arrow (bs1, c1),
                  FStar_Syntax_Syntax.Tm_arrow (bs2, c2)) ->
-                  let mk_c c uu___27_19529 =
-                    match uu___27_19529 with
+                  let mk_c c uu___27_19527 =
+                    match uu___27_19527 with
                     | [] -> c
                     | bs ->
-                        let uu____19557 =
+                        let uu____19555 =
                           FStar_Syntax_Syntax.mk
                             (FStar_Syntax_Syntax.Tm_arrow (bs, c))
                             c.FStar_Syntax_Syntax.pos in
-                        FStar_Syntax_Syntax.mk_Total uu____19557 in
-                  let uu____19568 =
+                        FStar_Syntax_Syntax.mk_Total uu____19555 in
+                  let uu____19566 =
                     match_num_binders (bs1, (mk_c c1)) (bs2, (mk_c c2)) in
-                  (match uu____19568 with
+                  (match uu____19566 with
                    | ((bs11, c11), (bs21, c21)) ->
                        solve_binders env bs11 bs21 orig wl
                          (fun wl1 ->
@@ -6943,9 +6943,9 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                                   let c22 =
                                     FStar_Syntax_Subst.subst_comp subst c21 in
                                   let rel =
-                                    let uu____19717 =
+                                    let uu____19715 =
                                       FStar_Options.use_eq_at_higher_order () in
-                                    if uu____19717
+                                    if uu____19715
                                     then FStar_TypeChecker_Common.EQ
                                     else
                                       problem.FStar_TypeChecker_Common.relation in
@@ -6954,36 +6954,36 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                                     "function co-domain"))
               | (FStar_Syntax_Syntax.Tm_abs (bs1, tbody1, lopt1),
                  FStar_Syntax_Syntax.Tm_abs (bs2, tbody2, lopt2)) ->
-                  let mk_t t l uu___28_19802 =
-                    match uu___28_19802 with
+                  let mk_t t l uu___28_19800 =
+                    match uu___28_19800 with
                     | [] -> t
                     | bs ->
                         FStar_Syntax_Syntax.mk
                           (FStar_Syntax_Syntax.Tm_abs (bs, t, l))
                           t.FStar_Syntax_Syntax.pos in
-                  let uu____19844 =
+                  let uu____19842 =
                     match_num_binders (bs1, (mk_t tbody1 lopt1))
                       (bs2, (mk_t tbody2 lopt2)) in
-                  (match uu____19844 with
+                  (match uu____19842 with
                    | ((bs11, tbody11), (bs21, tbody21)) ->
                        solve_binders env bs11 bs21 orig wl
                          (fun wl1 ->
                             fun scope ->
                               fun env1 ->
                                 fun subst ->
-                                  let uu____19989 =
+                                  let uu____19987 =
                                     FStar_Syntax_Subst.subst subst tbody11 in
-                                  let uu____19990 =
+                                  let uu____19988 =
                                     FStar_Syntax_Subst.subst subst tbody21 in
-                                  mk_t_problem wl1 scope orig uu____19989
+                                  mk_t_problem wl1 scope orig uu____19987
                                     problem.FStar_TypeChecker_Common.relation
-                                    uu____19990 FStar_Pervasives_Native.None
+                                    uu____19988 FStar_Pervasives_Native.None
                                     "lambda co-domain"))
-              | (FStar_Syntax_Syntax.Tm_abs uu____19991, uu____19992) ->
+              | (FStar_Syntax_Syntax.Tm_abs uu____19989, uu____19990) ->
                   let is_abs t =
                     match t.FStar_Syntax_Syntax.n with
-                    | FStar_Syntax_Syntax.Tm_abs uu____20021 -> true
-                    | uu____20040 -> false in
+                    | FStar_Syntax_Syntax.Tm_abs uu____20019 -> true
+                    | uu____20038 -> false in
                   let maybe_eta t =
                     if is_abs t
                     then FStar_Util.Inl t
@@ -6997,182 +6997,182 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                     if is_abs t
                     then t
                     else
-                      (let uu____20093 =
+                      (let uu____20091 =
                          env.FStar_TypeChecker_Env.type_of
-                           (let uu___3129_20101 = env in
+                           (let uu___3129_20099 = env in
                             {
                               FStar_TypeChecker_Env.solver =
-                                (uu___3129_20101.FStar_TypeChecker_Env.solver);
+                                (uu___3129_20099.FStar_TypeChecker_Env.solver);
                               FStar_TypeChecker_Env.range =
-                                (uu___3129_20101.FStar_TypeChecker_Env.range);
+                                (uu___3129_20099.FStar_TypeChecker_Env.range);
                               FStar_TypeChecker_Env.curmodule =
-                                (uu___3129_20101.FStar_TypeChecker_Env.curmodule);
+                                (uu___3129_20099.FStar_TypeChecker_Env.curmodule);
                               FStar_TypeChecker_Env.gamma =
-                                (uu___3129_20101.FStar_TypeChecker_Env.gamma);
+                                (uu___3129_20099.FStar_TypeChecker_Env.gamma);
                               FStar_TypeChecker_Env.gamma_sig =
-                                (uu___3129_20101.FStar_TypeChecker_Env.gamma_sig);
+                                (uu___3129_20099.FStar_TypeChecker_Env.gamma_sig);
                               FStar_TypeChecker_Env.gamma_cache =
-                                (uu___3129_20101.FStar_TypeChecker_Env.gamma_cache);
+                                (uu___3129_20099.FStar_TypeChecker_Env.gamma_cache);
                               FStar_TypeChecker_Env.modules =
-                                (uu___3129_20101.FStar_TypeChecker_Env.modules);
+                                (uu___3129_20099.FStar_TypeChecker_Env.modules);
                               FStar_TypeChecker_Env.expected_typ =
                                 FStar_Pervasives_Native.None;
                               FStar_TypeChecker_Env.sigtab =
-                                (uu___3129_20101.FStar_TypeChecker_Env.sigtab);
+                                (uu___3129_20099.FStar_TypeChecker_Env.sigtab);
                               FStar_TypeChecker_Env.attrtab =
-                                (uu___3129_20101.FStar_TypeChecker_Env.attrtab);
+                                (uu___3129_20099.FStar_TypeChecker_Env.attrtab);
                               FStar_TypeChecker_Env.instantiate_imp =
-                                (uu___3129_20101.FStar_TypeChecker_Env.instantiate_imp);
+                                (uu___3129_20099.FStar_TypeChecker_Env.instantiate_imp);
                               FStar_TypeChecker_Env.effects =
-                                (uu___3129_20101.FStar_TypeChecker_Env.effects);
+                                (uu___3129_20099.FStar_TypeChecker_Env.effects);
                               FStar_TypeChecker_Env.generalize =
-                                (uu___3129_20101.FStar_TypeChecker_Env.generalize);
+                                (uu___3129_20099.FStar_TypeChecker_Env.generalize);
                               FStar_TypeChecker_Env.letrecs =
-                                (uu___3129_20101.FStar_TypeChecker_Env.letrecs);
+                                (uu___3129_20099.FStar_TypeChecker_Env.letrecs);
                               FStar_TypeChecker_Env.top_level =
-                                (uu___3129_20101.FStar_TypeChecker_Env.top_level);
+                                (uu___3129_20099.FStar_TypeChecker_Env.top_level);
                               FStar_TypeChecker_Env.check_uvars =
-                                (uu___3129_20101.FStar_TypeChecker_Env.check_uvars);
+                                (uu___3129_20099.FStar_TypeChecker_Env.check_uvars);
                               FStar_TypeChecker_Env.use_eq =
-                                (uu___3129_20101.FStar_TypeChecker_Env.use_eq);
+                                (uu___3129_20099.FStar_TypeChecker_Env.use_eq);
                               FStar_TypeChecker_Env.use_eq_strict =
-                                (uu___3129_20101.FStar_TypeChecker_Env.use_eq_strict);
+                                (uu___3129_20099.FStar_TypeChecker_Env.use_eq_strict);
                               FStar_TypeChecker_Env.is_iface =
-                                (uu___3129_20101.FStar_TypeChecker_Env.is_iface);
+                                (uu___3129_20099.FStar_TypeChecker_Env.is_iface);
                               FStar_TypeChecker_Env.admit =
-                                (uu___3129_20101.FStar_TypeChecker_Env.admit);
+                                (uu___3129_20099.FStar_TypeChecker_Env.admit);
                               FStar_TypeChecker_Env.lax = true;
                               FStar_TypeChecker_Env.lax_universes =
-                                (uu___3129_20101.FStar_TypeChecker_Env.lax_universes);
+                                (uu___3129_20099.FStar_TypeChecker_Env.lax_universes);
                               FStar_TypeChecker_Env.phase1 =
-                                (uu___3129_20101.FStar_TypeChecker_Env.phase1);
+                                (uu___3129_20099.FStar_TypeChecker_Env.phase1);
                               FStar_TypeChecker_Env.failhard =
-                                (uu___3129_20101.FStar_TypeChecker_Env.failhard);
+                                (uu___3129_20099.FStar_TypeChecker_Env.failhard);
                               FStar_TypeChecker_Env.nosynth =
-                                (uu___3129_20101.FStar_TypeChecker_Env.nosynth);
+                                (uu___3129_20099.FStar_TypeChecker_Env.nosynth);
                               FStar_TypeChecker_Env.uvar_subtyping =
-                                (uu___3129_20101.FStar_TypeChecker_Env.uvar_subtyping);
+                                (uu___3129_20099.FStar_TypeChecker_Env.uvar_subtyping);
                               FStar_TypeChecker_Env.tc_term =
-                                (uu___3129_20101.FStar_TypeChecker_Env.tc_term);
+                                (uu___3129_20099.FStar_TypeChecker_Env.tc_term);
                               FStar_TypeChecker_Env.type_of =
-                                (uu___3129_20101.FStar_TypeChecker_Env.type_of);
+                                (uu___3129_20099.FStar_TypeChecker_Env.type_of);
                               FStar_TypeChecker_Env.universe_of =
-                                (uu___3129_20101.FStar_TypeChecker_Env.universe_of);
+                                (uu___3129_20099.FStar_TypeChecker_Env.universe_of);
                               FStar_TypeChecker_Env.check_type_of =
-                                (uu___3129_20101.FStar_TypeChecker_Env.check_type_of);
+                                (uu___3129_20099.FStar_TypeChecker_Env.check_type_of);
                               FStar_TypeChecker_Env.use_bv_sorts = true;
                               FStar_TypeChecker_Env.qtbl_name_and_index =
-                                (uu___3129_20101.FStar_TypeChecker_Env.qtbl_name_and_index);
+                                (uu___3129_20099.FStar_TypeChecker_Env.qtbl_name_and_index);
                               FStar_TypeChecker_Env.normalized_eff_names =
-                                (uu___3129_20101.FStar_TypeChecker_Env.normalized_eff_names);
+                                (uu___3129_20099.FStar_TypeChecker_Env.normalized_eff_names);
                               FStar_TypeChecker_Env.fv_delta_depths =
-                                (uu___3129_20101.FStar_TypeChecker_Env.fv_delta_depths);
+                                (uu___3129_20099.FStar_TypeChecker_Env.fv_delta_depths);
                               FStar_TypeChecker_Env.proof_ns =
-                                (uu___3129_20101.FStar_TypeChecker_Env.proof_ns);
+                                (uu___3129_20099.FStar_TypeChecker_Env.proof_ns);
                               FStar_TypeChecker_Env.synth_hook =
-                                (uu___3129_20101.FStar_TypeChecker_Env.synth_hook);
+                                (uu___3129_20099.FStar_TypeChecker_Env.synth_hook);
                               FStar_TypeChecker_Env.try_solve_implicits_hook
                                 =
-                                (uu___3129_20101.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                                (uu___3129_20099.FStar_TypeChecker_Env.try_solve_implicits_hook);
                               FStar_TypeChecker_Env.splice =
-                                (uu___3129_20101.FStar_TypeChecker_Env.splice);
+                                (uu___3129_20099.FStar_TypeChecker_Env.splice);
                               FStar_TypeChecker_Env.mpreprocess =
-                                (uu___3129_20101.FStar_TypeChecker_Env.mpreprocess);
+                                (uu___3129_20099.FStar_TypeChecker_Env.mpreprocess);
                               FStar_TypeChecker_Env.postprocess =
-                                (uu___3129_20101.FStar_TypeChecker_Env.postprocess);
+                                (uu___3129_20099.FStar_TypeChecker_Env.postprocess);
                               FStar_TypeChecker_Env.identifier_info =
-                                (uu___3129_20101.FStar_TypeChecker_Env.identifier_info);
+                                (uu___3129_20099.FStar_TypeChecker_Env.identifier_info);
                               FStar_TypeChecker_Env.tc_hooks =
-                                (uu___3129_20101.FStar_TypeChecker_Env.tc_hooks);
+                                (uu___3129_20099.FStar_TypeChecker_Env.tc_hooks);
                               FStar_TypeChecker_Env.dsenv =
-                                (uu___3129_20101.FStar_TypeChecker_Env.dsenv);
+                                (uu___3129_20099.FStar_TypeChecker_Env.dsenv);
                               FStar_TypeChecker_Env.nbe =
-                                (uu___3129_20101.FStar_TypeChecker_Env.nbe);
+                                (uu___3129_20099.FStar_TypeChecker_Env.nbe);
                               FStar_TypeChecker_Env.strict_args_tab =
-                                (uu___3129_20101.FStar_TypeChecker_Env.strict_args_tab);
+                                (uu___3129_20099.FStar_TypeChecker_Env.strict_args_tab);
                               FStar_TypeChecker_Env.erasable_types_tab =
-                                (uu___3129_20101.FStar_TypeChecker_Env.erasable_types_tab);
+                                (uu___3129_20099.FStar_TypeChecker_Env.erasable_types_tab);
                               FStar_TypeChecker_Env.enable_defer_to_tac =
-                                (uu___3129_20101.FStar_TypeChecker_Env.enable_defer_to_tac)
+                                (uu___3129_20099.FStar_TypeChecker_Env.enable_defer_to_tac)
                             }) t in
-                       match uu____20093 with
-                       | (uu____20104, ty, uu____20106) ->
+                       match uu____20091 with
+                       | (uu____20102, ty, uu____20104) ->
                            let ty1 =
                              let rec aux ty1 =
                                let ty2 =
                                  FStar_TypeChecker_Normalize.unfold_whnf env
                                    ty1 in
-                               let uu____20115 =
-                                 let uu____20116 =
+                               let uu____20113 =
+                                 let uu____20114 =
                                    FStar_Syntax_Subst.compress ty2 in
-                                 uu____20116.FStar_Syntax_Syntax.n in
-                               match uu____20115 with
-                               | FStar_Syntax_Syntax.Tm_refine uu____20119 ->
-                                   let uu____20126 =
+                                 uu____20114.FStar_Syntax_Syntax.n in
+                               match uu____20113 with
+                               | FStar_Syntax_Syntax.Tm_refine uu____20117 ->
+                                   let uu____20124 =
                                      FStar_Syntax_Util.unrefine ty2 in
-                                   aux uu____20126
-                               | uu____20127 -> ty2 in
+                                   aux uu____20124
+                               | uu____20125 -> ty2 in
                              aux ty in
                            let r1 =
                              FStar_TypeChecker_Normalize.eta_expand_with_type
                                env t ty1 in
-                           ((let uu____20130 =
+                           ((let uu____20128 =
                                FStar_All.pipe_left
                                  (FStar_TypeChecker_Env.debug wl.tcenv)
                                  (FStar_Options.Other "Rel") in
-                             if uu____20130
+                             if uu____20128
                              then
-                               let uu____20131 =
+                               let uu____20129 =
                                  FStar_Syntax_Print.term_to_string t in
-                               let uu____20132 =
-                                 let uu____20133 =
+                               let uu____20130 =
+                                 let uu____20131 =
                                    FStar_TypeChecker_Normalize.unfold_whnf
                                      env ty1 in
                                  FStar_Syntax_Print.term_to_string
-                                   uu____20133 in
-                               let uu____20134 =
+                                   uu____20131 in
+                               let uu____20132 =
                                  FStar_Syntax_Print.term_to_string r1 in
                                FStar_Util.print3
                                  "force_eta of (%s) at type (%s) = %s\n"
-                                 uu____20131 uu____20132 uu____20134
+                                 uu____20129 uu____20130 uu____20132
                              else ());
                             r1)) in
-                  let uu____20136 =
-                    let uu____20153 = maybe_eta t1 in
-                    let uu____20160 = maybe_eta t2 in
-                    (uu____20153, uu____20160) in
-                  (match uu____20136 with
+                  let uu____20134 =
+                    let uu____20151 = maybe_eta t1 in
+                    let uu____20158 = maybe_eta t2 in
+                    (uu____20151, uu____20158) in
+                  (match uu____20134 with
                    | (FStar_Util.Inl t11, FStar_Util.Inl t21) ->
                        solve_t env
-                         (let uu___3150_20202 = problem in
+                         (let uu___3150_20200 = problem in
                           {
                             FStar_TypeChecker_Common.pid =
-                              (uu___3150_20202.FStar_TypeChecker_Common.pid);
+                              (uu___3150_20200.FStar_TypeChecker_Common.pid);
                             FStar_TypeChecker_Common.lhs = t11;
                             FStar_TypeChecker_Common.relation =
-                              (uu___3150_20202.FStar_TypeChecker_Common.relation);
+                              (uu___3150_20200.FStar_TypeChecker_Common.relation);
                             FStar_TypeChecker_Common.rhs = t21;
                             FStar_TypeChecker_Common.element =
-                              (uu___3150_20202.FStar_TypeChecker_Common.element);
+                              (uu___3150_20200.FStar_TypeChecker_Common.element);
                             FStar_TypeChecker_Common.logical_guard =
-                              (uu___3150_20202.FStar_TypeChecker_Common.logical_guard);
+                              (uu___3150_20200.FStar_TypeChecker_Common.logical_guard);
                             FStar_TypeChecker_Common.logical_guard_uvar =
-                              (uu___3150_20202.FStar_TypeChecker_Common.logical_guard_uvar);
+                              (uu___3150_20200.FStar_TypeChecker_Common.logical_guard_uvar);
                             FStar_TypeChecker_Common.reason =
-                              (uu___3150_20202.FStar_TypeChecker_Common.reason);
+                              (uu___3150_20200.FStar_TypeChecker_Common.reason);
                             FStar_TypeChecker_Common.loc =
-                              (uu___3150_20202.FStar_TypeChecker_Common.loc);
+                              (uu___3150_20200.FStar_TypeChecker_Common.loc);
                             FStar_TypeChecker_Common.rank =
-                              (uu___3150_20202.FStar_TypeChecker_Common.rank)
+                              (uu___3150_20200.FStar_TypeChecker_Common.rank)
                           }) wl
                    | (FStar_Util.Inl t_abs, FStar_Util.Inr not_abs) ->
-                       let uu____20223 =
+                       let uu____20221 =
                          (is_flex not_abs) &&
                            ((p_rel orig) = FStar_TypeChecker_Common.EQ) in
-                       if uu____20223
+                       if uu____20221
                        then
-                         let uu____20224 = destruct_flex_t not_abs wl in
-                         (match uu____20224 with
+                         let uu____20222 = destruct_flex_t not_abs wl in
+                         (match uu____20222 with
                           | (flex, wl1) ->
                               solve_t_flex_rigid_eq env orig wl1 flex t_abs)
                        else
@@ -7181,41 +7181,41 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                           if (is_abs t11) && (is_abs t21)
                           then
                             solve_t env
-                              (let uu___3167_20239 = problem in
+                              (let uu___3167_20237 = problem in
                                {
                                  FStar_TypeChecker_Common.pid =
-                                   (uu___3167_20239.FStar_TypeChecker_Common.pid);
+                                   (uu___3167_20237.FStar_TypeChecker_Common.pid);
                                  FStar_TypeChecker_Common.lhs = t11;
                                  FStar_TypeChecker_Common.relation =
-                                   (uu___3167_20239.FStar_TypeChecker_Common.relation);
+                                   (uu___3167_20237.FStar_TypeChecker_Common.relation);
                                  FStar_TypeChecker_Common.rhs = t21;
                                  FStar_TypeChecker_Common.element =
-                                   (uu___3167_20239.FStar_TypeChecker_Common.element);
+                                   (uu___3167_20237.FStar_TypeChecker_Common.element);
                                  FStar_TypeChecker_Common.logical_guard =
-                                   (uu___3167_20239.FStar_TypeChecker_Common.logical_guard);
+                                   (uu___3167_20237.FStar_TypeChecker_Common.logical_guard);
                                  FStar_TypeChecker_Common.logical_guard_uvar
                                    =
-                                   (uu___3167_20239.FStar_TypeChecker_Common.logical_guard_uvar);
+                                   (uu___3167_20237.FStar_TypeChecker_Common.logical_guard_uvar);
                                  FStar_TypeChecker_Common.reason =
-                                   (uu___3167_20239.FStar_TypeChecker_Common.reason);
+                                   (uu___3167_20237.FStar_TypeChecker_Common.reason);
                                  FStar_TypeChecker_Common.loc =
-                                   (uu___3167_20239.FStar_TypeChecker_Common.loc);
+                                   (uu___3167_20237.FStar_TypeChecker_Common.loc);
                                  FStar_TypeChecker_Common.rank =
-                                   (uu___3167_20239.FStar_TypeChecker_Common.rank)
+                                   (uu___3167_20237.FStar_TypeChecker_Common.rank)
                                }) wl
                           else
-                            (let uu____20241 =
+                            (let uu____20239 =
                                FStar_Thunk.mkv
                                  "head tag mismatch: RHS is an abstraction" in
-                             giveup env uu____20241 orig))
+                             giveup env uu____20239 orig))
                    | (FStar_Util.Inr not_abs, FStar_Util.Inl t_abs) ->
-                       let uu____20262 =
+                       let uu____20260 =
                          (is_flex not_abs) &&
                            ((p_rel orig) = FStar_TypeChecker_Common.EQ) in
-                       if uu____20262
+                       if uu____20260
                        then
-                         let uu____20263 = destruct_flex_t not_abs wl in
-                         (match uu____20263 with
+                         let uu____20261 = destruct_flex_t not_abs wl in
+                         (match uu____20261 with
                           | (flex, wl1) ->
                               solve_t_flex_rigid_eq env orig wl1 flex t_abs)
                        else
@@ -7224,41 +7224,41 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                           if (is_abs t11) && (is_abs t21)
                           then
                             solve_t env
-                              (let uu___3167_20278 = problem in
+                              (let uu___3167_20276 = problem in
                                {
                                  FStar_TypeChecker_Common.pid =
-                                   (uu___3167_20278.FStar_TypeChecker_Common.pid);
+                                   (uu___3167_20276.FStar_TypeChecker_Common.pid);
                                  FStar_TypeChecker_Common.lhs = t11;
                                  FStar_TypeChecker_Common.relation =
-                                   (uu___3167_20278.FStar_TypeChecker_Common.relation);
+                                   (uu___3167_20276.FStar_TypeChecker_Common.relation);
                                  FStar_TypeChecker_Common.rhs = t21;
                                  FStar_TypeChecker_Common.element =
-                                   (uu___3167_20278.FStar_TypeChecker_Common.element);
+                                   (uu___3167_20276.FStar_TypeChecker_Common.element);
                                  FStar_TypeChecker_Common.logical_guard =
-                                   (uu___3167_20278.FStar_TypeChecker_Common.logical_guard);
+                                   (uu___3167_20276.FStar_TypeChecker_Common.logical_guard);
                                  FStar_TypeChecker_Common.logical_guard_uvar
                                    =
-                                   (uu___3167_20278.FStar_TypeChecker_Common.logical_guard_uvar);
+                                   (uu___3167_20276.FStar_TypeChecker_Common.logical_guard_uvar);
                                  FStar_TypeChecker_Common.reason =
-                                   (uu___3167_20278.FStar_TypeChecker_Common.reason);
+                                   (uu___3167_20276.FStar_TypeChecker_Common.reason);
                                  FStar_TypeChecker_Common.loc =
-                                   (uu___3167_20278.FStar_TypeChecker_Common.loc);
+                                   (uu___3167_20276.FStar_TypeChecker_Common.loc);
                                  FStar_TypeChecker_Common.rank =
-                                   (uu___3167_20278.FStar_TypeChecker_Common.rank)
+                                   (uu___3167_20276.FStar_TypeChecker_Common.rank)
                                }) wl
                           else
-                            (let uu____20280 =
+                            (let uu____20278 =
                                FStar_Thunk.mkv
                                  "head tag mismatch: RHS is an abstraction" in
-                             giveup env uu____20280 orig))
-                   | uu____20281 ->
+                             giveup env uu____20278 orig))
+                   | uu____20279 ->
                        failwith
                          "Impossible: at least one side is an abstraction")
-              | (uu____20298, FStar_Syntax_Syntax.Tm_abs uu____20299) ->
+              | (uu____20296, FStar_Syntax_Syntax.Tm_abs uu____20297) ->
                   let is_abs t =
                     match t.FStar_Syntax_Syntax.n with
-                    | FStar_Syntax_Syntax.Tm_abs uu____20328 -> true
-                    | uu____20347 -> false in
+                    | FStar_Syntax_Syntax.Tm_abs uu____20326 -> true
+                    | uu____20345 -> false in
                   let maybe_eta t =
                     if is_abs t
                     then FStar_Util.Inl t
@@ -7272,182 +7272,182 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                     if is_abs t
                     then t
                     else
-                      (let uu____20400 =
+                      (let uu____20398 =
                          env.FStar_TypeChecker_Env.type_of
-                           (let uu___3129_20408 = env in
+                           (let uu___3129_20406 = env in
                             {
                               FStar_TypeChecker_Env.solver =
-                                (uu___3129_20408.FStar_TypeChecker_Env.solver);
+                                (uu___3129_20406.FStar_TypeChecker_Env.solver);
                               FStar_TypeChecker_Env.range =
-                                (uu___3129_20408.FStar_TypeChecker_Env.range);
+                                (uu___3129_20406.FStar_TypeChecker_Env.range);
                               FStar_TypeChecker_Env.curmodule =
-                                (uu___3129_20408.FStar_TypeChecker_Env.curmodule);
+                                (uu___3129_20406.FStar_TypeChecker_Env.curmodule);
                               FStar_TypeChecker_Env.gamma =
-                                (uu___3129_20408.FStar_TypeChecker_Env.gamma);
+                                (uu___3129_20406.FStar_TypeChecker_Env.gamma);
                               FStar_TypeChecker_Env.gamma_sig =
-                                (uu___3129_20408.FStar_TypeChecker_Env.gamma_sig);
+                                (uu___3129_20406.FStar_TypeChecker_Env.gamma_sig);
                               FStar_TypeChecker_Env.gamma_cache =
-                                (uu___3129_20408.FStar_TypeChecker_Env.gamma_cache);
+                                (uu___3129_20406.FStar_TypeChecker_Env.gamma_cache);
                               FStar_TypeChecker_Env.modules =
-                                (uu___3129_20408.FStar_TypeChecker_Env.modules);
+                                (uu___3129_20406.FStar_TypeChecker_Env.modules);
                               FStar_TypeChecker_Env.expected_typ =
                                 FStar_Pervasives_Native.None;
                               FStar_TypeChecker_Env.sigtab =
-                                (uu___3129_20408.FStar_TypeChecker_Env.sigtab);
+                                (uu___3129_20406.FStar_TypeChecker_Env.sigtab);
                               FStar_TypeChecker_Env.attrtab =
-                                (uu___3129_20408.FStar_TypeChecker_Env.attrtab);
+                                (uu___3129_20406.FStar_TypeChecker_Env.attrtab);
                               FStar_TypeChecker_Env.instantiate_imp =
-                                (uu___3129_20408.FStar_TypeChecker_Env.instantiate_imp);
+                                (uu___3129_20406.FStar_TypeChecker_Env.instantiate_imp);
                               FStar_TypeChecker_Env.effects =
-                                (uu___3129_20408.FStar_TypeChecker_Env.effects);
+                                (uu___3129_20406.FStar_TypeChecker_Env.effects);
                               FStar_TypeChecker_Env.generalize =
-                                (uu___3129_20408.FStar_TypeChecker_Env.generalize);
+                                (uu___3129_20406.FStar_TypeChecker_Env.generalize);
                               FStar_TypeChecker_Env.letrecs =
-                                (uu___3129_20408.FStar_TypeChecker_Env.letrecs);
+                                (uu___3129_20406.FStar_TypeChecker_Env.letrecs);
                               FStar_TypeChecker_Env.top_level =
-                                (uu___3129_20408.FStar_TypeChecker_Env.top_level);
+                                (uu___3129_20406.FStar_TypeChecker_Env.top_level);
                               FStar_TypeChecker_Env.check_uvars =
-                                (uu___3129_20408.FStar_TypeChecker_Env.check_uvars);
+                                (uu___3129_20406.FStar_TypeChecker_Env.check_uvars);
                               FStar_TypeChecker_Env.use_eq =
-                                (uu___3129_20408.FStar_TypeChecker_Env.use_eq);
+                                (uu___3129_20406.FStar_TypeChecker_Env.use_eq);
                               FStar_TypeChecker_Env.use_eq_strict =
-                                (uu___3129_20408.FStar_TypeChecker_Env.use_eq_strict);
+                                (uu___3129_20406.FStar_TypeChecker_Env.use_eq_strict);
                               FStar_TypeChecker_Env.is_iface =
-                                (uu___3129_20408.FStar_TypeChecker_Env.is_iface);
+                                (uu___3129_20406.FStar_TypeChecker_Env.is_iface);
                               FStar_TypeChecker_Env.admit =
-                                (uu___3129_20408.FStar_TypeChecker_Env.admit);
+                                (uu___3129_20406.FStar_TypeChecker_Env.admit);
                               FStar_TypeChecker_Env.lax = true;
                               FStar_TypeChecker_Env.lax_universes =
-                                (uu___3129_20408.FStar_TypeChecker_Env.lax_universes);
+                                (uu___3129_20406.FStar_TypeChecker_Env.lax_universes);
                               FStar_TypeChecker_Env.phase1 =
-                                (uu___3129_20408.FStar_TypeChecker_Env.phase1);
+                                (uu___3129_20406.FStar_TypeChecker_Env.phase1);
                               FStar_TypeChecker_Env.failhard =
-                                (uu___3129_20408.FStar_TypeChecker_Env.failhard);
+                                (uu___3129_20406.FStar_TypeChecker_Env.failhard);
                               FStar_TypeChecker_Env.nosynth =
-                                (uu___3129_20408.FStar_TypeChecker_Env.nosynth);
+                                (uu___3129_20406.FStar_TypeChecker_Env.nosynth);
                               FStar_TypeChecker_Env.uvar_subtyping =
-                                (uu___3129_20408.FStar_TypeChecker_Env.uvar_subtyping);
+                                (uu___3129_20406.FStar_TypeChecker_Env.uvar_subtyping);
                               FStar_TypeChecker_Env.tc_term =
-                                (uu___3129_20408.FStar_TypeChecker_Env.tc_term);
+                                (uu___3129_20406.FStar_TypeChecker_Env.tc_term);
                               FStar_TypeChecker_Env.type_of =
-                                (uu___3129_20408.FStar_TypeChecker_Env.type_of);
+                                (uu___3129_20406.FStar_TypeChecker_Env.type_of);
                               FStar_TypeChecker_Env.universe_of =
-                                (uu___3129_20408.FStar_TypeChecker_Env.universe_of);
+                                (uu___3129_20406.FStar_TypeChecker_Env.universe_of);
                               FStar_TypeChecker_Env.check_type_of =
-                                (uu___3129_20408.FStar_TypeChecker_Env.check_type_of);
+                                (uu___3129_20406.FStar_TypeChecker_Env.check_type_of);
                               FStar_TypeChecker_Env.use_bv_sorts = true;
                               FStar_TypeChecker_Env.qtbl_name_and_index =
-                                (uu___3129_20408.FStar_TypeChecker_Env.qtbl_name_and_index);
+                                (uu___3129_20406.FStar_TypeChecker_Env.qtbl_name_and_index);
                               FStar_TypeChecker_Env.normalized_eff_names =
-                                (uu___3129_20408.FStar_TypeChecker_Env.normalized_eff_names);
+                                (uu___3129_20406.FStar_TypeChecker_Env.normalized_eff_names);
                               FStar_TypeChecker_Env.fv_delta_depths =
-                                (uu___3129_20408.FStar_TypeChecker_Env.fv_delta_depths);
+                                (uu___3129_20406.FStar_TypeChecker_Env.fv_delta_depths);
                               FStar_TypeChecker_Env.proof_ns =
-                                (uu___3129_20408.FStar_TypeChecker_Env.proof_ns);
+                                (uu___3129_20406.FStar_TypeChecker_Env.proof_ns);
                               FStar_TypeChecker_Env.synth_hook =
-                                (uu___3129_20408.FStar_TypeChecker_Env.synth_hook);
+                                (uu___3129_20406.FStar_TypeChecker_Env.synth_hook);
                               FStar_TypeChecker_Env.try_solve_implicits_hook
                                 =
-                                (uu___3129_20408.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                                (uu___3129_20406.FStar_TypeChecker_Env.try_solve_implicits_hook);
                               FStar_TypeChecker_Env.splice =
-                                (uu___3129_20408.FStar_TypeChecker_Env.splice);
+                                (uu___3129_20406.FStar_TypeChecker_Env.splice);
                               FStar_TypeChecker_Env.mpreprocess =
-                                (uu___3129_20408.FStar_TypeChecker_Env.mpreprocess);
+                                (uu___3129_20406.FStar_TypeChecker_Env.mpreprocess);
                               FStar_TypeChecker_Env.postprocess =
-                                (uu___3129_20408.FStar_TypeChecker_Env.postprocess);
+                                (uu___3129_20406.FStar_TypeChecker_Env.postprocess);
                               FStar_TypeChecker_Env.identifier_info =
-                                (uu___3129_20408.FStar_TypeChecker_Env.identifier_info);
+                                (uu___3129_20406.FStar_TypeChecker_Env.identifier_info);
                               FStar_TypeChecker_Env.tc_hooks =
-                                (uu___3129_20408.FStar_TypeChecker_Env.tc_hooks);
+                                (uu___3129_20406.FStar_TypeChecker_Env.tc_hooks);
                               FStar_TypeChecker_Env.dsenv =
-                                (uu___3129_20408.FStar_TypeChecker_Env.dsenv);
+                                (uu___3129_20406.FStar_TypeChecker_Env.dsenv);
                               FStar_TypeChecker_Env.nbe =
-                                (uu___3129_20408.FStar_TypeChecker_Env.nbe);
+                                (uu___3129_20406.FStar_TypeChecker_Env.nbe);
                               FStar_TypeChecker_Env.strict_args_tab =
-                                (uu___3129_20408.FStar_TypeChecker_Env.strict_args_tab);
+                                (uu___3129_20406.FStar_TypeChecker_Env.strict_args_tab);
                               FStar_TypeChecker_Env.erasable_types_tab =
-                                (uu___3129_20408.FStar_TypeChecker_Env.erasable_types_tab);
+                                (uu___3129_20406.FStar_TypeChecker_Env.erasable_types_tab);
                               FStar_TypeChecker_Env.enable_defer_to_tac =
-                                (uu___3129_20408.FStar_TypeChecker_Env.enable_defer_to_tac)
+                                (uu___3129_20406.FStar_TypeChecker_Env.enable_defer_to_tac)
                             }) t in
-                       match uu____20400 with
-                       | (uu____20411, ty, uu____20413) ->
+                       match uu____20398 with
+                       | (uu____20409, ty, uu____20411) ->
                            let ty1 =
                              let rec aux ty1 =
                                let ty2 =
                                  FStar_TypeChecker_Normalize.unfold_whnf env
                                    ty1 in
-                               let uu____20422 =
-                                 let uu____20423 =
+                               let uu____20420 =
+                                 let uu____20421 =
                                    FStar_Syntax_Subst.compress ty2 in
-                                 uu____20423.FStar_Syntax_Syntax.n in
-                               match uu____20422 with
-                               | FStar_Syntax_Syntax.Tm_refine uu____20426 ->
-                                   let uu____20433 =
+                                 uu____20421.FStar_Syntax_Syntax.n in
+                               match uu____20420 with
+                               | FStar_Syntax_Syntax.Tm_refine uu____20424 ->
+                                   let uu____20431 =
                                      FStar_Syntax_Util.unrefine ty2 in
-                                   aux uu____20433
-                               | uu____20434 -> ty2 in
+                                   aux uu____20431
+                               | uu____20432 -> ty2 in
                              aux ty in
                            let r1 =
                              FStar_TypeChecker_Normalize.eta_expand_with_type
                                env t ty1 in
-                           ((let uu____20437 =
+                           ((let uu____20435 =
                                FStar_All.pipe_left
                                  (FStar_TypeChecker_Env.debug wl.tcenv)
                                  (FStar_Options.Other "Rel") in
-                             if uu____20437
+                             if uu____20435
                              then
-                               let uu____20438 =
+                               let uu____20436 =
                                  FStar_Syntax_Print.term_to_string t in
-                               let uu____20439 =
-                                 let uu____20440 =
+                               let uu____20437 =
+                                 let uu____20438 =
                                    FStar_TypeChecker_Normalize.unfold_whnf
                                      env ty1 in
                                  FStar_Syntax_Print.term_to_string
-                                   uu____20440 in
-                               let uu____20441 =
+                                   uu____20438 in
+                               let uu____20439 =
                                  FStar_Syntax_Print.term_to_string r1 in
                                FStar_Util.print3
                                  "force_eta of (%s) at type (%s) = %s\n"
-                                 uu____20438 uu____20439 uu____20441
+                                 uu____20436 uu____20437 uu____20439
                              else ());
                             r1)) in
-                  let uu____20443 =
-                    let uu____20460 = maybe_eta t1 in
-                    let uu____20467 = maybe_eta t2 in
-                    (uu____20460, uu____20467) in
-                  (match uu____20443 with
+                  let uu____20441 =
+                    let uu____20458 = maybe_eta t1 in
+                    let uu____20465 = maybe_eta t2 in
+                    (uu____20458, uu____20465) in
+                  (match uu____20441 with
                    | (FStar_Util.Inl t11, FStar_Util.Inl t21) ->
                        solve_t env
-                         (let uu___3150_20509 = problem in
+                         (let uu___3150_20507 = problem in
                           {
                             FStar_TypeChecker_Common.pid =
-                              (uu___3150_20509.FStar_TypeChecker_Common.pid);
+                              (uu___3150_20507.FStar_TypeChecker_Common.pid);
                             FStar_TypeChecker_Common.lhs = t11;
                             FStar_TypeChecker_Common.relation =
-                              (uu___3150_20509.FStar_TypeChecker_Common.relation);
+                              (uu___3150_20507.FStar_TypeChecker_Common.relation);
                             FStar_TypeChecker_Common.rhs = t21;
                             FStar_TypeChecker_Common.element =
-                              (uu___3150_20509.FStar_TypeChecker_Common.element);
+                              (uu___3150_20507.FStar_TypeChecker_Common.element);
                             FStar_TypeChecker_Common.logical_guard =
-                              (uu___3150_20509.FStar_TypeChecker_Common.logical_guard);
+                              (uu___3150_20507.FStar_TypeChecker_Common.logical_guard);
                             FStar_TypeChecker_Common.logical_guard_uvar =
-                              (uu___3150_20509.FStar_TypeChecker_Common.logical_guard_uvar);
+                              (uu___3150_20507.FStar_TypeChecker_Common.logical_guard_uvar);
                             FStar_TypeChecker_Common.reason =
-                              (uu___3150_20509.FStar_TypeChecker_Common.reason);
+                              (uu___3150_20507.FStar_TypeChecker_Common.reason);
                             FStar_TypeChecker_Common.loc =
-                              (uu___3150_20509.FStar_TypeChecker_Common.loc);
+                              (uu___3150_20507.FStar_TypeChecker_Common.loc);
                             FStar_TypeChecker_Common.rank =
-                              (uu___3150_20509.FStar_TypeChecker_Common.rank)
+                              (uu___3150_20507.FStar_TypeChecker_Common.rank)
                           }) wl
                    | (FStar_Util.Inl t_abs, FStar_Util.Inr not_abs) ->
-                       let uu____20530 =
+                       let uu____20528 =
                          (is_flex not_abs) &&
                            ((p_rel orig) = FStar_TypeChecker_Common.EQ) in
-                       if uu____20530
+                       if uu____20528
                        then
-                         let uu____20531 = destruct_flex_t not_abs wl in
-                         (match uu____20531 with
+                         let uu____20529 = destruct_flex_t not_abs wl in
+                         (match uu____20529 with
                           | (flex, wl1) ->
                               solve_t_flex_rigid_eq env orig wl1 flex t_abs)
                        else
@@ -7456,41 +7456,41 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                           if (is_abs t11) && (is_abs t21)
                           then
                             solve_t env
-                              (let uu___3167_20546 = problem in
+                              (let uu___3167_20544 = problem in
                                {
                                  FStar_TypeChecker_Common.pid =
-                                   (uu___3167_20546.FStar_TypeChecker_Common.pid);
+                                   (uu___3167_20544.FStar_TypeChecker_Common.pid);
                                  FStar_TypeChecker_Common.lhs = t11;
                                  FStar_TypeChecker_Common.relation =
-                                   (uu___3167_20546.FStar_TypeChecker_Common.relation);
+                                   (uu___3167_20544.FStar_TypeChecker_Common.relation);
                                  FStar_TypeChecker_Common.rhs = t21;
                                  FStar_TypeChecker_Common.element =
-                                   (uu___3167_20546.FStar_TypeChecker_Common.element);
+                                   (uu___3167_20544.FStar_TypeChecker_Common.element);
                                  FStar_TypeChecker_Common.logical_guard =
-                                   (uu___3167_20546.FStar_TypeChecker_Common.logical_guard);
+                                   (uu___3167_20544.FStar_TypeChecker_Common.logical_guard);
                                  FStar_TypeChecker_Common.logical_guard_uvar
                                    =
-                                   (uu___3167_20546.FStar_TypeChecker_Common.logical_guard_uvar);
+                                   (uu___3167_20544.FStar_TypeChecker_Common.logical_guard_uvar);
                                  FStar_TypeChecker_Common.reason =
-                                   (uu___3167_20546.FStar_TypeChecker_Common.reason);
+                                   (uu___3167_20544.FStar_TypeChecker_Common.reason);
                                  FStar_TypeChecker_Common.loc =
-                                   (uu___3167_20546.FStar_TypeChecker_Common.loc);
+                                   (uu___3167_20544.FStar_TypeChecker_Common.loc);
                                  FStar_TypeChecker_Common.rank =
-                                   (uu___3167_20546.FStar_TypeChecker_Common.rank)
+                                   (uu___3167_20544.FStar_TypeChecker_Common.rank)
                                }) wl
                           else
-                            (let uu____20548 =
+                            (let uu____20546 =
                                FStar_Thunk.mkv
                                  "head tag mismatch: RHS is an abstraction" in
-                             giveup env uu____20548 orig))
+                             giveup env uu____20546 orig))
                    | (FStar_Util.Inr not_abs, FStar_Util.Inl t_abs) ->
-                       let uu____20569 =
+                       let uu____20567 =
                          (is_flex not_abs) &&
                            ((p_rel orig) = FStar_TypeChecker_Common.EQ) in
-                       if uu____20569
+                       if uu____20567
                        then
-                         let uu____20570 = destruct_flex_t not_abs wl in
-                         (match uu____20570 with
+                         let uu____20568 = destruct_flex_t not_abs wl in
+                         (match uu____20568 with
                           | (flex, wl1) ->
                               solve_t_flex_rigid_eq env orig wl1 flex t_abs)
                        else
@@ -7499,125 +7499,125 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                           if (is_abs t11) && (is_abs t21)
                           then
                             solve_t env
-                              (let uu___3167_20585 = problem in
+                              (let uu___3167_20583 = problem in
                                {
                                  FStar_TypeChecker_Common.pid =
-                                   (uu___3167_20585.FStar_TypeChecker_Common.pid);
+                                   (uu___3167_20583.FStar_TypeChecker_Common.pid);
                                  FStar_TypeChecker_Common.lhs = t11;
                                  FStar_TypeChecker_Common.relation =
-                                   (uu___3167_20585.FStar_TypeChecker_Common.relation);
+                                   (uu___3167_20583.FStar_TypeChecker_Common.relation);
                                  FStar_TypeChecker_Common.rhs = t21;
                                  FStar_TypeChecker_Common.element =
-                                   (uu___3167_20585.FStar_TypeChecker_Common.element);
+                                   (uu___3167_20583.FStar_TypeChecker_Common.element);
                                  FStar_TypeChecker_Common.logical_guard =
-                                   (uu___3167_20585.FStar_TypeChecker_Common.logical_guard);
+                                   (uu___3167_20583.FStar_TypeChecker_Common.logical_guard);
                                  FStar_TypeChecker_Common.logical_guard_uvar
                                    =
-                                   (uu___3167_20585.FStar_TypeChecker_Common.logical_guard_uvar);
+                                   (uu___3167_20583.FStar_TypeChecker_Common.logical_guard_uvar);
                                  FStar_TypeChecker_Common.reason =
-                                   (uu___3167_20585.FStar_TypeChecker_Common.reason);
+                                   (uu___3167_20583.FStar_TypeChecker_Common.reason);
                                  FStar_TypeChecker_Common.loc =
-                                   (uu___3167_20585.FStar_TypeChecker_Common.loc);
+                                   (uu___3167_20583.FStar_TypeChecker_Common.loc);
                                  FStar_TypeChecker_Common.rank =
-                                   (uu___3167_20585.FStar_TypeChecker_Common.rank)
+                                   (uu___3167_20583.FStar_TypeChecker_Common.rank)
                                }) wl
                           else
-                            (let uu____20587 =
+                            (let uu____20585 =
                                FStar_Thunk.mkv
                                  "head tag mismatch: RHS is an abstraction" in
-                             giveup env uu____20587 orig))
-                   | uu____20588 ->
+                             giveup env uu____20585 orig))
+                   | uu____20586 ->
                        failwith
                          "Impossible: at least one side is an abstraction")
               | (FStar_Syntax_Syntax.Tm_refine (x1, phi1),
                  FStar_Syntax_Syntax.Tm_refine (x2, phi2)) ->
-                  let uu____20617 =
-                    let uu____20622 =
+                  let uu____20615 =
+                    let uu____20620 =
                       head_matches_delta env wl x1.FStar_Syntax_Syntax.sort
                         x2.FStar_Syntax_Syntax.sort in
-                    match uu____20622 with
+                    match uu____20620 with
                     | (FullMatch, FStar_Pervasives_Native.Some (t11, t21)) ->
-                        ((let uu___3190_20650 = x1 in
+                        ((let uu___3190_20648 = x1 in
                           {
                             FStar_Syntax_Syntax.ppname =
-                              (uu___3190_20650.FStar_Syntax_Syntax.ppname);
+                              (uu___3190_20648.FStar_Syntax_Syntax.ppname);
                             FStar_Syntax_Syntax.index =
-                              (uu___3190_20650.FStar_Syntax_Syntax.index);
+                              (uu___3190_20648.FStar_Syntax_Syntax.index);
                             FStar_Syntax_Syntax.sort = t11
                           }),
-                          (let uu___3192_20652 = x2 in
+                          (let uu___3192_20650 = x2 in
                            {
                              FStar_Syntax_Syntax.ppname =
-                               (uu___3192_20652.FStar_Syntax_Syntax.ppname);
+                               (uu___3192_20650.FStar_Syntax_Syntax.ppname);
                              FStar_Syntax_Syntax.index =
-                               (uu___3192_20652.FStar_Syntax_Syntax.index);
+                               (uu___3192_20650.FStar_Syntax_Syntax.index);
                              FStar_Syntax_Syntax.sort = t21
                            }))
-                    | (HeadMatch uu____20653, FStar_Pervasives_Native.Some
+                    | (HeadMatch uu____20651, FStar_Pervasives_Native.Some
                        (t11, t21)) ->
-                        ((let uu___3190_20667 = x1 in
+                        ((let uu___3190_20665 = x1 in
                           {
                             FStar_Syntax_Syntax.ppname =
-                              (uu___3190_20667.FStar_Syntax_Syntax.ppname);
+                              (uu___3190_20665.FStar_Syntax_Syntax.ppname);
                             FStar_Syntax_Syntax.index =
-                              (uu___3190_20667.FStar_Syntax_Syntax.index);
+                              (uu___3190_20665.FStar_Syntax_Syntax.index);
                             FStar_Syntax_Syntax.sort = t11
                           }),
-                          (let uu___3192_20669 = x2 in
+                          (let uu___3192_20667 = x2 in
                            {
                              FStar_Syntax_Syntax.ppname =
-                               (uu___3192_20669.FStar_Syntax_Syntax.ppname);
+                               (uu___3192_20667.FStar_Syntax_Syntax.ppname);
                              FStar_Syntax_Syntax.index =
-                               (uu___3192_20669.FStar_Syntax_Syntax.index);
+                               (uu___3192_20667.FStar_Syntax_Syntax.index);
                              FStar_Syntax_Syntax.sort = t21
                            }))
-                    | uu____20670 -> (x1, x2) in
-                  (match uu____20617 with
+                    | uu____20668 -> (x1, x2) in
+                  (match uu____20615 with
                    | (x11, x21) ->
                        let t11 = FStar_Syntax_Util.refine x11 phi1 in
                        let t21 = FStar_Syntax_Util.refine x21 phi2 in
-                       let uu____20689 = as_refinement false env t11 in
-                       (match uu____20689 with
+                       let uu____20687 = as_refinement false env t11 in
+                       (match uu____20687 with
                         | (x12, phi11) ->
-                            let uu____20696 = as_refinement false env t21 in
-                            (match uu____20696 with
+                            let uu____20694 = as_refinement false env t21 in
+                            (match uu____20694 with
                              | (x22, phi21) ->
-                                 ((let uu____20704 =
+                                 ((let uu____20702 =
                                      FStar_TypeChecker_Env.debug env
                                        (FStar_Options.Other "Rel") in
-                                   if uu____20704
+                                   if uu____20702
                                    then
-                                     ((let uu____20706 =
+                                     ((let uu____20704 =
                                          FStar_Syntax_Print.bv_to_string x12 in
-                                       let uu____20707 =
+                                       let uu____20705 =
                                          FStar_Syntax_Print.term_to_string
                                            x12.FStar_Syntax_Syntax.sort in
-                                       let uu____20708 =
+                                       let uu____20706 =
                                          FStar_Syntax_Print.term_to_string
                                            phi11 in
                                        FStar_Util.print3
-                                         "ref1 = (%s):(%s){%s}\n" uu____20706
-                                         uu____20707 uu____20708);
-                                      (let uu____20709 =
+                                         "ref1 = (%s):(%s){%s}\n" uu____20704
+                                         uu____20705 uu____20706);
+                                      (let uu____20707 =
                                          FStar_Syntax_Print.bv_to_string x22 in
-                                       let uu____20710 =
+                                       let uu____20708 =
                                          FStar_Syntax_Print.term_to_string
                                            x22.FStar_Syntax_Syntax.sort in
-                                       let uu____20711 =
+                                       let uu____20709 =
                                          FStar_Syntax_Print.term_to_string
                                            phi21 in
                                        FStar_Util.print3
-                                         "ref2 = (%s):(%s){%s}\n" uu____20709
-                                         uu____20710 uu____20711))
+                                         "ref2 = (%s):(%s){%s}\n" uu____20707
+                                         uu____20708 uu____20709))
                                    else ());
-                                  (let uu____20713 =
+                                  (let uu____20711 =
                                      mk_t_problem wl [] orig
                                        x12.FStar_Syntax_Syntax.sort
                                        problem.FStar_TypeChecker_Common.relation
                                        x22.FStar_Syntax_Syntax.sort
                                        problem.FStar_TypeChecker_Common.element
                                        "refinement base type" in
-                                   match uu____20713 with
+                                   match uu____20711 with
                                    | (base_prob, wl1) ->
                                        let x13 =
                                          FStar_Syntax_Syntax.freshen_bv x12 in
@@ -7632,10 +7632,10 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                                          FStar_TypeChecker_Env.push_bv env
                                            x13 in
                                        let mk_imp imp phi13 phi23 =
-                                         let uu____20781 = imp phi13 phi23 in
-                                         FStar_All.pipe_right uu____20781
+                                         let uu____20779 = imp phi13 phi23 in
+                                         FStar_All.pipe_right uu____20779
                                            (guard_on_element wl1 problem x13) in
-                                       let fallback uu____20793 =
+                                       let fallback uu____20791 =
                                          let impl =
                                            if
                                              problem.FStar_TypeChecker_Common.relation
@@ -7649,42 +7649,42 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                                          let guard =
                                            FStar_Syntax_Util.mk_conj
                                              (p_guard base_prob) impl in
-                                         (let uu____20804 =
-                                            let uu____20807 = p_scope orig in
+                                         (let uu____20802 =
+                                            let uu____20805 = p_scope orig in
                                             FStar_List.map
                                               FStar_Pervasives_Native.fst
-                                              uu____20807 in
+                                              uu____20805 in
                                           FStar_TypeChecker_Env.def_check_closed_in
-                                            (p_loc orig) "ref.1" uu____20804
+                                            (p_loc orig) "ref.1" uu____20802
                                             (p_guard base_prob));
-                                         (let uu____20825 =
-                                            let uu____20828 = p_scope orig in
+                                         (let uu____20823 =
+                                            let uu____20826 = p_scope orig in
                                             FStar_List.map
                                               FStar_Pervasives_Native.fst
-                                              uu____20828 in
+                                              uu____20826 in
                                           FStar_TypeChecker_Env.def_check_closed_in
-                                            (p_loc orig) "ref.2" uu____20825
+                                            (p_loc orig) "ref.2" uu____20823
                                             impl);
                                          (let wl2 =
                                             solve_prob orig
                                               (FStar_Pervasives_Native.Some
                                                  guard) [] wl1 in
-                                          let uu____20846 =
+                                          let uu____20844 =
                                             attempt [base_prob] wl2 in
-                                          solve env1 uu____20846) in
+                                          solve env1 uu____20844) in
                                        let has_uvars =
-                                         (let uu____20850 =
-                                            let uu____20851 =
+                                         (let uu____20848 =
+                                            let uu____20849 =
                                               FStar_Syntax_Free.uvars phi12 in
                                             FStar_Util.set_is_empty
-                                              uu____20851 in
-                                          Prims.op_Negation uu____20850) ||
-                                           (let uu____20855 =
-                                              let uu____20856 =
+                                              uu____20849 in
+                                          Prims.op_Negation uu____20848) ||
+                                           (let uu____20853 =
+                                              let uu____20854 =
                                                 FStar_Syntax_Free.uvars phi22 in
                                               FStar_Util.set_is_empty
-                                                uu____20856 in
-                                            Prims.op_Negation uu____20855) in
+                                                uu____20854 in
+                                            Prims.op_Negation uu____20853) in
                                        if
                                          (problem.FStar_TypeChecker_Common.relation
                                             = FStar_TypeChecker_Common.EQ)
@@ -7693,46 +7693,46 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                                                env1.FStar_TypeChecker_Env.uvar_subtyping)
                                               && has_uvars)
                                        then
-                                         let uu____20859 =
-                                           let uu____20864 =
-                                             let uu____20873 =
+                                         let uu____20857 =
+                                           let uu____20862 =
+                                             let uu____20871 =
                                                FStar_Syntax_Syntax.mk_binder
                                                  x13 in
-                                             [uu____20873] in
-                                           mk_t_problem wl1 uu____20864 orig
+                                             [uu____20871] in
+                                           mk_t_problem wl1 uu____20862 orig
                                              phi12
                                              FStar_TypeChecker_Common.EQ
                                              phi22
                                              FStar_Pervasives_Native.None
                                              "refinement formula" in
-                                         (match uu____20859 with
+                                         (match uu____20857 with
                                           | (ref_prob, wl2) ->
                                               let tx =
                                                 FStar_Syntax_Unionfind.new_transaction
                                                   () in
-                                              let uu____20895 =
+                                              let uu____20893 =
                                                 solve env1
-                                                  (let uu___3235_20897 = wl2 in
+                                                  (let uu___3235_20895 = wl2 in
                                                    {
                                                      attempting = [ref_prob];
                                                      wl_deferred = [];
                                                      wl_deferred_to_tac =
-                                                       (uu___3235_20897.wl_deferred_to_tac);
+                                                       (uu___3235_20895.wl_deferred_to_tac);
                                                      ctr =
-                                                       (uu___3235_20897.ctr);
+                                                       (uu___3235_20895.ctr);
                                                      defer_ok = false;
                                                      smt_ok =
-                                                       (uu___3235_20897.smt_ok);
+                                                       (uu___3235_20895.smt_ok);
                                                      umax_heuristic_ok =
-                                                       (uu___3235_20897.umax_heuristic_ok);
+                                                       (uu___3235_20895.umax_heuristic_ok);
                                                      tcenv =
-                                                       (uu___3235_20897.tcenv);
+                                                       (uu___3235_20895.tcenv);
                                                      wl_implicits =
-                                                       (uu___3235_20897.wl_implicits);
+                                                       (uu___3235_20895.wl_implicits);
                                                      repr_subcomp_allowed =
-                                                       (uu___3235_20897.repr_subcomp_allowed)
+                                                       (uu___3235_20895.repr_subcomp_allowed)
                                                    }) in
-                                              (match uu____20895 with
+                                              (match uu____20893 with
                                                | Failed (prob, msg) ->
                                                    (FStar_Syntax_Unionfind.rollback
                                                       tx;
@@ -7746,67 +7746,67 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                                                     then giveup env1 msg prob
                                                     else fallback ())
                                                | Success
-                                                   (uu____20908,
+                                                   (uu____20906,
                                                     defer_to_tac,
-                                                    uu____20910)
+                                                    uu____20908)
                                                    ->
                                                    (FStar_Syntax_Unionfind.commit
                                                       tx;
                                                     (let guard =
-                                                       let uu____20915 =
+                                                       let uu____20913 =
                                                          FStar_All.pipe_right
                                                            (p_guard ref_prob)
                                                            (guard_on_element
                                                               wl2 problem x13) in
                                                        FStar_Syntax_Util.mk_conj
                                                          (p_guard base_prob)
-                                                         uu____20915 in
+                                                         uu____20913 in
                                                      let wl3 =
                                                        solve_prob orig
                                                          (FStar_Pervasives_Native.Some
                                                             guard) [] wl2 in
                                                      let wl4 =
-                                                       let uu___3251_20924 =
+                                                       let uu___3251_20922 =
                                                          wl3 in
                                                        {
                                                          attempting =
-                                                           (uu___3251_20924.attempting);
+                                                           (uu___3251_20922.attempting);
                                                          wl_deferred =
-                                                           (uu___3251_20924.wl_deferred);
+                                                           (uu___3251_20922.wl_deferred);
                                                          wl_deferred_to_tac =
-                                                           (uu___3251_20924.wl_deferred_to_tac);
+                                                           (uu___3251_20922.wl_deferred_to_tac);
                                                          ctr =
                                                            (wl3.ctr +
                                                               Prims.int_one);
                                                          defer_ok =
-                                                           (uu___3251_20924.defer_ok);
+                                                           (uu___3251_20922.defer_ok);
                                                          smt_ok =
-                                                           (uu___3251_20924.smt_ok);
+                                                           (uu___3251_20922.smt_ok);
                                                          umax_heuristic_ok =
-                                                           (uu___3251_20924.umax_heuristic_ok);
+                                                           (uu___3251_20922.umax_heuristic_ok);
                                                          tcenv =
-                                                           (uu___3251_20924.tcenv);
+                                                           (uu___3251_20922.tcenv);
                                                          wl_implicits =
-                                                           (uu___3251_20924.wl_implicits);
+                                                           (uu___3251_20922.wl_implicits);
                                                          repr_subcomp_allowed
                                                            =
-                                                           (uu___3251_20924.repr_subcomp_allowed)
+                                                           (uu___3251_20922.repr_subcomp_allowed)
                                                        } in
                                                      let wl5 =
                                                        extend_wl wl4
                                                          defer_to_tac [] in
-                                                     let uu____20926 =
+                                                     let uu____20924 =
                                                        attempt [base_prob]
                                                          wl5 in
-                                                     solve env1 uu____20926))))
+                                                     solve env1 uu____20924))))
                                        else fallback ())))))
-              | (FStar_Syntax_Syntax.Tm_uvar uu____20928,
-                 FStar_Syntax_Syntax.Tm_uvar uu____20929) ->
-                  let uu____20954 = ensure_no_uvar_subst t1 wl in
-                  (match uu____20954 with
+              | (FStar_Syntax_Syntax.Tm_uvar uu____20926,
+                 FStar_Syntax_Syntax.Tm_uvar uu____20927) ->
+                  let uu____20952 = ensure_no_uvar_subst t1 wl in
+                  (match uu____20952 with
                    | (t11, wl1) ->
-                       let uu____20961 = ensure_no_uvar_subst t2 wl1 in
-                       (match uu____20961 with
+                       let uu____20959 = ensure_no_uvar_subst t2 wl1 in
+                       (match uu____20959 with
                         | (t21, wl2) ->
                             let f1 = destruct_flex_t' t11 in
                             let f2 = destruct_flex_t' t21 in
@@ -7814,33 +7814,33 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
               | (FStar_Syntax_Syntax.Tm_app
                  ({
                     FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_uvar
-                      uu____20970;
-                    FStar_Syntax_Syntax.pos = uu____20971;
-                    FStar_Syntax_Syntax.vars = uu____20972;_},
-                  uu____20973),
-                 FStar_Syntax_Syntax.Tm_uvar uu____20974) ->
-                  let uu____21023 = ensure_no_uvar_subst t1 wl in
-                  (match uu____21023 with
+                      uu____20968;
+                    FStar_Syntax_Syntax.pos = uu____20969;
+                    FStar_Syntax_Syntax.vars = uu____20970;_},
+                  uu____20971),
+                 FStar_Syntax_Syntax.Tm_uvar uu____20972) ->
+                  let uu____21021 = ensure_no_uvar_subst t1 wl in
+                  (match uu____21021 with
                    | (t11, wl1) ->
-                       let uu____21030 = ensure_no_uvar_subst t2 wl1 in
-                       (match uu____21030 with
+                       let uu____21028 = ensure_no_uvar_subst t2 wl1 in
+                       (match uu____21028 with
                         | (t21, wl2) ->
                             let f1 = destruct_flex_t' t11 in
                             let f2 = destruct_flex_t' t21 in
                             solve_t_flex_flex env orig wl2 f1 f2))
-              | (FStar_Syntax_Syntax.Tm_uvar uu____21039,
+              | (FStar_Syntax_Syntax.Tm_uvar uu____21037,
                  FStar_Syntax_Syntax.Tm_app
                  ({
                     FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_uvar
-                      uu____21040;
-                    FStar_Syntax_Syntax.pos = uu____21041;
-                    FStar_Syntax_Syntax.vars = uu____21042;_},
-                  uu____21043)) ->
-                  let uu____21092 = ensure_no_uvar_subst t1 wl in
-                  (match uu____21092 with
+                      uu____21038;
+                    FStar_Syntax_Syntax.pos = uu____21039;
+                    FStar_Syntax_Syntax.vars = uu____21040;_},
+                  uu____21041)) ->
+                  let uu____21090 = ensure_no_uvar_subst t1 wl in
+                  (match uu____21090 with
                    | (t11, wl1) ->
-                       let uu____21099 = ensure_no_uvar_subst t2 wl1 in
-                       (match uu____21099 with
+                       let uu____21097 = ensure_no_uvar_subst t2 wl1 in
+                       (match uu____21097 with
                         | (t21, wl2) ->
                             let f1 = destruct_flex_t' t11 in
                             let f2 = destruct_flex_t' t21 in
@@ -7848,234 +7848,234 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
               | (FStar_Syntax_Syntax.Tm_app
                  ({
                     FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_uvar
-                      uu____21108;
-                    FStar_Syntax_Syntax.pos = uu____21109;
-                    FStar_Syntax_Syntax.vars = uu____21110;_},
-                  uu____21111),
+                      uu____21106;
+                    FStar_Syntax_Syntax.pos = uu____21107;
+                    FStar_Syntax_Syntax.vars = uu____21108;_},
+                  uu____21109),
                  FStar_Syntax_Syntax.Tm_app
                  ({
                     FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_uvar
-                      uu____21112;
-                    FStar_Syntax_Syntax.pos = uu____21113;
-                    FStar_Syntax_Syntax.vars = uu____21114;_},
-                  uu____21115)) ->
-                  let uu____21188 = ensure_no_uvar_subst t1 wl in
-                  (match uu____21188 with
+                      uu____21110;
+                    FStar_Syntax_Syntax.pos = uu____21111;
+                    FStar_Syntax_Syntax.vars = uu____21112;_},
+                  uu____21113)) ->
+                  let uu____21186 = ensure_no_uvar_subst t1 wl in
+                  (match uu____21186 with
                    | (t11, wl1) ->
-                       let uu____21195 = ensure_no_uvar_subst t2 wl1 in
-                       (match uu____21195 with
+                       let uu____21193 = ensure_no_uvar_subst t2 wl1 in
+                       (match uu____21193 with
                         | (t21, wl2) ->
                             let f1 = destruct_flex_t' t11 in
                             let f2 = destruct_flex_t' t21 in
                             solve_t_flex_flex env orig wl2 f1 f2))
-              | (FStar_Syntax_Syntax.Tm_uvar uu____21204, uu____21205) when
+              | (FStar_Syntax_Syntax.Tm_uvar uu____21202, uu____21203) when
                   problem.FStar_TypeChecker_Common.relation =
                     FStar_TypeChecker_Common.EQ
                   ->
-                  let uu____21218 = destruct_flex_t t1 wl in
-                  (match uu____21218 with
+                  let uu____21216 = destruct_flex_t t1 wl in
+                  (match uu____21216 with
                    | (f1, wl1) -> solve_t_flex_rigid_eq env orig wl1 f1 t2)
               | (FStar_Syntax_Syntax.Tm_app
                  ({
                     FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_uvar
-                      uu____21225;
-                    FStar_Syntax_Syntax.pos = uu____21226;
-                    FStar_Syntax_Syntax.vars = uu____21227;_},
-                  uu____21228),
-                 uu____21229) when
+                      uu____21223;
+                    FStar_Syntax_Syntax.pos = uu____21224;
+                    FStar_Syntax_Syntax.vars = uu____21225;_},
+                  uu____21226),
+                 uu____21227) when
                   problem.FStar_TypeChecker_Common.relation =
                     FStar_TypeChecker_Common.EQ
                   ->
-                  let uu____21266 = destruct_flex_t t1 wl in
-                  (match uu____21266 with
+                  let uu____21264 = destruct_flex_t t1 wl in
+                  (match uu____21264 with
                    | (f1, wl1) -> solve_t_flex_rigid_eq env orig wl1 f1 t2)
-              | (uu____21273, FStar_Syntax_Syntax.Tm_uvar uu____21274) when
+              | (uu____21271, FStar_Syntax_Syntax.Tm_uvar uu____21272) when
                   problem.FStar_TypeChecker_Common.relation =
                     FStar_TypeChecker_Common.EQ
                   -> solve_t env (invert problem) wl
-              | (uu____21287, FStar_Syntax_Syntax.Tm_app
+              | (uu____21285, FStar_Syntax_Syntax.Tm_app
                  ({
                     FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_uvar
-                      uu____21288;
-                    FStar_Syntax_Syntax.pos = uu____21289;
-                    FStar_Syntax_Syntax.vars = uu____21290;_},
-                  uu____21291)) when
+                      uu____21286;
+                    FStar_Syntax_Syntax.pos = uu____21287;
+                    FStar_Syntax_Syntax.vars = uu____21288;_},
+                  uu____21289)) when
                   problem.FStar_TypeChecker_Common.relation =
                     FStar_TypeChecker_Common.EQ
                   -> solve_t env (invert problem) wl
-              | (FStar_Syntax_Syntax.Tm_uvar uu____21328,
-                 FStar_Syntax_Syntax.Tm_arrow uu____21329) ->
+              | (FStar_Syntax_Syntax.Tm_uvar uu____21326,
+                 FStar_Syntax_Syntax.Tm_arrow uu____21327) ->
                   solve_t' env
-                    (let uu___3354_21357 = problem in
+                    (let uu___3354_21355 = problem in
                      {
                        FStar_TypeChecker_Common.pid =
-                         (uu___3354_21357.FStar_TypeChecker_Common.pid);
+                         (uu___3354_21355.FStar_TypeChecker_Common.pid);
                        FStar_TypeChecker_Common.lhs =
-                         (uu___3354_21357.FStar_TypeChecker_Common.lhs);
+                         (uu___3354_21355.FStar_TypeChecker_Common.lhs);
                        FStar_TypeChecker_Common.relation =
                          FStar_TypeChecker_Common.EQ;
                        FStar_TypeChecker_Common.rhs =
-                         (uu___3354_21357.FStar_TypeChecker_Common.rhs);
+                         (uu___3354_21355.FStar_TypeChecker_Common.rhs);
                        FStar_TypeChecker_Common.element =
-                         (uu___3354_21357.FStar_TypeChecker_Common.element);
+                         (uu___3354_21355.FStar_TypeChecker_Common.element);
                        FStar_TypeChecker_Common.logical_guard =
-                         (uu___3354_21357.FStar_TypeChecker_Common.logical_guard);
+                         (uu___3354_21355.FStar_TypeChecker_Common.logical_guard);
                        FStar_TypeChecker_Common.logical_guard_uvar =
-                         (uu___3354_21357.FStar_TypeChecker_Common.logical_guard_uvar);
+                         (uu___3354_21355.FStar_TypeChecker_Common.logical_guard_uvar);
                        FStar_TypeChecker_Common.reason =
-                         (uu___3354_21357.FStar_TypeChecker_Common.reason);
+                         (uu___3354_21355.FStar_TypeChecker_Common.reason);
                        FStar_TypeChecker_Common.loc =
-                         (uu___3354_21357.FStar_TypeChecker_Common.loc);
+                         (uu___3354_21355.FStar_TypeChecker_Common.loc);
                        FStar_TypeChecker_Common.rank =
-                         (uu___3354_21357.FStar_TypeChecker_Common.rank)
+                         (uu___3354_21355.FStar_TypeChecker_Common.rank)
                      }) wl
               | (FStar_Syntax_Syntax.Tm_app
                  ({
                     FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_uvar
-                      uu____21358;
-                    FStar_Syntax_Syntax.pos = uu____21359;
-                    FStar_Syntax_Syntax.vars = uu____21360;_},
-                  uu____21361),
-                 FStar_Syntax_Syntax.Tm_arrow uu____21362) ->
+                      uu____21356;
+                    FStar_Syntax_Syntax.pos = uu____21357;
+                    FStar_Syntax_Syntax.vars = uu____21358;_},
+                  uu____21359),
+                 FStar_Syntax_Syntax.Tm_arrow uu____21360) ->
                   solve_t' env
-                    (let uu___3354_21414 = problem in
+                    (let uu___3354_21412 = problem in
                      {
                        FStar_TypeChecker_Common.pid =
-                         (uu___3354_21414.FStar_TypeChecker_Common.pid);
+                         (uu___3354_21412.FStar_TypeChecker_Common.pid);
                        FStar_TypeChecker_Common.lhs =
-                         (uu___3354_21414.FStar_TypeChecker_Common.lhs);
+                         (uu___3354_21412.FStar_TypeChecker_Common.lhs);
                        FStar_TypeChecker_Common.relation =
                          FStar_TypeChecker_Common.EQ;
                        FStar_TypeChecker_Common.rhs =
-                         (uu___3354_21414.FStar_TypeChecker_Common.rhs);
+                         (uu___3354_21412.FStar_TypeChecker_Common.rhs);
                        FStar_TypeChecker_Common.element =
-                         (uu___3354_21414.FStar_TypeChecker_Common.element);
+                         (uu___3354_21412.FStar_TypeChecker_Common.element);
                        FStar_TypeChecker_Common.logical_guard =
-                         (uu___3354_21414.FStar_TypeChecker_Common.logical_guard);
+                         (uu___3354_21412.FStar_TypeChecker_Common.logical_guard);
                        FStar_TypeChecker_Common.logical_guard_uvar =
-                         (uu___3354_21414.FStar_TypeChecker_Common.logical_guard_uvar);
+                         (uu___3354_21412.FStar_TypeChecker_Common.logical_guard_uvar);
                        FStar_TypeChecker_Common.reason =
-                         (uu___3354_21414.FStar_TypeChecker_Common.reason);
+                         (uu___3354_21412.FStar_TypeChecker_Common.reason);
                        FStar_TypeChecker_Common.loc =
-                         (uu___3354_21414.FStar_TypeChecker_Common.loc);
+                         (uu___3354_21412.FStar_TypeChecker_Common.loc);
                        FStar_TypeChecker_Common.rank =
-                         (uu___3354_21414.FStar_TypeChecker_Common.rank)
+                         (uu___3354_21412.FStar_TypeChecker_Common.rank)
                      }) wl
-              | (uu____21415, FStar_Syntax_Syntax.Tm_uvar uu____21416) ->
-                  let uu____21429 =
+              | (uu____21413, FStar_Syntax_Syntax.Tm_uvar uu____21414) ->
+                  let uu____21427 =
                     attempt [FStar_TypeChecker_Common.TProb problem] wl in
-                  solve env uu____21429
-              | (uu____21430, FStar_Syntax_Syntax.Tm_app
+                  solve env uu____21427
+              | (uu____21428, FStar_Syntax_Syntax.Tm_app
                  ({
                     FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_uvar
-                      uu____21431;
-                    FStar_Syntax_Syntax.pos = uu____21432;
-                    FStar_Syntax_Syntax.vars = uu____21433;_},
-                  uu____21434)) ->
-                  let uu____21471 =
+                      uu____21429;
+                    FStar_Syntax_Syntax.pos = uu____21430;
+                    FStar_Syntax_Syntax.vars = uu____21431;_},
+                  uu____21432)) ->
+                  let uu____21469 =
                     attempt [FStar_TypeChecker_Common.TProb problem] wl in
-                  solve env uu____21471
-              | (FStar_Syntax_Syntax.Tm_uvar uu____21472, uu____21473) ->
-                  let uu____21486 =
+                  solve env uu____21469
+              | (FStar_Syntax_Syntax.Tm_uvar uu____21470, uu____21471) ->
+                  let uu____21484 =
                     attempt [FStar_TypeChecker_Common.TProb problem] wl in
-                  solve env uu____21486
+                  solve env uu____21484
               | (FStar_Syntax_Syntax.Tm_app
                  ({
                     FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_uvar
-                      uu____21487;
-                    FStar_Syntax_Syntax.pos = uu____21488;
-                    FStar_Syntax_Syntax.vars = uu____21489;_},
-                  uu____21490),
-                 uu____21491) ->
-                  let uu____21528 =
+                      uu____21485;
+                    FStar_Syntax_Syntax.pos = uu____21486;
+                    FStar_Syntax_Syntax.vars = uu____21487;_},
+                  uu____21488),
+                 uu____21489) ->
+                  let uu____21526 =
                     attempt [FStar_TypeChecker_Common.TProb problem] wl in
-                  solve env uu____21528
-              | (FStar_Syntax_Syntax.Tm_refine uu____21529, uu____21530) ->
+                  solve env uu____21526
+              | (FStar_Syntax_Syntax.Tm_refine uu____21527, uu____21528) ->
                   let t21 =
-                    let uu____21538 = base_and_refinement env t2 in
-                    FStar_All.pipe_left force_refinement uu____21538 in
+                    let uu____21536 = base_and_refinement env t2 in
+                    FStar_All.pipe_left force_refinement uu____21536 in
                   solve_t env
-                    (let uu___3389_21564 = problem in
+                    (let uu___3389_21562 = problem in
                      {
                        FStar_TypeChecker_Common.pid =
-                         (uu___3389_21564.FStar_TypeChecker_Common.pid);
+                         (uu___3389_21562.FStar_TypeChecker_Common.pid);
                        FStar_TypeChecker_Common.lhs =
-                         (uu___3389_21564.FStar_TypeChecker_Common.lhs);
+                         (uu___3389_21562.FStar_TypeChecker_Common.lhs);
                        FStar_TypeChecker_Common.relation =
-                         (uu___3389_21564.FStar_TypeChecker_Common.relation);
+                         (uu___3389_21562.FStar_TypeChecker_Common.relation);
                        FStar_TypeChecker_Common.rhs = t21;
                        FStar_TypeChecker_Common.element =
-                         (uu___3389_21564.FStar_TypeChecker_Common.element);
+                         (uu___3389_21562.FStar_TypeChecker_Common.element);
                        FStar_TypeChecker_Common.logical_guard =
-                         (uu___3389_21564.FStar_TypeChecker_Common.logical_guard);
+                         (uu___3389_21562.FStar_TypeChecker_Common.logical_guard);
                        FStar_TypeChecker_Common.logical_guard_uvar =
-                         (uu___3389_21564.FStar_TypeChecker_Common.logical_guard_uvar);
+                         (uu___3389_21562.FStar_TypeChecker_Common.logical_guard_uvar);
                        FStar_TypeChecker_Common.reason =
-                         (uu___3389_21564.FStar_TypeChecker_Common.reason);
+                         (uu___3389_21562.FStar_TypeChecker_Common.reason);
                        FStar_TypeChecker_Common.loc =
-                         (uu___3389_21564.FStar_TypeChecker_Common.loc);
+                         (uu___3389_21562.FStar_TypeChecker_Common.loc);
                        FStar_TypeChecker_Common.rank =
-                         (uu___3389_21564.FStar_TypeChecker_Common.rank)
+                         (uu___3389_21562.FStar_TypeChecker_Common.rank)
                      }) wl
-              | (uu____21565, FStar_Syntax_Syntax.Tm_refine uu____21566) ->
+              | (uu____21563, FStar_Syntax_Syntax.Tm_refine uu____21564) ->
                   let t11 =
-                    let uu____21574 = base_and_refinement env t1 in
-                    FStar_All.pipe_left force_refinement uu____21574 in
+                    let uu____21572 = base_and_refinement env t1 in
+                    FStar_All.pipe_left force_refinement uu____21572 in
                   solve_t env
-                    (let uu___3396_21600 = problem in
+                    (let uu___3396_21598 = problem in
                      {
                        FStar_TypeChecker_Common.pid =
-                         (uu___3396_21600.FStar_TypeChecker_Common.pid);
+                         (uu___3396_21598.FStar_TypeChecker_Common.pid);
                        FStar_TypeChecker_Common.lhs = t11;
                        FStar_TypeChecker_Common.relation =
-                         (uu___3396_21600.FStar_TypeChecker_Common.relation);
+                         (uu___3396_21598.FStar_TypeChecker_Common.relation);
                        FStar_TypeChecker_Common.rhs =
-                         (uu___3396_21600.FStar_TypeChecker_Common.rhs);
+                         (uu___3396_21598.FStar_TypeChecker_Common.rhs);
                        FStar_TypeChecker_Common.element =
-                         (uu___3396_21600.FStar_TypeChecker_Common.element);
+                         (uu___3396_21598.FStar_TypeChecker_Common.element);
                        FStar_TypeChecker_Common.logical_guard =
-                         (uu___3396_21600.FStar_TypeChecker_Common.logical_guard);
+                         (uu___3396_21598.FStar_TypeChecker_Common.logical_guard);
                        FStar_TypeChecker_Common.logical_guard_uvar =
-                         (uu___3396_21600.FStar_TypeChecker_Common.logical_guard_uvar);
+                         (uu___3396_21598.FStar_TypeChecker_Common.logical_guard_uvar);
                        FStar_TypeChecker_Common.reason =
-                         (uu___3396_21600.FStar_TypeChecker_Common.reason);
+                         (uu___3396_21598.FStar_TypeChecker_Common.reason);
                        FStar_TypeChecker_Common.loc =
-                         (uu___3396_21600.FStar_TypeChecker_Common.loc);
+                         (uu___3396_21598.FStar_TypeChecker_Common.loc);
                        FStar_TypeChecker_Common.rank =
-                         (uu___3396_21600.FStar_TypeChecker_Common.rank)
+                         (uu___3396_21598.FStar_TypeChecker_Common.rank)
                      }) wl
               | (FStar_Syntax_Syntax.Tm_match (s1, brs1),
                  FStar_Syntax_Syntax.Tm_match (s2, brs2)) ->
-                  let by_smt uu____21682 =
-                    let uu____21683 = guard_of_prob env wl problem t1 t2 in
-                    match uu____21683 with
+                  let by_smt uu____21680 =
+                    let uu____21681 = guard_of_prob env wl problem t1 t2 in
+                    match uu____21681 with
                     | (guard, wl1) ->
-                        let uu____21690 =
+                        let uu____21688 =
                           solve_prob orig
                             (FStar_Pervasives_Native.Some guard) [] wl1 in
-                        solve env uu____21690 in
+                        solve env uu____21688 in
                   let rec solve_branches wl1 brs11 brs21 =
                     match (brs11, brs21) with
                     | (br1::rs1, br2::rs2) ->
-                        let uu____21909 = br1 in
-                        (match uu____21909 with
-                         | (p1, w1, uu____21938) ->
-                             let uu____21955 = br2 in
-                             (match uu____21955 with
-                              | (p2, w2, uu____21978) ->
-                                  let uu____21983 =
-                                    let uu____21984 =
+                        let uu____21907 = br1 in
+                        (match uu____21907 with
+                         | (p1, w1, uu____21936) ->
+                             let uu____21953 = br2 in
+                             (match uu____21953 with
+                              | (p2, w2, uu____21976) ->
+                                  let uu____21981 =
+                                    let uu____21982 =
                                       FStar_Syntax_Syntax.eq_pat p1 p2 in
-                                    Prims.op_Negation uu____21984 in
-                                  if uu____21983
+                                    Prims.op_Negation uu____21982 in
+                                  if uu____21981
                                   then FStar_Pervasives_Native.None
                                   else
-                                    (let uu____22008 =
+                                    (let uu____22006 =
                                        FStar_Syntax_Subst.open_branch' br1 in
-                                     match uu____22008 with
+                                     match uu____22006 with
                                      | ((p11, w11, e1), s) ->
-                                         let uu____22045 = br2 in
-                                         (match uu____22045 with
+                                         let uu____22043 = br2 in
+                                         (match uu____22043 with
                                           | (p21, w21, e2) ->
                                               let w22 =
                                                 FStar_Util.map_opt w21
@@ -8083,23 +8083,23 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                                               let e21 =
                                                 FStar_Syntax_Subst.subst s e2 in
                                               let scope =
-                                                let uu____22078 =
+                                                let uu____22076 =
                                                   FStar_Syntax_Syntax.pat_bvs
                                                     p11 in
                                                 FStar_All.pipe_left
                                                   (FStar_List.map
                                                      FStar_Syntax_Syntax.mk_binder)
-                                                  uu____22078 in
-                                              let uu____22083 =
+                                                  uu____22076 in
+                                              let uu____22081 =
                                                 match (w11, w22) with
                                                 | (FStar_Pervasives_Native.Some
-                                                   uu____22114,
+                                                   uu____22112,
                                                    FStar_Pervasives_Native.None)
                                                     ->
                                                     FStar_Pervasives_Native.None
                                                 | (FStar_Pervasives_Native.None,
                                                    FStar_Pervasives_Native.Some
-                                                   uu____22135) ->
+                                                   uu____22133) ->
                                                     FStar_Pervasives_Native.None
                                                 | (FStar_Pervasives_Native.None,
                                                    FStar_Pervasives_Native.None)
@@ -8110,65 +8110,65 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                                                    w12,
                                                    FStar_Pervasives_Native.Some
                                                    w23) ->
-                                                    let uu____22194 =
+                                                    let uu____22192 =
                                                       mk_t_problem wl1 scope
                                                         orig w12
                                                         FStar_TypeChecker_Common.EQ
                                                         w23
                                                         FStar_Pervasives_Native.None
                                                         "when clause" in
-                                                    (match uu____22194 with
+                                                    (match uu____22192 with
                                                      | (p, wl2) ->
                                                          FStar_Pervasives_Native.Some
                                                            ([(scope, p)],
                                                              wl2)) in
-                                              FStar_Util.bind_opt uu____22083
-                                                (fun uu____22265 ->
-                                                   match uu____22265 with
+                                              FStar_Util.bind_opt uu____22081
+                                                (fun uu____22263 ->
+                                                   match uu____22263 with
                                                    | (wprobs, wl2) ->
-                                                       let uu____22302 =
+                                                       let uu____22300 =
                                                          mk_t_problem wl2
                                                            scope orig e1
                                                            FStar_TypeChecker_Common.EQ
                                                            e21
                                                            FStar_Pervasives_Native.None
                                                            "branch body" in
-                                                       (match uu____22302
+                                                       (match uu____22300
                                                         with
                                                         | (prob, wl3) ->
-                                                            ((let uu____22322
+                                                            ((let uu____22320
                                                                 =
                                                                 FStar_All.pipe_left
                                                                   (FStar_TypeChecker_Env.debug
                                                                     wl3.tcenv)
                                                                   (FStar_Options.Other
                                                                     "Rel") in
-                                                              if uu____22322
+                                                              if uu____22320
                                                               then
-                                                                let uu____22323
+                                                                let uu____22321
                                                                   =
                                                                   prob_to_string
                                                                     env prob in
-                                                                let uu____22324
+                                                                let uu____22322
                                                                   =
                                                                   FStar_Syntax_Print.binders_to_string
                                                                     ", "
                                                                     scope in
                                                                 FStar_Util.print2
                                                                   "Created problem for branches %s with scope %s\n"
-                                                                  uu____22323
-                                                                  uu____22324
+                                                                  uu____22321
+                                                                  uu____22322
                                                               else ());
-                                                             (let uu____22326
+                                                             (let uu____22324
                                                                 =
                                                                 solve_branches
                                                                   wl3 rs1 rs2 in
                                                               FStar_Util.bind_opt
-                                                                uu____22326
+                                                                uu____22324
                                                                 (fun
-                                                                   uu____22362
+                                                                   uu____22360
                                                                    ->
-                                                                   match uu____22362
+                                                                   match uu____22360
                                                                    with
                                                                    | 
                                                                    (r1, wl4)
@@ -8180,108 +8180,108 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                                                                     wprobs r1)),
                                                                     wl4))))))))))
                     | ([], []) -> FStar_Pervasives_Native.Some ([], wl1)
-                    | uu____22491 -> FStar_Pervasives_Native.None in
-                  let uu____22532 = solve_branches wl brs1 brs2 in
-                  (match uu____22532 with
+                    | uu____22489 -> FStar_Pervasives_Native.None in
+                  let uu____22530 = solve_branches wl brs1 brs2 in
+                  (match uu____22530 with
                    | FStar_Pervasives_Native.None ->
                        if wl.smt_ok
                        then by_smt ()
                        else
-                         (let uu____22556 =
+                         (let uu____22554 =
                             FStar_Thunk.mkv "Tm_match branches don't match" in
-                          giveup env uu____22556 orig)
+                          giveup env uu____22554 orig)
                    | FStar_Pervasives_Native.Some (sub_probs, wl1) ->
-                       let uu____22581 =
+                       let uu____22579 =
                          mk_t_problem wl1 [] orig s1
                            FStar_TypeChecker_Common.EQ s2
                            FStar_Pervasives_Native.None "match scrutinee" in
-                       (match uu____22581 with
+                       (match uu____22579 with
                         | (sc_prob, wl2) ->
                             let sub_probs1 = ([], sc_prob) :: sub_probs in
                             let formula =
-                              let uu____22614 =
+                              let uu____22612 =
                                 FStar_List.map
-                                  (fun uu____22626 ->
-                                     match uu____22626 with
+                                  (fun uu____22624 ->
+                                     match uu____22624 with
                                      | (scope, p) ->
                                          FStar_TypeChecker_Env.close_forall
                                            wl2.tcenv scope (p_guard p))
                                   sub_probs1 in
-                              FStar_Syntax_Util.mk_conj_l uu____22614 in
+                              FStar_Syntax_Util.mk_conj_l uu____22612 in
                             let tx =
                               FStar_Syntax_Unionfind.new_transaction () in
                             let wl3 =
                               solve_prob orig
                                 (FStar_Pervasives_Native.Some formula) [] wl2 in
-                            let uu____22635 =
-                              let uu____22636 =
-                                let uu____22637 =
+                            let uu____22633 =
+                              let uu____22634 =
+                                let uu____22635 =
                                   FStar_List.map FStar_Pervasives_Native.snd
                                     sub_probs1 in
-                                attempt uu____22637
-                                  (let uu___3495_22645 = wl3 in
+                                attempt uu____22635
+                                  (let uu___3495_22643 = wl3 in
                                    {
                                      attempting =
-                                       (uu___3495_22645.attempting);
+                                       (uu___3495_22643.attempting);
                                      wl_deferred =
-                                       (uu___3495_22645.wl_deferred);
+                                       (uu___3495_22643.wl_deferred);
                                      wl_deferred_to_tac =
-                                       (uu___3495_22645.wl_deferred_to_tac);
-                                     ctr = (uu___3495_22645.ctr);
-                                     defer_ok = (uu___3495_22645.defer_ok);
+                                       (uu___3495_22643.wl_deferred_to_tac);
+                                     ctr = (uu___3495_22643.ctr);
+                                     defer_ok = (uu___3495_22643.defer_ok);
                                      smt_ok = false;
                                      umax_heuristic_ok =
-                                       (uu___3495_22645.umax_heuristic_ok);
-                                     tcenv = (uu___3495_22645.tcenv);
+                                       (uu___3495_22643.umax_heuristic_ok);
+                                     tcenv = (uu___3495_22643.tcenv);
                                      wl_implicits =
-                                       (uu___3495_22645.wl_implicits);
+                                       (uu___3495_22643.wl_implicits);
                                      repr_subcomp_allowed =
-                                       (uu___3495_22645.repr_subcomp_allowed)
+                                       (uu___3495_22643.repr_subcomp_allowed)
                                    }) in
-                              solve env uu____22636 in
-                            (match uu____22635 with
+                              solve env uu____22634 in
+                            (match uu____22633 with
                              | Success (ds, ds', imp) ->
                                  (FStar_Syntax_Unionfind.commit tx;
                                   Success (ds, ds', imp))
-                             | Failed uu____22650 ->
+                             | Failed uu____22648 ->
                                  (FStar_Syntax_Unionfind.rollback tx;
                                   if wl3.smt_ok
                                   then by_smt ()
                                   else
-                                    (let uu____22657 =
+                                    (let uu____22655 =
                                        FStar_Thunk.mkv
                                          "Could not unify matches without SMT" in
-                                     giveup env uu____22657 orig)))))
-              | (FStar_Syntax_Syntax.Tm_match uu____22658, uu____22659) ->
+                                     giveup env uu____22655 orig)))))
+              | (FStar_Syntax_Syntax.Tm_match uu____22656, uu____22657) ->
                   let head1 =
-                    let uu____22683 = FStar_Syntax_Util.head_and_args t1 in
-                    FStar_All.pipe_right uu____22683
+                    let uu____22681 = FStar_Syntax_Util.head_and_args t1 in
+                    FStar_All.pipe_right uu____22681
                       FStar_Pervasives_Native.fst in
                   let head2 =
-                    let uu____22729 = FStar_Syntax_Util.head_and_args t2 in
-                    FStar_All.pipe_right uu____22729
+                    let uu____22727 = FStar_Syntax_Util.head_and_args t2 in
+                    FStar_All.pipe_right uu____22727
                       FStar_Pervasives_Native.fst in
-                  ((let uu____22775 =
+                  ((let uu____22773 =
                       FStar_TypeChecker_Env.debug env
                         (FStar_Options.Other "Rel") in
-                    if uu____22775
+                    if uu____22773
                     then
+                      let uu____22774 =
+                        FStar_Util.string_of_int
+                          problem.FStar_TypeChecker_Common.pid in
+                      let uu____22775 =
+                        FStar_Syntax_Print.term_to_string head1 in
                       let uu____22776 =
-                        FStar_Util.string_of_int
-                          problem.FStar_TypeChecker_Common.pid in
-                      let uu____22777 =
-                        FStar_Syntax_Print.term_to_string head1 in
-                      let uu____22778 =
                         FStar_Syntax_Print.term_to_string head2 in
                       FStar_Util.print3
                         ">> (%s)\n>>> head1 = %s\n>>> head2 = %s\n"
-                        uu____22776 uu____22777 uu____22778
+                        uu____22774 uu____22775 uu____22776
                     else ());
                    (let no_free_uvars t =
-                      (let uu____22788 = FStar_Syntax_Free.uvars t in
-                       FStar_Util.set_is_empty uu____22788) &&
-                        (let uu____22792 = FStar_Syntax_Free.univs t in
-                         FStar_Util.set_is_empty uu____22792) in
+                      (let uu____22786 = FStar_Syntax_Free.uvars t in
+                       FStar_Util.set_is_empty uu____22786) &&
+                        (let uu____22790 = FStar_Syntax_Free.univs t in
+                         FStar_Util.set_is_empty uu____22790) in
                     let equal t11 t21 =
                       let t12 =
                         norm_with_steps
@@ -8301,9 +8301,9 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                           FStar_TypeChecker_Env.Beta;
                           FStar_TypeChecker_Env.Eager_unfolding;
                           FStar_TypeChecker_Env.Iota] env t21 in
-                      let uu____22808 = FStar_Syntax_Util.eq_tm t12 t22 in
-                      uu____22808 = FStar_Syntax_Util.Equal in
-                    let uu____22809 =
+                      let uu____22806 = FStar_Syntax_Util.eq_tm t12 t22 in
+                      uu____22806 = FStar_Syntax_Util.Equal in
+                    let uu____22807 =
                       ((((FStar_TypeChecker_Env.is_interpreted env head1) ||
                            (FStar_TypeChecker_Env.is_interpreted env head2))
                           &&
@@ -8311,65 +8311,65 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                              FStar_TypeChecker_Common.EQ))
                          && (no_free_uvars t1))
                         && (no_free_uvars t2) in
-                    if uu____22809
+                    if uu____22807
                     then
                       (if Prims.op_Negation wl.smt_ok
                        then
-                         let uu____22810 = equal t1 t2 in
-                         (if uu____22810
+                         let uu____22808 = equal t1 t2 in
+                         (if uu____22808
                           then
-                            let uu____22811 =
+                            let uu____22809 =
                               solve_prob orig FStar_Pervasives_Native.None []
                                 wl in
-                            solve env uu____22811
+                            solve env uu____22809
                           else
                             rigid_rigid_delta env problem wl head1 head2 t1
                               t2)
                        else
-                         (let uu____22814 =
-                            let uu____22821 = equal t1 t2 in
-                            if uu____22821
+                         (let uu____22812 =
+                            let uu____22819 = equal t1 t2 in
+                            if uu____22819
                             then (FStar_Pervasives_Native.None, wl)
                             else
-                              (let uu____22831 = mk_eq2 wl env orig t1 t2 in
-                               match uu____22831 with
+                              (let uu____22829 = mk_eq2 wl env orig t1 t2 in
+                               match uu____22829 with
                                | (g, wl1) ->
                                    ((FStar_Pervasives_Native.Some g), wl1)) in
-                          match uu____22814 with
+                          match uu____22812 with
                           | (guard, wl1) ->
-                              let uu____22852 = solve_prob orig guard [] wl1 in
-                              solve env uu____22852))
+                              let uu____22850 = solve_prob orig guard [] wl1 in
+                              solve env uu____22850))
                     else rigid_rigid_delta env problem wl head1 head2 t1 t2))
-              | (FStar_Syntax_Syntax.Tm_uinst uu____22854, uu____22855) ->
+              | (FStar_Syntax_Syntax.Tm_uinst uu____22852, uu____22853) ->
                   let head1 =
-                    let uu____22863 = FStar_Syntax_Util.head_and_args t1 in
-                    FStar_All.pipe_right uu____22863
+                    let uu____22861 = FStar_Syntax_Util.head_and_args t1 in
+                    FStar_All.pipe_right uu____22861
                       FStar_Pervasives_Native.fst in
                   let head2 =
-                    let uu____22909 = FStar_Syntax_Util.head_and_args t2 in
-                    FStar_All.pipe_right uu____22909
+                    let uu____22907 = FStar_Syntax_Util.head_and_args t2 in
+                    FStar_All.pipe_right uu____22907
                       FStar_Pervasives_Native.fst in
-                  ((let uu____22955 =
+                  ((let uu____22953 =
                       FStar_TypeChecker_Env.debug env
                         (FStar_Options.Other "Rel") in
-                    if uu____22955
+                    if uu____22953
                     then
+                      let uu____22954 =
+                        FStar_Util.string_of_int
+                          problem.FStar_TypeChecker_Common.pid in
+                      let uu____22955 =
+                        FStar_Syntax_Print.term_to_string head1 in
                       let uu____22956 =
-                        FStar_Util.string_of_int
-                          problem.FStar_TypeChecker_Common.pid in
-                      let uu____22957 =
-                        FStar_Syntax_Print.term_to_string head1 in
-                      let uu____22958 =
                         FStar_Syntax_Print.term_to_string head2 in
                       FStar_Util.print3
                         ">> (%s)\n>>> head1 = %s\n>>> head2 = %s\n"
-                        uu____22956 uu____22957 uu____22958
+                        uu____22954 uu____22955 uu____22956
                     else ());
                    (let no_free_uvars t =
-                      (let uu____22968 = FStar_Syntax_Free.uvars t in
-                       FStar_Util.set_is_empty uu____22968) &&
-                        (let uu____22972 = FStar_Syntax_Free.univs t in
-                         FStar_Util.set_is_empty uu____22972) in
+                      (let uu____22966 = FStar_Syntax_Free.uvars t in
+                       FStar_Util.set_is_empty uu____22966) &&
+                        (let uu____22970 = FStar_Syntax_Free.univs t in
+                         FStar_Util.set_is_empty uu____22970) in
                     let equal t11 t21 =
                       let t12 =
                         norm_with_steps
@@ -8389,9 +8389,9 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                           FStar_TypeChecker_Env.Beta;
                           FStar_TypeChecker_Env.Eager_unfolding;
                           FStar_TypeChecker_Env.Iota] env t21 in
-                      let uu____22988 = FStar_Syntax_Util.eq_tm t12 t22 in
-                      uu____22988 = FStar_Syntax_Util.Equal in
-                    let uu____22989 =
+                      let uu____22986 = FStar_Syntax_Util.eq_tm t12 t22 in
+                      uu____22986 = FStar_Syntax_Util.Equal in
+                    let uu____22987 =
                       ((((FStar_TypeChecker_Env.is_interpreted env head1) ||
                            (FStar_TypeChecker_Env.is_interpreted env head2))
                           &&
@@ -8399,65 +8399,65 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                              FStar_TypeChecker_Common.EQ))
                          && (no_free_uvars t1))
                         && (no_free_uvars t2) in
-                    if uu____22989
+                    if uu____22987
                     then
                       (if Prims.op_Negation wl.smt_ok
                        then
-                         let uu____22990 = equal t1 t2 in
-                         (if uu____22990
+                         let uu____22988 = equal t1 t2 in
+                         (if uu____22988
                           then
-                            let uu____22991 =
+                            let uu____22989 =
                               solve_prob orig FStar_Pervasives_Native.None []
                                 wl in
-                            solve env uu____22991
+                            solve env uu____22989
                           else
                             rigid_rigid_delta env problem wl head1 head2 t1
                               t2)
                        else
-                         (let uu____22994 =
-                            let uu____23001 = equal t1 t2 in
-                            if uu____23001
+                         (let uu____22992 =
+                            let uu____22999 = equal t1 t2 in
+                            if uu____22999
                             then (FStar_Pervasives_Native.None, wl)
                             else
-                              (let uu____23011 = mk_eq2 wl env orig t1 t2 in
-                               match uu____23011 with
+                              (let uu____23009 = mk_eq2 wl env orig t1 t2 in
+                               match uu____23009 with
                                | (g, wl1) ->
                                    ((FStar_Pervasives_Native.Some g), wl1)) in
-                          match uu____22994 with
+                          match uu____22992 with
                           | (guard, wl1) ->
-                              let uu____23032 = solve_prob orig guard [] wl1 in
-                              solve env uu____23032))
+                              let uu____23030 = solve_prob orig guard [] wl1 in
+                              solve env uu____23030))
                     else rigid_rigid_delta env problem wl head1 head2 t1 t2))
-              | (FStar_Syntax_Syntax.Tm_name uu____23034, uu____23035) ->
+              | (FStar_Syntax_Syntax.Tm_name uu____23032, uu____23033) ->
                   let head1 =
-                    let uu____23037 = FStar_Syntax_Util.head_and_args t1 in
-                    FStar_All.pipe_right uu____23037
+                    let uu____23035 = FStar_Syntax_Util.head_and_args t1 in
+                    FStar_All.pipe_right uu____23035
                       FStar_Pervasives_Native.fst in
                   let head2 =
-                    let uu____23083 = FStar_Syntax_Util.head_and_args t2 in
-                    FStar_All.pipe_right uu____23083
+                    let uu____23081 = FStar_Syntax_Util.head_and_args t2 in
+                    FStar_All.pipe_right uu____23081
                       FStar_Pervasives_Native.fst in
-                  ((let uu____23129 =
+                  ((let uu____23127 =
                       FStar_TypeChecker_Env.debug env
                         (FStar_Options.Other "Rel") in
-                    if uu____23129
+                    if uu____23127
                     then
+                      let uu____23128 =
+                        FStar_Util.string_of_int
+                          problem.FStar_TypeChecker_Common.pid in
+                      let uu____23129 =
+                        FStar_Syntax_Print.term_to_string head1 in
                       let uu____23130 =
-                        FStar_Util.string_of_int
-                          problem.FStar_TypeChecker_Common.pid in
-                      let uu____23131 =
-                        FStar_Syntax_Print.term_to_string head1 in
-                      let uu____23132 =
                         FStar_Syntax_Print.term_to_string head2 in
                       FStar_Util.print3
                         ">> (%s)\n>>> head1 = %s\n>>> head2 = %s\n"
-                        uu____23130 uu____23131 uu____23132
+                        uu____23128 uu____23129 uu____23130
                     else ());
                    (let no_free_uvars t =
-                      (let uu____23142 = FStar_Syntax_Free.uvars t in
-                       FStar_Util.set_is_empty uu____23142) &&
-                        (let uu____23146 = FStar_Syntax_Free.univs t in
-                         FStar_Util.set_is_empty uu____23146) in
+                      (let uu____23140 = FStar_Syntax_Free.uvars t in
+                       FStar_Util.set_is_empty uu____23140) &&
+                        (let uu____23144 = FStar_Syntax_Free.univs t in
+                         FStar_Util.set_is_empty uu____23144) in
                     let equal t11 t21 =
                       let t12 =
                         norm_with_steps
@@ -8477,9 +8477,9 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                           FStar_TypeChecker_Env.Beta;
                           FStar_TypeChecker_Env.Eager_unfolding;
                           FStar_TypeChecker_Env.Iota] env t21 in
-                      let uu____23162 = FStar_Syntax_Util.eq_tm t12 t22 in
-                      uu____23162 = FStar_Syntax_Util.Equal in
-                    let uu____23163 =
+                      let uu____23160 = FStar_Syntax_Util.eq_tm t12 t22 in
+                      uu____23160 = FStar_Syntax_Util.Equal in
+                    let uu____23161 =
                       ((((FStar_TypeChecker_Env.is_interpreted env head1) ||
                            (FStar_TypeChecker_Env.is_interpreted env head2))
                           &&
@@ -8487,65 +8487,65 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                              FStar_TypeChecker_Common.EQ))
                          && (no_free_uvars t1))
                         && (no_free_uvars t2) in
-                    if uu____23163
+                    if uu____23161
                     then
                       (if Prims.op_Negation wl.smt_ok
                        then
-                         let uu____23164 = equal t1 t2 in
-                         (if uu____23164
+                         let uu____23162 = equal t1 t2 in
+                         (if uu____23162
                           then
-                            let uu____23165 =
+                            let uu____23163 =
                               solve_prob orig FStar_Pervasives_Native.None []
                                 wl in
-                            solve env uu____23165
+                            solve env uu____23163
                           else
                             rigid_rigid_delta env problem wl head1 head2 t1
                               t2)
                        else
-                         (let uu____23168 =
-                            let uu____23175 = equal t1 t2 in
-                            if uu____23175
+                         (let uu____23166 =
+                            let uu____23173 = equal t1 t2 in
+                            if uu____23173
                             then (FStar_Pervasives_Native.None, wl)
                             else
-                              (let uu____23185 = mk_eq2 wl env orig t1 t2 in
-                               match uu____23185 with
+                              (let uu____23183 = mk_eq2 wl env orig t1 t2 in
+                               match uu____23183 with
                                | (g, wl1) ->
                                    ((FStar_Pervasives_Native.Some g), wl1)) in
-                          match uu____23168 with
+                          match uu____23166 with
                           | (guard, wl1) ->
-                              let uu____23206 = solve_prob orig guard [] wl1 in
-                              solve env uu____23206))
+                              let uu____23204 = solve_prob orig guard [] wl1 in
+                              solve env uu____23204))
                     else rigid_rigid_delta env problem wl head1 head2 t1 t2))
-              | (FStar_Syntax_Syntax.Tm_constant uu____23208, uu____23209) ->
+              | (FStar_Syntax_Syntax.Tm_constant uu____23206, uu____23207) ->
                   let head1 =
-                    let uu____23211 = FStar_Syntax_Util.head_and_args t1 in
-                    FStar_All.pipe_right uu____23211
+                    let uu____23209 = FStar_Syntax_Util.head_and_args t1 in
+                    FStar_All.pipe_right uu____23209
                       FStar_Pervasives_Native.fst in
                   let head2 =
-                    let uu____23257 = FStar_Syntax_Util.head_and_args t2 in
-                    FStar_All.pipe_right uu____23257
+                    let uu____23255 = FStar_Syntax_Util.head_and_args t2 in
+                    FStar_All.pipe_right uu____23255
                       FStar_Pervasives_Native.fst in
-                  ((let uu____23303 =
+                  ((let uu____23301 =
                       FStar_TypeChecker_Env.debug env
                         (FStar_Options.Other "Rel") in
-                    if uu____23303
+                    if uu____23301
                     then
+                      let uu____23302 =
+                        FStar_Util.string_of_int
+                          problem.FStar_TypeChecker_Common.pid in
+                      let uu____23303 =
+                        FStar_Syntax_Print.term_to_string head1 in
                       let uu____23304 =
-                        FStar_Util.string_of_int
-                          problem.FStar_TypeChecker_Common.pid in
-                      let uu____23305 =
-                        FStar_Syntax_Print.term_to_string head1 in
-                      let uu____23306 =
                         FStar_Syntax_Print.term_to_string head2 in
                       FStar_Util.print3
                         ">> (%s)\n>>> head1 = %s\n>>> head2 = %s\n"
-                        uu____23304 uu____23305 uu____23306
+                        uu____23302 uu____23303 uu____23304
                     else ());
                    (let no_free_uvars t =
-                      (let uu____23316 = FStar_Syntax_Free.uvars t in
-                       FStar_Util.set_is_empty uu____23316) &&
-                        (let uu____23320 = FStar_Syntax_Free.univs t in
-                         FStar_Util.set_is_empty uu____23320) in
+                      (let uu____23314 = FStar_Syntax_Free.uvars t in
+                       FStar_Util.set_is_empty uu____23314) &&
+                        (let uu____23318 = FStar_Syntax_Free.univs t in
+                         FStar_Util.set_is_empty uu____23318) in
                     let equal t11 t21 =
                       let t12 =
                         norm_with_steps
@@ -8565,9 +8565,9 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                           FStar_TypeChecker_Env.Beta;
                           FStar_TypeChecker_Env.Eager_unfolding;
                           FStar_TypeChecker_Env.Iota] env t21 in
-                      let uu____23336 = FStar_Syntax_Util.eq_tm t12 t22 in
-                      uu____23336 = FStar_Syntax_Util.Equal in
-                    let uu____23337 =
+                      let uu____23334 = FStar_Syntax_Util.eq_tm t12 t22 in
+                      uu____23334 = FStar_Syntax_Util.Equal in
+                    let uu____23335 =
                       ((((FStar_TypeChecker_Env.is_interpreted env head1) ||
                            (FStar_TypeChecker_Env.is_interpreted env head2))
                           &&
@@ -8575,65 +8575,65 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                              FStar_TypeChecker_Common.EQ))
                          && (no_free_uvars t1))
                         && (no_free_uvars t2) in
-                    if uu____23337
+                    if uu____23335
                     then
                       (if Prims.op_Negation wl.smt_ok
                        then
-                         let uu____23338 = equal t1 t2 in
-                         (if uu____23338
+                         let uu____23336 = equal t1 t2 in
+                         (if uu____23336
                           then
-                            let uu____23339 =
+                            let uu____23337 =
                               solve_prob orig FStar_Pervasives_Native.None []
                                 wl in
-                            solve env uu____23339
+                            solve env uu____23337
                           else
                             rigid_rigid_delta env problem wl head1 head2 t1
                               t2)
                        else
-                         (let uu____23342 =
-                            let uu____23349 = equal t1 t2 in
-                            if uu____23349
+                         (let uu____23340 =
+                            let uu____23347 = equal t1 t2 in
+                            if uu____23347
                             then (FStar_Pervasives_Native.None, wl)
                             else
-                              (let uu____23359 = mk_eq2 wl env orig t1 t2 in
-                               match uu____23359 with
+                              (let uu____23357 = mk_eq2 wl env orig t1 t2 in
+                               match uu____23357 with
                                | (g, wl1) ->
                                    ((FStar_Pervasives_Native.Some g), wl1)) in
-                          match uu____23342 with
+                          match uu____23340 with
                           | (guard, wl1) ->
-                              let uu____23380 = solve_prob orig guard [] wl1 in
-                              solve env uu____23380))
+                              let uu____23378 = solve_prob orig guard [] wl1 in
+                              solve env uu____23378))
                     else rigid_rigid_delta env problem wl head1 head2 t1 t2))
-              | (FStar_Syntax_Syntax.Tm_fvar uu____23382, uu____23383) ->
+              | (FStar_Syntax_Syntax.Tm_fvar uu____23380, uu____23381) ->
                   let head1 =
-                    let uu____23385 = FStar_Syntax_Util.head_and_args t1 in
-                    FStar_All.pipe_right uu____23385
+                    let uu____23383 = FStar_Syntax_Util.head_and_args t1 in
+                    FStar_All.pipe_right uu____23383
                       FStar_Pervasives_Native.fst in
                   let head2 =
-                    let uu____23425 = FStar_Syntax_Util.head_and_args t2 in
-                    FStar_All.pipe_right uu____23425
+                    let uu____23423 = FStar_Syntax_Util.head_and_args t2 in
+                    FStar_All.pipe_right uu____23423
                       FStar_Pervasives_Native.fst in
-                  ((let uu____23465 =
+                  ((let uu____23463 =
                       FStar_TypeChecker_Env.debug env
                         (FStar_Options.Other "Rel") in
-                    if uu____23465
+                    if uu____23463
                     then
+                      let uu____23464 =
+                        FStar_Util.string_of_int
+                          problem.FStar_TypeChecker_Common.pid in
+                      let uu____23465 =
+                        FStar_Syntax_Print.term_to_string head1 in
                       let uu____23466 =
-                        FStar_Util.string_of_int
-                          problem.FStar_TypeChecker_Common.pid in
-                      let uu____23467 =
-                        FStar_Syntax_Print.term_to_string head1 in
-                      let uu____23468 =
                         FStar_Syntax_Print.term_to_string head2 in
                       FStar_Util.print3
                         ">> (%s)\n>>> head1 = %s\n>>> head2 = %s\n"
-                        uu____23466 uu____23467 uu____23468
+                        uu____23464 uu____23465 uu____23466
                     else ());
                    (let no_free_uvars t =
-                      (let uu____23478 = FStar_Syntax_Free.uvars t in
-                       FStar_Util.set_is_empty uu____23478) &&
-                        (let uu____23482 = FStar_Syntax_Free.univs t in
-                         FStar_Util.set_is_empty uu____23482) in
+                      (let uu____23476 = FStar_Syntax_Free.uvars t in
+                       FStar_Util.set_is_empty uu____23476) &&
+                        (let uu____23480 = FStar_Syntax_Free.univs t in
+                         FStar_Util.set_is_empty uu____23480) in
                     let equal t11 t21 =
                       let t12 =
                         norm_with_steps
@@ -8653,9 +8653,9 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                           FStar_TypeChecker_Env.Beta;
                           FStar_TypeChecker_Env.Eager_unfolding;
                           FStar_TypeChecker_Env.Iota] env t21 in
-                      let uu____23498 = FStar_Syntax_Util.eq_tm t12 t22 in
-                      uu____23498 = FStar_Syntax_Util.Equal in
-                    let uu____23499 =
+                      let uu____23496 = FStar_Syntax_Util.eq_tm t12 t22 in
+                      uu____23496 = FStar_Syntax_Util.Equal in
+                    let uu____23497 =
                       ((((FStar_TypeChecker_Env.is_interpreted env head1) ||
                            (FStar_TypeChecker_Env.is_interpreted env head2))
                           &&
@@ -8663,65 +8663,65 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                              FStar_TypeChecker_Common.EQ))
                          && (no_free_uvars t1))
                         && (no_free_uvars t2) in
-                    if uu____23499
+                    if uu____23497
                     then
                       (if Prims.op_Negation wl.smt_ok
                        then
-                         let uu____23500 = equal t1 t2 in
-                         (if uu____23500
+                         let uu____23498 = equal t1 t2 in
+                         (if uu____23498
                           then
-                            let uu____23501 =
+                            let uu____23499 =
                               solve_prob orig FStar_Pervasives_Native.None []
                                 wl in
-                            solve env uu____23501
+                            solve env uu____23499
                           else
                             rigid_rigid_delta env problem wl head1 head2 t1
                               t2)
                        else
-                         (let uu____23504 =
-                            let uu____23511 = equal t1 t2 in
-                            if uu____23511
+                         (let uu____23502 =
+                            let uu____23509 = equal t1 t2 in
+                            if uu____23509
                             then (FStar_Pervasives_Native.None, wl)
                             else
-                              (let uu____23521 = mk_eq2 wl env orig t1 t2 in
-                               match uu____23521 with
+                              (let uu____23519 = mk_eq2 wl env orig t1 t2 in
+                               match uu____23519 with
                                | (g, wl1) ->
                                    ((FStar_Pervasives_Native.Some g), wl1)) in
-                          match uu____23504 with
+                          match uu____23502 with
                           | (guard, wl1) ->
-                              let uu____23542 = solve_prob orig guard [] wl1 in
-                              solve env uu____23542))
+                              let uu____23540 = solve_prob orig guard [] wl1 in
+                              solve env uu____23540))
                     else rigid_rigid_delta env problem wl head1 head2 t1 t2))
-              | (FStar_Syntax_Syntax.Tm_app uu____23544, uu____23545) ->
+              | (FStar_Syntax_Syntax.Tm_app uu____23542, uu____23543) ->
                   let head1 =
-                    let uu____23563 = FStar_Syntax_Util.head_and_args t1 in
-                    FStar_All.pipe_right uu____23563
+                    let uu____23561 = FStar_Syntax_Util.head_and_args t1 in
+                    FStar_All.pipe_right uu____23561
                       FStar_Pervasives_Native.fst in
                   let head2 =
-                    let uu____23603 = FStar_Syntax_Util.head_and_args t2 in
-                    FStar_All.pipe_right uu____23603
+                    let uu____23601 = FStar_Syntax_Util.head_and_args t2 in
+                    FStar_All.pipe_right uu____23601
                       FStar_Pervasives_Native.fst in
-                  ((let uu____23643 =
+                  ((let uu____23641 =
                       FStar_TypeChecker_Env.debug env
                         (FStar_Options.Other "Rel") in
-                    if uu____23643
+                    if uu____23641
                     then
+                      let uu____23642 =
+                        FStar_Util.string_of_int
+                          problem.FStar_TypeChecker_Common.pid in
+                      let uu____23643 =
+                        FStar_Syntax_Print.term_to_string head1 in
                       let uu____23644 =
-                        FStar_Util.string_of_int
-                          problem.FStar_TypeChecker_Common.pid in
-                      let uu____23645 =
-                        FStar_Syntax_Print.term_to_string head1 in
-                      let uu____23646 =
                         FStar_Syntax_Print.term_to_string head2 in
                       FStar_Util.print3
                         ">> (%s)\n>>> head1 = %s\n>>> head2 = %s\n"
-                        uu____23644 uu____23645 uu____23646
+                        uu____23642 uu____23643 uu____23644
                     else ());
                    (let no_free_uvars t =
-                      (let uu____23656 = FStar_Syntax_Free.uvars t in
-                       FStar_Util.set_is_empty uu____23656) &&
-                        (let uu____23660 = FStar_Syntax_Free.univs t in
-                         FStar_Util.set_is_empty uu____23660) in
+                      (let uu____23654 = FStar_Syntax_Free.uvars t in
+                       FStar_Util.set_is_empty uu____23654) &&
+                        (let uu____23658 = FStar_Syntax_Free.univs t in
+                         FStar_Util.set_is_empty uu____23658) in
                     let equal t11 t21 =
                       let t12 =
                         norm_with_steps
@@ -8741,9 +8741,9 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                           FStar_TypeChecker_Env.Beta;
                           FStar_TypeChecker_Env.Eager_unfolding;
                           FStar_TypeChecker_Env.Iota] env t21 in
-                      let uu____23676 = FStar_Syntax_Util.eq_tm t12 t22 in
-                      uu____23676 = FStar_Syntax_Util.Equal in
-                    let uu____23677 =
+                      let uu____23674 = FStar_Syntax_Util.eq_tm t12 t22 in
+                      uu____23674 = FStar_Syntax_Util.Equal in
+                    let uu____23675 =
                       ((((FStar_TypeChecker_Env.is_interpreted env head1) ||
                            (FStar_TypeChecker_Env.is_interpreted env head2))
                           &&
@@ -8751,65 +8751,65 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                              FStar_TypeChecker_Common.EQ))
                          && (no_free_uvars t1))
                         && (no_free_uvars t2) in
-                    if uu____23677
+                    if uu____23675
                     then
                       (if Prims.op_Negation wl.smt_ok
                        then
-                         let uu____23678 = equal t1 t2 in
-                         (if uu____23678
+                         let uu____23676 = equal t1 t2 in
+                         (if uu____23676
                           then
-                            let uu____23679 =
+                            let uu____23677 =
                               solve_prob orig FStar_Pervasives_Native.None []
                                 wl in
-                            solve env uu____23679
+                            solve env uu____23677
                           else
                             rigid_rigid_delta env problem wl head1 head2 t1
                               t2)
                        else
-                         (let uu____23682 =
-                            let uu____23689 = equal t1 t2 in
-                            if uu____23689
+                         (let uu____23680 =
+                            let uu____23687 = equal t1 t2 in
+                            if uu____23687
                             then (FStar_Pervasives_Native.None, wl)
                             else
-                              (let uu____23699 = mk_eq2 wl env orig t1 t2 in
-                               match uu____23699 with
+                              (let uu____23697 = mk_eq2 wl env orig t1 t2 in
+                               match uu____23697 with
                                | (g, wl1) ->
                                    ((FStar_Pervasives_Native.Some g), wl1)) in
-                          match uu____23682 with
+                          match uu____23680 with
                           | (guard, wl1) ->
-                              let uu____23720 = solve_prob orig guard [] wl1 in
-                              solve env uu____23720))
+                              let uu____23718 = solve_prob orig guard [] wl1 in
+                              solve env uu____23718))
                     else rigid_rigid_delta env problem wl head1 head2 t1 t2))
-              | (uu____23722, FStar_Syntax_Syntax.Tm_match uu____23723) ->
+              | (uu____23720, FStar_Syntax_Syntax.Tm_match uu____23721) ->
                   let head1 =
-                    let uu____23747 = FStar_Syntax_Util.head_and_args t1 in
-                    FStar_All.pipe_right uu____23747
+                    let uu____23745 = FStar_Syntax_Util.head_and_args t1 in
+                    FStar_All.pipe_right uu____23745
                       FStar_Pervasives_Native.fst in
                   let head2 =
-                    let uu____23787 = FStar_Syntax_Util.head_and_args t2 in
-                    FStar_All.pipe_right uu____23787
+                    let uu____23785 = FStar_Syntax_Util.head_and_args t2 in
+                    FStar_All.pipe_right uu____23785
                       FStar_Pervasives_Native.fst in
-                  ((let uu____23827 =
+                  ((let uu____23825 =
                       FStar_TypeChecker_Env.debug env
                         (FStar_Options.Other "Rel") in
-                    if uu____23827
+                    if uu____23825
                     then
+                      let uu____23826 =
+                        FStar_Util.string_of_int
+                          problem.FStar_TypeChecker_Common.pid in
+                      let uu____23827 =
+                        FStar_Syntax_Print.term_to_string head1 in
                       let uu____23828 =
-                        FStar_Util.string_of_int
-                          problem.FStar_TypeChecker_Common.pid in
-                      let uu____23829 =
-                        FStar_Syntax_Print.term_to_string head1 in
-                      let uu____23830 =
                         FStar_Syntax_Print.term_to_string head2 in
                       FStar_Util.print3
                         ">> (%s)\n>>> head1 = %s\n>>> head2 = %s\n"
-                        uu____23828 uu____23829 uu____23830
+                        uu____23826 uu____23827 uu____23828
                     else ());
                    (let no_free_uvars t =
-                      (let uu____23840 = FStar_Syntax_Free.uvars t in
-                       FStar_Util.set_is_empty uu____23840) &&
-                        (let uu____23844 = FStar_Syntax_Free.univs t in
-                         FStar_Util.set_is_empty uu____23844) in
+                      (let uu____23838 = FStar_Syntax_Free.uvars t in
+                       FStar_Util.set_is_empty uu____23838) &&
+                        (let uu____23842 = FStar_Syntax_Free.univs t in
+                         FStar_Util.set_is_empty uu____23842) in
                     let equal t11 t21 =
                       let t12 =
                         norm_with_steps
@@ -8829,9 +8829,9 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                           FStar_TypeChecker_Env.Beta;
                           FStar_TypeChecker_Env.Eager_unfolding;
                           FStar_TypeChecker_Env.Iota] env t21 in
-                      let uu____23860 = FStar_Syntax_Util.eq_tm t12 t22 in
-                      uu____23860 = FStar_Syntax_Util.Equal in
-                    let uu____23861 =
+                      let uu____23858 = FStar_Syntax_Util.eq_tm t12 t22 in
+                      uu____23858 = FStar_Syntax_Util.Equal in
+                    let uu____23859 =
                       ((((FStar_TypeChecker_Env.is_interpreted env head1) ||
                            (FStar_TypeChecker_Env.is_interpreted env head2))
                           &&
@@ -8839,65 +8839,65 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                              FStar_TypeChecker_Common.EQ))
                          && (no_free_uvars t1))
                         && (no_free_uvars t2) in
-                    if uu____23861
+                    if uu____23859
                     then
                       (if Prims.op_Negation wl.smt_ok
                        then
-                         let uu____23862 = equal t1 t2 in
-                         (if uu____23862
+                         let uu____23860 = equal t1 t2 in
+                         (if uu____23860
                           then
-                            let uu____23863 =
+                            let uu____23861 =
                               solve_prob orig FStar_Pervasives_Native.None []
                                 wl in
-                            solve env uu____23863
+                            solve env uu____23861
                           else
                             rigid_rigid_delta env problem wl head1 head2 t1
                               t2)
                        else
-                         (let uu____23866 =
-                            let uu____23873 = equal t1 t2 in
-                            if uu____23873
+                         (let uu____23864 =
+                            let uu____23871 = equal t1 t2 in
+                            if uu____23871
                             then (FStar_Pervasives_Native.None, wl)
                             else
-                              (let uu____23883 = mk_eq2 wl env orig t1 t2 in
-                               match uu____23883 with
+                              (let uu____23881 = mk_eq2 wl env orig t1 t2 in
+                               match uu____23881 with
                                | (g, wl1) ->
                                    ((FStar_Pervasives_Native.Some g), wl1)) in
-                          match uu____23866 with
+                          match uu____23864 with
                           | (guard, wl1) ->
-                              let uu____23904 = solve_prob orig guard [] wl1 in
-                              solve env uu____23904))
+                              let uu____23902 = solve_prob orig guard [] wl1 in
+                              solve env uu____23902))
                     else rigid_rigid_delta env problem wl head1 head2 t1 t2))
-              | (uu____23906, FStar_Syntax_Syntax.Tm_uinst uu____23907) ->
+              | (uu____23904, FStar_Syntax_Syntax.Tm_uinst uu____23905) ->
                   let head1 =
-                    let uu____23915 = FStar_Syntax_Util.head_and_args t1 in
-                    FStar_All.pipe_right uu____23915
+                    let uu____23913 = FStar_Syntax_Util.head_and_args t1 in
+                    FStar_All.pipe_right uu____23913
                       FStar_Pervasives_Native.fst in
                   let head2 =
-                    let uu____23955 = FStar_Syntax_Util.head_and_args t2 in
-                    FStar_All.pipe_right uu____23955
+                    let uu____23953 = FStar_Syntax_Util.head_and_args t2 in
+                    FStar_All.pipe_right uu____23953
                       FStar_Pervasives_Native.fst in
-                  ((let uu____23995 =
+                  ((let uu____23993 =
                       FStar_TypeChecker_Env.debug env
                         (FStar_Options.Other "Rel") in
-                    if uu____23995
+                    if uu____23993
                     then
+                      let uu____23994 =
+                        FStar_Util.string_of_int
+                          problem.FStar_TypeChecker_Common.pid in
+                      let uu____23995 =
+                        FStar_Syntax_Print.term_to_string head1 in
                       let uu____23996 =
-                        FStar_Util.string_of_int
-                          problem.FStar_TypeChecker_Common.pid in
-                      let uu____23997 =
-                        FStar_Syntax_Print.term_to_string head1 in
-                      let uu____23998 =
                         FStar_Syntax_Print.term_to_string head2 in
                       FStar_Util.print3
                         ">> (%s)\n>>> head1 = %s\n>>> head2 = %s\n"
-                        uu____23996 uu____23997 uu____23998
+                        uu____23994 uu____23995 uu____23996
                     else ());
                    (let no_free_uvars t =
-                      (let uu____24008 = FStar_Syntax_Free.uvars t in
-                       FStar_Util.set_is_empty uu____24008) &&
-                        (let uu____24012 = FStar_Syntax_Free.univs t in
-                         FStar_Util.set_is_empty uu____24012) in
+                      (let uu____24006 = FStar_Syntax_Free.uvars t in
+                       FStar_Util.set_is_empty uu____24006) &&
+                        (let uu____24010 = FStar_Syntax_Free.univs t in
+                         FStar_Util.set_is_empty uu____24010) in
                     let equal t11 t21 =
                       let t12 =
                         norm_with_steps
@@ -8917,9 +8917,9 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                           FStar_TypeChecker_Env.Beta;
                           FStar_TypeChecker_Env.Eager_unfolding;
                           FStar_TypeChecker_Env.Iota] env t21 in
-                      let uu____24028 = FStar_Syntax_Util.eq_tm t12 t22 in
-                      uu____24028 = FStar_Syntax_Util.Equal in
-                    let uu____24029 =
+                      let uu____24026 = FStar_Syntax_Util.eq_tm t12 t22 in
+                      uu____24026 = FStar_Syntax_Util.Equal in
+                    let uu____24027 =
                       ((((FStar_TypeChecker_Env.is_interpreted env head1) ||
                            (FStar_TypeChecker_Env.is_interpreted env head2))
                           &&
@@ -8927,65 +8927,65 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                              FStar_TypeChecker_Common.EQ))
                          && (no_free_uvars t1))
                         && (no_free_uvars t2) in
-                    if uu____24029
+                    if uu____24027
                     then
                       (if Prims.op_Negation wl.smt_ok
                        then
-                         let uu____24030 = equal t1 t2 in
-                         (if uu____24030
+                         let uu____24028 = equal t1 t2 in
+                         (if uu____24028
                           then
-                            let uu____24031 =
+                            let uu____24029 =
                               solve_prob orig FStar_Pervasives_Native.None []
                                 wl in
-                            solve env uu____24031
+                            solve env uu____24029
                           else
                             rigid_rigid_delta env problem wl head1 head2 t1
                               t2)
                        else
-                         (let uu____24034 =
-                            let uu____24041 = equal t1 t2 in
-                            if uu____24041
+                         (let uu____24032 =
+                            let uu____24039 = equal t1 t2 in
+                            if uu____24039
                             then (FStar_Pervasives_Native.None, wl)
                             else
-                              (let uu____24051 = mk_eq2 wl env orig t1 t2 in
-                               match uu____24051 with
+                              (let uu____24049 = mk_eq2 wl env orig t1 t2 in
+                               match uu____24049 with
                                | (g, wl1) ->
                                    ((FStar_Pervasives_Native.Some g), wl1)) in
-                          match uu____24034 with
+                          match uu____24032 with
                           | (guard, wl1) ->
-                              let uu____24072 = solve_prob orig guard [] wl1 in
-                              solve env uu____24072))
+                              let uu____24070 = solve_prob orig guard [] wl1 in
+                              solve env uu____24070))
                     else rigid_rigid_delta env problem wl head1 head2 t1 t2))
-              | (uu____24074, FStar_Syntax_Syntax.Tm_name uu____24075) ->
+              | (uu____24072, FStar_Syntax_Syntax.Tm_name uu____24073) ->
                   let head1 =
-                    let uu____24077 = FStar_Syntax_Util.head_and_args t1 in
-                    FStar_All.pipe_right uu____24077
+                    let uu____24075 = FStar_Syntax_Util.head_and_args t1 in
+                    FStar_All.pipe_right uu____24075
                       FStar_Pervasives_Native.fst in
                   let head2 =
-                    let uu____24117 = FStar_Syntax_Util.head_and_args t2 in
-                    FStar_All.pipe_right uu____24117
+                    let uu____24115 = FStar_Syntax_Util.head_and_args t2 in
+                    FStar_All.pipe_right uu____24115
                       FStar_Pervasives_Native.fst in
-                  ((let uu____24157 =
+                  ((let uu____24155 =
                       FStar_TypeChecker_Env.debug env
                         (FStar_Options.Other "Rel") in
-                    if uu____24157
+                    if uu____24155
                     then
+                      let uu____24156 =
+                        FStar_Util.string_of_int
+                          problem.FStar_TypeChecker_Common.pid in
+                      let uu____24157 =
+                        FStar_Syntax_Print.term_to_string head1 in
                       let uu____24158 =
-                        FStar_Util.string_of_int
-                          problem.FStar_TypeChecker_Common.pid in
-                      let uu____24159 =
-                        FStar_Syntax_Print.term_to_string head1 in
-                      let uu____24160 =
                         FStar_Syntax_Print.term_to_string head2 in
                       FStar_Util.print3
                         ">> (%s)\n>>> head1 = %s\n>>> head2 = %s\n"
-                        uu____24158 uu____24159 uu____24160
+                        uu____24156 uu____24157 uu____24158
                     else ());
                    (let no_free_uvars t =
-                      (let uu____24170 = FStar_Syntax_Free.uvars t in
-                       FStar_Util.set_is_empty uu____24170) &&
-                        (let uu____24174 = FStar_Syntax_Free.univs t in
-                         FStar_Util.set_is_empty uu____24174) in
+                      (let uu____24168 = FStar_Syntax_Free.uvars t in
+                       FStar_Util.set_is_empty uu____24168) &&
+                        (let uu____24172 = FStar_Syntax_Free.univs t in
+                         FStar_Util.set_is_empty uu____24172) in
                     let equal t11 t21 =
                       let t12 =
                         norm_with_steps
@@ -9005,9 +9005,9 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                           FStar_TypeChecker_Env.Beta;
                           FStar_TypeChecker_Env.Eager_unfolding;
                           FStar_TypeChecker_Env.Iota] env t21 in
-                      let uu____24190 = FStar_Syntax_Util.eq_tm t12 t22 in
-                      uu____24190 = FStar_Syntax_Util.Equal in
-                    let uu____24191 =
+                      let uu____24188 = FStar_Syntax_Util.eq_tm t12 t22 in
+                      uu____24188 = FStar_Syntax_Util.Equal in
+                    let uu____24189 =
                       ((((FStar_TypeChecker_Env.is_interpreted env head1) ||
                            (FStar_TypeChecker_Env.is_interpreted env head2))
                           &&
@@ -9015,65 +9015,65 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                              FStar_TypeChecker_Common.EQ))
                          && (no_free_uvars t1))
                         && (no_free_uvars t2) in
-                    if uu____24191
+                    if uu____24189
                     then
                       (if Prims.op_Negation wl.smt_ok
                        then
-                         let uu____24192 = equal t1 t2 in
-                         (if uu____24192
+                         let uu____24190 = equal t1 t2 in
+                         (if uu____24190
                           then
-                            let uu____24193 =
+                            let uu____24191 =
                               solve_prob orig FStar_Pervasives_Native.None []
                                 wl in
-                            solve env uu____24193
+                            solve env uu____24191
                           else
                             rigid_rigid_delta env problem wl head1 head2 t1
                               t2)
                        else
-                         (let uu____24196 =
-                            let uu____24203 = equal t1 t2 in
-                            if uu____24203
+                         (let uu____24194 =
+                            let uu____24201 = equal t1 t2 in
+                            if uu____24201
                             then (FStar_Pervasives_Native.None, wl)
                             else
-                              (let uu____24213 = mk_eq2 wl env orig t1 t2 in
-                               match uu____24213 with
+                              (let uu____24211 = mk_eq2 wl env orig t1 t2 in
+                               match uu____24211 with
                                | (g, wl1) ->
                                    ((FStar_Pervasives_Native.Some g), wl1)) in
-                          match uu____24196 with
+                          match uu____24194 with
                           | (guard, wl1) ->
-                              let uu____24234 = solve_prob orig guard [] wl1 in
-                              solve env uu____24234))
+                              let uu____24232 = solve_prob orig guard [] wl1 in
+                              solve env uu____24232))
                     else rigid_rigid_delta env problem wl head1 head2 t1 t2))
-              | (uu____24236, FStar_Syntax_Syntax.Tm_constant uu____24237) ->
+              | (uu____24234, FStar_Syntax_Syntax.Tm_constant uu____24235) ->
                   let head1 =
-                    let uu____24239 = FStar_Syntax_Util.head_and_args t1 in
-                    FStar_All.pipe_right uu____24239
+                    let uu____24237 = FStar_Syntax_Util.head_and_args t1 in
+                    FStar_All.pipe_right uu____24237
                       FStar_Pervasives_Native.fst in
                   let head2 =
-                    let uu____24279 = FStar_Syntax_Util.head_and_args t2 in
-                    FStar_All.pipe_right uu____24279
+                    let uu____24277 = FStar_Syntax_Util.head_and_args t2 in
+                    FStar_All.pipe_right uu____24277
                       FStar_Pervasives_Native.fst in
-                  ((let uu____24319 =
+                  ((let uu____24317 =
                       FStar_TypeChecker_Env.debug env
                         (FStar_Options.Other "Rel") in
-                    if uu____24319
+                    if uu____24317
                     then
+                      let uu____24318 =
+                        FStar_Util.string_of_int
+                          problem.FStar_TypeChecker_Common.pid in
+                      let uu____24319 =
+                        FStar_Syntax_Print.term_to_string head1 in
                       let uu____24320 =
-                        FStar_Util.string_of_int
-                          problem.FStar_TypeChecker_Common.pid in
-                      let uu____24321 =
-                        FStar_Syntax_Print.term_to_string head1 in
-                      let uu____24322 =
                         FStar_Syntax_Print.term_to_string head2 in
                       FStar_Util.print3
                         ">> (%s)\n>>> head1 = %s\n>>> head2 = %s\n"
-                        uu____24320 uu____24321 uu____24322
+                        uu____24318 uu____24319 uu____24320
                     else ());
                    (let no_free_uvars t =
-                      (let uu____24332 = FStar_Syntax_Free.uvars t in
-                       FStar_Util.set_is_empty uu____24332) &&
-                        (let uu____24336 = FStar_Syntax_Free.univs t in
-                         FStar_Util.set_is_empty uu____24336) in
+                      (let uu____24330 = FStar_Syntax_Free.uvars t in
+                       FStar_Util.set_is_empty uu____24330) &&
+                        (let uu____24334 = FStar_Syntax_Free.univs t in
+                         FStar_Util.set_is_empty uu____24334) in
                     let equal t11 t21 =
                       let t12 =
                         norm_with_steps
@@ -9093,9 +9093,9 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                           FStar_TypeChecker_Env.Beta;
                           FStar_TypeChecker_Env.Eager_unfolding;
                           FStar_TypeChecker_Env.Iota] env t21 in
-                      let uu____24352 = FStar_Syntax_Util.eq_tm t12 t22 in
-                      uu____24352 = FStar_Syntax_Util.Equal in
-                    let uu____24353 =
+                      let uu____24350 = FStar_Syntax_Util.eq_tm t12 t22 in
+                      uu____24350 = FStar_Syntax_Util.Equal in
+                    let uu____24351 =
                       ((((FStar_TypeChecker_Env.is_interpreted env head1) ||
                            (FStar_TypeChecker_Env.is_interpreted env head2))
                           &&
@@ -9103,65 +9103,65 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                              FStar_TypeChecker_Common.EQ))
                          && (no_free_uvars t1))
                         && (no_free_uvars t2) in
-                    if uu____24353
+                    if uu____24351
                     then
                       (if Prims.op_Negation wl.smt_ok
                        then
-                         let uu____24354 = equal t1 t2 in
-                         (if uu____24354
+                         let uu____24352 = equal t1 t2 in
+                         (if uu____24352
                           then
-                            let uu____24355 =
+                            let uu____24353 =
                               solve_prob orig FStar_Pervasives_Native.None []
                                 wl in
-                            solve env uu____24355
+                            solve env uu____24353
                           else
                             rigid_rigid_delta env problem wl head1 head2 t1
                               t2)
                        else
-                         (let uu____24358 =
-                            let uu____24365 = equal t1 t2 in
-                            if uu____24365
+                         (let uu____24356 =
+                            let uu____24363 = equal t1 t2 in
+                            if uu____24363
                             then (FStar_Pervasives_Native.None, wl)
                             else
-                              (let uu____24375 = mk_eq2 wl env orig t1 t2 in
-                               match uu____24375 with
+                              (let uu____24373 = mk_eq2 wl env orig t1 t2 in
+                               match uu____24373 with
                                | (g, wl1) ->
                                    ((FStar_Pervasives_Native.Some g), wl1)) in
-                          match uu____24358 with
+                          match uu____24356 with
                           | (guard, wl1) ->
-                              let uu____24396 = solve_prob orig guard [] wl1 in
-                              solve env uu____24396))
+                              let uu____24394 = solve_prob orig guard [] wl1 in
+                              solve env uu____24394))
                     else rigid_rigid_delta env problem wl head1 head2 t1 t2))
-              | (uu____24398, FStar_Syntax_Syntax.Tm_fvar uu____24399) ->
+              | (uu____24396, FStar_Syntax_Syntax.Tm_fvar uu____24397) ->
                   let head1 =
-                    let uu____24401 = FStar_Syntax_Util.head_and_args t1 in
-                    FStar_All.pipe_right uu____24401
+                    let uu____24399 = FStar_Syntax_Util.head_and_args t1 in
+                    FStar_All.pipe_right uu____24399
                       FStar_Pervasives_Native.fst in
                   let head2 =
-                    let uu____24447 = FStar_Syntax_Util.head_and_args t2 in
-                    FStar_All.pipe_right uu____24447
+                    let uu____24445 = FStar_Syntax_Util.head_and_args t2 in
+                    FStar_All.pipe_right uu____24445
                       FStar_Pervasives_Native.fst in
-                  ((let uu____24493 =
+                  ((let uu____24491 =
                       FStar_TypeChecker_Env.debug env
                         (FStar_Options.Other "Rel") in
-                    if uu____24493
+                    if uu____24491
                     then
+                      let uu____24492 =
+                        FStar_Util.string_of_int
+                          problem.FStar_TypeChecker_Common.pid in
+                      let uu____24493 =
+                        FStar_Syntax_Print.term_to_string head1 in
                       let uu____24494 =
-                        FStar_Util.string_of_int
-                          problem.FStar_TypeChecker_Common.pid in
-                      let uu____24495 =
-                        FStar_Syntax_Print.term_to_string head1 in
-                      let uu____24496 =
                         FStar_Syntax_Print.term_to_string head2 in
                       FStar_Util.print3
                         ">> (%s)\n>>> head1 = %s\n>>> head2 = %s\n"
-                        uu____24494 uu____24495 uu____24496
+                        uu____24492 uu____24493 uu____24494
                     else ());
                    (let no_free_uvars t =
-                      (let uu____24506 = FStar_Syntax_Free.uvars t in
-                       FStar_Util.set_is_empty uu____24506) &&
-                        (let uu____24510 = FStar_Syntax_Free.univs t in
-                         FStar_Util.set_is_empty uu____24510) in
+                      (let uu____24504 = FStar_Syntax_Free.uvars t in
+                       FStar_Util.set_is_empty uu____24504) &&
+                        (let uu____24508 = FStar_Syntax_Free.univs t in
+                         FStar_Util.set_is_empty uu____24508) in
                     let equal t11 t21 =
                       let t12 =
                         norm_with_steps
@@ -9181,9 +9181,9 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                           FStar_TypeChecker_Env.Beta;
                           FStar_TypeChecker_Env.Eager_unfolding;
                           FStar_TypeChecker_Env.Iota] env t21 in
-                      let uu____24526 = FStar_Syntax_Util.eq_tm t12 t22 in
-                      uu____24526 = FStar_Syntax_Util.Equal in
-                    let uu____24527 =
+                      let uu____24524 = FStar_Syntax_Util.eq_tm t12 t22 in
+                      uu____24524 = FStar_Syntax_Util.Equal in
+                    let uu____24525 =
                       ((((FStar_TypeChecker_Env.is_interpreted env head1) ||
                            (FStar_TypeChecker_Env.is_interpreted env head2))
                           &&
@@ -9191,65 +9191,65 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                              FStar_TypeChecker_Common.EQ))
                          && (no_free_uvars t1))
                         && (no_free_uvars t2) in
-                    if uu____24527
+                    if uu____24525
                     then
                       (if Prims.op_Negation wl.smt_ok
                        then
-                         let uu____24528 = equal t1 t2 in
-                         (if uu____24528
+                         let uu____24526 = equal t1 t2 in
+                         (if uu____24526
                           then
-                            let uu____24529 =
+                            let uu____24527 =
                               solve_prob orig FStar_Pervasives_Native.None []
                                 wl in
-                            solve env uu____24529
+                            solve env uu____24527
                           else
                             rigid_rigid_delta env problem wl head1 head2 t1
                               t2)
                        else
-                         (let uu____24532 =
-                            let uu____24539 = equal t1 t2 in
-                            if uu____24539
+                         (let uu____24530 =
+                            let uu____24537 = equal t1 t2 in
+                            if uu____24537
                             then (FStar_Pervasives_Native.None, wl)
                             else
-                              (let uu____24549 = mk_eq2 wl env orig t1 t2 in
-                               match uu____24549 with
+                              (let uu____24547 = mk_eq2 wl env orig t1 t2 in
+                               match uu____24547 with
                                | (g, wl1) ->
                                    ((FStar_Pervasives_Native.Some g), wl1)) in
-                          match uu____24532 with
+                          match uu____24530 with
                           | (guard, wl1) ->
-                              let uu____24570 = solve_prob orig guard [] wl1 in
-                              solve env uu____24570))
+                              let uu____24568 = solve_prob orig guard [] wl1 in
+                              solve env uu____24568))
                     else rigid_rigid_delta env problem wl head1 head2 t1 t2))
-              | (uu____24572, FStar_Syntax_Syntax.Tm_app uu____24573) ->
+              | (uu____24570, FStar_Syntax_Syntax.Tm_app uu____24571) ->
                   let head1 =
-                    let uu____24591 = FStar_Syntax_Util.head_and_args t1 in
-                    FStar_All.pipe_right uu____24591
+                    let uu____24589 = FStar_Syntax_Util.head_and_args t1 in
+                    FStar_All.pipe_right uu____24589
                       FStar_Pervasives_Native.fst in
                   let head2 =
-                    let uu____24631 = FStar_Syntax_Util.head_and_args t2 in
-                    FStar_All.pipe_right uu____24631
+                    let uu____24629 = FStar_Syntax_Util.head_and_args t2 in
+                    FStar_All.pipe_right uu____24629
                       FStar_Pervasives_Native.fst in
-                  ((let uu____24671 =
+                  ((let uu____24669 =
                       FStar_TypeChecker_Env.debug env
                         (FStar_Options.Other "Rel") in
-                    if uu____24671
+                    if uu____24669
                     then
-                      let uu____24672 =
+                      let uu____24670 =
                         FStar_Util.string_of_int
                           problem.FStar_TypeChecker_Common.pid in
-                      let uu____24673 =
+                      let uu____24671 =
                         FStar_Syntax_Print.term_to_string head1 in
-                      let uu____24674 =
+                      let uu____24672 =
                         FStar_Syntax_Print.term_to_string head2 in
                       FStar_Util.print3
                         ">> (%s)\n>>> head1 = %s\n>>> head2 = %s\n"
-                        uu____24672 uu____24673 uu____24674
+                        uu____24670 uu____24671 uu____24672
                     else ());
                    (let no_free_uvars t =
-                      (let uu____24684 = FStar_Syntax_Free.uvars t in
-                       FStar_Util.set_is_empty uu____24684) &&
-                        (let uu____24688 = FStar_Syntax_Free.univs t in
-                         FStar_Util.set_is_empty uu____24688) in
+                      (let uu____24682 = FStar_Syntax_Free.uvars t in
+                       FStar_Util.set_is_empty uu____24682) &&
+                        (let uu____24686 = FStar_Syntax_Free.univs t in
+                         FStar_Util.set_is_empty uu____24686) in
                     let equal t11 t21 =
                       let t12 =
                         norm_with_steps
@@ -9269,9 +9269,9 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                           FStar_TypeChecker_Env.Beta;
                           FStar_TypeChecker_Env.Eager_unfolding;
                           FStar_TypeChecker_Env.Iota] env t21 in
-                      let uu____24704 = FStar_Syntax_Util.eq_tm t12 t22 in
-                      uu____24704 = FStar_Syntax_Util.Equal in
-                    let uu____24705 =
+                      let uu____24702 = FStar_Syntax_Util.eq_tm t12 t22 in
+                      uu____24702 = FStar_Syntax_Util.Equal in
+                    let uu____24703 =
                       ((((FStar_TypeChecker_Env.is_interpreted env head1) ||
                            (FStar_TypeChecker_Env.is_interpreted env head2))
                           &&
@@ -9279,77 +9279,77 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                              FStar_TypeChecker_Common.EQ))
                          && (no_free_uvars t1))
                         && (no_free_uvars t2) in
-                    if uu____24705
+                    if uu____24703
                     then
                       (if Prims.op_Negation wl.smt_ok
                        then
-                         let uu____24706 = equal t1 t2 in
-                         (if uu____24706
+                         let uu____24704 = equal t1 t2 in
+                         (if uu____24704
                           then
-                            let uu____24707 =
+                            let uu____24705 =
                               solve_prob orig FStar_Pervasives_Native.None []
                                 wl in
-                            solve env uu____24707
+                            solve env uu____24705
                           else
                             rigid_rigid_delta env problem wl head1 head2 t1
                               t2)
                        else
-                         (let uu____24710 =
-                            let uu____24717 = equal t1 t2 in
-                            if uu____24717
+                         (let uu____24708 =
+                            let uu____24715 = equal t1 t2 in
+                            if uu____24715
                             then (FStar_Pervasives_Native.None, wl)
                             else
-                              (let uu____24727 = mk_eq2 wl env orig t1 t2 in
-                               match uu____24727 with
+                              (let uu____24725 = mk_eq2 wl env orig t1 t2 in
+                               match uu____24725 with
                                | (g, wl1) ->
                                    ((FStar_Pervasives_Native.Some g), wl1)) in
-                          match uu____24710 with
+                          match uu____24708 with
                           | (guard, wl1) ->
-                              let uu____24748 = solve_prob orig guard [] wl1 in
-                              solve env uu____24748))
+                              let uu____24746 = solve_prob orig guard [] wl1 in
+                              solve env uu____24746))
                     else rigid_rigid_delta env problem wl head1 head2 t1 t2))
-              | (FStar_Syntax_Syntax.Tm_let uu____24750,
-                 FStar_Syntax_Syntax.Tm_let uu____24751) ->
-                  let uu____24776 = FStar_Syntax_Util.term_eq t1 t2 in
-                  if uu____24776
+              | (FStar_Syntax_Syntax.Tm_let uu____24748,
+                 FStar_Syntax_Syntax.Tm_let uu____24749) ->
+                  let uu____24774 = FStar_Syntax_Util.term_eq t1 t2 in
+                  if uu____24774
                   then
-                    let uu____24777 =
+                    let uu____24775 =
                       solve_prob orig FStar_Pervasives_Native.None [] wl in
-                    solve env uu____24777
+                    solve env uu____24775
                   else
-                    (let uu____24779 = FStar_Thunk.mkv "Tm_let mismatch" in
-                     giveup env uu____24779 orig)
-              | (FStar_Syntax_Syntax.Tm_let uu____24780, uu____24781) ->
-                  let uu____24794 =
-                    let uu____24799 =
-                      let uu____24800 = FStar_Syntax_Print.tag_of_term t1 in
-                      let uu____24801 = FStar_Syntax_Print.tag_of_term t2 in
-                      let uu____24802 = FStar_Syntax_Print.term_to_string t1 in
-                      let uu____24803 = FStar_Syntax_Print.term_to_string t2 in
+                    (let uu____24777 = FStar_Thunk.mkv "Tm_let mismatch" in
+                     giveup env uu____24777 orig)
+              | (FStar_Syntax_Syntax.Tm_let uu____24778, uu____24779) ->
+                  let uu____24792 =
+                    let uu____24797 =
+                      let uu____24798 = FStar_Syntax_Print.tag_of_term t1 in
+                      let uu____24799 = FStar_Syntax_Print.tag_of_term t2 in
+                      let uu____24800 = FStar_Syntax_Print.term_to_string t1 in
+                      let uu____24801 = FStar_Syntax_Print.term_to_string t2 in
                       FStar_Util.format4
                         "Internal error: unexpected flex-flex of %s and %s\n>>> (%s) -- (%s)"
-                        uu____24800 uu____24801 uu____24802 uu____24803 in
+                        uu____24798 uu____24799 uu____24800 uu____24801 in
                     (FStar_Errors.Fatal_UnificationNotWellFormed,
-                      uu____24799) in
-                  FStar_Errors.raise_error uu____24794
+                      uu____24797) in
+                  FStar_Errors.raise_error uu____24792
                     t1.FStar_Syntax_Syntax.pos
-              | (uu____24804, FStar_Syntax_Syntax.Tm_let uu____24805) ->
-                  let uu____24818 =
-                    let uu____24823 =
-                      let uu____24824 = FStar_Syntax_Print.tag_of_term t1 in
-                      let uu____24825 = FStar_Syntax_Print.tag_of_term t2 in
-                      let uu____24826 = FStar_Syntax_Print.term_to_string t1 in
-                      let uu____24827 = FStar_Syntax_Print.term_to_string t2 in
+              | (uu____24802, FStar_Syntax_Syntax.Tm_let uu____24803) ->
+                  let uu____24816 =
+                    let uu____24821 =
+                      let uu____24822 = FStar_Syntax_Print.tag_of_term t1 in
+                      let uu____24823 = FStar_Syntax_Print.tag_of_term t2 in
+                      let uu____24824 = FStar_Syntax_Print.term_to_string t1 in
+                      let uu____24825 = FStar_Syntax_Print.term_to_string t2 in
                       FStar_Util.format4
                         "Internal error: unexpected flex-flex of %s and %s\n>>> (%s) -- (%s)"
-                        uu____24824 uu____24825 uu____24826 uu____24827 in
+                        uu____24822 uu____24823 uu____24824 uu____24825 in
                     (FStar_Errors.Fatal_UnificationNotWellFormed,
-                      uu____24823) in
-                  FStar_Errors.raise_error uu____24818
+                      uu____24821) in
+                  FStar_Errors.raise_error uu____24816
                     t1.FStar_Syntax_Syntax.pos
-              | uu____24828 ->
-                  let uu____24833 = FStar_Thunk.mkv "head tag mismatch" in
-                  giveup env uu____24833 orig))))
+              | uu____24826 ->
+                  let uu____24831 = FStar_Thunk.mkv "head tag mismatch" in
+                  giveup env uu____24831 orig))))
 and (solve_c :
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.comp FStar_TypeChecker_Common.problem ->
@@ -9365,181 +9365,181 @@ and (solve_c :
           mk_t_problem wl1 [] orig t1 rel t2 FStar_Pervasives_Native.None
             reason in
         let solve_eq c1_comp c2_comp g_lift =
-          (let uu____24895 =
+          (let uu____24893 =
              FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
                (FStar_Options.Other "EQ") in
-           if uu____24895
+           if uu____24893
            then
+             let uu____24894 =
+               let uu____24895 = FStar_Syntax_Syntax.mk_Comp c1_comp in
+               FStar_Syntax_Print.comp_to_string uu____24895 in
              let uu____24896 =
-               let uu____24897 = FStar_Syntax_Syntax.mk_Comp c1_comp in
+               let uu____24897 = FStar_Syntax_Syntax.mk_Comp c2_comp in
                FStar_Syntax_Print.comp_to_string uu____24897 in
-             let uu____24898 =
-               let uu____24899 = FStar_Syntax_Syntax.mk_Comp c2_comp in
-               FStar_Syntax_Print.comp_to_string uu____24899 in
              FStar_Util.print2
                "solve_c is using an equality constraint (%s vs %s)\n"
-               uu____24896 uu____24898
+               uu____24894 uu____24896
            else ());
-          (let uu____24901 =
-             let uu____24902 =
+          (let uu____24899 =
+             let uu____24900 =
                FStar_Ident.lid_equals c1_comp.FStar_Syntax_Syntax.effect_name
                  c2_comp.FStar_Syntax_Syntax.effect_name in
-             Prims.op_Negation uu____24902 in
-           if uu____24901
+             Prims.op_Negation uu____24900 in
+           if uu____24899
            then
-             let uu____24903 =
+             let uu____24901 =
                mklstr
-                 (fun uu____24910 ->
-                    let uu____24911 =
+                 (fun uu____24908 ->
+                    let uu____24909 =
                       FStar_Syntax_Print.lid_to_string
                         c1_comp.FStar_Syntax_Syntax.effect_name in
-                    let uu____24912 =
+                    let uu____24910 =
                       FStar_Syntax_Print.lid_to_string
                         c2_comp.FStar_Syntax_Syntax.effect_name in
                     FStar_Util.format2 "incompatible effects: %s <> %s"
-                      uu____24911 uu____24912) in
-             giveup env uu____24903 orig
+                      uu____24909 uu____24910) in
+             giveup env uu____24901 orig
            else
              if
                (FStar_List.length c1_comp.FStar_Syntax_Syntax.effect_args) <>
                  (FStar_List.length c2_comp.FStar_Syntax_Syntax.effect_args)
              then
-               (let uu____24930 =
+               (let uu____24928 =
                   mklstr
-                    (fun uu____24937 ->
-                       let uu____24938 =
+                    (fun uu____24935 ->
+                       let uu____24936 =
                          FStar_Syntax_Print.args_to_string
                            c1_comp.FStar_Syntax_Syntax.effect_args in
-                       let uu____24939 =
+                       let uu____24937 =
                          FStar_Syntax_Print.args_to_string
                            c2_comp.FStar_Syntax_Syntax.effect_args in
                        FStar_Util.format2
                          "incompatible effect arguments: %s <> %s"
-                         uu____24938 uu____24939) in
-                giveup env uu____24930 orig)
+                         uu____24936 uu____24937) in
+                giveup env uu____24928 orig)
              else
-               (let uu____24941 =
+               (let uu____24939 =
                   FStar_List.fold_left2
-                    (fun uu____24962 ->
+                    (fun uu____24960 ->
                        fun u1 ->
                          fun u2 ->
-                           match uu____24962 with
+                           match uu____24960 with
                            | (univ_sub_probs, wl1) ->
-                               let uu____24983 =
-                                 let uu____24988 =
+                               let uu____24981 =
+                                 let uu____24986 =
                                    FStar_Syntax_Syntax.mk
                                      (FStar_Syntax_Syntax.Tm_type u1)
                                      FStar_Range.dummyRange in
-                                 let uu____24989 =
+                                 let uu____24987 =
                                    FStar_Syntax_Syntax.mk
                                      (FStar_Syntax_Syntax.Tm_type u2)
                                      FStar_Range.dummyRange in
-                                 sub_prob wl1 uu____24988
-                                   FStar_TypeChecker_Common.EQ uu____24989
+                                 sub_prob wl1 uu____24986
+                                   FStar_TypeChecker_Common.EQ uu____24987
                                    "effect universes" in
-                               (match uu____24983 with
+                               (match uu____24981 with
                                 | (p, wl2) ->
                                     ((FStar_List.append univ_sub_probs [p]),
                                       wl2))) ([], wl)
                     c1_comp.FStar_Syntax_Syntax.comp_univs
                     c2_comp.FStar_Syntax_Syntax.comp_univs in
-                match uu____24941 with
+                match uu____24939 with
                 | (univ_sub_probs, wl1) ->
-                    let uu____25008 =
+                    let uu____25006 =
                       sub_prob wl1 c1_comp.FStar_Syntax_Syntax.result_typ
                         FStar_TypeChecker_Common.EQ
                         c2_comp.FStar_Syntax_Syntax.result_typ
                         "effect ret type" in
-                    (match uu____25008 with
+                    (match uu____25006 with
                      | (ret_sub_prob, wl2) ->
-                         let uu____25015 =
+                         let uu____25013 =
                            FStar_List.fold_right2
-                             (fun uu____25052 ->
-                                fun uu____25053 ->
-                                  fun uu____25054 ->
-                                    match (uu____25052, uu____25053,
-                                            uu____25054)
+                             (fun uu____25050 ->
+                                fun uu____25051 ->
+                                  fun uu____25052 ->
+                                    match (uu____25050, uu____25051,
+                                            uu____25052)
                                     with
-                                    | ((a1, uu____25098), (a2, uu____25100),
+                                    | ((a1, uu____25096), (a2, uu____25098),
                                        (arg_sub_probs, wl3)) ->
-                                        let uu____25133 =
+                                        let uu____25131 =
                                           sub_prob wl3 a1
                                             FStar_TypeChecker_Common.EQ a2
                                             "effect arg" in
-                                        (match uu____25133 with
+                                        (match uu____25131 with
                                          | (p, wl4) ->
                                              ((p :: arg_sub_probs), wl4)))
                              c1_comp.FStar_Syntax_Syntax.effect_args
                              c2_comp.FStar_Syntax_Syntax.effect_args
                              ([], wl2) in
-                         (match uu____25015 with
+                         (match uu____25013 with
                           | (arg_sub_probs, wl3) ->
                               let sub_probs =
-                                let uu____25159 =
-                                  let uu____25162 =
-                                    let uu____25165 =
+                                let uu____25157 =
+                                  let uu____25160 =
+                                    let uu____25163 =
                                       FStar_All.pipe_right
                                         g_lift.FStar_TypeChecker_Common.deferred
                                         (FStar_List.map
                                            FStar_Pervasives_Native.snd) in
                                     FStar_List.append arg_sub_probs
-                                      uu____25165 in
+                                      uu____25163 in
                                   FStar_List.append [ret_sub_prob]
-                                    uu____25162 in
-                                FStar_List.append univ_sub_probs uu____25159 in
+                                    uu____25160 in
+                                FStar_List.append univ_sub_probs uu____25157 in
                               let guard =
                                 let guard =
-                                  let uu____25184 =
+                                  let uu____25182 =
                                     FStar_List.map p_guard sub_probs in
-                                  FStar_Syntax_Util.mk_conj_l uu____25184 in
+                                  FStar_Syntax_Util.mk_conj_l uu____25182 in
                                 match g_lift.FStar_TypeChecker_Common.guard_f
                                 with
                                 | FStar_TypeChecker_Common.Trivial -> guard
                                 | FStar_TypeChecker_Common.NonTrivial f ->
                                     FStar_Syntax_Util.mk_conj guard f in
                               let wl4 =
-                                let uu___3648_25193 = wl3 in
+                                let uu___3648_25191 = wl3 in
                                 {
-                                  attempting = (uu___3648_25193.attempting);
-                                  wl_deferred = (uu___3648_25193.wl_deferred);
+                                  attempting = (uu___3648_25191.attempting);
+                                  wl_deferred = (uu___3648_25191.wl_deferred);
                                   wl_deferred_to_tac =
-                                    (uu___3648_25193.wl_deferred_to_tac);
-                                  ctr = (uu___3648_25193.ctr);
-                                  defer_ok = (uu___3648_25193.defer_ok);
-                                  smt_ok = (uu___3648_25193.smt_ok);
+                                    (uu___3648_25191.wl_deferred_to_tac);
+                                  ctr = (uu___3648_25191.ctr);
+                                  defer_ok = (uu___3648_25191.defer_ok);
+                                  smt_ok = (uu___3648_25191.smt_ok);
                                   umax_heuristic_ok =
-                                    (uu___3648_25193.umax_heuristic_ok);
-                                  tcenv = (uu___3648_25193.tcenv);
+                                    (uu___3648_25191.umax_heuristic_ok);
+                                  tcenv = (uu___3648_25191.tcenv);
                                   wl_implicits =
                                     (FStar_List.append
                                        g_lift.FStar_TypeChecker_Common.implicits
                                        wl3.wl_implicits);
                                   repr_subcomp_allowed =
-                                    (uu___3648_25193.repr_subcomp_allowed)
+                                    (uu___3648_25191.repr_subcomp_allowed)
                                 } in
                               let wl5 =
                                 solve_prob orig
                                   (FStar_Pervasives_Native.Some guard) [] wl4 in
-                              let uu____25195 = attempt sub_probs wl5 in
-                              solve env uu____25195)))) in
+                              let uu____25193 = attempt sub_probs wl5 in
+                              solve env uu____25193)))) in
         let solve_layered_sub c11 c21 =
-          (let uu____25208 =
+          (let uu____25206 =
              FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
                (FStar_Options.Other "LayeredEffectsApp") in
-           if uu____25208
+           if uu____25206
            then
+             let uu____25207 =
+               let uu____25208 =
+                 FStar_All.pipe_right c11 FStar_Syntax_Syntax.mk_Comp in
+               FStar_All.pipe_right uu____25208
+                 FStar_Syntax_Print.comp_to_string in
              let uu____25209 =
                let uu____25210 =
-                 FStar_All.pipe_right c11 FStar_Syntax_Syntax.mk_Comp in
+                 FStar_All.pipe_right c21 FStar_Syntax_Syntax.mk_Comp in
                FStar_All.pipe_right uu____25210
                  FStar_Syntax_Print.comp_to_string in
-             let uu____25211 =
-               let uu____25212 =
-                 FStar_All.pipe_right c21 FStar_Syntax_Syntax.mk_Comp in
-               FStar_All.pipe_right uu____25212
-                 FStar_Syntax_Print.comp_to_string in
              FStar_Util.print2 "solve_layered_sub c1: %s and c2: %s\n"
-               uu____25209 uu____25211
+               uu____25207 uu____25209
            else ());
           if
             problem.FStar_TypeChecker_Common.relation =
@@ -9548,435 +9548,435 @@ and (solve_c :
           else
             (let r = FStar_TypeChecker_Env.get_range env in
              let subcomp_name =
-               let uu____25217 =
-                 let uu____25218 =
+               let uu____25215 =
+                 let uu____25216 =
                    FStar_All.pipe_right c11.FStar_Syntax_Syntax.effect_name
                      FStar_Ident.ident_of_lid in
-                 FStar_All.pipe_right uu____25218 FStar_Ident.string_of_id in
-               let uu____25219 =
-                 let uu____25220 =
+                 FStar_All.pipe_right uu____25216 FStar_Ident.string_of_id in
+               let uu____25217 =
+                 let uu____25218 =
                    FStar_All.pipe_right c21.FStar_Syntax_Syntax.effect_name
                      FStar_Ident.ident_of_lid in
-                 FStar_All.pipe_right uu____25220 FStar_Ident.string_of_id in
-               FStar_Util.format2 "%s <: %s" uu____25217 uu____25219 in
+                 FStar_All.pipe_right uu____25218 FStar_Ident.string_of_id in
+               FStar_Util.format2 "%s <: %s" uu____25215 uu____25217 in
              let lift_c1 edge =
-               let uu____25235 =
-                 let uu____25240 =
+               let uu____25233 =
+                 let uu____25238 =
                    FStar_All.pipe_right c11 FStar_Syntax_Syntax.mk_Comp in
-                 FStar_All.pipe_right uu____25240
+                 FStar_All.pipe_right uu____25238
                    ((edge.FStar_TypeChecker_Env.mlift).FStar_TypeChecker_Env.mlift_wp
                       env) in
-               FStar_All.pipe_right uu____25235
-                 (fun uu____25257 ->
-                    match uu____25257 with
+               FStar_All.pipe_right uu____25233
+                 (fun uu____25255 ->
+                    match uu____25255 with
                     | (c, g) ->
-                        let uu____25268 =
+                        let uu____25266 =
                           FStar_Syntax_Util.comp_to_comp_typ c in
-                        (uu____25268, g)) in
-             let uu____25269 =
-               let uu____25280 =
+                        (uu____25266, g)) in
+             let uu____25267 =
+               let uu____25278 =
                  FStar_TypeChecker_Env.exists_polymonadic_subcomp env
                    c11.FStar_Syntax_Syntax.effect_name
                    c21.FStar_Syntax_Syntax.effect_name in
-               match uu____25280 with
+               match uu____25278 with
                | FStar_Pervasives_Native.None ->
-                   let uu____25293 =
+                   let uu____25291 =
                      FStar_TypeChecker_Env.monad_leq env
                        c11.FStar_Syntax_Syntax.effect_name
                        c21.FStar_Syntax_Syntax.effect_name in
-                   (match uu____25293 with
+                   (match uu____25291 with
                     | FStar_Pervasives_Native.None ->
                         (c11, FStar_TypeChecker_Env.trivial_guard,
                           FStar_Pervasives_Native.None, false)
                     | FStar_Pervasives_Native.Some edge ->
-                        let uu____25309 = lift_c1 edge in
-                        (match uu____25309 with
+                        let uu____25307 = lift_c1 edge in
+                        (match uu____25307 with
                          | (c12, g_lift) ->
-                             let uu____25326 =
-                               let uu____25329 =
-                                 let uu____25330 =
+                             let uu____25324 =
+                               let uu____25327 =
+                                 let uu____25328 =
                                    FStar_All.pipe_right
                                      c21.FStar_Syntax_Syntax.effect_name
                                      (FStar_TypeChecker_Env.get_effect_decl
                                         env) in
-                                 FStar_All.pipe_right uu____25330
+                                 FStar_All.pipe_right uu____25328
                                    FStar_Syntax_Util.get_stronger_vc_combinator in
-                               FStar_All.pipe_right uu____25329
+                               FStar_All.pipe_right uu____25327
                                  (fun ts ->
-                                    let uu____25336 =
-                                      let uu____25337 =
+                                    let uu____25334 =
+                                      let uu____25335 =
                                         FStar_TypeChecker_Env.inst_tscheme_with
                                           ts
                                           c21.FStar_Syntax_Syntax.comp_univs in
-                                      FStar_All.pipe_right uu____25337
+                                      FStar_All.pipe_right uu____25335
                                         FStar_Pervasives_Native.snd in
-                                    FStar_All.pipe_right uu____25336
-                                      (fun uu____25348 ->
+                                    FStar_All.pipe_right uu____25334
+                                      (fun uu____25346 ->
                                          FStar_Pervasives_Native.Some
-                                           uu____25348)) in
-                             (c12, g_lift, uu____25326, false)))
+                                           uu____25346)) in
+                             (c12, g_lift, uu____25324, false)))
                | FStar_Pervasives_Native.Some t ->
-                   let uu____25352 =
-                     let uu____25355 =
-                       let uu____25356 =
+                   let uu____25350 =
+                     let uu____25353 =
+                       let uu____25354 =
                          FStar_TypeChecker_Env.inst_tscheme_with t
                            c21.FStar_Syntax_Syntax.comp_univs in
-                       FStar_All.pipe_right uu____25356
+                       FStar_All.pipe_right uu____25354
                          FStar_Pervasives_Native.snd in
-                     FStar_All.pipe_right uu____25355
-                       (fun uu____25367 ->
-                          FStar_Pervasives_Native.Some uu____25367) in
-                   (c11, FStar_TypeChecker_Env.trivial_guard, uu____25352,
+                     FStar_All.pipe_right uu____25353
+                       (fun uu____25365 ->
+                          FStar_Pervasives_Native.Some uu____25365) in
+                   (c11, FStar_TypeChecker_Env.trivial_guard, uu____25350,
                      true) in
-             match uu____25269 with
+             match uu____25267 with
              | (c12, g_lift, stronger_t_opt, is_polymonadic) ->
                  if FStar_Util.is_none stronger_t_opt
                  then
-                   let uu____25378 =
+                   let uu____25376 =
                      mklstr
-                       (fun uu____25385 ->
-                          let uu____25386 =
+                       (fun uu____25383 ->
+                          let uu____25384 =
                             FStar_Syntax_Print.lid_to_string
                               c12.FStar_Syntax_Syntax.effect_name in
-                          let uu____25387 =
+                          let uu____25385 =
                             FStar_Syntax_Print.lid_to_string
                               c21.FStar_Syntax_Syntax.effect_name in
                           FStar_Util.format2
                             "incompatible monad ordering: %s </: %s"
-                            uu____25386 uu____25387) in
-                   giveup env uu____25378 orig
+                            uu____25384 uu____25385) in
+                   giveup env uu____25376 orig
                  else
                    (let stronger_t =
                       FStar_All.pipe_right stronger_t_opt FStar_Util.must in
                     let wl1 =
-                      let uu___3683_25393 = wl in
+                      let uu___3683_25391 = wl in
                       {
-                        attempting = (uu___3683_25393.attempting);
-                        wl_deferred = (uu___3683_25393.wl_deferred);
+                        attempting = (uu___3683_25391.attempting);
+                        wl_deferred = (uu___3683_25391.wl_deferred);
                         wl_deferred_to_tac =
-                          (uu___3683_25393.wl_deferred_to_tac);
-                        ctr = (uu___3683_25393.ctr);
-                        defer_ok = (uu___3683_25393.defer_ok);
-                        smt_ok = (uu___3683_25393.smt_ok);
+                          (uu___3683_25391.wl_deferred_to_tac);
+                        ctr = (uu___3683_25391.ctr);
+                        defer_ok = (uu___3683_25391.defer_ok);
+                        smt_ok = (uu___3683_25391.smt_ok);
                         umax_heuristic_ok =
-                          (uu___3683_25393.umax_heuristic_ok);
-                        tcenv = (uu___3683_25393.tcenv);
+                          (uu___3683_25391.umax_heuristic_ok);
+                        tcenv = (uu___3683_25391.tcenv);
                         wl_implicits =
                           (FStar_List.append
                              g_lift.FStar_TypeChecker_Common.implicits
                              wl.wl_implicits);
                         repr_subcomp_allowed =
-                          (uu___3683_25393.repr_subcomp_allowed)
+                          (uu___3683_25391.repr_subcomp_allowed)
                       } in
-                    let uu____25394 =
+                    let uu____25392 =
                       if is_polymonadic
                       then ([], wl1)
                       else
                         (let rec is_uvar t =
-                           let uu____25416 =
-                             let uu____25417 = FStar_Syntax_Subst.compress t in
-                             uu____25417.FStar_Syntax_Syntax.n in
-                           match uu____25416 with
-                           | FStar_Syntax_Syntax.Tm_uvar uu____25420 -> true
-                           | FStar_Syntax_Syntax.Tm_uinst (t1, uu____25434)
+                           let uu____25414 =
+                             let uu____25415 = FStar_Syntax_Subst.compress t in
+                             uu____25415.FStar_Syntax_Syntax.n in
+                           match uu____25414 with
+                           | FStar_Syntax_Syntax.Tm_uvar uu____25418 -> true
+                           | FStar_Syntax_Syntax.Tm_uinst (t1, uu____25432)
                                -> is_uvar t1
-                           | FStar_Syntax_Syntax.Tm_app (t1, uu____25440) ->
+                           | FStar_Syntax_Syntax.Tm_app (t1, uu____25438) ->
                                is_uvar t1
-                           | uu____25465 -> false in
+                           | uu____25463 -> false in
                          FStar_List.fold_right2
-                           (fun uu____25498 ->
-                              fun uu____25499 ->
-                                fun uu____25500 ->
-                                  match (uu____25498, uu____25499,
-                                          uu____25500)
+                           (fun uu____25496 ->
+                              fun uu____25497 ->
+                                fun uu____25498 ->
+                                  match (uu____25496, uu____25497,
+                                          uu____25498)
                                   with
-                                  | ((a1, uu____25544), (a2, uu____25546),
+                                  | ((a1, uu____25542), (a2, uu____25544),
                                      (is_sub_probs, wl2)) ->
-                                      let uu____25579 = is_uvar a1 in
-                                      if uu____25579
+                                      let uu____25577 = is_uvar a1 in
+                                      if uu____25577
                                       then
-                                        ((let uu____25587 =
+                                        ((let uu____25585 =
                                             FStar_All.pipe_left
                                               (FStar_TypeChecker_Env.debug
                                                  env)
                                               (FStar_Options.Other
                                                  "LayeredEffectsEqns") in
-                                          if uu____25587
+                                          if uu____25585
                                           then
-                                            let uu____25588 =
+                                            let uu____25586 =
                                               FStar_Syntax_Print.term_to_string
                                                 a1 in
-                                            let uu____25589 =
+                                            let uu____25587 =
                                               FStar_Syntax_Print.term_to_string
                                                 a2 in
                                             FStar_Util.print2
                                               "Layered Effects teq (rel c1 index uvar) %s = %s\n"
-                                              uu____25588 uu____25589
+                                              uu____25586 uu____25587
                                           else ());
-                                         (let uu____25591 =
+                                         (let uu____25589 =
                                             sub_prob wl2 a1
                                               FStar_TypeChecker_Common.EQ a2
                                               "l.h.s. effect index uvar" in
-                                          match uu____25591 with
+                                          match uu____25589 with
                                           | (p, wl3) ->
                                               ((p :: is_sub_probs), wl3)))
                                       else (is_sub_probs, wl2))
                            c12.FStar_Syntax_Syntax.effect_args
                            c21.FStar_Syntax_Syntax.effect_args ([], wl1)) in
-                    match uu____25394 with
+                    match uu____25392 with
                     | (is_sub_probs, wl2) ->
-                        let uu____25617 =
+                        let uu____25615 =
                           sub_prob wl2 c12.FStar_Syntax_Syntax.result_typ
                             problem.FStar_TypeChecker_Common.relation
                             c21.FStar_Syntax_Syntax.result_typ "result type" in
-                        (match uu____25617 with
+                        (match uu____25615 with
                          | (ret_sub_prob, wl3) ->
                              let stronger_t_shape_error s =
-                               let uu____25630 =
+                               let uu____25628 =
                                  FStar_Ident.string_of_lid
                                    c21.FStar_Syntax_Syntax.effect_name in
-                               let uu____25631 =
+                               let uu____25629 =
                                  FStar_Syntax_Print.term_to_string stronger_t in
                                FStar_Util.format3
                                  "Unexpected shape of stronger for %s, reason: %s (t:%s)"
-                                 uu____25630 s uu____25631 in
-                             let uu____25632 =
-                               let uu____25661 =
-                                 let uu____25662 =
+                                 uu____25628 s uu____25629 in
+                             let uu____25630 =
+                               let uu____25659 =
+                                 let uu____25660 =
                                    FStar_Syntax_Subst.compress stronger_t in
-                                 uu____25662.FStar_Syntax_Syntax.n in
-                               match uu____25661 with
+                                 uu____25660.FStar_Syntax_Syntax.n in
+                               match uu____25659 with
                                | FStar_Syntax_Syntax.Tm_arrow (bs, c) when
                                    (FStar_List.length bs) >=
                                      (Prims.of_int (2))
                                    ->
-                                   let uu____25721 =
+                                   let uu____25719 =
                                      FStar_Syntax_Subst.open_comp bs c in
-                                   (match uu____25721 with
+                                   (match uu____25719 with
                                     | (bs', c3) ->
                                         let a = FStar_List.hd bs' in
                                         let bs1 = FStar_List.tail bs' in
-                                        let uu____25784 =
-                                          let uu____25803 =
+                                        let uu____25782 =
+                                          let uu____25801 =
                                             FStar_All.pipe_right bs1
                                               (FStar_List.splitAt
                                                  ((FStar_List.length bs1) -
                                                     Prims.int_one)) in
-                                          FStar_All.pipe_right uu____25803
-                                            (fun uu____25906 ->
-                                               match uu____25906 with
+                                          FStar_All.pipe_right uu____25801
+                                            (fun uu____25904 ->
+                                               match uu____25904 with
                                                | (l1, l2) ->
-                                                   let uu____25979 =
+                                                   let uu____25977 =
                                                      FStar_List.hd l2 in
-                                                   (l1, uu____25979)) in
-                                        (match uu____25784 with
+                                                   (l1, uu____25977)) in
+                                        (match uu____25782 with
                                          | (rest_bs, f_b) ->
                                              (a, rest_bs, f_b, c3)))
-                               | uu____26084 ->
-                                   let uu____26085 =
-                                     let uu____26090 =
+                               | uu____26082 ->
+                                   let uu____26083 =
+                                     let uu____26088 =
                                        stronger_t_shape_error
                                          "not an arrow or not enough binders" in
                                      (FStar_Errors.Fatal_UnexpectedExpressionType,
-                                       uu____26090) in
-                                   FStar_Errors.raise_error uu____26085 r in
-                             (match uu____25632 with
+                                       uu____26088) in
+                                   FStar_Errors.raise_error uu____26083 r in
+                             (match uu____25630 with
                               | (a_b, rest_bs, f_b, stronger_c) ->
-                                  let uu____26163 =
-                                    let uu____26170 =
-                                      let uu____26171 =
-                                        let uu____26172 =
-                                          let uu____26179 =
+                                  let uu____26161 =
+                                    let uu____26168 =
+                                      let uu____26169 =
+                                        let uu____26170 =
+                                          let uu____26177 =
                                             FStar_All.pipe_right a_b
                                               FStar_Pervasives_Native.fst in
-                                          (uu____26179,
+                                          (uu____26177,
                                             (c21.FStar_Syntax_Syntax.result_typ)) in
-                                        FStar_Syntax_Syntax.NT uu____26172 in
-                                      [uu____26171] in
+                                        FStar_Syntax_Syntax.NT uu____26170 in
+                                      [uu____26169] in
                                     FStar_TypeChecker_Env.uvars_for_binders
-                                      env rest_bs uu____26170
+                                      env rest_bs uu____26168
                                       (fun b ->
-                                         let uu____26195 =
+                                         let uu____26193 =
                                            FStar_Syntax_Print.binder_to_string
                                              b in
-                                         let uu____26196 =
+                                         let uu____26194 =
                                            FStar_Ident.string_of_lid
                                              c21.FStar_Syntax_Syntax.effect_name in
-                                         let uu____26197 =
+                                         let uu____26195 =
                                            FStar_Range.string_of_range r in
                                          FStar_Util.format3
                                            "implicit for binder %s in subcomp of %s at %s"
-                                           uu____26195 uu____26196
-                                           uu____26197) r in
-                                  (match uu____26163 with
+                                           uu____26193 uu____26194
+                                           uu____26195) r in
+                                  (match uu____26161 with
                                    | (rest_bs_uvars, g_uvars) ->
                                        let wl4 =
-                                         let uu___3748_26205 = wl3 in
+                                         let uu___3748_26203 = wl3 in
                                          {
                                            attempting =
-                                             (uu___3748_26205.attempting);
+                                             (uu___3748_26203.attempting);
                                            wl_deferred =
-                                             (uu___3748_26205.wl_deferred);
+                                             (uu___3748_26203.wl_deferred);
                                            wl_deferred_to_tac =
-                                             (uu___3748_26205.wl_deferred_to_tac);
-                                           ctr = (uu___3748_26205.ctr);
+                                             (uu___3748_26203.wl_deferred_to_tac);
+                                           ctr = (uu___3748_26203.ctr);
                                            defer_ok =
-                                             (uu___3748_26205.defer_ok);
-                                           smt_ok = (uu___3748_26205.smt_ok);
+                                             (uu___3748_26203.defer_ok);
+                                           smt_ok = (uu___3748_26203.smt_ok);
                                            umax_heuristic_ok =
-                                             (uu___3748_26205.umax_heuristic_ok);
-                                           tcenv = (uu___3748_26205.tcenv);
+                                             (uu___3748_26203.umax_heuristic_ok);
+                                           tcenv = (uu___3748_26203.tcenv);
                                            wl_implicits =
                                              (FStar_List.append
                                                 g_uvars.FStar_TypeChecker_Common.implicits
                                                 wl3.wl_implicits);
                                            repr_subcomp_allowed =
-                                             (uu___3748_26205.repr_subcomp_allowed)
+                                             (uu___3748_26203.repr_subcomp_allowed)
                                          } in
                                        let substs =
                                          FStar_List.map2
                                            (fun b ->
                                               fun t ->
-                                                let uu____26230 =
-                                                  let uu____26237 =
+                                                let uu____26228 =
+                                                  let uu____26235 =
                                                     FStar_All.pipe_right b
                                                       FStar_Pervasives_Native.fst in
-                                                  (uu____26237, t) in
+                                                  (uu____26235, t) in
                                                 FStar_Syntax_Syntax.NT
-                                                  uu____26230) (a_b ::
+                                                  uu____26228) (a_b ::
                                            rest_bs)
                                            ((c21.FStar_Syntax_Syntax.result_typ)
                                            :: rest_bs_uvars) in
-                                       let uu____26254 =
+                                       let uu____26252 =
                                          let f_sort_is =
-                                           let uu____26264 =
-                                             let uu____26267 =
-                                               let uu____26268 =
+                                           let uu____26262 =
+                                             let uu____26265 =
+                                               let uu____26266 =
                                                  FStar_All.pipe_right f_b
                                                    FStar_Pervasives_Native.fst in
-                                               uu____26268.FStar_Syntax_Syntax.sort in
-                                             let uu____26277 =
+                                               uu____26266.FStar_Syntax_Syntax.sort in
+                                             let uu____26275 =
                                                FStar_TypeChecker_Env.is_layered_effect
                                                  env
                                                  c12.FStar_Syntax_Syntax.effect_name in
-                                             let uu____26278 =
+                                             let uu____26276 =
                                                stronger_t_shape_error
                                                  "type of f is not a repr type" in
                                              FStar_Syntax_Util.effect_indices_from_repr
-                                               uu____26267 uu____26277 r
-                                               uu____26278 in
-                                           FStar_All.pipe_right uu____26264
+                                               uu____26265 uu____26275 r
+                                               uu____26276 in
+                                           FStar_All.pipe_right uu____26262
                                              (FStar_List.map
                                                 (FStar_Syntax_Subst.subst
                                                    substs)) in
-                                         let uu____26283 =
+                                         let uu____26281 =
                                            FStar_All.pipe_right
                                              c12.FStar_Syntax_Syntax.effect_args
                                              (FStar_List.map
                                                 FStar_Pervasives_Native.fst) in
                                          FStar_List.fold_left2
-                                           (fun uu____26319 ->
+                                           (fun uu____26317 ->
                                               fun f_sort_i ->
                                                 fun c1_i ->
-                                                  match uu____26319 with
+                                                  match uu____26317 with
                                                   | (ps, wl5) ->
-                                                      ((let uu____26341 =
+                                                      ((let uu____26339 =
                                                           FStar_All.pipe_left
                                                             (FStar_TypeChecker_Env.debug
                                                                env)
                                                             (FStar_Options.Other
                                                                "LayeredEffectsEqns") in
-                                                        if uu____26341
+                                                        if uu____26339
                                                         then
-                                                          let uu____26342 =
+                                                          let uu____26340 =
                                                             FStar_Syntax_Print.term_to_string
                                                               f_sort_i in
-                                                          let uu____26343 =
+                                                          let uu____26341 =
                                                             FStar_Syntax_Print.term_to_string
                                                               c1_i in
                                                           FStar_Util.print3
                                                             "Layered Effects (%s) %s = %s\n"
                                                             subcomp_name
-                                                            uu____26342
-                                                            uu____26343
+                                                            uu____26340
+                                                            uu____26341
                                                         else ());
-                                                       (let uu____26345 =
+                                                       (let uu____26343 =
                                                           sub_prob wl5
                                                             f_sort_i
                                                             FStar_TypeChecker_Common.EQ
                                                             c1_i
                                                             "indices of c1" in
-                                                        match uu____26345
+                                                        match uu____26343
                                                         with
                                                         | (p, wl6) ->
                                                             ((FStar_List.append
                                                                 ps [p]), wl6))))
-                                           ([], wl4) f_sort_is uu____26283 in
-                                       (match uu____26254 with
+                                           ([], wl4) f_sort_is uu____26281 in
+                                       (match uu____26252 with
                                         | (f_sub_probs, wl5) ->
                                             let stronger_ct =
-                                              let uu____26369 =
+                                              let uu____26367 =
                                                 FStar_All.pipe_right
                                                   stronger_c
                                                   (FStar_Syntax_Subst.subst_comp
                                                      substs) in
                                               FStar_All.pipe_right
-                                                uu____26369
+                                                uu____26367
                                                 FStar_Syntax_Util.comp_to_comp_typ in
-                                            let uu____26370 =
+                                            let uu____26368 =
                                               let g_sort_is =
-                                                let uu____26380 =
+                                                let uu____26378 =
                                                   FStar_TypeChecker_Env.is_layered_effect
                                                     env
                                                     c21.FStar_Syntax_Syntax.effect_name in
-                                                let uu____26381 =
+                                                let uu____26379 =
                                                   stronger_t_shape_error
                                                     "subcomp return type is not a repr" in
                                                 FStar_Syntax_Util.effect_indices_from_repr
                                                   stronger_ct.FStar_Syntax_Syntax.result_typ
-                                                  uu____26380 r uu____26381 in
-                                              let uu____26382 =
+                                                  uu____26378 r uu____26379 in
+                                              let uu____26380 =
                                                 FStar_All.pipe_right
                                                   c21.FStar_Syntax_Syntax.effect_args
                                                   (FStar_List.map
                                                      FStar_Pervasives_Native.fst) in
                                               FStar_List.fold_left2
-                                                (fun uu____26418 ->
+                                                (fun uu____26416 ->
                                                    fun g_sort_i ->
                                                      fun c2_i ->
-                                                       match uu____26418 with
+                                                       match uu____26416 with
                                                        | (ps, wl6) ->
-                                                           ((let uu____26440
+                                                           ((let uu____26438
                                                                =
                                                                FStar_All.pipe_left
                                                                  (FStar_TypeChecker_Env.debug
                                                                     env)
                                                                  (FStar_Options.Other
                                                                     "LayeredEffectsEqns") in
-                                                             if uu____26440
+                                                             if uu____26438
                                                              then
-                                                               let uu____26441
+                                                               let uu____26439
                                                                  =
                                                                  FStar_Syntax_Print.term_to_string
                                                                    g_sort_i in
-                                                               let uu____26442
+                                                               let uu____26440
                                                                  =
                                                                  FStar_Syntax_Print.term_to_string
                                                                    c2_i in
                                                                FStar_Util.print3
                                                                  "Layered Effects (%s) %s = %s\n"
                                                                  subcomp_name
-                                                                 uu____26441
-                                                                 uu____26442
+                                                                 uu____26439
+                                                                 uu____26440
                                                              else ());
-                                                            (let uu____26444
+                                                            (let uu____26442
                                                                =
                                                                sub_prob wl6
                                                                  g_sort_i
                                                                  FStar_TypeChecker_Common.EQ
                                                                  c2_i
                                                                  "indices of c2" in
-                                                             match uu____26444
+                                                             match uu____26442
                                                              with
                                                              | (p, wl7) ->
                                                                  ((FStar_List.append
@@ -9984,23 +9984,23 @@ and (solve_c :
                                                                     [p]),
                                                                    wl7))))
                                                 ([], wl5) g_sort_is
-                                                uu____26382 in
-                                            (match uu____26370 with
+                                                uu____26380 in
+                                            (match uu____26368 with
                                              | (g_sub_probs, wl6) ->
                                                  let fml =
-                                                   let uu____26470 =
-                                                     let uu____26475 =
+                                                   let uu____26468 =
+                                                     let uu____26473 =
                                                        FStar_List.hd
                                                          stronger_ct.FStar_Syntax_Syntax.comp_univs in
-                                                     let uu____26476 =
-                                                       let uu____26477 =
+                                                     let uu____26474 =
+                                                       let uu____26475 =
                                                          FStar_List.hd
                                                            stronger_ct.FStar_Syntax_Syntax.effect_args in
                                                        FStar_Pervasives_Native.fst
-                                                         uu____26477 in
-                                                     (uu____26475,
-                                                       uu____26476) in
-                                                   match uu____26470 with
+                                                         uu____26475 in
+                                                     (uu____26473,
+                                                       uu____26474) in
+                                                   match uu____26468 with
                                                    | (u, wp) ->
                                                        FStar_TypeChecker_Env.pure_precondition_for_trivial_post
                                                          env u
@@ -10008,32 +10008,32 @@ and (solve_c :
                                                          wp
                                                          FStar_Range.dummyRange in
                                                  let sub_probs =
-                                                   let uu____26505 =
-                                                     let uu____26508 =
-                                                       let uu____26511 =
-                                                         let uu____26514 =
+                                                   let uu____26503 =
+                                                     let uu____26506 =
+                                                       let uu____26509 =
+                                                         let uu____26512 =
                                                            FStar_All.pipe_right
                                                              g_lift.FStar_TypeChecker_Common.deferred
                                                              (FStar_List.map
                                                                 FStar_Pervasives_Native.snd) in
                                                          FStar_List.append
                                                            g_sub_probs
-                                                           uu____26514 in
+                                                           uu____26512 in
                                                        FStar_List.append
                                                          f_sub_probs
-                                                         uu____26511 in
+                                                         uu____26509 in
                                                      FStar_List.append
                                                        is_sub_probs
-                                                       uu____26508 in
+                                                       uu____26506 in
                                                    ret_sub_prob ::
-                                                     uu____26505 in
+                                                     uu____26503 in
                                                  let guard =
                                                    let guard =
-                                                     let uu____26535 =
+                                                     let uu____26533 =
                                                        FStar_List.map p_guard
                                                          sub_probs in
                                                      FStar_Syntax_Util.mk_conj_l
-                                                       uu____26535 in
+                                                       uu____26533 in
                                                    match g_lift.FStar_TypeChecker_Common.guard_f
                                                    with
                                                    | FStar_TypeChecker_Common.Trivial
@@ -10043,20 +10043,20 @@ and (solve_c :
                                                        FStar_Syntax_Util.mk_conj
                                                          guard f in
                                                  let wl7 =
-                                                   let uu____26546 =
-                                                     let uu____26549 =
+                                                   let uu____26544 =
+                                                     let uu____26547 =
                                                        FStar_Syntax_Util.mk_conj
                                                          guard fml in
                                                      FStar_All.pipe_left
-                                                       (fun uu____26552 ->
+                                                       (fun uu____26550 ->
                                                           FStar_Pervasives_Native.Some
-                                                            uu____26552)
-                                                       uu____26549 in
+                                                            uu____26550)
+                                                       uu____26547 in
                                                    solve_prob orig
-                                                     uu____26546 [] wl6 in
-                                                 let uu____26553 =
+                                                     uu____26544 [] wl6 in
+                                                 let uu____26551 =
                                                    attempt sub_probs wl7 in
-                                                 solve env uu____26553))))))) in
+                                                 solve env uu____26551))))))) in
         let solve_sub c11 edge c21 =
           if
             problem.FStar_TypeChecker_Common.relation <>
@@ -10064,219 +10064,219 @@ and (solve_c :
           then failwith "impossible: solve_sub"
           else ();
           (let r = FStar_TypeChecker_Env.get_range env in
-           let lift_c1 uu____26578 =
+           let lift_c1 uu____26576 =
              let univs =
                match c11.FStar_Syntax_Syntax.comp_univs with
                | [] ->
-                   let uu____26580 =
+                   let uu____26578 =
                      env.FStar_TypeChecker_Env.universe_of env
                        c11.FStar_Syntax_Syntax.result_typ in
-                   [uu____26580]
+                   [uu____26578]
                | x -> x in
              let c12 =
-               let uu___3806_26583 = c11 in
+               let uu___3806_26581 = c11 in
                {
                  FStar_Syntax_Syntax.comp_univs = univs;
                  FStar_Syntax_Syntax.effect_name =
-                   (uu___3806_26583.FStar_Syntax_Syntax.effect_name);
+                   (uu___3806_26581.FStar_Syntax_Syntax.effect_name);
                  FStar_Syntax_Syntax.result_typ =
-                   (uu___3806_26583.FStar_Syntax_Syntax.result_typ);
+                   (uu___3806_26581.FStar_Syntax_Syntax.result_typ);
                  FStar_Syntax_Syntax.effect_args =
-                   (uu___3806_26583.FStar_Syntax_Syntax.effect_args);
+                   (uu___3806_26581.FStar_Syntax_Syntax.effect_args);
                  FStar_Syntax_Syntax.flags =
-                   (uu___3806_26583.FStar_Syntax_Syntax.flags)
+                   (uu___3806_26581.FStar_Syntax_Syntax.flags)
                } in
-             let uu____26584 =
-               let uu____26589 =
+             let uu____26582 =
+               let uu____26587 =
                  FStar_All.pipe_right
-                   (let uu___3809_26591 = c12 in
+                   (let uu___3809_26589 = c12 in
                     {
                       FStar_Syntax_Syntax.comp_univs = univs;
                       FStar_Syntax_Syntax.effect_name =
-                        (uu___3809_26591.FStar_Syntax_Syntax.effect_name);
+                        (uu___3809_26589.FStar_Syntax_Syntax.effect_name);
                       FStar_Syntax_Syntax.result_typ =
-                        (uu___3809_26591.FStar_Syntax_Syntax.result_typ);
+                        (uu___3809_26589.FStar_Syntax_Syntax.result_typ);
                       FStar_Syntax_Syntax.effect_args =
-                        (uu___3809_26591.FStar_Syntax_Syntax.effect_args);
+                        (uu___3809_26589.FStar_Syntax_Syntax.effect_args);
                       FStar_Syntax_Syntax.flags =
-                        (uu___3809_26591.FStar_Syntax_Syntax.flags)
+                        (uu___3809_26589.FStar_Syntax_Syntax.flags)
                     }) FStar_Syntax_Syntax.mk_Comp in
-               FStar_All.pipe_right uu____26589
+               FStar_All.pipe_right uu____26587
                  ((edge.FStar_TypeChecker_Env.mlift).FStar_TypeChecker_Env.mlift_wp
                     env) in
-             FStar_All.pipe_right uu____26584
-               (fun uu____26605 ->
-                  match uu____26605 with
+             FStar_All.pipe_right uu____26582
+               (fun uu____26603 ->
+                  match uu____26603 with
                   | (c, g) ->
-                      let uu____26612 =
-                        let uu____26613 = FStar_TypeChecker_Env.is_trivial g in
-                        Prims.op_Negation uu____26613 in
-                      if uu____26612
+                      let uu____26610 =
+                        let uu____26611 = FStar_TypeChecker_Env.is_trivial g in
+                        Prims.op_Negation uu____26611 in
+                      if uu____26610
                       then
-                        let uu____26614 =
-                          let uu____26619 =
-                            let uu____26620 =
+                        let uu____26612 =
+                          let uu____26617 =
+                            let uu____26618 =
                               FStar_Ident.string_of_lid
                                 c12.FStar_Syntax_Syntax.effect_name in
-                            let uu____26621 =
+                            let uu____26619 =
                               FStar_Ident.string_of_lid
                                 c21.FStar_Syntax_Syntax.effect_name in
                             FStar_Util.format2
                               "Lift between wp-effects (%s~>%s) should not have returned a non-trivial guard"
-                              uu____26620 uu____26621 in
-                          (FStar_Errors.Fatal_UnexpectedEffect, uu____26619) in
-                        FStar_Errors.raise_error uu____26614 r
+                              uu____26618 uu____26619 in
+                          (FStar_Errors.Fatal_UnexpectedEffect, uu____26617) in
+                        FStar_Errors.raise_error uu____26612 r
                       else FStar_Syntax_Util.comp_to_comp_typ c) in
-           let uu____26623 =
+           let uu____26621 =
              ((Prims.op_Negation wl.repr_subcomp_allowed) &&
-                (let uu____26625 =
+                (let uu____26623 =
                    FStar_Ident.lid_equals c11.FStar_Syntax_Syntax.effect_name
                      c21.FStar_Syntax_Syntax.effect_name in
-                 Prims.op_Negation uu____26625))
+                 Prims.op_Negation uu____26623))
                &&
                (FStar_TypeChecker_Env.is_reifiable_effect env
                   c21.FStar_Syntax_Syntax.effect_name) in
-           if uu____26623
+           if uu____26621
            then
-             let uu____26626 =
+             let uu____26624 =
                mklstr
-                 (fun uu____26633 ->
-                    let uu____26634 =
+                 (fun uu____26631 ->
+                    let uu____26632 =
                       FStar_Ident.string_of_lid
                         c11.FStar_Syntax_Syntax.effect_name in
-                    let uu____26635 =
+                    let uu____26633 =
                       FStar_Ident.string_of_lid
                         c21.FStar_Syntax_Syntax.effect_name in
                     FStar_Util.format2
                       "Cannot lift from %s to %s, it needs a lift\n"
-                      uu____26634 uu____26635) in
-             giveup env uu____26626 orig
+                      uu____26632 uu____26633) in
+             giveup env uu____26624 orig
            else
              (let is_null_wp_2 =
                 FStar_All.pipe_right c21.FStar_Syntax_Syntax.flags
                   (FStar_Util.for_some
-                     (fun uu___29_26641 ->
-                        match uu___29_26641 with
+                     (fun uu___29_26639 ->
+                        match uu___29_26639 with
                         | FStar_Syntax_Syntax.TOTAL -> true
                         | FStar_Syntax_Syntax.MLEFFECT -> true
                         | FStar_Syntax_Syntax.SOMETRIVIAL -> true
-                        | uu____26642 -> false)) in
-              let uu____26643 =
+                        | uu____26640 -> false)) in
+              let uu____26641 =
                 match ((c11.FStar_Syntax_Syntax.effect_args),
                         (c21.FStar_Syntax_Syntax.effect_args))
                 with
-                | ((wp1, uu____26673)::uu____26674,
-                   (wp2, uu____26676)::uu____26677) -> (wp1, wp2)
-                | uu____26750 ->
-                    let uu____26775 =
-                      let uu____26780 =
-                        let uu____26781 =
+                | ((wp1, uu____26675)::uu____26676,
+                   (wp2, uu____26678)::uu____26679) -> (wp1, wp2)
+                | uu____26754 ->
+                    let uu____26779 =
+                      let uu____26784 =
+                        let uu____26785 =
                           FStar_Syntax_Print.lid_to_string
                             c11.FStar_Syntax_Syntax.effect_name in
-                        let uu____26782 =
+                        let uu____26786 =
                           FStar_Syntax_Print.lid_to_string
                             c21.FStar_Syntax_Syntax.effect_name in
                         FStar_Util.format2
                           "Got effects %s and %s, expected normalized effects"
-                          uu____26781 uu____26782 in
+                          uu____26785 uu____26786 in
                       (FStar_Errors.Fatal_ExpectNormalizedEffect,
-                        uu____26780) in
-                    FStar_Errors.raise_error uu____26775
+                        uu____26784) in
+                    FStar_Errors.raise_error uu____26779
                       env.FStar_TypeChecker_Env.range in
-              match uu____26643 with
+              match uu____26641 with
               | (wpc1, wpc2) ->
-                  let uu____26789 = FStar_Util.physical_equality wpc1 wpc2 in
-                  if uu____26789
+                  let uu____26799 = FStar_Util.physical_equality wpc1 wpc2 in
+                  if uu____26799
                   then
-                    let uu____26790 =
+                    let uu____26802 =
                       problem_using_guard orig
                         c11.FStar_Syntax_Syntax.result_typ
                         problem.FStar_TypeChecker_Common.relation
                         c21.FStar_Syntax_Syntax.result_typ
                         FStar_Pervasives_Native.None "result type" in
-                    solve_t env uu____26790 wl
+                    solve_t env uu____26802 wl
                   else
-                    (let uu____26792 =
-                       let uu____26799 =
+                    (let uu____26804 =
+                       let uu____26811 =
                          FStar_TypeChecker_Env.effect_decl_opt env
                            c21.FStar_Syntax_Syntax.effect_name in
-                       FStar_Util.must uu____26799 in
-                     match uu____26792 with
+                       FStar_Util.must uu____26811 in
+                     match uu____26804 with
                      | (c2_decl, qualifiers) ->
-                         let uu____26820 =
+                         let uu____26832 =
                            FStar_All.pipe_right qualifiers
                              (FStar_List.contains
                                 FStar_Syntax_Syntax.Reifiable) in
-                         if uu____26820
+                         if uu____26832
                          then
                            let c1_repr =
-                             let uu____26824 =
-                               let uu____26825 =
-                                 let uu____26826 = lift_c1 () in
-                                 FStar_Syntax_Syntax.mk_Comp uu____26826 in
-                               let uu____26827 =
+                             let uu____26836 =
+                               let uu____26837 =
+                                 let uu____26838 = lift_c1 () in
+                                 FStar_Syntax_Syntax.mk_Comp uu____26838 in
+                               let uu____26839 =
                                  env.FStar_TypeChecker_Env.universe_of env
                                    c11.FStar_Syntax_Syntax.result_typ in
                                FStar_TypeChecker_Env.reify_comp env
-                                 uu____26825 uu____26827 in
+                                 uu____26837 uu____26839 in
                              norm_with_steps
                                "FStar.TypeChecker.Rel.norm_with_steps.4"
                                [FStar_TypeChecker_Env.UnfoldUntil
                                   FStar_Syntax_Syntax.delta_constant;
                                FStar_TypeChecker_Env.Weak;
-                               FStar_TypeChecker_Env.HNF] env uu____26824 in
+                               FStar_TypeChecker_Env.HNF] env uu____26836 in
                            let c2_repr =
-                             let uu____26829 =
-                               let uu____26830 =
+                             let uu____26841 =
+                               let uu____26842 =
                                  FStar_Syntax_Syntax.mk_Comp c21 in
-                               let uu____26831 =
+                               let uu____26843 =
                                  env.FStar_TypeChecker_Env.universe_of env
                                    c21.FStar_Syntax_Syntax.result_typ in
                                FStar_TypeChecker_Env.reify_comp env
-                                 uu____26830 uu____26831 in
+                                 uu____26842 uu____26843 in
                              norm_with_steps
                                "FStar.TypeChecker.Rel.norm_with_steps.5"
                                [FStar_TypeChecker_Env.UnfoldUntil
                                   FStar_Syntax_Syntax.delta_constant;
                                FStar_TypeChecker_Env.Weak;
-                               FStar_TypeChecker_Env.HNF] env uu____26829 in
-                           let uu____26832 =
-                             let uu____26837 =
-                               let uu____26838 =
+                               FStar_TypeChecker_Env.HNF] env uu____26841 in
+                           let uu____26844 =
+                             let uu____26849 =
+                               let uu____26850 =
                                  FStar_Syntax_Print.term_to_string c1_repr in
-                               let uu____26839 =
+                               let uu____26851 =
                                  FStar_Syntax_Print.term_to_string c2_repr in
                                FStar_Util.format2 "sub effect repr: %s <: %s"
-                                 uu____26838 uu____26839 in
+                                 uu____26850 uu____26851 in
                              sub_prob wl c1_repr
                                problem.FStar_TypeChecker_Common.relation
-                               c2_repr uu____26837 in
-                           (match uu____26832 with
+                               c2_repr uu____26849 in
+                           (match uu____26844 with
                             | (prob, wl1) ->
                                 let wl2 =
                                   solve_prob orig
                                     (FStar_Pervasives_Native.Some
                                        (p_guard prob)) [] wl1 in
-                                let uu____26843 = attempt [prob] wl2 in
-                                solve env uu____26843)
+                                let uu____26855 = attempt [prob] wl2 in
+                                solve env uu____26855)
                          else
                            (let g =
                               if env.FStar_TypeChecker_Env.lax
                               then FStar_Syntax_Util.t_true
                               else
                                 (let wpc1_2 =
-                                   let uu____26860 = lift_c1 () in
-                                   FStar_All.pipe_right uu____26860
+                                   let uu____26872 = lift_c1 () in
+                                   FStar_All.pipe_right uu____26872
                                      (fun ct ->
                                         FStar_List.hd
                                           ct.FStar_Syntax_Syntax.effect_args) in
                                  if is_null_wp_2
                                  then
-                                   ((let uu____26882 =
+                                   ((let uu____26894 =
                                        FStar_All.pipe_left
                                          (FStar_TypeChecker_Env.debug env)
                                          (FStar_Options.Other "Rel") in
-                                     if uu____26882
+                                     if uu____26894
                                      then
                                        FStar_Util.print_string
                                          "Using trivial wp ... \n"
@@ -10286,27 +10286,27 @@ and (solve_c :
                                          env
                                          c11.FStar_Syntax_Syntax.result_typ in
                                      let trivial =
-                                       let uu____26886 =
+                                       let uu____26898 =
                                          FStar_All.pipe_right c2_decl
                                            FStar_Syntax_Util.get_wp_trivial_combinator in
-                                       match uu____26886 with
+                                       match uu____26898 with
                                        | FStar_Pervasives_Native.None ->
                                            failwith
                                              "Rel doesn't yet handle undefined trivial combinator in an effect"
                                        | FStar_Pervasives_Native.Some t -> t in
-                                     let uu____26892 =
-                                       let uu____26893 =
-                                         let uu____26910 =
+                                     let uu____26904 =
+                                       let uu____26905 =
+                                         let uu____26922 =
                                            FStar_TypeChecker_Env.inst_effect_fun_with
                                              [c1_univ] env c2_decl trivial in
-                                         let uu____26913 =
-                                           let uu____26924 =
+                                         let uu____26925 =
+                                           let uu____26936 =
                                              FStar_Syntax_Syntax.as_arg
                                                c11.FStar_Syntax_Syntax.result_typ in
-                                           [uu____26924; wpc1_2] in
-                                         (uu____26910, uu____26913) in
-                                       FStar_Syntax_Syntax.Tm_app uu____26893 in
-                                     FStar_Syntax_Syntax.mk uu____26892 r))
+                                           [uu____26936; wpc1_2] in
+                                         (uu____26922, uu____26925) in
+                                       FStar_Syntax_Syntax.Tm_app uu____26905 in
+                                     FStar_Syntax_Syntax.mk uu____26904 r))
                                  else
                                    (let c2_univ =
                                       env.FStar_TypeChecker_Env.universe_of
@@ -10315,258 +10315,258 @@ and (solve_c :
                                     let stronger =
                                       FStar_All.pipe_right c2_decl
                                         FStar_Syntax_Util.get_stronger_vc_combinator in
-                                    let uu____26972 =
-                                      let uu____26973 =
-                                        let uu____26990 =
+                                    let uu____26984 =
+                                      let uu____26985 =
+                                        let uu____27002 =
                                           FStar_TypeChecker_Env.inst_effect_fun_with
                                             [c2_univ] env c2_decl stronger in
-                                        let uu____26993 =
-                                          let uu____27004 =
+                                        let uu____27005 =
+                                          let uu____27016 =
                                             FStar_Syntax_Syntax.as_arg
                                               c21.FStar_Syntax_Syntax.result_typ in
-                                          let uu____27013 =
-                                            let uu____27024 =
+                                          let uu____27025 =
+                                            let uu____27036 =
                                               FStar_Syntax_Syntax.as_arg wpc2 in
-                                            [uu____27024; wpc1_2] in
-                                          uu____27004 :: uu____27013 in
-                                        (uu____26990, uu____26993) in
-                                      FStar_Syntax_Syntax.Tm_app uu____26973 in
-                                    FStar_Syntax_Syntax.mk uu____26972 r)) in
-                            (let uu____27078 =
+                                            [uu____27036; wpc1_2] in
+                                          uu____27016 :: uu____27025 in
+                                        (uu____27002, uu____27005) in
+                                      FStar_Syntax_Syntax.Tm_app uu____26985 in
+                                    FStar_Syntax_Syntax.mk uu____26984 r)) in
+                            (let uu____27090 =
                                FStar_All.pipe_left
                                  (FStar_TypeChecker_Env.debug env)
                                  (FStar_Options.Other "Rel") in
-                             if uu____27078
+                             if uu____27090
                              then
-                               let uu____27079 =
-                                 let uu____27080 =
+                               let uu____27091 =
+                                 let uu____27092 =
                                    FStar_TypeChecker_Normalize.normalize
                                      [FStar_TypeChecker_Env.Iota;
                                      FStar_TypeChecker_Env.Eager_unfolding;
                                      FStar_TypeChecker_Env.Primops;
                                      FStar_TypeChecker_Env.Simplify] env g in
                                  FStar_Syntax_Print.term_to_string
-                                   uu____27080 in
+                                   uu____27092 in
                                FStar_Util.print1
-                                 "WP guard (simplifed) is (%s)\n" uu____27079
+                                 "WP guard (simplifed) is (%s)\n" uu____27091
                              else ());
-                            (let uu____27082 =
+                            (let uu____27094 =
                                sub_prob wl c11.FStar_Syntax_Syntax.result_typ
                                  problem.FStar_TypeChecker_Common.relation
                                  c21.FStar_Syntax_Syntax.result_typ
                                  "result type" in
-                             match uu____27082 with
+                             match uu____27094 with
                              | (base_prob, wl1) ->
                                  let wl2 =
-                                   let uu____27090 =
-                                     let uu____27093 =
+                                   let uu____27102 =
+                                     let uu____27105 =
                                        FStar_Syntax_Util.mk_conj
                                          (p_guard base_prob) g in
                                      FStar_All.pipe_left
-                                       (fun uu____27096 ->
+                                       (fun uu____27108 ->
                                           FStar_Pervasives_Native.Some
-                                            uu____27096) uu____27093 in
-                                   solve_prob orig uu____27090 [] wl1 in
-                                 let uu____27097 = attempt [base_prob] wl2 in
-                                 solve env uu____27097))))) in
-        let uu____27098 = FStar_Util.physical_equality c1 c2 in
-        if uu____27098
+                                            uu____27108) uu____27105 in
+                                   solve_prob orig uu____27102 [] wl1 in
+                                 let uu____27109 = attempt [base_prob] wl2 in
+                                 solve env uu____27109))))) in
+        let uu____27110 = FStar_Util.physical_equality c1 c2 in
+        if uu____27110
         then
-          let uu____27099 =
+          let uu____27111 =
             solve_prob orig FStar_Pervasives_Native.None [] wl in
-          solve env uu____27099
+          solve env uu____27111
         else
-          ((let uu____27102 =
+          ((let uu____27114 =
               FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
                 (FStar_Options.Other "Rel") in
-            if uu____27102
+            if uu____27114
             then
-              let uu____27103 = FStar_Syntax_Print.comp_to_string c1 in
-              let uu____27104 = FStar_Syntax_Print.comp_to_string c2 in
-              FStar_Util.print3 "solve_c %s %s %s\n" uu____27103
+              let uu____27115 = FStar_Syntax_Print.comp_to_string c1 in
+              let uu____27116 = FStar_Syntax_Print.comp_to_string c2 in
+              FStar_Util.print3 "solve_c %s %s %s\n" uu____27115
                 (rel_to_string problem.FStar_TypeChecker_Common.relation)
-                uu____27104
+                uu____27116
             else ());
-           (let uu____27106 =
-              let uu____27115 =
+           (let uu____27118 =
+              let uu____27127 =
                 FStar_TypeChecker_Normalize.ghost_to_pure env c1 in
-              let uu____27118 =
+              let uu____27130 =
                 FStar_TypeChecker_Normalize.ghost_to_pure env c2 in
-              (uu____27115, uu____27118) in
-            match uu____27106 with
+              (uu____27127, uu____27130) in
+            match uu____27118 with
             | (c11, c21) ->
                 (match ((c11.FStar_Syntax_Syntax.n),
                          (c21.FStar_Syntax_Syntax.n))
                  with
-                 | (FStar_Syntax_Syntax.GTotal (t1, uu____27136),
-                    FStar_Syntax_Syntax.Total (t2, uu____27138)) when
+                 | (FStar_Syntax_Syntax.GTotal (t1, uu____27148),
+                    FStar_Syntax_Syntax.Total (t2, uu____27150)) when
                      FStar_TypeChecker_Env.non_informative env t2 ->
-                     let uu____27155 =
+                     let uu____27167 =
                        problem_using_guard orig t1
                          problem.FStar_TypeChecker_Common.relation t2
                          FStar_Pervasives_Native.None "result type" in
-                     solve_t env uu____27155 wl
-                 | (FStar_Syntax_Syntax.GTotal uu____27156,
-                    FStar_Syntax_Syntax.Total uu____27157) ->
-                     let uu____27174 =
+                     solve_t env uu____27167 wl
+                 | (FStar_Syntax_Syntax.GTotal uu____27168,
+                    FStar_Syntax_Syntax.Total uu____27169) ->
+                     let uu____27186 =
                        FStar_Thunk.mkv
                          "incompatible monad ordering: GTot </: Tot" in
-                     giveup env uu____27174 orig
-                 | (FStar_Syntax_Syntax.Total (t1, uu____27176),
-                    FStar_Syntax_Syntax.Total (t2, uu____27178)) ->
-                     let uu____27195 =
+                     giveup env uu____27186 orig
+                 | (FStar_Syntax_Syntax.Total (t1, uu____27188),
+                    FStar_Syntax_Syntax.Total (t2, uu____27190)) ->
+                     let uu____27207 =
                        problem_using_guard orig t1
                          problem.FStar_TypeChecker_Common.relation t2
                          FStar_Pervasives_Native.None "result type" in
-                     solve_t env uu____27195 wl
-                 | (FStar_Syntax_Syntax.GTotal (t1, uu____27197),
-                    FStar_Syntax_Syntax.GTotal (t2, uu____27199)) ->
-                     let uu____27216 =
+                     solve_t env uu____27207 wl
+                 | (FStar_Syntax_Syntax.GTotal (t1, uu____27209),
+                    FStar_Syntax_Syntax.GTotal (t2, uu____27211)) ->
+                     let uu____27228 =
                        problem_using_guard orig t1
                          problem.FStar_TypeChecker_Common.relation t2
                          FStar_Pervasives_Native.None "result type" in
-                     solve_t env uu____27216 wl
-                 | (FStar_Syntax_Syntax.Total (t1, uu____27218),
-                    FStar_Syntax_Syntax.GTotal (t2, uu____27220)) when
+                     solve_t env uu____27228 wl
+                 | (FStar_Syntax_Syntax.Total (t1, uu____27230),
+                    FStar_Syntax_Syntax.GTotal (t2, uu____27232)) when
                      problem.FStar_TypeChecker_Common.relation =
                        FStar_TypeChecker_Common.SUB
                      ->
-                     let uu____27237 =
+                     let uu____27249 =
                        problem_using_guard orig t1
                          problem.FStar_TypeChecker_Common.relation t2
                          FStar_Pervasives_Native.None "result type" in
-                     solve_t env uu____27237 wl
-                 | (FStar_Syntax_Syntax.Total (t1, uu____27239),
-                    FStar_Syntax_Syntax.GTotal (t2, uu____27241)) ->
-                     let uu____27258 = FStar_Thunk.mkv "GTot =/= Tot" in
-                     giveup env uu____27258 orig
-                 | (FStar_Syntax_Syntax.GTotal uu____27259,
-                    FStar_Syntax_Syntax.Comp uu____27260) ->
-                     let uu____27269 =
-                       let uu___3933_27272 = problem in
-                       let uu____27275 =
-                         let uu____27276 =
+                     solve_t env uu____27249 wl
+                 | (FStar_Syntax_Syntax.Total (t1, uu____27251),
+                    FStar_Syntax_Syntax.GTotal (t2, uu____27253)) ->
+                     let uu____27270 = FStar_Thunk.mkv "GTot =/= Tot" in
+                     giveup env uu____27270 orig
+                 | (FStar_Syntax_Syntax.GTotal uu____27271,
+                    FStar_Syntax_Syntax.Comp uu____27272) ->
+                     let uu____27281 =
+                       let uu___3933_27284 = problem in
+                       let uu____27287 =
+                         let uu____27288 =
                            FStar_TypeChecker_Env.comp_to_comp_typ env c11 in
                          FStar_All.pipe_left FStar_Syntax_Syntax.mk_Comp
-                           uu____27276 in
+                           uu____27288 in
                        {
                          FStar_TypeChecker_Common.pid =
-                           (uu___3933_27272.FStar_TypeChecker_Common.pid);
-                         FStar_TypeChecker_Common.lhs = uu____27275;
+                           (uu___3933_27284.FStar_TypeChecker_Common.pid);
+                         FStar_TypeChecker_Common.lhs = uu____27287;
                          FStar_TypeChecker_Common.relation =
-                           (uu___3933_27272.FStar_TypeChecker_Common.relation);
+                           (uu___3933_27284.FStar_TypeChecker_Common.relation);
                          FStar_TypeChecker_Common.rhs =
-                           (uu___3933_27272.FStar_TypeChecker_Common.rhs);
+                           (uu___3933_27284.FStar_TypeChecker_Common.rhs);
                          FStar_TypeChecker_Common.element =
-                           (uu___3933_27272.FStar_TypeChecker_Common.element);
+                           (uu___3933_27284.FStar_TypeChecker_Common.element);
                          FStar_TypeChecker_Common.logical_guard =
-                           (uu___3933_27272.FStar_TypeChecker_Common.logical_guard);
+                           (uu___3933_27284.FStar_TypeChecker_Common.logical_guard);
                          FStar_TypeChecker_Common.logical_guard_uvar =
-                           (uu___3933_27272.FStar_TypeChecker_Common.logical_guard_uvar);
+                           (uu___3933_27284.FStar_TypeChecker_Common.logical_guard_uvar);
                          FStar_TypeChecker_Common.reason =
-                           (uu___3933_27272.FStar_TypeChecker_Common.reason);
+                           (uu___3933_27284.FStar_TypeChecker_Common.reason);
                          FStar_TypeChecker_Common.loc =
-                           (uu___3933_27272.FStar_TypeChecker_Common.loc);
+                           (uu___3933_27284.FStar_TypeChecker_Common.loc);
                          FStar_TypeChecker_Common.rank =
-                           (uu___3933_27272.FStar_TypeChecker_Common.rank)
+                           (uu___3933_27284.FStar_TypeChecker_Common.rank)
                        } in
-                     solve_c env uu____27269 wl
-                 | (FStar_Syntax_Syntax.Total uu____27277,
-                    FStar_Syntax_Syntax.Comp uu____27278) ->
-                     let uu____27287 =
-                       let uu___3933_27290 = problem in
-                       let uu____27293 =
-                         let uu____27294 =
+                     solve_c env uu____27281 wl
+                 | (FStar_Syntax_Syntax.Total uu____27289,
+                    FStar_Syntax_Syntax.Comp uu____27290) ->
+                     let uu____27299 =
+                       let uu___3933_27302 = problem in
+                       let uu____27305 =
+                         let uu____27306 =
                            FStar_TypeChecker_Env.comp_to_comp_typ env c11 in
                          FStar_All.pipe_left FStar_Syntax_Syntax.mk_Comp
-                           uu____27294 in
+                           uu____27306 in
                        {
                          FStar_TypeChecker_Common.pid =
-                           (uu___3933_27290.FStar_TypeChecker_Common.pid);
-                         FStar_TypeChecker_Common.lhs = uu____27293;
+                           (uu___3933_27302.FStar_TypeChecker_Common.pid);
+                         FStar_TypeChecker_Common.lhs = uu____27305;
                          FStar_TypeChecker_Common.relation =
-                           (uu___3933_27290.FStar_TypeChecker_Common.relation);
+                           (uu___3933_27302.FStar_TypeChecker_Common.relation);
                          FStar_TypeChecker_Common.rhs =
-                           (uu___3933_27290.FStar_TypeChecker_Common.rhs);
+                           (uu___3933_27302.FStar_TypeChecker_Common.rhs);
                          FStar_TypeChecker_Common.element =
-                           (uu___3933_27290.FStar_TypeChecker_Common.element);
+                           (uu___3933_27302.FStar_TypeChecker_Common.element);
                          FStar_TypeChecker_Common.logical_guard =
-                           (uu___3933_27290.FStar_TypeChecker_Common.logical_guard);
+                           (uu___3933_27302.FStar_TypeChecker_Common.logical_guard);
                          FStar_TypeChecker_Common.logical_guard_uvar =
-                           (uu___3933_27290.FStar_TypeChecker_Common.logical_guard_uvar);
+                           (uu___3933_27302.FStar_TypeChecker_Common.logical_guard_uvar);
                          FStar_TypeChecker_Common.reason =
-                           (uu___3933_27290.FStar_TypeChecker_Common.reason);
+                           (uu___3933_27302.FStar_TypeChecker_Common.reason);
                          FStar_TypeChecker_Common.loc =
-                           (uu___3933_27290.FStar_TypeChecker_Common.loc);
+                           (uu___3933_27302.FStar_TypeChecker_Common.loc);
                          FStar_TypeChecker_Common.rank =
-                           (uu___3933_27290.FStar_TypeChecker_Common.rank)
+                           (uu___3933_27302.FStar_TypeChecker_Common.rank)
                        } in
-                     solve_c env uu____27287 wl
-                 | (FStar_Syntax_Syntax.Comp uu____27295,
-                    FStar_Syntax_Syntax.GTotal uu____27296) ->
-                     let uu____27305 =
-                       let uu___3945_27308 = problem in
-                       let uu____27311 =
-                         let uu____27312 =
+                     solve_c env uu____27299 wl
+                 | (FStar_Syntax_Syntax.Comp uu____27307,
+                    FStar_Syntax_Syntax.GTotal uu____27308) ->
+                     let uu____27317 =
+                       let uu___3945_27320 = problem in
+                       let uu____27323 =
+                         let uu____27324 =
                            FStar_TypeChecker_Env.comp_to_comp_typ env c21 in
                          FStar_All.pipe_left FStar_Syntax_Syntax.mk_Comp
-                           uu____27312 in
+                           uu____27324 in
                        {
                          FStar_TypeChecker_Common.pid =
-                           (uu___3945_27308.FStar_TypeChecker_Common.pid);
+                           (uu___3945_27320.FStar_TypeChecker_Common.pid);
                          FStar_TypeChecker_Common.lhs =
-                           (uu___3945_27308.FStar_TypeChecker_Common.lhs);
+                           (uu___3945_27320.FStar_TypeChecker_Common.lhs);
                          FStar_TypeChecker_Common.relation =
-                           (uu___3945_27308.FStar_TypeChecker_Common.relation);
-                         FStar_TypeChecker_Common.rhs = uu____27311;
+                           (uu___3945_27320.FStar_TypeChecker_Common.relation);
+                         FStar_TypeChecker_Common.rhs = uu____27323;
                          FStar_TypeChecker_Common.element =
-                           (uu___3945_27308.FStar_TypeChecker_Common.element);
+                           (uu___3945_27320.FStar_TypeChecker_Common.element);
                          FStar_TypeChecker_Common.logical_guard =
-                           (uu___3945_27308.FStar_TypeChecker_Common.logical_guard);
+                           (uu___3945_27320.FStar_TypeChecker_Common.logical_guard);
                          FStar_TypeChecker_Common.logical_guard_uvar =
-                           (uu___3945_27308.FStar_TypeChecker_Common.logical_guard_uvar);
+                           (uu___3945_27320.FStar_TypeChecker_Common.logical_guard_uvar);
                          FStar_TypeChecker_Common.reason =
-                           (uu___3945_27308.FStar_TypeChecker_Common.reason);
+                           (uu___3945_27320.FStar_TypeChecker_Common.reason);
                          FStar_TypeChecker_Common.loc =
-                           (uu___3945_27308.FStar_TypeChecker_Common.loc);
+                           (uu___3945_27320.FStar_TypeChecker_Common.loc);
                          FStar_TypeChecker_Common.rank =
-                           (uu___3945_27308.FStar_TypeChecker_Common.rank)
+                           (uu___3945_27320.FStar_TypeChecker_Common.rank)
                        } in
-                     solve_c env uu____27305 wl
-                 | (FStar_Syntax_Syntax.Comp uu____27313,
-                    FStar_Syntax_Syntax.Total uu____27314) ->
-                     let uu____27323 =
-                       let uu___3945_27326 = problem in
-                       let uu____27329 =
-                         let uu____27330 =
+                     solve_c env uu____27317 wl
+                 | (FStar_Syntax_Syntax.Comp uu____27325,
+                    FStar_Syntax_Syntax.Total uu____27326) ->
+                     let uu____27335 =
+                       let uu___3945_27338 = problem in
+                       let uu____27341 =
+                         let uu____27342 =
                            FStar_TypeChecker_Env.comp_to_comp_typ env c21 in
                          FStar_All.pipe_left FStar_Syntax_Syntax.mk_Comp
-                           uu____27330 in
+                           uu____27342 in
                        {
                          FStar_TypeChecker_Common.pid =
-                           (uu___3945_27326.FStar_TypeChecker_Common.pid);
+                           (uu___3945_27338.FStar_TypeChecker_Common.pid);
                          FStar_TypeChecker_Common.lhs =
-                           (uu___3945_27326.FStar_TypeChecker_Common.lhs);
+                           (uu___3945_27338.FStar_TypeChecker_Common.lhs);
                          FStar_TypeChecker_Common.relation =
-                           (uu___3945_27326.FStar_TypeChecker_Common.relation);
-                         FStar_TypeChecker_Common.rhs = uu____27329;
+                           (uu___3945_27338.FStar_TypeChecker_Common.relation);
+                         FStar_TypeChecker_Common.rhs = uu____27341;
                          FStar_TypeChecker_Common.element =
-                           (uu___3945_27326.FStar_TypeChecker_Common.element);
+                           (uu___3945_27338.FStar_TypeChecker_Common.element);
                          FStar_TypeChecker_Common.logical_guard =
-                           (uu___3945_27326.FStar_TypeChecker_Common.logical_guard);
+                           (uu___3945_27338.FStar_TypeChecker_Common.logical_guard);
                          FStar_TypeChecker_Common.logical_guard_uvar =
-                           (uu___3945_27326.FStar_TypeChecker_Common.logical_guard_uvar);
+                           (uu___3945_27338.FStar_TypeChecker_Common.logical_guard_uvar);
                          FStar_TypeChecker_Common.reason =
-                           (uu___3945_27326.FStar_TypeChecker_Common.reason);
+                           (uu___3945_27338.FStar_TypeChecker_Common.reason);
                          FStar_TypeChecker_Common.loc =
-                           (uu___3945_27326.FStar_TypeChecker_Common.loc);
+                           (uu___3945_27338.FStar_TypeChecker_Common.loc);
                          FStar_TypeChecker_Common.rank =
-                           (uu___3945_27326.FStar_TypeChecker_Common.rank)
+                           (uu___3945_27338.FStar_TypeChecker_Common.rank)
                        } in
-                     solve_c env uu____27323 wl
-                 | (FStar_Syntax_Syntax.Comp uu____27331,
-                    FStar_Syntax_Syntax.Comp uu____27332) ->
-                     let uu____27333 =
+                     solve_c env uu____27335 wl
+                 | (FStar_Syntax_Syntax.Comp uu____27343,
+                    FStar_Syntax_Syntax.Comp uu____27344) ->
+                     let uu____27345 =
                        (((FStar_Syntax_Util.is_ml_comp c11) &&
                            (FStar_Syntax_Util.is_ml_comp c21))
                           ||
@@ -10578,15 +10578,15 @@ and (solve_c :
                             &&
                             (problem.FStar_TypeChecker_Common.relation =
                                FStar_TypeChecker_Common.SUB)) in
-                     if uu____27333
+                     if uu____27345
                      then
-                       let uu____27334 =
+                       let uu____27346 =
                          problem_using_guard orig
                            (FStar_Syntax_Util.comp_result c11)
                            problem.FStar_TypeChecker_Common.relation
                            (FStar_Syntax_Util.comp_result c21)
                            FStar_Pervasives_Native.None "result type" in
-                       solve_t env uu____27334 wl
+                       solve_t env uu____27346 wl
                      else
                        (let c1_comp =
                           FStar_TypeChecker_Env.comp_to_comp_typ env c11 in
@@ -10596,22 +10596,22 @@ and (solve_c :
                           problem.FStar_TypeChecker_Common.relation =
                             FStar_TypeChecker_Common.EQ
                         then
-                          let uu____27338 =
-                            let uu____27343 =
+                          let uu____27350 =
+                            let uu____27355 =
                               FStar_Ident.lid_equals
                                 c1_comp.FStar_Syntax_Syntax.effect_name
                                 c2_comp.FStar_Syntax_Syntax.effect_name in
-                            if uu____27343
+                            if uu____27355
                             then (c1_comp, c2_comp)
                             else
-                              (let uu____27349 =
+                              (let uu____27361 =
                                  FStar_TypeChecker_Env.unfold_effect_abbrev
                                    env c11 in
-                               let uu____27350 =
+                               let uu____27362 =
                                  FStar_TypeChecker_Env.unfold_effect_abbrev
                                    env c21 in
-                               (uu____27349, uu____27350)) in
-                          match uu____27338 with
+                               (uu____27361, uu____27362)) in
+                          match uu____27350 with
                           | (c1_comp1, c2_comp1) ->
                               solve_eq c1_comp1 c2_comp1
                                 FStar_TypeChecker_Env.trivial_guard
@@ -10622,79 +10622,79 @@ and (solve_c :
                            let c22 =
                              FStar_TypeChecker_Env.unfold_effect_abbrev env
                                c21 in
-                           (let uu____27357 =
+                           (let uu____27369 =
                               FStar_All.pipe_left
                                 (FStar_TypeChecker_Env.debug env)
                                 (FStar_Options.Other "Rel") in
-                            if uu____27357
+                            if uu____27369
                             then
-                              let uu____27358 =
+                              let uu____27370 =
                                 FStar_Ident.string_of_lid
                                   c12.FStar_Syntax_Syntax.effect_name in
-                              let uu____27359 =
+                              let uu____27371 =
                                 FStar_Ident.string_of_lid
                                   c22.FStar_Syntax_Syntax.effect_name in
                               FStar_Util.print2 "solve_c for %s and %s\n"
-                                uu____27358 uu____27359
+                                uu____27370 uu____27371
                             else ());
-                           (let uu____27361 =
+                           (let uu____27373 =
                               FStar_TypeChecker_Env.is_layered_effect env
                                 c22.FStar_Syntax_Syntax.effect_name in
-                            if uu____27361
+                            if uu____27373
                             then solve_layered_sub c12 c22
                             else
-                              (let uu____27363 =
+                              (let uu____27375 =
                                  FStar_TypeChecker_Env.monad_leq env
                                    c12.FStar_Syntax_Syntax.effect_name
                                    c22.FStar_Syntax_Syntax.effect_name in
-                               match uu____27363 with
+                               match uu____27375 with
                                | FStar_Pervasives_Native.None ->
-                                   let uu____27366 =
+                                   let uu____27378 =
                                      mklstr
-                                       (fun uu____27373 ->
-                                          let uu____27374 =
+                                       (fun uu____27385 ->
+                                          let uu____27386 =
                                             FStar_Syntax_Print.lid_to_string
                                               c12.FStar_Syntax_Syntax.effect_name in
-                                          let uu____27375 =
+                                          let uu____27387 =
                                             FStar_Syntax_Print.lid_to_string
                                               c22.FStar_Syntax_Syntax.effect_name in
                                           FStar_Util.format2
                                             "incompatible monad ordering: %s </: %s"
-                                            uu____27374 uu____27375) in
-                                   giveup env uu____27366 orig
+                                            uu____27386 uu____27387) in
+                                   giveup env uu____27378 orig
                                | FStar_Pervasives_Native.Some edge ->
                                    solve_sub c12 edge c22)))))))
 let (print_pending_implicits :
   FStar_TypeChecker_Common.guard_t -> Prims.string) =
   fun g ->
-    let uu____27382 =
+    let uu____27394 =
       FStar_All.pipe_right g.FStar_TypeChecker_Common.implicits
         (FStar_List.map
            (fun i ->
               FStar_Syntax_Print.term_to_string
                 i.FStar_TypeChecker_Common.imp_tm)) in
-    FStar_All.pipe_right uu____27382 (FStar_String.concat ", ")
+    FStar_All.pipe_right uu____27394 (FStar_String.concat ", ")
 let (ineqs_to_string :
   (FStar_Syntax_Syntax.universe Prims.list * (FStar_Syntax_Syntax.universe *
     FStar_Syntax_Syntax.universe) Prims.list) -> Prims.string)
   =
   fun ineqs ->
     let vars =
-      let uu____27423 =
+      let uu____27435 =
         FStar_All.pipe_right (FStar_Pervasives_Native.fst ineqs)
           (FStar_List.map FStar_Syntax_Print.univ_to_string) in
-      FStar_All.pipe_right uu____27423 (FStar_String.concat ", ") in
+      FStar_All.pipe_right uu____27435 (FStar_String.concat ", ") in
     let ineqs1 =
-      let uu____27441 =
+      let uu____27453 =
         FStar_All.pipe_right (FStar_Pervasives_Native.snd ineqs)
           (FStar_List.map
-             (fun uu____27469 ->
-                match uu____27469 with
+             (fun uu____27481 ->
+                match uu____27481 with
                 | (u1, u2) ->
-                    let uu____27476 = FStar_Syntax_Print.univ_to_string u1 in
-                    let uu____27477 = FStar_Syntax_Print.univ_to_string u2 in
-                    FStar_Util.format2 "%s < %s" uu____27476 uu____27477)) in
-      FStar_All.pipe_right uu____27441 (FStar_String.concat ", ") in
+                    let uu____27488 = FStar_Syntax_Print.univ_to_string u1 in
+                    let uu____27489 = FStar_Syntax_Print.univ_to_string u2 in
+                    FStar_Util.format2 "%s < %s" uu____27488 uu____27489)) in
+      FStar_All.pipe_right uu____27453 (FStar_String.concat ", ") in
     FStar_Util.format2 "Solving for {%s}; inequalities are {%s}" vars ineqs1
 let (guard_to_string :
   FStar_TypeChecker_Env.env ->
@@ -10706,43 +10706,43 @@ let (guard_to_string :
               (g.FStar_TypeChecker_Common.deferred),
               (g.FStar_TypeChecker_Common.univ_ineqs))
       with
-      | (FStar_TypeChecker_Common.Trivial, [], (uu____27504, [])) when
-          let uu____27529 = FStar_Options.print_implicits () in
-          Prims.op_Negation uu____27529 -> "{}"
-      | uu____27530 ->
+      | (FStar_TypeChecker_Common.Trivial, [], (uu____27516, [])) when
+          let uu____27541 = FStar_Options.print_implicits () in
+          Prims.op_Negation uu____27541 -> "{}"
+      | uu____27542 ->
           let form =
             match g.FStar_TypeChecker_Common.guard_f with
             | FStar_TypeChecker_Common.Trivial -> "trivial"
             | FStar_TypeChecker_Common.NonTrivial f ->
-                let uu____27553 =
+                let uu____27565 =
                   ((FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
                       (FStar_Options.Other "Rel"))
                      ||
                      (FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
                         FStar_Options.Extreme))
                     || (FStar_Options.print_implicits ()) in
-                if uu____27553
+                if uu____27565
                 then FStar_TypeChecker_Normalize.term_to_string env f
                 else "non-trivial" in
           let carry defs =
-            let uu____27573 =
+            let uu____27585 =
               FStar_List.map
-                (fun uu____27584 ->
-                   match uu____27584 with
+                (fun uu____27596 ->
+                   match uu____27596 with
                    | (msg, x) ->
-                       let uu____27591 =
-                         let uu____27592 = prob_to_string env x in
-                         Prims.op_Hat ": " uu____27592 in
-                       Prims.op_Hat msg uu____27591) defs in
-            FStar_All.pipe_right uu____27573 (FStar_String.concat ",\n") in
+                       let uu____27603 =
+                         let uu____27604 = prob_to_string env x in
+                         Prims.op_Hat ": " uu____27604 in
+                       Prims.op_Hat msg uu____27603) defs in
+            FStar_All.pipe_right uu____27585 (FStar_String.concat ",\n") in
           let imps = print_pending_implicits g in
-          let uu____27596 = carry g.FStar_TypeChecker_Common.deferred in
-          let uu____27597 = carry g.FStar_TypeChecker_Common.deferred_to_tac in
-          let uu____27598 =
+          let uu____27608 = carry g.FStar_TypeChecker_Common.deferred in
+          let uu____27609 = carry g.FStar_TypeChecker_Common.deferred_to_tac in
+          let uu____27610 =
             ineqs_to_string g.FStar_TypeChecker_Common.univ_ineqs in
           FStar_Util.format5
             "\n\t{guard_f=%s;\n\t deferred={\n%s};\n\t deferred_to_tac={\n%s};\n\t univ_ineqs={%s};\n\t implicits={%s}}\n"
-            form uu____27596 uu____27597 uu____27598 imps
+            form uu____27608 uu____27609 uu____27610 imps
 let (new_t_problem :
   worklist ->
     FStar_TypeChecker_Env.env ->
@@ -10760,24 +10760,24 @@ let (new_t_problem :
             fun elt ->
               fun loc ->
                 let reason =
-                  let uu____27651 =
+                  let uu____27663 =
                     (FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
                        (FStar_Options.Other "ExplainRel"))
                       ||
                       (FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
                          (FStar_Options.Other "Rel")) in
-                  if uu____27651
+                  if uu____27663
                   then
-                    let uu____27652 =
+                    let uu____27664 =
                       FStar_TypeChecker_Normalize.term_to_string env lhs in
-                    let uu____27653 =
+                    let uu____27665 =
                       FStar_TypeChecker_Normalize.term_to_string env rhs in
-                    FStar_Util.format3 "Top-level:\n%s\n\t%s\n%s" uu____27652
-                      (rel_to_string rel) uu____27653
+                    FStar_Util.format3 "Top-level:\n%s\n\t%s\n%s" uu____27664
+                      (rel_to_string rel) uu____27665
                   else "TOP" in
-                let uu____27655 =
+                let uu____27667 =
                   new_problem wl env lhs rel rhs elt loc reason in
-                match uu____27655 with
+                match uu____27667 with
                 | (p, wl1) ->
                     (def_check_prob (Prims.op_Hat "new_t_problem." reason)
                        (FStar_TypeChecker_Common.TProb p);
@@ -10797,17 +10797,17 @@ let (new_t_prob :
         fun rel ->
           fun t2 ->
             let x =
-              let uu____27713 =
-                let uu____27716 = FStar_TypeChecker_Env.get_range env in
+              let uu____27725 =
+                let uu____27728 = FStar_TypeChecker_Env.get_range env in
                 FStar_All.pipe_left
-                  (fun uu____27719 ->
-                     FStar_Pervasives_Native.Some uu____27719) uu____27716 in
-              FStar_Syntax_Syntax.new_bv uu____27713 t1 in
-            let uu____27720 =
-              let uu____27725 = FStar_TypeChecker_Env.get_range env in
+                  (fun uu____27731 ->
+                     FStar_Pervasives_Native.Some uu____27731) uu____27728 in
+              FStar_Syntax_Syntax.new_bv uu____27725 t1 in
+            let uu____27732 =
+              let uu____27737 = FStar_TypeChecker_Env.get_range env in
               new_t_problem wl env t1 rel t2 (FStar_Pervasives_Native.Some x)
-                uu____27725 in
-            match uu____27720 with | (p, wl1) -> (p, x, wl1)
+                uu____27737 in
+            match uu____27732 with | (p, wl1) -> (p, x, wl1)
 let (solve_and_commit :
   FStar_TypeChecker_Env.env ->
     worklist ->
@@ -10824,60 +10824,60 @@ let (solve_and_commit :
     fun probs ->
       fun err ->
         let tx = FStar_Syntax_Unionfind.new_transaction () in
-        (let uu____27796 =
+        (let uu____27808 =
            FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
              (FStar_Options.Other "RelBench") in
-         if uu____27796
+         if uu____27808
          then
-           let uu____27797 =
+           let uu____27809 =
              FStar_Common.string_of_list
                (fun p -> FStar_Util.string_of_int (p_pid p)) probs.attempting in
-           FStar_Util.print1 "solving problems %s {\n" uu____27797
+           FStar_Util.print1 "solving problems %s {\n" uu____27809
          else ());
-        (let uu____27801 =
-           FStar_Util.record_time (fun uu____27807 -> solve env probs) in
-         match uu____27801 with
+        (let uu____27813 =
+           FStar_Util.record_time (fun uu____27819 -> solve env probs) in
+         match uu____27813 with
          | (sol, ms) ->
-             ((let uu____27819 =
+             ((let uu____27831 =
                  FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
                    (FStar_Options.Other "RelBench") in
-               if uu____27819
+               if uu____27831
                then
-                 let uu____27820 = FStar_Util.string_of_int ms in
-                 FStar_Util.print1 "} solved in %s ms\n" uu____27820
+                 let uu____27832 = FStar_Util.string_of_int ms in
+                 FStar_Util.print1 "} solved in %s ms\n" uu____27832
                else ());
               (match sol with
                | Success (deferred, defer_to_tac, implicits) ->
-                   let uu____27833 =
+                   let uu____27845 =
                      FStar_Util.record_time
-                       (fun uu____27839 -> FStar_Syntax_Unionfind.commit tx) in
-                   (match uu____27833 with
+                       (fun uu____27851 -> FStar_Syntax_Unionfind.commit tx) in
+                   (match uu____27845 with
                     | ((), ms1) ->
-                        ((let uu____27850 =
+                        ((let uu____27862 =
                             FStar_All.pipe_left
                               (FStar_TypeChecker_Env.debug env)
                               (FStar_Options.Other "RelBench") in
-                          if uu____27850
+                          if uu____27862
                           then
-                            let uu____27851 = FStar_Util.string_of_int ms1 in
+                            let uu____27863 = FStar_Util.string_of_int ms1 in
                             FStar_Util.print1 "committed in %s ms\n"
-                              uu____27851
+                              uu____27863
                           else ());
                          FStar_Pervasives_Native.Some
                            (deferred, defer_to_tac, implicits)))
                | Failed (d, s) ->
-                   ((let uu____27862 =
+                   ((let uu____27874 =
                        (FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
                           (FStar_Options.Other "ExplainRel"))
                          ||
                          (FStar_All.pipe_left
                             (FStar_TypeChecker_Env.debug env)
                             (FStar_Options.Other "Rel")) in
-                     if uu____27862
+                     if uu____27874
                      then
-                       let uu____27863 = explain env d s in
+                       let uu____27875 = explain env d s in
                        FStar_All.pipe_left FStar_Util.print_string
-                         uu____27863
+                         uu____27875
                      else ());
                     (let result = err (d, s) in
                      FStar_Syntax_Unionfind.rollback tx; result)))))
@@ -10890,13 +10890,13 @@ let (simplify_guard :
       match g.FStar_TypeChecker_Common.guard_f with
       | FStar_TypeChecker_Common.Trivial -> g
       | FStar_TypeChecker_Common.NonTrivial f ->
-          ((let uu____27887 =
+          ((let uu____27899 =
               FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
                 (FStar_Options.Other "Simplification") in
-            if uu____27887
+            if uu____27899
             then
-              let uu____27888 = FStar_Syntax_Print.term_to_string f in
-              FStar_Util.print1 "Simplifying guard %s\n" uu____27888
+              let uu____27900 = FStar_Syntax_Print.term_to_string f in
+              FStar_Util.print1 "Simplifying guard %s\n" uu____27900
             else ());
            (let f1 =
               norm_with_steps "FStar.TypeChecker.Rel.norm_with_steps.6"
@@ -10905,35 +10905,35 @@ let (simplify_guard :
                 FStar_TypeChecker_Env.Simplify;
                 FStar_TypeChecker_Env.Primops;
                 FStar_TypeChecker_Env.NoFullNorm] env f in
-            (let uu____27892 =
+            (let uu____27904 =
                FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
                  (FStar_Options.Other "Simplification") in
-             if uu____27892
+             if uu____27904
              then
-               let uu____27893 = FStar_Syntax_Print.term_to_string f1 in
-               FStar_Util.print1 "Simplified guard to %s\n" uu____27893
+               let uu____27905 = FStar_Syntax_Print.term_to_string f1 in
+               FStar_Util.print1 "Simplified guard to %s\n" uu____27905
              else ());
             (let f2 =
-               let uu____27896 =
-                 let uu____27897 = FStar_Syntax_Util.unmeta f1 in
-                 uu____27897.FStar_Syntax_Syntax.n in
-               match uu____27896 with
+               let uu____27908 =
+                 let uu____27909 = FStar_Syntax_Util.unmeta f1 in
+                 uu____27909.FStar_Syntax_Syntax.n in
+               match uu____27908 with
                | FStar_Syntax_Syntax.Tm_fvar fv when
                    FStar_Syntax_Syntax.fv_eq_lid fv
                      FStar_Parser_Const.true_lid
                    -> FStar_TypeChecker_Common.Trivial
-               | uu____27901 -> FStar_TypeChecker_Common.NonTrivial f1 in
-             let uu___4065_27902 = g in
+               | uu____27913 -> FStar_TypeChecker_Common.NonTrivial f1 in
+             let uu___4065_27914 = g in
              {
                FStar_TypeChecker_Common.guard_f = f2;
                FStar_TypeChecker_Common.deferred_to_tac =
-                 (uu___4065_27902.FStar_TypeChecker_Common.deferred_to_tac);
+                 (uu___4065_27914.FStar_TypeChecker_Common.deferred_to_tac);
                FStar_TypeChecker_Common.deferred =
-                 (uu___4065_27902.FStar_TypeChecker_Common.deferred);
+                 (uu___4065_27914.FStar_TypeChecker_Common.deferred);
                FStar_TypeChecker_Common.univ_ineqs =
-                 (uu___4065_27902.FStar_TypeChecker_Common.univ_ineqs);
+                 (uu___4065_27914.FStar_TypeChecker_Common.univ_ineqs);
                FStar_TypeChecker_Common.implicits =
-                 (uu___4065_27902.FStar_TypeChecker_Common.implicits)
+                 (uu___4065_27914.FStar_TypeChecker_Common.implicits)
              })))
 let (with_guard :
   FStar_TypeChecker_Env.env ->
@@ -10948,26 +10948,26 @@ let (with_guard :
         match dopt with
         | FStar_Pervasives_Native.None -> FStar_Pervasives_Native.None
         | FStar_Pervasives_Native.Some (deferred, defer_to_tac, implicits) ->
-            let uu____27953 =
-              let uu____27954 =
-                let uu____27955 =
+            let uu____27965 =
+              let uu____27966 =
+                let uu____27967 =
                   FStar_All.pipe_right (p_guard prob)
-                    (fun uu____27956 ->
-                       FStar_TypeChecker_Common.NonTrivial uu____27956) in
+                    (fun uu____27968 ->
+                       FStar_TypeChecker_Common.NonTrivial uu____27968) in
                 {
-                  FStar_TypeChecker_Common.guard_f = uu____27955;
+                  FStar_TypeChecker_Common.guard_f = uu____27967;
                   FStar_TypeChecker_Common.deferred_to_tac = defer_to_tac;
                   FStar_TypeChecker_Common.deferred = deferred;
                   FStar_TypeChecker_Common.univ_ineqs = ([], []);
                   FStar_TypeChecker_Common.implicits = implicits
                 } in
-              simplify_guard env uu____27954 in
+              simplify_guard env uu____27966 in
             FStar_All.pipe_left
-              (fun uu____27963 -> FStar_Pervasives_Native.Some uu____27963)
-              uu____27953
+              (fun uu____27975 -> FStar_Pervasives_Native.Some uu____27975)
+              uu____27965
 let with_guard_no_simp :
-  'uuuuuu27972 .
-    'uuuuuu27972 ->
+  'uuuuuu27984 .
+    'uuuuuu27984 ->
       FStar_TypeChecker_Common.prob ->
         (FStar_TypeChecker_Common.deferred *
           FStar_TypeChecker_Common.deferred *
@@ -10980,19 +10980,19 @@ let with_guard_no_simp :
         match dopt with
         | FStar_Pervasives_Native.None -> FStar_Pervasives_Native.None
         | FStar_Pervasives_Native.Some (deferred, defer_to_tac, implicits) ->
-            let uu____28021 =
-              let uu____28022 =
+            let uu____28033 =
+              let uu____28034 =
                 FStar_All.pipe_right (p_guard prob)
-                  (fun uu____28023 ->
-                     FStar_TypeChecker_Common.NonTrivial uu____28023) in
+                  (fun uu____28035 ->
+                     FStar_TypeChecker_Common.NonTrivial uu____28035) in
               {
-                FStar_TypeChecker_Common.guard_f = uu____28022;
+                FStar_TypeChecker_Common.guard_f = uu____28034;
                 FStar_TypeChecker_Common.deferred_to_tac = defer_to_tac;
                 FStar_TypeChecker_Common.deferred = deferred;
                 FStar_TypeChecker_Common.univ_ineqs = ([], []);
                 FStar_TypeChecker_Common.implicits = implicits
               } in
-            FStar_Pervasives_Native.Some uu____28021
+            FStar_Pervasives_Native.Some uu____28033
 let (try_teq :
   Prims.bool ->
     FStar_TypeChecker_Env.env ->
@@ -11004,36 +11004,36 @@ let (try_teq :
     fun env ->
       fun t1 ->
         fun t2 ->
-          (let uu____28053 =
+          (let uu____28065 =
              FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
                (FStar_Options.Other "Rel") in
-           if uu____28053
+           if uu____28065
            then
-             let uu____28054 = FStar_Syntax_Print.term_to_string t1 in
-             let uu____28055 = FStar_Syntax_Print.term_to_string t2 in
-             FStar_Util.print2 "try_teq of %s and %s {\n" uu____28054
-               uu____28055
+             let uu____28066 = FStar_Syntax_Print.term_to_string t1 in
+             let uu____28067 = FStar_Syntax_Print.term_to_string t2 in
+             FStar_Util.print2 "try_teq of %s and %s {\n" uu____28066
+               uu____28067
            else ());
-          (let uu____28057 =
-             let uu____28062 = FStar_TypeChecker_Env.get_range env in
+          (let uu____28069 =
+             let uu____28074 = FStar_TypeChecker_Env.get_range env in
              new_t_problem (empty_worklist env) env t1
                FStar_TypeChecker_Common.EQ t2 FStar_Pervasives_Native.None
-               uu____28062 in
-           match uu____28057 with
+               uu____28074 in
+           match uu____28069 with
            | (prob, wl) ->
                let g =
-                 let uu____28070 =
+                 let uu____28082 =
                    solve_and_commit env (singleton wl prob smt_ok)
-                     (fun uu____28080 -> FStar_Pervasives_Native.None) in
-                 FStar_All.pipe_left (with_guard env prob) uu____28070 in
-               ((let uu____28102 =
+                     (fun uu____28092 -> FStar_Pervasives_Native.None) in
+                 FStar_All.pipe_left (with_guard env prob) uu____28082 in
+               ((let uu____28114 =
                    FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
                      (FStar_Options.Other "Rel") in
-                 if uu____28102
+                 if uu____28114
                  then
-                   let uu____28103 =
+                   let uu____28115 =
                      FStar_Common.string_of_option (guard_to_string env) g in
-                   FStar_Util.print1 "} res = %s\n" uu____28103
+                   FStar_Util.print1 "} res = %s\n" uu____28115
                  else ());
                 g))
 let (teq :
@@ -11044,27 +11044,27 @@ let (teq :
   fun env ->
     fun t1 ->
       fun t2 ->
-        let uu____28120 = try_teq true env t1 t2 in
-        match uu____28120 with
+        let uu____28132 = try_teq true env t1 t2 in
+        match uu____28132 with
         | FStar_Pervasives_Native.None ->
-            ((let uu____28124 = FStar_TypeChecker_Env.get_range env in
-              let uu____28125 =
+            ((let uu____28136 = FStar_TypeChecker_Env.get_range env in
+              let uu____28137 =
                 FStar_TypeChecker_Err.basic_type_error env
                   FStar_Pervasives_Native.None t2 t1 in
-              FStar_Errors.log_issue uu____28124 uu____28125);
+              FStar_Errors.log_issue uu____28136 uu____28137);
              FStar_TypeChecker_Common.trivial_guard)
         | FStar_Pervasives_Native.Some g ->
-            ((let uu____28132 =
+            ((let uu____28144 =
                 FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
                   (FStar_Options.Other "Rel") in
-              if uu____28132
+              if uu____28144
               then
-                let uu____28133 = FStar_Syntax_Print.term_to_string t1 in
-                let uu____28134 = FStar_Syntax_Print.term_to_string t2 in
-                let uu____28135 = guard_to_string env g in
+                let uu____28145 = FStar_Syntax_Print.term_to_string t1 in
+                let uu____28146 = FStar_Syntax_Print.term_to_string t2 in
+                let uu____28147 = guard_to_string env g in
                 FStar_Util.print3
-                  "teq of %s and %s succeeded with guard %s\n" uu____28133
-                  uu____28134 uu____28135
+                  "teq of %s and %s succeeded with guard %s\n" uu____28145
+                  uu____28146 uu____28147
               else ());
              g)
 let (get_teq_predicate :
@@ -11076,42 +11076,42 @@ let (get_teq_predicate :
   fun env ->
     fun t1 ->
       fun t2 ->
-        (let uu____28155 =
+        (let uu____28167 =
            FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
              (FStar_Options.Other "Rel") in
-         if uu____28155
+         if uu____28167
          then
-           let uu____28156 = FStar_Syntax_Print.term_to_string t1 in
-           let uu____28157 = FStar_Syntax_Print.term_to_string t2 in
-           FStar_Util.print2 "get_teq_predicate of %s and %s {\n" uu____28156
-             uu____28157
+           let uu____28168 = FStar_Syntax_Print.term_to_string t1 in
+           let uu____28169 = FStar_Syntax_Print.term_to_string t2 in
+           FStar_Util.print2 "get_teq_predicate of %s and %s {\n" uu____28168
+             uu____28169
          else ());
-        (let uu____28159 =
+        (let uu____28171 =
            new_t_prob (empty_worklist env) env t1 FStar_TypeChecker_Common.EQ
              t2 in
-         match uu____28159 with
+         match uu____28171 with
          | (prob, x, wl) ->
              let g =
-               let uu____28174 =
+               let uu____28186 =
                  solve_and_commit env (singleton wl prob true)
-                   (fun uu____28184 -> FStar_Pervasives_Native.None) in
-               FStar_All.pipe_left (with_guard env prob) uu____28174 in
-             ((let uu____28206 =
+                   (fun uu____28196 -> FStar_Pervasives_Native.None) in
+               FStar_All.pipe_left (with_guard env prob) uu____28186 in
+             ((let uu____28218 =
                  FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
                    (FStar_Options.Other "Rel") in
-               if uu____28206
+               if uu____28218
                then
-                 let uu____28207 =
+                 let uu____28219 =
                    FStar_Common.string_of_option (guard_to_string env) g in
-                 FStar_Util.print1 "} res teq predicate = %s\n" uu____28207
+                 FStar_Util.print1 "} res teq predicate = %s\n" uu____28219
                else ());
               (match g with
                | FStar_Pervasives_Native.None -> FStar_Pervasives_Native.None
                | FStar_Pervasives_Native.Some g1 ->
-                   let uu____28212 =
-                     let uu____28213 = FStar_Syntax_Syntax.mk_binder x in
-                     FStar_TypeChecker_Env.abstract_guard uu____28213 g1 in
-                   FStar_Pervasives_Native.Some uu____28212)))
+                   let uu____28224 =
+                     let uu____28225 = FStar_Syntax_Syntax.mk_binder x in
+                     FStar_TypeChecker_Env.abstract_guard uu____28225 g1 in
+                   FStar_Pervasives_Native.Some uu____28224)))
 let (subtype_fail :
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.term ->
@@ -11121,11 +11121,11 @@ let (subtype_fail :
     fun e ->
       fun t1 ->
         fun t2 ->
-          let uu____28234 = FStar_TypeChecker_Env.get_range env in
-          let uu____28235 =
+          let uu____28246 = FStar_TypeChecker_Env.get_range env in
+          let uu____28247 =
             FStar_TypeChecker_Err.basic_type_error env
               (FStar_Pervasives_Native.Some e) t2 t1 in
-          FStar_Errors.log_issue uu____28234 uu____28235
+          FStar_Errors.log_issue uu____28246 uu____28247
 let (sub_comp :
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.comp ->
@@ -11139,62 +11139,62 @@ let (sub_comp :
           if env.FStar_TypeChecker_Env.use_eq
           then FStar_TypeChecker_Common.EQ
           else FStar_TypeChecker_Common.SUB in
-        (let uu____28260 =
+        (let uu____28272 =
            FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
              (FStar_Options.Other "Rel") in
-         if uu____28260
+         if uu____28272
          then
-           let uu____28261 = FStar_Syntax_Print.comp_to_string c1 in
-           let uu____28262 = FStar_Syntax_Print.comp_to_string c2 in
+           let uu____28273 = FStar_Syntax_Print.comp_to_string c1 in
+           let uu____28274 = FStar_Syntax_Print.comp_to_string c2 in
            FStar_Util.print3 "sub_comp of %s --and-- %s --with-- %s\n"
-             uu____28261 uu____28262
+             uu____28273 uu____28274
              (if rel = FStar_TypeChecker_Common.EQ then "EQ" else "SUB")
          else ());
-        (let uu____28265 =
-           let uu____28272 = FStar_TypeChecker_Env.get_range env in
+        (let uu____28277 =
+           let uu____28284 = FStar_TypeChecker_Env.get_range env in
            new_problem (empty_worklist env) env c1 rel c2
-             FStar_Pervasives_Native.None uu____28272 "sub_comp" in
-         match uu____28265 with
+             FStar_Pervasives_Native.None uu____28284 "sub_comp" in
+         match uu____28277 with
          | (prob, wl) ->
              let wl1 =
-               let uu___4138_28282 = wl in
+               let uu___4138_28294 = wl in
                {
-                 attempting = (uu___4138_28282.attempting);
-                 wl_deferred = (uu___4138_28282.wl_deferred);
-                 wl_deferred_to_tac = (uu___4138_28282.wl_deferred_to_tac);
-                 ctr = (uu___4138_28282.ctr);
-                 defer_ok = (uu___4138_28282.defer_ok);
-                 smt_ok = (uu___4138_28282.smt_ok);
-                 umax_heuristic_ok = (uu___4138_28282.umax_heuristic_ok);
-                 tcenv = (uu___4138_28282.tcenv);
-                 wl_implicits = (uu___4138_28282.wl_implicits);
+                 attempting = (uu___4138_28294.attempting);
+                 wl_deferred = (uu___4138_28294.wl_deferred);
+                 wl_deferred_to_tac = (uu___4138_28294.wl_deferred_to_tac);
+                 ctr = (uu___4138_28294.ctr);
+                 defer_ok = (uu___4138_28294.defer_ok);
+                 smt_ok = (uu___4138_28294.smt_ok);
+                 umax_heuristic_ok = (uu___4138_28294.umax_heuristic_ok);
+                 tcenv = (uu___4138_28294.tcenv);
+                 wl_implicits = (uu___4138_28294.wl_implicits);
                  repr_subcomp_allowed = true
                } in
              let prob1 = FStar_TypeChecker_Common.CProb prob in
              (def_check_prob "sub_comp" prob1;
-              (let uu____28285 =
+              (let uu____28297 =
                  FStar_Util.record_time
-                   (fun uu____28296 ->
-                      let uu____28297 =
+                   (fun uu____28308 ->
+                      let uu____28309 =
                         solve_and_commit env (singleton wl1 prob1 true)
-                          (fun uu____28307 -> FStar_Pervasives_Native.None) in
-                      FStar_All.pipe_left (with_guard env prob1) uu____28297) in
-               match uu____28285 with
+                          (fun uu____28319 -> FStar_Pervasives_Native.None) in
+                      FStar_All.pipe_left (with_guard env prob1) uu____28309) in
+               match uu____28297 with
                | (r, ms) ->
-                   ((let uu____28337 =
+                   ((let uu____28349 =
                        FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
                          (FStar_Options.Other "RelBench") in
-                     if uu____28337
+                     if uu____28349
                      then
-                       let uu____28338 = FStar_Syntax_Print.comp_to_string c1 in
-                       let uu____28339 = FStar_Syntax_Print.comp_to_string c2 in
-                       let uu____28340 = FStar_Util.string_of_int ms in
+                       let uu____28350 = FStar_Syntax_Print.comp_to_string c1 in
+                       let uu____28351 = FStar_Syntax_Print.comp_to_string c2 in
+                       let uu____28352 = FStar_Util.string_of_int ms in
                        FStar_Util.print4
                          "sub_comp of %s --and-- %s --with-- %s --- solved in %s ms\n"
-                         uu____28338 uu____28339
+                         uu____28350 uu____28351
                          (if rel = FStar_TypeChecker_Common.EQ
                           then "EQ"
-                          else "SUB") uu____28340
+                          else "SUB") uu____28352
                      else ());
                     r))))
 let (solve_universe_inequalities' :
@@ -11206,91 +11206,91 @@ let (solve_universe_inequalities' :
   =
   fun tx ->
     fun env ->
-      fun uu____28369 ->
-        match uu____28369 with
+      fun uu____28381 ->
+        match uu____28381 with
         | (variables, ineqs) ->
             let fail u1 u2 =
               FStar_Syntax_Unionfind.rollback tx;
-              (let uu____28412 =
-                 let uu____28417 =
-                   let uu____28418 = FStar_Syntax_Print.univ_to_string u1 in
-                   let uu____28419 = FStar_Syntax_Print.univ_to_string u2 in
+              (let uu____28424 =
+                 let uu____28429 =
+                   let uu____28430 = FStar_Syntax_Print.univ_to_string u1 in
+                   let uu____28431 = FStar_Syntax_Print.univ_to_string u2 in
                    FStar_Util.format2 "Universe %s and %s are incompatible"
-                     uu____28418 uu____28419 in
-                 (FStar_Errors.Fatal_IncompatibleUniverse, uu____28417) in
-               let uu____28420 = FStar_TypeChecker_Env.get_range env in
-               FStar_Errors.raise_error uu____28412 uu____28420) in
+                     uu____28430 uu____28431 in
+                 (FStar_Errors.Fatal_IncompatibleUniverse, uu____28429) in
+               let uu____28432 = FStar_TypeChecker_Env.get_range env in
+               FStar_Errors.raise_error uu____28424 uu____28432) in
             let equiv v v' =
-              let uu____28432 =
-                let uu____28437 = FStar_Syntax_Subst.compress_univ v in
-                let uu____28438 = FStar_Syntax_Subst.compress_univ v' in
-                (uu____28437, uu____28438) in
-              match uu____28432 with
+              let uu____28444 =
+                let uu____28449 = FStar_Syntax_Subst.compress_univ v in
+                let uu____28450 = FStar_Syntax_Subst.compress_univ v' in
+                (uu____28449, uu____28450) in
+              match uu____28444 with
               | (FStar_Syntax_Syntax.U_unif v0, FStar_Syntax_Syntax.U_unif
                  v0') -> FStar_Syntax_Unionfind.univ_equiv v0 v0'
-              | uu____28461 -> false in
+              | uu____28473 -> false in
             let sols =
               FStar_All.pipe_right variables
                 (FStar_List.collect
                    (fun v ->
-                      let uu____28491 = FStar_Syntax_Subst.compress_univ v in
-                      match uu____28491 with
-                      | FStar_Syntax_Syntax.U_unif uu____28498 ->
+                      let uu____28503 = FStar_Syntax_Subst.compress_univ v in
+                      match uu____28503 with
+                      | FStar_Syntax_Syntax.U_unif uu____28510 ->
                           let lower_bounds_of_v =
                             FStar_All.pipe_right ineqs
                               (FStar_List.collect
-                                 (fun uu____28529 ->
-                                    match uu____28529 with
+                                 (fun uu____28541 ->
+                                    match uu____28541 with
                                     | (u, v') ->
-                                        let uu____28538 = equiv v v' in
-                                        if uu____28538
+                                        let uu____28550 = equiv v v' in
+                                        if uu____28550
                                         then
-                                          let uu____28541 =
+                                          let uu____28553 =
                                             FStar_All.pipe_right variables
                                               (FStar_Util.for_some (equiv u)) in
-                                          (if uu____28541 then [] else [u])
+                                          (if uu____28553 then [] else [u])
                                         else [])) in
                           let lb =
                             FStar_TypeChecker_Normalize.normalize_universe
                               env
                               (FStar_Syntax_Syntax.U_max lower_bounds_of_v) in
                           [(lb, v)]
-                      | uu____28557 -> [])) in
-            let uu____28562 =
+                      | uu____28569 -> [])) in
+            let uu____28574 =
               let wl =
-                let uu___4181_28566 = empty_worklist env in
+                let uu___4181_28578 = empty_worklist env in
                 {
-                  attempting = (uu___4181_28566.attempting);
-                  wl_deferred = (uu___4181_28566.wl_deferred);
-                  wl_deferred_to_tac = (uu___4181_28566.wl_deferred_to_tac);
-                  ctr = (uu___4181_28566.ctr);
+                  attempting = (uu___4181_28578.attempting);
+                  wl_deferred = (uu___4181_28578.wl_deferred);
+                  wl_deferred_to_tac = (uu___4181_28578.wl_deferred_to_tac);
+                  ctr = (uu___4181_28578.ctr);
                   defer_ok = false;
-                  smt_ok = (uu___4181_28566.smt_ok);
-                  umax_heuristic_ok = (uu___4181_28566.umax_heuristic_ok);
-                  tcenv = (uu___4181_28566.tcenv);
-                  wl_implicits = (uu___4181_28566.wl_implicits);
+                  smt_ok = (uu___4181_28578.smt_ok);
+                  umax_heuristic_ok = (uu___4181_28578.umax_heuristic_ok);
+                  tcenv = (uu___4181_28578.tcenv);
+                  wl_implicits = (uu___4181_28578.wl_implicits);
                   repr_subcomp_allowed =
-                    (uu___4181_28566.repr_subcomp_allowed)
+                    (uu___4181_28578.repr_subcomp_allowed)
                 } in
               FStar_All.pipe_right sols
                 (FStar_List.map
-                   (fun uu____28584 ->
-                      match uu____28584 with
+                   (fun uu____28596 ->
+                      match uu____28596 with
                       | (lb, v) ->
-                          let uu____28591 =
+                          let uu____28603 =
                             solve_universe_eq (~- Prims.int_one) wl lb v in
-                          (match uu____28591 with
+                          (match uu____28603 with
                            | USolved wl1 -> ()
-                           | uu____28593 -> fail lb v))) in
-            let rec check_ineq uu____28603 =
-              match uu____28603 with
+                           | uu____28605 -> fail lb v))) in
+            let rec check_ineq uu____28615 =
+              match uu____28615 with
               | (u, v) ->
                   let u1 =
                     FStar_TypeChecker_Normalize.normalize_universe env u in
                   let v1 =
                     FStar_TypeChecker_Normalize.normalize_universe env v in
                   (match (u1, v1) with
-                   | (FStar_Syntax_Syntax.U_zero, uu____28612) -> true
+                   | (FStar_Syntax_Syntax.U_zero, uu____28624) -> true
                    | (FStar_Syntax_Syntax.U_succ u0,
                       FStar_Syntax_Syntax.U_succ v0) -> check_ineq (u0, v0)
                    | (FStar_Syntax_Syntax.U_name u0,
@@ -11299,64 +11299,64 @@ let (solve_universe_inequalities' :
                    | (FStar_Syntax_Syntax.U_unif u0,
                       FStar_Syntax_Syntax.U_unif v0) ->
                        FStar_Syntax_Unionfind.univ_equiv u0 v0
-                   | (FStar_Syntax_Syntax.U_name uu____28639,
+                   | (FStar_Syntax_Syntax.U_name uu____28651,
                       FStar_Syntax_Syntax.U_succ v0) -> check_ineq (u1, v0)
-                   | (FStar_Syntax_Syntax.U_unif uu____28641,
+                   | (FStar_Syntax_Syntax.U_unif uu____28653,
                       FStar_Syntax_Syntax.U_succ v0) -> check_ineq (u1, v0)
-                   | (FStar_Syntax_Syntax.U_max us, uu____28654) ->
+                   | (FStar_Syntax_Syntax.U_max us, uu____28666) ->
                        FStar_All.pipe_right us
                          (FStar_Util.for_all (fun u2 -> check_ineq (u2, v1)))
-                   | (uu____28661, FStar_Syntax_Syntax.U_max vs) ->
+                   | (uu____28673, FStar_Syntax_Syntax.U_max vs) ->
                        FStar_All.pipe_right vs
                          (FStar_Util.for_some (fun v2 -> check_ineq (u1, v2)))
-                   | uu____28669 -> false) in
-            let uu____28674 =
+                   | uu____28681 -> false) in
+            let uu____28686 =
               FStar_All.pipe_right ineqs
                 (FStar_Util.for_all
-                   (fun uu____28689 ->
-                      match uu____28689 with
+                   (fun uu____28701 ->
+                      match uu____28701 with
                       | (u, v) ->
-                          let uu____28696 = check_ineq (u, v) in
-                          if uu____28696
+                          let uu____28708 = check_ineq (u, v) in
+                          if uu____28708
                           then true
                           else
-                            ((let uu____28699 =
+                            ((let uu____28711 =
                                 FStar_All.pipe_left
                                   (FStar_TypeChecker_Env.debug env)
                                   (FStar_Options.Other "GenUniverses") in
-                              if uu____28699
+                              if uu____28711
                               then
-                                let uu____28700 =
+                                let uu____28712 =
                                   FStar_Syntax_Print.univ_to_string u in
-                                let uu____28701 =
+                                let uu____28713 =
                                   FStar_Syntax_Print.univ_to_string v in
-                                FStar_Util.print2 "%s </= %s" uu____28700
-                                  uu____28701
+                                FStar_Util.print2 "%s </= %s" uu____28712
+                                  uu____28713
                               else ());
                              false))) in
-            if uu____28674
+            if uu____28686
             then ()
             else
-              ((let uu____28705 =
+              ((let uu____28717 =
                   FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
                     (FStar_Options.Other "GenUniverses") in
-                if uu____28705
+                if uu____28717
                 then
-                  ((let uu____28707 = ineqs_to_string (variables, ineqs) in
+                  ((let uu____28719 = ineqs_to_string (variables, ineqs) in
                     FStar_Util.print1
                       "Partially solved inequality constraints are: %s\n"
-                      uu____28707);
+                      uu____28719);
                    FStar_Syntax_Unionfind.rollback tx;
-                   (let uu____28717 = ineqs_to_string (variables, ineqs) in
+                   (let uu____28729 = ineqs_to_string (variables, ineqs) in
                     FStar_Util.print1
                       "Original solved inequality constraints are: %s\n"
-                      uu____28717))
+                      uu____28729))
                 else ());
-               (let uu____28727 = FStar_TypeChecker_Env.get_range env in
+               (let uu____28739 = FStar_TypeChecker_Env.get_range env in
                 FStar_Errors.raise_error
                   (FStar_Errors.Fatal_FailToSolveUniverseInEquality,
                     "Failed to solve universe inequalities for inductives")
-                  uu____28727))
+                  uu____28739))
 let (solve_universe_inequalities :
   FStar_TypeChecker_Env.env ->
     (FStar_Syntax_Syntax.universe Prims.list * (FStar_Syntax_Syntax.universe
@@ -11377,94 +11377,94 @@ let (try_solve_deferred_constraints :
     fun smt_ok ->
       fun env ->
         fun g ->
-          let fail uu____28801 =
-            match uu____28801 with
+          let fail uu____28813 =
+            match uu____28813 with
             | (d, s) ->
                 let msg = explain env d s in
                 FStar_Errors.raise_error
                   (FStar_Errors.Fatal_ErrorInSolveDeferredConstraints, msg)
                   (p_loc d) in
           let wl =
-            let uu___4259_28826 =
+            let uu___4259_28838 =
               wl_of_guard env g.FStar_TypeChecker_Common.deferred in
             {
-              attempting = (uu___4259_28826.attempting);
-              wl_deferred = (uu___4259_28826.wl_deferred);
-              wl_deferred_to_tac = (uu___4259_28826.wl_deferred_to_tac);
-              ctr = (uu___4259_28826.ctr);
+              attempting = (uu___4259_28838.attempting);
+              wl_deferred = (uu___4259_28838.wl_deferred);
+              wl_deferred_to_tac = (uu___4259_28838.wl_deferred_to_tac);
+              ctr = (uu___4259_28838.ctr);
               defer_ok;
               smt_ok;
-              umax_heuristic_ok = (uu___4259_28826.umax_heuristic_ok);
-              tcenv = (uu___4259_28826.tcenv);
-              wl_implicits = (uu___4259_28826.wl_implicits);
-              repr_subcomp_allowed = (uu___4259_28826.repr_subcomp_allowed)
+              umax_heuristic_ok = (uu___4259_28838.umax_heuristic_ok);
+              tcenv = (uu___4259_28838.tcenv);
+              wl_implicits = (uu___4259_28838.wl_implicits);
+              repr_subcomp_allowed = (uu___4259_28838.repr_subcomp_allowed)
             } in
-          (let uu____28828 =
+          (let uu____28840 =
              FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
                (FStar_Options.Other "Rel") in
-           if uu____28828
+           if uu____28840
            then
-             let uu____28829 = FStar_Util.string_of_bool defer_ok in
-             let uu____28830 = wl_to_string wl in
-             let uu____28831 =
+             let uu____28841 = FStar_Util.string_of_bool defer_ok in
+             let uu____28842 = wl_to_string wl in
+             let uu____28843 =
                FStar_Util.string_of_int
                  (FStar_List.length g.FStar_TypeChecker_Common.implicits) in
              FStar_Util.print3
                "Trying to solve carried problems (defer_ok=%s): begin\n\t%s\nend\n and %s implicits\n"
-               uu____28829 uu____28830 uu____28831
+               uu____28841 uu____28842 uu____28843
            else ());
           (let g1 =
-             let uu____28834 = solve_and_commit env wl fail in
-             match uu____28834 with
+             let uu____28846 = solve_and_commit env wl fail in
+             match uu____28846 with
              | FStar_Pervasives_Native.Some
-                 (uu____28843::uu____28844, uu____28845, uu____28846) when
+                 (uu____28855::uu____28856, uu____28857, uu____28858) when
                  Prims.op_Negation defer_ok ->
                  failwith
                    "Impossible: Unexpected deferred constraints remain"
              | FStar_Pervasives_Native.Some (deferred, defer_to_tac, imps) ->
-                 let uu___4276_28876 = g in
+                 let uu___4276_28888 = g in
                  {
                    FStar_TypeChecker_Common.guard_f =
-                     (uu___4276_28876.FStar_TypeChecker_Common.guard_f);
+                     (uu___4276_28888.FStar_TypeChecker_Common.guard_f);
                    FStar_TypeChecker_Common.deferred_to_tac =
                      (FStar_List.append
                         g.FStar_TypeChecker_Common.deferred_to_tac
                         defer_to_tac);
                    FStar_TypeChecker_Common.deferred = deferred;
                    FStar_TypeChecker_Common.univ_ineqs =
-                     (uu___4276_28876.FStar_TypeChecker_Common.univ_ineqs);
+                     (uu___4276_28888.FStar_TypeChecker_Common.univ_ineqs);
                    FStar_TypeChecker_Common.implicits =
                      (FStar_List.append g.FStar_TypeChecker_Common.implicits
                         imps)
                  }
-             | uu____28881 ->
+             | uu____28893 ->
                  failwith "Impossible: should have raised a failure already" in
            solve_universe_inequalities env
              g1.FStar_TypeChecker_Common.univ_ineqs;
            (let g2 =
               FStar_TypeChecker_DeferredImplicits.solve_deferred_to_tactic_goals
                 env g1 in
-            (let uu____28893 =
+            (let uu____28905 =
                FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
                  (FStar_Options.Other "ResolveImplicitsHook") in
-             if uu____28893
+             if uu____28905
              then
-               let uu____28894 = guard_to_string env g2 in
+               let uu____28906 = guard_to_string env g2 in
                FStar_Util.print1
                  "ResolveImplicitsHook: Solved deferred to tactic goals, remaining guard is\n%s\n"
-                 uu____28894
+                 uu____28906
              else ());
-            (let uu___4284_28896 = g2 in
+            (let uu___4284_28908 = g2 in
              {
                FStar_TypeChecker_Common.guard_f =
-                 (uu___4284_28896.FStar_TypeChecker_Common.guard_f);
+                 (uu___4284_28908.FStar_TypeChecker_Common.guard_f);
                FStar_TypeChecker_Common.deferred_to_tac =
-                 (uu___4284_28896.FStar_TypeChecker_Common.deferred_to_tac);
+                 (uu___4284_28908.FStar_TypeChecker_Common.deferred_to_tac);
                FStar_TypeChecker_Common.deferred =
-                 (uu___4284_28896.FStar_TypeChecker_Common.deferred);
+                 (uu___4284_28908.FStar_TypeChecker_Common.deferred);
                FStar_TypeChecker_Common.univ_ineqs = ([], []);
                FStar_TypeChecker_Common.implicits =
-                 (uu___4284_28896.FStar_TypeChecker_Common.implicits)
+                 (uu___4284_28908.FStar_TypeChecker_Common.implicits)
              })))
 let (solve_deferred_constraints' :
   Prims.bool ->
@@ -11501,35 +11501,35 @@ let (discharge_guard' :
               ||
               (FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
                  (FStar_Options.Other "Tac")) in
-          (let uu____28971 =
+          (let uu____28983 =
              FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
                (FStar_Options.Other "ResolveImplicitsHook") in
-           if uu____28971
+           if uu____28983
            then
-             let uu____28972 = guard_to_string env g in
+             let uu____28984 = guard_to_string env g in
              FStar_Util.print1
                "///////////////////ResolveImplicitsHook: discharge_guard'\nguard = %s\n"
-               uu____28972
+               uu____28984
            else ());
           (let g1 = solve_deferred_constraints' use_smt env g in
            let ret_g =
-             let uu___4301_28976 = g1 in
+             let uu___4301_28988 = g1 in
              {
                FStar_TypeChecker_Common.guard_f =
                  FStar_TypeChecker_Common.Trivial;
                FStar_TypeChecker_Common.deferred_to_tac =
-                 (uu___4301_28976.FStar_TypeChecker_Common.deferred_to_tac);
+                 (uu___4301_28988.FStar_TypeChecker_Common.deferred_to_tac);
                FStar_TypeChecker_Common.deferred =
-                 (uu___4301_28976.FStar_TypeChecker_Common.deferred);
+                 (uu___4301_28988.FStar_TypeChecker_Common.deferred);
                FStar_TypeChecker_Common.univ_ineqs =
-                 (uu___4301_28976.FStar_TypeChecker_Common.univ_ineqs);
+                 (uu___4301_28988.FStar_TypeChecker_Common.univ_ineqs);
                FStar_TypeChecker_Common.implicits =
-                 (uu___4301_28976.FStar_TypeChecker_Common.implicits)
+                 (uu___4301_28988.FStar_TypeChecker_Common.implicits)
              } in
-           let uu____28977 =
-             let uu____28978 = FStar_TypeChecker_Env.should_verify env in
-             Prims.op_Negation uu____28978 in
-           if uu____28977
+           let uu____28989 =
+             let uu____28990 = FStar_TypeChecker_Env.should_verify env in
+             Prims.op_Negation uu____28990 in
+           if uu____28989
            then FStar_Pervasives_Native.Some ret_g
            else
              (match g1.FStar_TypeChecker_Common.guard_f with
@@ -11538,44 +11538,44 @@ let (discharge_guard' :
               | FStar_TypeChecker_Common.NonTrivial vc ->
                   (if debug
                    then
-                     (let uu____28986 = FStar_TypeChecker_Env.get_range env in
-                      let uu____28987 =
-                        let uu____28988 =
+                     (let uu____28998 = FStar_TypeChecker_Env.get_range env in
+                      let uu____28999 =
+                        let uu____29000 =
                           FStar_Syntax_Print.term_to_string vc in
                         FStar_Util.format1 "Before normalization VC=\n%s\n"
-                          uu____28988 in
-                      FStar_Errors.diag uu____28986 uu____28987)
+                          uu____29000 in
+                      FStar_Errors.diag uu____28998 uu____28999)
                    else ();
                    (let vc1 =
-                      let uu____28991 =
-                        let uu____28994 =
-                          let uu____28995 =
+                      let uu____29003 =
+                        let uu____29006 =
+                          let uu____29007 =
                             FStar_TypeChecker_Env.current_module env in
-                          FStar_Ident.string_of_lid uu____28995 in
-                        FStar_Pervasives_Native.Some uu____28994 in
+                          FStar_Ident.string_of_lid uu____29007 in
+                        FStar_Pervasives_Native.Some uu____29006 in
                       FStar_Profiling.profile
-                        (fun uu____28997 ->
+                        (fun uu____29009 ->
                            FStar_TypeChecker_Normalize.normalize
                              [FStar_TypeChecker_Env.Eager_unfolding;
                              FStar_TypeChecker_Env.Simplify;
                              FStar_TypeChecker_Env.Primops] env vc)
-                        uu____28991 "FStar.TypeChecker.Rel.vc_normalization" in
+                        uu____29003 "FStar.TypeChecker.Rel.vc_normalization" in
                     if debug
                     then
-                      (let uu____28999 = FStar_TypeChecker_Env.get_range env in
-                       let uu____29000 =
-                         let uu____29001 =
+                      (let uu____29011 = FStar_TypeChecker_Env.get_range env in
+                       let uu____29012 =
+                         let uu____29013 =
                            FStar_Syntax_Print.term_to_string vc1 in
                          FStar_Util.format1 "After normalization VC=\n%s\n"
-                           uu____29001 in
-                       FStar_Errors.diag uu____28999 uu____29000)
+                           uu____29013 in
+                       FStar_Errors.diag uu____29011 uu____29012)
                     else ();
-                    (let uu____29004 = FStar_TypeChecker_Env.get_range env in
+                    (let uu____29016 = FStar_TypeChecker_Env.get_range env in
                      FStar_TypeChecker_Env.def_check_closed_in_env
-                       uu____29004 "discharge_guard'" env vc1);
-                    (let uu____29005 =
+                       uu____29016 "discharge_guard'" env vc1);
+                    (let uu____29017 =
                        FStar_TypeChecker_Common.check_trivial vc1 in
-                     match uu____29005 with
+                     match uu____29017 with
                      | FStar_TypeChecker_Common.Trivial ->
                          FStar_Pervasives_Native.Some ret_g
                      | FStar_TypeChecker_Common.NonTrivial vc2 ->
@@ -11583,69 +11583,69 @@ let (discharge_guard' :
                          then
                            (if debug
                             then
-                              (let uu____29012 =
+                              (let uu____29024 =
                                  FStar_TypeChecker_Env.get_range env in
-                               let uu____29013 =
-                                 let uu____29014 =
+                               let uu____29025 =
+                                 let uu____29026 =
                                    FStar_Syntax_Print.term_to_string vc2 in
                                  FStar_Util.format1
                                    "Cannot solve without SMT : %s\n"
-                                   uu____29014 in
-                               FStar_Errors.diag uu____29012 uu____29013)
+                                   uu____29026 in
+                               FStar_Errors.diag uu____29024 uu____29025)
                             else ();
                             FStar_Pervasives_Native.None)
                          else
                            (if debug
                             then
-                              (let uu____29019 =
+                              (let uu____29031 =
                                  FStar_TypeChecker_Env.get_range env in
-                               let uu____29020 =
-                                 let uu____29021 =
+                               let uu____29032 =
+                                 let uu____29033 =
                                    FStar_Syntax_Print.term_to_string vc2 in
                                  FStar_Util.format1 "Checking VC=\n%s\n"
-                                   uu____29021 in
-                               FStar_Errors.diag uu____29019 uu____29020)
+                                   uu____29033 in
+                               FStar_Errors.diag uu____29031 uu____29032)
                             else ();
                             (let vcs =
-                               let uu____29032 = FStar_Options.use_tactics () in
-                               if uu____29032
+                               let uu____29044 = FStar_Options.use_tactics () in
+                               if uu____29044
                                then
                                  FStar_Options.with_saved_options
-                                   (fun uu____29052 ->
-                                      (let uu____29054 =
+                                   (fun uu____29064 ->
+                                      (let uu____29066 =
                                          FStar_Options.set_options
                                            "--no_tactics" in
                                        FStar_All.pipe_left
-                                         (fun uu____29055 -> ()) uu____29054);
+                                         (fun uu____29067 -> ()) uu____29066);
                                       (let vcs =
                                          (env.FStar_TypeChecker_Env.solver).FStar_TypeChecker_Env.preprocess
                                            env vc2 in
                                        FStar_All.pipe_right vcs
                                          (FStar_List.map
-                                            (fun uu____29098 ->
-                                               match uu____29098 with
+                                            (fun uu____29110 ->
+                                               match uu____29110 with
                                                | (env1, goal, opts) ->
-                                                   let uu____29114 =
+                                                   let uu____29126 =
                                                      norm_with_steps
                                                        "FStar.TypeChecker.Rel.norm_with_steps.7"
                                                        [FStar_TypeChecker_Env.Simplify;
                                                        FStar_TypeChecker_Env.Primops]
                                                        env1 goal in
-                                                   (env1, uu____29114, opts)))))
+                                                   (env1, uu____29126, opts)))))
                                else
-                                 (let uu____29116 =
-                                    let uu____29123 = FStar_Options.peek () in
-                                    (env, vc2, uu____29123) in
-                                  [uu____29116]) in
+                                 (let uu____29128 =
+                                    let uu____29135 = FStar_Options.peek () in
+                                    (env, vc2, uu____29135) in
+                                  [uu____29128]) in
                              FStar_All.pipe_right vcs
                                (FStar_List.iter
-                                  (fun uu____29156 ->
-                                     match uu____29156 with
+                                  (fun uu____29168 ->
+                                     match uu____29168 with
                                      | (env1, goal, opts) ->
-                                         let uu____29166 =
+                                         let uu____29178 =
                                            FStar_TypeChecker_Common.check_trivial
                                              goal in
-                                         (match uu____29166 with
+                                         (match uu____29178 with
                                           | FStar_TypeChecker_Common.Trivial
                                               ->
                                               if debug
@@ -11659,36 +11659,36 @@ let (discharge_guard' :
                                                FStar_Options.set opts;
                                                if debug
                                                then
-                                                 (let uu____29173 =
+                                                 (let uu____29185 =
                                                     FStar_TypeChecker_Env.get_range
                                                       env1 in
-                                                  let uu____29174 =
-                                                    let uu____29175 =
+                                                  let uu____29186 =
+                                                    let uu____29187 =
                                                       FStar_Syntax_Print.term_to_string
                                                         goal1 in
-                                                    let uu____29176 =
+                                                    let uu____29188 =
                                                       FStar_TypeChecker_Env.string_of_proof_ns
                                                         env1 in
                                                     FStar_Util.format2
                                                       "Trying to solve:\n> %s\nWith proof_ns:\n %s\n"
-                                                      uu____29175 uu____29176 in
+                                                      uu____29187 uu____29188 in
                                                   FStar_Errors.diag
-                                                    uu____29173 uu____29174)
+                                                    uu____29185 uu____29186)
                                                else ();
                                                if debug
                                                then
-                                                 (let uu____29179 =
+                                                 (let uu____29191 =
                                                     FStar_TypeChecker_Env.get_range
                                                       env1 in
-                                                  let uu____29180 =
-                                                    let uu____29181 =
+                                                  let uu____29192 =
+                                                    let uu____29193 =
                                                       FStar_Syntax_Print.term_to_string
                                                         goal1 in
                                                     FStar_Util.format1
                                                       "Before calling solver VC=\n%s\n"
-                                                      uu____29181 in
+                                                      uu____29193 in
                                                   FStar_Errors.diag
-                                                    uu____29179 uu____29180)
+                                                    uu____29191 uu____29192)
                                                else ();
                                                (env1.FStar_TypeChecker_Env.solver).FStar_TypeChecker_Env.solve
                                                  use_env_range_msg env1 goal1;
@@ -11700,24 +11700,24 @@ let (discharge_guard_no_smt :
   =
   fun env ->
     fun g ->
-      let uu____29195 =
+      let uu____29207 =
         discharge_guard' FStar_Pervasives_Native.None env g false in
-      match uu____29195 with
+      match uu____29207 with
       | FStar_Pervasives_Native.Some g1 -> g1
       | FStar_Pervasives_Native.None ->
-          let uu____29202 = FStar_TypeChecker_Env.get_range env in
+          let uu____29214 = FStar_TypeChecker_Env.get_range env in
           FStar_Errors.raise_error
             (FStar_Errors.Fatal_ExpectTrivialPreCondition,
-              "Expected a trivial pre-condition") uu____29202
+              "Expected a trivial pre-condition") uu____29214
 let (discharge_guard :
   FStar_TypeChecker_Env.env ->
     FStar_TypeChecker_Common.guard_t -> FStar_TypeChecker_Common.guard_t)
   =
   fun env ->
     fun g ->
-      let uu____29213 =
+      let uu____29225 =
         discharge_guard' FStar_Pervasives_Native.None env g true in
-      match uu____29213 with
+      match uu____29225 with
       | FStar_Pervasives_Native.Some g1 -> g1
       | FStar_Pervasives_Native.None ->
           failwith
@@ -11731,8 +11731,8 @@ let (teq_nosmt :
   fun env ->
     fun t1 ->
       fun t2 ->
-        let uu____29239 = try_teq false env t1 t2 in
-        match uu____29239 with
+        let uu____29251 = try_teq false env t1 t2 in
+        match uu____29251 with
         | FStar_Pervasives_Native.None -> FStar_Pervasives_Native.None
         | FStar_Pervasives_Native.Some g ->
             discharge_guard' FStar_Pervasives_Native.None env g false
@@ -11749,51 +11749,51 @@ let (try_solve_single_valued_implicits :
         then (imps, false)
         else
           (let imp_value imp =
-             let uu____29282 =
+             let uu____29294 =
                ((imp.FStar_TypeChecker_Common.imp_uvar),
                  (imp.FStar_TypeChecker_Common.imp_range)) in
-             match uu____29282 with
+             match uu____29294 with
              | (ctx_u, r) ->
                  let t_norm =
                    FStar_TypeChecker_Normalize.normalize
                      FStar_TypeChecker_Normalize.whnf_steps env
                      ctx_u.FStar_Syntax_Syntax.ctx_uvar_typ in
-                 let uu____29292 =
-                   let uu____29293 = FStar_Syntax_Subst.compress t_norm in
-                   uu____29293.FStar_Syntax_Syntax.n in
-                 (match uu____29292 with
+                 let uu____29304 =
+                   let uu____29305 = FStar_Syntax_Subst.compress t_norm in
+                   uu____29305.FStar_Syntax_Syntax.n in
+                 (match uu____29304 with
                   | FStar_Syntax_Syntax.Tm_fvar fv when
                       FStar_Syntax_Syntax.fv_eq_lid fv
                         FStar_Parser_Const.unit_lid
                       ->
-                      let uu____29299 =
+                      let uu____29311 =
                         FStar_All.pipe_right r
                           FStar_Syntax_Syntax.unit_const_with_range in
-                      FStar_All.pipe_right uu____29299
-                        (fun uu____29302 ->
-                           FStar_Pervasives_Native.Some uu____29302)
-                  | FStar_Syntax_Syntax.Tm_refine (b, uu____29304) when
+                      FStar_All.pipe_right uu____29311
+                        (fun uu____29314 ->
+                           FStar_Pervasives_Native.Some uu____29314)
+                  | FStar_Syntax_Syntax.Tm_refine (b, uu____29316) when
                       FStar_Syntax_Util.is_unit b.FStar_Syntax_Syntax.sort ->
-                      let uu____29309 =
+                      let uu____29321 =
                         FStar_All.pipe_right r
                           FStar_Syntax_Syntax.unit_const_with_range in
-                      FStar_All.pipe_right uu____29309
-                        (fun uu____29312 ->
-                           FStar_Pervasives_Native.Some uu____29312)
-                  | uu____29313 -> FStar_Pervasives_Native.None) in
+                      FStar_All.pipe_right uu____29321
+                        (fun uu____29324 ->
+                           FStar_Pervasives_Native.Some uu____29324)
+                  | uu____29325 -> FStar_Pervasives_Native.None) in
            let b =
              FStar_List.fold_left
                (fun b ->
                   fun imp ->
-                    let uu____29323 =
-                      let uu____29324 =
+                    let uu____29335 =
+                      let uu____29336 =
                         FStar_Syntax_Unionfind.find
                           (imp.FStar_TypeChecker_Common.imp_uvar).FStar_Syntax_Syntax.ctx_uvar_head in
-                      FStar_All.pipe_right uu____29324 FStar_Util.is_none in
-                    if uu____29323
+                      FStar_All.pipe_right uu____29336 FStar_Util.is_none in
+                    if uu____29335
                     then
-                      let uu____29329 = imp_value imp in
-                      match uu____29329 with
+                      let uu____29341 = imp_value imp in
+                      match uu____29341 with
                       | FStar_Pervasives_Native.Some tm ->
                           (commit
                              [TERM
@@ -11810,50 +11810,50 @@ let (resolve_implicits' :
   fun env ->
     fun is_tac ->
       fun g ->
-        let uu____29350 =
+        let uu____29362 =
           if is_tac
           then (false, true)
           else
             (((Prims.op_Negation env.FStar_TypeChecker_Env.phase1) &&
                 (Prims.op_Negation env.FStar_TypeChecker_Env.lax)), false) in
-        match uu____29350 with
+        match uu____29362 with
         | (must_total, forcelax) ->
             let rec unresolved ctx_u =
-              let uu____29368 =
+              let uu____29380 =
                 FStar_Syntax_Unionfind.find
                   ctx_u.FStar_Syntax_Syntax.ctx_uvar_head in
-              match uu____29368 with
+              match uu____29380 with
               | FStar_Pervasives_Native.Some r ->
                   (match ctx_u.FStar_Syntax_Syntax.ctx_uvar_meta with
                    | FStar_Pervasives_Native.None -> false
-                   | FStar_Pervasives_Native.Some uu____29372 ->
-                       let uu____29373 =
-                         let uu____29374 = FStar_Syntax_Subst.compress r in
-                         uu____29374.FStar_Syntax_Syntax.n in
-                       (match uu____29373 with
-                        | FStar_Syntax_Syntax.Tm_uvar (ctx_u', uu____29378)
+                   | FStar_Pervasives_Native.Some uu____29384 ->
+                       let uu____29385 =
+                         let uu____29386 = FStar_Syntax_Subst.compress r in
+                         uu____29386.FStar_Syntax_Syntax.n in
+                       (match uu____29385 with
+                        | FStar_Syntax_Syntax.Tm_uvar (ctx_u', uu____29390)
                             -> unresolved ctx_u'
-                        | uu____29395 -> false))
+                        | uu____29407 -> false))
               | FStar_Pervasives_Native.None -> true in
             let rec until_fixpoint acc implicits =
-              let uu____29415 = acc in
-              match uu____29415 with
+              let uu____29427 = acc in
+              match uu____29427 with
               | (out, changed) ->
                   (match implicits with
                    | [] ->
                        if Prims.op_Negation changed
                        then
-                         let uu____29422 =
+                         let uu____29434 =
                            try_solve_single_valued_implicits env is_tac out in
-                         (match uu____29422 with
+                         (match uu____29434 with
                           | (out1, changed1) ->
                               if changed1
                               then until_fixpoint ([], false) out1
                               else out1)
                        else until_fixpoint ([], false) out
                    | hd::tl ->
-                       let uu____29435 = hd in
-                       (match uu____29435 with
+                       let uu____29447 = hd in
+                       (match uu____29447 with
                         | { FStar_TypeChecker_Common.imp_reason = reason;
                             FStar_TypeChecker_Common.imp_uvar = ctx_u;
                             FStar_TypeChecker_Common.imp_tm = tm;
@@ -11863,8 +11863,8 @@ let (resolve_implicits' :
                                 = FStar_Syntax_Syntax.Allow_unresolved
                             then until_fixpoint (out, true) tl
                             else
-                              (let uu____29441 = unresolved ctx_u in
-                               if uu____29441
+                              (let uu____29453 = unresolved ctx_u in
+                               if uu____29453
                                then
                                  match ctx_u.FStar_Syntax_Syntax.ctx_uvar_meta
                                  with
@@ -11872,17 +11872,17 @@ let (resolve_implicits' :
                                      (FStar_Syntax_Syntax.Ctx_uvar_meta_tac
                                      (env_dyn, tau)) ->
                                      let env1 = FStar_Dyn.undyn env_dyn in
-                                     ((let uu____29450 =
+                                     ((let uu____29462 =
                                          FStar_TypeChecker_Env.debug env1
                                            (FStar_Options.Other "Tac") in
-                                       if uu____29450
+                                       if uu____29462
                                        then
-                                         let uu____29451 =
+                                         let uu____29463 =
                                            FStar_Syntax_Print.ctx_uvar_to_string
                                              ctx_u in
                                          FStar_Util.print1
                                            "Running tactic for meta-arg %s\n"
-                                           uu____29451
+                                           uu____29463
                                        else ());
                                       (let t =
                                          env1.FStar_TypeChecker_Env.synth_hook
@@ -11890,57 +11890,57 @@ let (resolve_implicits' :
                                            (hd.FStar_TypeChecker_Common.imp_uvar).FStar_Syntax_Syntax.ctx_uvar_typ
                                            tau in
                                        let extra =
-                                         let uu____29457 =
+                                         let uu____29469 =
                                            teq_nosmt env1 t tm in
-                                         match uu____29457 with
+                                         match uu____29469 with
                                          | FStar_Pervasives_Native.None ->
                                              failwith
                                                "resolve_implicits: unifying with an unresolved uvar failed?"
                                          | FStar_Pervasives_Native.Some g1 ->
                                              g1.FStar_TypeChecker_Common.implicits in
                                        let ctx_u1 =
-                                         let uu___4446_29466 = ctx_u in
+                                         let uu___4446_29478 = ctx_u in
                                          {
                                            FStar_Syntax_Syntax.ctx_uvar_head
                                              =
-                                             (uu___4446_29466.FStar_Syntax_Syntax.ctx_uvar_head);
+                                             (uu___4446_29478.FStar_Syntax_Syntax.ctx_uvar_head);
                                            FStar_Syntax_Syntax.ctx_uvar_gamma
                                              =
-                                             (uu___4446_29466.FStar_Syntax_Syntax.ctx_uvar_gamma);
+                                             (uu___4446_29478.FStar_Syntax_Syntax.ctx_uvar_gamma);
                                            FStar_Syntax_Syntax.ctx_uvar_binders
                                              =
-                                             (uu___4446_29466.FStar_Syntax_Syntax.ctx_uvar_binders);
+                                             (uu___4446_29478.FStar_Syntax_Syntax.ctx_uvar_binders);
                                            FStar_Syntax_Syntax.ctx_uvar_typ =
-                                             (uu___4446_29466.FStar_Syntax_Syntax.ctx_uvar_typ);
+                                             (uu___4446_29478.FStar_Syntax_Syntax.ctx_uvar_typ);
                                            FStar_Syntax_Syntax.ctx_uvar_reason
                                              =
-                                             (uu___4446_29466.FStar_Syntax_Syntax.ctx_uvar_reason);
+                                             (uu___4446_29478.FStar_Syntax_Syntax.ctx_uvar_reason);
                                            FStar_Syntax_Syntax.ctx_uvar_should_check
                                              =
-                                             (uu___4446_29466.FStar_Syntax_Syntax.ctx_uvar_should_check);
+                                             (uu___4446_29478.FStar_Syntax_Syntax.ctx_uvar_should_check);
                                            FStar_Syntax_Syntax.ctx_uvar_range
                                              =
-                                             (uu___4446_29466.FStar_Syntax_Syntax.ctx_uvar_range);
+                                             (uu___4446_29478.FStar_Syntax_Syntax.ctx_uvar_range);
                                            FStar_Syntax_Syntax.ctx_uvar_meta
                                              = FStar_Pervasives_Native.None
                                          } in
                                        let hd1 =
-                                         let uu___4449_29468 = hd in
+                                         let uu___4449_29480 = hd in
                                          {
                                            FStar_TypeChecker_Common.imp_reason
                                              =
-                                             (uu___4449_29468.FStar_TypeChecker_Common.imp_reason);
+                                             (uu___4449_29480.FStar_TypeChecker_Common.imp_reason);
                                            FStar_TypeChecker_Common.imp_uvar
                                              = ctx_u1;
                                            FStar_TypeChecker_Common.imp_tm =
-                                             (uu___4449_29468.FStar_TypeChecker_Common.imp_tm);
+                                             (uu___4449_29480.FStar_TypeChecker_Common.imp_tm);
                                            FStar_TypeChecker_Common.imp_range
                                              =
-                                             (uu___4449_29468.FStar_TypeChecker_Common.imp_range)
+                                             (uu___4449_29480.FStar_TypeChecker_Common.imp_range)
                                          } in
                                        until_fixpoint (out, true)
                                          (FStar_List.append extra tl)))
-                                 | uu____29469 ->
+                                 | uu____29481 ->
                                      until_fixpoint ((hd :: out), changed) tl
                                else
                                  if
@@ -11949,112 +11949,112 @@ let (resolve_implicits' :
                                  then until_fixpoint (out, true) tl
                                  else
                                    (let env1 =
-                                      let uu___4454_29475 = env in
+                                      let uu___4454_29487 = env in
                                       {
                                         FStar_TypeChecker_Env.solver =
-                                          (uu___4454_29475.FStar_TypeChecker_Env.solver);
+                                          (uu___4454_29487.FStar_TypeChecker_Env.solver);
                                         FStar_TypeChecker_Env.range =
-                                          (uu___4454_29475.FStar_TypeChecker_Env.range);
+                                          (uu___4454_29487.FStar_TypeChecker_Env.range);
                                         FStar_TypeChecker_Env.curmodule =
-                                          (uu___4454_29475.FStar_TypeChecker_Env.curmodule);
+                                          (uu___4454_29487.FStar_TypeChecker_Env.curmodule);
                                         FStar_TypeChecker_Env.gamma =
                                           (ctx_u.FStar_Syntax_Syntax.ctx_uvar_gamma);
                                         FStar_TypeChecker_Env.gamma_sig =
-                                          (uu___4454_29475.FStar_TypeChecker_Env.gamma_sig);
+                                          (uu___4454_29487.FStar_TypeChecker_Env.gamma_sig);
                                         FStar_TypeChecker_Env.gamma_cache =
-                                          (uu___4454_29475.FStar_TypeChecker_Env.gamma_cache);
+                                          (uu___4454_29487.FStar_TypeChecker_Env.gamma_cache);
                                         FStar_TypeChecker_Env.modules =
-                                          (uu___4454_29475.FStar_TypeChecker_Env.modules);
+                                          (uu___4454_29487.FStar_TypeChecker_Env.modules);
                                         FStar_TypeChecker_Env.expected_typ =
-                                          (uu___4454_29475.FStar_TypeChecker_Env.expected_typ);
+                                          (uu___4454_29487.FStar_TypeChecker_Env.expected_typ);
                                         FStar_TypeChecker_Env.sigtab =
-                                          (uu___4454_29475.FStar_TypeChecker_Env.sigtab);
+                                          (uu___4454_29487.FStar_TypeChecker_Env.sigtab);
                                         FStar_TypeChecker_Env.attrtab =
-                                          (uu___4454_29475.FStar_TypeChecker_Env.attrtab);
+                                          (uu___4454_29487.FStar_TypeChecker_Env.attrtab);
                                         FStar_TypeChecker_Env.instantiate_imp
                                           =
-                                          (uu___4454_29475.FStar_TypeChecker_Env.instantiate_imp);
+                                          (uu___4454_29487.FStar_TypeChecker_Env.instantiate_imp);
                                         FStar_TypeChecker_Env.effects =
-                                          (uu___4454_29475.FStar_TypeChecker_Env.effects);
+                                          (uu___4454_29487.FStar_TypeChecker_Env.effects);
                                         FStar_TypeChecker_Env.generalize =
-                                          (uu___4454_29475.FStar_TypeChecker_Env.generalize);
+                                          (uu___4454_29487.FStar_TypeChecker_Env.generalize);
                                         FStar_TypeChecker_Env.letrecs =
-                                          (uu___4454_29475.FStar_TypeChecker_Env.letrecs);
+                                          (uu___4454_29487.FStar_TypeChecker_Env.letrecs);
                                         FStar_TypeChecker_Env.top_level =
-                                          (uu___4454_29475.FStar_TypeChecker_Env.top_level);
+                                          (uu___4454_29487.FStar_TypeChecker_Env.top_level);
                                         FStar_TypeChecker_Env.check_uvars =
-                                          (uu___4454_29475.FStar_TypeChecker_Env.check_uvars);
+                                          (uu___4454_29487.FStar_TypeChecker_Env.check_uvars);
                                         FStar_TypeChecker_Env.use_eq =
-                                          (uu___4454_29475.FStar_TypeChecker_Env.use_eq);
+                                          (uu___4454_29487.FStar_TypeChecker_Env.use_eq);
                                         FStar_TypeChecker_Env.use_eq_strict =
-                                          (uu___4454_29475.FStar_TypeChecker_Env.use_eq_strict);
+                                          (uu___4454_29487.FStar_TypeChecker_Env.use_eq_strict);
                                         FStar_TypeChecker_Env.is_iface =
-                                          (uu___4454_29475.FStar_TypeChecker_Env.is_iface);
+                                          (uu___4454_29487.FStar_TypeChecker_Env.is_iface);
                                         FStar_TypeChecker_Env.admit =
-                                          (uu___4454_29475.FStar_TypeChecker_Env.admit);
+                                          (uu___4454_29487.FStar_TypeChecker_Env.admit);
                                         FStar_TypeChecker_Env.lax =
-                                          (uu___4454_29475.FStar_TypeChecker_Env.lax);
+                                          (uu___4454_29487.FStar_TypeChecker_Env.lax);
                                         FStar_TypeChecker_Env.lax_universes =
-                                          (uu___4454_29475.FStar_TypeChecker_Env.lax_universes);
+                                          (uu___4454_29487.FStar_TypeChecker_Env.lax_universes);
                                         FStar_TypeChecker_Env.phase1 =
-                                          (uu___4454_29475.FStar_TypeChecker_Env.phase1);
+                                          (uu___4454_29487.FStar_TypeChecker_Env.phase1);
                                         FStar_TypeChecker_Env.failhard =
-                                          (uu___4454_29475.FStar_TypeChecker_Env.failhard);
+                                          (uu___4454_29487.FStar_TypeChecker_Env.failhard);
                                         FStar_TypeChecker_Env.nosynth =
-                                          (uu___4454_29475.FStar_TypeChecker_Env.nosynth);
+                                          (uu___4454_29487.FStar_TypeChecker_Env.nosynth);
                                         FStar_TypeChecker_Env.uvar_subtyping
                                           =
-                                          (uu___4454_29475.FStar_TypeChecker_Env.uvar_subtyping);
+                                          (uu___4454_29487.FStar_TypeChecker_Env.uvar_subtyping);
                                         FStar_TypeChecker_Env.tc_term =
-                                          (uu___4454_29475.FStar_TypeChecker_Env.tc_term);
+                                          (uu___4454_29487.FStar_TypeChecker_Env.tc_term);
                                         FStar_TypeChecker_Env.type_of =
-                                          (uu___4454_29475.FStar_TypeChecker_Env.type_of);
+                                          (uu___4454_29487.FStar_TypeChecker_Env.type_of);
                                         FStar_TypeChecker_Env.universe_of =
-                                          (uu___4454_29475.FStar_TypeChecker_Env.universe_of);
+                                          (uu___4454_29487.FStar_TypeChecker_Env.universe_of);
                                         FStar_TypeChecker_Env.check_type_of =
-                                          (uu___4454_29475.FStar_TypeChecker_Env.check_type_of);
+                                          (uu___4454_29487.FStar_TypeChecker_Env.check_type_of);
                                         FStar_TypeChecker_Env.use_bv_sorts =
-                                          (uu___4454_29475.FStar_TypeChecker_Env.use_bv_sorts);
+                                          (uu___4454_29487.FStar_TypeChecker_Env.use_bv_sorts);
                                         FStar_TypeChecker_Env.qtbl_name_and_index
                                           =
-                                          (uu___4454_29475.FStar_TypeChecker_Env.qtbl_name_and_index);
+                                          (uu___4454_29487.FStar_TypeChecker_Env.qtbl_name_and_index);
                                         FStar_TypeChecker_Env.normalized_eff_names
                                           =
-                                          (uu___4454_29475.FStar_TypeChecker_Env.normalized_eff_names);
+                                          (uu___4454_29487.FStar_TypeChecker_Env.normalized_eff_names);
                                         FStar_TypeChecker_Env.fv_delta_depths
                                           =
-                                          (uu___4454_29475.FStar_TypeChecker_Env.fv_delta_depths);
+                                          (uu___4454_29487.FStar_TypeChecker_Env.fv_delta_depths);
                                         FStar_TypeChecker_Env.proof_ns =
-                                          (uu___4454_29475.FStar_TypeChecker_Env.proof_ns);
+                                          (uu___4454_29487.FStar_TypeChecker_Env.proof_ns);
                                         FStar_TypeChecker_Env.synth_hook =
-                                          (uu___4454_29475.FStar_TypeChecker_Env.synth_hook);
+                                          (uu___4454_29487.FStar_TypeChecker_Env.synth_hook);
                                         FStar_TypeChecker_Env.try_solve_implicits_hook
                                           =
-                                          (uu___4454_29475.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                                          (uu___4454_29487.FStar_TypeChecker_Env.try_solve_implicits_hook);
                                         FStar_TypeChecker_Env.splice =
-                                          (uu___4454_29475.FStar_TypeChecker_Env.splice);
+                                          (uu___4454_29487.FStar_TypeChecker_Env.splice);
                                         FStar_TypeChecker_Env.mpreprocess =
-                                          (uu___4454_29475.FStar_TypeChecker_Env.mpreprocess);
+                                          (uu___4454_29487.FStar_TypeChecker_Env.mpreprocess);
                                         FStar_TypeChecker_Env.postprocess =
-                                          (uu___4454_29475.FStar_TypeChecker_Env.postprocess);
+                                          (uu___4454_29487.FStar_TypeChecker_Env.postprocess);
                                         FStar_TypeChecker_Env.identifier_info
                                           =
-                                          (uu___4454_29475.FStar_TypeChecker_Env.identifier_info);
+                                          (uu___4454_29487.FStar_TypeChecker_Env.identifier_info);
                                         FStar_TypeChecker_Env.tc_hooks =
-                                          (uu___4454_29475.FStar_TypeChecker_Env.tc_hooks);
+                                          (uu___4454_29487.FStar_TypeChecker_Env.tc_hooks);
                                         FStar_TypeChecker_Env.dsenv =
-                                          (uu___4454_29475.FStar_TypeChecker_Env.dsenv);
+                                          (uu___4454_29487.FStar_TypeChecker_Env.dsenv);
                                         FStar_TypeChecker_Env.nbe =
-                                          (uu___4454_29475.FStar_TypeChecker_Env.nbe);
+                                          (uu___4454_29487.FStar_TypeChecker_Env.nbe);
                                         FStar_TypeChecker_Env.strict_args_tab
                                           =
-                                          (uu___4454_29475.FStar_TypeChecker_Env.strict_args_tab);
+                                          (uu___4454_29487.FStar_TypeChecker_Env.strict_args_tab);
                                         FStar_TypeChecker_Env.erasable_types_tab
                                           =
-                                          (uu___4454_29475.FStar_TypeChecker_Env.erasable_types_tab);
+                                          (uu___4454_29487.FStar_TypeChecker_Env.erasable_types_tab);
                                         FStar_TypeChecker_Env.enable_defer_to_tac
                                           =
-                                          (uu___4454_29475.FStar_TypeChecker_Env.enable_defer_to_tac)
+                                          (uu___4454_29487.FStar_TypeChecker_Env.enable_defer_to_tac)
                                       } in
                                     let tm1 =
                                       norm_with_steps
@@ -12063,143 +12063,143 @@ let (resolve_implicits' :
                                     let env2 =
                                       if forcelax
                                       then
-                                        let uu___4459_29478 = env1 in
+                                        let uu___4459_29490 = env1 in
                                         {
                                           FStar_TypeChecker_Env.solver =
-                                            (uu___4459_29478.FStar_TypeChecker_Env.solver);
+                                            (uu___4459_29490.FStar_TypeChecker_Env.solver);
                                           FStar_TypeChecker_Env.range =
-                                            (uu___4459_29478.FStar_TypeChecker_Env.range);
+                                            (uu___4459_29490.FStar_TypeChecker_Env.range);
                                           FStar_TypeChecker_Env.curmodule =
-                                            (uu___4459_29478.FStar_TypeChecker_Env.curmodule);
+                                            (uu___4459_29490.FStar_TypeChecker_Env.curmodule);
                                           FStar_TypeChecker_Env.gamma =
-                                            (uu___4459_29478.FStar_TypeChecker_Env.gamma);
+                                            (uu___4459_29490.FStar_TypeChecker_Env.gamma);
                                           FStar_TypeChecker_Env.gamma_sig =
-                                            (uu___4459_29478.FStar_TypeChecker_Env.gamma_sig);
+                                            (uu___4459_29490.FStar_TypeChecker_Env.gamma_sig);
                                           FStar_TypeChecker_Env.gamma_cache =
-                                            (uu___4459_29478.FStar_TypeChecker_Env.gamma_cache);
+                                            (uu___4459_29490.FStar_TypeChecker_Env.gamma_cache);
                                           FStar_TypeChecker_Env.modules =
-                                            (uu___4459_29478.FStar_TypeChecker_Env.modules);
+                                            (uu___4459_29490.FStar_TypeChecker_Env.modules);
                                           FStar_TypeChecker_Env.expected_typ
                                             =
-                                            (uu___4459_29478.FStar_TypeChecker_Env.expected_typ);
+                                            (uu___4459_29490.FStar_TypeChecker_Env.expected_typ);
                                           FStar_TypeChecker_Env.sigtab =
-                                            (uu___4459_29478.FStar_TypeChecker_Env.sigtab);
+                                            (uu___4459_29490.FStar_TypeChecker_Env.sigtab);
                                           FStar_TypeChecker_Env.attrtab =
-                                            (uu___4459_29478.FStar_TypeChecker_Env.attrtab);
+                                            (uu___4459_29490.FStar_TypeChecker_Env.attrtab);
                                           FStar_TypeChecker_Env.instantiate_imp
                                             =
-                                            (uu___4459_29478.FStar_TypeChecker_Env.instantiate_imp);
+                                            (uu___4459_29490.FStar_TypeChecker_Env.instantiate_imp);
                                           FStar_TypeChecker_Env.effects =
-                                            (uu___4459_29478.FStar_TypeChecker_Env.effects);
+                                            (uu___4459_29490.FStar_TypeChecker_Env.effects);
                                           FStar_TypeChecker_Env.generalize =
-                                            (uu___4459_29478.FStar_TypeChecker_Env.generalize);
+                                            (uu___4459_29490.FStar_TypeChecker_Env.generalize);
                                           FStar_TypeChecker_Env.letrecs =
-                                            (uu___4459_29478.FStar_TypeChecker_Env.letrecs);
+                                            (uu___4459_29490.FStar_TypeChecker_Env.letrecs);
                                           FStar_TypeChecker_Env.top_level =
-                                            (uu___4459_29478.FStar_TypeChecker_Env.top_level);
+                                            (uu___4459_29490.FStar_TypeChecker_Env.top_level);
                                           FStar_TypeChecker_Env.check_uvars =
-                                            (uu___4459_29478.FStar_TypeChecker_Env.check_uvars);
+                                            (uu___4459_29490.FStar_TypeChecker_Env.check_uvars);
                                           FStar_TypeChecker_Env.use_eq =
-                                            (uu___4459_29478.FStar_TypeChecker_Env.use_eq);
+                                            (uu___4459_29490.FStar_TypeChecker_Env.use_eq);
                                           FStar_TypeChecker_Env.use_eq_strict
                                             =
-                                            (uu___4459_29478.FStar_TypeChecker_Env.use_eq_strict);
+                                            (uu___4459_29490.FStar_TypeChecker_Env.use_eq_strict);
                                           FStar_TypeChecker_Env.is_iface =
-                                            (uu___4459_29478.FStar_TypeChecker_Env.is_iface);
+                                            (uu___4459_29490.FStar_TypeChecker_Env.is_iface);
                                           FStar_TypeChecker_Env.admit =
-                                            (uu___4459_29478.FStar_TypeChecker_Env.admit);
+                                            (uu___4459_29490.FStar_TypeChecker_Env.admit);
                                           FStar_TypeChecker_Env.lax = true;
                                           FStar_TypeChecker_Env.lax_universes
                                             =
-                                            (uu___4459_29478.FStar_TypeChecker_Env.lax_universes);
+                                            (uu___4459_29490.FStar_TypeChecker_Env.lax_universes);
                                           FStar_TypeChecker_Env.phase1 =
-                                            (uu___4459_29478.FStar_TypeChecker_Env.phase1);
+                                            (uu___4459_29490.FStar_TypeChecker_Env.phase1);
                                           FStar_TypeChecker_Env.failhard =
-                                            (uu___4459_29478.FStar_TypeChecker_Env.failhard);
+                                            (uu___4459_29490.FStar_TypeChecker_Env.failhard);
                                           FStar_TypeChecker_Env.nosynth =
-                                            (uu___4459_29478.FStar_TypeChecker_Env.nosynth);
+                                            (uu___4459_29490.FStar_TypeChecker_Env.nosynth);
                                           FStar_TypeChecker_Env.uvar_subtyping
                                             =
-                                            (uu___4459_29478.FStar_TypeChecker_Env.uvar_subtyping);
+                                            (uu___4459_29490.FStar_TypeChecker_Env.uvar_subtyping);
                                           FStar_TypeChecker_Env.tc_term =
-                                            (uu___4459_29478.FStar_TypeChecker_Env.tc_term);
+                                            (uu___4459_29490.FStar_TypeChecker_Env.tc_term);
                                           FStar_TypeChecker_Env.type_of =
-                                            (uu___4459_29478.FStar_TypeChecker_Env.type_of);
+                                            (uu___4459_29490.FStar_TypeChecker_Env.type_of);
                                           FStar_TypeChecker_Env.universe_of =
-                                            (uu___4459_29478.FStar_TypeChecker_Env.universe_of);
+                                            (uu___4459_29490.FStar_TypeChecker_Env.universe_of);
                                           FStar_TypeChecker_Env.check_type_of
                                             =
-                                            (uu___4459_29478.FStar_TypeChecker_Env.check_type_of);
+                                            (uu___4459_29490.FStar_TypeChecker_Env.check_type_of);
                                           FStar_TypeChecker_Env.use_bv_sorts
                                             =
-                                            (uu___4459_29478.FStar_TypeChecker_Env.use_bv_sorts);
+                                            (uu___4459_29490.FStar_TypeChecker_Env.use_bv_sorts);
                                           FStar_TypeChecker_Env.qtbl_name_and_index
                                             =
-                                            (uu___4459_29478.FStar_TypeChecker_Env.qtbl_name_and_index);
+                                            (uu___4459_29490.FStar_TypeChecker_Env.qtbl_name_and_index);
                                           FStar_TypeChecker_Env.normalized_eff_names
                                             =
-                                            (uu___4459_29478.FStar_TypeChecker_Env.normalized_eff_names);
+                                            (uu___4459_29490.FStar_TypeChecker_Env.normalized_eff_names);
                                           FStar_TypeChecker_Env.fv_delta_depths
                                             =
-                                            (uu___4459_29478.FStar_TypeChecker_Env.fv_delta_depths);
+                                            (uu___4459_29490.FStar_TypeChecker_Env.fv_delta_depths);
                                           FStar_TypeChecker_Env.proof_ns =
-                                            (uu___4459_29478.FStar_TypeChecker_Env.proof_ns);
+                                            (uu___4459_29490.FStar_TypeChecker_Env.proof_ns);
                                           FStar_TypeChecker_Env.synth_hook =
-                                            (uu___4459_29478.FStar_TypeChecker_Env.synth_hook);
+                                            (uu___4459_29490.FStar_TypeChecker_Env.synth_hook);
                                           FStar_TypeChecker_Env.try_solve_implicits_hook
                                             =
-                                            (uu___4459_29478.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                                            (uu___4459_29490.FStar_TypeChecker_Env.try_solve_implicits_hook);
                                           FStar_TypeChecker_Env.splice =
-                                            (uu___4459_29478.FStar_TypeChecker_Env.splice);
+                                            (uu___4459_29490.FStar_TypeChecker_Env.splice);
                                           FStar_TypeChecker_Env.mpreprocess =
-                                            (uu___4459_29478.FStar_TypeChecker_Env.mpreprocess);
+                                            (uu___4459_29490.FStar_TypeChecker_Env.mpreprocess);
                                           FStar_TypeChecker_Env.postprocess =
-                                            (uu___4459_29478.FStar_TypeChecker_Env.postprocess);
+                                            (uu___4459_29490.FStar_TypeChecker_Env.postprocess);
                                           FStar_TypeChecker_Env.identifier_info
                                             =
-                                            (uu___4459_29478.FStar_TypeChecker_Env.identifier_info);
+                                            (uu___4459_29490.FStar_TypeChecker_Env.identifier_info);
                                           FStar_TypeChecker_Env.tc_hooks =
-                                            (uu___4459_29478.FStar_TypeChecker_Env.tc_hooks);
+                                            (uu___4459_29490.FStar_TypeChecker_Env.tc_hooks);
                                           FStar_TypeChecker_Env.dsenv =
-                                            (uu___4459_29478.FStar_TypeChecker_Env.dsenv);
+                                            (uu___4459_29490.FStar_TypeChecker_Env.dsenv);
                                           FStar_TypeChecker_Env.nbe =
-                                            (uu___4459_29478.FStar_TypeChecker_Env.nbe);
+                                            (uu___4459_29490.FStar_TypeChecker_Env.nbe);
                                           FStar_TypeChecker_Env.strict_args_tab
                                             =
-                                            (uu___4459_29478.FStar_TypeChecker_Env.strict_args_tab);
+                                            (uu___4459_29490.FStar_TypeChecker_Env.strict_args_tab);
                                           FStar_TypeChecker_Env.erasable_types_tab
                                             =
-                                            (uu___4459_29478.FStar_TypeChecker_Env.erasable_types_tab);
+                                            (uu___4459_29490.FStar_TypeChecker_Env.erasable_types_tab);
                                           FStar_TypeChecker_Env.enable_defer_to_tac
                                             =
-                                            (uu___4459_29478.FStar_TypeChecker_Env.enable_defer_to_tac)
+                                            (uu___4459_29490.FStar_TypeChecker_Env.enable_defer_to_tac)
                                         }
                                       else env1 in
-                                    (let uu____29481 =
+                                    (let uu____29493 =
                                        FStar_All.pipe_left
                                          (FStar_TypeChecker_Env.debug env2)
                                          (FStar_Options.Other "Rel") in
-                                     if uu____29481
+                                     if uu____29493
                                      then
-                                       let uu____29482 =
+                                       let uu____29494 =
                                          FStar_Syntax_Print.uvar_to_string
                                            ctx_u.FStar_Syntax_Syntax.ctx_uvar_head in
-                                       let uu____29483 =
+                                       let uu____29495 =
                                          FStar_Syntax_Print.term_to_string
                                            tm1 in
-                                       let uu____29484 =
+                                       let uu____29496 =
                                          FStar_Syntax_Print.term_to_string
                                            ctx_u.FStar_Syntax_Syntax.ctx_uvar_typ in
-                                       let uu____29485 =
+                                       let uu____29497 =
                                          FStar_Range.string_of_range r in
                                        FStar_Util.print5
                                          "Checking uvar %s resolved to %s at type %s, introduce for %s at %s\n"
-                                         uu____29482 uu____29483 uu____29484
-                                         reason uu____29485
+                                         uu____29494 uu____29495 uu____29496
+                                         reason uu____29497
                                      else ());
                                     (let g1 =
                                        try
-                                         (fun uu___4465_29489 ->
+                                         (fun uu___4465_29501 ->
                                             match () with
                                             | () ->
                                                 env2.FStar_TypeChecker_Env.check_type_of
@@ -12208,49 +12208,49 @@ let (resolve_implicits' :
                                            ()
                                        with
                                        | e when FStar_Errors.handleable e ->
-                                           ((let uu____29496 =
-                                               let uu____29505 =
-                                                 let uu____29512 =
-                                                   let uu____29513 =
+                                           ((let uu____29508 =
+                                               let uu____29517 =
+                                                 let uu____29524 =
+                                                   let uu____29525 =
                                                      FStar_Syntax_Print.uvar_to_string
                                                        ctx_u.FStar_Syntax_Syntax.ctx_uvar_head in
-                                                   let uu____29514 =
+                                                   let uu____29526 =
                                                      FStar_TypeChecker_Normalize.term_to_string
                                                        env2 tm1 in
-                                                   let uu____29515 =
+                                                   let uu____29527 =
                                                      FStar_TypeChecker_Normalize.term_to_string
                                                        env2
                                                        ctx_u.FStar_Syntax_Syntax.ctx_uvar_typ in
                                                    FStar_Util.format3
                                                      "Failed while checking implicit %s set to %s of expected type %s"
-                                                     uu____29513 uu____29514
-                                                     uu____29515 in
+                                                     uu____29525 uu____29526
+                                                     uu____29527 in
                                                  (FStar_Errors.Error_BadImplicit,
-                                                   uu____29512, r) in
-                                               [uu____29505] in
+                                                   uu____29524, r) in
+                                               [uu____29517] in
                                              FStar_Errors.add_errors
-                                               uu____29496);
+                                               uu____29508);
                                             FStar_Exn.raise e) in
                                      let g' =
-                                       let uu____29529 =
+                                       let uu____29541 =
                                          discharge_guard'
                                            (FStar_Pervasives_Native.Some
-                                              (fun uu____29539 ->
-                                                 let uu____29540 =
+                                              (fun uu____29551 ->
+                                                 let uu____29552 =
                                                    FStar_Syntax_Print.term_to_string
                                                      tm1 in
-                                                 let uu____29541 =
+                                                 let uu____29553 =
                                                    FStar_Range.string_of_range
                                                      r in
-                                                 let uu____29542 =
+                                                 let uu____29554 =
                                                    FStar_Range.string_of_range
                                                      tm1.FStar_Syntax_Syntax.pos in
                                                  FStar_Util.format4
                                                    "%s (Introduced at %s for %s resolved at %s)"
-                                                   uu____29540 uu____29541
-                                                   reason uu____29542)) env2
+                                                   uu____29552 uu____29553
+                                                   reason uu____29554)) env2
                                            g1 true in
-                                       match uu____29529 with
+                                       match uu____29541 with
                                        | FStar_Pervasives_Native.Some g2 ->
                                            g2
                                        | FStar_Pervasives_Native.None ->
@@ -12260,19 +12260,19 @@ let (resolve_implicits' :
                                        ((FStar_List.append
                                            g'.FStar_TypeChecker_Common.implicits
                                            out), true) tl))))) in
-            let uu___4477_29544 = g in
-            let uu____29545 =
+            let uu___4477_29556 = g in
+            let uu____29557 =
               until_fixpoint ([], false) g.FStar_TypeChecker_Common.implicits in
             {
               FStar_TypeChecker_Common.guard_f =
-                (uu___4477_29544.FStar_TypeChecker_Common.guard_f);
+                (uu___4477_29556.FStar_TypeChecker_Common.guard_f);
               FStar_TypeChecker_Common.deferred_to_tac =
-                (uu___4477_29544.FStar_TypeChecker_Common.deferred_to_tac);
+                (uu___4477_29556.FStar_TypeChecker_Common.deferred_to_tac);
               FStar_TypeChecker_Common.deferred =
-                (uu___4477_29544.FStar_TypeChecker_Common.deferred);
+                (uu___4477_29556.FStar_TypeChecker_Common.deferred);
               FStar_TypeChecker_Common.univ_ineqs =
-                (uu___4477_29544.FStar_TypeChecker_Common.univ_ineqs);
-              FStar_TypeChecker_Common.implicits = uu____29545
+                (uu___4477_29556.FStar_TypeChecker_Common.univ_ineqs);
+              FStar_TypeChecker_Common.implicits = uu____29557
             }
 let (resolve_implicits :
   FStar_TypeChecker_Env.env ->
@@ -12280,15 +12280,15 @@ let (resolve_implicits :
   =
   fun env ->
     fun g ->
-      (let uu____29557 =
+      (let uu____29569 =
          FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
            (FStar_Options.Other "ResolveImplicitsHook") in
-       if uu____29557
+       if uu____29569
        then
-         let uu____29558 = guard_to_string env g in
+         let uu____29570 = guard_to_string env g in
          FStar_Util.print1
            "//////////////////////////ResolveImplicitsHook: resolve_implicits////////////\nguard = %s\n"
-           uu____29558
+           uu____29570
        else ());
       resolve_implicits' env false g
 let (resolve_implicits_tac :
@@ -12299,37 +12299,37 @@ let (force_trivial_guard :
   FStar_TypeChecker_Env.env -> FStar_TypeChecker_Common.guard_t -> unit) =
   fun env ->
     fun g ->
-      (let uu____29581 =
+      (let uu____29593 =
          FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
            (FStar_Options.Other "ResolveImplicitsHook") in
-       if uu____29581
+       if uu____29593
        then
-         let uu____29582 = guard_to_string env g in
+         let uu____29594 = guard_to_string env g in
          FStar_Util.print1
            "//////////////////////////ResolveImplicitsHook: force_trivial_guard////////////\nguard = %s\n"
-           uu____29582
+           uu____29594
        else ());
       (let g1 = solve_deferred_constraints env g in
        let g2 = resolve_implicits env g1 in
        match g2.FStar_TypeChecker_Common.implicits with
        | [] ->
-           let uu____29586 = discharge_guard env g2 in
-           FStar_All.pipe_left (fun uu____29587 -> ()) uu____29586
-       | imp::uu____29589 ->
-           let uu____29592 =
-             let uu____29597 =
-               let uu____29598 =
+           let uu____29598 = discharge_guard env g2 in
+           FStar_All.pipe_left (fun uu____29599 -> ()) uu____29598
+       | imp::uu____29601 ->
+           let uu____29604 =
+             let uu____29609 =
+               let uu____29610 =
                  FStar_Syntax_Print.uvar_to_string
                    (imp.FStar_TypeChecker_Common.imp_uvar).FStar_Syntax_Syntax.ctx_uvar_head in
-               let uu____29599 =
+               let uu____29611 =
                  FStar_TypeChecker_Normalize.term_to_string env
                    (imp.FStar_TypeChecker_Common.imp_uvar).FStar_Syntax_Syntax.ctx_uvar_typ in
                FStar_Util.format3
                  "Failed to resolve implicit argument %s of type %s introduced for %s"
-                 uu____29598 uu____29599
+                 uu____29610 uu____29611
                  imp.FStar_TypeChecker_Common.imp_reason in
-             (FStar_Errors.Fatal_FailToResolveImplicitArgument, uu____29597) in
-           FStar_Errors.raise_error uu____29592
+             (FStar_Errors.Fatal_FailToResolveImplicitArgument, uu____29609) in
+           FStar_Errors.raise_error uu____29604
              imp.FStar_TypeChecker_Common.imp_range)
 let (teq_force :
   FStar_TypeChecker_Env.env ->
@@ -12338,8 +12338,8 @@ let (teq_force :
   fun env ->
     fun t1 ->
       fun t2 ->
-        let uu____29615 = teq env t1 t2 in
-        force_trivial_guard env uu____29615
+        let uu____29627 = teq env t1 t2 in
+        force_trivial_guard env uu____29627
 let (teq_nosmt_force :
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.typ -> FStar_Syntax_Syntax.typ -> Prims.bool)
@@ -12347,8 +12347,8 @@ let (teq_nosmt_force :
   fun env ->
     fun t1 ->
       fun t2 ->
-        let uu____29631 = teq_nosmt env t1 t2 in
-        match uu____29631 with
+        let uu____29643 = teq_nosmt env t1 t2 in
+        match uu____29643 with
         | FStar_Pervasives_Native.None -> false
         | FStar_Pervasives_Native.Some g -> (force_trivial_guard env g; true)
 let (layered_effect_teq :
@@ -12362,21 +12362,21 @@ let (layered_effect_teq :
     fun t1 ->
       fun t2 ->
         fun reason ->
-          (let uu____29661 =
+          (let uu____29673 =
              FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
                (FStar_Options.Other "LayeredEffectsEqns") in
-           if uu____29661
+           if uu____29673
            then
-             let uu____29662 =
-               let uu____29663 =
+             let uu____29674 =
+               let uu____29675 =
                  FStar_All.pipe_right reason FStar_Util.is_none in
-               if uu____29663
+               if uu____29675
                then "_"
                else FStar_All.pipe_right reason FStar_Util.must in
-             let uu____29669 = FStar_Syntax_Print.term_to_string t1 in
-             let uu____29670 = FStar_Syntax_Print.term_to_string t2 in
-             FStar_Util.print3 "Layered Effect (%s) %s = %s\n" uu____29662
-               uu____29669 uu____29670
+             let uu____29681 = FStar_Syntax_Print.term_to_string t1 in
+             let uu____29682 = FStar_Syntax_Print.term_to_string t2 in
+             FStar_Util.print3 "Layered Effect (%s) %s = %s\n" uu____29674
+               uu____29681 uu____29682
            else ());
           teq env t1 t2
 let (universe_inequality :
@@ -12385,17 +12385,17 @@ let (universe_inequality :
   =
   fun u1 ->
     fun u2 ->
-      let uu___4515_29682 = FStar_TypeChecker_Common.trivial_guard in
+      let uu___4515_29694 = FStar_TypeChecker_Common.trivial_guard in
       {
         FStar_TypeChecker_Common.guard_f =
-          (uu___4515_29682.FStar_TypeChecker_Common.guard_f);
+          (uu___4515_29694.FStar_TypeChecker_Common.guard_f);
         FStar_TypeChecker_Common.deferred_to_tac =
-          (uu___4515_29682.FStar_TypeChecker_Common.deferred_to_tac);
+          (uu___4515_29694.FStar_TypeChecker_Common.deferred_to_tac);
         FStar_TypeChecker_Common.deferred =
-          (uu___4515_29682.FStar_TypeChecker_Common.deferred);
+          (uu___4515_29694.FStar_TypeChecker_Common.deferred);
         FStar_TypeChecker_Common.univ_ineqs = ([], [(u1, u2)]);
         FStar_TypeChecker_Common.implicits =
-          (uu___4515_29682.FStar_TypeChecker_Common.implicits)
+          (uu___4515_29694.FStar_TypeChecker_Common.implicits)
       }
 let (check_subtyping :
   FStar_TypeChecker_Env.env ->
@@ -12407,44 +12407,44 @@ let (check_subtyping :
   fun env ->
     fun t1 ->
       fun t2 ->
-        (let uu____29717 =
+        (let uu____29729 =
            FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
              (FStar_Options.Other "Rel") in
-         if uu____29717
+         if uu____29729
          then
-           let uu____29718 =
+           let uu____29730 =
              FStar_TypeChecker_Normalize.term_to_string env t1 in
-           let uu____29719 =
+           let uu____29731 =
              FStar_TypeChecker_Normalize.term_to_string env t2 in
-           FStar_Util.print2 "check_subtyping of %s and %s\n" uu____29718
-             uu____29719
+           FStar_Util.print2 "check_subtyping of %s and %s\n" uu____29730
+             uu____29731
          else ());
-        (let uu____29721 =
+        (let uu____29733 =
            new_t_prob (empty_worklist env) env t1
              FStar_TypeChecker_Common.SUB t2 in
-         match uu____29721 with
+         match uu____29733 with
          | (prob, x, wl) ->
              let g =
-               let uu____29740 =
+               let uu____29752 =
                  solve_and_commit env (singleton wl prob true)
-                   (fun uu____29750 -> FStar_Pervasives_Native.None) in
-               FStar_All.pipe_left (with_guard env prob) uu____29740 in
-             ((let uu____29772 =
+                   (fun uu____29762 -> FStar_Pervasives_Native.None) in
+               FStar_All.pipe_left (with_guard env prob) uu____29752 in
+             ((let uu____29784 =
                  (FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
                     (FStar_Options.Other "Rel"))
                    && (FStar_Util.is_some g) in
-               if uu____29772
+               if uu____29784
                then
-                 let uu____29773 =
+                 let uu____29785 =
                    FStar_TypeChecker_Normalize.term_to_string env t1 in
-                 let uu____29774 =
+                 let uu____29786 =
                    FStar_TypeChecker_Normalize.term_to_string env t2 in
-                 let uu____29775 =
-                   let uu____29776 = FStar_Util.must g in
-                   guard_to_string env uu____29776 in
+                 let uu____29787 =
+                   let uu____29788 = FStar_Util.must g in
+                   guard_to_string env uu____29788 in
                  FStar_Util.print3
                    "check_subtyping succeeded: %s <: %s\n\tguard is %s\n"
-                   uu____29773 uu____29774 uu____29775
+                   uu____29785 uu____29786 uu____29787
                else ());
               (match g with
                | FStar_Pervasives_Native.None -> FStar_Pervasives_Native.None
@@ -12459,14 +12459,14 @@ let (get_subtyping_predicate :
   fun env ->
     fun t1 ->
       fun t2 ->
-        let uu____29810 = check_subtyping env t1 t2 in
-        match uu____29810 with
+        let uu____29822 = check_subtyping env t1 t2 in
+        match uu____29822 with
         | FStar_Pervasives_Native.None -> FStar_Pervasives_Native.None
         | FStar_Pervasives_Native.Some (x, g) ->
-            let uu____29829 =
-              let uu____29830 = FStar_Syntax_Syntax.mk_binder x in
-              FStar_TypeChecker_Env.abstract_guard uu____29830 g in
-            FStar_Pervasives_Native.Some uu____29829
+            let uu____29841 =
+              let uu____29842 = FStar_Syntax_Syntax.mk_binder x in
+              FStar_TypeChecker_Env.abstract_guard uu____29842 g in
+            FStar_Pervasives_Native.Some uu____29841
 let (get_subtyping_prop :
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.typ ->
@@ -12476,16 +12476,16 @@ let (get_subtyping_prop :
   fun env ->
     fun t1 ->
       fun t2 ->
-        let uu____29848 = check_subtyping env t1 t2 in
-        match uu____29848 with
+        let uu____29860 = check_subtyping env t1 t2 in
+        match uu____29860 with
         | FStar_Pervasives_Native.None -> FStar_Pervasives_Native.None
         | FStar_Pervasives_Native.Some (x, g) ->
-            let uu____29867 =
-              let uu____29868 =
-                let uu____29869 = FStar_Syntax_Syntax.mk_binder x in
-                [uu____29869] in
-              FStar_TypeChecker_Env.close_guard env uu____29868 g in
-            FStar_Pervasives_Native.Some uu____29867
+            let uu____29879 =
+              let uu____29880 =
+                let uu____29881 = FStar_Syntax_Syntax.mk_binder x in
+                [uu____29881] in
+              FStar_TypeChecker_Env.close_guard env uu____29880 g in
+            FStar_Pervasives_Native.Some uu____29879
 let (subtype_nosmt :
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.typ ->
@@ -12495,36 +12495,36 @@ let (subtype_nosmt :
   fun env ->
     fun t1 ->
       fun t2 ->
-        (let uu____29906 =
+        (let uu____29918 =
            FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
              (FStar_Options.Other "Rel") in
-         if uu____29906
+         if uu____29918
          then
-           let uu____29907 =
+           let uu____29919 =
              FStar_TypeChecker_Normalize.term_to_string env t1 in
-           let uu____29908 =
+           let uu____29920 =
              FStar_TypeChecker_Normalize.term_to_string env t2 in
-           FStar_Util.print2 "try_subtype_no_smt of %s and %s\n" uu____29907
-             uu____29908
+           FStar_Util.print2 "try_subtype_no_smt of %s and %s\n" uu____29919
+             uu____29920
          else ());
-        (let uu____29910 =
+        (let uu____29922 =
            new_t_prob (empty_worklist env) env t1
              FStar_TypeChecker_Common.SUB t2 in
-         match uu____29910 with
+         match uu____29922 with
          | (prob, x, wl) ->
              let g =
-               let uu____29925 =
+               let uu____29937 =
                  solve_and_commit env (singleton wl prob false)
-                   (fun uu____29935 -> FStar_Pervasives_Native.None) in
-               FStar_All.pipe_left (with_guard env prob) uu____29925 in
+                   (fun uu____29947 -> FStar_Pervasives_Native.None) in
+               FStar_All.pipe_left (with_guard env prob) uu____29937 in
              (match g with
               | FStar_Pervasives_Native.None -> FStar_Pervasives_Native.None
               | FStar_Pervasives_Native.Some g1 ->
                   let g2 =
-                    let uu____29960 =
-                      let uu____29961 = FStar_Syntax_Syntax.mk_binder x in
-                      [uu____29961] in
-                    FStar_TypeChecker_Env.close_guard env uu____29960 g1 in
+                    let uu____29972 =
+                      let uu____29973 = FStar_Syntax_Syntax.mk_binder x in
+                      [uu____29973] in
+                    FStar_TypeChecker_Env.close_guard env uu____29972 g1 in
                   discharge_guard' FStar_Pervasives_Native.None env g2 false))
 let (subtype_nosmt_force :
   FStar_TypeChecker_Env.env ->
@@ -12533,7 +12533,7 @@ let (subtype_nosmt_force :
   fun env ->
     fun t1 ->
       fun t2 ->
-        let uu____29998 = subtype_nosmt env t1 t2 in
-        match uu____29998 with
+        let uu____30010 = subtype_nosmt env t1 t2 in
+        match uu____30010 with
         | FStar_Pervasives_Native.None -> false
         | FStar_Pervasives_Native.Some g -> (force_trivial_guard env g; true)

--- a/src/ocaml-output/FStar_TypeChecker_Tc.ml
+++ b/src/ocaml-output/FStar_TypeChecker_Tc.ml
@@ -1252,211 +1252,211 @@ let (tc_decl' :
                       | {
                           FStar_Syntax_Syntax.n =
                             FStar_Syntax_Syntax.Tm_unknown;
-                          FStar_Syntax_Syntax.pos = uu____1646;
-                          FStar_Syntax_Syntax.vars = uu____1647;_} -> true
-                      | uu____1650 -> false)
-                 | uu____1653 -> false in
+                          FStar_Syntax_Syntax.pos = uu____1650;
+                          FStar_Syntax_Syntax.vars = uu____1651;_} -> true
+                      | uu____1654 -> false)
+                 | uu____1657 -> false in
                if is_unelaborated_dm4f
                then
                  let env1 = FStar_TypeChecker_Env.set_range env r in
-                 let uu____1665 =
+                 let uu____1669 =
                    FStar_TypeChecker_TcEffect.dmff_cps_and_elaborate env1 ne in
-                 (match uu____1665 with
+                 (match uu____1669 with
                   | (ses, ne1, lift_from_pure_opt) ->
                       let effect_and_lift_ses =
                         match lift_from_pure_opt with
                         | FStar_Pervasives_Native.Some lift ->
-                            [(let uu___344_1704 = se1 in
+                            [(let uu___344_1708 = se1 in
                               {
                                 FStar_Syntax_Syntax.sigel =
                                   (FStar_Syntax_Syntax.Sig_new_effect ne1);
                                 FStar_Syntax_Syntax.sigrng =
-                                  (uu___344_1704.FStar_Syntax_Syntax.sigrng);
+                                  (uu___344_1708.FStar_Syntax_Syntax.sigrng);
                                 FStar_Syntax_Syntax.sigquals =
-                                  (uu___344_1704.FStar_Syntax_Syntax.sigquals);
+                                  (uu___344_1708.FStar_Syntax_Syntax.sigquals);
                                 FStar_Syntax_Syntax.sigmeta =
-                                  (uu___344_1704.FStar_Syntax_Syntax.sigmeta);
+                                  (uu___344_1708.FStar_Syntax_Syntax.sigmeta);
                                 FStar_Syntax_Syntax.sigattrs =
-                                  (uu___344_1704.FStar_Syntax_Syntax.sigattrs);
+                                  (uu___344_1708.FStar_Syntax_Syntax.sigattrs);
                                 FStar_Syntax_Syntax.sigopts =
-                                  (uu___344_1704.FStar_Syntax_Syntax.sigopts)
+                                  (uu___344_1708.FStar_Syntax_Syntax.sigopts)
                               });
                             lift]
                         | FStar_Pervasives_Native.None ->
-                            [(let uu___347_1706 = se1 in
+                            [(let uu___347_1710 = se1 in
                               {
                                 FStar_Syntax_Syntax.sigel =
                                   (FStar_Syntax_Syntax.Sig_new_effect ne1);
                                 FStar_Syntax_Syntax.sigrng =
-                                  (uu___347_1706.FStar_Syntax_Syntax.sigrng);
+                                  (uu___347_1710.FStar_Syntax_Syntax.sigrng);
                                 FStar_Syntax_Syntax.sigquals =
-                                  (uu___347_1706.FStar_Syntax_Syntax.sigquals);
+                                  (uu___347_1710.FStar_Syntax_Syntax.sigquals);
                                 FStar_Syntax_Syntax.sigmeta =
-                                  (uu___347_1706.FStar_Syntax_Syntax.sigmeta);
+                                  (uu___347_1710.FStar_Syntax_Syntax.sigmeta);
                                 FStar_Syntax_Syntax.sigattrs =
-                                  (uu___347_1706.FStar_Syntax_Syntax.sigattrs);
+                                  (uu___347_1710.FStar_Syntax_Syntax.sigattrs);
                                 FStar_Syntax_Syntax.sigopts =
-                                  (uu___347_1706.FStar_Syntax_Syntax.sigopts)
+                                  (uu___347_1710.FStar_Syntax_Syntax.sigopts)
                               })] in
                       ([], (FStar_List.append ses effect_and_lift_ses), env0))
                else
                  (let ne1 =
-                    let uu____1713 =
+                    let uu____1717 =
                       (FStar_Options.use_two_phase_tc ()) &&
                         (FStar_TypeChecker_Env.should_verify env) in
-                    if uu____1713
+                    if uu____1717
                     then
                       let ne1 =
-                        let uu____1715 =
-                          let uu____1716 =
-                            let uu____1717 =
+                        let uu____1719 =
+                          let uu____1720 =
+                            let uu____1721 =
                               FStar_TypeChecker_TcEffect.tc_eff_decl
-                                (let uu___351_1720 = env in
+                                (let uu___351_1724 = env in
                                  {
                                    FStar_TypeChecker_Env.solver =
-                                     (uu___351_1720.FStar_TypeChecker_Env.solver);
+                                     (uu___351_1724.FStar_TypeChecker_Env.solver);
                                    FStar_TypeChecker_Env.range =
-                                     (uu___351_1720.FStar_TypeChecker_Env.range);
+                                     (uu___351_1724.FStar_TypeChecker_Env.range);
                                    FStar_TypeChecker_Env.curmodule =
-                                     (uu___351_1720.FStar_TypeChecker_Env.curmodule);
+                                     (uu___351_1724.FStar_TypeChecker_Env.curmodule);
                                    FStar_TypeChecker_Env.gamma =
-                                     (uu___351_1720.FStar_TypeChecker_Env.gamma);
+                                     (uu___351_1724.FStar_TypeChecker_Env.gamma);
                                    FStar_TypeChecker_Env.gamma_sig =
-                                     (uu___351_1720.FStar_TypeChecker_Env.gamma_sig);
+                                     (uu___351_1724.FStar_TypeChecker_Env.gamma_sig);
                                    FStar_TypeChecker_Env.gamma_cache =
-                                     (uu___351_1720.FStar_TypeChecker_Env.gamma_cache);
+                                     (uu___351_1724.FStar_TypeChecker_Env.gamma_cache);
                                    FStar_TypeChecker_Env.modules =
-                                     (uu___351_1720.FStar_TypeChecker_Env.modules);
+                                     (uu___351_1724.FStar_TypeChecker_Env.modules);
                                    FStar_TypeChecker_Env.expected_typ =
-                                     (uu___351_1720.FStar_TypeChecker_Env.expected_typ);
+                                     (uu___351_1724.FStar_TypeChecker_Env.expected_typ);
                                    FStar_TypeChecker_Env.sigtab =
-                                     (uu___351_1720.FStar_TypeChecker_Env.sigtab);
+                                     (uu___351_1724.FStar_TypeChecker_Env.sigtab);
                                    FStar_TypeChecker_Env.attrtab =
-                                     (uu___351_1720.FStar_TypeChecker_Env.attrtab);
+                                     (uu___351_1724.FStar_TypeChecker_Env.attrtab);
                                    FStar_TypeChecker_Env.instantiate_imp =
-                                     (uu___351_1720.FStar_TypeChecker_Env.instantiate_imp);
+                                     (uu___351_1724.FStar_TypeChecker_Env.instantiate_imp);
                                    FStar_TypeChecker_Env.effects =
-                                     (uu___351_1720.FStar_TypeChecker_Env.effects);
+                                     (uu___351_1724.FStar_TypeChecker_Env.effects);
                                    FStar_TypeChecker_Env.generalize =
-                                     (uu___351_1720.FStar_TypeChecker_Env.generalize);
+                                     (uu___351_1724.FStar_TypeChecker_Env.generalize);
                                    FStar_TypeChecker_Env.letrecs =
-                                     (uu___351_1720.FStar_TypeChecker_Env.letrecs);
+                                     (uu___351_1724.FStar_TypeChecker_Env.letrecs);
                                    FStar_TypeChecker_Env.top_level =
-                                     (uu___351_1720.FStar_TypeChecker_Env.top_level);
+                                     (uu___351_1724.FStar_TypeChecker_Env.top_level);
                                    FStar_TypeChecker_Env.check_uvars =
-                                     (uu___351_1720.FStar_TypeChecker_Env.check_uvars);
+                                     (uu___351_1724.FStar_TypeChecker_Env.check_uvars);
                                    FStar_TypeChecker_Env.use_eq =
-                                     (uu___351_1720.FStar_TypeChecker_Env.use_eq);
+                                     (uu___351_1724.FStar_TypeChecker_Env.use_eq);
                                    FStar_TypeChecker_Env.use_eq_strict =
-                                     (uu___351_1720.FStar_TypeChecker_Env.use_eq_strict);
+                                     (uu___351_1724.FStar_TypeChecker_Env.use_eq_strict);
                                    FStar_TypeChecker_Env.is_iface =
-                                     (uu___351_1720.FStar_TypeChecker_Env.is_iface);
+                                     (uu___351_1724.FStar_TypeChecker_Env.is_iface);
                                    FStar_TypeChecker_Env.admit =
-                                     (uu___351_1720.FStar_TypeChecker_Env.admit);
+                                     (uu___351_1724.FStar_TypeChecker_Env.admit);
                                    FStar_TypeChecker_Env.lax = true;
                                    FStar_TypeChecker_Env.lax_universes =
-                                     (uu___351_1720.FStar_TypeChecker_Env.lax_universes);
+                                     (uu___351_1724.FStar_TypeChecker_Env.lax_universes);
                                    FStar_TypeChecker_Env.phase1 = true;
                                    FStar_TypeChecker_Env.failhard =
-                                     (uu___351_1720.FStar_TypeChecker_Env.failhard);
+                                     (uu___351_1724.FStar_TypeChecker_Env.failhard);
                                    FStar_TypeChecker_Env.nosynth =
-                                     (uu___351_1720.FStar_TypeChecker_Env.nosynth);
+                                     (uu___351_1724.FStar_TypeChecker_Env.nosynth);
                                    FStar_TypeChecker_Env.uvar_subtyping =
-                                     (uu___351_1720.FStar_TypeChecker_Env.uvar_subtyping);
+                                     (uu___351_1724.FStar_TypeChecker_Env.uvar_subtyping);
                                    FStar_TypeChecker_Env.tc_term =
-                                     (uu___351_1720.FStar_TypeChecker_Env.tc_term);
+                                     (uu___351_1724.FStar_TypeChecker_Env.tc_term);
                                    FStar_TypeChecker_Env.type_of =
-                                     (uu___351_1720.FStar_TypeChecker_Env.type_of);
+                                     (uu___351_1724.FStar_TypeChecker_Env.type_of);
                                    FStar_TypeChecker_Env.universe_of =
-                                     (uu___351_1720.FStar_TypeChecker_Env.universe_of);
+                                     (uu___351_1724.FStar_TypeChecker_Env.universe_of);
                                    FStar_TypeChecker_Env.check_type_of =
-                                     (uu___351_1720.FStar_TypeChecker_Env.check_type_of);
+                                     (uu___351_1724.FStar_TypeChecker_Env.check_type_of);
                                    FStar_TypeChecker_Env.use_bv_sorts =
-                                     (uu___351_1720.FStar_TypeChecker_Env.use_bv_sorts);
+                                     (uu___351_1724.FStar_TypeChecker_Env.use_bv_sorts);
                                    FStar_TypeChecker_Env.qtbl_name_and_index
                                      =
-                                     (uu___351_1720.FStar_TypeChecker_Env.qtbl_name_and_index);
+                                     (uu___351_1724.FStar_TypeChecker_Env.qtbl_name_and_index);
                                    FStar_TypeChecker_Env.normalized_eff_names
                                      =
-                                     (uu___351_1720.FStar_TypeChecker_Env.normalized_eff_names);
+                                     (uu___351_1724.FStar_TypeChecker_Env.normalized_eff_names);
                                    FStar_TypeChecker_Env.fv_delta_depths =
-                                     (uu___351_1720.FStar_TypeChecker_Env.fv_delta_depths);
+                                     (uu___351_1724.FStar_TypeChecker_Env.fv_delta_depths);
                                    FStar_TypeChecker_Env.proof_ns =
-                                     (uu___351_1720.FStar_TypeChecker_Env.proof_ns);
+                                     (uu___351_1724.FStar_TypeChecker_Env.proof_ns);
                                    FStar_TypeChecker_Env.synth_hook =
-                                     (uu___351_1720.FStar_TypeChecker_Env.synth_hook);
+                                     (uu___351_1724.FStar_TypeChecker_Env.synth_hook);
                                    FStar_TypeChecker_Env.try_solve_implicits_hook
                                      =
-                                     (uu___351_1720.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                                     (uu___351_1724.FStar_TypeChecker_Env.try_solve_implicits_hook);
                                    FStar_TypeChecker_Env.splice =
-                                     (uu___351_1720.FStar_TypeChecker_Env.splice);
+                                     (uu___351_1724.FStar_TypeChecker_Env.splice);
                                    FStar_TypeChecker_Env.mpreprocess =
-                                     (uu___351_1720.FStar_TypeChecker_Env.mpreprocess);
+                                     (uu___351_1724.FStar_TypeChecker_Env.mpreprocess);
                                    FStar_TypeChecker_Env.postprocess =
-                                     (uu___351_1720.FStar_TypeChecker_Env.postprocess);
+                                     (uu___351_1724.FStar_TypeChecker_Env.postprocess);
                                    FStar_TypeChecker_Env.identifier_info =
-                                     (uu___351_1720.FStar_TypeChecker_Env.identifier_info);
+                                     (uu___351_1724.FStar_TypeChecker_Env.identifier_info);
                                    FStar_TypeChecker_Env.tc_hooks =
-                                     (uu___351_1720.FStar_TypeChecker_Env.tc_hooks);
+                                     (uu___351_1724.FStar_TypeChecker_Env.tc_hooks);
                                    FStar_TypeChecker_Env.dsenv =
-                                     (uu___351_1720.FStar_TypeChecker_Env.dsenv);
+                                     (uu___351_1724.FStar_TypeChecker_Env.dsenv);
                                    FStar_TypeChecker_Env.nbe =
-                                     (uu___351_1720.FStar_TypeChecker_Env.nbe);
+                                     (uu___351_1724.FStar_TypeChecker_Env.nbe);
                                    FStar_TypeChecker_Env.strict_args_tab =
-                                     (uu___351_1720.FStar_TypeChecker_Env.strict_args_tab);
+                                     (uu___351_1724.FStar_TypeChecker_Env.strict_args_tab);
                                    FStar_TypeChecker_Env.erasable_types_tab =
-                                     (uu___351_1720.FStar_TypeChecker_Env.erasable_types_tab);
+                                     (uu___351_1724.FStar_TypeChecker_Env.erasable_types_tab);
                                    FStar_TypeChecker_Env.enable_defer_to_tac
                                      =
-                                     (uu___351_1720.FStar_TypeChecker_Env.enable_defer_to_tac)
+                                     (uu___351_1724.FStar_TypeChecker_Env.enable_defer_to_tac)
                                  }) ne se1.FStar_Syntax_Syntax.sigquals
                                 se1.FStar_Syntax_Syntax.sigattrs in
-                            FStar_All.pipe_right uu____1717
+                            FStar_All.pipe_right uu____1721
                               (fun ne1 ->
-                                 let uu___354_1724 = se1 in
+                                 let uu___354_1728 = se1 in
                                  {
                                    FStar_Syntax_Syntax.sigel =
                                      (FStar_Syntax_Syntax.Sig_new_effect ne1);
                                    FStar_Syntax_Syntax.sigrng =
-                                     (uu___354_1724.FStar_Syntax_Syntax.sigrng);
+                                     (uu___354_1728.FStar_Syntax_Syntax.sigrng);
                                    FStar_Syntax_Syntax.sigquals =
-                                     (uu___354_1724.FStar_Syntax_Syntax.sigquals);
+                                     (uu___354_1728.FStar_Syntax_Syntax.sigquals);
                                    FStar_Syntax_Syntax.sigmeta =
-                                     (uu___354_1724.FStar_Syntax_Syntax.sigmeta);
+                                     (uu___354_1728.FStar_Syntax_Syntax.sigmeta);
                                    FStar_Syntax_Syntax.sigattrs =
-                                     (uu___354_1724.FStar_Syntax_Syntax.sigattrs);
+                                     (uu___354_1728.FStar_Syntax_Syntax.sigattrs);
                                    FStar_Syntax_Syntax.sigopts =
-                                     (uu___354_1724.FStar_Syntax_Syntax.sigopts)
+                                     (uu___354_1728.FStar_Syntax_Syntax.sigopts)
                                  }) in
-                          FStar_All.pipe_right uu____1716
+                          FStar_All.pipe_right uu____1720
                             (FStar_TypeChecker_Normalize.elim_uvars env) in
-                        FStar_All.pipe_right uu____1715
+                        FStar_All.pipe_right uu____1719
                           FStar_Syntax_Util.eff_decl_of_new_effect in
-                      ((let uu____1726 =
+                      ((let uu____1730 =
                           FStar_All.pipe_left
                             (FStar_TypeChecker_Env.debug env)
                             (FStar_Options.Other "TwoPhases") in
-                        if uu____1726
+                        if uu____1730
                         then
-                          let uu____1727 =
+                          let uu____1731 =
                             FStar_Syntax_Print.sigelt_to_string
-                              (let uu___358_1730 = se1 in
+                              (let uu___358_1734 = se1 in
                                {
                                  FStar_Syntax_Syntax.sigel =
                                    (FStar_Syntax_Syntax.Sig_new_effect ne1);
                                  FStar_Syntax_Syntax.sigrng =
-                                   (uu___358_1730.FStar_Syntax_Syntax.sigrng);
+                                   (uu___358_1734.FStar_Syntax_Syntax.sigrng);
                                  FStar_Syntax_Syntax.sigquals =
-                                   (uu___358_1730.FStar_Syntax_Syntax.sigquals);
+                                   (uu___358_1734.FStar_Syntax_Syntax.sigquals);
                                  FStar_Syntax_Syntax.sigmeta =
-                                   (uu___358_1730.FStar_Syntax_Syntax.sigmeta);
+                                   (uu___358_1734.FStar_Syntax_Syntax.sigmeta);
                                  FStar_Syntax_Syntax.sigattrs =
-                                   (uu___358_1730.FStar_Syntax_Syntax.sigattrs);
+                                   (uu___358_1734.FStar_Syntax_Syntax.sigattrs);
                                  FStar_Syntax_Syntax.sigopts =
-                                   (uu___358_1730.FStar_Syntax_Syntax.sigopts)
+                                   (uu___358_1734.FStar_Syntax_Syntax.sigopts)
                                }) in
                           FStar_Util.print1 "Effect decl after phase 1: %s\n"
-                            uu____1727
+                            uu____1731
                         else ());
                        ne1)
                     else ne in
@@ -1465,552 +1465,552 @@ let (tc_decl' :
                       se1.FStar_Syntax_Syntax.sigquals
                       se1.FStar_Syntax_Syntax.sigattrs in
                   let se2 =
-                    let uu___363_1735 = se1 in
+                    let uu___363_1739 = se1 in
                     {
                       FStar_Syntax_Syntax.sigel =
                         (FStar_Syntax_Syntax.Sig_new_effect ne2);
                       FStar_Syntax_Syntax.sigrng =
-                        (uu___363_1735.FStar_Syntax_Syntax.sigrng);
+                        (uu___363_1739.FStar_Syntax_Syntax.sigrng);
                       FStar_Syntax_Syntax.sigquals =
-                        (uu___363_1735.FStar_Syntax_Syntax.sigquals);
+                        (uu___363_1739.FStar_Syntax_Syntax.sigquals);
                       FStar_Syntax_Syntax.sigmeta =
-                        (uu___363_1735.FStar_Syntax_Syntax.sigmeta);
+                        (uu___363_1739.FStar_Syntax_Syntax.sigmeta);
                       FStar_Syntax_Syntax.sigattrs =
-                        (uu___363_1735.FStar_Syntax_Syntax.sigattrs);
+                        (uu___363_1739.FStar_Syntax_Syntax.sigattrs);
                       FStar_Syntax_Syntax.sigopts =
-                        (uu___363_1735.FStar_Syntax_Syntax.sigopts)
+                        (uu___363_1739.FStar_Syntax_Syntax.sigopts)
                     } in
                   ([se2], [], env0))
            | FStar_Syntax_Syntax.Sig_sub_effect sub ->
                let sub1 = FStar_TypeChecker_TcEffect.tc_lift env sub r in
                let se2 =
-                 let uu___369_1743 = se1 in
+                 let uu___369_1747 = se1 in
                  {
                    FStar_Syntax_Syntax.sigel =
                      (FStar_Syntax_Syntax.Sig_sub_effect sub1);
                    FStar_Syntax_Syntax.sigrng =
-                     (uu___369_1743.FStar_Syntax_Syntax.sigrng);
+                     (uu___369_1747.FStar_Syntax_Syntax.sigrng);
                    FStar_Syntax_Syntax.sigquals =
-                     (uu___369_1743.FStar_Syntax_Syntax.sigquals);
+                     (uu___369_1747.FStar_Syntax_Syntax.sigquals);
                    FStar_Syntax_Syntax.sigmeta =
-                     (uu___369_1743.FStar_Syntax_Syntax.sigmeta);
+                     (uu___369_1747.FStar_Syntax_Syntax.sigmeta);
                    FStar_Syntax_Syntax.sigattrs =
-                     (uu___369_1743.FStar_Syntax_Syntax.sigattrs);
+                     (uu___369_1747.FStar_Syntax_Syntax.sigattrs);
                    FStar_Syntax_Syntax.sigopts =
-                     (uu___369_1743.FStar_Syntax_Syntax.sigopts)
+                     (uu___369_1747.FStar_Syntax_Syntax.sigopts)
                  } in
                ([se2], [], env)
            | FStar_Syntax_Syntax.Sig_effect_abbrev (lid, uvs, tps, c, flags)
                ->
-               let uu____1757 =
-                 let uu____1766 =
+               let uu____1761 =
+                 let uu____1770 =
                    (FStar_Options.use_two_phase_tc ()) &&
                      (FStar_TypeChecker_Env.should_verify env) in
-                 if uu____1766
+                 if uu____1770
                  then
-                   let uu____1775 =
-                     let uu____1776 =
-                       let uu____1777 =
+                   let uu____1779 =
+                     let uu____1780 =
+                       let uu____1781 =
                          FStar_TypeChecker_TcEffect.tc_effect_abbrev
-                           (let uu___380_1788 = env in
+                           (let uu___380_1792 = env in
                             {
                               FStar_TypeChecker_Env.solver =
-                                (uu___380_1788.FStar_TypeChecker_Env.solver);
+                                (uu___380_1792.FStar_TypeChecker_Env.solver);
                               FStar_TypeChecker_Env.range =
-                                (uu___380_1788.FStar_TypeChecker_Env.range);
+                                (uu___380_1792.FStar_TypeChecker_Env.range);
                               FStar_TypeChecker_Env.curmodule =
-                                (uu___380_1788.FStar_TypeChecker_Env.curmodule);
+                                (uu___380_1792.FStar_TypeChecker_Env.curmodule);
                               FStar_TypeChecker_Env.gamma =
-                                (uu___380_1788.FStar_TypeChecker_Env.gamma);
+                                (uu___380_1792.FStar_TypeChecker_Env.gamma);
                               FStar_TypeChecker_Env.gamma_sig =
-                                (uu___380_1788.FStar_TypeChecker_Env.gamma_sig);
+                                (uu___380_1792.FStar_TypeChecker_Env.gamma_sig);
                               FStar_TypeChecker_Env.gamma_cache =
-                                (uu___380_1788.FStar_TypeChecker_Env.gamma_cache);
+                                (uu___380_1792.FStar_TypeChecker_Env.gamma_cache);
                               FStar_TypeChecker_Env.modules =
-                                (uu___380_1788.FStar_TypeChecker_Env.modules);
+                                (uu___380_1792.FStar_TypeChecker_Env.modules);
                               FStar_TypeChecker_Env.expected_typ =
-                                (uu___380_1788.FStar_TypeChecker_Env.expected_typ);
+                                (uu___380_1792.FStar_TypeChecker_Env.expected_typ);
                               FStar_TypeChecker_Env.sigtab =
-                                (uu___380_1788.FStar_TypeChecker_Env.sigtab);
+                                (uu___380_1792.FStar_TypeChecker_Env.sigtab);
                               FStar_TypeChecker_Env.attrtab =
-                                (uu___380_1788.FStar_TypeChecker_Env.attrtab);
+                                (uu___380_1792.FStar_TypeChecker_Env.attrtab);
                               FStar_TypeChecker_Env.instantiate_imp =
-                                (uu___380_1788.FStar_TypeChecker_Env.instantiate_imp);
+                                (uu___380_1792.FStar_TypeChecker_Env.instantiate_imp);
                               FStar_TypeChecker_Env.effects =
-                                (uu___380_1788.FStar_TypeChecker_Env.effects);
+                                (uu___380_1792.FStar_TypeChecker_Env.effects);
                               FStar_TypeChecker_Env.generalize =
-                                (uu___380_1788.FStar_TypeChecker_Env.generalize);
+                                (uu___380_1792.FStar_TypeChecker_Env.generalize);
                               FStar_TypeChecker_Env.letrecs =
-                                (uu___380_1788.FStar_TypeChecker_Env.letrecs);
+                                (uu___380_1792.FStar_TypeChecker_Env.letrecs);
                               FStar_TypeChecker_Env.top_level =
-                                (uu___380_1788.FStar_TypeChecker_Env.top_level);
+                                (uu___380_1792.FStar_TypeChecker_Env.top_level);
                               FStar_TypeChecker_Env.check_uvars =
-                                (uu___380_1788.FStar_TypeChecker_Env.check_uvars);
+                                (uu___380_1792.FStar_TypeChecker_Env.check_uvars);
                               FStar_TypeChecker_Env.use_eq =
-                                (uu___380_1788.FStar_TypeChecker_Env.use_eq);
+                                (uu___380_1792.FStar_TypeChecker_Env.use_eq);
                               FStar_TypeChecker_Env.use_eq_strict =
-                                (uu___380_1788.FStar_TypeChecker_Env.use_eq_strict);
+                                (uu___380_1792.FStar_TypeChecker_Env.use_eq_strict);
                               FStar_TypeChecker_Env.is_iface =
-                                (uu___380_1788.FStar_TypeChecker_Env.is_iface);
+                                (uu___380_1792.FStar_TypeChecker_Env.is_iface);
                               FStar_TypeChecker_Env.admit =
-                                (uu___380_1788.FStar_TypeChecker_Env.admit);
+                                (uu___380_1792.FStar_TypeChecker_Env.admit);
                               FStar_TypeChecker_Env.lax = true;
                               FStar_TypeChecker_Env.lax_universes =
-                                (uu___380_1788.FStar_TypeChecker_Env.lax_universes);
+                                (uu___380_1792.FStar_TypeChecker_Env.lax_universes);
                               FStar_TypeChecker_Env.phase1 = true;
                               FStar_TypeChecker_Env.failhard =
-                                (uu___380_1788.FStar_TypeChecker_Env.failhard);
+                                (uu___380_1792.FStar_TypeChecker_Env.failhard);
                               FStar_TypeChecker_Env.nosynth =
-                                (uu___380_1788.FStar_TypeChecker_Env.nosynth);
+                                (uu___380_1792.FStar_TypeChecker_Env.nosynth);
                               FStar_TypeChecker_Env.uvar_subtyping =
-                                (uu___380_1788.FStar_TypeChecker_Env.uvar_subtyping);
+                                (uu___380_1792.FStar_TypeChecker_Env.uvar_subtyping);
                               FStar_TypeChecker_Env.tc_term =
-                                (uu___380_1788.FStar_TypeChecker_Env.tc_term);
+                                (uu___380_1792.FStar_TypeChecker_Env.tc_term);
                               FStar_TypeChecker_Env.type_of =
-                                (uu___380_1788.FStar_TypeChecker_Env.type_of);
+                                (uu___380_1792.FStar_TypeChecker_Env.type_of);
                               FStar_TypeChecker_Env.universe_of =
-                                (uu___380_1788.FStar_TypeChecker_Env.universe_of);
+                                (uu___380_1792.FStar_TypeChecker_Env.universe_of);
                               FStar_TypeChecker_Env.check_type_of =
-                                (uu___380_1788.FStar_TypeChecker_Env.check_type_of);
+                                (uu___380_1792.FStar_TypeChecker_Env.check_type_of);
                               FStar_TypeChecker_Env.use_bv_sorts =
-                                (uu___380_1788.FStar_TypeChecker_Env.use_bv_sorts);
+                                (uu___380_1792.FStar_TypeChecker_Env.use_bv_sorts);
                               FStar_TypeChecker_Env.qtbl_name_and_index =
-                                (uu___380_1788.FStar_TypeChecker_Env.qtbl_name_and_index);
+                                (uu___380_1792.FStar_TypeChecker_Env.qtbl_name_and_index);
                               FStar_TypeChecker_Env.normalized_eff_names =
-                                (uu___380_1788.FStar_TypeChecker_Env.normalized_eff_names);
+                                (uu___380_1792.FStar_TypeChecker_Env.normalized_eff_names);
                               FStar_TypeChecker_Env.fv_delta_depths =
-                                (uu___380_1788.FStar_TypeChecker_Env.fv_delta_depths);
+                                (uu___380_1792.FStar_TypeChecker_Env.fv_delta_depths);
                               FStar_TypeChecker_Env.proof_ns =
-                                (uu___380_1788.FStar_TypeChecker_Env.proof_ns);
+                                (uu___380_1792.FStar_TypeChecker_Env.proof_ns);
                               FStar_TypeChecker_Env.synth_hook =
-                                (uu___380_1788.FStar_TypeChecker_Env.synth_hook);
+                                (uu___380_1792.FStar_TypeChecker_Env.synth_hook);
                               FStar_TypeChecker_Env.try_solve_implicits_hook
                                 =
-                                (uu___380_1788.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                                (uu___380_1792.FStar_TypeChecker_Env.try_solve_implicits_hook);
                               FStar_TypeChecker_Env.splice =
-                                (uu___380_1788.FStar_TypeChecker_Env.splice);
+                                (uu___380_1792.FStar_TypeChecker_Env.splice);
                               FStar_TypeChecker_Env.mpreprocess =
-                                (uu___380_1788.FStar_TypeChecker_Env.mpreprocess);
+                                (uu___380_1792.FStar_TypeChecker_Env.mpreprocess);
                               FStar_TypeChecker_Env.postprocess =
-                                (uu___380_1788.FStar_TypeChecker_Env.postprocess);
+                                (uu___380_1792.FStar_TypeChecker_Env.postprocess);
                               FStar_TypeChecker_Env.identifier_info =
-                                (uu___380_1788.FStar_TypeChecker_Env.identifier_info);
+                                (uu___380_1792.FStar_TypeChecker_Env.identifier_info);
                               FStar_TypeChecker_Env.tc_hooks =
-                                (uu___380_1788.FStar_TypeChecker_Env.tc_hooks);
+                                (uu___380_1792.FStar_TypeChecker_Env.tc_hooks);
                               FStar_TypeChecker_Env.dsenv =
-                                (uu___380_1788.FStar_TypeChecker_Env.dsenv);
+                                (uu___380_1792.FStar_TypeChecker_Env.dsenv);
                               FStar_TypeChecker_Env.nbe =
-                                (uu___380_1788.FStar_TypeChecker_Env.nbe);
+                                (uu___380_1792.FStar_TypeChecker_Env.nbe);
                               FStar_TypeChecker_Env.strict_args_tab =
-                                (uu___380_1788.FStar_TypeChecker_Env.strict_args_tab);
+                                (uu___380_1792.FStar_TypeChecker_Env.strict_args_tab);
                               FStar_TypeChecker_Env.erasable_types_tab =
-                                (uu___380_1788.FStar_TypeChecker_Env.erasable_types_tab);
+                                (uu___380_1792.FStar_TypeChecker_Env.erasable_types_tab);
                               FStar_TypeChecker_Env.enable_defer_to_tac =
-                                (uu___380_1788.FStar_TypeChecker_Env.enable_defer_to_tac)
+                                (uu___380_1792.FStar_TypeChecker_Env.enable_defer_to_tac)
                             }) (lid, uvs, tps, c) r in
-                       FStar_All.pipe_right uu____1777
-                         (fun uu____1803 ->
-                            match uu____1803 with
+                       FStar_All.pipe_right uu____1781
+                         (fun uu____1807 ->
+                            match uu____1807 with
                             | (lid1, uvs1, tps1, c1) ->
-                                let uu___387_1816 = se1 in
+                                let uu___387_1820 = se1 in
                                 {
                                   FStar_Syntax_Syntax.sigel =
                                     (FStar_Syntax_Syntax.Sig_effect_abbrev
                                        (lid1, uvs1, tps1, c1, flags));
                                   FStar_Syntax_Syntax.sigrng =
-                                    (uu___387_1816.FStar_Syntax_Syntax.sigrng);
+                                    (uu___387_1820.FStar_Syntax_Syntax.sigrng);
                                   FStar_Syntax_Syntax.sigquals =
-                                    (uu___387_1816.FStar_Syntax_Syntax.sigquals);
+                                    (uu___387_1820.FStar_Syntax_Syntax.sigquals);
                                   FStar_Syntax_Syntax.sigmeta =
-                                    (uu___387_1816.FStar_Syntax_Syntax.sigmeta);
+                                    (uu___387_1820.FStar_Syntax_Syntax.sigmeta);
                                   FStar_Syntax_Syntax.sigattrs =
-                                    (uu___387_1816.FStar_Syntax_Syntax.sigattrs);
+                                    (uu___387_1820.FStar_Syntax_Syntax.sigattrs);
                                   FStar_Syntax_Syntax.sigopts =
-                                    (uu___387_1816.FStar_Syntax_Syntax.sigopts)
+                                    (uu___387_1820.FStar_Syntax_Syntax.sigopts)
                                 }) in
-                     FStar_All.pipe_right uu____1776
+                     FStar_All.pipe_right uu____1780
                        (FStar_TypeChecker_Normalize.elim_uvars env) in
-                   FStar_All.pipe_right uu____1775
+                   FStar_All.pipe_right uu____1779
                      (fun se2 ->
                         match se2.FStar_Syntax_Syntax.sigel with
                         | FStar_Syntax_Syntax.Sig_effect_abbrev
-                            (lid1, uvs1, tps1, c1, uu____1846) ->
+                            (lid1, uvs1, tps1, c1, uu____1850) ->
                             (lid1, uvs1, tps1, c1)
-                        | uu____1851 ->
+                        | uu____1855 ->
                             failwith
                               "Did not expect Sig_effect_abbrev to not be one after phase 1")
                  else (lid, uvs, tps, c) in
-               (match uu____1757 with
+               (match uu____1761 with
                 | (lid1, uvs1, tps1, c1) ->
-                    let uu____1875 =
+                    let uu____1879 =
                       FStar_TypeChecker_TcEffect.tc_effect_abbrev env
                         (lid1, uvs1, tps1, c1) r in
-                    (match uu____1875 with
+                    (match uu____1879 with
                      | (lid2, uvs2, tps2, c2) ->
                          let se2 =
-                           let uu___408_1899 = se1 in
+                           let uu___408_1903 = se1 in
                            {
                              FStar_Syntax_Syntax.sigel =
                                (FStar_Syntax_Syntax.Sig_effect_abbrev
                                   (lid2, uvs2, tps2, c2, flags));
                              FStar_Syntax_Syntax.sigrng =
-                               (uu___408_1899.FStar_Syntax_Syntax.sigrng);
+                               (uu___408_1903.FStar_Syntax_Syntax.sigrng);
                              FStar_Syntax_Syntax.sigquals =
-                               (uu___408_1899.FStar_Syntax_Syntax.sigquals);
+                               (uu___408_1903.FStar_Syntax_Syntax.sigquals);
                              FStar_Syntax_Syntax.sigmeta =
-                               (uu___408_1899.FStar_Syntax_Syntax.sigmeta);
+                               (uu___408_1903.FStar_Syntax_Syntax.sigmeta);
                              FStar_Syntax_Syntax.sigattrs =
-                               (uu___408_1899.FStar_Syntax_Syntax.sigattrs);
+                               (uu___408_1903.FStar_Syntax_Syntax.sigattrs);
                              FStar_Syntax_Syntax.sigopts =
-                               (uu___408_1899.FStar_Syntax_Syntax.sigopts)
+                               (uu___408_1903.FStar_Syntax_Syntax.sigopts)
                            } in
                          ([se2], [], env0)))
            | FStar_Syntax_Syntax.Sig_declare_typ
-               (uu____1906, uu____1907, uu____1908) when
+               (uu____1910, uu____1911, uu____1912) when
                FStar_All.pipe_right se1.FStar_Syntax_Syntax.sigquals
                  (FStar_Util.for_some
-                    (fun uu___0_1912 ->
-                       match uu___0_1912 with
+                    (fun uu___0_1916 ->
+                       match uu___0_1916 with
                        | FStar_Syntax_Syntax.OnlyName -> true
-                       | uu____1913 -> false))
+                       | uu____1917 -> false))
                -> ([], [], env0)
-           | FStar_Syntax_Syntax.Sig_let (uu____1918, uu____1919) when
+           | FStar_Syntax_Syntax.Sig_let (uu____1922, uu____1923) when
                FStar_All.pipe_right se1.FStar_Syntax_Syntax.sigquals
                  (FStar_Util.for_some
-                    (fun uu___0_1927 ->
-                       match uu___0_1927 with
+                    (fun uu___0_1931 ->
+                       match uu___0_1931 with
                        | FStar_Syntax_Syntax.OnlyName -> true
-                       | uu____1928 -> false))
+                       | uu____1932 -> false))
                -> ([], [], env0)
            | FStar_Syntax_Syntax.Sig_declare_typ (lid, uvs, t) ->
                let env1 = FStar_TypeChecker_Env.set_range env r in
-               ((let uu____1938 = FStar_TypeChecker_Env.lid_exists env1 lid in
-                 if uu____1938
+               ((let uu____1942 = FStar_TypeChecker_Env.lid_exists env1 lid in
+                 if uu____1942
                  then
-                   let uu____1939 =
-                     let uu____1944 =
-                       let uu____1945 = FStar_Ident.string_of_lid lid in
+                   let uu____1943 =
+                     let uu____1948 =
+                       let uu____1949 = FStar_Ident.string_of_lid lid in
                        FStar_Util.format1
                          "Top-level declaration %s for a name that is already used in this module; top-level declarations must be unique in their module"
-                         uu____1945 in
+                         uu____1949 in
                      (FStar_Errors.Fatal_AlreadyDefinedTopLevelDeclaration,
-                       uu____1944) in
-                   FStar_Errors.raise_error uu____1939 r
+                       uu____1948) in
+                   FStar_Errors.raise_error uu____1943 r
                  else ());
-                (let uu____1947 =
-                   let uu____1956 =
+                (let uu____1951 =
+                   let uu____1960 =
                      (FStar_Options.use_two_phase_tc ()) &&
                        (FStar_TypeChecker_Env.should_verify env1) in
-                   if uu____1956
+                   if uu____1960
                    then
-                     let uu____1965 =
+                     let uu____1969 =
                        tc_declare_typ
-                         (let uu___432_1968 = env1 in
+                         (let uu___432_1972 = env1 in
                           {
                             FStar_TypeChecker_Env.solver =
-                              (uu___432_1968.FStar_TypeChecker_Env.solver);
+                              (uu___432_1972.FStar_TypeChecker_Env.solver);
                             FStar_TypeChecker_Env.range =
-                              (uu___432_1968.FStar_TypeChecker_Env.range);
+                              (uu___432_1972.FStar_TypeChecker_Env.range);
                             FStar_TypeChecker_Env.curmodule =
-                              (uu___432_1968.FStar_TypeChecker_Env.curmodule);
+                              (uu___432_1972.FStar_TypeChecker_Env.curmodule);
                             FStar_TypeChecker_Env.gamma =
-                              (uu___432_1968.FStar_TypeChecker_Env.gamma);
+                              (uu___432_1972.FStar_TypeChecker_Env.gamma);
                             FStar_TypeChecker_Env.gamma_sig =
-                              (uu___432_1968.FStar_TypeChecker_Env.gamma_sig);
+                              (uu___432_1972.FStar_TypeChecker_Env.gamma_sig);
                             FStar_TypeChecker_Env.gamma_cache =
-                              (uu___432_1968.FStar_TypeChecker_Env.gamma_cache);
+                              (uu___432_1972.FStar_TypeChecker_Env.gamma_cache);
                             FStar_TypeChecker_Env.modules =
-                              (uu___432_1968.FStar_TypeChecker_Env.modules);
+                              (uu___432_1972.FStar_TypeChecker_Env.modules);
                             FStar_TypeChecker_Env.expected_typ =
-                              (uu___432_1968.FStar_TypeChecker_Env.expected_typ);
+                              (uu___432_1972.FStar_TypeChecker_Env.expected_typ);
                             FStar_TypeChecker_Env.sigtab =
-                              (uu___432_1968.FStar_TypeChecker_Env.sigtab);
+                              (uu___432_1972.FStar_TypeChecker_Env.sigtab);
                             FStar_TypeChecker_Env.attrtab =
-                              (uu___432_1968.FStar_TypeChecker_Env.attrtab);
+                              (uu___432_1972.FStar_TypeChecker_Env.attrtab);
                             FStar_TypeChecker_Env.instantiate_imp =
-                              (uu___432_1968.FStar_TypeChecker_Env.instantiate_imp);
+                              (uu___432_1972.FStar_TypeChecker_Env.instantiate_imp);
                             FStar_TypeChecker_Env.effects =
-                              (uu___432_1968.FStar_TypeChecker_Env.effects);
+                              (uu___432_1972.FStar_TypeChecker_Env.effects);
                             FStar_TypeChecker_Env.generalize =
-                              (uu___432_1968.FStar_TypeChecker_Env.generalize);
+                              (uu___432_1972.FStar_TypeChecker_Env.generalize);
                             FStar_TypeChecker_Env.letrecs =
-                              (uu___432_1968.FStar_TypeChecker_Env.letrecs);
+                              (uu___432_1972.FStar_TypeChecker_Env.letrecs);
                             FStar_TypeChecker_Env.top_level =
-                              (uu___432_1968.FStar_TypeChecker_Env.top_level);
+                              (uu___432_1972.FStar_TypeChecker_Env.top_level);
                             FStar_TypeChecker_Env.check_uvars =
-                              (uu___432_1968.FStar_TypeChecker_Env.check_uvars);
+                              (uu___432_1972.FStar_TypeChecker_Env.check_uvars);
                             FStar_TypeChecker_Env.use_eq =
-                              (uu___432_1968.FStar_TypeChecker_Env.use_eq);
+                              (uu___432_1972.FStar_TypeChecker_Env.use_eq);
                             FStar_TypeChecker_Env.use_eq_strict =
-                              (uu___432_1968.FStar_TypeChecker_Env.use_eq_strict);
+                              (uu___432_1972.FStar_TypeChecker_Env.use_eq_strict);
                             FStar_TypeChecker_Env.is_iface =
-                              (uu___432_1968.FStar_TypeChecker_Env.is_iface);
+                              (uu___432_1972.FStar_TypeChecker_Env.is_iface);
                             FStar_TypeChecker_Env.admit =
-                              (uu___432_1968.FStar_TypeChecker_Env.admit);
+                              (uu___432_1972.FStar_TypeChecker_Env.admit);
                             FStar_TypeChecker_Env.lax = true;
                             FStar_TypeChecker_Env.lax_universes =
-                              (uu___432_1968.FStar_TypeChecker_Env.lax_universes);
+                              (uu___432_1972.FStar_TypeChecker_Env.lax_universes);
                             FStar_TypeChecker_Env.phase1 = true;
                             FStar_TypeChecker_Env.failhard =
-                              (uu___432_1968.FStar_TypeChecker_Env.failhard);
+                              (uu___432_1972.FStar_TypeChecker_Env.failhard);
                             FStar_TypeChecker_Env.nosynth =
-                              (uu___432_1968.FStar_TypeChecker_Env.nosynth);
+                              (uu___432_1972.FStar_TypeChecker_Env.nosynth);
                             FStar_TypeChecker_Env.uvar_subtyping =
-                              (uu___432_1968.FStar_TypeChecker_Env.uvar_subtyping);
+                              (uu___432_1972.FStar_TypeChecker_Env.uvar_subtyping);
                             FStar_TypeChecker_Env.tc_term =
-                              (uu___432_1968.FStar_TypeChecker_Env.tc_term);
+                              (uu___432_1972.FStar_TypeChecker_Env.tc_term);
                             FStar_TypeChecker_Env.type_of =
-                              (uu___432_1968.FStar_TypeChecker_Env.type_of);
+                              (uu___432_1972.FStar_TypeChecker_Env.type_of);
                             FStar_TypeChecker_Env.universe_of =
-                              (uu___432_1968.FStar_TypeChecker_Env.universe_of);
+                              (uu___432_1972.FStar_TypeChecker_Env.universe_of);
                             FStar_TypeChecker_Env.check_type_of =
-                              (uu___432_1968.FStar_TypeChecker_Env.check_type_of);
+                              (uu___432_1972.FStar_TypeChecker_Env.check_type_of);
                             FStar_TypeChecker_Env.use_bv_sorts =
-                              (uu___432_1968.FStar_TypeChecker_Env.use_bv_sorts);
+                              (uu___432_1972.FStar_TypeChecker_Env.use_bv_sorts);
                             FStar_TypeChecker_Env.qtbl_name_and_index =
-                              (uu___432_1968.FStar_TypeChecker_Env.qtbl_name_and_index);
+                              (uu___432_1972.FStar_TypeChecker_Env.qtbl_name_and_index);
                             FStar_TypeChecker_Env.normalized_eff_names =
-                              (uu___432_1968.FStar_TypeChecker_Env.normalized_eff_names);
+                              (uu___432_1972.FStar_TypeChecker_Env.normalized_eff_names);
                             FStar_TypeChecker_Env.fv_delta_depths =
-                              (uu___432_1968.FStar_TypeChecker_Env.fv_delta_depths);
+                              (uu___432_1972.FStar_TypeChecker_Env.fv_delta_depths);
                             FStar_TypeChecker_Env.proof_ns =
-                              (uu___432_1968.FStar_TypeChecker_Env.proof_ns);
+                              (uu___432_1972.FStar_TypeChecker_Env.proof_ns);
                             FStar_TypeChecker_Env.synth_hook =
-                              (uu___432_1968.FStar_TypeChecker_Env.synth_hook);
+                              (uu___432_1972.FStar_TypeChecker_Env.synth_hook);
                             FStar_TypeChecker_Env.try_solve_implicits_hook =
-                              (uu___432_1968.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                              (uu___432_1972.FStar_TypeChecker_Env.try_solve_implicits_hook);
                             FStar_TypeChecker_Env.splice =
-                              (uu___432_1968.FStar_TypeChecker_Env.splice);
+                              (uu___432_1972.FStar_TypeChecker_Env.splice);
                             FStar_TypeChecker_Env.mpreprocess =
-                              (uu___432_1968.FStar_TypeChecker_Env.mpreprocess);
+                              (uu___432_1972.FStar_TypeChecker_Env.mpreprocess);
                             FStar_TypeChecker_Env.postprocess =
-                              (uu___432_1968.FStar_TypeChecker_Env.postprocess);
+                              (uu___432_1972.FStar_TypeChecker_Env.postprocess);
                             FStar_TypeChecker_Env.identifier_info =
-                              (uu___432_1968.FStar_TypeChecker_Env.identifier_info);
+                              (uu___432_1972.FStar_TypeChecker_Env.identifier_info);
                             FStar_TypeChecker_Env.tc_hooks =
-                              (uu___432_1968.FStar_TypeChecker_Env.tc_hooks);
+                              (uu___432_1972.FStar_TypeChecker_Env.tc_hooks);
                             FStar_TypeChecker_Env.dsenv =
-                              (uu___432_1968.FStar_TypeChecker_Env.dsenv);
+                              (uu___432_1972.FStar_TypeChecker_Env.dsenv);
                             FStar_TypeChecker_Env.nbe =
-                              (uu___432_1968.FStar_TypeChecker_Env.nbe);
+                              (uu___432_1972.FStar_TypeChecker_Env.nbe);
                             FStar_TypeChecker_Env.strict_args_tab =
-                              (uu___432_1968.FStar_TypeChecker_Env.strict_args_tab);
+                              (uu___432_1972.FStar_TypeChecker_Env.strict_args_tab);
                             FStar_TypeChecker_Env.erasable_types_tab =
-                              (uu___432_1968.FStar_TypeChecker_Env.erasable_types_tab);
+                              (uu___432_1972.FStar_TypeChecker_Env.erasable_types_tab);
                             FStar_TypeChecker_Env.enable_defer_to_tac =
-                              (uu___432_1968.FStar_TypeChecker_Env.enable_defer_to_tac)
+                              (uu___432_1972.FStar_TypeChecker_Env.enable_defer_to_tac)
                           }) (uvs, t) se1.FStar_Syntax_Syntax.sigrng in
-                     match uu____1965 with
+                     match uu____1969 with
                      | (uvs1, t1) ->
-                         ((let uu____1992 =
+                         ((let uu____1996 =
                              FStar_All.pipe_left
                                (FStar_TypeChecker_Env.debug env1)
                                (FStar_Options.Other "TwoPhases") in
-                           if uu____1992
+                           if uu____1996
                            then
-                             let uu____1993 =
+                             let uu____1997 =
                                FStar_Syntax_Print.term_to_string t1 in
-                             let uu____1994 =
+                             let uu____1998 =
                                FStar_Syntax_Print.univ_names_to_string uvs1 in
                              FStar_Util.print2
                                "Val declaration after phase 1: %s and uvs: %s\n"
-                               uu____1993 uu____1994
+                               uu____1997 uu____1998
                            else ());
                           (uvs1, t1))
                    else (uvs, t) in
-                 match uu____1947 with
+                 match uu____1951 with
                  | (uvs1, t1) ->
-                     let uu____2025 =
+                     let uu____2029 =
                        tc_declare_typ env1 (uvs1, t1)
                          se1.FStar_Syntax_Syntax.sigrng in
-                     (match uu____2025 with
+                     (match uu____2029 with
                       | (uvs2, t2) ->
-                          ([(let uu___445_2055 = se1 in
+                          ([(let uu___445_2059 = se1 in
                              {
                                FStar_Syntax_Syntax.sigel =
                                  (FStar_Syntax_Syntax.Sig_declare_typ
                                     (lid, uvs2, t2));
                                FStar_Syntax_Syntax.sigrng =
-                                 (uu___445_2055.FStar_Syntax_Syntax.sigrng);
+                                 (uu___445_2059.FStar_Syntax_Syntax.sigrng);
                                FStar_Syntax_Syntax.sigquals =
-                                 (uu___445_2055.FStar_Syntax_Syntax.sigquals);
+                                 (uu___445_2059.FStar_Syntax_Syntax.sigquals);
                                FStar_Syntax_Syntax.sigmeta =
-                                 (uu___445_2055.FStar_Syntax_Syntax.sigmeta);
+                                 (uu___445_2059.FStar_Syntax_Syntax.sigmeta);
                                FStar_Syntax_Syntax.sigattrs =
-                                 (uu___445_2055.FStar_Syntax_Syntax.sigattrs);
+                                 (uu___445_2059.FStar_Syntax_Syntax.sigattrs);
                                FStar_Syntax_Syntax.sigopts =
-                                 (uu___445_2055.FStar_Syntax_Syntax.sigopts)
+                                 (uu___445_2059.FStar_Syntax_Syntax.sigopts)
                              })], [], env0))))
            | FStar_Syntax_Syntax.Sig_assume (lid, uvs, t) ->
-               ((let uu____2060 =
-                   let uu____2065 =
-                     let uu____2066 = FStar_Syntax_Print.lid_to_string lid in
+               ((let uu____2064 =
+                   let uu____2069 =
+                     let uu____2070 = FStar_Syntax_Print.lid_to_string lid in
                      FStar_Util.format1 "Admitting a top-level assumption %s"
-                       uu____2066 in
-                   (FStar_Errors.Warning_WarnOnUse, uu____2065) in
-                 FStar_Errors.log_issue r uu____2060);
+                       uu____2070 in
+                   (FStar_Errors.Warning_WarnOnUse, uu____2069) in
+                 FStar_Errors.log_issue r uu____2064);
                 (let env1 = FStar_TypeChecker_Env.set_range env r in
-                 let uu____2068 =
-                   let uu____2077 =
+                 let uu____2072 =
+                   let uu____2081 =
                      (FStar_Options.use_two_phase_tc ()) &&
                        (FStar_TypeChecker_Env.should_verify env1) in
-                   if uu____2077
+                   if uu____2081
                    then
-                     let uu____2086 =
+                     let uu____2090 =
                        tc_assume
-                         (let uu___455_2089 = env1 in
+                         (let uu___455_2093 = env1 in
                           {
                             FStar_TypeChecker_Env.solver =
-                              (uu___455_2089.FStar_TypeChecker_Env.solver);
+                              (uu___455_2093.FStar_TypeChecker_Env.solver);
                             FStar_TypeChecker_Env.range =
-                              (uu___455_2089.FStar_TypeChecker_Env.range);
+                              (uu___455_2093.FStar_TypeChecker_Env.range);
                             FStar_TypeChecker_Env.curmodule =
-                              (uu___455_2089.FStar_TypeChecker_Env.curmodule);
+                              (uu___455_2093.FStar_TypeChecker_Env.curmodule);
                             FStar_TypeChecker_Env.gamma =
-                              (uu___455_2089.FStar_TypeChecker_Env.gamma);
+                              (uu___455_2093.FStar_TypeChecker_Env.gamma);
                             FStar_TypeChecker_Env.gamma_sig =
-                              (uu___455_2089.FStar_TypeChecker_Env.gamma_sig);
+                              (uu___455_2093.FStar_TypeChecker_Env.gamma_sig);
                             FStar_TypeChecker_Env.gamma_cache =
-                              (uu___455_2089.FStar_TypeChecker_Env.gamma_cache);
+                              (uu___455_2093.FStar_TypeChecker_Env.gamma_cache);
                             FStar_TypeChecker_Env.modules =
-                              (uu___455_2089.FStar_TypeChecker_Env.modules);
+                              (uu___455_2093.FStar_TypeChecker_Env.modules);
                             FStar_TypeChecker_Env.expected_typ =
-                              (uu___455_2089.FStar_TypeChecker_Env.expected_typ);
+                              (uu___455_2093.FStar_TypeChecker_Env.expected_typ);
                             FStar_TypeChecker_Env.sigtab =
-                              (uu___455_2089.FStar_TypeChecker_Env.sigtab);
+                              (uu___455_2093.FStar_TypeChecker_Env.sigtab);
                             FStar_TypeChecker_Env.attrtab =
-                              (uu___455_2089.FStar_TypeChecker_Env.attrtab);
+                              (uu___455_2093.FStar_TypeChecker_Env.attrtab);
                             FStar_TypeChecker_Env.instantiate_imp =
-                              (uu___455_2089.FStar_TypeChecker_Env.instantiate_imp);
+                              (uu___455_2093.FStar_TypeChecker_Env.instantiate_imp);
                             FStar_TypeChecker_Env.effects =
-                              (uu___455_2089.FStar_TypeChecker_Env.effects);
+                              (uu___455_2093.FStar_TypeChecker_Env.effects);
                             FStar_TypeChecker_Env.generalize =
-                              (uu___455_2089.FStar_TypeChecker_Env.generalize);
+                              (uu___455_2093.FStar_TypeChecker_Env.generalize);
                             FStar_TypeChecker_Env.letrecs =
-                              (uu___455_2089.FStar_TypeChecker_Env.letrecs);
+                              (uu___455_2093.FStar_TypeChecker_Env.letrecs);
                             FStar_TypeChecker_Env.top_level =
-                              (uu___455_2089.FStar_TypeChecker_Env.top_level);
+                              (uu___455_2093.FStar_TypeChecker_Env.top_level);
                             FStar_TypeChecker_Env.check_uvars =
-                              (uu___455_2089.FStar_TypeChecker_Env.check_uvars);
+                              (uu___455_2093.FStar_TypeChecker_Env.check_uvars);
                             FStar_TypeChecker_Env.use_eq =
-                              (uu___455_2089.FStar_TypeChecker_Env.use_eq);
+                              (uu___455_2093.FStar_TypeChecker_Env.use_eq);
                             FStar_TypeChecker_Env.use_eq_strict =
-                              (uu___455_2089.FStar_TypeChecker_Env.use_eq_strict);
+                              (uu___455_2093.FStar_TypeChecker_Env.use_eq_strict);
                             FStar_TypeChecker_Env.is_iface =
-                              (uu___455_2089.FStar_TypeChecker_Env.is_iface);
+                              (uu___455_2093.FStar_TypeChecker_Env.is_iface);
                             FStar_TypeChecker_Env.admit =
-                              (uu___455_2089.FStar_TypeChecker_Env.admit);
+                              (uu___455_2093.FStar_TypeChecker_Env.admit);
                             FStar_TypeChecker_Env.lax = true;
                             FStar_TypeChecker_Env.lax_universes =
-                              (uu___455_2089.FStar_TypeChecker_Env.lax_universes);
+                              (uu___455_2093.FStar_TypeChecker_Env.lax_universes);
                             FStar_TypeChecker_Env.phase1 = true;
                             FStar_TypeChecker_Env.failhard =
-                              (uu___455_2089.FStar_TypeChecker_Env.failhard);
+                              (uu___455_2093.FStar_TypeChecker_Env.failhard);
                             FStar_TypeChecker_Env.nosynth =
-                              (uu___455_2089.FStar_TypeChecker_Env.nosynth);
+                              (uu___455_2093.FStar_TypeChecker_Env.nosynth);
                             FStar_TypeChecker_Env.uvar_subtyping =
-                              (uu___455_2089.FStar_TypeChecker_Env.uvar_subtyping);
+                              (uu___455_2093.FStar_TypeChecker_Env.uvar_subtyping);
                             FStar_TypeChecker_Env.tc_term =
-                              (uu___455_2089.FStar_TypeChecker_Env.tc_term);
+                              (uu___455_2093.FStar_TypeChecker_Env.tc_term);
                             FStar_TypeChecker_Env.type_of =
-                              (uu___455_2089.FStar_TypeChecker_Env.type_of);
+                              (uu___455_2093.FStar_TypeChecker_Env.type_of);
                             FStar_TypeChecker_Env.universe_of =
-                              (uu___455_2089.FStar_TypeChecker_Env.universe_of);
+                              (uu___455_2093.FStar_TypeChecker_Env.universe_of);
                             FStar_TypeChecker_Env.check_type_of =
-                              (uu___455_2089.FStar_TypeChecker_Env.check_type_of);
+                              (uu___455_2093.FStar_TypeChecker_Env.check_type_of);
                             FStar_TypeChecker_Env.use_bv_sorts =
-                              (uu___455_2089.FStar_TypeChecker_Env.use_bv_sorts);
+                              (uu___455_2093.FStar_TypeChecker_Env.use_bv_sorts);
                             FStar_TypeChecker_Env.qtbl_name_and_index =
-                              (uu___455_2089.FStar_TypeChecker_Env.qtbl_name_and_index);
+                              (uu___455_2093.FStar_TypeChecker_Env.qtbl_name_and_index);
                             FStar_TypeChecker_Env.normalized_eff_names =
-                              (uu___455_2089.FStar_TypeChecker_Env.normalized_eff_names);
+                              (uu___455_2093.FStar_TypeChecker_Env.normalized_eff_names);
                             FStar_TypeChecker_Env.fv_delta_depths =
-                              (uu___455_2089.FStar_TypeChecker_Env.fv_delta_depths);
+                              (uu___455_2093.FStar_TypeChecker_Env.fv_delta_depths);
                             FStar_TypeChecker_Env.proof_ns =
-                              (uu___455_2089.FStar_TypeChecker_Env.proof_ns);
+                              (uu___455_2093.FStar_TypeChecker_Env.proof_ns);
                             FStar_TypeChecker_Env.synth_hook =
-                              (uu___455_2089.FStar_TypeChecker_Env.synth_hook);
+                              (uu___455_2093.FStar_TypeChecker_Env.synth_hook);
                             FStar_TypeChecker_Env.try_solve_implicits_hook =
-                              (uu___455_2089.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                              (uu___455_2093.FStar_TypeChecker_Env.try_solve_implicits_hook);
                             FStar_TypeChecker_Env.splice =
-                              (uu___455_2089.FStar_TypeChecker_Env.splice);
+                              (uu___455_2093.FStar_TypeChecker_Env.splice);
                             FStar_TypeChecker_Env.mpreprocess =
-                              (uu___455_2089.FStar_TypeChecker_Env.mpreprocess);
+                              (uu___455_2093.FStar_TypeChecker_Env.mpreprocess);
                             FStar_TypeChecker_Env.postprocess =
-                              (uu___455_2089.FStar_TypeChecker_Env.postprocess);
+                              (uu___455_2093.FStar_TypeChecker_Env.postprocess);
                             FStar_TypeChecker_Env.identifier_info =
-                              (uu___455_2089.FStar_TypeChecker_Env.identifier_info);
+                              (uu___455_2093.FStar_TypeChecker_Env.identifier_info);
                             FStar_TypeChecker_Env.tc_hooks =
-                              (uu___455_2089.FStar_TypeChecker_Env.tc_hooks);
+                              (uu___455_2093.FStar_TypeChecker_Env.tc_hooks);
                             FStar_TypeChecker_Env.dsenv =
-                              (uu___455_2089.FStar_TypeChecker_Env.dsenv);
+                              (uu___455_2093.FStar_TypeChecker_Env.dsenv);
                             FStar_TypeChecker_Env.nbe =
-                              (uu___455_2089.FStar_TypeChecker_Env.nbe);
+                              (uu___455_2093.FStar_TypeChecker_Env.nbe);
                             FStar_TypeChecker_Env.strict_args_tab =
-                              (uu___455_2089.FStar_TypeChecker_Env.strict_args_tab);
+                              (uu___455_2093.FStar_TypeChecker_Env.strict_args_tab);
                             FStar_TypeChecker_Env.erasable_types_tab =
-                              (uu___455_2089.FStar_TypeChecker_Env.erasable_types_tab);
+                              (uu___455_2093.FStar_TypeChecker_Env.erasable_types_tab);
                             FStar_TypeChecker_Env.enable_defer_to_tac =
-                              (uu___455_2089.FStar_TypeChecker_Env.enable_defer_to_tac)
+                              (uu___455_2093.FStar_TypeChecker_Env.enable_defer_to_tac)
                           }) (uvs, t) se1.FStar_Syntax_Syntax.sigrng in
-                     match uu____2086 with
+                     match uu____2090 with
                      | (uvs1, t1) ->
-                         ((let uu____2113 =
+                         ((let uu____2117 =
                              FStar_All.pipe_left
                                (FStar_TypeChecker_Env.debug env1)
                                (FStar_Options.Other "TwoPhases") in
-                           if uu____2113
+                           if uu____2117
                            then
-                             let uu____2114 =
+                             let uu____2118 =
                                FStar_Syntax_Print.term_to_string t1 in
-                             let uu____2115 =
+                             let uu____2119 =
                                FStar_Syntax_Print.univ_names_to_string uvs1 in
                              FStar_Util.print2
                                "Assume after phase 1: %s and uvs: %s\n"
-                               uu____2114 uu____2115
+                               uu____2118 uu____2119
                            else ());
                           (uvs1, t1))
                    else (uvs, t) in
-                 match uu____2068 with
+                 match uu____2072 with
                  | (uvs1, t1) ->
-                     let uu____2146 =
+                     let uu____2150 =
                        tc_assume env1 (uvs1, t1)
                          se1.FStar_Syntax_Syntax.sigrng in
-                     (match uu____2146 with
+                     (match uu____2150 with
                       | (uvs2, t2) ->
-                          ([(let uu___468_2176 = se1 in
+                          ([(let uu___468_2180 = se1 in
                              {
                                FStar_Syntax_Syntax.sigel =
                                  (FStar_Syntax_Syntax.Sig_assume
                                     (lid, uvs2, t2));
                                FStar_Syntax_Syntax.sigrng =
-                                 (uu___468_2176.FStar_Syntax_Syntax.sigrng);
+                                 (uu___468_2180.FStar_Syntax_Syntax.sigrng);
                                FStar_Syntax_Syntax.sigquals =
-                                 (uu___468_2176.FStar_Syntax_Syntax.sigquals);
+                                 (uu___468_2180.FStar_Syntax_Syntax.sigquals);
                                FStar_Syntax_Syntax.sigmeta =
-                                 (uu___468_2176.FStar_Syntax_Syntax.sigmeta);
+                                 (uu___468_2180.FStar_Syntax_Syntax.sigmeta);
                                FStar_Syntax_Syntax.sigattrs =
-                                 (uu___468_2176.FStar_Syntax_Syntax.sigattrs);
+                                 (uu___468_2180.FStar_Syntax_Syntax.sigattrs);
                                FStar_Syntax_Syntax.sigopts =
-                                 (uu___468_2176.FStar_Syntax_Syntax.sigopts)
+                                 (uu___468_2180.FStar_Syntax_Syntax.sigopts)
                              })], [], env0))))
            | FStar_Syntax_Syntax.Sig_splice (lids, t) ->
-               ((let uu____2184 = FStar_Options.debug_any () in
-                 if uu____2184
+               ((let uu____2188 = FStar_Options.debug_any () in
+                 if uu____2188
                  then
-                   let uu____2185 =
+                   let uu____2189 =
                      FStar_Ident.string_of_lid
                        env.FStar_TypeChecker_Env.curmodule in
-                   let uu____2186 = FStar_Syntax_Print.term_to_string t in
-                   FStar_Util.print2 "%s: Found splice of (%s)\n" uu____2185
-                     uu____2186
+                   let uu____2190 = FStar_Syntax_Print.term_to_string t in
+                   FStar_Util.print2 "%s: Found splice of (%s)\n" uu____2189
+                     uu____2190
                  else ());
-                (let uu____2188 =
+                (let uu____2192 =
                    FStar_TypeChecker_TcTerm.tc_tactic
                      FStar_Syntax_Syntax.t_unit FStar_Syntax_Syntax.t_decls
                      env t in
-                 match uu____2188 with
-                 | (t1, uu____2206, g) ->
+                 match uu____2192 with
+                 | (t1, uu____2210, g) ->
                      (FStar_TypeChecker_Rel.force_trivial_guard env g;
                       (let ses =
                          env.FStar_TypeChecker_Env.splice env
@@ -2020,144 +2020,144 @@ let (tc_decl' :
                            ses in
                        FStar_List.iter
                          (fun lid ->
-                            let uu____2220 =
+                            let uu____2224 =
                               FStar_List.tryFind (FStar_Ident.lid_equals lid)
                                 lids' in
-                            match uu____2220 with
+                            match uu____2224 with
                             | FStar_Pervasives_Native.None when
                                 Prims.op_Negation
                                   env.FStar_TypeChecker_Env.nosynth
                                 ->
-                                let uu____2223 =
-                                  let uu____2228 =
-                                    let uu____2229 =
+                                let uu____2227 =
+                                  let uu____2232 =
+                                    let uu____2233 =
                                       FStar_Ident.string_of_lid lid in
-                                    let uu____2230 =
-                                      let uu____2231 =
+                                    let uu____2234 =
+                                      let uu____2235 =
                                         FStar_List.map
                                           FStar_Ident.string_of_lid lids' in
                                       FStar_All.pipe_left
-                                        (FStar_String.concat ", ") uu____2231 in
+                                        (FStar_String.concat ", ") uu____2235 in
                                     FStar_Util.format2
                                       "Splice declared the name %s but it was not defined.\nThose defined were: %s"
-                                      uu____2229 uu____2230 in
+                                      uu____2233 uu____2234 in
                                   (FStar_Errors.Fatal_SplicedUndef,
-                                    uu____2228) in
-                                FStar_Errors.raise_error uu____2223 r
-                            | uu____2236 -> ()) lids;
+                                    uu____2232) in
+                                FStar_Errors.raise_error uu____2227 r
+                            | uu____2240 -> ()) lids;
                        (let dsenv =
                           FStar_List.fold_left
                             FStar_Syntax_DsEnv.push_sigelt_force
                             env.FStar_TypeChecker_Env.dsenv ses in
                         let env1 =
-                          let uu___488_2241 = env in
+                          let uu___488_2245 = env in
                           {
                             FStar_TypeChecker_Env.solver =
-                              (uu___488_2241.FStar_TypeChecker_Env.solver);
+                              (uu___488_2245.FStar_TypeChecker_Env.solver);
                             FStar_TypeChecker_Env.range =
-                              (uu___488_2241.FStar_TypeChecker_Env.range);
+                              (uu___488_2245.FStar_TypeChecker_Env.range);
                             FStar_TypeChecker_Env.curmodule =
-                              (uu___488_2241.FStar_TypeChecker_Env.curmodule);
+                              (uu___488_2245.FStar_TypeChecker_Env.curmodule);
                             FStar_TypeChecker_Env.gamma =
-                              (uu___488_2241.FStar_TypeChecker_Env.gamma);
+                              (uu___488_2245.FStar_TypeChecker_Env.gamma);
                             FStar_TypeChecker_Env.gamma_sig =
-                              (uu___488_2241.FStar_TypeChecker_Env.gamma_sig);
+                              (uu___488_2245.FStar_TypeChecker_Env.gamma_sig);
                             FStar_TypeChecker_Env.gamma_cache =
-                              (uu___488_2241.FStar_TypeChecker_Env.gamma_cache);
+                              (uu___488_2245.FStar_TypeChecker_Env.gamma_cache);
                             FStar_TypeChecker_Env.modules =
-                              (uu___488_2241.FStar_TypeChecker_Env.modules);
+                              (uu___488_2245.FStar_TypeChecker_Env.modules);
                             FStar_TypeChecker_Env.expected_typ =
-                              (uu___488_2241.FStar_TypeChecker_Env.expected_typ);
+                              (uu___488_2245.FStar_TypeChecker_Env.expected_typ);
                             FStar_TypeChecker_Env.sigtab =
-                              (uu___488_2241.FStar_TypeChecker_Env.sigtab);
+                              (uu___488_2245.FStar_TypeChecker_Env.sigtab);
                             FStar_TypeChecker_Env.attrtab =
-                              (uu___488_2241.FStar_TypeChecker_Env.attrtab);
+                              (uu___488_2245.FStar_TypeChecker_Env.attrtab);
                             FStar_TypeChecker_Env.instantiate_imp =
-                              (uu___488_2241.FStar_TypeChecker_Env.instantiate_imp);
+                              (uu___488_2245.FStar_TypeChecker_Env.instantiate_imp);
                             FStar_TypeChecker_Env.effects =
-                              (uu___488_2241.FStar_TypeChecker_Env.effects);
+                              (uu___488_2245.FStar_TypeChecker_Env.effects);
                             FStar_TypeChecker_Env.generalize =
-                              (uu___488_2241.FStar_TypeChecker_Env.generalize);
+                              (uu___488_2245.FStar_TypeChecker_Env.generalize);
                             FStar_TypeChecker_Env.letrecs =
-                              (uu___488_2241.FStar_TypeChecker_Env.letrecs);
+                              (uu___488_2245.FStar_TypeChecker_Env.letrecs);
                             FStar_TypeChecker_Env.top_level =
-                              (uu___488_2241.FStar_TypeChecker_Env.top_level);
+                              (uu___488_2245.FStar_TypeChecker_Env.top_level);
                             FStar_TypeChecker_Env.check_uvars =
-                              (uu___488_2241.FStar_TypeChecker_Env.check_uvars);
+                              (uu___488_2245.FStar_TypeChecker_Env.check_uvars);
                             FStar_TypeChecker_Env.use_eq =
-                              (uu___488_2241.FStar_TypeChecker_Env.use_eq);
+                              (uu___488_2245.FStar_TypeChecker_Env.use_eq);
                             FStar_TypeChecker_Env.use_eq_strict =
-                              (uu___488_2241.FStar_TypeChecker_Env.use_eq_strict);
+                              (uu___488_2245.FStar_TypeChecker_Env.use_eq_strict);
                             FStar_TypeChecker_Env.is_iface =
-                              (uu___488_2241.FStar_TypeChecker_Env.is_iface);
+                              (uu___488_2245.FStar_TypeChecker_Env.is_iface);
                             FStar_TypeChecker_Env.admit =
-                              (uu___488_2241.FStar_TypeChecker_Env.admit);
+                              (uu___488_2245.FStar_TypeChecker_Env.admit);
                             FStar_TypeChecker_Env.lax =
-                              (uu___488_2241.FStar_TypeChecker_Env.lax);
+                              (uu___488_2245.FStar_TypeChecker_Env.lax);
                             FStar_TypeChecker_Env.lax_universes =
-                              (uu___488_2241.FStar_TypeChecker_Env.lax_universes);
+                              (uu___488_2245.FStar_TypeChecker_Env.lax_universes);
                             FStar_TypeChecker_Env.phase1 =
-                              (uu___488_2241.FStar_TypeChecker_Env.phase1);
+                              (uu___488_2245.FStar_TypeChecker_Env.phase1);
                             FStar_TypeChecker_Env.failhard =
-                              (uu___488_2241.FStar_TypeChecker_Env.failhard);
+                              (uu___488_2245.FStar_TypeChecker_Env.failhard);
                             FStar_TypeChecker_Env.nosynth =
-                              (uu___488_2241.FStar_TypeChecker_Env.nosynth);
+                              (uu___488_2245.FStar_TypeChecker_Env.nosynth);
                             FStar_TypeChecker_Env.uvar_subtyping =
-                              (uu___488_2241.FStar_TypeChecker_Env.uvar_subtyping);
+                              (uu___488_2245.FStar_TypeChecker_Env.uvar_subtyping);
                             FStar_TypeChecker_Env.tc_term =
-                              (uu___488_2241.FStar_TypeChecker_Env.tc_term);
+                              (uu___488_2245.FStar_TypeChecker_Env.tc_term);
                             FStar_TypeChecker_Env.type_of =
-                              (uu___488_2241.FStar_TypeChecker_Env.type_of);
+                              (uu___488_2245.FStar_TypeChecker_Env.type_of);
                             FStar_TypeChecker_Env.universe_of =
-                              (uu___488_2241.FStar_TypeChecker_Env.universe_of);
+                              (uu___488_2245.FStar_TypeChecker_Env.universe_of);
                             FStar_TypeChecker_Env.check_type_of =
-                              (uu___488_2241.FStar_TypeChecker_Env.check_type_of);
+                              (uu___488_2245.FStar_TypeChecker_Env.check_type_of);
                             FStar_TypeChecker_Env.use_bv_sorts =
-                              (uu___488_2241.FStar_TypeChecker_Env.use_bv_sorts);
+                              (uu___488_2245.FStar_TypeChecker_Env.use_bv_sorts);
                             FStar_TypeChecker_Env.qtbl_name_and_index =
-                              (uu___488_2241.FStar_TypeChecker_Env.qtbl_name_and_index);
+                              (uu___488_2245.FStar_TypeChecker_Env.qtbl_name_and_index);
                             FStar_TypeChecker_Env.normalized_eff_names =
-                              (uu___488_2241.FStar_TypeChecker_Env.normalized_eff_names);
+                              (uu___488_2245.FStar_TypeChecker_Env.normalized_eff_names);
                             FStar_TypeChecker_Env.fv_delta_depths =
-                              (uu___488_2241.FStar_TypeChecker_Env.fv_delta_depths);
+                              (uu___488_2245.FStar_TypeChecker_Env.fv_delta_depths);
                             FStar_TypeChecker_Env.proof_ns =
-                              (uu___488_2241.FStar_TypeChecker_Env.proof_ns);
+                              (uu___488_2245.FStar_TypeChecker_Env.proof_ns);
                             FStar_TypeChecker_Env.synth_hook =
-                              (uu___488_2241.FStar_TypeChecker_Env.synth_hook);
+                              (uu___488_2245.FStar_TypeChecker_Env.synth_hook);
                             FStar_TypeChecker_Env.try_solve_implicits_hook =
-                              (uu___488_2241.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                              (uu___488_2245.FStar_TypeChecker_Env.try_solve_implicits_hook);
                             FStar_TypeChecker_Env.splice =
-                              (uu___488_2241.FStar_TypeChecker_Env.splice);
+                              (uu___488_2245.FStar_TypeChecker_Env.splice);
                             FStar_TypeChecker_Env.mpreprocess =
-                              (uu___488_2241.FStar_TypeChecker_Env.mpreprocess);
+                              (uu___488_2245.FStar_TypeChecker_Env.mpreprocess);
                             FStar_TypeChecker_Env.postprocess =
-                              (uu___488_2241.FStar_TypeChecker_Env.postprocess);
+                              (uu___488_2245.FStar_TypeChecker_Env.postprocess);
                             FStar_TypeChecker_Env.identifier_info =
-                              (uu___488_2241.FStar_TypeChecker_Env.identifier_info);
+                              (uu___488_2245.FStar_TypeChecker_Env.identifier_info);
                             FStar_TypeChecker_Env.tc_hooks =
-                              (uu___488_2241.FStar_TypeChecker_Env.tc_hooks);
+                              (uu___488_2245.FStar_TypeChecker_Env.tc_hooks);
                             FStar_TypeChecker_Env.dsenv = dsenv;
                             FStar_TypeChecker_Env.nbe =
-                              (uu___488_2241.FStar_TypeChecker_Env.nbe);
+                              (uu___488_2245.FStar_TypeChecker_Env.nbe);
                             FStar_TypeChecker_Env.strict_args_tab =
-                              (uu___488_2241.FStar_TypeChecker_Env.strict_args_tab);
+                              (uu___488_2245.FStar_TypeChecker_Env.strict_args_tab);
                             FStar_TypeChecker_Env.erasable_types_tab =
-                              (uu___488_2241.FStar_TypeChecker_Env.erasable_types_tab);
+                              (uu___488_2245.FStar_TypeChecker_Env.erasable_types_tab);
                             FStar_TypeChecker_Env.enable_defer_to_tac =
-                              (uu___488_2241.FStar_TypeChecker_Env.enable_defer_to_tac)
+                              (uu___488_2245.FStar_TypeChecker_Env.enable_defer_to_tac)
                           } in
-                        (let uu____2243 =
+                        (let uu____2247 =
                            FStar_TypeChecker_Env.debug env1 FStar_Options.Low in
-                         if uu____2243
+                         if uu____2247
                          then
-                           let uu____2244 =
-                             let uu____2245 =
+                           let uu____2248 =
+                             let uu____2249 =
                                FStar_List.map
                                  FStar_Syntax_Print.sigelt_to_string ses in
                              FStar_All.pipe_left (FStar_String.concat "\n")
-                               uu____2245 in
+                               uu____2249 in
                            FStar_Util.print1
-                             "Splice returned sigelts {\n%s\n}\n" uu____2244
+                             "Splice returned sigelts {\n%s\n}\n" uu____2248
                          else ());
                         ([], ses, env1))))))
            | FStar_Syntax_Syntax.Sig_let (lbs, lids) ->
@@ -2171,138 +2171,138 @@ let (tc_decl' :
                        FStar_List.filter
                          (fun x ->
                             Prims.op_Negation (x = FStar_Syntax_Syntax.Logic)) in
-                     let uu____2318 =
-                       let uu____2319 =
-                         let uu____2328 = drop_logic val_q in
-                         let uu____2331 = drop_logic q' in
-                         (uu____2328, uu____2331) in
-                       match uu____2319 with
+                     let uu____2322 =
+                       let uu____2323 =
+                         let uu____2332 = drop_logic val_q in
+                         let uu____2335 = drop_logic q' in
+                         (uu____2332, uu____2335) in
+                       match uu____2323 with
                        | (val_q1, q'1) ->
                            ((FStar_List.length val_q1) =
                               (FStar_List.length q'1))
                              &&
                              (FStar_List.forall2
                                 FStar_Syntax_Util.qualifier_equal val_q1 q'1) in
-                     if uu____2318
+                     if uu____2322
                      then FStar_Pervasives_Native.Some q'
                      else
-                       (let uu____2355 =
-                          let uu____2360 =
-                            let uu____2361 =
+                       (let uu____2359 =
+                          let uu____2364 =
+                            let uu____2365 =
                               FStar_Syntax_Print.lid_to_string l in
-                            let uu____2362 =
+                            let uu____2366 =
                               FStar_Syntax_Print.quals_to_string val_q in
-                            let uu____2363 =
+                            let uu____2367 =
                               FStar_Syntax_Print.quals_to_string q' in
                             FStar_Util.format3
                               "Inconsistent qualifier annotations on %s; Expected {%s}, got {%s}"
-                              uu____2361 uu____2362 uu____2363 in
+                              uu____2365 uu____2366 uu____2367 in
                           (FStar_Errors.Fatal_InconsistentQualifierAnnotation,
-                            uu____2360) in
-                        FStar_Errors.raise_error uu____2355 r) in
+                            uu____2364) in
+                        FStar_Errors.raise_error uu____2359 r) in
                let rename_parameters lb =
                  let rename_in_typ def typ =
                    let typ1 = FStar_Syntax_Subst.compress typ in
                    let def_bs =
-                     let uu____2397 =
-                       let uu____2398 = FStar_Syntax_Subst.compress def in
-                       uu____2398.FStar_Syntax_Syntax.n in
-                     match uu____2397 with
+                     let uu____2401 =
+                       let uu____2402 = FStar_Syntax_Subst.compress def in
+                       uu____2402.FStar_Syntax_Syntax.n in
+                     match uu____2401 with
                      | FStar_Syntax_Syntax.Tm_abs
-                         (binders, uu____2410, uu____2411) -> binders
-                     | uu____2436 -> [] in
+                         (binders, uu____2414, uu____2415) -> binders
+                     | uu____2440 -> [] in
                    match typ1 with
                    | {
                        FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_arrow
                          (val_bs, c);
                        FStar_Syntax_Syntax.pos = r1;
-                       FStar_Syntax_Syntax.vars = uu____2448;_} ->
+                       FStar_Syntax_Syntax.vars = uu____2452;_} ->
                        let has_auto_name bv =
-                         let uu____2477 =
+                         let uu____2481 =
                            FStar_Ident.string_of_id
                              bv.FStar_Syntax_Syntax.ppname in
-                         FStar_Util.starts_with uu____2477
+                         FStar_Util.starts_with uu____2481
                            FStar_Ident.reserved_prefix in
                        let rec rename_binders def_bs1 val_bs1 =
                          match (def_bs1, val_bs1) with
-                         | ([], uu____2553) -> val_bs1
-                         | (uu____2584, []) -> val_bs1
-                         | ((body_bv, uu____2616)::bt, (val_bv, aqual)::vt)
+                         | ([], uu____2557) -> val_bs1
+                         | (uu____2588, []) -> val_bs1
+                         | ((body_bv, uu____2620)::bt, (val_bv, aqual)::vt)
                              ->
-                             let uu____2673 =
-                               let uu____2680 =
-                                 let uu____2685 = has_auto_name body_bv in
-                                 let uu____2686 = has_auto_name val_bv in
-                                 (uu____2685, uu____2686) in
-                               match uu____2680 with
-                               | (true, uu____2693) -> (val_bv, aqual)
+                             let uu____2677 =
+                               let uu____2684 =
+                                 let uu____2689 = has_auto_name body_bv in
+                                 let uu____2690 = has_auto_name val_bv in
+                                 (uu____2689, uu____2690) in
+                               match uu____2684 with
+                               | (true, uu____2697) -> (val_bv, aqual)
                                | (false, true) ->
-                                   let uu____2696 =
-                                     let uu___559_2697 = val_bv in
-                                     let uu____2698 =
-                                       let uu____2699 =
-                                         let uu____2704 =
+                                   let uu____2700 =
+                                     let uu___559_2701 = val_bv in
+                                     let uu____2702 =
+                                       let uu____2703 =
+                                         let uu____2708 =
                                            FStar_Ident.string_of_id
                                              body_bv.FStar_Syntax_Syntax.ppname in
-                                         let uu____2705 =
+                                         let uu____2709 =
                                            FStar_Ident.range_of_id
                                              val_bv.FStar_Syntax_Syntax.ppname in
-                                         (uu____2704, uu____2705) in
-                                       FStar_Ident.mk_ident uu____2699 in
+                                         (uu____2708, uu____2709) in
+                                       FStar_Ident.mk_ident uu____2703 in
                                      {
                                        FStar_Syntax_Syntax.ppname =
-                                         uu____2698;
+                                         uu____2702;
                                        FStar_Syntax_Syntax.index =
-                                         (uu___559_2697.FStar_Syntax_Syntax.index);
+                                         (uu___559_2701.FStar_Syntax_Syntax.index);
                                        FStar_Syntax_Syntax.sort =
-                                         (uu___559_2697.FStar_Syntax_Syntax.sort)
+                                         (uu___559_2701.FStar_Syntax_Syntax.sort)
                                      } in
-                                   (uu____2696, aqual)
+                                   (uu____2700, aqual)
                                | (false, false) -> (val_bv, aqual) in
-                             let uu____2710 = rename_binders bt vt in
-                             uu____2673 :: uu____2710 in
-                       let uu____2725 =
-                         let uu____2726 =
-                           let uu____2741 = rename_binders def_bs val_bs in
-                           (uu____2741, c) in
-                         FStar_Syntax_Syntax.Tm_arrow uu____2726 in
-                       FStar_Syntax_Syntax.mk uu____2725 r1
-                   | uu____2760 -> typ1 in
-                 let uu___565_2761 = lb in
-                 let uu____2762 =
+                             let uu____2714 = rename_binders bt vt in
+                             uu____2677 :: uu____2714 in
+                       let uu____2729 =
+                         let uu____2730 =
+                           let uu____2745 = rename_binders def_bs val_bs in
+                           (uu____2745, c) in
+                         FStar_Syntax_Syntax.Tm_arrow uu____2730 in
+                       FStar_Syntax_Syntax.mk uu____2729 r1
+                   | uu____2764 -> typ1 in
+                 let uu___565_2765 = lb in
+                 let uu____2766 =
                    rename_in_typ lb.FStar_Syntax_Syntax.lbdef
                      lb.FStar_Syntax_Syntax.lbtyp in
                  {
                    FStar_Syntax_Syntax.lbname =
-                     (uu___565_2761.FStar_Syntax_Syntax.lbname);
+                     (uu___565_2765.FStar_Syntax_Syntax.lbname);
                    FStar_Syntax_Syntax.lbunivs =
-                     (uu___565_2761.FStar_Syntax_Syntax.lbunivs);
-                   FStar_Syntax_Syntax.lbtyp = uu____2762;
+                     (uu___565_2765.FStar_Syntax_Syntax.lbunivs);
+                   FStar_Syntax_Syntax.lbtyp = uu____2766;
                    FStar_Syntax_Syntax.lbeff =
-                     (uu___565_2761.FStar_Syntax_Syntax.lbeff);
+                     (uu___565_2765.FStar_Syntax_Syntax.lbeff);
                    FStar_Syntax_Syntax.lbdef =
-                     (uu___565_2761.FStar_Syntax_Syntax.lbdef);
+                     (uu___565_2765.FStar_Syntax_Syntax.lbdef);
                    FStar_Syntax_Syntax.lbattrs =
-                     (uu___565_2761.FStar_Syntax_Syntax.lbattrs);
+                     (uu___565_2765.FStar_Syntax_Syntax.lbattrs);
                    FStar_Syntax_Syntax.lbpos =
-                     (uu___565_2761.FStar_Syntax_Syntax.lbpos)
+                     (uu___565_2765.FStar_Syntax_Syntax.lbpos)
                  } in
-               let uu____2765 =
+               let uu____2769 =
                  FStar_All.pipe_right (FStar_Pervasives_Native.snd lbs)
                    (FStar_List.fold_left
-                      (fun uu____2816 ->
+                      (fun uu____2820 ->
                          fun lb ->
-                           match uu____2816 with
+                           match uu____2820 with
                            | (gen, lbs1, quals_opt) ->
                                let lbname =
                                  FStar_Util.right
                                    lb.FStar_Syntax_Syntax.lbname in
-                               let uu____2858 =
-                                 let uu____2869 =
+                               let uu____2862 =
+                                 let uu____2873 =
                                    FStar_TypeChecker_Env.try_lookup_val_decl
                                      env1
                                      (lbname.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-                                 match uu____2869 with
+                                 match uu____2873 with
                                  | FStar_Pervasives_Native.None ->
                                      if lb.FStar_Syntax_Syntax.lbunivs <> []
                                      then (false, lb, quals_opt)
@@ -2318,7 +2318,7 @@ let (tc_decl' :
                                        with
                                        | FStar_Syntax_Syntax.Tm_unknown ->
                                            lb.FStar_Syntax_Syntax.lbdef
-                                       | uu____2942 ->
+                                       | uu____2946 ->
                                            FStar_Syntax_Syntax.mk
                                              (FStar_Syntax_Syntax.Tm_ascribed
                                                 ((lb.FStar_Syntax_Syntax.lbdef),
@@ -2339,14 +2339,14 @@ let (tc_decl' :
                                             "Inline universes are incoherent with annotation from val declaration")
                                           r
                                       else ();
-                                      (let uu____2985 =
+                                      (let uu____2989 =
                                          FStar_Syntax_Syntax.mk_lb
                                            ((FStar_Util.Inr lbname), uvs,
                                              FStar_Parser_Const.effect_ALL_lid,
                                              tval, def, [],
                                              (lb.FStar_Syntax_Syntax.lbpos)) in
-                                       (false, uu____2985, quals_opt1))) in
-                               (match uu____2858 with
+                                       (false, uu____2989, quals_opt1))) in
+                               (match uu____2862 with
                                 | (gen1, lb1, quals_opt1) ->
                                     (gen1, (lb1 :: lbs1), quals_opt1)))
                       (true, [],
@@ -2355,34 +2355,34 @@ let (tc_decl' :
                          else
                            FStar_Pervasives_Native.Some
                              (se1.FStar_Syntax_Syntax.sigquals)))) in
-               (match uu____2765 with
+               (match uu____2769 with
                 | (should_generalize, lbs', quals_opt) ->
                     let quals =
                       match quals_opt with
                       | FStar_Pervasives_Native.None ->
                           [FStar_Syntax_Syntax.Visible_default]
                       | FStar_Pervasives_Native.Some q ->
-                          let uu____3077 =
+                          let uu____3081 =
                             FStar_All.pipe_right q
                               (FStar_Util.for_some
-                                 (fun uu___1_3081 ->
-                                    match uu___1_3081 with
+                                 (fun uu___1_3085 ->
+                                    match uu___1_3085 with
                                     | FStar_Syntax_Syntax.Irreducible -> true
                                     | FStar_Syntax_Syntax.Visible_default ->
                                         true
                                     | FStar_Syntax_Syntax.Unfold_for_unification_and_vcgen
                                         -> true
-                                    | uu____3082 -> false)) in
-                          if uu____3077
+                                    | uu____3086 -> false)) in
+                          if uu____3081
                           then q
                           else FStar_Syntax_Syntax.Visible_default :: q in
                     let lbs'1 = FStar_List.rev lbs' in
-                    let uu____3089 =
-                      let uu____3098 =
+                    let uu____3093 =
+                      let uu____3102 =
                         FStar_Syntax_Util.extract_attr'
                           FStar_Parser_Const.preprocess_with
                           se1.FStar_Syntax_Syntax.sigattrs in
-                      match uu____3098 with
+                      match uu____3102 with
                       | FStar_Pervasives_Native.None ->
                           ((se1.FStar_Syntax_Syntax.sigattrs),
                             FStar_Pervasives_Native.None)
@@ -2395,53 +2395,53 @@ let (tc_decl' :
                                "Ill-formed application of `preprocess_with`");
                            ((se1.FStar_Syntax_Syntax.sigattrs),
                              FStar_Pervasives_Native.None)) in
-                    (match uu____3089 with
+                    (match uu____3093 with
                      | (attrs, pre_tau) ->
                          let se2 =
-                           let uu___623_3201 = se1 in
+                           let uu___623_3205 = se1 in
                            {
                              FStar_Syntax_Syntax.sigel =
-                               (uu___623_3201.FStar_Syntax_Syntax.sigel);
+                               (uu___623_3205.FStar_Syntax_Syntax.sigel);
                              FStar_Syntax_Syntax.sigrng =
-                               (uu___623_3201.FStar_Syntax_Syntax.sigrng);
+                               (uu___623_3205.FStar_Syntax_Syntax.sigrng);
                              FStar_Syntax_Syntax.sigquals =
-                               (uu___623_3201.FStar_Syntax_Syntax.sigquals);
+                               (uu___623_3205.FStar_Syntax_Syntax.sigquals);
                              FStar_Syntax_Syntax.sigmeta =
-                               (uu___623_3201.FStar_Syntax_Syntax.sigmeta);
+                               (uu___623_3205.FStar_Syntax_Syntax.sigmeta);
                              FStar_Syntax_Syntax.sigattrs = attrs;
                              FStar_Syntax_Syntax.sigopts =
-                               (uu___623_3201.FStar_Syntax_Syntax.sigopts)
+                               (uu___623_3205.FStar_Syntax_Syntax.sigopts)
                            } in
                          let preprocess_lb tau lb =
                            let lbdef =
                              FStar_TypeChecker_Env.preprocess env1 tau
                                lb.FStar_Syntax_Syntax.lbdef in
-                           (let uu____3215 =
+                           (let uu____3219 =
                               FStar_All.pipe_left
                                 (FStar_TypeChecker_Env.debug env1)
                                 (FStar_Options.Other "TwoPhases") in
-                            if uu____3215
+                            if uu____3219
                             then
-                              let uu____3216 =
+                              let uu____3220 =
                                 FStar_Syntax_Print.term_to_string lbdef in
                               FStar_Util.print1 "lb preprocessed into: %s\n"
-                                uu____3216
+                                uu____3220
                             else ());
-                           (let uu___632_3218 = lb in
+                           (let uu___632_3222 = lb in
                             {
                               FStar_Syntax_Syntax.lbname =
-                                (uu___632_3218.FStar_Syntax_Syntax.lbname);
+                                (uu___632_3222.FStar_Syntax_Syntax.lbname);
                               FStar_Syntax_Syntax.lbunivs =
-                                (uu___632_3218.FStar_Syntax_Syntax.lbunivs);
+                                (uu___632_3222.FStar_Syntax_Syntax.lbunivs);
                               FStar_Syntax_Syntax.lbtyp =
-                                (uu___632_3218.FStar_Syntax_Syntax.lbtyp);
+                                (uu___632_3222.FStar_Syntax_Syntax.lbtyp);
                               FStar_Syntax_Syntax.lbeff =
-                                (uu___632_3218.FStar_Syntax_Syntax.lbeff);
+                                (uu___632_3222.FStar_Syntax_Syntax.lbeff);
                               FStar_Syntax_Syntax.lbdef = lbdef;
                               FStar_Syntax_Syntax.lbattrs =
-                                (uu___632_3218.FStar_Syntax_Syntax.lbattrs);
+                                (uu___632_3222.FStar_Syntax_Syntax.lbattrs);
                               FStar_Syntax_Syntax.lbpos =
-                                (uu___632_3218.FStar_Syntax_Syntax.lbpos)
+                                (uu___632_3222.FStar_Syntax_Syntax.lbpos)
                             }) in
                          let lbs'2 =
                            match pre_tau with
@@ -2449,370 +2449,370 @@ let (tc_decl' :
                                FStar_List.map (preprocess_lb tau) lbs'1
                            | FStar_Pervasives_Native.None -> lbs'1 in
                          let e =
-                           let uu____3228 =
-                             let uu____3229 =
-                               let uu____3242 =
+                           let uu____3232 =
+                             let uu____3233 =
+                               let uu____3246 =
                                  FStar_Syntax_Syntax.mk
                                    (FStar_Syntax_Syntax.Tm_constant
                                       FStar_Const.Const_unit) r in
                                (((FStar_Pervasives_Native.fst lbs), lbs'2),
-                                 uu____3242) in
-                             FStar_Syntax_Syntax.Tm_let uu____3229 in
-                           FStar_Syntax_Syntax.mk uu____3228 r in
+                                 uu____3246) in
+                             FStar_Syntax_Syntax.Tm_let uu____3233 in
+                           FStar_Syntax_Syntax.mk uu____3232 r in
                          let env' =
-                           let uu___639_3258 = env1 in
+                           let uu___639_3262 = env1 in
                            {
                              FStar_TypeChecker_Env.solver =
-                               (uu___639_3258.FStar_TypeChecker_Env.solver);
+                               (uu___639_3262.FStar_TypeChecker_Env.solver);
                              FStar_TypeChecker_Env.range =
-                               (uu___639_3258.FStar_TypeChecker_Env.range);
+                               (uu___639_3262.FStar_TypeChecker_Env.range);
                              FStar_TypeChecker_Env.curmodule =
-                               (uu___639_3258.FStar_TypeChecker_Env.curmodule);
+                               (uu___639_3262.FStar_TypeChecker_Env.curmodule);
                              FStar_TypeChecker_Env.gamma =
-                               (uu___639_3258.FStar_TypeChecker_Env.gamma);
+                               (uu___639_3262.FStar_TypeChecker_Env.gamma);
                              FStar_TypeChecker_Env.gamma_sig =
-                               (uu___639_3258.FStar_TypeChecker_Env.gamma_sig);
+                               (uu___639_3262.FStar_TypeChecker_Env.gamma_sig);
                              FStar_TypeChecker_Env.gamma_cache =
-                               (uu___639_3258.FStar_TypeChecker_Env.gamma_cache);
+                               (uu___639_3262.FStar_TypeChecker_Env.gamma_cache);
                              FStar_TypeChecker_Env.modules =
-                               (uu___639_3258.FStar_TypeChecker_Env.modules);
+                               (uu___639_3262.FStar_TypeChecker_Env.modules);
                              FStar_TypeChecker_Env.expected_typ =
-                               (uu___639_3258.FStar_TypeChecker_Env.expected_typ);
+                               (uu___639_3262.FStar_TypeChecker_Env.expected_typ);
                              FStar_TypeChecker_Env.sigtab =
-                               (uu___639_3258.FStar_TypeChecker_Env.sigtab);
+                               (uu___639_3262.FStar_TypeChecker_Env.sigtab);
                              FStar_TypeChecker_Env.attrtab =
-                               (uu___639_3258.FStar_TypeChecker_Env.attrtab);
+                               (uu___639_3262.FStar_TypeChecker_Env.attrtab);
                              FStar_TypeChecker_Env.instantiate_imp =
-                               (uu___639_3258.FStar_TypeChecker_Env.instantiate_imp);
+                               (uu___639_3262.FStar_TypeChecker_Env.instantiate_imp);
                              FStar_TypeChecker_Env.effects =
-                               (uu___639_3258.FStar_TypeChecker_Env.effects);
+                               (uu___639_3262.FStar_TypeChecker_Env.effects);
                              FStar_TypeChecker_Env.generalize =
                                should_generalize;
                              FStar_TypeChecker_Env.letrecs =
-                               (uu___639_3258.FStar_TypeChecker_Env.letrecs);
+                               (uu___639_3262.FStar_TypeChecker_Env.letrecs);
                              FStar_TypeChecker_Env.top_level = true;
                              FStar_TypeChecker_Env.check_uvars =
-                               (uu___639_3258.FStar_TypeChecker_Env.check_uvars);
+                               (uu___639_3262.FStar_TypeChecker_Env.check_uvars);
                              FStar_TypeChecker_Env.use_eq =
-                               (uu___639_3258.FStar_TypeChecker_Env.use_eq);
+                               (uu___639_3262.FStar_TypeChecker_Env.use_eq);
                              FStar_TypeChecker_Env.use_eq_strict =
-                               (uu___639_3258.FStar_TypeChecker_Env.use_eq_strict);
+                               (uu___639_3262.FStar_TypeChecker_Env.use_eq_strict);
                              FStar_TypeChecker_Env.is_iface =
-                               (uu___639_3258.FStar_TypeChecker_Env.is_iface);
+                               (uu___639_3262.FStar_TypeChecker_Env.is_iface);
                              FStar_TypeChecker_Env.admit =
-                               (uu___639_3258.FStar_TypeChecker_Env.admit);
+                               (uu___639_3262.FStar_TypeChecker_Env.admit);
                              FStar_TypeChecker_Env.lax =
-                               (uu___639_3258.FStar_TypeChecker_Env.lax);
+                               (uu___639_3262.FStar_TypeChecker_Env.lax);
                              FStar_TypeChecker_Env.lax_universes =
-                               (uu___639_3258.FStar_TypeChecker_Env.lax_universes);
+                               (uu___639_3262.FStar_TypeChecker_Env.lax_universes);
                              FStar_TypeChecker_Env.phase1 =
-                               (uu___639_3258.FStar_TypeChecker_Env.phase1);
+                               (uu___639_3262.FStar_TypeChecker_Env.phase1);
                              FStar_TypeChecker_Env.failhard =
-                               (uu___639_3258.FStar_TypeChecker_Env.failhard);
+                               (uu___639_3262.FStar_TypeChecker_Env.failhard);
                              FStar_TypeChecker_Env.nosynth =
-                               (uu___639_3258.FStar_TypeChecker_Env.nosynth);
+                               (uu___639_3262.FStar_TypeChecker_Env.nosynth);
                              FStar_TypeChecker_Env.uvar_subtyping =
-                               (uu___639_3258.FStar_TypeChecker_Env.uvar_subtyping);
+                               (uu___639_3262.FStar_TypeChecker_Env.uvar_subtyping);
                              FStar_TypeChecker_Env.tc_term =
-                               (uu___639_3258.FStar_TypeChecker_Env.tc_term);
+                               (uu___639_3262.FStar_TypeChecker_Env.tc_term);
                              FStar_TypeChecker_Env.type_of =
-                               (uu___639_3258.FStar_TypeChecker_Env.type_of);
+                               (uu___639_3262.FStar_TypeChecker_Env.type_of);
                              FStar_TypeChecker_Env.universe_of =
-                               (uu___639_3258.FStar_TypeChecker_Env.universe_of);
+                               (uu___639_3262.FStar_TypeChecker_Env.universe_of);
                              FStar_TypeChecker_Env.check_type_of =
-                               (uu___639_3258.FStar_TypeChecker_Env.check_type_of);
+                               (uu___639_3262.FStar_TypeChecker_Env.check_type_of);
                              FStar_TypeChecker_Env.use_bv_sorts =
-                               (uu___639_3258.FStar_TypeChecker_Env.use_bv_sorts);
+                               (uu___639_3262.FStar_TypeChecker_Env.use_bv_sorts);
                              FStar_TypeChecker_Env.qtbl_name_and_index =
-                               (uu___639_3258.FStar_TypeChecker_Env.qtbl_name_and_index);
+                               (uu___639_3262.FStar_TypeChecker_Env.qtbl_name_and_index);
                              FStar_TypeChecker_Env.normalized_eff_names =
-                               (uu___639_3258.FStar_TypeChecker_Env.normalized_eff_names);
+                               (uu___639_3262.FStar_TypeChecker_Env.normalized_eff_names);
                              FStar_TypeChecker_Env.fv_delta_depths =
-                               (uu___639_3258.FStar_TypeChecker_Env.fv_delta_depths);
+                               (uu___639_3262.FStar_TypeChecker_Env.fv_delta_depths);
                              FStar_TypeChecker_Env.proof_ns =
-                               (uu___639_3258.FStar_TypeChecker_Env.proof_ns);
+                               (uu___639_3262.FStar_TypeChecker_Env.proof_ns);
                              FStar_TypeChecker_Env.synth_hook =
-                               (uu___639_3258.FStar_TypeChecker_Env.synth_hook);
+                               (uu___639_3262.FStar_TypeChecker_Env.synth_hook);
                              FStar_TypeChecker_Env.try_solve_implicits_hook =
-                               (uu___639_3258.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                               (uu___639_3262.FStar_TypeChecker_Env.try_solve_implicits_hook);
                              FStar_TypeChecker_Env.splice =
-                               (uu___639_3258.FStar_TypeChecker_Env.splice);
+                               (uu___639_3262.FStar_TypeChecker_Env.splice);
                              FStar_TypeChecker_Env.mpreprocess =
-                               (uu___639_3258.FStar_TypeChecker_Env.mpreprocess);
+                               (uu___639_3262.FStar_TypeChecker_Env.mpreprocess);
                              FStar_TypeChecker_Env.postprocess =
-                               (uu___639_3258.FStar_TypeChecker_Env.postprocess);
+                               (uu___639_3262.FStar_TypeChecker_Env.postprocess);
                              FStar_TypeChecker_Env.identifier_info =
-                               (uu___639_3258.FStar_TypeChecker_Env.identifier_info);
+                               (uu___639_3262.FStar_TypeChecker_Env.identifier_info);
                              FStar_TypeChecker_Env.tc_hooks =
-                               (uu___639_3258.FStar_TypeChecker_Env.tc_hooks);
+                               (uu___639_3262.FStar_TypeChecker_Env.tc_hooks);
                              FStar_TypeChecker_Env.dsenv =
-                               (uu___639_3258.FStar_TypeChecker_Env.dsenv);
+                               (uu___639_3262.FStar_TypeChecker_Env.dsenv);
                              FStar_TypeChecker_Env.nbe =
-                               (uu___639_3258.FStar_TypeChecker_Env.nbe);
+                               (uu___639_3262.FStar_TypeChecker_Env.nbe);
                              FStar_TypeChecker_Env.strict_args_tab =
-                               (uu___639_3258.FStar_TypeChecker_Env.strict_args_tab);
+                               (uu___639_3262.FStar_TypeChecker_Env.strict_args_tab);
                              FStar_TypeChecker_Env.erasable_types_tab =
-                               (uu___639_3258.FStar_TypeChecker_Env.erasable_types_tab);
+                               (uu___639_3262.FStar_TypeChecker_Env.erasable_types_tab);
                              FStar_TypeChecker_Env.enable_defer_to_tac =
-                               (uu___639_3258.FStar_TypeChecker_Env.enable_defer_to_tac)
+                               (uu___639_3262.FStar_TypeChecker_Env.enable_defer_to_tac)
                            } in
                          let e1 =
-                           let uu____3260 =
+                           let uu____3264 =
                              (FStar_Options.use_two_phase_tc ()) &&
                                (FStar_TypeChecker_Env.should_verify env') in
-                           if uu____3260
+                           if uu____3264
                            then
                              let drop_lbtyp e_lax =
-                               let uu____3267 =
-                                 let uu____3268 =
+                               let uu____3271 =
+                                 let uu____3272 =
                                    FStar_Syntax_Subst.compress e_lax in
-                                 uu____3268.FStar_Syntax_Syntax.n in
-                               match uu____3267 with
+                                 uu____3272.FStar_Syntax_Syntax.n in
+                               match uu____3271 with
                                | FStar_Syntax_Syntax.Tm_let
                                    ((false, lb::[]), e2) ->
                                    let lb_unannotated =
-                                     let uu____3286 =
-                                       let uu____3287 =
+                                     let uu____3290 =
+                                       let uu____3291 =
                                          FStar_Syntax_Subst.compress e in
-                                       uu____3287.FStar_Syntax_Syntax.n in
-                                     match uu____3286 with
+                                       uu____3291.FStar_Syntax_Syntax.n in
+                                     match uu____3290 with
                                      | FStar_Syntax_Syntax.Tm_let
-                                         ((uu____3290, lb1::[]), uu____3292)
+                                         ((uu____3294, lb1::[]), uu____3296)
                                          ->
-                                         let uu____3305 =
-                                           let uu____3306 =
+                                         let uu____3309 =
+                                           let uu____3310 =
                                              FStar_Syntax_Subst.compress
                                                lb1.FStar_Syntax_Syntax.lbtyp in
-                                           uu____3306.FStar_Syntax_Syntax.n in
-                                         (match uu____3305 with
+                                           uu____3310.FStar_Syntax_Syntax.n in
+                                         (match uu____3309 with
                                           | FStar_Syntax_Syntax.Tm_unknown ->
                                               true
-                                          | uu____3309 -> false)
-                                     | uu____3310 ->
+                                          | uu____3313 -> false)
+                                     | uu____3314 ->
                                          failwith
                                            "Impossible: first phase lb and second phase lb differ in structure!" in
                                    if lb_unannotated
                                    then
-                                     let uu___664_3311 = e_lax in
+                                     let uu___664_3315 = e_lax in
                                      {
                                        FStar_Syntax_Syntax.n =
                                          (FStar_Syntax_Syntax.Tm_let
                                             ((false,
-                                               [(let uu___666_3323 = lb in
+                                               [(let uu___666_3327 = lb in
                                                  {
                                                    FStar_Syntax_Syntax.lbname
                                                      =
-                                                     (uu___666_3323.FStar_Syntax_Syntax.lbname);
+                                                     (uu___666_3327.FStar_Syntax_Syntax.lbname);
                                                    FStar_Syntax_Syntax.lbunivs
                                                      =
-                                                     (uu___666_3323.FStar_Syntax_Syntax.lbunivs);
+                                                     (uu___666_3327.FStar_Syntax_Syntax.lbunivs);
                                                    FStar_Syntax_Syntax.lbtyp
                                                      =
                                                      FStar_Syntax_Syntax.tun;
                                                    FStar_Syntax_Syntax.lbeff
                                                      =
-                                                     (uu___666_3323.FStar_Syntax_Syntax.lbeff);
+                                                     (uu___666_3327.FStar_Syntax_Syntax.lbeff);
                                                    FStar_Syntax_Syntax.lbdef
                                                      =
-                                                     (uu___666_3323.FStar_Syntax_Syntax.lbdef);
+                                                     (uu___666_3327.FStar_Syntax_Syntax.lbdef);
                                                    FStar_Syntax_Syntax.lbattrs
                                                      =
-                                                     (uu___666_3323.FStar_Syntax_Syntax.lbattrs);
+                                                     (uu___666_3327.FStar_Syntax_Syntax.lbattrs);
                                                    FStar_Syntax_Syntax.lbpos
                                                      =
-                                                     (uu___666_3323.FStar_Syntax_Syntax.lbpos)
+                                                     (uu___666_3327.FStar_Syntax_Syntax.lbpos)
                                                  })]), e2));
                                        FStar_Syntax_Syntax.pos =
-                                         (uu___664_3311.FStar_Syntax_Syntax.pos);
+                                         (uu___664_3315.FStar_Syntax_Syntax.pos);
                                        FStar_Syntax_Syntax.vars =
-                                         (uu___664_3311.FStar_Syntax_Syntax.vars)
+                                         (uu___664_3315.FStar_Syntax_Syntax.vars)
                                      }
                                    else e_lax
-                               | uu____3325 -> e_lax in
-                             let uu____3326 =
+                               | uu____3329 -> e_lax in
+                             let uu____3330 =
                                FStar_Util.record_time
-                                 (fun uu____3333 ->
-                                    let uu____3334 =
-                                      let uu____3335 =
-                                        let uu____3336 =
+                                 (fun uu____3337 ->
+                                    let uu____3338 =
+                                      let uu____3339 =
+                                        let uu____3340 =
                                           FStar_TypeChecker_TcTerm.tc_maybe_toplevel_term
-                                            (let uu___670_3345 = env' in
+                                            (let uu___670_3349 = env' in
                                              {
                                                FStar_TypeChecker_Env.solver =
-                                                 (uu___670_3345.FStar_TypeChecker_Env.solver);
+                                                 (uu___670_3349.FStar_TypeChecker_Env.solver);
                                                FStar_TypeChecker_Env.range =
-                                                 (uu___670_3345.FStar_TypeChecker_Env.range);
+                                                 (uu___670_3349.FStar_TypeChecker_Env.range);
                                                FStar_TypeChecker_Env.curmodule
                                                  =
-                                                 (uu___670_3345.FStar_TypeChecker_Env.curmodule);
+                                                 (uu___670_3349.FStar_TypeChecker_Env.curmodule);
                                                FStar_TypeChecker_Env.gamma =
-                                                 (uu___670_3345.FStar_TypeChecker_Env.gamma);
+                                                 (uu___670_3349.FStar_TypeChecker_Env.gamma);
                                                FStar_TypeChecker_Env.gamma_sig
                                                  =
-                                                 (uu___670_3345.FStar_TypeChecker_Env.gamma_sig);
+                                                 (uu___670_3349.FStar_TypeChecker_Env.gamma_sig);
                                                FStar_TypeChecker_Env.gamma_cache
                                                  =
-                                                 (uu___670_3345.FStar_TypeChecker_Env.gamma_cache);
+                                                 (uu___670_3349.FStar_TypeChecker_Env.gamma_cache);
                                                FStar_TypeChecker_Env.modules
                                                  =
-                                                 (uu___670_3345.FStar_TypeChecker_Env.modules);
+                                                 (uu___670_3349.FStar_TypeChecker_Env.modules);
                                                FStar_TypeChecker_Env.expected_typ
                                                  =
-                                                 (uu___670_3345.FStar_TypeChecker_Env.expected_typ);
+                                                 (uu___670_3349.FStar_TypeChecker_Env.expected_typ);
                                                FStar_TypeChecker_Env.sigtab =
-                                                 (uu___670_3345.FStar_TypeChecker_Env.sigtab);
+                                                 (uu___670_3349.FStar_TypeChecker_Env.sigtab);
                                                FStar_TypeChecker_Env.attrtab
                                                  =
-                                                 (uu___670_3345.FStar_TypeChecker_Env.attrtab);
+                                                 (uu___670_3349.FStar_TypeChecker_Env.attrtab);
                                                FStar_TypeChecker_Env.instantiate_imp
                                                  =
-                                                 (uu___670_3345.FStar_TypeChecker_Env.instantiate_imp);
+                                                 (uu___670_3349.FStar_TypeChecker_Env.instantiate_imp);
                                                FStar_TypeChecker_Env.effects
                                                  =
-                                                 (uu___670_3345.FStar_TypeChecker_Env.effects);
+                                                 (uu___670_3349.FStar_TypeChecker_Env.effects);
                                                FStar_TypeChecker_Env.generalize
                                                  =
-                                                 (uu___670_3345.FStar_TypeChecker_Env.generalize);
+                                                 (uu___670_3349.FStar_TypeChecker_Env.generalize);
                                                FStar_TypeChecker_Env.letrecs
                                                  =
-                                                 (uu___670_3345.FStar_TypeChecker_Env.letrecs);
+                                                 (uu___670_3349.FStar_TypeChecker_Env.letrecs);
                                                FStar_TypeChecker_Env.top_level
                                                  =
-                                                 (uu___670_3345.FStar_TypeChecker_Env.top_level);
+                                                 (uu___670_3349.FStar_TypeChecker_Env.top_level);
                                                FStar_TypeChecker_Env.check_uvars
                                                  =
-                                                 (uu___670_3345.FStar_TypeChecker_Env.check_uvars);
+                                                 (uu___670_3349.FStar_TypeChecker_Env.check_uvars);
                                                FStar_TypeChecker_Env.use_eq =
-                                                 (uu___670_3345.FStar_TypeChecker_Env.use_eq);
+                                                 (uu___670_3349.FStar_TypeChecker_Env.use_eq);
                                                FStar_TypeChecker_Env.use_eq_strict
                                                  =
-                                                 (uu___670_3345.FStar_TypeChecker_Env.use_eq_strict);
+                                                 (uu___670_3349.FStar_TypeChecker_Env.use_eq_strict);
                                                FStar_TypeChecker_Env.is_iface
                                                  =
-                                                 (uu___670_3345.FStar_TypeChecker_Env.is_iface);
+                                                 (uu___670_3349.FStar_TypeChecker_Env.is_iface);
                                                FStar_TypeChecker_Env.admit =
-                                                 (uu___670_3345.FStar_TypeChecker_Env.admit);
+                                                 (uu___670_3349.FStar_TypeChecker_Env.admit);
                                                FStar_TypeChecker_Env.lax =
                                                  true;
                                                FStar_TypeChecker_Env.lax_universes
                                                  =
-                                                 (uu___670_3345.FStar_TypeChecker_Env.lax_universes);
+                                                 (uu___670_3349.FStar_TypeChecker_Env.lax_universes);
                                                FStar_TypeChecker_Env.phase1 =
                                                  true;
                                                FStar_TypeChecker_Env.failhard
                                                  =
-                                                 (uu___670_3345.FStar_TypeChecker_Env.failhard);
+                                                 (uu___670_3349.FStar_TypeChecker_Env.failhard);
                                                FStar_TypeChecker_Env.nosynth
                                                  =
-                                                 (uu___670_3345.FStar_TypeChecker_Env.nosynth);
+                                                 (uu___670_3349.FStar_TypeChecker_Env.nosynth);
                                                FStar_TypeChecker_Env.uvar_subtyping
                                                  =
-                                                 (uu___670_3345.FStar_TypeChecker_Env.uvar_subtyping);
+                                                 (uu___670_3349.FStar_TypeChecker_Env.uvar_subtyping);
                                                FStar_TypeChecker_Env.tc_term
                                                  =
-                                                 (uu___670_3345.FStar_TypeChecker_Env.tc_term);
+                                                 (uu___670_3349.FStar_TypeChecker_Env.tc_term);
                                                FStar_TypeChecker_Env.type_of
                                                  =
-                                                 (uu___670_3345.FStar_TypeChecker_Env.type_of);
+                                                 (uu___670_3349.FStar_TypeChecker_Env.type_of);
                                                FStar_TypeChecker_Env.universe_of
                                                  =
-                                                 (uu___670_3345.FStar_TypeChecker_Env.universe_of);
+                                                 (uu___670_3349.FStar_TypeChecker_Env.universe_of);
                                                FStar_TypeChecker_Env.check_type_of
                                                  =
-                                                 (uu___670_3345.FStar_TypeChecker_Env.check_type_of);
+                                                 (uu___670_3349.FStar_TypeChecker_Env.check_type_of);
                                                FStar_TypeChecker_Env.use_bv_sorts
                                                  =
-                                                 (uu___670_3345.FStar_TypeChecker_Env.use_bv_sorts);
+                                                 (uu___670_3349.FStar_TypeChecker_Env.use_bv_sorts);
                                                FStar_TypeChecker_Env.qtbl_name_and_index
                                                  =
-                                                 (uu___670_3345.FStar_TypeChecker_Env.qtbl_name_and_index);
+                                                 (uu___670_3349.FStar_TypeChecker_Env.qtbl_name_and_index);
                                                FStar_TypeChecker_Env.normalized_eff_names
                                                  =
-                                                 (uu___670_3345.FStar_TypeChecker_Env.normalized_eff_names);
+                                                 (uu___670_3349.FStar_TypeChecker_Env.normalized_eff_names);
                                                FStar_TypeChecker_Env.fv_delta_depths
                                                  =
-                                                 (uu___670_3345.FStar_TypeChecker_Env.fv_delta_depths);
+                                                 (uu___670_3349.FStar_TypeChecker_Env.fv_delta_depths);
                                                FStar_TypeChecker_Env.proof_ns
                                                  =
-                                                 (uu___670_3345.FStar_TypeChecker_Env.proof_ns);
+                                                 (uu___670_3349.FStar_TypeChecker_Env.proof_ns);
                                                FStar_TypeChecker_Env.synth_hook
                                                  =
-                                                 (uu___670_3345.FStar_TypeChecker_Env.synth_hook);
+                                                 (uu___670_3349.FStar_TypeChecker_Env.synth_hook);
                                                FStar_TypeChecker_Env.try_solve_implicits_hook
                                                  =
-                                                 (uu___670_3345.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                                                 (uu___670_3349.FStar_TypeChecker_Env.try_solve_implicits_hook);
                                                FStar_TypeChecker_Env.splice =
-                                                 (uu___670_3345.FStar_TypeChecker_Env.splice);
+                                                 (uu___670_3349.FStar_TypeChecker_Env.splice);
                                                FStar_TypeChecker_Env.mpreprocess
                                                  =
-                                                 (uu___670_3345.FStar_TypeChecker_Env.mpreprocess);
+                                                 (uu___670_3349.FStar_TypeChecker_Env.mpreprocess);
                                                FStar_TypeChecker_Env.postprocess
                                                  =
-                                                 (uu___670_3345.FStar_TypeChecker_Env.postprocess);
+                                                 (uu___670_3349.FStar_TypeChecker_Env.postprocess);
                                                FStar_TypeChecker_Env.identifier_info
                                                  =
-                                                 (uu___670_3345.FStar_TypeChecker_Env.identifier_info);
+                                                 (uu___670_3349.FStar_TypeChecker_Env.identifier_info);
                                                FStar_TypeChecker_Env.tc_hooks
                                                  =
-                                                 (uu___670_3345.FStar_TypeChecker_Env.tc_hooks);
+                                                 (uu___670_3349.FStar_TypeChecker_Env.tc_hooks);
                                                FStar_TypeChecker_Env.dsenv =
-                                                 (uu___670_3345.FStar_TypeChecker_Env.dsenv);
+                                                 (uu___670_3349.FStar_TypeChecker_Env.dsenv);
                                                FStar_TypeChecker_Env.nbe =
-                                                 (uu___670_3345.FStar_TypeChecker_Env.nbe);
+                                                 (uu___670_3349.FStar_TypeChecker_Env.nbe);
                                                FStar_TypeChecker_Env.strict_args_tab
                                                  =
-                                                 (uu___670_3345.FStar_TypeChecker_Env.strict_args_tab);
+                                                 (uu___670_3349.FStar_TypeChecker_Env.strict_args_tab);
                                                FStar_TypeChecker_Env.erasable_types_tab
                                                  =
-                                                 (uu___670_3345.FStar_TypeChecker_Env.erasable_types_tab);
+                                                 (uu___670_3349.FStar_TypeChecker_Env.erasable_types_tab);
                                                FStar_TypeChecker_Env.enable_defer_to_tac
                                                  =
-                                                 (uu___670_3345.FStar_TypeChecker_Env.enable_defer_to_tac)
+                                                 (uu___670_3349.FStar_TypeChecker_Env.enable_defer_to_tac)
                                              }) e in
-                                        FStar_All.pipe_right uu____3336
-                                          (fun uu____3356 ->
-                                             match uu____3356 with
-                                             | (e1, uu____3364, uu____3365)
+                                        FStar_All.pipe_right uu____3340
+                                          (fun uu____3360 ->
+                                             match uu____3360 with
+                                             | (e1, uu____3368, uu____3369)
                                                  -> e1) in
-                                      FStar_All.pipe_right uu____3335
+                                      FStar_All.pipe_right uu____3339
                                         (FStar_TypeChecker_Normalize.remove_uvar_solutions
                                            env') in
-                                    FStar_All.pipe_right uu____3334
+                                    FStar_All.pipe_right uu____3338
                                       drop_lbtyp) in
-                             match uu____3326 with
+                             match uu____3330 with
                              | (e1, ms) ->
-                                 ((let uu____3369 =
+                                 ((let uu____3373 =
                                      FStar_All.pipe_left
                                        (FStar_TypeChecker_Env.debug env1)
                                        (FStar_Options.Other "TwoPhases") in
-                                   if uu____3369
-                                   then
-                                     let uu____3370 =
-                                       FStar_Syntax_Print.term_to_string e1 in
-                                     FStar_Util.print1
-                                       "Let binding after phase 1: %s\n"
-                                       uu____3370
-                                   else ());
-                                  (let uu____3373 =
-                                     FStar_All.pipe_left
-                                       (FStar_TypeChecker_Env.debug env1)
-                                       (FStar_Options.Other "TCDeclTime") in
                                    if uu____3373
                                    then
                                      let uu____3374 =
+                                       FStar_Syntax_Print.term_to_string e1 in
+                                     FStar_Util.print1
+                                       "Let binding after phase 1: %s\n"
+                                       uu____3374
+                                   else ());
+                                  (let uu____3377 =
+                                     FStar_All.pipe_left
+                                       (FStar_TypeChecker_Env.debug env1)
+                                       (FStar_Options.Other "TCDeclTime") in
+                                   if uu____3377
+                                   then
+                                     let uu____3378 =
                                        FStar_Util.string_of_int ms in
                                      FStar_Util.print1
                                        "Let binding elaborated (phase 1) in %s milliseconds\n"
-                                       uu____3374
+                                       uu____3378
                                    else ());
                                   e1)
                            else e in
-                         let uu____3377 =
-                           let uu____3386 =
+                         let uu____3381 =
+                           let uu____3390 =
                              FStar_Syntax_Util.extract_attr'
                                FStar_Parser_Const.postprocess_with
                                se2.FStar_Syntax_Syntax.sigattrs in
-                           match uu____3386 with
+                           match uu____3390 with
                            | FStar_Pervasives_Native.None ->
                                ((se2.FStar_Syntax_Syntax.sigattrs),
                                  FStar_Pervasives_Native.None)
@@ -2825,28 +2825,28 @@ let (tc_decl' :
                                     "Ill-formed application of `postprocess_with`");
                                 ((se2.FStar_Syntax_Syntax.sigattrs),
                                   FStar_Pervasives_Native.None)) in
-                         (match uu____3377 with
+                         (match uu____3381 with
                           | (attrs1, post_tau) ->
                               let se3 =
-                                let uu___700_3489 = se2 in
+                                let uu___700_3493 = se2 in
                                 {
                                   FStar_Syntax_Syntax.sigel =
-                                    (uu___700_3489.FStar_Syntax_Syntax.sigel);
+                                    (uu___700_3493.FStar_Syntax_Syntax.sigel);
                                   FStar_Syntax_Syntax.sigrng =
-                                    (uu___700_3489.FStar_Syntax_Syntax.sigrng);
+                                    (uu___700_3493.FStar_Syntax_Syntax.sigrng);
                                   FStar_Syntax_Syntax.sigquals =
-                                    (uu___700_3489.FStar_Syntax_Syntax.sigquals);
+                                    (uu___700_3493.FStar_Syntax_Syntax.sigquals);
                                   FStar_Syntax_Syntax.sigmeta =
-                                    (uu___700_3489.FStar_Syntax_Syntax.sigmeta);
+                                    (uu___700_3493.FStar_Syntax_Syntax.sigmeta);
                                   FStar_Syntax_Syntax.sigattrs = attrs1;
                                   FStar_Syntax_Syntax.sigopts =
-                                    (uu___700_3489.FStar_Syntax_Syntax.sigopts)
+                                    (uu___700_3493.FStar_Syntax_Syntax.sigopts)
                                 } in
                               let postprocess_lb tau lb =
-                                let uu____3501 =
+                                let uu____3505 =
                                   FStar_Syntax_Subst.univ_var_opening
                                     lb.FStar_Syntax_Syntax.lbunivs in
-                                match uu____3501 with
+                                match uu____3505 with
                                 | (s, univnames) ->
                                     let lbdef =
                                       FStar_Syntax_Subst.subst s
@@ -2863,65 +2863,65 @@ let (tc_decl' :
                                     let lbdef2 =
                                       FStar_Syntax_Subst.close_univ_vars
                                         univnames lbdef1 in
-                                    let uu___714_3525 = lb in
+                                    let uu___714_3529 = lb in
                                     {
                                       FStar_Syntax_Syntax.lbname =
-                                        (uu___714_3525.FStar_Syntax_Syntax.lbname);
+                                        (uu___714_3529.FStar_Syntax_Syntax.lbname);
                                       FStar_Syntax_Syntax.lbunivs =
-                                        (uu___714_3525.FStar_Syntax_Syntax.lbunivs);
+                                        (uu___714_3529.FStar_Syntax_Syntax.lbunivs);
                                       FStar_Syntax_Syntax.lbtyp =
-                                        (uu___714_3525.FStar_Syntax_Syntax.lbtyp);
+                                        (uu___714_3529.FStar_Syntax_Syntax.lbtyp);
                                       FStar_Syntax_Syntax.lbeff =
-                                        (uu___714_3525.FStar_Syntax_Syntax.lbeff);
+                                        (uu___714_3529.FStar_Syntax_Syntax.lbeff);
                                       FStar_Syntax_Syntax.lbdef = lbdef2;
                                       FStar_Syntax_Syntax.lbattrs =
-                                        (uu___714_3525.FStar_Syntax_Syntax.lbattrs);
+                                        (uu___714_3529.FStar_Syntax_Syntax.lbattrs);
                                       FStar_Syntax_Syntax.lbpos =
-                                        (uu___714_3525.FStar_Syntax_Syntax.lbpos)
+                                        (uu___714_3529.FStar_Syntax_Syntax.lbpos)
                                     } in
-                              let uu____3526 =
+                              let uu____3530 =
                                 FStar_Util.record_time
-                                  (fun uu____3544 ->
+                                  (fun uu____3548 ->
                                      FStar_TypeChecker_TcTerm.tc_maybe_toplevel_term
                                        env' e1) in
-                              (match uu____3526 with
+                              (match uu____3530 with
                                | (r1, ms) ->
-                                   ((let uu____3570 =
+                                   ((let uu____3574 =
                                        FStar_All.pipe_left
                                          (FStar_TypeChecker_Env.debug env1)
                                          (FStar_Options.Other "TCDeclTime") in
-                                     if uu____3570
+                                     if uu____3574
                                      then
-                                       let uu____3571 =
+                                       let uu____3575 =
                                          FStar_Util.string_of_int ms in
                                        FStar_Util.print1
                                          "Let binding typechecked in phase 2 in %s milliseconds\n"
-                                         uu____3571
+                                         uu____3575
                                      else ());
-                                    (let uu____3573 =
+                                    (let uu____3577 =
                                        match r1 with
                                        | ({
                                             FStar_Syntax_Syntax.n =
                                               FStar_Syntax_Syntax.Tm_let
                                               (lbs1, e2);
                                             FStar_Syntax_Syntax.pos =
-                                              uu____3596;
+                                              uu____3600;
                                             FStar_Syntax_Syntax.vars =
-                                              uu____3597;_},
-                                          uu____3598, g) when
+                                              uu____3601;_},
+                                          uu____3602, g) when
                                            FStar_TypeChecker_Env.is_trivial g
                                            ->
                                            let lbs2 =
-                                             let uu____3625 =
+                                             let uu____3629 =
                                                FStar_All.pipe_right
                                                  (FStar_Pervasives_Native.snd
                                                     lbs1)
                                                  (FStar_List.map
                                                     rename_parameters) in
                                              ((FStar_Pervasives_Native.fst
-                                                 lbs1), uu____3625) in
+                                                 lbs1), uu____3629) in
                                            let lbs3 =
-                                             let uu____3645 =
+                                             let uu____3649 =
                                                match post_tau with
                                                | FStar_Pervasives_Native.Some
                                                    tau ->
@@ -2934,38 +2934,38 @@ let (tc_decl' :
                                                    FStar_Pervasives_Native.snd
                                                      lbs2 in
                                              ((FStar_Pervasives_Native.fst
-                                                 lbs2), uu____3645) in
+                                                 lbs2), uu____3649) in
                                            let quals1 =
                                              match e2.FStar_Syntax_Syntax.n
                                              with
                                              | FStar_Syntax_Syntax.Tm_meta
-                                                 (uu____3664,
+                                                 (uu____3668,
                                                   FStar_Syntax_Syntax.Meta_desugared
                                                   (FStar_Syntax_Syntax.Masked_effect))
                                                  ->
                                                  FStar_Syntax_Syntax.HasMaskedEffect
                                                  :: quals
-                                             | uu____3669 -> quals in
-                                           ((let uu___744_3677 = se3 in
+                                             | uu____3673 -> quals in
+                                           ((let uu___744_3681 = se3 in
                                              {
                                                FStar_Syntax_Syntax.sigel =
                                                  (FStar_Syntax_Syntax.Sig_let
                                                     (lbs3, lids));
                                                FStar_Syntax_Syntax.sigrng =
-                                                 (uu___744_3677.FStar_Syntax_Syntax.sigrng);
+                                                 (uu___744_3681.FStar_Syntax_Syntax.sigrng);
                                                FStar_Syntax_Syntax.sigquals =
                                                  quals1;
                                                FStar_Syntax_Syntax.sigmeta =
-                                                 (uu___744_3677.FStar_Syntax_Syntax.sigmeta);
+                                                 (uu___744_3681.FStar_Syntax_Syntax.sigmeta);
                                                FStar_Syntax_Syntax.sigattrs =
-                                                 (uu___744_3677.FStar_Syntax_Syntax.sigattrs);
+                                                 (uu___744_3681.FStar_Syntax_Syntax.sigattrs);
                                                FStar_Syntax_Syntax.sigopts =
-                                                 (uu___744_3677.FStar_Syntax_Syntax.sigopts)
+                                                 (uu___744_3681.FStar_Syntax_Syntax.sigopts)
                                              }), lbs3)
-                                       | uu____3680 ->
+                                       | uu____3684 ->
                                            failwith
                                              "impossible (typechecking should preserve Tm_let)" in
-                                     match uu____3573 with
+                                     match uu____3577 with
                                      | (se4, lbs1) ->
                                          (FStar_All.pipe_right
                                             (FStar_Pervasives_Native.snd lbs1)
@@ -2977,442 +2977,442 @@ let (tc_decl' :
                                                   FStar_TypeChecker_Env.insert_fv_info
                                                     env1 fv
                                                     lb.FStar_Syntax_Syntax.lbtyp));
-                                          (let uu____3731 = log env1 in
-                                           if uu____3731
+                                          (let uu____3735 = log env1 in
+                                           if uu____3735
                                            then
-                                             let uu____3732 =
-                                               let uu____3733 =
+                                             let uu____3736 =
+                                               let uu____3737 =
                                                  FStar_All.pipe_right
                                                    (FStar_Pervasives_Native.snd
                                                       lbs1)
                                                    (FStar_List.map
                                                       (fun lb ->
                                                          let should_log =
-                                                           let uu____3748 =
-                                                             let uu____3757 =
-                                                               let uu____3758
+                                                           let uu____3752 =
+                                                             let uu____3761 =
+                                                               let uu____3762
                                                                  =
-                                                                 let uu____3761
+                                                                 let uu____3765
                                                                    =
                                                                    FStar_Util.right
                                                                     lb.FStar_Syntax_Syntax.lbname in
-                                                                 uu____3761.FStar_Syntax_Syntax.fv_name in
-                                                               uu____3758.FStar_Syntax_Syntax.v in
+                                                                 uu____3765.FStar_Syntax_Syntax.fv_name in
+                                                               uu____3762.FStar_Syntax_Syntax.v in
                                                              FStar_TypeChecker_Env.try_lookup_val_decl
                                                                env1
-                                                               uu____3757 in
-                                                           match uu____3748
+                                                               uu____3761 in
+                                                           match uu____3752
                                                            with
                                                            | FStar_Pervasives_Native.None
                                                                -> true
-                                                           | uu____3768 ->
+                                                           | uu____3772 ->
                                                                false in
                                                          if should_log
                                                          then
-                                                           let uu____3777 =
+                                                           let uu____3781 =
                                                              FStar_Syntax_Print.lbname_to_string
                                                                lb.FStar_Syntax_Syntax.lbname in
-                                                           let uu____3778 =
+                                                           let uu____3782 =
                                                              FStar_Syntax_Print.term_to_string
                                                                lb.FStar_Syntax_Syntax.lbtyp in
                                                            FStar_Util.format2
                                                              "let %s : %s"
-                                                             uu____3777
-                                                             uu____3778
+                                                             uu____3781
+                                                             uu____3782
                                                          else "")) in
                                                FStar_All.pipe_right
-                                                 uu____3733
+                                                 uu____3737
                                                  (FStar_String.concat "\n") in
                                              FStar_Util.print1 "%s\n"
-                                               uu____3732
+                                               uu____3736
                                            else ());
                                           check_must_erase_attribute env0 se4;
                                           ([se4], [], env0))))))))
            | FStar_Syntax_Syntax.Sig_polymonadic_bind
-               (m, n, p, t, uu____3792) ->
+               (m, n, p, t, uu____3796) ->
                let t1 =
-                 let uu____3794 =
+                 let uu____3798 =
                    (FStar_Options.use_two_phase_tc ()) &&
                      (FStar_TypeChecker_Env.should_verify env) in
-                 if uu____3794
+                 if uu____3798
                  then
-                   let uu____3795 =
-                     let uu____3800 =
-                       let uu____3801 =
-                         let uu____3802 =
+                   let uu____3799 =
+                     let uu____3804 =
+                       let uu____3805 =
+                         let uu____3806 =
                            FStar_TypeChecker_TcEffect.tc_polymonadic_bind
-                             (let uu___769_3809 = env in
+                             (let uu___769_3813 = env in
                               {
                                 FStar_TypeChecker_Env.solver =
-                                  (uu___769_3809.FStar_TypeChecker_Env.solver);
+                                  (uu___769_3813.FStar_TypeChecker_Env.solver);
                                 FStar_TypeChecker_Env.range =
-                                  (uu___769_3809.FStar_TypeChecker_Env.range);
+                                  (uu___769_3813.FStar_TypeChecker_Env.range);
                                 FStar_TypeChecker_Env.curmodule =
-                                  (uu___769_3809.FStar_TypeChecker_Env.curmodule);
+                                  (uu___769_3813.FStar_TypeChecker_Env.curmodule);
                                 FStar_TypeChecker_Env.gamma =
-                                  (uu___769_3809.FStar_TypeChecker_Env.gamma);
+                                  (uu___769_3813.FStar_TypeChecker_Env.gamma);
                                 FStar_TypeChecker_Env.gamma_sig =
-                                  (uu___769_3809.FStar_TypeChecker_Env.gamma_sig);
+                                  (uu___769_3813.FStar_TypeChecker_Env.gamma_sig);
                                 FStar_TypeChecker_Env.gamma_cache =
-                                  (uu___769_3809.FStar_TypeChecker_Env.gamma_cache);
+                                  (uu___769_3813.FStar_TypeChecker_Env.gamma_cache);
                                 FStar_TypeChecker_Env.modules =
-                                  (uu___769_3809.FStar_TypeChecker_Env.modules);
+                                  (uu___769_3813.FStar_TypeChecker_Env.modules);
                                 FStar_TypeChecker_Env.expected_typ =
-                                  (uu___769_3809.FStar_TypeChecker_Env.expected_typ);
+                                  (uu___769_3813.FStar_TypeChecker_Env.expected_typ);
                                 FStar_TypeChecker_Env.sigtab =
-                                  (uu___769_3809.FStar_TypeChecker_Env.sigtab);
+                                  (uu___769_3813.FStar_TypeChecker_Env.sigtab);
                                 FStar_TypeChecker_Env.attrtab =
-                                  (uu___769_3809.FStar_TypeChecker_Env.attrtab);
+                                  (uu___769_3813.FStar_TypeChecker_Env.attrtab);
                                 FStar_TypeChecker_Env.instantiate_imp =
-                                  (uu___769_3809.FStar_TypeChecker_Env.instantiate_imp);
+                                  (uu___769_3813.FStar_TypeChecker_Env.instantiate_imp);
                                 FStar_TypeChecker_Env.effects =
-                                  (uu___769_3809.FStar_TypeChecker_Env.effects);
+                                  (uu___769_3813.FStar_TypeChecker_Env.effects);
                                 FStar_TypeChecker_Env.generalize =
-                                  (uu___769_3809.FStar_TypeChecker_Env.generalize);
+                                  (uu___769_3813.FStar_TypeChecker_Env.generalize);
                                 FStar_TypeChecker_Env.letrecs =
-                                  (uu___769_3809.FStar_TypeChecker_Env.letrecs);
+                                  (uu___769_3813.FStar_TypeChecker_Env.letrecs);
                                 FStar_TypeChecker_Env.top_level =
-                                  (uu___769_3809.FStar_TypeChecker_Env.top_level);
+                                  (uu___769_3813.FStar_TypeChecker_Env.top_level);
                                 FStar_TypeChecker_Env.check_uvars =
-                                  (uu___769_3809.FStar_TypeChecker_Env.check_uvars);
+                                  (uu___769_3813.FStar_TypeChecker_Env.check_uvars);
                                 FStar_TypeChecker_Env.use_eq =
-                                  (uu___769_3809.FStar_TypeChecker_Env.use_eq);
+                                  (uu___769_3813.FStar_TypeChecker_Env.use_eq);
                                 FStar_TypeChecker_Env.use_eq_strict =
-                                  (uu___769_3809.FStar_TypeChecker_Env.use_eq_strict);
+                                  (uu___769_3813.FStar_TypeChecker_Env.use_eq_strict);
                                 FStar_TypeChecker_Env.is_iface =
-                                  (uu___769_3809.FStar_TypeChecker_Env.is_iface);
+                                  (uu___769_3813.FStar_TypeChecker_Env.is_iface);
                                 FStar_TypeChecker_Env.admit =
-                                  (uu___769_3809.FStar_TypeChecker_Env.admit);
+                                  (uu___769_3813.FStar_TypeChecker_Env.admit);
                                 FStar_TypeChecker_Env.lax = true;
                                 FStar_TypeChecker_Env.lax_universes =
-                                  (uu___769_3809.FStar_TypeChecker_Env.lax_universes);
+                                  (uu___769_3813.FStar_TypeChecker_Env.lax_universes);
                                 FStar_TypeChecker_Env.phase1 = true;
                                 FStar_TypeChecker_Env.failhard =
-                                  (uu___769_3809.FStar_TypeChecker_Env.failhard);
+                                  (uu___769_3813.FStar_TypeChecker_Env.failhard);
                                 FStar_TypeChecker_Env.nosynth =
-                                  (uu___769_3809.FStar_TypeChecker_Env.nosynth);
+                                  (uu___769_3813.FStar_TypeChecker_Env.nosynth);
                                 FStar_TypeChecker_Env.uvar_subtyping =
-                                  (uu___769_3809.FStar_TypeChecker_Env.uvar_subtyping);
+                                  (uu___769_3813.FStar_TypeChecker_Env.uvar_subtyping);
                                 FStar_TypeChecker_Env.tc_term =
-                                  (uu___769_3809.FStar_TypeChecker_Env.tc_term);
+                                  (uu___769_3813.FStar_TypeChecker_Env.tc_term);
                                 FStar_TypeChecker_Env.type_of =
-                                  (uu___769_3809.FStar_TypeChecker_Env.type_of);
+                                  (uu___769_3813.FStar_TypeChecker_Env.type_of);
                                 FStar_TypeChecker_Env.universe_of =
-                                  (uu___769_3809.FStar_TypeChecker_Env.universe_of);
+                                  (uu___769_3813.FStar_TypeChecker_Env.universe_of);
                                 FStar_TypeChecker_Env.check_type_of =
-                                  (uu___769_3809.FStar_TypeChecker_Env.check_type_of);
+                                  (uu___769_3813.FStar_TypeChecker_Env.check_type_of);
                                 FStar_TypeChecker_Env.use_bv_sorts =
-                                  (uu___769_3809.FStar_TypeChecker_Env.use_bv_sorts);
+                                  (uu___769_3813.FStar_TypeChecker_Env.use_bv_sorts);
                                 FStar_TypeChecker_Env.qtbl_name_and_index =
-                                  (uu___769_3809.FStar_TypeChecker_Env.qtbl_name_and_index);
+                                  (uu___769_3813.FStar_TypeChecker_Env.qtbl_name_and_index);
                                 FStar_TypeChecker_Env.normalized_eff_names =
-                                  (uu___769_3809.FStar_TypeChecker_Env.normalized_eff_names);
+                                  (uu___769_3813.FStar_TypeChecker_Env.normalized_eff_names);
                                 FStar_TypeChecker_Env.fv_delta_depths =
-                                  (uu___769_3809.FStar_TypeChecker_Env.fv_delta_depths);
+                                  (uu___769_3813.FStar_TypeChecker_Env.fv_delta_depths);
                                 FStar_TypeChecker_Env.proof_ns =
-                                  (uu___769_3809.FStar_TypeChecker_Env.proof_ns);
+                                  (uu___769_3813.FStar_TypeChecker_Env.proof_ns);
                                 FStar_TypeChecker_Env.synth_hook =
-                                  (uu___769_3809.FStar_TypeChecker_Env.synth_hook);
+                                  (uu___769_3813.FStar_TypeChecker_Env.synth_hook);
                                 FStar_TypeChecker_Env.try_solve_implicits_hook
                                   =
-                                  (uu___769_3809.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                                  (uu___769_3813.FStar_TypeChecker_Env.try_solve_implicits_hook);
                                 FStar_TypeChecker_Env.splice =
-                                  (uu___769_3809.FStar_TypeChecker_Env.splice);
+                                  (uu___769_3813.FStar_TypeChecker_Env.splice);
                                 FStar_TypeChecker_Env.mpreprocess =
-                                  (uu___769_3809.FStar_TypeChecker_Env.mpreprocess);
+                                  (uu___769_3813.FStar_TypeChecker_Env.mpreprocess);
                                 FStar_TypeChecker_Env.postprocess =
-                                  (uu___769_3809.FStar_TypeChecker_Env.postprocess);
+                                  (uu___769_3813.FStar_TypeChecker_Env.postprocess);
                                 FStar_TypeChecker_Env.identifier_info =
-                                  (uu___769_3809.FStar_TypeChecker_Env.identifier_info);
+                                  (uu___769_3813.FStar_TypeChecker_Env.identifier_info);
                                 FStar_TypeChecker_Env.tc_hooks =
-                                  (uu___769_3809.FStar_TypeChecker_Env.tc_hooks);
+                                  (uu___769_3813.FStar_TypeChecker_Env.tc_hooks);
                                 FStar_TypeChecker_Env.dsenv =
-                                  (uu___769_3809.FStar_TypeChecker_Env.dsenv);
+                                  (uu___769_3813.FStar_TypeChecker_Env.dsenv);
                                 FStar_TypeChecker_Env.nbe =
-                                  (uu___769_3809.FStar_TypeChecker_Env.nbe);
+                                  (uu___769_3813.FStar_TypeChecker_Env.nbe);
                                 FStar_TypeChecker_Env.strict_args_tab =
-                                  (uu___769_3809.FStar_TypeChecker_Env.strict_args_tab);
+                                  (uu___769_3813.FStar_TypeChecker_Env.strict_args_tab);
                                 FStar_TypeChecker_Env.erasable_types_tab =
-                                  (uu___769_3809.FStar_TypeChecker_Env.erasable_types_tab);
+                                  (uu___769_3813.FStar_TypeChecker_Env.erasable_types_tab);
                                 FStar_TypeChecker_Env.enable_defer_to_tac =
-                                  (uu___769_3809.FStar_TypeChecker_Env.enable_defer_to_tac)
+                                  (uu___769_3813.FStar_TypeChecker_Env.enable_defer_to_tac)
                               }) m n p t in
-                         FStar_All.pipe_right uu____3802
-                           (fun uu____3818 ->
-                              match uu____3818 with
+                         FStar_All.pipe_right uu____3806
+                           (fun uu____3822 ->
+                              match uu____3822 with
                               | (t1, ty) ->
-                                  let uu___774_3825 = se1 in
+                                  let uu___774_3829 = se1 in
                                   {
                                     FStar_Syntax_Syntax.sigel =
                                       (FStar_Syntax_Syntax.Sig_polymonadic_bind
                                          (m, n, p, t1, ty));
                                     FStar_Syntax_Syntax.sigrng =
-                                      (uu___774_3825.FStar_Syntax_Syntax.sigrng);
+                                      (uu___774_3829.FStar_Syntax_Syntax.sigrng);
                                     FStar_Syntax_Syntax.sigquals =
-                                      (uu___774_3825.FStar_Syntax_Syntax.sigquals);
+                                      (uu___774_3829.FStar_Syntax_Syntax.sigquals);
                                     FStar_Syntax_Syntax.sigmeta =
-                                      (uu___774_3825.FStar_Syntax_Syntax.sigmeta);
+                                      (uu___774_3829.FStar_Syntax_Syntax.sigmeta);
                                     FStar_Syntax_Syntax.sigattrs =
-                                      (uu___774_3825.FStar_Syntax_Syntax.sigattrs);
+                                      (uu___774_3829.FStar_Syntax_Syntax.sigattrs);
                                     FStar_Syntax_Syntax.sigopts =
-                                      (uu___774_3825.FStar_Syntax_Syntax.sigopts)
+                                      (uu___774_3829.FStar_Syntax_Syntax.sigopts)
                                   }) in
-                       FStar_All.pipe_right uu____3801
+                       FStar_All.pipe_right uu____3805
                          (FStar_TypeChecker_Normalize.elim_uvars env) in
-                     FStar_All.pipe_right uu____3800
+                     FStar_All.pipe_right uu____3804
                        (fun se2 ->
                           match se2.FStar_Syntax_Syntax.sigel with
                           | FStar_Syntax_Syntax.Sig_polymonadic_bind
-                              (uu____3841, uu____3842, uu____3843, t1, ty) ->
+                              (uu____3845, uu____3846, uu____3847, t1, ty) ->
                               (t1, ty)
-                          | uu____3846 ->
+                          | uu____3850 ->
                               failwith
                                 "Impossible! tc for Sig_polymonadic_bind must be a Sig_polymonadic_bind") in
-                   match uu____3795 with
+                   match uu____3799 with
                    | (t1, ty) ->
-                       ((let uu____3854 =
+                       ((let uu____3858 =
                            FStar_All.pipe_left
                              (FStar_TypeChecker_Env.debug env)
                              (FStar_Options.Other "TwoPhases") in
-                         if uu____3854
+                         if uu____3858
                          then
-                           let uu____3855 =
+                           let uu____3859 =
                              FStar_Syntax_Print.sigelt_to_string
-                               (let uu___789_3858 = se1 in
+                               (let uu___789_3862 = se1 in
                                 {
                                   FStar_Syntax_Syntax.sigel =
                                     (FStar_Syntax_Syntax.Sig_polymonadic_bind
                                        (m, n, p, t1, ty));
                                   FStar_Syntax_Syntax.sigrng =
-                                    (uu___789_3858.FStar_Syntax_Syntax.sigrng);
+                                    (uu___789_3862.FStar_Syntax_Syntax.sigrng);
                                   FStar_Syntax_Syntax.sigquals =
-                                    (uu___789_3858.FStar_Syntax_Syntax.sigquals);
+                                    (uu___789_3862.FStar_Syntax_Syntax.sigquals);
                                   FStar_Syntax_Syntax.sigmeta =
-                                    (uu___789_3858.FStar_Syntax_Syntax.sigmeta);
+                                    (uu___789_3862.FStar_Syntax_Syntax.sigmeta);
                                   FStar_Syntax_Syntax.sigattrs =
-                                    (uu___789_3858.FStar_Syntax_Syntax.sigattrs);
+                                    (uu___789_3862.FStar_Syntax_Syntax.sigattrs);
                                   FStar_Syntax_Syntax.sigopts =
-                                    (uu___789_3858.FStar_Syntax_Syntax.sigopts)
+                                    (uu___789_3862.FStar_Syntax_Syntax.sigopts)
                                 }) in
                            FStar_Util.print1
                              "Polymonadic bind after phase 1: %s\n"
-                             uu____3855
+                             uu____3859
                          else ());
                         t1)
                  else t in
-               let uu____3861 =
+               let uu____3865 =
                  FStar_TypeChecker_TcEffect.tc_polymonadic_bind env m n p t1 in
-               (match uu____3861 with
+               (match uu____3865 with
                 | (t2, ty) ->
                     let se2 =
-                      let uu___796_3879 = se1 in
+                      let uu___796_3883 = se1 in
                       {
                         FStar_Syntax_Syntax.sigel =
                           (FStar_Syntax_Syntax.Sig_polymonadic_bind
                              (m, n, p, t2, ty));
                         FStar_Syntax_Syntax.sigrng =
-                          (uu___796_3879.FStar_Syntax_Syntax.sigrng);
+                          (uu___796_3883.FStar_Syntax_Syntax.sigrng);
                         FStar_Syntax_Syntax.sigquals =
-                          (uu___796_3879.FStar_Syntax_Syntax.sigquals);
+                          (uu___796_3883.FStar_Syntax_Syntax.sigquals);
                         FStar_Syntax_Syntax.sigmeta =
-                          (uu___796_3879.FStar_Syntax_Syntax.sigmeta);
+                          (uu___796_3883.FStar_Syntax_Syntax.sigmeta);
                         FStar_Syntax_Syntax.sigattrs =
-                          (uu___796_3879.FStar_Syntax_Syntax.sigattrs);
+                          (uu___796_3883.FStar_Syntax_Syntax.sigattrs);
                         FStar_Syntax_Syntax.sigopts =
-                          (uu___796_3879.FStar_Syntax_Syntax.sigopts)
+                          (uu___796_3883.FStar_Syntax_Syntax.sigopts)
                       } in
                     ([se2], [], env0))
            | FStar_Syntax_Syntax.Sig_polymonadic_subcomp
-               (m, n, t, uu____3887) ->
+               (m, n, t, uu____3891) ->
                let t1 =
-                 let uu____3889 =
+                 let uu____3893 =
                    (FStar_Options.use_two_phase_tc ()) &&
                      (FStar_TypeChecker_Env.should_verify env) in
-                 if uu____3889
+                 if uu____3893
                  then
-                   let uu____3890 =
-                     let uu____3895 =
-                       let uu____3896 =
-                         let uu____3897 =
+                   let uu____3894 =
+                     let uu____3899 =
+                       let uu____3900 =
+                         let uu____3901 =
                            FStar_TypeChecker_TcEffect.tc_polymonadic_subcomp
-                             (let uu___806_3904 = env in
+                             (let uu___806_3908 = env in
                               {
                                 FStar_TypeChecker_Env.solver =
-                                  (uu___806_3904.FStar_TypeChecker_Env.solver);
+                                  (uu___806_3908.FStar_TypeChecker_Env.solver);
                                 FStar_TypeChecker_Env.range =
-                                  (uu___806_3904.FStar_TypeChecker_Env.range);
+                                  (uu___806_3908.FStar_TypeChecker_Env.range);
                                 FStar_TypeChecker_Env.curmodule =
-                                  (uu___806_3904.FStar_TypeChecker_Env.curmodule);
+                                  (uu___806_3908.FStar_TypeChecker_Env.curmodule);
                                 FStar_TypeChecker_Env.gamma =
-                                  (uu___806_3904.FStar_TypeChecker_Env.gamma);
+                                  (uu___806_3908.FStar_TypeChecker_Env.gamma);
                                 FStar_TypeChecker_Env.gamma_sig =
-                                  (uu___806_3904.FStar_TypeChecker_Env.gamma_sig);
+                                  (uu___806_3908.FStar_TypeChecker_Env.gamma_sig);
                                 FStar_TypeChecker_Env.gamma_cache =
-                                  (uu___806_3904.FStar_TypeChecker_Env.gamma_cache);
+                                  (uu___806_3908.FStar_TypeChecker_Env.gamma_cache);
                                 FStar_TypeChecker_Env.modules =
-                                  (uu___806_3904.FStar_TypeChecker_Env.modules);
+                                  (uu___806_3908.FStar_TypeChecker_Env.modules);
                                 FStar_TypeChecker_Env.expected_typ =
-                                  (uu___806_3904.FStar_TypeChecker_Env.expected_typ);
+                                  (uu___806_3908.FStar_TypeChecker_Env.expected_typ);
                                 FStar_TypeChecker_Env.sigtab =
-                                  (uu___806_3904.FStar_TypeChecker_Env.sigtab);
+                                  (uu___806_3908.FStar_TypeChecker_Env.sigtab);
                                 FStar_TypeChecker_Env.attrtab =
-                                  (uu___806_3904.FStar_TypeChecker_Env.attrtab);
+                                  (uu___806_3908.FStar_TypeChecker_Env.attrtab);
                                 FStar_TypeChecker_Env.instantiate_imp =
-                                  (uu___806_3904.FStar_TypeChecker_Env.instantiate_imp);
+                                  (uu___806_3908.FStar_TypeChecker_Env.instantiate_imp);
                                 FStar_TypeChecker_Env.effects =
-                                  (uu___806_3904.FStar_TypeChecker_Env.effects);
+                                  (uu___806_3908.FStar_TypeChecker_Env.effects);
                                 FStar_TypeChecker_Env.generalize =
-                                  (uu___806_3904.FStar_TypeChecker_Env.generalize);
+                                  (uu___806_3908.FStar_TypeChecker_Env.generalize);
                                 FStar_TypeChecker_Env.letrecs =
-                                  (uu___806_3904.FStar_TypeChecker_Env.letrecs);
+                                  (uu___806_3908.FStar_TypeChecker_Env.letrecs);
                                 FStar_TypeChecker_Env.top_level =
-                                  (uu___806_3904.FStar_TypeChecker_Env.top_level);
+                                  (uu___806_3908.FStar_TypeChecker_Env.top_level);
                                 FStar_TypeChecker_Env.check_uvars =
-                                  (uu___806_3904.FStar_TypeChecker_Env.check_uvars);
+                                  (uu___806_3908.FStar_TypeChecker_Env.check_uvars);
                                 FStar_TypeChecker_Env.use_eq =
-                                  (uu___806_3904.FStar_TypeChecker_Env.use_eq);
+                                  (uu___806_3908.FStar_TypeChecker_Env.use_eq);
                                 FStar_TypeChecker_Env.use_eq_strict =
-                                  (uu___806_3904.FStar_TypeChecker_Env.use_eq_strict);
+                                  (uu___806_3908.FStar_TypeChecker_Env.use_eq_strict);
                                 FStar_TypeChecker_Env.is_iface =
-                                  (uu___806_3904.FStar_TypeChecker_Env.is_iface);
+                                  (uu___806_3908.FStar_TypeChecker_Env.is_iface);
                                 FStar_TypeChecker_Env.admit =
-                                  (uu___806_3904.FStar_TypeChecker_Env.admit);
+                                  (uu___806_3908.FStar_TypeChecker_Env.admit);
                                 FStar_TypeChecker_Env.lax = true;
                                 FStar_TypeChecker_Env.lax_universes =
-                                  (uu___806_3904.FStar_TypeChecker_Env.lax_universes);
+                                  (uu___806_3908.FStar_TypeChecker_Env.lax_universes);
                                 FStar_TypeChecker_Env.phase1 = true;
                                 FStar_TypeChecker_Env.failhard =
-                                  (uu___806_3904.FStar_TypeChecker_Env.failhard);
+                                  (uu___806_3908.FStar_TypeChecker_Env.failhard);
                                 FStar_TypeChecker_Env.nosynth =
-                                  (uu___806_3904.FStar_TypeChecker_Env.nosynth);
+                                  (uu___806_3908.FStar_TypeChecker_Env.nosynth);
                                 FStar_TypeChecker_Env.uvar_subtyping =
-                                  (uu___806_3904.FStar_TypeChecker_Env.uvar_subtyping);
+                                  (uu___806_3908.FStar_TypeChecker_Env.uvar_subtyping);
                                 FStar_TypeChecker_Env.tc_term =
-                                  (uu___806_3904.FStar_TypeChecker_Env.tc_term);
+                                  (uu___806_3908.FStar_TypeChecker_Env.tc_term);
                                 FStar_TypeChecker_Env.type_of =
-                                  (uu___806_3904.FStar_TypeChecker_Env.type_of);
+                                  (uu___806_3908.FStar_TypeChecker_Env.type_of);
                                 FStar_TypeChecker_Env.universe_of =
-                                  (uu___806_3904.FStar_TypeChecker_Env.universe_of);
+                                  (uu___806_3908.FStar_TypeChecker_Env.universe_of);
                                 FStar_TypeChecker_Env.check_type_of =
-                                  (uu___806_3904.FStar_TypeChecker_Env.check_type_of);
+                                  (uu___806_3908.FStar_TypeChecker_Env.check_type_of);
                                 FStar_TypeChecker_Env.use_bv_sorts =
-                                  (uu___806_3904.FStar_TypeChecker_Env.use_bv_sorts);
+                                  (uu___806_3908.FStar_TypeChecker_Env.use_bv_sorts);
                                 FStar_TypeChecker_Env.qtbl_name_and_index =
-                                  (uu___806_3904.FStar_TypeChecker_Env.qtbl_name_and_index);
+                                  (uu___806_3908.FStar_TypeChecker_Env.qtbl_name_and_index);
                                 FStar_TypeChecker_Env.normalized_eff_names =
-                                  (uu___806_3904.FStar_TypeChecker_Env.normalized_eff_names);
+                                  (uu___806_3908.FStar_TypeChecker_Env.normalized_eff_names);
                                 FStar_TypeChecker_Env.fv_delta_depths =
-                                  (uu___806_3904.FStar_TypeChecker_Env.fv_delta_depths);
+                                  (uu___806_3908.FStar_TypeChecker_Env.fv_delta_depths);
                                 FStar_TypeChecker_Env.proof_ns =
-                                  (uu___806_3904.FStar_TypeChecker_Env.proof_ns);
+                                  (uu___806_3908.FStar_TypeChecker_Env.proof_ns);
                                 FStar_TypeChecker_Env.synth_hook =
-                                  (uu___806_3904.FStar_TypeChecker_Env.synth_hook);
+                                  (uu___806_3908.FStar_TypeChecker_Env.synth_hook);
                                 FStar_TypeChecker_Env.try_solve_implicits_hook
                                   =
-                                  (uu___806_3904.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                                  (uu___806_3908.FStar_TypeChecker_Env.try_solve_implicits_hook);
                                 FStar_TypeChecker_Env.splice =
-                                  (uu___806_3904.FStar_TypeChecker_Env.splice);
+                                  (uu___806_3908.FStar_TypeChecker_Env.splice);
                                 FStar_TypeChecker_Env.mpreprocess =
-                                  (uu___806_3904.FStar_TypeChecker_Env.mpreprocess);
+                                  (uu___806_3908.FStar_TypeChecker_Env.mpreprocess);
                                 FStar_TypeChecker_Env.postprocess =
-                                  (uu___806_3904.FStar_TypeChecker_Env.postprocess);
+                                  (uu___806_3908.FStar_TypeChecker_Env.postprocess);
                                 FStar_TypeChecker_Env.identifier_info =
-                                  (uu___806_3904.FStar_TypeChecker_Env.identifier_info);
+                                  (uu___806_3908.FStar_TypeChecker_Env.identifier_info);
                                 FStar_TypeChecker_Env.tc_hooks =
-                                  (uu___806_3904.FStar_TypeChecker_Env.tc_hooks);
+                                  (uu___806_3908.FStar_TypeChecker_Env.tc_hooks);
                                 FStar_TypeChecker_Env.dsenv =
-                                  (uu___806_3904.FStar_TypeChecker_Env.dsenv);
+                                  (uu___806_3908.FStar_TypeChecker_Env.dsenv);
                                 FStar_TypeChecker_Env.nbe =
-                                  (uu___806_3904.FStar_TypeChecker_Env.nbe);
+                                  (uu___806_3908.FStar_TypeChecker_Env.nbe);
                                 FStar_TypeChecker_Env.strict_args_tab =
-                                  (uu___806_3904.FStar_TypeChecker_Env.strict_args_tab);
+                                  (uu___806_3908.FStar_TypeChecker_Env.strict_args_tab);
                                 FStar_TypeChecker_Env.erasable_types_tab =
-                                  (uu___806_3904.FStar_TypeChecker_Env.erasable_types_tab);
+                                  (uu___806_3908.FStar_TypeChecker_Env.erasable_types_tab);
                                 FStar_TypeChecker_Env.enable_defer_to_tac =
-                                  (uu___806_3904.FStar_TypeChecker_Env.enable_defer_to_tac)
+                                  (uu___806_3908.FStar_TypeChecker_Env.enable_defer_to_tac)
                               }) m n t in
-                         FStar_All.pipe_right uu____3897
-                           (fun uu____3913 ->
-                              match uu____3913 with
+                         FStar_All.pipe_right uu____3901
+                           (fun uu____3917 ->
+                              match uu____3917 with
                               | (t1, ty) ->
-                                  let uu___811_3920 = se1 in
+                                  let uu___811_3924 = se1 in
                                   {
                                     FStar_Syntax_Syntax.sigel =
                                       (FStar_Syntax_Syntax.Sig_polymonadic_subcomp
                                          (m, n, t1, ty));
                                     FStar_Syntax_Syntax.sigrng =
-                                      (uu___811_3920.FStar_Syntax_Syntax.sigrng);
+                                      (uu___811_3924.FStar_Syntax_Syntax.sigrng);
                                     FStar_Syntax_Syntax.sigquals =
-                                      (uu___811_3920.FStar_Syntax_Syntax.sigquals);
+                                      (uu___811_3924.FStar_Syntax_Syntax.sigquals);
                                     FStar_Syntax_Syntax.sigmeta =
-                                      (uu___811_3920.FStar_Syntax_Syntax.sigmeta);
+                                      (uu___811_3924.FStar_Syntax_Syntax.sigmeta);
                                     FStar_Syntax_Syntax.sigattrs =
-                                      (uu___811_3920.FStar_Syntax_Syntax.sigattrs);
+                                      (uu___811_3924.FStar_Syntax_Syntax.sigattrs);
                                     FStar_Syntax_Syntax.sigopts =
-                                      (uu___811_3920.FStar_Syntax_Syntax.sigopts)
+                                      (uu___811_3924.FStar_Syntax_Syntax.sigopts)
                                   }) in
-                       FStar_All.pipe_right uu____3896
+                       FStar_All.pipe_right uu____3900
                          (FStar_TypeChecker_Normalize.elim_uvars env) in
-                     FStar_All.pipe_right uu____3895
+                     FStar_All.pipe_right uu____3899
                        (fun se2 ->
                           match se2.FStar_Syntax_Syntax.sigel with
                           | FStar_Syntax_Syntax.Sig_polymonadic_subcomp
-                              (uu____3935, uu____3936, t1, ty) -> (t1, ty)
-                          | uu____3939 ->
+                              (uu____3939, uu____3940, t1, ty) -> (t1, ty)
+                          | uu____3943 ->
                               failwith
                                 "Impossible! tc for Sig_polymonadic_subcomp must be a Sig_polymonadic_subcomp") in
-                   match uu____3890 with
+                   match uu____3894 with
                    | (t1, ty) ->
-                       ((let uu____3947 =
+                       ((let uu____3951 =
                            FStar_All.pipe_left
                              (FStar_TypeChecker_Env.debug env)
                              (FStar_Options.Other "TwoPhases") in
-                         if uu____3947
+                         if uu____3951
                          then
-                           let uu____3948 =
+                           let uu____3952 =
                              FStar_Syntax_Print.sigelt_to_string
-                               (let uu___825_3951 = se1 in
+                               (let uu___825_3955 = se1 in
                                 {
                                   FStar_Syntax_Syntax.sigel =
                                     (FStar_Syntax_Syntax.Sig_polymonadic_subcomp
                                        (m, n, t1, ty));
                                   FStar_Syntax_Syntax.sigrng =
-                                    (uu___825_3951.FStar_Syntax_Syntax.sigrng);
+                                    (uu___825_3955.FStar_Syntax_Syntax.sigrng);
                                   FStar_Syntax_Syntax.sigquals =
-                                    (uu___825_3951.FStar_Syntax_Syntax.sigquals);
+                                    (uu___825_3955.FStar_Syntax_Syntax.sigquals);
                                   FStar_Syntax_Syntax.sigmeta =
-                                    (uu___825_3951.FStar_Syntax_Syntax.sigmeta);
+                                    (uu___825_3955.FStar_Syntax_Syntax.sigmeta);
                                   FStar_Syntax_Syntax.sigattrs =
-                                    (uu___825_3951.FStar_Syntax_Syntax.sigattrs);
+                                    (uu___825_3955.FStar_Syntax_Syntax.sigattrs);
                                   FStar_Syntax_Syntax.sigopts =
-                                    (uu___825_3951.FStar_Syntax_Syntax.sigopts)
+                                    (uu___825_3955.FStar_Syntax_Syntax.sigopts)
                                 }) in
                            FStar_Util.print1
                              "Polymonadic subcomp after phase 1: %s\n"
-                             uu____3948
+                             uu____3952
                          else ());
                         t1)
                  else t in
-               let uu____3954 =
+               let uu____3958 =
                  FStar_TypeChecker_TcEffect.tc_polymonadic_subcomp env m n t1 in
-               (match uu____3954 with
+               (match uu____3958 with
                 | (t2, ty) ->
                     let se2 =
-                      let uu___832_3972 = se1 in
+                      let uu___832_3976 = se1 in
                       {
                         FStar_Syntax_Syntax.sigel =
                           (FStar_Syntax_Syntax.Sig_polymonadic_subcomp
                              (m, n, t2, ty));
                         FStar_Syntax_Syntax.sigrng =
-                          (uu___832_3972.FStar_Syntax_Syntax.sigrng);
+                          (uu___832_3976.FStar_Syntax_Syntax.sigrng);
                         FStar_Syntax_Syntax.sigquals =
-                          (uu___832_3972.FStar_Syntax_Syntax.sigquals);
+                          (uu___832_3976.FStar_Syntax_Syntax.sigquals);
                         FStar_Syntax_Syntax.sigmeta =
-                          (uu___832_3972.FStar_Syntax_Syntax.sigmeta);
+                          (uu___832_3976.FStar_Syntax_Syntax.sigmeta);
                         FStar_Syntax_Syntax.sigattrs =
-                          (uu___832_3972.FStar_Syntax_Syntax.sigattrs);
+                          (uu___832_3976.FStar_Syntax_Syntax.sigattrs);
                         FStar_Syntax_Syntax.sigopts =
-                          (uu___832_3972.FStar_Syntax_Syntax.sigopts)
+                          (uu___832_3976.FStar_Syntax_Syntax.sigopts)
                       } in
                     ([se2], [], env0)))
 let (tc_decl :
@@ -3424,24 +3424,24 @@ let (tc_decl :
   fun env ->
     fun se ->
       let env1 = set_hint_correlator env se in
-      (let uu____4009 =
-         let uu____4010 =
+      (let uu____4013 =
+         let uu____4014 =
            FStar_Ident.string_of_lid env1.FStar_TypeChecker_Env.curmodule in
-         FStar_Options.debug_module uu____4010 in
-       if uu____4009
+         FStar_Options.debug_module uu____4014 in
+       if uu____4013
        then
-         let uu____4011 =
-           let uu____4012 =
+         let uu____4015 =
+           let uu____4016 =
              FStar_All.pipe_right (FStar_Syntax_Util.lids_of_sigelt se)
                (FStar_List.map FStar_Ident.string_of_lid) in
-           FStar_All.pipe_right uu____4012 (FStar_String.concat ", ") in
-         FStar_Util.print1 "Processing %s\n" uu____4011
+           FStar_All.pipe_right uu____4016 (FStar_String.concat ", ") in
+         FStar_Util.print1 "Processing %s\n" uu____4015
        else ());
-      (let uu____4023 = FStar_TypeChecker_Env.debug env1 FStar_Options.Low in
-       if uu____4023
+      (let uu____4027 = FStar_TypeChecker_Env.debug env1 FStar_Options.Low in
+       if uu____4027
        then
-         let uu____4024 = FStar_Syntax_Print.sigelt_to_string se in
-         FStar_Util.print1 ">>>>>>>>>>>>>>tc_decl %s\n" uu____4024
+         let uu____4028 = FStar_Syntax_Print.sigelt_to_string se in
+         FStar_Util.print1 ">>>>>>>>>>>>>>tc_decl %s\n" uu____4028
        else ());
       if (se.FStar_Syntax_Syntax.sigmeta).FStar_Syntax_Syntax.sigmeta_admit
       then
@@ -3457,262 +3457,160 @@ let (add_sigelt_to_env :
   fun env ->
     fun se ->
       fun from_cache ->
-        (let uu____4067 = FStar_TypeChecker_Env.debug env FStar_Options.Low in
-         if uu____4067
+        (let uu____4071 = FStar_TypeChecker_Env.debug env FStar_Options.Low in
+         if uu____4071
          then
-           let uu____4068 = FStar_Syntax_Print.sigelt_to_string se in
-           let uu____4069 = FStar_Util.string_of_bool from_cache in
+           let uu____4072 = FStar_Syntax_Print.sigelt_to_string se in
+           let uu____4073 = FStar_Util.string_of_bool from_cache in
            FStar_Util.print2
              ">>>>>>>>>>>>>>Adding top-level decl to environment: %s (from_cache:%s)\n"
-             uu____4068 uu____4069
+             uu____4072 uu____4073
          else ());
         (match se.FStar_Syntax_Syntax.sigel with
-         | FStar_Syntax_Syntax.Sig_inductive_typ uu____4071 ->
-             let uu____4088 =
-               let uu____4093 =
-                 let uu____4094 = FStar_Syntax_Print.sigelt_to_string se in
+         | FStar_Syntax_Syntax.Sig_inductive_typ uu____4075 ->
+             let uu____4092 =
+               let uu____4097 =
+                 let uu____4098 = FStar_Syntax_Print.sigelt_to_string se in
                  FStar_Util.format1
                    "add_sigelt_to_env: unexpected bare type/data constructor: %s"
-                   uu____4094 in
-               (FStar_Errors.Fatal_UnexpectedInductivetype, uu____4093) in
-             FStar_Errors.raise_error uu____4088
+                   uu____4098 in
+               (FStar_Errors.Fatal_UnexpectedInductivetype, uu____4097) in
+             FStar_Errors.raise_error uu____4092
                se.FStar_Syntax_Syntax.sigrng
-         | FStar_Syntax_Syntax.Sig_datacon uu____4095 ->
-             let uu____4110 =
-               let uu____4115 =
-                 let uu____4116 = FStar_Syntax_Print.sigelt_to_string se in
+         | FStar_Syntax_Syntax.Sig_datacon uu____4099 ->
+             let uu____4114 =
+               let uu____4119 =
+                 let uu____4120 = FStar_Syntax_Print.sigelt_to_string se in
                  FStar_Util.format1
                    "add_sigelt_to_env: unexpected bare type/data constructor: %s"
-                   uu____4116 in
-               (FStar_Errors.Fatal_UnexpectedInductivetype, uu____4115) in
-             FStar_Errors.raise_error uu____4110
+                   uu____4120 in
+               (FStar_Errors.Fatal_UnexpectedInductivetype, uu____4119) in
+             FStar_Errors.raise_error uu____4114
                se.FStar_Syntax_Syntax.sigrng
          | FStar_Syntax_Syntax.Sig_declare_typ
-             (uu____4117, uu____4118, uu____4119) when
+             (uu____4121, uu____4122, uu____4123) when
              FStar_All.pipe_right se.FStar_Syntax_Syntax.sigquals
                (FStar_Util.for_some
-                  (fun uu___2_4123 ->
-                     match uu___2_4123 with
+                  (fun uu___2_4127 ->
+                     match uu___2_4127 with
                      | FStar_Syntax_Syntax.OnlyName -> true
-                     | uu____4124 -> false))
+                     | uu____4128 -> false))
              -> env
-         | FStar_Syntax_Syntax.Sig_let (uu____4125, uu____4126) when
+         | FStar_Syntax_Syntax.Sig_let (uu____4129, uu____4130) when
              FStar_All.pipe_right se.FStar_Syntax_Syntax.sigquals
                (FStar_Util.for_some
-                  (fun uu___2_4134 ->
-                     match uu___2_4134 with
+                  (fun uu___2_4138 ->
+                     match uu___2_4138 with
                      | FStar_Syntax_Syntax.OnlyName -> true
-                     | uu____4135 -> false))
+                     | uu____4139 -> false))
              -> env
-         | uu____4136 ->
+         | uu____4140 ->
              let env1 = FStar_TypeChecker_Env.push_sigelt env se in
              (match se.FStar_Syntax_Syntax.sigel with
               | FStar_Syntax_Syntax.Sig_pragma
-                  (FStar_Syntax_Syntax.PushOptions uu____4138) ->
+                  (FStar_Syntax_Syntax.PushOptions uu____4142) ->
                   if from_cache
                   then env1
                   else
-                    (let uu___882_4142 = env1 in
-                     let uu____4143 = FStar_Options.using_facts_from () in
+                    (let uu___882_4146 = env1 in
+                     let uu____4147 = FStar_Options.using_facts_from () in
                      {
                        FStar_TypeChecker_Env.solver =
-                         (uu___882_4142.FStar_TypeChecker_Env.solver);
+                         (uu___882_4146.FStar_TypeChecker_Env.solver);
                        FStar_TypeChecker_Env.range =
-                         (uu___882_4142.FStar_TypeChecker_Env.range);
+                         (uu___882_4146.FStar_TypeChecker_Env.range);
                        FStar_TypeChecker_Env.curmodule =
-                         (uu___882_4142.FStar_TypeChecker_Env.curmodule);
+                         (uu___882_4146.FStar_TypeChecker_Env.curmodule);
                        FStar_TypeChecker_Env.gamma =
-                         (uu___882_4142.FStar_TypeChecker_Env.gamma);
+                         (uu___882_4146.FStar_TypeChecker_Env.gamma);
                        FStar_TypeChecker_Env.gamma_sig =
-                         (uu___882_4142.FStar_TypeChecker_Env.gamma_sig);
+                         (uu___882_4146.FStar_TypeChecker_Env.gamma_sig);
                        FStar_TypeChecker_Env.gamma_cache =
-                         (uu___882_4142.FStar_TypeChecker_Env.gamma_cache);
+                         (uu___882_4146.FStar_TypeChecker_Env.gamma_cache);
                        FStar_TypeChecker_Env.modules =
-                         (uu___882_4142.FStar_TypeChecker_Env.modules);
+                         (uu___882_4146.FStar_TypeChecker_Env.modules);
                        FStar_TypeChecker_Env.expected_typ =
-                         (uu___882_4142.FStar_TypeChecker_Env.expected_typ);
+                         (uu___882_4146.FStar_TypeChecker_Env.expected_typ);
                        FStar_TypeChecker_Env.sigtab =
-                         (uu___882_4142.FStar_TypeChecker_Env.sigtab);
+                         (uu___882_4146.FStar_TypeChecker_Env.sigtab);
                        FStar_TypeChecker_Env.attrtab =
-                         (uu___882_4142.FStar_TypeChecker_Env.attrtab);
+                         (uu___882_4146.FStar_TypeChecker_Env.attrtab);
                        FStar_TypeChecker_Env.instantiate_imp =
-                         (uu___882_4142.FStar_TypeChecker_Env.instantiate_imp);
+                         (uu___882_4146.FStar_TypeChecker_Env.instantiate_imp);
                        FStar_TypeChecker_Env.effects =
-                         (uu___882_4142.FStar_TypeChecker_Env.effects);
+                         (uu___882_4146.FStar_TypeChecker_Env.effects);
                        FStar_TypeChecker_Env.generalize =
-                         (uu___882_4142.FStar_TypeChecker_Env.generalize);
+                         (uu___882_4146.FStar_TypeChecker_Env.generalize);
                        FStar_TypeChecker_Env.letrecs =
-                         (uu___882_4142.FStar_TypeChecker_Env.letrecs);
+                         (uu___882_4146.FStar_TypeChecker_Env.letrecs);
                        FStar_TypeChecker_Env.top_level =
-                         (uu___882_4142.FStar_TypeChecker_Env.top_level);
+                         (uu___882_4146.FStar_TypeChecker_Env.top_level);
                        FStar_TypeChecker_Env.check_uvars =
-                         (uu___882_4142.FStar_TypeChecker_Env.check_uvars);
+                         (uu___882_4146.FStar_TypeChecker_Env.check_uvars);
                        FStar_TypeChecker_Env.use_eq =
-                         (uu___882_4142.FStar_TypeChecker_Env.use_eq);
+                         (uu___882_4146.FStar_TypeChecker_Env.use_eq);
                        FStar_TypeChecker_Env.use_eq_strict =
-                         (uu___882_4142.FStar_TypeChecker_Env.use_eq_strict);
+                         (uu___882_4146.FStar_TypeChecker_Env.use_eq_strict);
                        FStar_TypeChecker_Env.is_iface =
-                         (uu___882_4142.FStar_TypeChecker_Env.is_iface);
+                         (uu___882_4146.FStar_TypeChecker_Env.is_iface);
                        FStar_TypeChecker_Env.admit =
-                         (uu___882_4142.FStar_TypeChecker_Env.admit);
+                         (uu___882_4146.FStar_TypeChecker_Env.admit);
                        FStar_TypeChecker_Env.lax =
-                         (uu___882_4142.FStar_TypeChecker_Env.lax);
+                         (uu___882_4146.FStar_TypeChecker_Env.lax);
                        FStar_TypeChecker_Env.lax_universes =
-                         (uu___882_4142.FStar_TypeChecker_Env.lax_universes);
+                         (uu___882_4146.FStar_TypeChecker_Env.lax_universes);
                        FStar_TypeChecker_Env.phase1 =
-                         (uu___882_4142.FStar_TypeChecker_Env.phase1);
+                         (uu___882_4146.FStar_TypeChecker_Env.phase1);
                        FStar_TypeChecker_Env.failhard =
-                         (uu___882_4142.FStar_TypeChecker_Env.failhard);
+                         (uu___882_4146.FStar_TypeChecker_Env.failhard);
                        FStar_TypeChecker_Env.nosynth =
-                         (uu___882_4142.FStar_TypeChecker_Env.nosynth);
+                         (uu___882_4146.FStar_TypeChecker_Env.nosynth);
                        FStar_TypeChecker_Env.uvar_subtyping =
-                         (uu___882_4142.FStar_TypeChecker_Env.uvar_subtyping);
+                         (uu___882_4146.FStar_TypeChecker_Env.uvar_subtyping);
                        FStar_TypeChecker_Env.tc_term =
-                         (uu___882_4142.FStar_TypeChecker_Env.tc_term);
+                         (uu___882_4146.FStar_TypeChecker_Env.tc_term);
                        FStar_TypeChecker_Env.type_of =
-                         (uu___882_4142.FStar_TypeChecker_Env.type_of);
+                         (uu___882_4146.FStar_TypeChecker_Env.type_of);
                        FStar_TypeChecker_Env.universe_of =
-                         (uu___882_4142.FStar_TypeChecker_Env.universe_of);
+                         (uu___882_4146.FStar_TypeChecker_Env.universe_of);
                        FStar_TypeChecker_Env.check_type_of =
-                         (uu___882_4142.FStar_TypeChecker_Env.check_type_of);
+                         (uu___882_4146.FStar_TypeChecker_Env.check_type_of);
                        FStar_TypeChecker_Env.use_bv_sorts =
-                         (uu___882_4142.FStar_TypeChecker_Env.use_bv_sorts);
+                         (uu___882_4146.FStar_TypeChecker_Env.use_bv_sorts);
                        FStar_TypeChecker_Env.qtbl_name_and_index =
-                         (uu___882_4142.FStar_TypeChecker_Env.qtbl_name_and_index);
+                         (uu___882_4146.FStar_TypeChecker_Env.qtbl_name_and_index);
                        FStar_TypeChecker_Env.normalized_eff_names =
-                         (uu___882_4142.FStar_TypeChecker_Env.normalized_eff_names);
+                         (uu___882_4146.FStar_TypeChecker_Env.normalized_eff_names);
                        FStar_TypeChecker_Env.fv_delta_depths =
-                         (uu___882_4142.FStar_TypeChecker_Env.fv_delta_depths);
-                       FStar_TypeChecker_Env.proof_ns = uu____4143;
+                         (uu___882_4146.FStar_TypeChecker_Env.fv_delta_depths);
+                       FStar_TypeChecker_Env.proof_ns = uu____4147;
                        FStar_TypeChecker_Env.synth_hook =
-                         (uu___882_4142.FStar_TypeChecker_Env.synth_hook);
+                         (uu___882_4146.FStar_TypeChecker_Env.synth_hook);
                        FStar_TypeChecker_Env.try_solve_implicits_hook =
-                         (uu___882_4142.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                         (uu___882_4146.FStar_TypeChecker_Env.try_solve_implicits_hook);
                        FStar_TypeChecker_Env.splice =
-                         (uu___882_4142.FStar_TypeChecker_Env.splice);
+                         (uu___882_4146.FStar_TypeChecker_Env.splice);
                        FStar_TypeChecker_Env.mpreprocess =
-                         (uu___882_4142.FStar_TypeChecker_Env.mpreprocess);
+                         (uu___882_4146.FStar_TypeChecker_Env.mpreprocess);
                        FStar_TypeChecker_Env.postprocess =
-                         (uu___882_4142.FStar_TypeChecker_Env.postprocess);
+                         (uu___882_4146.FStar_TypeChecker_Env.postprocess);
                        FStar_TypeChecker_Env.identifier_info =
-                         (uu___882_4142.FStar_TypeChecker_Env.identifier_info);
+                         (uu___882_4146.FStar_TypeChecker_Env.identifier_info);
                        FStar_TypeChecker_Env.tc_hooks =
-                         (uu___882_4142.FStar_TypeChecker_Env.tc_hooks);
+                         (uu___882_4146.FStar_TypeChecker_Env.tc_hooks);
                        FStar_TypeChecker_Env.dsenv =
-                         (uu___882_4142.FStar_TypeChecker_Env.dsenv);
+                         (uu___882_4146.FStar_TypeChecker_Env.dsenv);
                        FStar_TypeChecker_Env.nbe =
-                         (uu___882_4142.FStar_TypeChecker_Env.nbe);
+                         (uu___882_4146.FStar_TypeChecker_Env.nbe);
                        FStar_TypeChecker_Env.strict_args_tab =
-                         (uu___882_4142.FStar_TypeChecker_Env.strict_args_tab);
+                         (uu___882_4146.FStar_TypeChecker_Env.strict_args_tab);
                        FStar_TypeChecker_Env.erasable_types_tab =
-                         (uu___882_4142.FStar_TypeChecker_Env.erasable_types_tab);
+                         (uu___882_4146.FStar_TypeChecker_Env.erasable_types_tab);
                        FStar_TypeChecker_Env.enable_defer_to_tac =
-                         (uu___882_4142.FStar_TypeChecker_Env.enable_defer_to_tac)
+                         (uu___882_4146.FStar_TypeChecker_Env.enable_defer_to_tac)
                      })
               | FStar_Syntax_Syntax.Sig_pragma
                   (FStar_Syntax_Syntax.PopOptions) ->
-                  if from_cache
-                  then env1
-                  else
-                    (let uu___882_4145 = env1 in
-                     let uu____4146 = FStar_Options.using_facts_from () in
-                     {
-                       FStar_TypeChecker_Env.solver =
-                         (uu___882_4145.FStar_TypeChecker_Env.solver);
-                       FStar_TypeChecker_Env.range =
-                         (uu___882_4145.FStar_TypeChecker_Env.range);
-                       FStar_TypeChecker_Env.curmodule =
-                         (uu___882_4145.FStar_TypeChecker_Env.curmodule);
-                       FStar_TypeChecker_Env.gamma =
-                         (uu___882_4145.FStar_TypeChecker_Env.gamma);
-                       FStar_TypeChecker_Env.gamma_sig =
-                         (uu___882_4145.FStar_TypeChecker_Env.gamma_sig);
-                       FStar_TypeChecker_Env.gamma_cache =
-                         (uu___882_4145.FStar_TypeChecker_Env.gamma_cache);
-                       FStar_TypeChecker_Env.modules =
-                         (uu___882_4145.FStar_TypeChecker_Env.modules);
-                       FStar_TypeChecker_Env.expected_typ =
-                         (uu___882_4145.FStar_TypeChecker_Env.expected_typ);
-                       FStar_TypeChecker_Env.sigtab =
-                         (uu___882_4145.FStar_TypeChecker_Env.sigtab);
-                       FStar_TypeChecker_Env.attrtab =
-                         (uu___882_4145.FStar_TypeChecker_Env.attrtab);
-                       FStar_TypeChecker_Env.instantiate_imp =
-                         (uu___882_4145.FStar_TypeChecker_Env.instantiate_imp);
-                       FStar_TypeChecker_Env.effects =
-                         (uu___882_4145.FStar_TypeChecker_Env.effects);
-                       FStar_TypeChecker_Env.generalize =
-                         (uu___882_4145.FStar_TypeChecker_Env.generalize);
-                       FStar_TypeChecker_Env.letrecs =
-                         (uu___882_4145.FStar_TypeChecker_Env.letrecs);
-                       FStar_TypeChecker_Env.top_level =
-                         (uu___882_4145.FStar_TypeChecker_Env.top_level);
-                       FStar_TypeChecker_Env.check_uvars =
-                         (uu___882_4145.FStar_TypeChecker_Env.check_uvars);
-                       FStar_TypeChecker_Env.use_eq =
-                         (uu___882_4145.FStar_TypeChecker_Env.use_eq);
-                       FStar_TypeChecker_Env.use_eq_strict =
-                         (uu___882_4145.FStar_TypeChecker_Env.use_eq_strict);
-                       FStar_TypeChecker_Env.is_iface =
-                         (uu___882_4145.FStar_TypeChecker_Env.is_iface);
-                       FStar_TypeChecker_Env.admit =
-                         (uu___882_4145.FStar_TypeChecker_Env.admit);
-                       FStar_TypeChecker_Env.lax =
-                         (uu___882_4145.FStar_TypeChecker_Env.lax);
-                       FStar_TypeChecker_Env.lax_universes =
-                         (uu___882_4145.FStar_TypeChecker_Env.lax_universes);
-                       FStar_TypeChecker_Env.phase1 =
-                         (uu___882_4145.FStar_TypeChecker_Env.phase1);
-                       FStar_TypeChecker_Env.failhard =
-                         (uu___882_4145.FStar_TypeChecker_Env.failhard);
-                       FStar_TypeChecker_Env.nosynth =
-                         (uu___882_4145.FStar_TypeChecker_Env.nosynth);
-                       FStar_TypeChecker_Env.uvar_subtyping =
-                         (uu___882_4145.FStar_TypeChecker_Env.uvar_subtyping);
-                       FStar_TypeChecker_Env.tc_term =
-                         (uu___882_4145.FStar_TypeChecker_Env.tc_term);
-                       FStar_TypeChecker_Env.type_of =
-                         (uu___882_4145.FStar_TypeChecker_Env.type_of);
-                       FStar_TypeChecker_Env.universe_of =
-                         (uu___882_4145.FStar_TypeChecker_Env.universe_of);
-                       FStar_TypeChecker_Env.check_type_of =
-                         (uu___882_4145.FStar_TypeChecker_Env.check_type_of);
-                       FStar_TypeChecker_Env.use_bv_sorts =
-                         (uu___882_4145.FStar_TypeChecker_Env.use_bv_sorts);
-                       FStar_TypeChecker_Env.qtbl_name_and_index =
-                         (uu___882_4145.FStar_TypeChecker_Env.qtbl_name_and_index);
-                       FStar_TypeChecker_Env.normalized_eff_names =
-                         (uu___882_4145.FStar_TypeChecker_Env.normalized_eff_names);
-                       FStar_TypeChecker_Env.fv_delta_depths =
-                         (uu___882_4145.FStar_TypeChecker_Env.fv_delta_depths);
-                       FStar_TypeChecker_Env.proof_ns = uu____4146;
-                       FStar_TypeChecker_Env.synth_hook =
-                         (uu___882_4145.FStar_TypeChecker_Env.synth_hook);
-                       FStar_TypeChecker_Env.try_solve_implicits_hook =
-                         (uu___882_4145.FStar_TypeChecker_Env.try_solve_implicits_hook);
-                       FStar_TypeChecker_Env.splice =
-                         (uu___882_4145.FStar_TypeChecker_Env.splice);
-                       FStar_TypeChecker_Env.mpreprocess =
-                         (uu___882_4145.FStar_TypeChecker_Env.mpreprocess);
-                       FStar_TypeChecker_Env.postprocess =
-                         (uu___882_4145.FStar_TypeChecker_Env.postprocess);
-                       FStar_TypeChecker_Env.identifier_info =
-                         (uu___882_4145.FStar_TypeChecker_Env.identifier_info);
-                       FStar_TypeChecker_Env.tc_hooks =
-                         (uu___882_4145.FStar_TypeChecker_Env.tc_hooks);
-                       FStar_TypeChecker_Env.dsenv =
-                         (uu___882_4145.FStar_TypeChecker_Env.dsenv);
-                       FStar_TypeChecker_Env.nbe =
-                         (uu___882_4145.FStar_TypeChecker_Env.nbe);
-                       FStar_TypeChecker_Env.strict_args_tab =
-                         (uu___882_4145.FStar_TypeChecker_Env.strict_args_tab);
-                       FStar_TypeChecker_Env.erasable_types_tab =
-                         (uu___882_4145.FStar_TypeChecker_Env.erasable_types_tab);
-                       FStar_TypeChecker_Env.enable_defer_to_tac =
-                         (uu___882_4145.FStar_TypeChecker_Env.enable_defer_to_tac)
-                     })
-              | FStar_Syntax_Syntax.Sig_pragma
-                  (FStar_Syntax_Syntax.SetOptions uu____4147) ->
                   if from_cache
                   then env1
                   else
@@ -3814,106 +3712,208 @@ let (add_sigelt_to_env :
                          (uu___882_4149.FStar_TypeChecker_Env.enable_defer_to_tac)
                      })
               | FStar_Syntax_Syntax.Sig_pragma
-                  (FStar_Syntax_Syntax.ResetOptions uu____4151) ->
+                  (FStar_Syntax_Syntax.SetOptions uu____4151) ->
                   if from_cache
                   then env1
                   else
-                    (let uu___882_4155 = env1 in
-                     let uu____4156 = FStar_Options.using_facts_from () in
+                    (let uu___882_4153 = env1 in
+                     let uu____4154 = FStar_Options.using_facts_from () in
                      {
                        FStar_TypeChecker_Env.solver =
-                         (uu___882_4155.FStar_TypeChecker_Env.solver);
+                         (uu___882_4153.FStar_TypeChecker_Env.solver);
                        FStar_TypeChecker_Env.range =
-                         (uu___882_4155.FStar_TypeChecker_Env.range);
+                         (uu___882_4153.FStar_TypeChecker_Env.range);
                        FStar_TypeChecker_Env.curmodule =
-                         (uu___882_4155.FStar_TypeChecker_Env.curmodule);
+                         (uu___882_4153.FStar_TypeChecker_Env.curmodule);
                        FStar_TypeChecker_Env.gamma =
-                         (uu___882_4155.FStar_TypeChecker_Env.gamma);
+                         (uu___882_4153.FStar_TypeChecker_Env.gamma);
                        FStar_TypeChecker_Env.gamma_sig =
-                         (uu___882_4155.FStar_TypeChecker_Env.gamma_sig);
+                         (uu___882_4153.FStar_TypeChecker_Env.gamma_sig);
                        FStar_TypeChecker_Env.gamma_cache =
-                         (uu___882_4155.FStar_TypeChecker_Env.gamma_cache);
+                         (uu___882_4153.FStar_TypeChecker_Env.gamma_cache);
                        FStar_TypeChecker_Env.modules =
-                         (uu___882_4155.FStar_TypeChecker_Env.modules);
+                         (uu___882_4153.FStar_TypeChecker_Env.modules);
                        FStar_TypeChecker_Env.expected_typ =
-                         (uu___882_4155.FStar_TypeChecker_Env.expected_typ);
+                         (uu___882_4153.FStar_TypeChecker_Env.expected_typ);
                        FStar_TypeChecker_Env.sigtab =
-                         (uu___882_4155.FStar_TypeChecker_Env.sigtab);
+                         (uu___882_4153.FStar_TypeChecker_Env.sigtab);
                        FStar_TypeChecker_Env.attrtab =
-                         (uu___882_4155.FStar_TypeChecker_Env.attrtab);
+                         (uu___882_4153.FStar_TypeChecker_Env.attrtab);
                        FStar_TypeChecker_Env.instantiate_imp =
-                         (uu___882_4155.FStar_TypeChecker_Env.instantiate_imp);
+                         (uu___882_4153.FStar_TypeChecker_Env.instantiate_imp);
                        FStar_TypeChecker_Env.effects =
-                         (uu___882_4155.FStar_TypeChecker_Env.effects);
+                         (uu___882_4153.FStar_TypeChecker_Env.effects);
                        FStar_TypeChecker_Env.generalize =
-                         (uu___882_4155.FStar_TypeChecker_Env.generalize);
+                         (uu___882_4153.FStar_TypeChecker_Env.generalize);
                        FStar_TypeChecker_Env.letrecs =
-                         (uu___882_4155.FStar_TypeChecker_Env.letrecs);
+                         (uu___882_4153.FStar_TypeChecker_Env.letrecs);
                        FStar_TypeChecker_Env.top_level =
-                         (uu___882_4155.FStar_TypeChecker_Env.top_level);
+                         (uu___882_4153.FStar_TypeChecker_Env.top_level);
                        FStar_TypeChecker_Env.check_uvars =
-                         (uu___882_4155.FStar_TypeChecker_Env.check_uvars);
+                         (uu___882_4153.FStar_TypeChecker_Env.check_uvars);
                        FStar_TypeChecker_Env.use_eq =
-                         (uu___882_4155.FStar_TypeChecker_Env.use_eq);
+                         (uu___882_4153.FStar_TypeChecker_Env.use_eq);
                        FStar_TypeChecker_Env.use_eq_strict =
-                         (uu___882_4155.FStar_TypeChecker_Env.use_eq_strict);
+                         (uu___882_4153.FStar_TypeChecker_Env.use_eq_strict);
                        FStar_TypeChecker_Env.is_iface =
-                         (uu___882_4155.FStar_TypeChecker_Env.is_iface);
+                         (uu___882_4153.FStar_TypeChecker_Env.is_iface);
                        FStar_TypeChecker_Env.admit =
-                         (uu___882_4155.FStar_TypeChecker_Env.admit);
+                         (uu___882_4153.FStar_TypeChecker_Env.admit);
                        FStar_TypeChecker_Env.lax =
-                         (uu___882_4155.FStar_TypeChecker_Env.lax);
+                         (uu___882_4153.FStar_TypeChecker_Env.lax);
                        FStar_TypeChecker_Env.lax_universes =
-                         (uu___882_4155.FStar_TypeChecker_Env.lax_universes);
+                         (uu___882_4153.FStar_TypeChecker_Env.lax_universes);
                        FStar_TypeChecker_Env.phase1 =
-                         (uu___882_4155.FStar_TypeChecker_Env.phase1);
+                         (uu___882_4153.FStar_TypeChecker_Env.phase1);
                        FStar_TypeChecker_Env.failhard =
-                         (uu___882_4155.FStar_TypeChecker_Env.failhard);
+                         (uu___882_4153.FStar_TypeChecker_Env.failhard);
                        FStar_TypeChecker_Env.nosynth =
-                         (uu___882_4155.FStar_TypeChecker_Env.nosynth);
+                         (uu___882_4153.FStar_TypeChecker_Env.nosynth);
                        FStar_TypeChecker_Env.uvar_subtyping =
-                         (uu___882_4155.FStar_TypeChecker_Env.uvar_subtyping);
+                         (uu___882_4153.FStar_TypeChecker_Env.uvar_subtyping);
                        FStar_TypeChecker_Env.tc_term =
-                         (uu___882_4155.FStar_TypeChecker_Env.tc_term);
+                         (uu___882_4153.FStar_TypeChecker_Env.tc_term);
                        FStar_TypeChecker_Env.type_of =
-                         (uu___882_4155.FStar_TypeChecker_Env.type_of);
+                         (uu___882_4153.FStar_TypeChecker_Env.type_of);
                        FStar_TypeChecker_Env.universe_of =
-                         (uu___882_4155.FStar_TypeChecker_Env.universe_of);
+                         (uu___882_4153.FStar_TypeChecker_Env.universe_of);
                        FStar_TypeChecker_Env.check_type_of =
-                         (uu___882_4155.FStar_TypeChecker_Env.check_type_of);
+                         (uu___882_4153.FStar_TypeChecker_Env.check_type_of);
                        FStar_TypeChecker_Env.use_bv_sorts =
-                         (uu___882_4155.FStar_TypeChecker_Env.use_bv_sorts);
+                         (uu___882_4153.FStar_TypeChecker_Env.use_bv_sorts);
                        FStar_TypeChecker_Env.qtbl_name_and_index =
-                         (uu___882_4155.FStar_TypeChecker_Env.qtbl_name_and_index);
+                         (uu___882_4153.FStar_TypeChecker_Env.qtbl_name_and_index);
                        FStar_TypeChecker_Env.normalized_eff_names =
-                         (uu___882_4155.FStar_TypeChecker_Env.normalized_eff_names);
+                         (uu___882_4153.FStar_TypeChecker_Env.normalized_eff_names);
                        FStar_TypeChecker_Env.fv_delta_depths =
-                         (uu___882_4155.FStar_TypeChecker_Env.fv_delta_depths);
-                       FStar_TypeChecker_Env.proof_ns = uu____4156;
+                         (uu___882_4153.FStar_TypeChecker_Env.fv_delta_depths);
+                       FStar_TypeChecker_Env.proof_ns = uu____4154;
                        FStar_TypeChecker_Env.synth_hook =
-                         (uu___882_4155.FStar_TypeChecker_Env.synth_hook);
+                         (uu___882_4153.FStar_TypeChecker_Env.synth_hook);
                        FStar_TypeChecker_Env.try_solve_implicits_hook =
-                         (uu___882_4155.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                         (uu___882_4153.FStar_TypeChecker_Env.try_solve_implicits_hook);
                        FStar_TypeChecker_Env.splice =
-                         (uu___882_4155.FStar_TypeChecker_Env.splice);
+                         (uu___882_4153.FStar_TypeChecker_Env.splice);
                        FStar_TypeChecker_Env.mpreprocess =
-                         (uu___882_4155.FStar_TypeChecker_Env.mpreprocess);
+                         (uu___882_4153.FStar_TypeChecker_Env.mpreprocess);
                        FStar_TypeChecker_Env.postprocess =
-                         (uu___882_4155.FStar_TypeChecker_Env.postprocess);
+                         (uu___882_4153.FStar_TypeChecker_Env.postprocess);
                        FStar_TypeChecker_Env.identifier_info =
-                         (uu___882_4155.FStar_TypeChecker_Env.identifier_info);
+                         (uu___882_4153.FStar_TypeChecker_Env.identifier_info);
                        FStar_TypeChecker_Env.tc_hooks =
-                         (uu___882_4155.FStar_TypeChecker_Env.tc_hooks);
+                         (uu___882_4153.FStar_TypeChecker_Env.tc_hooks);
                        FStar_TypeChecker_Env.dsenv =
-                         (uu___882_4155.FStar_TypeChecker_Env.dsenv);
+                         (uu___882_4153.FStar_TypeChecker_Env.dsenv);
                        FStar_TypeChecker_Env.nbe =
-                         (uu___882_4155.FStar_TypeChecker_Env.nbe);
+                         (uu___882_4153.FStar_TypeChecker_Env.nbe);
                        FStar_TypeChecker_Env.strict_args_tab =
-                         (uu___882_4155.FStar_TypeChecker_Env.strict_args_tab);
+                         (uu___882_4153.FStar_TypeChecker_Env.strict_args_tab);
                        FStar_TypeChecker_Env.erasable_types_tab =
-                         (uu___882_4155.FStar_TypeChecker_Env.erasable_types_tab);
+                         (uu___882_4153.FStar_TypeChecker_Env.erasable_types_tab);
                        FStar_TypeChecker_Env.enable_defer_to_tac =
-                         (uu___882_4155.FStar_TypeChecker_Env.enable_defer_to_tac)
+                         (uu___882_4153.FStar_TypeChecker_Env.enable_defer_to_tac)
+                     })
+              | FStar_Syntax_Syntax.Sig_pragma
+                  (FStar_Syntax_Syntax.ResetOptions uu____4155) ->
+                  if from_cache
+                  then env1
+                  else
+                    (let uu___882_4159 = env1 in
+                     let uu____4160 = FStar_Options.using_facts_from () in
+                     {
+                       FStar_TypeChecker_Env.solver =
+                         (uu___882_4159.FStar_TypeChecker_Env.solver);
+                       FStar_TypeChecker_Env.range =
+                         (uu___882_4159.FStar_TypeChecker_Env.range);
+                       FStar_TypeChecker_Env.curmodule =
+                         (uu___882_4159.FStar_TypeChecker_Env.curmodule);
+                       FStar_TypeChecker_Env.gamma =
+                         (uu___882_4159.FStar_TypeChecker_Env.gamma);
+                       FStar_TypeChecker_Env.gamma_sig =
+                         (uu___882_4159.FStar_TypeChecker_Env.gamma_sig);
+                       FStar_TypeChecker_Env.gamma_cache =
+                         (uu___882_4159.FStar_TypeChecker_Env.gamma_cache);
+                       FStar_TypeChecker_Env.modules =
+                         (uu___882_4159.FStar_TypeChecker_Env.modules);
+                       FStar_TypeChecker_Env.expected_typ =
+                         (uu___882_4159.FStar_TypeChecker_Env.expected_typ);
+                       FStar_TypeChecker_Env.sigtab =
+                         (uu___882_4159.FStar_TypeChecker_Env.sigtab);
+                       FStar_TypeChecker_Env.attrtab =
+                         (uu___882_4159.FStar_TypeChecker_Env.attrtab);
+                       FStar_TypeChecker_Env.instantiate_imp =
+                         (uu___882_4159.FStar_TypeChecker_Env.instantiate_imp);
+                       FStar_TypeChecker_Env.effects =
+                         (uu___882_4159.FStar_TypeChecker_Env.effects);
+                       FStar_TypeChecker_Env.generalize =
+                         (uu___882_4159.FStar_TypeChecker_Env.generalize);
+                       FStar_TypeChecker_Env.letrecs =
+                         (uu___882_4159.FStar_TypeChecker_Env.letrecs);
+                       FStar_TypeChecker_Env.top_level =
+                         (uu___882_4159.FStar_TypeChecker_Env.top_level);
+                       FStar_TypeChecker_Env.check_uvars =
+                         (uu___882_4159.FStar_TypeChecker_Env.check_uvars);
+                       FStar_TypeChecker_Env.use_eq =
+                         (uu___882_4159.FStar_TypeChecker_Env.use_eq);
+                       FStar_TypeChecker_Env.use_eq_strict =
+                         (uu___882_4159.FStar_TypeChecker_Env.use_eq_strict);
+                       FStar_TypeChecker_Env.is_iface =
+                         (uu___882_4159.FStar_TypeChecker_Env.is_iface);
+                       FStar_TypeChecker_Env.admit =
+                         (uu___882_4159.FStar_TypeChecker_Env.admit);
+                       FStar_TypeChecker_Env.lax =
+                         (uu___882_4159.FStar_TypeChecker_Env.lax);
+                       FStar_TypeChecker_Env.lax_universes =
+                         (uu___882_4159.FStar_TypeChecker_Env.lax_universes);
+                       FStar_TypeChecker_Env.phase1 =
+                         (uu___882_4159.FStar_TypeChecker_Env.phase1);
+                       FStar_TypeChecker_Env.failhard =
+                         (uu___882_4159.FStar_TypeChecker_Env.failhard);
+                       FStar_TypeChecker_Env.nosynth =
+                         (uu___882_4159.FStar_TypeChecker_Env.nosynth);
+                       FStar_TypeChecker_Env.uvar_subtyping =
+                         (uu___882_4159.FStar_TypeChecker_Env.uvar_subtyping);
+                       FStar_TypeChecker_Env.tc_term =
+                         (uu___882_4159.FStar_TypeChecker_Env.tc_term);
+                       FStar_TypeChecker_Env.type_of =
+                         (uu___882_4159.FStar_TypeChecker_Env.type_of);
+                       FStar_TypeChecker_Env.universe_of =
+                         (uu___882_4159.FStar_TypeChecker_Env.universe_of);
+                       FStar_TypeChecker_Env.check_type_of =
+                         (uu___882_4159.FStar_TypeChecker_Env.check_type_of);
+                       FStar_TypeChecker_Env.use_bv_sorts =
+                         (uu___882_4159.FStar_TypeChecker_Env.use_bv_sorts);
+                       FStar_TypeChecker_Env.qtbl_name_and_index =
+                         (uu___882_4159.FStar_TypeChecker_Env.qtbl_name_and_index);
+                       FStar_TypeChecker_Env.normalized_eff_names =
+                         (uu___882_4159.FStar_TypeChecker_Env.normalized_eff_names);
+                       FStar_TypeChecker_Env.fv_delta_depths =
+                         (uu___882_4159.FStar_TypeChecker_Env.fv_delta_depths);
+                       FStar_TypeChecker_Env.proof_ns = uu____4160;
+                       FStar_TypeChecker_Env.synth_hook =
+                         (uu___882_4159.FStar_TypeChecker_Env.synth_hook);
+                       FStar_TypeChecker_Env.try_solve_implicits_hook =
+                         (uu___882_4159.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                       FStar_TypeChecker_Env.splice =
+                         (uu___882_4159.FStar_TypeChecker_Env.splice);
+                       FStar_TypeChecker_Env.mpreprocess =
+                         (uu___882_4159.FStar_TypeChecker_Env.mpreprocess);
+                       FStar_TypeChecker_Env.postprocess =
+                         (uu___882_4159.FStar_TypeChecker_Env.postprocess);
+                       FStar_TypeChecker_Env.identifier_info =
+                         (uu___882_4159.FStar_TypeChecker_Env.identifier_info);
+                       FStar_TypeChecker_Env.tc_hooks =
+                         (uu___882_4159.FStar_TypeChecker_Env.tc_hooks);
+                       FStar_TypeChecker_Env.dsenv =
+                         (uu___882_4159.FStar_TypeChecker_Env.dsenv);
+                       FStar_TypeChecker_Env.nbe =
+                         (uu___882_4159.FStar_TypeChecker_Env.nbe);
+                       FStar_TypeChecker_Env.strict_args_tab =
+                         (uu___882_4159.FStar_TypeChecker_Env.strict_args_tab);
+                       FStar_TypeChecker_Env.erasable_types_tab =
+                         (uu___882_4159.FStar_TypeChecker_Env.erasable_types_tab);
+                       FStar_TypeChecker_Env.enable_defer_to_tac =
+                         (uu___882_4159.FStar_TypeChecker_Env.enable_defer_to_tac)
                      })
               | FStar_Syntax_Syntax.Sig_pragma
                   (FStar_Syntax_Syntax.RestartSolver) ->
@@ -3931,23 +3931,23 @@ let (add_sigelt_to_env :
                     (FStar_List.fold_left
                        (fun env3 ->
                           fun a ->
-                            let uu____4170 =
+                            let uu____4174 =
                               FStar_Syntax_Util.action_as_lb
                                 ne.FStar_Syntax_Syntax.mname a
                                 (a.FStar_Syntax_Syntax.action_defn).FStar_Syntax_Syntax.pos in
-                            FStar_TypeChecker_Env.push_sigelt env3 uu____4170)
+                            FStar_TypeChecker_Env.push_sigelt env3 uu____4174)
                        env2)
               | FStar_Syntax_Syntax.Sig_sub_effect sub ->
                   FStar_TypeChecker_Util.update_env_sub_eff env1 sub
                     se.FStar_Syntax_Syntax.sigrng
               | FStar_Syntax_Syntax.Sig_polymonadic_bind
-                  (m, n, p, uu____4175, ty) ->
+                  (m, n, p, uu____4179, ty) ->
                   FStar_TypeChecker_Util.update_env_polymonadic_bind env1 m n
                     p ty
               | FStar_Syntax_Syntax.Sig_polymonadic_subcomp
-                  (m, n, uu____4179, ty) ->
+                  (m, n, uu____4183, ty) ->
                   FStar_TypeChecker_Env.add_polymonadic_subcomp env1 m n ty
-              | uu____4181 -> env1))
+              | uu____4185 -> env1))
 let (tc_decls :
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.sigelt Prims.list ->
@@ -3955,57 +3955,57 @@ let (tc_decls :
   =
   fun env ->
     fun ses ->
-      let rec process_one_decl uu____4229 se =
-        match uu____4229 with
+      let rec process_one_decl uu____4233 se =
+        match uu____4233 with
         | (ses1, env1) ->
-            let uu____4255 =
+            let uu____4259 =
               env1.FStar_TypeChecker_Env.nosynth &&
                 (FStar_Options.debug_any ()) in
-            if uu____4255
+            if uu____4259
             then ((ses1, env1), [])
             else
-              ((let uu____4280 =
+              ((let uu____4284 =
                   FStar_TypeChecker_Env.debug env1 FStar_Options.Low in
-                if uu____4280
+                if uu____4284
                 then
-                  let uu____4281 = FStar_Syntax_Print.tag_of_sigelt se in
-                  let uu____4282 = FStar_Syntax_Print.sigelt_to_string se in
+                  let uu____4285 = FStar_Syntax_Print.tag_of_sigelt se in
+                  let uu____4286 = FStar_Syntax_Print.sigelt_to_string se in
                   FStar_Util.print2
                     ">>>>>>>>>>>>>>Checking top-level %s decl %s\n"
-                    uu____4281 uu____4282
+                    uu____4285 uu____4286
                 else ());
-               (let uu____4284 = tc_decl env1 se in
-                match uu____4284 with
+               (let uu____4288 = tc_decl env1 se in
+                match uu____4288 with
                 | (ses', ses_elaborated, env2) ->
                     let ses'1 =
                       FStar_All.pipe_right ses'
                         (FStar_List.map
                            (fun se1 ->
-                              (let uu____4329 =
+                              (let uu____4333 =
                                  FStar_TypeChecker_Env.debug env2
                                    (FStar_Options.Other "UF") in
-                               if uu____4329
+                               if uu____4333
                                then
-                                 let uu____4330 =
+                                 let uu____4334 =
                                    FStar_Syntax_Print.sigelt_to_string se1 in
                                  FStar_Util.print1
-                                   "About to elim vars from %s\n" uu____4330
+                                   "About to elim vars from %s\n" uu____4334
                                else ());
                               FStar_TypeChecker_Normalize.elim_uvars env2 se1)) in
                     let ses_elaborated1 =
                       FStar_All.pipe_right ses_elaborated
                         (FStar_List.map
                            (fun se1 ->
-                              (let uu____4343 =
+                              (let uu____4347 =
                                  FStar_TypeChecker_Env.debug env2
                                    (FStar_Options.Other "UF") in
-                               if uu____4343
+                               if uu____4347
                                then
-                                 let uu____4344 =
+                                 let uu____4348 =
                                    FStar_Syntax_Print.sigelt_to_string se1 in
                                  FStar_Util.print1
                                    "About to elim vars from (elaborated) %s\n"
-                                   uu____4344
+                                   uu____4348
                                else ());
                               FStar_TypeChecker_Normalize.elim_uvars env2 se1)) in
                     (FStar_TypeChecker_Env.promote_id_info env2
@@ -4028,23 +4028,23 @@ let (tc_decls :
                                 fun se1 -> add_sigelt_to_env env3 se1 false)
                              env2) in
                       FStar_Syntax_Unionfind.reset ();
-                      (let uu____4358 =
+                      (let uu____4362 =
                          (FStar_Options.log_types ()) ||
                            (FStar_All.pipe_left
                               (FStar_TypeChecker_Env.debug env3)
                               (FStar_Options.Other "LogTypes")) in
-                       if uu____4358
+                       if uu____4362
                        then
-                         let uu____4359 =
+                         let uu____4363 =
                            FStar_List.fold_left
                              (fun s ->
                                 fun se1 ->
-                                  let uu____4365 =
-                                    let uu____4366 =
+                                  let uu____4369 =
+                                    let uu____4370 =
                                       FStar_Syntax_Print.sigelt_to_string se1 in
-                                    Prims.op_Hat uu____4366 "\n" in
-                                  Prims.op_Hat s uu____4365) "" ses'1 in
-                         FStar_Util.print1 "Checked: %s\n" uu____4359
+                                    Prims.op_Hat uu____4370 "\n" in
+                                  Prims.op_Hat s uu____4369) "" ses'1 in
+                         FStar_Util.print1 "Checked: %s\n" uu____4363
                        else ());
                       FStar_List.iter
                         (fun se1 ->
@@ -4053,35 +4053,35 @@ let (tc_decls :
                       (((FStar_List.rev_append ses'1 ses1), env3),
                         ses_elaborated1))))) in
       let process_one_decl_timed acc se =
-        let uu____4416 = acc in
-        match uu____4416 with
-        | (uu____4435, env1) ->
+        let uu____4420 = acc in
+        match uu____4420 with
+        | (uu____4439, env1) ->
             let r =
-              let uu____4454 =
-                let uu____4457 =
-                  let uu____4458 = FStar_TypeChecker_Env.current_module env1 in
-                  FStar_Ident.string_of_lid uu____4458 in
-                FStar_Pervasives_Native.Some uu____4457 in
+              let uu____4458 =
+                let uu____4461 =
+                  let uu____4462 = FStar_TypeChecker_Env.current_module env1 in
+                  FStar_Ident.string_of_lid uu____4462 in
+                FStar_Pervasives_Native.Some uu____4461 in
               FStar_Profiling.profile
-                (fun uu____4472 -> process_one_decl acc se) uu____4454
+                (fun uu____4476 -> process_one_decl acc se) uu____4458
                 "FStar.TypeChecker.Tc.process_one_decl" in
-            ((let uu____4474 = FStar_Options.profile_group_by_decls () in
-              if uu____4474
+            ((let uu____4478 = FStar_Options.profile_group_by_decls () in
+              if uu____4478
               then
                 let tag =
                   match FStar_Syntax_Util.lids_of_sigelt se with
-                  | hd::uu____4477 -> FStar_Ident.string_of_lid hd
-                  | uu____4480 ->
+                  | hd::uu____4481 -> FStar_Ident.string_of_lid hd
+                  | uu____4484 ->
                       FStar_Range.string_of_range
                         (FStar_Syntax_Util.range_of_sigelt se) in
                 FStar_Profiling.report_and_clear tag
               else ());
              r) in
-      let uu____4484 =
+      let uu____4488 =
         FStar_Syntax_Unionfind.with_uf_enabled
-          (fun uu____4498 ->
+          (fun uu____4502 ->
              FStar_Util.fold_flatten process_one_decl_timed ([], env) ses) in
-      match uu____4484 with
+      match uu____4488 with
       | (ses1, env1) -> ((FStar_List.rev_append ses1 []), env1)
 let (uu___962 : unit) =
   FStar_ST.op_Colon_Equals tc_decls_knot
@@ -4095,7 +4095,7 @@ let (snapshot_context :
   fun env ->
     fun msg ->
       FStar_Util.atomically
-        (fun uu____4600 -> FStar_TypeChecker_Env.snapshot env msg)
+        (fun uu____4604 -> FStar_TypeChecker_Env.snapshot env msg)
 let (rollback_context :
   FStar_TypeChecker_Env.solver_t ->
     Prims.string ->
@@ -4107,14 +4107,14 @@ let (rollback_context :
     fun msg ->
       fun depth ->
         FStar_Util.atomically
-          (fun uu____4638 ->
+          (fun uu____4642 ->
              let env = FStar_TypeChecker_Env.rollback solver msg depth in env)
 let (push_context :
   FStar_TypeChecker_Env.env -> Prims.string -> FStar_TypeChecker_Env.env) =
   fun env ->
     fun msg ->
-      let uu____4650 = snapshot_context env msg in
-      FStar_Pervasives_Native.snd uu____4650
+      let uu____4654 = snapshot_context env msg in
+      FStar_Pervasives_Native.snd uu____4654
 let (pop_context :
   FStar_TypeChecker_Env.env -> Prims.string -> FStar_TypeChecker_Env.env) =
   fun env ->
@@ -4129,138 +4129,138 @@ let (tc_partial_modul :
   fun env ->
     fun modul ->
       let verify =
-        let uu____4704 =
+        let uu____4708 =
           FStar_Ident.string_of_lid modul.FStar_Syntax_Syntax.name in
-        FStar_Options.should_verify uu____4704 in
+        FStar_Options.should_verify uu____4708 in
       let action = if verify then "Verifying" else "Lax-checking" in
       let label =
         if modul.FStar_Syntax_Syntax.is_interface
         then "interface"
         else "implementation" in
-      (let uu____4710 = FStar_Options.debug_any () in
-       if uu____4710
+      (let uu____4714 = FStar_Options.debug_any () in
+       if uu____4714
        then
-         let uu____4711 =
+         let uu____4715 =
            FStar_Ident.string_of_lid modul.FStar_Syntax_Syntax.name in
-         FStar_Util.print3 "%s %s of %s\n" action label uu____4711
+         FStar_Util.print3 "%s %s of %s\n" action label uu____4715
        else ());
       (let name =
-         let uu____4714 =
+         let uu____4718 =
            FStar_Ident.string_of_lid modul.FStar_Syntax_Syntax.name in
          FStar_Util.format2 "%s %s"
            (if modul.FStar_Syntax_Syntax.is_interface
             then "interface"
-            else "module") uu____4714 in
+            else "module") uu____4718 in
        let env1 =
-         let uu___986_4717 = env in
+         let uu___986_4721 = env in
          {
            FStar_TypeChecker_Env.solver =
-             (uu___986_4717.FStar_TypeChecker_Env.solver);
+             (uu___986_4721.FStar_TypeChecker_Env.solver);
            FStar_TypeChecker_Env.range =
-             (uu___986_4717.FStar_TypeChecker_Env.range);
+             (uu___986_4721.FStar_TypeChecker_Env.range);
            FStar_TypeChecker_Env.curmodule =
-             (uu___986_4717.FStar_TypeChecker_Env.curmodule);
+             (uu___986_4721.FStar_TypeChecker_Env.curmodule);
            FStar_TypeChecker_Env.gamma =
-             (uu___986_4717.FStar_TypeChecker_Env.gamma);
+             (uu___986_4721.FStar_TypeChecker_Env.gamma);
            FStar_TypeChecker_Env.gamma_sig =
-             (uu___986_4717.FStar_TypeChecker_Env.gamma_sig);
+             (uu___986_4721.FStar_TypeChecker_Env.gamma_sig);
            FStar_TypeChecker_Env.gamma_cache =
-             (uu___986_4717.FStar_TypeChecker_Env.gamma_cache);
+             (uu___986_4721.FStar_TypeChecker_Env.gamma_cache);
            FStar_TypeChecker_Env.modules =
-             (uu___986_4717.FStar_TypeChecker_Env.modules);
+             (uu___986_4721.FStar_TypeChecker_Env.modules);
            FStar_TypeChecker_Env.expected_typ =
-             (uu___986_4717.FStar_TypeChecker_Env.expected_typ);
+             (uu___986_4721.FStar_TypeChecker_Env.expected_typ);
            FStar_TypeChecker_Env.sigtab =
-             (uu___986_4717.FStar_TypeChecker_Env.sigtab);
+             (uu___986_4721.FStar_TypeChecker_Env.sigtab);
            FStar_TypeChecker_Env.attrtab =
-             (uu___986_4717.FStar_TypeChecker_Env.attrtab);
+             (uu___986_4721.FStar_TypeChecker_Env.attrtab);
            FStar_TypeChecker_Env.instantiate_imp =
-             (uu___986_4717.FStar_TypeChecker_Env.instantiate_imp);
+             (uu___986_4721.FStar_TypeChecker_Env.instantiate_imp);
            FStar_TypeChecker_Env.effects =
-             (uu___986_4717.FStar_TypeChecker_Env.effects);
+             (uu___986_4721.FStar_TypeChecker_Env.effects);
            FStar_TypeChecker_Env.generalize =
-             (uu___986_4717.FStar_TypeChecker_Env.generalize);
+             (uu___986_4721.FStar_TypeChecker_Env.generalize);
            FStar_TypeChecker_Env.letrecs =
-             (uu___986_4717.FStar_TypeChecker_Env.letrecs);
+             (uu___986_4721.FStar_TypeChecker_Env.letrecs);
            FStar_TypeChecker_Env.top_level =
-             (uu___986_4717.FStar_TypeChecker_Env.top_level);
+             (uu___986_4721.FStar_TypeChecker_Env.top_level);
            FStar_TypeChecker_Env.check_uvars =
-             (uu___986_4717.FStar_TypeChecker_Env.check_uvars);
+             (uu___986_4721.FStar_TypeChecker_Env.check_uvars);
            FStar_TypeChecker_Env.use_eq =
-             (uu___986_4717.FStar_TypeChecker_Env.use_eq);
+             (uu___986_4721.FStar_TypeChecker_Env.use_eq);
            FStar_TypeChecker_Env.use_eq_strict =
-             (uu___986_4717.FStar_TypeChecker_Env.use_eq_strict);
+             (uu___986_4721.FStar_TypeChecker_Env.use_eq_strict);
            FStar_TypeChecker_Env.is_iface =
              (modul.FStar_Syntax_Syntax.is_interface);
            FStar_TypeChecker_Env.admit = (Prims.op_Negation verify);
            FStar_TypeChecker_Env.lax =
-             (uu___986_4717.FStar_TypeChecker_Env.lax);
+             (uu___986_4721.FStar_TypeChecker_Env.lax);
            FStar_TypeChecker_Env.lax_universes =
-             (uu___986_4717.FStar_TypeChecker_Env.lax_universes);
+             (uu___986_4721.FStar_TypeChecker_Env.lax_universes);
            FStar_TypeChecker_Env.phase1 =
-             (uu___986_4717.FStar_TypeChecker_Env.phase1);
+             (uu___986_4721.FStar_TypeChecker_Env.phase1);
            FStar_TypeChecker_Env.failhard =
-             (uu___986_4717.FStar_TypeChecker_Env.failhard);
+             (uu___986_4721.FStar_TypeChecker_Env.failhard);
            FStar_TypeChecker_Env.nosynth =
-             (uu___986_4717.FStar_TypeChecker_Env.nosynth);
+             (uu___986_4721.FStar_TypeChecker_Env.nosynth);
            FStar_TypeChecker_Env.uvar_subtyping =
-             (uu___986_4717.FStar_TypeChecker_Env.uvar_subtyping);
+             (uu___986_4721.FStar_TypeChecker_Env.uvar_subtyping);
            FStar_TypeChecker_Env.tc_term =
-             (uu___986_4717.FStar_TypeChecker_Env.tc_term);
+             (uu___986_4721.FStar_TypeChecker_Env.tc_term);
            FStar_TypeChecker_Env.type_of =
-             (uu___986_4717.FStar_TypeChecker_Env.type_of);
+             (uu___986_4721.FStar_TypeChecker_Env.type_of);
            FStar_TypeChecker_Env.universe_of =
-             (uu___986_4717.FStar_TypeChecker_Env.universe_of);
+             (uu___986_4721.FStar_TypeChecker_Env.universe_of);
            FStar_TypeChecker_Env.check_type_of =
-             (uu___986_4717.FStar_TypeChecker_Env.check_type_of);
+             (uu___986_4721.FStar_TypeChecker_Env.check_type_of);
            FStar_TypeChecker_Env.use_bv_sorts =
-             (uu___986_4717.FStar_TypeChecker_Env.use_bv_sorts);
+             (uu___986_4721.FStar_TypeChecker_Env.use_bv_sorts);
            FStar_TypeChecker_Env.qtbl_name_and_index =
-             (uu___986_4717.FStar_TypeChecker_Env.qtbl_name_and_index);
+             (uu___986_4721.FStar_TypeChecker_Env.qtbl_name_and_index);
            FStar_TypeChecker_Env.normalized_eff_names =
-             (uu___986_4717.FStar_TypeChecker_Env.normalized_eff_names);
+             (uu___986_4721.FStar_TypeChecker_Env.normalized_eff_names);
            FStar_TypeChecker_Env.fv_delta_depths =
-             (uu___986_4717.FStar_TypeChecker_Env.fv_delta_depths);
+             (uu___986_4721.FStar_TypeChecker_Env.fv_delta_depths);
            FStar_TypeChecker_Env.proof_ns =
-             (uu___986_4717.FStar_TypeChecker_Env.proof_ns);
+             (uu___986_4721.FStar_TypeChecker_Env.proof_ns);
            FStar_TypeChecker_Env.synth_hook =
-             (uu___986_4717.FStar_TypeChecker_Env.synth_hook);
+             (uu___986_4721.FStar_TypeChecker_Env.synth_hook);
            FStar_TypeChecker_Env.try_solve_implicits_hook =
-             (uu___986_4717.FStar_TypeChecker_Env.try_solve_implicits_hook);
+             (uu___986_4721.FStar_TypeChecker_Env.try_solve_implicits_hook);
            FStar_TypeChecker_Env.splice =
-             (uu___986_4717.FStar_TypeChecker_Env.splice);
+             (uu___986_4721.FStar_TypeChecker_Env.splice);
            FStar_TypeChecker_Env.mpreprocess =
-             (uu___986_4717.FStar_TypeChecker_Env.mpreprocess);
+             (uu___986_4721.FStar_TypeChecker_Env.mpreprocess);
            FStar_TypeChecker_Env.postprocess =
-             (uu___986_4717.FStar_TypeChecker_Env.postprocess);
+             (uu___986_4721.FStar_TypeChecker_Env.postprocess);
            FStar_TypeChecker_Env.identifier_info =
-             (uu___986_4717.FStar_TypeChecker_Env.identifier_info);
+             (uu___986_4721.FStar_TypeChecker_Env.identifier_info);
            FStar_TypeChecker_Env.tc_hooks =
-             (uu___986_4717.FStar_TypeChecker_Env.tc_hooks);
+             (uu___986_4721.FStar_TypeChecker_Env.tc_hooks);
            FStar_TypeChecker_Env.dsenv =
-             (uu___986_4717.FStar_TypeChecker_Env.dsenv);
+             (uu___986_4721.FStar_TypeChecker_Env.dsenv);
            FStar_TypeChecker_Env.nbe =
-             (uu___986_4717.FStar_TypeChecker_Env.nbe);
+             (uu___986_4721.FStar_TypeChecker_Env.nbe);
            FStar_TypeChecker_Env.strict_args_tab =
-             (uu___986_4717.FStar_TypeChecker_Env.strict_args_tab);
+             (uu___986_4721.FStar_TypeChecker_Env.strict_args_tab);
            FStar_TypeChecker_Env.erasable_types_tab =
-             (uu___986_4717.FStar_TypeChecker_Env.erasable_types_tab);
+             (uu___986_4721.FStar_TypeChecker_Env.erasable_types_tab);
            FStar_TypeChecker_Env.enable_defer_to_tac =
-             (uu___986_4717.FStar_TypeChecker_Env.enable_defer_to_tac)
+             (uu___986_4721.FStar_TypeChecker_Env.enable_defer_to_tac)
          } in
        let env2 =
          FStar_TypeChecker_Env.set_current_module env1
            modul.FStar_Syntax_Syntax.name in
-       let uu____4719 = tc_decls env2 modul.FStar_Syntax_Syntax.declarations in
-       match uu____4719 with
+       let uu____4723 = tc_decls env2 modul.FStar_Syntax_Syntax.declarations in
+       match uu____4723 with
        | (ses, env3) ->
-           ((let uu___993_4737 = modul in
+           ((let uu___993_4741 = modul in
              {
                FStar_Syntax_Syntax.name =
-                 (uu___993_4737.FStar_Syntax_Syntax.name);
+                 (uu___993_4741.FStar_Syntax_Syntax.name);
                FStar_Syntax_Syntax.declarations = ses;
                FStar_Syntax_Syntax.is_interface =
-                 (uu___993_4737.FStar_Syntax_Syntax.is_interface)
+                 (uu___993_4741.FStar_Syntax_Syntax.is_interface)
              }), env3))
 let (tc_more_partial_modul :
   FStar_TypeChecker_Env.env ->
@@ -4272,19 +4272,19 @@ let (tc_more_partial_modul :
   fun env ->
     fun modul ->
       fun decls ->
-        let uu____4765 = tc_decls env decls in
-        match uu____4765 with
+        let uu____4769 = tc_decls env decls in
+        match uu____4769 with
         | (ses, env1) ->
             let modul1 =
-              let uu___1001_4787 = modul in
+              let uu___1001_4791 = modul in
               {
                 FStar_Syntax_Syntax.name =
-                  (uu___1001_4787.FStar_Syntax_Syntax.name);
+                  (uu___1001_4791.FStar_Syntax_Syntax.name);
                 FStar_Syntax_Syntax.declarations =
                   (FStar_List.append modul.FStar_Syntax_Syntax.declarations
                      ses);
                 FStar_Syntax_Syntax.is_interface =
-                  (uu___1001_4787.FStar_Syntax_Syntax.is_interface)
+                  (uu___1001_4791.FStar_Syntax_Syntax.is_interface)
               } in
             (modul1, ses, env1)
 let (finish_partial_modul :
@@ -4299,18 +4299,18 @@ let (finish_partial_modul :
       fun en ->
         fun m ->
           let env = FStar_TypeChecker_Env.finish_module en m in
-          (let uu____4820 =
+          (let uu____4824 =
              FStar_All.pipe_right
                env.FStar_TypeChecker_Env.qtbl_name_and_index
                FStar_Pervasives_Native.fst in
-           FStar_All.pipe_right uu____4820 FStar_Util.smap_clear);
-          (let uu____4848 =
-             let uu____4849 =
-               let uu____4850 =
+           FStar_All.pipe_right uu____4824 FStar_Util.smap_clear);
+          (let uu____4852 =
+             let uu____4853 =
+               let uu____4854 =
                  FStar_Ident.string_of_lid m.FStar_Syntax_Syntax.name in
-               Prims.op_Hat "Ending modul " uu____4850 in
-             pop_context env uu____4849 in
-           FStar_All.pipe_right uu____4848 (fun uu____4851 -> ()));
+               Prims.op_Hat "Ending modul " uu____4854 in
+             pop_context env uu____4853 in
+           FStar_All.pipe_right uu____4852 (fun uu____4855 -> ()));
           (m, env)
 let (tc_modul :
   FStar_TypeChecker_Env.env ->
@@ -4321,12 +4321,12 @@ let (tc_modul :
     fun m ->
       fun iface_exists ->
         let msg =
-          let uu____4876 =
+          let uu____4880 =
             FStar_Ident.string_of_lid m.FStar_Syntax_Syntax.name in
-          Prims.op_Hat "Internals for " uu____4876 in
+          Prims.op_Hat "Internals for " uu____4880 in
         let env01 = push_context env0 msg in
-        let uu____4878 = tc_partial_modul env01 m in
-        match uu____4878 with
+        let uu____4882 = tc_partial_modul env01 m in
+        match uu____4882 with
         | (modul, env) -> finish_partial_modul false iface_exists env modul
 let (load_checked_module :
   FStar_TypeChecker_Env.env ->
@@ -4338,11 +4338,11 @@ let (load_checked_module :
         FStar_TypeChecker_Env.set_current_module en
           m.FStar_Syntax_Syntax.name in
       let env1 =
-        let uu____4901 =
-          let uu____4902 =
+        let uu____4905 =
+          let uu____4906 =
             FStar_Ident.string_of_lid m.FStar_Syntax_Syntax.name in
-          Prims.op_Hat "Internals for " uu____4902 in
-        push_context env uu____4901 in
+          Prims.op_Hat "Internals for " uu____4906 in
+        push_context env uu____4905 in
       let env2 =
         FStar_List.fold_left
           (fun env2 ->
@@ -4352,12 +4352,12 @@ let (load_checked_module :
                FStar_All.pipe_right lids
                  (FStar_List.iter
                     (fun lid ->
-                       let uu____4921 =
+                       let uu____4925 =
                          FStar_TypeChecker_Env.lookup_sigelt env3 lid in
                        ()));
                env3) env1 m.FStar_Syntax_Syntax.declarations in
-      let uu____4924 = finish_partial_modul true true env2 m in
-      match uu____4924 with | (uu____4929, env3) -> env3
+      let uu____4928 = finish_partial_modul true true env2 m in
+      match uu____4928 with | (uu____4933, env3) -> env3
 let (check_module :
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.modul ->
@@ -4366,150 +4366,150 @@ let (check_module :
   fun env ->
     fun m ->
       fun b ->
-        (let uu____4951 = FStar_Options.debug_any () in
-         if uu____4951
+        (let uu____4955 = FStar_Options.debug_any () in
+         if uu____4955
          then
-           let uu____4952 =
+           let uu____4956 =
              FStar_Syntax_Print.lid_to_string m.FStar_Syntax_Syntax.name in
            FStar_Util.print2 "Checking %s: %s\n"
              (if m.FStar_Syntax_Syntax.is_interface
               then "i'face"
-              else "module") uu____4952
+              else "module") uu____4956
          else ());
-        (let uu____4956 =
-           let uu____4957 =
+        (let uu____4960 =
+           let uu____4961 =
              FStar_Ident.string_of_lid m.FStar_Syntax_Syntax.name in
-           FStar_Options.dump_module uu____4957 in
-         if uu____4956
+           FStar_Options.dump_module uu____4961 in
+         if uu____4960
          then
-           let uu____4958 = FStar_Syntax_Print.modul_to_string m in
-           FStar_Util.print1 "Module before type checking:\n%s\n" uu____4958
+           let uu____4962 = FStar_Syntax_Print.modul_to_string m in
+           FStar_Util.print1 "Module before type checking:\n%s\n" uu____4962
          else ());
         (let env1 =
-           let uu___1041_4961 = env in
-           let uu____4962 =
-             let uu____4963 =
-               let uu____4964 =
+           let uu___1041_4965 = env in
+           let uu____4966 =
+             let uu____4967 =
+               let uu____4968 =
                  FStar_Ident.string_of_lid m.FStar_Syntax_Syntax.name in
-               FStar_Options.should_verify uu____4964 in
-             Prims.op_Negation uu____4963 in
+               FStar_Options.should_verify uu____4968 in
+             Prims.op_Negation uu____4967 in
            {
              FStar_TypeChecker_Env.solver =
-               (uu___1041_4961.FStar_TypeChecker_Env.solver);
+               (uu___1041_4965.FStar_TypeChecker_Env.solver);
              FStar_TypeChecker_Env.range =
-               (uu___1041_4961.FStar_TypeChecker_Env.range);
+               (uu___1041_4965.FStar_TypeChecker_Env.range);
              FStar_TypeChecker_Env.curmodule =
-               (uu___1041_4961.FStar_TypeChecker_Env.curmodule);
+               (uu___1041_4965.FStar_TypeChecker_Env.curmodule);
              FStar_TypeChecker_Env.gamma =
-               (uu___1041_4961.FStar_TypeChecker_Env.gamma);
+               (uu___1041_4965.FStar_TypeChecker_Env.gamma);
              FStar_TypeChecker_Env.gamma_sig =
-               (uu___1041_4961.FStar_TypeChecker_Env.gamma_sig);
+               (uu___1041_4965.FStar_TypeChecker_Env.gamma_sig);
              FStar_TypeChecker_Env.gamma_cache =
-               (uu___1041_4961.FStar_TypeChecker_Env.gamma_cache);
+               (uu___1041_4965.FStar_TypeChecker_Env.gamma_cache);
              FStar_TypeChecker_Env.modules =
-               (uu___1041_4961.FStar_TypeChecker_Env.modules);
+               (uu___1041_4965.FStar_TypeChecker_Env.modules);
              FStar_TypeChecker_Env.expected_typ =
-               (uu___1041_4961.FStar_TypeChecker_Env.expected_typ);
+               (uu___1041_4965.FStar_TypeChecker_Env.expected_typ);
              FStar_TypeChecker_Env.sigtab =
-               (uu___1041_4961.FStar_TypeChecker_Env.sigtab);
+               (uu___1041_4965.FStar_TypeChecker_Env.sigtab);
              FStar_TypeChecker_Env.attrtab =
-               (uu___1041_4961.FStar_TypeChecker_Env.attrtab);
+               (uu___1041_4965.FStar_TypeChecker_Env.attrtab);
              FStar_TypeChecker_Env.instantiate_imp =
-               (uu___1041_4961.FStar_TypeChecker_Env.instantiate_imp);
+               (uu___1041_4965.FStar_TypeChecker_Env.instantiate_imp);
              FStar_TypeChecker_Env.effects =
-               (uu___1041_4961.FStar_TypeChecker_Env.effects);
+               (uu___1041_4965.FStar_TypeChecker_Env.effects);
              FStar_TypeChecker_Env.generalize =
-               (uu___1041_4961.FStar_TypeChecker_Env.generalize);
+               (uu___1041_4965.FStar_TypeChecker_Env.generalize);
              FStar_TypeChecker_Env.letrecs =
-               (uu___1041_4961.FStar_TypeChecker_Env.letrecs);
+               (uu___1041_4965.FStar_TypeChecker_Env.letrecs);
              FStar_TypeChecker_Env.top_level =
-               (uu___1041_4961.FStar_TypeChecker_Env.top_level);
+               (uu___1041_4965.FStar_TypeChecker_Env.top_level);
              FStar_TypeChecker_Env.check_uvars =
-               (uu___1041_4961.FStar_TypeChecker_Env.check_uvars);
+               (uu___1041_4965.FStar_TypeChecker_Env.check_uvars);
              FStar_TypeChecker_Env.use_eq =
-               (uu___1041_4961.FStar_TypeChecker_Env.use_eq);
+               (uu___1041_4965.FStar_TypeChecker_Env.use_eq);
              FStar_TypeChecker_Env.use_eq_strict =
-               (uu___1041_4961.FStar_TypeChecker_Env.use_eq_strict);
+               (uu___1041_4965.FStar_TypeChecker_Env.use_eq_strict);
              FStar_TypeChecker_Env.is_iface =
-               (uu___1041_4961.FStar_TypeChecker_Env.is_iface);
+               (uu___1041_4965.FStar_TypeChecker_Env.is_iface);
              FStar_TypeChecker_Env.admit =
-               (uu___1041_4961.FStar_TypeChecker_Env.admit);
-             FStar_TypeChecker_Env.lax = uu____4962;
+               (uu___1041_4965.FStar_TypeChecker_Env.admit);
+             FStar_TypeChecker_Env.lax = uu____4966;
              FStar_TypeChecker_Env.lax_universes =
-               (uu___1041_4961.FStar_TypeChecker_Env.lax_universes);
+               (uu___1041_4965.FStar_TypeChecker_Env.lax_universes);
              FStar_TypeChecker_Env.phase1 =
-               (uu___1041_4961.FStar_TypeChecker_Env.phase1);
+               (uu___1041_4965.FStar_TypeChecker_Env.phase1);
              FStar_TypeChecker_Env.failhard =
-               (uu___1041_4961.FStar_TypeChecker_Env.failhard);
+               (uu___1041_4965.FStar_TypeChecker_Env.failhard);
              FStar_TypeChecker_Env.nosynth =
-               (uu___1041_4961.FStar_TypeChecker_Env.nosynth);
+               (uu___1041_4965.FStar_TypeChecker_Env.nosynth);
              FStar_TypeChecker_Env.uvar_subtyping =
-               (uu___1041_4961.FStar_TypeChecker_Env.uvar_subtyping);
+               (uu___1041_4965.FStar_TypeChecker_Env.uvar_subtyping);
              FStar_TypeChecker_Env.tc_term =
-               (uu___1041_4961.FStar_TypeChecker_Env.tc_term);
+               (uu___1041_4965.FStar_TypeChecker_Env.tc_term);
              FStar_TypeChecker_Env.type_of =
-               (uu___1041_4961.FStar_TypeChecker_Env.type_of);
+               (uu___1041_4965.FStar_TypeChecker_Env.type_of);
              FStar_TypeChecker_Env.universe_of =
-               (uu___1041_4961.FStar_TypeChecker_Env.universe_of);
+               (uu___1041_4965.FStar_TypeChecker_Env.universe_of);
              FStar_TypeChecker_Env.check_type_of =
-               (uu___1041_4961.FStar_TypeChecker_Env.check_type_of);
+               (uu___1041_4965.FStar_TypeChecker_Env.check_type_of);
              FStar_TypeChecker_Env.use_bv_sorts =
-               (uu___1041_4961.FStar_TypeChecker_Env.use_bv_sorts);
+               (uu___1041_4965.FStar_TypeChecker_Env.use_bv_sorts);
              FStar_TypeChecker_Env.qtbl_name_and_index =
-               (uu___1041_4961.FStar_TypeChecker_Env.qtbl_name_and_index);
+               (uu___1041_4965.FStar_TypeChecker_Env.qtbl_name_and_index);
              FStar_TypeChecker_Env.normalized_eff_names =
-               (uu___1041_4961.FStar_TypeChecker_Env.normalized_eff_names);
+               (uu___1041_4965.FStar_TypeChecker_Env.normalized_eff_names);
              FStar_TypeChecker_Env.fv_delta_depths =
-               (uu___1041_4961.FStar_TypeChecker_Env.fv_delta_depths);
+               (uu___1041_4965.FStar_TypeChecker_Env.fv_delta_depths);
              FStar_TypeChecker_Env.proof_ns =
-               (uu___1041_4961.FStar_TypeChecker_Env.proof_ns);
+               (uu___1041_4965.FStar_TypeChecker_Env.proof_ns);
              FStar_TypeChecker_Env.synth_hook =
-               (uu___1041_4961.FStar_TypeChecker_Env.synth_hook);
+               (uu___1041_4965.FStar_TypeChecker_Env.synth_hook);
              FStar_TypeChecker_Env.try_solve_implicits_hook =
-               (uu___1041_4961.FStar_TypeChecker_Env.try_solve_implicits_hook);
+               (uu___1041_4965.FStar_TypeChecker_Env.try_solve_implicits_hook);
              FStar_TypeChecker_Env.splice =
-               (uu___1041_4961.FStar_TypeChecker_Env.splice);
+               (uu___1041_4965.FStar_TypeChecker_Env.splice);
              FStar_TypeChecker_Env.mpreprocess =
-               (uu___1041_4961.FStar_TypeChecker_Env.mpreprocess);
+               (uu___1041_4965.FStar_TypeChecker_Env.mpreprocess);
              FStar_TypeChecker_Env.postprocess =
-               (uu___1041_4961.FStar_TypeChecker_Env.postprocess);
+               (uu___1041_4965.FStar_TypeChecker_Env.postprocess);
              FStar_TypeChecker_Env.identifier_info =
-               (uu___1041_4961.FStar_TypeChecker_Env.identifier_info);
+               (uu___1041_4965.FStar_TypeChecker_Env.identifier_info);
              FStar_TypeChecker_Env.tc_hooks =
-               (uu___1041_4961.FStar_TypeChecker_Env.tc_hooks);
+               (uu___1041_4965.FStar_TypeChecker_Env.tc_hooks);
              FStar_TypeChecker_Env.dsenv =
-               (uu___1041_4961.FStar_TypeChecker_Env.dsenv);
+               (uu___1041_4965.FStar_TypeChecker_Env.dsenv);
              FStar_TypeChecker_Env.nbe =
-               (uu___1041_4961.FStar_TypeChecker_Env.nbe);
+               (uu___1041_4965.FStar_TypeChecker_Env.nbe);
              FStar_TypeChecker_Env.strict_args_tab =
-               (uu___1041_4961.FStar_TypeChecker_Env.strict_args_tab);
+               (uu___1041_4965.FStar_TypeChecker_Env.strict_args_tab);
              FStar_TypeChecker_Env.erasable_types_tab =
-               (uu___1041_4961.FStar_TypeChecker_Env.erasable_types_tab);
+               (uu___1041_4965.FStar_TypeChecker_Env.erasable_types_tab);
              FStar_TypeChecker_Env.enable_defer_to_tac =
-               (uu___1041_4961.FStar_TypeChecker_Env.enable_defer_to_tac)
+               (uu___1041_4965.FStar_TypeChecker_Env.enable_defer_to_tac)
            } in
-         let uu____4965 = tc_modul env1 m b in
-         match uu____4965 with
+         let uu____4969 = tc_modul env1 m b in
+         match uu____4969 with
          | (m1, env2) ->
-             ((let uu____4977 =
-                 let uu____4978 =
+             ((let uu____4981 =
+                 let uu____4982 =
                    FStar_Ident.string_of_lid m1.FStar_Syntax_Syntax.name in
-                 FStar_Options.dump_module uu____4978 in
-               if uu____4977
+                 FStar_Options.dump_module uu____4982 in
+               if uu____4981
                then
-                 let uu____4979 = FStar_Syntax_Print.modul_to_string m1 in
+                 let uu____4983 = FStar_Syntax_Print.modul_to_string m1 in
                  FStar_Util.print1 "Module after type checking:\n%s\n"
-                   uu____4979
+                   uu____4983
                else ());
-              (let uu____4982 =
-                 (let uu____4985 =
+              (let uu____4986 =
+                 (let uu____4989 =
                     FStar_Ident.string_of_lid m1.FStar_Syntax_Syntax.name in
-                  FStar_Options.dump_module uu____4985) &&
-                   (let uu____4987 =
+                  FStar_Options.dump_module uu____4989) &&
+                   (let uu____4991 =
                       FStar_Ident.string_of_lid m1.FStar_Syntax_Syntax.name in
-                    FStar_Options.debug_at_level uu____4987
+                    FStar_Options.debug_at_level uu____4991
                       (FStar_Options.Other "Normalize")) in
-               if uu____4982
+               if uu____4986
                then
                  let normalize_toplevel_lets se =
                    match se.FStar_Syntax_Syntax.sigel with
@@ -4525,69 +4525,69 @@ let (check_module :
                              FStar_Syntax_Syntax.delta_constant;
                            FStar_TypeChecker_Env.AllowUnboundUniverses] in
                        let update lb =
-                         let uu____5020 =
+                         let uu____5024 =
                            FStar_Syntax_Subst.open_univ_vars
                              lb.FStar_Syntax_Syntax.lbunivs
                              lb.FStar_Syntax_Syntax.lbdef in
-                         match uu____5020 with
+                         match uu____5024 with
                          | (univnames, e) ->
-                             let uu___1063_5027 = lb in
-                             let uu____5028 =
-                               let uu____5031 =
+                             let uu___1063_5031 = lb in
+                             let uu____5032 =
+                               let uu____5035 =
                                  FStar_TypeChecker_Env.push_univ_vars env2
                                    univnames in
-                               n uu____5031 e in
+                               n uu____5035 e in
                              {
                                FStar_Syntax_Syntax.lbname =
-                                 (uu___1063_5027.FStar_Syntax_Syntax.lbname);
+                                 (uu___1063_5031.FStar_Syntax_Syntax.lbname);
                                FStar_Syntax_Syntax.lbunivs =
-                                 (uu___1063_5027.FStar_Syntax_Syntax.lbunivs);
+                                 (uu___1063_5031.FStar_Syntax_Syntax.lbunivs);
                                FStar_Syntax_Syntax.lbtyp =
-                                 (uu___1063_5027.FStar_Syntax_Syntax.lbtyp);
+                                 (uu___1063_5031.FStar_Syntax_Syntax.lbtyp);
                                FStar_Syntax_Syntax.lbeff =
-                                 (uu___1063_5027.FStar_Syntax_Syntax.lbeff);
-                               FStar_Syntax_Syntax.lbdef = uu____5028;
+                                 (uu___1063_5031.FStar_Syntax_Syntax.lbeff);
+                               FStar_Syntax_Syntax.lbdef = uu____5032;
                                FStar_Syntax_Syntax.lbattrs =
-                                 (uu___1063_5027.FStar_Syntax_Syntax.lbattrs);
+                                 (uu___1063_5031.FStar_Syntax_Syntax.lbattrs);
                                FStar_Syntax_Syntax.lbpos =
-                                 (uu___1063_5027.FStar_Syntax_Syntax.lbpos)
+                                 (uu___1063_5031.FStar_Syntax_Syntax.lbpos)
                              } in
-                       let uu___1065_5032 = se in
-                       let uu____5033 =
-                         let uu____5034 =
-                           let uu____5041 =
-                             let uu____5042 = FStar_List.map update lbs in
-                             (b1, uu____5042) in
-                           (uu____5041, ids) in
-                         FStar_Syntax_Syntax.Sig_let uu____5034 in
+                       let uu___1065_5036 = se in
+                       let uu____5037 =
+                         let uu____5038 =
+                           let uu____5045 =
+                             let uu____5046 = FStar_List.map update lbs in
+                             (b1, uu____5046) in
+                           (uu____5045, ids) in
+                         FStar_Syntax_Syntax.Sig_let uu____5038 in
                        {
-                         FStar_Syntax_Syntax.sigel = uu____5033;
+                         FStar_Syntax_Syntax.sigel = uu____5037;
                          FStar_Syntax_Syntax.sigrng =
-                           (uu___1065_5032.FStar_Syntax_Syntax.sigrng);
+                           (uu___1065_5036.FStar_Syntax_Syntax.sigrng);
                          FStar_Syntax_Syntax.sigquals =
-                           (uu___1065_5032.FStar_Syntax_Syntax.sigquals);
+                           (uu___1065_5036.FStar_Syntax_Syntax.sigquals);
                          FStar_Syntax_Syntax.sigmeta =
-                           (uu___1065_5032.FStar_Syntax_Syntax.sigmeta);
+                           (uu___1065_5036.FStar_Syntax_Syntax.sigmeta);
                          FStar_Syntax_Syntax.sigattrs =
-                           (uu___1065_5032.FStar_Syntax_Syntax.sigattrs);
+                           (uu___1065_5036.FStar_Syntax_Syntax.sigattrs);
                          FStar_Syntax_Syntax.sigopts =
-                           (uu___1065_5032.FStar_Syntax_Syntax.sigopts)
+                           (uu___1065_5036.FStar_Syntax_Syntax.sigopts)
                        }
-                   | uu____5049 -> se in
+                   | uu____5053 -> se in
                  let normalized_module =
-                   let uu___1069_5051 = m1 in
-                   let uu____5052 =
+                   let uu___1069_5055 = m1 in
+                   let uu____5056 =
                      FStar_List.map normalize_toplevel_lets
                        m1.FStar_Syntax_Syntax.declarations in
                    {
                      FStar_Syntax_Syntax.name =
-                       (uu___1069_5051.FStar_Syntax_Syntax.name);
-                     FStar_Syntax_Syntax.declarations = uu____5052;
+                       (uu___1069_5055.FStar_Syntax_Syntax.name);
+                     FStar_Syntax_Syntax.declarations = uu____5056;
                      FStar_Syntax_Syntax.is_interface =
-                       (uu___1069_5051.FStar_Syntax_Syntax.is_interface)
+                       (uu___1069_5055.FStar_Syntax_Syntax.is_interface)
                    } in
-                 let uu____5053 =
+                 let uu____5057 =
                    FStar_Syntax_Print.modul_to_string normalized_module in
-                 FStar_Util.print1 "%s\n" uu____5053
+                 FStar_Util.print1 "%s\n" uu____5057
                else ());
               (m1, env2)))

--- a/src/ocaml-output/FStar_TypeChecker_TcEffect.ml
+++ b/src/ocaml-output/FStar_TypeChecker_TcEffect.ml
@@ -755,44 +755,44 @@ let (tc_layered_eff_decl :
                   FStar_All.pipe_right uu____2018 FStar_Util.must in
                 let r =
                   (FStar_Pervasives_Native.snd bind_repr_ts).FStar_Syntax_Syntax.pos in
-                let uu____2046 =
+                let uu____2030 =
                   check_and_gen1 "bind_repr" (Prims.of_int (2)) bind_repr_ts in
-                match uu____2046 with
+                match uu____2030 with
                 | (bind_us, bind_t, bind_ty) ->
-                    let uu____2068 =
+                    let uu____2052 =
                       FStar_Syntax_Subst.open_univ_vars bind_us bind_ty in
-                    (match uu____2068 with
+                    (match uu____2052 with
                      | (us, ty) ->
                          let env =
                            FStar_TypeChecker_Env.push_univ_vars env0 us in
                          (check_no_subtyping_for_layered_combinator env ty
                             FStar_Pervasives_Native.None;
-                          (let uu____2089 = fresh_a_and_u_a "a" in
-                           match uu____2089 with
+                          (let uu____2073 = fresh_a_and_u_a "a" in
+                           match uu____2073 with
                            | (a, u_a) ->
-                               let uu____2108 = fresh_a_and_u_a "b" in
-                               (match uu____2108 with
+                               let uu____2092 = fresh_a_and_u_a "b" in
+                               (match uu____2092 with
                                 | (b, u_b) ->
                                     let rest_bs =
-                                      let uu____2136 =
-                                        let uu____2137 =
+                                      let uu____2120 =
+                                        let uu____2121 =
                                           FStar_Syntax_Subst.compress ty in
-                                        uu____2137.FStar_Syntax_Syntax.n in
-                                      match uu____2136 with
+                                        uu____2121.FStar_Syntax_Syntax.n in
+                                      match uu____2120 with
                                       | FStar_Syntax_Syntax.Tm_arrow
-                                          (bs, uu____2149) when
+                                          (bs, uu____2133) when
                                           (FStar_List.length bs) >=
                                             (Prims.of_int (4))
                                           ->
-                                          let uu____2176 =
+                                          let uu____2160 =
                                             FStar_Syntax_Subst.open_binders
                                               bs in
-                                          (match uu____2176 with
-                                           | (a', uu____2186)::(b',
-                                                                uu____2188)::bs1
+                                          (match uu____2160 with
+                                           | (a', uu____2170)::(b',
+                                                                uu____2172)::bs1
                                                ->
-                                               let uu____2218 =
-                                                 let uu____2219 =
+                                               let uu____2202 =
+                                                 let uu____2203 =
                                                    FStar_All.pipe_right bs1
                                                      (FStar_List.splitAt
                                                         ((FStar_List.length
@@ -800,153 +800,153 @@ let (tc_layered_eff_decl :
                                                            -
                                                            (Prims.of_int (2)))) in
                                                  FStar_All.pipe_right
-                                                   uu____2219
+                                                   uu____2203
                                                    FStar_Pervasives_Native.fst in
-                                               let uu____2284 =
-                                                 let uu____2297 =
-                                                   let uu____2300 =
-                                                     let uu____2301 =
-                                                       let uu____2308 =
+                                               let uu____2300 =
+                                                 let uu____2313 =
+                                                   let uu____2316 =
+                                                     let uu____2317 =
+                                                       let uu____2324 =
                                                          FStar_Syntax_Syntax.bv_to_name
                                                            (FStar_Pervasives_Native.fst
                                                               a) in
-                                                       (a', uu____2308) in
+                                                       (a', uu____2324) in
                                                      FStar_Syntax_Syntax.NT
-                                                       uu____2301 in
-                                                   let uu____2315 =
-                                                     let uu____2318 =
-                                                       let uu____2319 =
-                                                         let uu____2326 =
+                                                       uu____2317 in
+                                                   let uu____2331 =
+                                                     let uu____2334 =
+                                                       let uu____2335 =
+                                                         let uu____2342 =
                                                            FStar_Syntax_Syntax.bv_to_name
                                                              (FStar_Pervasives_Native.fst
                                                                 b) in
-                                                         (b', uu____2326) in
+                                                         (b', uu____2342) in
                                                        FStar_Syntax_Syntax.NT
-                                                         uu____2319 in
-                                                     [uu____2318] in
-                                                   uu____2300 :: uu____2315 in
+                                                         uu____2335 in
+                                                     [uu____2334] in
+                                                   uu____2316 :: uu____2331 in
                                                  FStar_Syntax_Subst.subst_binders
-                                                   uu____2297 in
+                                                   uu____2313 in
                                                FStar_All.pipe_right
-                                                 uu____2218 uu____2284)
-                                      | uu____2341 ->
+                                                 uu____2202 uu____2300)
+                                      | uu____2357 ->
                                           not_an_arrow_error "bind"
                                             (Prims.of_int (4)) ty r in
                                     let bs = a :: b :: rest_bs in
-                                    let uu____2363 =
-                                      let uu____2374 =
-                                        let uu____2379 =
+                                    let uu____2379 =
+                                      let uu____2390 =
+                                        let uu____2395 =
                                           FStar_TypeChecker_Env.push_binders
                                             env bs in
-                                        let uu____2380 =
+                                        let uu____2396 =
                                           FStar_All.pipe_right
                                             (FStar_Pervasives_Native.fst a)
                                             FStar_Syntax_Syntax.bv_to_name in
-                                        fresh_repr r uu____2379 u_a
-                                          uu____2380 in
-                                      match uu____2374 with
+                                        fresh_repr r uu____2395 u_a
+                                          uu____2396 in
+                                      match uu____2390 with
                                       | (repr1, g) ->
-                                          let uu____2395 =
-                                            let uu____2402 =
+                                          let uu____2411 =
+                                            let uu____2418 =
                                               FStar_Syntax_Syntax.gen_bv "f"
                                                 FStar_Pervasives_Native.None
                                                 repr1 in
-                                            FStar_All.pipe_right uu____2402
+                                            FStar_All.pipe_right uu____2418
                                               FStar_Syntax_Syntax.mk_binder in
-                                          (uu____2395, g) in
-                                    (match uu____2363 with
+                                          (uu____2411, g) in
+                                    (match uu____2379 with
                                      | (f, guard_f) ->
-                                         let uu____2441 =
+                                         let uu____2457 =
                                            let x_a = fresh_x_a "x" a in
-                                           let uu____2453 =
-                                             let uu____2458 =
+                                           let uu____2469 =
+                                             let uu____2474 =
                                                FStar_TypeChecker_Env.push_binders
                                                  env
                                                  (FStar_List.append bs [x_a]) in
-                                             let uu____2477 =
+                                             let uu____2493 =
                                                FStar_All.pipe_right
                                                  (FStar_Pervasives_Native.fst
                                                     b)
                                                  FStar_Syntax_Syntax.bv_to_name in
-                                             fresh_repr r uu____2458 u_b
-                                               uu____2477 in
-                                           match uu____2453 with
+                                             fresh_repr r uu____2474 u_b
+                                               uu____2493 in
+                                           match uu____2469 with
                                            | (repr1, g) ->
-                                               let uu____2492 =
-                                                 let uu____2499 =
-                                                   let uu____2500 =
-                                                     let uu____2501 =
-                                                       let uu____2504 =
-                                                         let uu____2507 =
+                                               let uu____2508 =
+                                                 let uu____2515 =
+                                                   let uu____2516 =
+                                                     let uu____2517 =
+                                                       let uu____2520 =
+                                                         let uu____2523 =
                                                            FStar_TypeChecker_Env.new_u_univ
                                                              () in
                                                          FStar_Pervasives_Native.Some
-                                                           uu____2507 in
+                                                           uu____2523 in
                                                        FStar_Syntax_Syntax.mk_Total'
-                                                         repr1 uu____2504 in
+                                                         repr1 uu____2520 in
                                                      FStar_Syntax_Util.arrow
-                                                       [x_a] uu____2501 in
+                                                       [x_a] uu____2517 in
                                                    FStar_Syntax_Syntax.gen_bv
                                                      "g"
                                                      FStar_Pervasives_Native.None
-                                                     uu____2500 in
+                                                     uu____2516 in
                                                  FStar_All.pipe_right
-                                                   uu____2499
+                                                   uu____2515
                                                    FStar_Syntax_Syntax.mk_binder in
-                                               (uu____2492, g) in
-                                         (match uu____2441 with
+                                               (uu____2508, g) in
+                                         (match uu____2457 with
                                           | (g, guard_g) ->
-                                              let uu____2558 =
-                                                let uu____2563 =
+                                              let uu____2574 =
+                                                let uu____2579 =
                                                   FStar_TypeChecker_Env.push_binders
                                                     env bs in
-                                                let uu____2564 =
+                                                let uu____2580 =
                                                   FStar_All.pipe_right
                                                     (FStar_Pervasives_Native.fst
                                                        b)
                                                     FStar_Syntax_Syntax.bv_to_name in
-                                                fresh_repr r uu____2563 u_b
-                                                  uu____2564 in
-                                              (match uu____2558 with
+                                                fresh_repr r uu____2579 u_b
+                                                  uu____2580 in
+                                              (match uu____2574 with
                                                | (repr1, guard_repr) ->
-                                                   let uu____2581 =
-                                                     let uu____2586 =
+                                                   let uu____2597 =
+                                                     let uu____2602 =
                                                        FStar_TypeChecker_Env.push_binders
                                                          env bs in
-                                                     let uu____2587 =
-                                                       let uu____2588 =
+                                                     let uu____2603 =
+                                                       let uu____2604 =
                                                          FStar_Ident.string_of_lid
                                                            ed.FStar_Syntax_Syntax.mname in
                                                        FStar_Util.format1
                                                          "implicit for pure_wp in checking bind for %s"
-                                                         uu____2588 in
-                                                     pure_wp_uvar uu____2586
-                                                       repr1 uu____2587 r in
-                                                   (match uu____2581 with
+                                                         uu____2604 in
+                                                     pure_wp_uvar uu____2602
+                                                       repr1 uu____2603 r in
+                                                   (match uu____2597 with
                                                     | (pure_wp_uvar1,
                                                        g_pure_wp_uvar) ->
                                                         let k =
-                                                          let uu____2606 =
-                                                            let uu____2609 =
-                                                              let uu____2610
+                                                          let uu____2622 =
+                                                            let uu____2625 =
+                                                              let uu____2626
                                                                 =
-                                                                let uu____2611
+                                                                let uu____2627
                                                                   =
                                                                   FStar_TypeChecker_Env.new_u_univ
                                                                     () in
-                                                                [uu____2611] in
-                                                              let uu____2612
+                                                                [uu____2627] in
+                                                              let uu____2628
                                                                 =
-                                                                let uu____2623
+                                                                let uu____2639
                                                                   =
                                                                   FStar_All.pipe_right
                                                                     pure_wp_uvar1
                                                                     FStar_Syntax_Syntax.as_arg in
-                                                                [uu____2623] in
+                                                                [uu____2639] in
                                                               {
                                                                 FStar_Syntax_Syntax.comp_univs
                                                                   =
-                                                                  uu____2610;
+                                                                  uu____2626;
                                                                 FStar_Syntax_Syntax.effect_name
                                                                   =
                                                                   FStar_Parser_Const.effect_PURE_lid;
@@ -954,16 +954,16 @@ let (tc_layered_eff_decl :
                                                                   = repr1;
                                                                 FStar_Syntax_Syntax.effect_args
                                                                   =
-                                                                  uu____2612;
+                                                                  uu____2628;
                                                                 FStar_Syntax_Syntax.flags
                                                                   = []
                                                               } in
                                                             FStar_Syntax_Syntax.mk_Comp
-                                                              uu____2609 in
+                                                              uu____2625 in
                                                           FStar_Syntax_Util.arrow
                                                             (FStar_List.append
                                                                bs [f; g])
-                                                            uu____2606 in
+                                                            uu____2622 in
                                                         let guard_eq =
                                                           FStar_TypeChecker_Rel.teq
                                                             env ty k in
@@ -980,20 +980,20 @@ let (tc_layered_eff_decl :
                                                               k
                                                               (FStar_TypeChecker_Normalize.remove_uvar_solutions
                                                                  env) in
-                                                          (let uu____2684 =
-                                                             let uu____2685 =
+                                                          (let uu____2700 =
+                                                             let uu____2701 =
                                                                FStar_Syntax_Subst.compress
                                                                  k1 in
-                                                             uu____2685.FStar_Syntax_Syntax.n in
-                                                           match uu____2684
+                                                             uu____2701.FStar_Syntax_Syntax.n in
+                                                           match uu____2700
                                                            with
                                                            | FStar_Syntax_Syntax.Tm_arrow
                                                                (bs1, c) ->
-                                                               let uu____2710
+                                                               let uu____2726
                                                                  =
                                                                  FStar_Syntax_Subst.open_comp
                                                                    bs1 c in
-                                                               (match uu____2710
+                                                               (match uu____2726
                                                                 with
                                                                 | (a1::b1::bs2,
                                                                    c1) ->
@@ -1001,9 +1001,9 @@ let (tc_layered_eff_decl :
                                                                     =
                                                                     FStar_Syntax_Util.comp_result
                                                                     c1 in
-                                                                    let uu____2754
+                                                                    let uu____2770
                                                                     =
-                                                                    let uu____2781
+                                                                    let uu____2797
                                                                     =
                                                                     FStar_List.splitAt
                                                                     ((FStar_List.length
@@ -1011,34 +1011,34 @@ let (tc_layered_eff_decl :
                                                                     (Prims.of_int (2)))
                                                                     bs2 in
                                                                     FStar_All.pipe_right
-                                                                    uu____2781
+                                                                    uu____2797
                                                                     (fun
-                                                                    uu____2865
+                                                                    uu____2881
                                                                     ->
-                                                                    match uu____2865
+                                                                    match uu____2881
                                                                     with
                                                                     | 
                                                                     (l1, l2)
                                                                     ->
-                                                                    let uu____2946
+                                                                    let uu____2962
                                                                     =
                                                                     FStar_All.pipe_right
                                                                     l2
                                                                     FStar_List.hd in
-                                                                    let uu____2973
+                                                                    let uu____2989
                                                                     =
-                                                                    let uu____2980
+                                                                    let uu____2996
                                                                     =
                                                                     FStar_All.pipe_right
                                                                     l2
                                                                     FStar_List.tl in
                                                                     FStar_All.pipe_right
-                                                                    uu____2980
+                                                                    uu____2996
                                                                     FStar_List.hd in
                                                                     (l1,
-                                                                    uu____2946,
-                                                                    uu____2973)) in
-                                                                    (match uu____2754
+                                                                    uu____2962,
+                                                                    uu____2989)) in
+                                                                    (match uu____2770
                                                                     with
                                                                     | 
                                                                     (bs3,
@@ -1046,19 +1046,19 @@ let (tc_layered_eff_decl :
                                                                     ->
                                                                     let g_sort
                                                                     =
-                                                                    let uu____3095
+                                                                    let uu____3111
                                                                     =
-                                                                    let uu____3096
+                                                                    let uu____3112
                                                                     =
                                                                     FStar_Syntax_Subst.compress
                                                                     (FStar_Pervasives_Native.fst
                                                                     g_b).FStar_Syntax_Syntax.sort in
-                                                                    uu____3096.FStar_Syntax_Syntax.n in
-                                                                    match uu____3095
+                                                                    uu____3112.FStar_Syntax_Syntax.n in
+                                                                    match uu____3111
                                                                     with
                                                                     | 
                                                                     FStar_Syntax_Syntax.Tm_arrow
-                                                                    (uu____3101,
+                                                                    (uu____3117,
                                                                     c2) ->
                                                                     FStar_Syntax_Util.comp_result
                                                                     c2 in
@@ -1076,264 +1076,264 @@ let (tc_layered_eff_decl :
                                                                     res_t]
                                                                     check_non_informative_binders
                                                                     r)));
-                                                          (let uu____3144 =
+                                                          (let uu____3160 =
                                                              FStar_All.pipe_right
                                                                k1
                                                                (FStar_Syntax_Subst.close_univ_vars
                                                                   bind_us) in
                                                            (bind_us, bind_t,
-                                                             uu____3144)))))))))))) in
+                                                             uu____3160)))))))))))) in
               log_combinator "bind_repr" bind_repr;
               (let stronger_repr =
                  let stronger_repr =
                    let ts =
-                     let uu____3179 =
+                     let uu____3195 =
                        FStar_All.pipe_right ed
                          FStar_Syntax_Util.get_stronger_repr in
-                     FStar_All.pipe_right uu____3179 FStar_Util.must in
-                   let uu____3190 =
-                     let uu____3191 =
-                       let uu____3194 =
+                     FStar_All.pipe_right uu____3195 FStar_Util.must in
+                   let uu____3222 =
+                     let uu____3223 =
+                       let uu____3226 =
                          FStar_All.pipe_right ts FStar_Pervasives_Native.snd in
-                       FStar_All.pipe_right uu____3194
+                       FStar_All.pipe_right uu____3226
                          FStar_Syntax_Subst.compress in
-                     uu____3191.FStar_Syntax_Syntax.n in
-                   match uu____3190 with
+                     uu____3223.FStar_Syntax_Syntax.n in
+                   match uu____3222 with
                    | FStar_Syntax_Syntax.Tm_unknown ->
                        let signature_ts =
-                         let uu____3206 = signature in
-                         match uu____3206 with
-                         | (us, t, uu____3221) -> (us, t) in
-                       let uu____3238 =
+                         let uu____3238 = signature in
+                         match uu____3238 with
+                         | (us, t, uu____3253) -> (us, t) in
+                       let uu____3270 =
                          FStar_TypeChecker_Env.inst_tscheme_with signature_ts
                            [FStar_Syntax_Syntax.U_unknown] in
-                       (match uu____3238 with
-                        | (uu____3247, signature_t) ->
-                            let uu____3249 =
-                              let uu____3250 =
+                       (match uu____3270 with
+                        | (uu____3279, signature_t) ->
+                            let uu____3281 =
+                              let uu____3282 =
                                 FStar_Syntax_Subst.compress signature_t in
-                              uu____3250.FStar_Syntax_Syntax.n in
-                            (match uu____3249 with
-                             | FStar_Syntax_Syntax.Tm_arrow (bs, uu____3258)
+                              uu____3282.FStar_Syntax_Syntax.n in
+                            (match uu____3281 with
+                             | FStar_Syntax_Syntax.Tm_arrow (bs, uu____3290)
                                  ->
                                  let bs1 = FStar_Syntax_Subst.open_binders bs in
                                  let repr_t =
                                    let repr_ts =
-                                     let uu____3284 = repr in
-                                     match uu____3284 with
-                                     | (us, t, uu____3299) -> (us, t) in
-                                   let uu____3316 =
+                                     let uu____3316 = repr in
+                                     match uu____3316 with
+                                     | (us, t, uu____3331) -> (us, t) in
+                                   let uu____3348 =
                                      FStar_TypeChecker_Env.inst_tscheme_with
                                        repr_ts
                                        [FStar_Syntax_Syntax.U_unknown] in
-                                   FStar_All.pipe_right uu____3316
+                                   FStar_All.pipe_right uu____3348
                                      FStar_Pervasives_Native.snd in
                                  let repr_t_applied =
-                                   let uu____3330 =
-                                     let uu____3331 =
-                                       let uu____3348 =
-                                         let uu____3359 =
-                                           let uu____3362 =
+                                   let uu____3368 =
+                                     let uu____3369 =
+                                       let uu____3386 =
+                                         let uu____3397 =
+                                           let uu____3400 =
                                              FStar_All.pipe_right bs1
                                                (FStar_List.map
                                                   FStar_Pervasives_Native.fst) in
-                                           FStar_All.pipe_right uu____3362
+                                           FStar_All.pipe_right uu____3400
                                              (FStar_List.map
                                                 FStar_Syntax_Syntax.bv_to_name) in
-                                         FStar_All.pipe_right uu____3359
+                                         FStar_All.pipe_right uu____3397
                                            (FStar_List.map
                                               FStar_Syntax_Syntax.as_arg) in
-                                       (repr_t, uu____3348) in
-                                     FStar_Syntax_Syntax.Tm_app uu____3331 in
-                                   FStar_Syntax_Syntax.mk uu____3330
+                                       (repr_t, uu____3386) in
+                                     FStar_Syntax_Syntax.Tm_app uu____3369 in
+                                   FStar_Syntax_Syntax.mk uu____3368
                                      FStar_Range.dummyRange in
                                  let f_b =
                                    FStar_Syntax_Syntax.null_binder
                                      repr_t_applied in
-                                 let uu____3412 =
-                                   let uu____3413 =
-                                     let uu____3416 =
+                                 let uu____3450 =
+                                   let uu____3451 =
+                                     let uu____3454 =
                                        FStar_All.pipe_right f_b
                                          FStar_Pervasives_Native.fst in
-                                     FStar_All.pipe_right uu____3416
+                                     FStar_All.pipe_right uu____3454
                                        FStar_Syntax_Syntax.bv_to_name in
                                    FStar_Syntax_Util.abs
-                                     (FStar_List.append bs1 [f_b]) uu____3413
+                                     (FStar_List.append bs1 [f_b]) uu____3451
                                      FStar_Pervasives_Native.None in
-                                 ([], uu____3412)
-                             | uu____3445 -> failwith "Impossible!"))
-                   | uu____3450 -> ts in
+                                 ([], uu____3450)
+                             | uu____3483 -> failwith "Impossible!"))
+                   | uu____3488 -> ts in
                  let r =
                    (FStar_Pervasives_Native.snd stronger_repr).FStar_Syntax_Syntax.pos in
-                 let uu____3452 =
+                 let uu____3490 =
                    check_and_gen1 "stronger_repr" Prims.int_one stronger_repr in
-                 match uu____3452 with
+                 match uu____3490 with
                  | (stronger_us, stronger_t, stronger_ty) ->
-                     ((let uu____3475 =
+                     ((let uu____3513 =
                          FStar_All.pipe_left
                            (FStar_TypeChecker_Env.debug env0)
                            (FStar_Options.Other "LayeredEffectsTc") in
-                       if uu____3475
+                       if uu____3513
                        then
-                         let uu____3476 =
+                         let uu____3514 =
                            FStar_Syntax_Print.tscheme_to_string
                              (stronger_us, stronger_t) in
-                         let uu____3481 =
+                         let uu____3519 =
                            FStar_Syntax_Print.tscheme_to_string
                              (stronger_us, stronger_ty) in
                          FStar_Util.print2
                            "stronger combinator typechecked with term: %s and type: %s\n"
-                           uu____3476 uu____3481
+                           uu____3514 uu____3519
                        else ());
-                      (let uu____3487 =
+                      (let uu____3525 =
                          FStar_Syntax_Subst.open_univ_vars stronger_us
                            stronger_ty in
-                       match uu____3487 with
+                       match uu____3525 with
                        | (us, ty) ->
                            let env =
                              FStar_TypeChecker_Env.push_univ_vars env0 us in
                            (check_no_subtyping_for_layered_combinator env ty
                               FStar_Pervasives_Native.None;
-                            (let uu____3508 = fresh_a_and_u_a "a" in
-                             match uu____3508 with
+                            (let uu____3546 = fresh_a_and_u_a "a" in
+                             match uu____3546 with
                              | (a, u) ->
                                  let rest_bs =
-                                   let uu____3536 =
-                                     let uu____3537 =
+                                   let uu____3574 =
+                                     let uu____3575 =
                                        FStar_Syntax_Subst.compress ty in
-                                     uu____3537.FStar_Syntax_Syntax.n in
-                                   match uu____3536 with
+                                     uu____3575.FStar_Syntax_Syntax.n in
+                                   match uu____3574 with
                                    | FStar_Syntax_Syntax.Tm_arrow
-                                       (bs, uu____3549) when
+                                       (bs, uu____3587) when
                                        (FStar_List.length bs) >=
                                          (Prims.of_int (2))
                                        ->
-                                       let uu____3576 =
+                                       let uu____3614 =
                                          FStar_Syntax_Subst.open_binders bs in
-                                       (match uu____3576 with
-                                        | (a', uu____3586)::bs1 ->
-                                            let uu____3606 =
-                                              let uu____3607 =
+                                       (match uu____3614 with
+                                        | (a', uu____3624)::bs1 ->
+                                            let uu____3644 =
+                                              let uu____3645 =
                                                 FStar_All.pipe_right bs1
                                                   (FStar_List.splitAt
                                                      ((FStar_List.length bs1)
                                                         - Prims.int_one)) in
-                                              FStar_All.pipe_right uu____3607
+                                              FStar_All.pipe_right uu____3645
                                                 FStar_Pervasives_Native.fst in
-                                            let uu____3704 =
-                                              let uu____3717 =
-                                                let uu____3720 =
-                                                  let uu____3721 =
-                                                    let uu____3728 =
+                                            let uu____3742 =
+                                              let uu____3755 =
+                                                let uu____3758 =
+                                                  let uu____3759 =
+                                                    let uu____3766 =
                                                       FStar_Syntax_Syntax.bv_to_name
                                                         (FStar_Pervasives_Native.fst
                                                            a) in
-                                                    (a', uu____3728) in
+                                                    (a', uu____3766) in
                                                   FStar_Syntax_Syntax.NT
-                                                    uu____3721 in
-                                                [uu____3720] in
+                                                    uu____3759 in
+                                                [uu____3758] in
                                               FStar_Syntax_Subst.subst_binders
-                                                uu____3717 in
-                                            FStar_All.pipe_right uu____3606
-                                              uu____3704)
-                                   | uu____3743 ->
+                                                uu____3755 in
+                                            FStar_All.pipe_right uu____3644
+                                              uu____3742)
+                                   | uu____3781 ->
                                        not_an_arrow_error "stronger"
                                          (Prims.of_int (2)) ty r in
                                  let bs = a :: rest_bs in
-                                 let uu____3759 =
-                                   let uu____3770 =
-                                     let uu____3775 =
+                                 let uu____3797 =
+                                   let uu____3808 =
+                                     let uu____3813 =
                                        FStar_TypeChecker_Env.push_binders env
                                          bs in
-                                     let uu____3776 =
+                                     let uu____3814 =
                                        FStar_All.pipe_right
                                          (FStar_Pervasives_Native.fst a)
                                          FStar_Syntax_Syntax.bv_to_name in
-                                     fresh_repr r uu____3775 u uu____3776 in
-                                   match uu____3770 with
+                                     fresh_repr r uu____3813 u uu____3814 in
+                                   match uu____3808 with
                                    | (repr1, g) ->
-                                       let uu____3791 =
-                                         let uu____3798 =
+                                       let uu____3829 =
+                                         let uu____3836 =
                                            FStar_Syntax_Syntax.gen_bv "f"
                                              FStar_Pervasives_Native.None
                                              repr1 in
-                                         FStar_All.pipe_right uu____3798
+                                         FStar_All.pipe_right uu____3836
                                            FStar_Syntax_Syntax.mk_binder in
-                                       (uu____3791, g) in
-                                 (match uu____3759 with
+                                       (uu____3829, g) in
+                                 (match uu____3797 with
                                   | (f, guard_f) ->
-                                      let uu____3837 =
-                                        let uu____3842 =
+                                      let uu____3875 =
+                                        let uu____3880 =
                                           FStar_TypeChecker_Env.push_binders
                                             env bs in
-                                        let uu____3843 =
+                                        let uu____3881 =
                                           FStar_All.pipe_right
                                             (FStar_Pervasives_Native.fst a)
                                             FStar_Syntax_Syntax.bv_to_name in
-                                        fresh_repr r uu____3842 u uu____3843 in
-                                      (match uu____3837 with
+                                        fresh_repr r uu____3880 u uu____3881 in
+                                      (match uu____3875 with
                                        | (ret_t, guard_ret_t) ->
-                                           let uu____3860 =
-                                             let uu____3865 =
+                                           let uu____3898 =
+                                             let uu____3903 =
                                                FStar_TypeChecker_Env.push_binders
                                                  env bs in
-                                             let uu____3866 =
-                                               let uu____3867 =
+                                             let uu____3904 =
+                                               let uu____3905 =
                                                  FStar_Ident.string_of_lid
                                                    ed.FStar_Syntax_Syntax.mname in
                                                FStar_Util.format1
                                                  "implicit for pure_wp in checking stronger for %s"
-                                                 uu____3867 in
-                                             pure_wp_uvar uu____3865 ret_t
-                                               uu____3866 r in
-                                           (match uu____3860 with
+                                                 uu____3905 in
+                                             pure_wp_uvar uu____3903 ret_t
+                                               uu____3904 r in
+                                           (match uu____3898 with
                                             | (pure_wp_uvar1, guard_wp) ->
                                                 let c =
-                                                  let uu____3883 =
-                                                    let uu____3884 =
-                                                      let uu____3885 =
+                                                  let uu____3921 =
+                                                    let uu____3922 =
+                                                      let uu____3923 =
                                                         FStar_TypeChecker_Env.new_u_univ
                                                           () in
-                                                      [uu____3885] in
-                                                    let uu____3886 =
-                                                      let uu____3897 =
+                                                      [uu____3923] in
+                                                    let uu____3924 =
+                                                      let uu____3935 =
                                                         FStar_All.pipe_right
                                                           pure_wp_uvar1
                                                           FStar_Syntax_Syntax.as_arg in
-                                                      [uu____3897] in
+                                                      [uu____3935] in
                                                     {
                                                       FStar_Syntax_Syntax.comp_univs
-                                                        = uu____3884;
+                                                        = uu____3922;
                                                       FStar_Syntax_Syntax.effect_name
                                                         =
                                                         FStar_Parser_Const.effect_PURE_lid;
                                                       FStar_Syntax_Syntax.result_typ
                                                         = ret_t;
                                                       FStar_Syntax_Syntax.effect_args
-                                                        = uu____3886;
+                                                        = uu____3924;
                                                       FStar_Syntax_Syntax.flags
                                                         = []
                                                     } in
                                                   FStar_Syntax_Syntax.mk_Comp
-                                                    uu____3883 in
+                                                    uu____3921 in
                                                 let k =
                                                   FStar_Syntax_Util.arrow
                                                     (FStar_List.append bs [f])
                                                     c in
-                                                ((let uu____3952 =
+                                                ((let uu____3990 =
                                                     FStar_All.pipe_left
                                                       (FStar_TypeChecker_Env.debug
                                                          env)
                                                       (FStar_Options.Other
                                                          "LayeredEffectsTc") in
-                                                  if uu____3952
+                                                  if uu____3990
                                                   then
-                                                    let uu____3953 =
+                                                    let uu____3991 =
                                                       FStar_Syntax_Print.term_to_string
                                                         k in
                                                     FStar_Util.print1
                                                       "Expected type of subcomp before unification: %s\n"
-                                                      uu____3953
+                                                      uu____3991
                                                   else ());
                                                  (let guard_eq =
                                                     FStar_TypeChecker_Rel.teq
@@ -1346,35 +1346,35 @@ let (tc_layered_eff_decl :
                                                     guard_wp;
                                                     guard_eq];
                                                   (let k1 =
-                                                     let uu____3958 =
+                                                     let uu____3996 =
                                                        FStar_All.pipe_right k
                                                          (FStar_TypeChecker_Normalize.remove_uvar_solutions
                                                             env) in
                                                      FStar_All.pipe_right
-                                                       uu____3958
+                                                       uu____3996
                                                        (FStar_TypeChecker_Normalize.normalize
                                                           [FStar_TypeChecker_Env.Beta;
                                                           FStar_TypeChecker_Env.Eager_unfolding]
                                                           env) in
-                                                   (let uu____3960 =
-                                                      let uu____3961 =
+                                                   (let uu____3998 =
+                                                      let uu____3999 =
                                                         FStar_Syntax_Subst.compress
                                                           k1 in
-                                                      uu____3961.FStar_Syntax_Syntax.n in
-                                                    match uu____3960 with
+                                                      uu____3999.FStar_Syntax_Syntax.n in
+                                                    match uu____3998 with
                                                     | FStar_Syntax_Syntax.Tm_arrow
                                                         (bs1, c1) ->
-                                                        let uu____3986 =
+                                                        let uu____4024 =
                                                           FStar_Syntax_Subst.open_comp
                                                             bs1 c1 in
-                                                        (match uu____3986
+                                                        (match uu____4024
                                                          with
                                                          | (a1::bs2, c2) ->
                                                              let res_t =
                                                                FStar_Syntax_Util.comp_result
                                                                  c2 in
-                                                             let uu____4017 =
-                                                               let uu____4036
+                                                             let uu____4055 =
+                                                               let uu____4074
                                                                  =
                                                                  FStar_List.splitAt
                                                                    ((FStar_List.length
@@ -1382,22 +1382,22 @@ let (tc_layered_eff_decl :
                                                                     Prims.int_one)
                                                                    bs2 in
                                                                FStar_All.pipe_right
-                                                                 uu____4036
+                                                                 uu____4074
                                                                  (fun
-                                                                    uu____4111
+                                                                    uu____4149
                                                                     ->
-                                                                    match uu____4111
+                                                                    match uu____4149
                                                                     with
                                                                     | 
                                                                     (l1, l2)
                                                                     ->
-                                                                    let uu____4184
+                                                                    let uu____4222
                                                                     =
                                                                     FStar_List.hd
                                                                     l2 in
                                                                     (l1,
-                                                                    uu____4184)) in
-                                                             (match uu____4017
+                                                                    uu____4222)) in
+                                                             (match uu____4055
                                                               with
                                                               | (bs3, f_b) ->
                                                                   let env1 =
@@ -1412,76 +1412,76 @@ let (tc_layered_eff_decl :
                                                                     res_t]
                                                                     check_non_informative_binders
                                                                     r)));
-                                                   (let uu____4256 =
+                                                   (let uu____4294 =
                                                       FStar_All.pipe_right k1
                                                         (FStar_Syntax_Subst.close_univ_vars
                                                            stronger_us) in
                                                     (stronger_us, stronger_t,
-                                                      uu____4256)))))))))))) in
+                                                      uu____4294)))))))))))) in
                log_combinator "stronger_repr" stronger_repr;
                (let if_then_else =
                   let if_then_else_ts =
                     let ts =
-                      let uu____4291 =
+                      let uu____4329 =
                         FStar_All.pipe_right ed
                           FStar_Syntax_Util.get_layered_if_then_else_combinator in
-                      FStar_All.pipe_right uu____4291 FStar_Util.must in
-                    let uu____4318 =
-                      let uu____4319 =
-                        let uu____4322 =
+                      FStar_All.pipe_right uu____4329 FStar_Util.must in
+                    let uu____4356 =
+                      let uu____4357 =
+                        let uu____4360 =
                           FStar_All.pipe_right ts FStar_Pervasives_Native.snd in
-                        FStar_All.pipe_right uu____4322
+                        FStar_All.pipe_right uu____4360
                           FStar_Syntax_Subst.compress in
-                      uu____4319.FStar_Syntax_Syntax.n in
-                    match uu____4318 with
+                      uu____4357.FStar_Syntax_Syntax.n in
+                    match uu____4356 with
                     | FStar_Syntax_Syntax.Tm_unknown ->
                         let signature_ts =
-                          let uu____4334 = signature in
-                          match uu____4334 with
-                          | (us, t, uu____4349) -> (us, t) in
-                        let uu____4366 =
+                          let uu____4372 = signature in
+                          match uu____4372 with
+                          | (us, t, uu____4387) -> (us, t) in
+                        let uu____4404 =
                           FStar_TypeChecker_Env.inst_tscheme_with
                             signature_ts [FStar_Syntax_Syntax.U_unknown] in
-                        (match uu____4366 with
-                         | (uu____4375, signature_t) ->
-                             let uu____4377 =
-                               let uu____4378 =
+                        (match uu____4404 with
+                         | (uu____4413, signature_t) ->
+                             let uu____4415 =
+                               let uu____4416 =
                                  FStar_Syntax_Subst.compress signature_t in
-                               uu____4378.FStar_Syntax_Syntax.n in
-                             (match uu____4377 with
-                              | FStar_Syntax_Syntax.Tm_arrow (bs, uu____4386)
+                               uu____4416.FStar_Syntax_Syntax.n in
+                             (match uu____4415 with
+                              | FStar_Syntax_Syntax.Tm_arrow (bs, uu____4424)
                                   ->
                                   let bs1 =
                                     FStar_Syntax_Subst.open_binders bs in
                                   let repr_t =
                                     let repr_ts =
-                                      let uu____4412 = repr in
-                                      match uu____4412 with
-                                      | (us, t, uu____4427) -> (us, t) in
-                                    let uu____4444 =
+                                      let uu____4450 = repr in
+                                      match uu____4450 with
+                                      | (us, t, uu____4465) -> (us, t) in
+                                    let uu____4482 =
                                       FStar_TypeChecker_Env.inst_tscheme_with
                                         repr_ts
                                         [FStar_Syntax_Syntax.U_unknown] in
-                                    FStar_All.pipe_right uu____4444
+                                    FStar_All.pipe_right uu____4482
                                       FStar_Pervasives_Native.snd in
                                   let repr_t_applied =
-                                    let uu____4458 =
-                                      let uu____4459 =
-                                        let uu____4476 =
-                                          let uu____4487 =
-                                            let uu____4490 =
+                                    let uu____4496 =
+                                      let uu____4497 =
+                                        let uu____4514 =
+                                          let uu____4525 =
+                                            let uu____4528 =
                                               FStar_All.pipe_right bs1
                                                 (FStar_List.map
                                                    FStar_Pervasives_Native.fst) in
-                                            FStar_All.pipe_right uu____4490
+                                            FStar_All.pipe_right uu____4528
                                               (FStar_List.map
                                                  FStar_Syntax_Syntax.bv_to_name) in
-                                          FStar_All.pipe_right uu____4487
+                                          FStar_All.pipe_right uu____4525
                                             (FStar_List.map
                                                FStar_Syntax_Syntax.as_arg) in
-                                        (repr_t, uu____4476) in
-                                      FStar_Syntax_Syntax.Tm_app uu____4459 in
-                                    FStar_Syntax_Syntax.mk uu____4458
+                                        (repr_t, uu____4514) in
+                                      FStar_Syntax_Syntax.Tm_app uu____4497 in
+                                    FStar_Syntax_Syntax.mk uu____4496
                                       FStar_Range.dummyRange in
                                   let f_b =
                                     FStar_Syntax_Syntax.null_binder
@@ -1492,57 +1492,57 @@ let (tc_layered_eff_decl :
                                   let b_b =
                                     FStar_Syntax_Syntax.null_binder
                                       FStar_Syntax_Util.t_bool in
-                                  let uu____4542 =
+                                  let uu____4580 =
                                     FStar_Syntax_Util.abs
                                       (FStar_List.append bs1 [f_b; g_b; b_b])
                                       repr_t_applied
                                       FStar_Pervasives_Native.None in
-                                  ([], uu____4542)
-                              | uu____4573 -> failwith "Impossible!"))
-                    | uu____4578 -> ts in
+                                  ([], uu____4580)
+                              | uu____4611 -> failwith "Impossible!"))
+                    | uu____4616 -> ts in
                   let r =
                     (FStar_Pervasives_Native.snd if_then_else_ts).FStar_Syntax_Syntax.pos in
-                  let uu____4580 =
+                  let uu____4618 =
                     check_and_gen1 "if_then_else" Prims.int_one
                       if_then_else_ts in
-                  match uu____4580 with
+                  match uu____4618 with
                   | (if_then_else_us, if_then_else_t, if_then_else_ty) ->
-                      let uu____4602 =
+                      let uu____4640 =
                         FStar_Syntax_Subst.open_univ_vars if_then_else_us
                           if_then_else_t in
-                      (match uu____4602 with
+                      (match uu____4640 with
                        | (us, t) ->
-                           let uu____4621 =
+                           let uu____4659 =
                              FStar_Syntax_Subst.open_univ_vars
                                if_then_else_us if_then_else_ty in
-                           (match uu____4621 with
-                            | (uu____4638, ty) ->
+                           (match uu____4659 with
+                            | (uu____4676, ty) ->
                                 let env =
                                   FStar_TypeChecker_Env.push_univ_vars env0
                                     us in
                                 (check_no_subtyping_for_layered_combinator
                                    env t (FStar_Pervasives_Native.Some ty);
-                                 (let uu____4642 = fresh_a_and_u_a "a" in
-                                  match uu____4642 with
+                                 (let uu____4680 = fresh_a_and_u_a "a" in
+                                  match uu____4680 with
                                   | (a, u_a) ->
                                       let rest_bs =
-                                        let uu____4670 =
-                                          let uu____4671 =
+                                        let uu____4708 =
+                                          let uu____4709 =
                                             FStar_Syntax_Subst.compress ty in
-                                          uu____4671.FStar_Syntax_Syntax.n in
-                                        match uu____4670 with
+                                          uu____4709.FStar_Syntax_Syntax.n in
+                                        match uu____4708 with
                                         | FStar_Syntax_Syntax.Tm_arrow
-                                            (bs, uu____4683) when
+                                            (bs, uu____4721) when
                                             (FStar_List.length bs) >=
                                               (Prims.of_int (4))
                                             ->
-                                            let uu____4710 =
+                                            let uu____4748 =
                                               FStar_Syntax_Subst.open_binders
                                                 bs in
-                                            (match uu____4710 with
-                                             | (a', uu____4720)::bs1 ->
-                                                 let uu____4740 =
-                                                   let uu____4741 =
+                                            (match uu____4748 with
+                                             | (a', uu____4758)::bs1 ->
+                                                 let uu____4778 =
+                                                   let uu____4779 =
                                                      FStar_All.pipe_right bs1
                                                        (FStar_List.splitAt
                                                           ((FStar_List.length
@@ -1550,111 +1550,111 @@ let (tc_layered_eff_decl :
                                                              -
                                                              (Prims.of_int (3)))) in
                                                    FStar_All.pipe_right
-                                                     uu____4741
+                                                     uu____4779
                                                      FStar_Pervasives_Native.fst in
-                                                 let uu____4838 =
-                                                   let uu____4851 =
-                                                     let uu____4854 =
-                                                       let uu____4855 =
-                                                         let uu____4862 =
-                                                           let uu____4865 =
+                                                 let uu____4876 =
+                                                   let uu____4889 =
+                                                     let uu____4892 =
+                                                       let uu____4893 =
+                                                         let uu____4900 =
+                                                           let uu____4903 =
                                                              FStar_All.pipe_right
                                                                a
                                                                FStar_Pervasives_Native.fst in
                                                            FStar_All.pipe_right
-                                                             uu____4865
+                                                             uu____4903
                                                              FStar_Syntax_Syntax.bv_to_name in
-                                                         (a', uu____4862) in
+                                                         (a', uu____4900) in
                                                        FStar_Syntax_Syntax.NT
-                                                         uu____4855 in
-                                                     [uu____4854] in
+                                                         uu____4893 in
+                                                     [uu____4892] in
                                                    FStar_Syntax_Subst.subst_binders
-                                                     uu____4851 in
+                                                     uu____4889 in
                                                  FStar_All.pipe_right
-                                                   uu____4740 uu____4838)
-                                        | uu____4886 ->
+                                                   uu____4778 uu____4876)
+                                        | uu____4924 ->
                                             not_an_arrow_error "if_then_else"
                                               (Prims.of_int (4)) ty r in
                                       let bs = a :: rest_bs in
-                                      let uu____4902 =
-                                        let uu____4913 =
-                                          let uu____4918 =
+                                      let uu____4940 =
+                                        let uu____4951 =
+                                          let uu____4956 =
                                             FStar_TypeChecker_Env.push_binders
                                               env bs in
-                                          let uu____4919 =
-                                            let uu____4920 =
+                                          let uu____4957 =
+                                            let uu____4958 =
                                               FStar_All.pipe_right a
                                                 FStar_Pervasives_Native.fst in
-                                            FStar_All.pipe_right uu____4920
+                                            FStar_All.pipe_right uu____4958
                                               FStar_Syntax_Syntax.bv_to_name in
-                                          fresh_repr r uu____4918 u_a
-                                            uu____4919 in
-                                        match uu____4913 with
+                                          fresh_repr r uu____4956 u_a
+                                            uu____4957 in
+                                        match uu____4951 with
                                         | (repr1, g) ->
-                                            let uu____4941 =
-                                              let uu____4948 =
+                                            let uu____4979 =
+                                              let uu____4986 =
                                                 FStar_Syntax_Syntax.gen_bv
                                                   "f"
                                                   FStar_Pervasives_Native.None
                                                   repr1 in
-                                              FStar_All.pipe_right uu____4948
+                                              FStar_All.pipe_right uu____4986
                                                 FStar_Syntax_Syntax.mk_binder in
-                                            (uu____4941, g) in
-                                      (match uu____4902 with
+                                            (uu____4979, g) in
+                                      (match uu____4940 with
                                        | (f_bs, guard_f) ->
-                                           let uu____4987 =
-                                             let uu____4998 =
-                                               let uu____5003 =
+                                           let uu____5025 =
+                                             let uu____5036 =
+                                               let uu____5041 =
                                                  FStar_TypeChecker_Env.push_binders
                                                    env bs in
-                                               let uu____5004 =
-                                                 let uu____5005 =
+                                               let uu____5042 =
+                                                 let uu____5043 =
                                                    FStar_All.pipe_right a
                                                      FStar_Pervasives_Native.fst in
                                                  FStar_All.pipe_right
-                                                   uu____5005
+                                                   uu____5043
                                                    FStar_Syntax_Syntax.bv_to_name in
-                                               fresh_repr r uu____5003 u_a
-                                                 uu____5004 in
-                                             match uu____4998 with
+                                               fresh_repr r uu____5041 u_a
+                                                 uu____5042 in
+                                             match uu____5036 with
                                              | (repr1, g) ->
-                                                 let uu____5026 =
-                                                   let uu____5033 =
+                                                 let uu____5064 =
+                                                   let uu____5071 =
                                                      FStar_Syntax_Syntax.gen_bv
                                                        "g"
                                                        FStar_Pervasives_Native.None
                                                        repr1 in
                                                    FStar_All.pipe_right
-                                                     uu____5033
+                                                     uu____5071
                                                      FStar_Syntax_Syntax.mk_binder in
-                                                 (uu____5026, g) in
-                                           (match uu____4987 with
+                                                 (uu____5064, g) in
+                                           (match uu____5025 with
                                             | (g_bs, guard_g) ->
                                                 let p_b =
-                                                  let uu____5079 =
+                                                  let uu____5117 =
                                                     FStar_Syntax_Syntax.gen_bv
                                                       "p"
                                                       FStar_Pervasives_Native.None
                                                       FStar_Syntax_Util.t_bool in
                                                   FStar_All.pipe_right
-                                                    uu____5079
+                                                    uu____5117
                                                     FStar_Syntax_Syntax.mk_binder in
-                                                let uu____5086 =
-                                                  let uu____5091 =
+                                                let uu____5124 =
+                                                  let uu____5129 =
                                                     FStar_TypeChecker_Env.push_binders
                                                       env
                                                       (FStar_List.append bs
                                                          [p_b]) in
-                                                  let uu____5110 =
-                                                    let uu____5111 =
+                                                  let uu____5148 =
+                                                    let uu____5149 =
                                                       FStar_All.pipe_right a
                                                         FStar_Pervasives_Native.fst in
                                                     FStar_All.pipe_right
-                                                      uu____5111
+                                                      uu____5149
                                                       FStar_Syntax_Syntax.bv_to_name in
-                                                  fresh_repr r uu____5091 u_a
-                                                    uu____5110 in
-                                                (match uu____5086 with
+                                                  fresh_repr r uu____5129 u_a
+                                                    uu____5148 in
+                                                (match uu____5124 with
                                                  | (t_body, guard_body) ->
                                                      let k =
                                                        FStar_Syntax_Util.abs
@@ -1679,26 +1679,26 @@ let (tc_layered_eff_decl :
                                                            k
                                                            (FStar_TypeChecker_Normalize.remove_uvar_solutions
                                                               env) in
-                                                       (let uu____5173 =
-                                                          let uu____5174 =
+                                                       (let uu____5211 =
+                                                          let uu____5212 =
                                                             FStar_Syntax_Subst.compress
                                                               k1 in
-                                                          uu____5174.FStar_Syntax_Syntax.n in
-                                                        match uu____5173 with
+                                                          uu____5212.FStar_Syntax_Syntax.n in
+                                                        match uu____5211 with
                                                         | FStar_Syntax_Syntax.Tm_abs
                                                             (bs1, body,
-                                                             uu____5179)
+                                                             uu____5217)
                                                             ->
-                                                            let uu____5204 =
+                                                            let uu____5242 =
                                                               FStar_Syntax_Subst.open_term
                                                                 bs1 body in
-                                                            (match uu____5204
+                                                            (match uu____5242
                                                              with
                                                              | (a1::bs2,
                                                                 body1) ->
-                                                                 let uu____5232
+                                                                 let uu____5270
                                                                    =
-                                                                   let uu____5259
+                                                                   let uu____5297
                                                                     =
                                                                     FStar_List.splitAt
                                                                     ((FStar_List.length
@@ -1706,34 +1706,34 @@ let (tc_layered_eff_decl :
                                                                     (Prims.of_int (3)))
                                                                     bs2 in
                                                                    FStar_All.pipe_right
-                                                                    uu____5259
+                                                                    uu____5297
                                                                     (fun
-                                                                    uu____5343
+                                                                    uu____5381
                                                                     ->
-                                                                    match uu____5343
+                                                                    match uu____5381
                                                                     with
                                                                     | 
                                                                     (l1, l2)
                                                                     ->
-                                                                    let uu____5424
+                                                                    let uu____5462
                                                                     =
                                                                     FStar_All.pipe_right
                                                                     l2
                                                                     FStar_List.hd in
-                                                                    let uu____5451
+                                                                    let uu____5489
                                                                     =
-                                                                    let uu____5458
+                                                                    let uu____5496
                                                                     =
                                                                     FStar_All.pipe_right
                                                                     l2
                                                                     FStar_List.tl in
                                                                     FStar_All.pipe_right
-                                                                    uu____5458
+                                                                    uu____5496
                                                                     FStar_List.hd in
                                                                     (l1,
-                                                                    uu____5424,
-                                                                    uu____5451)) in
-                                                                 (match uu____5232
+                                                                    uu____5462,
+                                                                    uu____5489)) in
+                                                                 (match uu____5270
                                                                   with
                                                                   | (bs3,
                                                                     f_b, g_b)
@@ -1753,125 +1753,125 @@ let (tc_layered_eff_decl :
                                                                     body1]
                                                                     check_non_informative_binders
                                                                     r)));
-                                                       (let uu____5589 =
+                                                       (let uu____5627 =
                                                           FStar_All.pipe_right
                                                             k1
                                                             (FStar_Syntax_Subst.close_univ_vars
                                                                if_then_else_us) in
                                                         (if_then_else_us,
-                                                          uu____5589,
+                                                          uu____5627,
                                                           if_then_else_ty))))))))))) in
                 log_combinator "if_then_else" if_then_else;
                 (let r =
-                   let uu____5603 =
-                     let uu____5606 =
-                       let uu____5615 =
+                   let uu____5641 =
+                     let uu____5644 =
+                       let uu____5653 =
                          FStar_All.pipe_right ed
                            FStar_Syntax_Util.get_layered_if_then_else_combinator in
-                       FStar_All.pipe_right uu____5615 FStar_Util.must in
-                     FStar_All.pipe_right uu____5606
+                       FStar_All.pipe_right uu____5653 FStar_Util.must in
+                     FStar_All.pipe_right uu____5644
                        FStar_Pervasives_Native.snd in
-                   uu____5603.FStar_Syntax_Syntax.pos in
+                   uu____5641.FStar_Syntax_Syntax.pos in
                  let binder_aq_to_arg_aq aq =
                    match aq with
                    | FStar_Pervasives_Native.Some
-                       (FStar_Syntax_Syntax.Implicit uu____5690) -> aq
+                       (FStar_Syntax_Syntax.Implicit uu____5728) -> aq
                    | FStar_Pervasives_Native.Some (FStar_Syntax_Syntax.Meta
-                       uu____5691) ->
+                       uu____5729) ->
                        FStar_Pervasives_Native.Some
                          (FStar_Syntax_Syntax.Implicit false)
-                   | uu____5692 -> FStar_Pervasives_Native.None in
-                 let uu____5695 = if_then_else in
-                 match uu____5695 with
-                 | (ite_us, ite_t, uu____5710) ->
-                     let uu____5723 =
+                   | uu____5730 -> FStar_Pervasives_Native.None in
+                 let uu____5733 = if_then_else in
+                 match uu____5733 with
+                 | (ite_us, ite_t, uu____5748) ->
+                     let uu____5761 =
                        FStar_Syntax_Subst.open_univ_vars ite_us ite_t in
-                     (match uu____5723 with
+                     (match uu____5761 with
                       | (us, ite_t1) ->
-                          let uu____5730 =
-                            let uu____5747 =
-                              let uu____5748 =
+                          let uu____5768 =
+                            let uu____5785 =
+                              let uu____5786 =
                                 FStar_Syntax_Subst.compress ite_t1 in
-                              uu____5748.FStar_Syntax_Syntax.n in
-                            match uu____5747 with
+                              uu____5786.FStar_Syntax_Syntax.n in
+                            match uu____5785 with
                             | FStar_Syntax_Syntax.Tm_abs
-                                (bs, uu____5768, uu____5769) ->
+                                (bs, uu____5806, uu____5807) ->
                                 let bs1 = FStar_Syntax_Subst.open_binders bs in
-                                let uu____5795 =
-                                  let uu____5808 =
-                                    let uu____5813 =
-                                      let uu____5816 =
-                                        let uu____5825 =
+                                let uu____5833 =
+                                  let uu____5846 =
+                                    let uu____5851 =
+                                      let uu____5854 =
+                                        let uu____5863 =
                                           FStar_All.pipe_right bs1
                                             (FStar_List.splitAt
                                                ((FStar_List.length bs1) -
                                                   (Prims.of_int (3)))) in
-                                        FStar_All.pipe_right uu____5825
+                                        FStar_All.pipe_right uu____5863
                                           FStar_Pervasives_Native.snd in
-                                      FStar_All.pipe_right uu____5816
+                                      FStar_All.pipe_right uu____5854
                                         (FStar_List.map
                                            FStar_Pervasives_Native.fst) in
-                                    FStar_All.pipe_right uu____5813
+                                    FStar_All.pipe_right uu____5851
                                       (FStar_List.map
                                          FStar_Syntax_Syntax.bv_to_name) in
-                                  FStar_All.pipe_right uu____5808
+                                  FStar_All.pipe_right uu____5846
                                     (fun l ->
-                                       let uu____5980 = l in
-                                       match uu____5980 with
+                                       let uu____6018 = l in
+                                       match uu____6018 with
                                        | f::g::p::[] -> (f, g, p)) in
-                                (match uu____5795 with
+                                (match uu____5833 with
                                  | (f, g, p) ->
-                                     let uu____6051 =
-                                       let uu____6052 =
+                                     let uu____6089 =
+                                       let uu____6090 =
                                          FStar_TypeChecker_Env.push_univ_vars
                                            env0 us in
                                        FStar_TypeChecker_Env.push_binders
-                                         uu____6052 bs1 in
-                                     let uu____6053 =
-                                       let uu____6054 =
+                                         uu____6090 bs1 in
+                                     let uu____6091 =
+                                       let uu____6092 =
                                          FStar_All.pipe_right bs1
                                            (FStar_List.map
-                                              (fun uu____6079 ->
-                                                 match uu____6079 with
+                                              (fun uu____6117 ->
+                                                 match uu____6117 with
                                                  | (b, qual) ->
-                                                     let uu____6098 =
+                                                     let uu____6136 =
                                                        FStar_Syntax_Syntax.bv_to_name
                                                          b in
-                                                     (uu____6098,
+                                                     (uu____6136,
                                                        (binder_aq_to_arg_aq
                                                           qual)))) in
                                        FStar_Syntax_Syntax.mk_Tm_app ite_t1
-                                         uu____6054 r in
-                                     (uu____6051, uu____6053, f, g, p))
-                            | uu____6107 ->
+                                         uu____6092 r in
+                                     (uu____6089, uu____6091, f, g, p))
+                            | uu____6145 ->
                                 failwith
                                   "Impossible! ite_t must have been an abstraction with at least 3 binders" in
-                          (match uu____5730 with
+                          (match uu____5768 with
                            | (env, ite_t_applied, f_t, g_t, p_t) ->
-                               let uu____6141 =
-                                 let uu____6150 = stronger_repr in
-                                 match uu____6150 with
-                                 | (uu____6171, subcomp_t, subcomp_ty) ->
-                                     let uu____6186 =
+                               let uu____6179 =
+                                 let uu____6188 = stronger_repr in
+                                 match uu____6188 with
+                                 | (uu____6209, subcomp_t, subcomp_ty) ->
+                                     let uu____6224 =
                                        FStar_Syntax_Subst.open_univ_vars us
                                          subcomp_t in
-                                     (match uu____6186 with
-                                      | (uu____6199, subcomp_t1) ->
-                                          let uu____6201 =
-                                            let uu____6212 =
+                                     (match uu____6224 with
+                                      | (uu____6237, subcomp_t1) ->
+                                          let uu____6239 =
+                                            let uu____6250 =
                                               FStar_Syntax_Subst.open_univ_vars
                                                 us subcomp_ty in
-                                            match uu____6212 with
-                                            | (uu____6227, subcomp_ty1) ->
-                                                let uu____6229 =
-                                                  let uu____6230 =
+                                            match uu____6250 with
+                                            | (uu____6265, subcomp_ty1) ->
+                                                let uu____6267 =
+                                                  let uu____6268 =
                                                     FStar_Syntax_Subst.compress
                                                       subcomp_ty1 in
-                                                  uu____6230.FStar_Syntax_Syntax.n in
-                                                (match uu____6229 with
+                                                  uu____6268.FStar_Syntax_Syntax.n in
+                                                (match uu____6267 with
                                                  | FStar_Syntax_Syntax.Tm_arrow
-                                                     (bs, uu____6244) ->
-                                                     let uu____6265 =
+                                                     (bs, uu____6282) ->
+                                                     let uu____6303 =
                                                        FStar_All.pipe_right
                                                          bs
                                                          (FStar_List.splitAt
@@ -1879,41 +1879,41 @@ let (tc_layered_eff_decl :
                                                                 bs)
                                                                -
                                                                Prims.int_one)) in
-                                                     (match uu____6265 with
+                                                     (match uu____6303 with
                                                       | (bs_except_last,
                                                          last_b) ->
-                                                          let uu____6370 =
+                                                          let uu____6408 =
                                                             FStar_All.pipe_right
                                                               bs_except_last
                                                               (FStar_List.map
                                                                  FStar_Pervasives_Native.snd) in
-                                                          let uu____6397 =
-                                                            let uu____6400 =
+                                                          let uu____6435 =
+                                                            let uu____6438 =
                                                               FStar_All.pipe_right
                                                                 last_b
                                                                 FStar_List.hd in
                                                             FStar_All.pipe_right
-                                                              uu____6400
+                                                              uu____6438
                                                               FStar_Pervasives_Native.snd in
-                                                          (uu____6370,
-                                                            uu____6397))
-                                                 | uu____6443 ->
+                                                          (uu____6408,
+                                                            uu____6435))
+                                                 | uu____6481 ->
                                                      failwith
                                                        "Impossible! subcomp_ty must have been an arrow with at lease 1 binder") in
-                                          (match uu____6201 with
+                                          (match uu____6239 with
                                            | (aqs_except_last, last_aq) ->
-                                               let uu____6476 =
-                                                 let uu____6487 =
+                                               let uu____6514 =
+                                                 let uu____6525 =
                                                    FStar_All.pipe_right
                                                      aqs_except_last
                                                      (FStar_List.map
                                                         binder_aq_to_arg_aq) in
-                                                 let uu____6504 =
+                                                 let uu____6542 =
                                                    FStar_All.pipe_right
                                                      last_aq
                                                      binder_aq_to_arg_aq in
-                                                 (uu____6487, uu____6504) in
-                                               (match uu____6476 with
+                                                 (uu____6525, uu____6542) in
+                                               (match uu____6514 with
                                                 | (aqs_except_last1,
                                                    last_aq1) ->
                                                     let aux t =
@@ -1929,106 +1929,106 @@ let (tc_layered_eff_decl :
                                                         (FStar_List.append
                                                            tun_args
                                                            [(t, last_aq1)]) r in
-                                                    let uu____6616 = aux f_t in
-                                                    let uu____6619 = aux g_t in
-                                                    (uu____6616, uu____6619)))) in
-                               (match uu____6141 with
+                                                    let uu____6654 = aux f_t in
+                                                    let uu____6657 = aux g_t in
+                                                    (uu____6654, uu____6657)))) in
+                               (match uu____6179 with
                                 | (subcomp_f, subcomp_g) ->
-                                    let uu____6636 =
+                                    let uu____6674 =
                                       let aux t =
-                                        let uu____6653 =
-                                          let uu____6654 =
-                                            let uu____6681 =
-                                              let uu____6698 =
-                                                let uu____6707 =
+                                        let uu____6691 =
+                                          let uu____6692 =
+                                            let uu____6719 =
+                                              let uu____6736 =
+                                                let uu____6745 =
                                                   FStar_Syntax_Syntax.mk_Total
                                                     ite_t_applied in
-                                                FStar_Util.Inr uu____6707 in
-                                              (uu____6698,
+                                                FStar_Util.Inr uu____6745 in
+                                              (uu____6736,
                                                 FStar_Pervasives_Native.None) in
-                                            (t, uu____6681,
+                                            (t, uu____6719,
                                               FStar_Pervasives_Native.None) in
                                           FStar_Syntax_Syntax.Tm_ascribed
-                                            uu____6654 in
-                                        FStar_Syntax_Syntax.mk uu____6653 r in
-                                      let uu____6748 = aux subcomp_f in
-                                      let uu____6749 = aux subcomp_g in
-                                      (uu____6748, uu____6749) in
-                                    (match uu____6636 with
+                                            uu____6692 in
+                                        FStar_Syntax_Syntax.mk uu____6691 r in
+                                      let uu____6786 = aux subcomp_f in
+                                      let uu____6787 = aux subcomp_g in
+                                      (uu____6786, uu____6787) in
+                                    (match uu____6674 with
                                      | (tm_subcomp_ascribed_f,
                                         tm_subcomp_ascribed_g) ->
-                                         ((let uu____6753 =
+                                         ((let uu____6791 =
                                              FStar_All.pipe_left
                                                (FStar_TypeChecker_Env.debug
                                                   env)
                                                (FStar_Options.Other
                                                   "LayeredEffectsTc") in
-                                           if uu____6753
+                                           if uu____6791
                                            then
-                                             let uu____6754 =
+                                             let uu____6792 =
                                                FStar_Syntax_Print.term_to_string
                                                  tm_subcomp_ascribed_f in
-                                             let uu____6755 =
+                                             let uu____6793 =
                                                FStar_Syntax_Print.term_to_string
                                                  tm_subcomp_ascribed_g in
                                              FStar_Util.print2
                                                "Checking the soundness of the if_then_else combinators, f: %s, g: %s\n"
-                                               uu____6754 uu____6755
+                                               uu____6792 uu____6793
                                            else ());
                                           (let env1 =
-                                             let uu____6759 =
-                                               let uu____6760 =
-                                                 let uu____6761 =
+                                             let uu____6797 =
+                                               let uu____6798 =
+                                                 let uu____6799 =
                                                    FStar_All.pipe_right p_t
                                                      FStar_Syntax_Util.b2t in
                                                  FStar_Syntax_Util.mk_squash
                                                    FStar_Syntax_Syntax.U_zero
-                                                   uu____6761 in
+                                                   uu____6799 in
                                                FStar_Syntax_Syntax.new_bv
                                                  FStar_Pervasives_Native.None
-                                                 uu____6760 in
+                                                 uu____6798 in
                                              FStar_TypeChecker_Env.push_bv
-                                               env uu____6759 in
-                                           let uu____6764 =
+                                               env uu____6797 in
+                                           let uu____6802 =
                                              FStar_TypeChecker_TcTerm.tc_tot_or_gtot_term
                                                env1 tm_subcomp_ascribed_f in
-                                           match uu____6764 with
-                                           | (uu____6771, uu____6772, g_f) ->
+                                           match uu____6802 with
+                                           | (uu____6809, uu____6810, g_f) ->
                                                FStar_TypeChecker_Rel.force_trivial_guard
                                                  env1 g_f);
                                           (let not_p =
-                                             let uu____6776 =
-                                               let uu____6777 =
+                                             let uu____6814 =
+                                               let uu____6815 =
                                                  FStar_Syntax_Syntax.lid_as_fv
                                                    FStar_Parser_Const.not_lid
                                                    FStar_Syntax_Syntax.delta_constant
                                                    FStar_Pervasives_Native.None in
                                                FStar_All.pipe_right
-                                                 uu____6777
+                                                 uu____6815
                                                  FStar_Syntax_Syntax.fv_to_tm in
-                                             let uu____6778 =
-                                               let uu____6779 =
-                                                 let uu____6788 =
+                                             let uu____6816 =
+                                               let uu____6817 =
+                                                 let uu____6826 =
                                                    FStar_All.pipe_right p_t
                                                      FStar_Syntax_Util.b2t in
                                                  FStar_All.pipe_right
-                                                   uu____6788
+                                                   uu____6826
                                                    FStar_Syntax_Syntax.as_arg in
-                                               [uu____6779] in
+                                               [uu____6817] in
                                              FStar_Syntax_Syntax.mk_Tm_app
-                                               uu____6776 uu____6778 r in
+                                               uu____6814 uu____6816 r in
                                            let env1 =
-                                             let uu____6816 =
+                                             let uu____6854 =
                                                FStar_Syntax_Syntax.new_bv
                                                  FStar_Pervasives_Native.None
                                                  not_p in
                                              FStar_TypeChecker_Env.push_bv
-                                               env uu____6816 in
-                                           let uu____6817 =
+                                               env uu____6854 in
+                                           let uu____6855 =
                                              FStar_TypeChecker_TcTerm.tc_tot_or_gtot_term
                                                env1 tm_subcomp_ascribed_g in
-                                           match uu____6817 with
-                                           | (uu____6824, uu____6825, g_g) ->
+                                           match uu____6855 with
+                                           | (uu____6862, uu____6863, g_g) ->
                                                FStar_TypeChecker_Rel.force_trivial_guard
                                                  env1 g_g)))))));
                 (let tc_action env act =
@@ -2039,334 +2039,334 @@ let (tc_layered_eff_decl :
                      (FStar_List.length act.FStar_Syntax_Syntax.action_params)
                        <> Prims.int_zero
                    then
-                     (let uu____6847 =
-                        let uu____6852 =
-                          let uu____6853 =
+                     (let uu____6885 =
+                        let uu____6890 =
+                          let uu____6891 =
                             FStar_Ident.string_of_lid
                               ed.FStar_Syntax_Syntax.mname in
-                          let uu____6854 =
+                          let uu____6892 =
                             FStar_Ident.string_of_lid
                               act.FStar_Syntax_Syntax.action_name in
-                          let uu____6855 =
+                          let uu____6893 =
                             FStar_Syntax_Print.binders_to_string "; "
                               act.FStar_Syntax_Syntax.action_params in
                           FStar_Util.format3
                             "Action %s:%s has non-empty action params (%s)"
-                            uu____6853 uu____6854 uu____6855 in
+                            uu____6891 uu____6892 uu____6893 in
                         (FStar_Errors.Fatal_MalformedActionDeclaration,
-                          uu____6852) in
-                      FStar_Errors.raise_error uu____6847 r)
+                          uu____6890) in
+                      FStar_Errors.raise_error uu____6885 r)
                    else ();
-                   (let uu____6857 =
-                      let uu____6862 =
+                   (let uu____6895 =
+                      let uu____6900 =
                         FStar_Syntax_Subst.univ_var_opening
                           act.FStar_Syntax_Syntax.action_univs in
-                      match uu____6862 with
+                      match uu____6900 with
                       | (usubst, us) ->
-                          let uu____6885 =
+                          let uu____6923 =
                             FStar_TypeChecker_Env.push_univ_vars env us in
-                          let uu____6886 =
-                            let uu___651_6887 = act in
-                            let uu____6888 =
+                          let uu____6924 =
+                            let uu___651_6925 = act in
+                            let uu____6926 =
                               FStar_Syntax_Subst.subst usubst
                                 act.FStar_Syntax_Syntax.action_defn in
-                            let uu____6889 =
+                            let uu____6927 =
                               FStar_Syntax_Subst.subst usubst
                                 act.FStar_Syntax_Syntax.action_typ in
                             {
                               FStar_Syntax_Syntax.action_name =
-                                (uu___651_6887.FStar_Syntax_Syntax.action_name);
+                                (uu___651_6925.FStar_Syntax_Syntax.action_name);
                               FStar_Syntax_Syntax.action_unqualified_name =
-                                (uu___651_6887.FStar_Syntax_Syntax.action_unqualified_name);
+                                (uu___651_6925.FStar_Syntax_Syntax.action_unqualified_name);
                               FStar_Syntax_Syntax.action_univs = us;
                               FStar_Syntax_Syntax.action_params =
-                                (uu___651_6887.FStar_Syntax_Syntax.action_params);
-                              FStar_Syntax_Syntax.action_defn = uu____6888;
-                              FStar_Syntax_Syntax.action_typ = uu____6889
+                                (uu___651_6925.FStar_Syntax_Syntax.action_params);
+                              FStar_Syntax_Syntax.action_defn = uu____6926;
+                              FStar_Syntax_Syntax.action_typ = uu____6927
                             } in
-                          (uu____6885, uu____6886) in
-                    match uu____6857 with
+                          (uu____6923, uu____6924) in
+                    match uu____6895 with
                     | (env1, act1) ->
                         let act_typ =
-                          let uu____6893 =
-                            let uu____6894 =
+                          let uu____6931 =
+                            let uu____6932 =
                               FStar_Syntax_Subst.compress
                                 act1.FStar_Syntax_Syntax.action_typ in
-                            uu____6894.FStar_Syntax_Syntax.n in
-                          match uu____6893 with
+                            uu____6932.FStar_Syntax_Syntax.n in
+                          match uu____6931 with
                           | FStar_Syntax_Syntax.Tm_arrow (bs, c) ->
                               let ct = FStar_Syntax_Util.comp_to_comp_typ c in
-                              let uu____6920 =
+                              let uu____6958 =
                                 FStar_Ident.lid_equals
                                   ct.FStar_Syntax_Syntax.effect_name
                                   ed.FStar_Syntax_Syntax.mname in
-                              if uu____6920
+                              if uu____6958
                               then
                                 let repr_ts =
-                                  let uu____6922 = repr in
-                                  match uu____6922 with
-                                  | (us, t, uu____6937) -> (us, t) in
+                                  let uu____6960 = repr in
+                                  match uu____6960 with
+                                  | (us, t, uu____6975) -> (us, t) in
                                 let repr1 =
-                                  let uu____6955 =
+                                  let uu____6993 =
                                     FStar_TypeChecker_Env.inst_tscheme_with
                                       repr_ts
                                       ct.FStar_Syntax_Syntax.comp_univs in
-                                  FStar_All.pipe_right uu____6955
+                                  FStar_All.pipe_right uu____6993
                                     FStar_Pervasives_Native.snd in
                                 let repr2 =
-                                  let uu____6965 =
-                                    let uu____6966 =
+                                  let uu____7003 =
+                                    let uu____7004 =
                                       FStar_Syntax_Syntax.as_arg
                                         ct.FStar_Syntax_Syntax.result_typ in
-                                    uu____6966 ::
+                                    uu____7004 ::
                                       (ct.FStar_Syntax_Syntax.effect_args) in
                                   FStar_Syntax_Syntax.mk_Tm_app repr1
-                                    uu____6965 r in
+                                    uu____7003 r in
                                 let c1 =
-                                  let uu____6984 =
-                                    let uu____6987 =
+                                  let uu____7022 =
+                                    let uu____7025 =
                                       FStar_TypeChecker_Env.new_u_univ () in
-                                    FStar_Pervasives_Native.Some uu____6987 in
+                                    FStar_Pervasives_Native.Some uu____7025 in
                                   FStar_Syntax_Syntax.mk_Total' repr2
-                                    uu____6984 in
+                                    uu____7022 in
                                 FStar_Syntax_Util.arrow bs c1
                               else act1.FStar_Syntax_Syntax.action_typ
-                          | uu____6989 -> act1.FStar_Syntax_Syntax.action_typ in
-                        let uu____6990 =
+                          | uu____7027 -> act1.FStar_Syntax_Syntax.action_typ in
+                        let uu____7028 =
                           FStar_TypeChecker_TcTerm.tc_tot_or_gtot_term env1
                             act_typ in
-                        (match uu____6990 with
-                         | (act_typ1, uu____6998, g_t) ->
-                             let uu____7000 =
-                               let uu____7007 =
-                                 let uu___676_7008 =
+                        (match uu____7028 with
+                         | (act_typ1, uu____7036, g_t) ->
+                             let uu____7038 =
+                               let uu____7045 =
+                                 let uu___676_7046 =
                                    FStar_TypeChecker_Env.set_expected_typ
                                      env1 act_typ1 in
                                  {
                                    FStar_TypeChecker_Env.solver =
-                                     (uu___676_7008.FStar_TypeChecker_Env.solver);
+                                     (uu___676_7046.FStar_TypeChecker_Env.solver);
                                    FStar_TypeChecker_Env.range =
-                                     (uu___676_7008.FStar_TypeChecker_Env.range);
+                                     (uu___676_7046.FStar_TypeChecker_Env.range);
                                    FStar_TypeChecker_Env.curmodule =
-                                     (uu___676_7008.FStar_TypeChecker_Env.curmodule);
+                                     (uu___676_7046.FStar_TypeChecker_Env.curmodule);
                                    FStar_TypeChecker_Env.gamma =
-                                     (uu___676_7008.FStar_TypeChecker_Env.gamma);
+                                     (uu___676_7046.FStar_TypeChecker_Env.gamma);
                                    FStar_TypeChecker_Env.gamma_sig =
-                                     (uu___676_7008.FStar_TypeChecker_Env.gamma_sig);
+                                     (uu___676_7046.FStar_TypeChecker_Env.gamma_sig);
                                    FStar_TypeChecker_Env.gamma_cache =
-                                     (uu___676_7008.FStar_TypeChecker_Env.gamma_cache);
+                                     (uu___676_7046.FStar_TypeChecker_Env.gamma_cache);
                                    FStar_TypeChecker_Env.modules =
-                                     (uu___676_7008.FStar_TypeChecker_Env.modules);
+                                     (uu___676_7046.FStar_TypeChecker_Env.modules);
                                    FStar_TypeChecker_Env.expected_typ =
-                                     (uu___676_7008.FStar_TypeChecker_Env.expected_typ);
+                                     (uu___676_7046.FStar_TypeChecker_Env.expected_typ);
                                    FStar_TypeChecker_Env.sigtab =
-                                     (uu___676_7008.FStar_TypeChecker_Env.sigtab);
+                                     (uu___676_7046.FStar_TypeChecker_Env.sigtab);
                                    FStar_TypeChecker_Env.attrtab =
-                                     (uu___676_7008.FStar_TypeChecker_Env.attrtab);
+                                     (uu___676_7046.FStar_TypeChecker_Env.attrtab);
                                    FStar_TypeChecker_Env.instantiate_imp =
                                      false;
                                    FStar_TypeChecker_Env.effects =
-                                     (uu___676_7008.FStar_TypeChecker_Env.effects);
+                                     (uu___676_7046.FStar_TypeChecker_Env.effects);
                                    FStar_TypeChecker_Env.generalize =
-                                     (uu___676_7008.FStar_TypeChecker_Env.generalize);
+                                     (uu___676_7046.FStar_TypeChecker_Env.generalize);
                                    FStar_TypeChecker_Env.letrecs =
-                                     (uu___676_7008.FStar_TypeChecker_Env.letrecs);
+                                     (uu___676_7046.FStar_TypeChecker_Env.letrecs);
                                    FStar_TypeChecker_Env.top_level =
-                                     (uu___676_7008.FStar_TypeChecker_Env.top_level);
+                                     (uu___676_7046.FStar_TypeChecker_Env.top_level);
                                    FStar_TypeChecker_Env.check_uvars =
-                                     (uu___676_7008.FStar_TypeChecker_Env.check_uvars);
+                                     (uu___676_7046.FStar_TypeChecker_Env.check_uvars);
                                    FStar_TypeChecker_Env.use_eq =
-                                     (uu___676_7008.FStar_TypeChecker_Env.use_eq);
+                                     (uu___676_7046.FStar_TypeChecker_Env.use_eq);
                                    FStar_TypeChecker_Env.use_eq_strict =
-                                     (uu___676_7008.FStar_TypeChecker_Env.use_eq_strict);
+                                     (uu___676_7046.FStar_TypeChecker_Env.use_eq_strict);
                                    FStar_TypeChecker_Env.is_iface =
-                                     (uu___676_7008.FStar_TypeChecker_Env.is_iface);
+                                     (uu___676_7046.FStar_TypeChecker_Env.is_iface);
                                    FStar_TypeChecker_Env.admit =
-                                     (uu___676_7008.FStar_TypeChecker_Env.admit);
+                                     (uu___676_7046.FStar_TypeChecker_Env.admit);
                                    FStar_TypeChecker_Env.lax =
-                                     (uu___676_7008.FStar_TypeChecker_Env.lax);
+                                     (uu___676_7046.FStar_TypeChecker_Env.lax);
                                    FStar_TypeChecker_Env.lax_universes =
-                                     (uu___676_7008.FStar_TypeChecker_Env.lax_universes);
+                                     (uu___676_7046.FStar_TypeChecker_Env.lax_universes);
                                    FStar_TypeChecker_Env.phase1 =
-                                     (uu___676_7008.FStar_TypeChecker_Env.phase1);
+                                     (uu___676_7046.FStar_TypeChecker_Env.phase1);
                                    FStar_TypeChecker_Env.failhard =
-                                     (uu___676_7008.FStar_TypeChecker_Env.failhard);
+                                     (uu___676_7046.FStar_TypeChecker_Env.failhard);
                                    FStar_TypeChecker_Env.nosynth =
-                                     (uu___676_7008.FStar_TypeChecker_Env.nosynth);
+                                     (uu___676_7046.FStar_TypeChecker_Env.nosynth);
                                    FStar_TypeChecker_Env.uvar_subtyping =
-                                     (uu___676_7008.FStar_TypeChecker_Env.uvar_subtyping);
+                                     (uu___676_7046.FStar_TypeChecker_Env.uvar_subtyping);
                                    FStar_TypeChecker_Env.tc_term =
-                                     (uu___676_7008.FStar_TypeChecker_Env.tc_term);
+                                     (uu___676_7046.FStar_TypeChecker_Env.tc_term);
                                    FStar_TypeChecker_Env.type_of =
-                                     (uu___676_7008.FStar_TypeChecker_Env.type_of);
+                                     (uu___676_7046.FStar_TypeChecker_Env.type_of);
                                    FStar_TypeChecker_Env.universe_of =
-                                     (uu___676_7008.FStar_TypeChecker_Env.universe_of);
+                                     (uu___676_7046.FStar_TypeChecker_Env.universe_of);
                                    FStar_TypeChecker_Env.check_type_of =
-                                     (uu___676_7008.FStar_TypeChecker_Env.check_type_of);
+                                     (uu___676_7046.FStar_TypeChecker_Env.check_type_of);
                                    FStar_TypeChecker_Env.use_bv_sorts =
-                                     (uu___676_7008.FStar_TypeChecker_Env.use_bv_sorts);
+                                     (uu___676_7046.FStar_TypeChecker_Env.use_bv_sorts);
                                    FStar_TypeChecker_Env.qtbl_name_and_index
                                      =
-                                     (uu___676_7008.FStar_TypeChecker_Env.qtbl_name_and_index);
+                                     (uu___676_7046.FStar_TypeChecker_Env.qtbl_name_and_index);
                                    FStar_TypeChecker_Env.normalized_eff_names
                                      =
-                                     (uu___676_7008.FStar_TypeChecker_Env.normalized_eff_names);
+                                     (uu___676_7046.FStar_TypeChecker_Env.normalized_eff_names);
                                    FStar_TypeChecker_Env.fv_delta_depths =
-                                     (uu___676_7008.FStar_TypeChecker_Env.fv_delta_depths);
+                                     (uu___676_7046.FStar_TypeChecker_Env.fv_delta_depths);
                                    FStar_TypeChecker_Env.proof_ns =
-                                     (uu___676_7008.FStar_TypeChecker_Env.proof_ns);
+                                     (uu___676_7046.FStar_TypeChecker_Env.proof_ns);
                                    FStar_TypeChecker_Env.synth_hook =
-                                     (uu___676_7008.FStar_TypeChecker_Env.synth_hook);
+                                     (uu___676_7046.FStar_TypeChecker_Env.synth_hook);
                                    FStar_TypeChecker_Env.try_solve_implicits_hook
                                      =
-                                     (uu___676_7008.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                                     (uu___676_7046.FStar_TypeChecker_Env.try_solve_implicits_hook);
                                    FStar_TypeChecker_Env.splice =
-                                     (uu___676_7008.FStar_TypeChecker_Env.splice);
+                                     (uu___676_7046.FStar_TypeChecker_Env.splice);
                                    FStar_TypeChecker_Env.mpreprocess =
-                                     (uu___676_7008.FStar_TypeChecker_Env.mpreprocess);
+                                     (uu___676_7046.FStar_TypeChecker_Env.mpreprocess);
                                    FStar_TypeChecker_Env.postprocess =
-                                     (uu___676_7008.FStar_TypeChecker_Env.postprocess);
+                                     (uu___676_7046.FStar_TypeChecker_Env.postprocess);
                                    FStar_TypeChecker_Env.identifier_info =
-                                     (uu___676_7008.FStar_TypeChecker_Env.identifier_info);
+                                     (uu___676_7046.FStar_TypeChecker_Env.identifier_info);
                                    FStar_TypeChecker_Env.tc_hooks =
-                                     (uu___676_7008.FStar_TypeChecker_Env.tc_hooks);
+                                     (uu___676_7046.FStar_TypeChecker_Env.tc_hooks);
                                    FStar_TypeChecker_Env.dsenv =
-                                     (uu___676_7008.FStar_TypeChecker_Env.dsenv);
+                                     (uu___676_7046.FStar_TypeChecker_Env.dsenv);
                                    FStar_TypeChecker_Env.nbe =
-                                     (uu___676_7008.FStar_TypeChecker_Env.nbe);
+                                     (uu___676_7046.FStar_TypeChecker_Env.nbe);
                                    FStar_TypeChecker_Env.strict_args_tab =
-                                     (uu___676_7008.FStar_TypeChecker_Env.strict_args_tab);
+                                     (uu___676_7046.FStar_TypeChecker_Env.strict_args_tab);
                                    FStar_TypeChecker_Env.erasable_types_tab =
-                                     (uu___676_7008.FStar_TypeChecker_Env.erasable_types_tab);
+                                     (uu___676_7046.FStar_TypeChecker_Env.erasable_types_tab);
                                    FStar_TypeChecker_Env.enable_defer_to_tac
                                      =
-                                     (uu___676_7008.FStar_TypeChecker_Env.enable_defer_to_tac)
+                                     (uu___676_7046.FStar_TypeChecker_Env.enable_defer_to_tac)
                                  } in
                                FStar_TypeChecker_TcTerm.tc_tot_or_gtot_term
-                                 uu____7007
+                                 uu____7045
                                  act1.FStar_Syntax_Syntax.action_defn in
-                             (match uu____7000 with
-                              | (act_defn, uu____7010, g_d) ->
-                                  ((let uu____7013 =
+                             (match uu____7038 with
+                              | (act_defn, uu____7048, g_d) ->
+                                  ((let uu____7051 =
                                       FStar_All.pipe_left
                                         (FStar_TypeChecker_Env.debug env1)
                                         (FStar_Options.Other
                                            "LayeredEffectsTc") in
-                                    if uu____7013
+                                    if uu____7051
                                     then
-                                      let uu____7014 =
+                                      let uu____7052 =
                                         FStar_Syntax_Print.term_to_string
                                           act_defn in
-                                      let uu____7015 =
+                                      let uu____7053 =
                                         FStar_Syntax_Print.term_to_string
                                           act_typ1 in
                                       FStar_Util.print2
                                         "Typechecked action definition: %s and action type: %s\n"
-                                        uu____7014 uu____7015
+                                        uu____7052 uu____7053
                                     else ());
-                                   (let uu____7017 =
+                                   (let uu____7055 =
                                       let act_typ2 =
                                         FStar_TypeChecker_Normalize.normalize
                                           [FStar_TypeChecker_Env.Beta] env1
                                           act_typ1 in
-                                      let uu____7025 =
-                                        let uu____7026 =
+                                      let uu____7063 =
+                                        let uu____7064 =
                                           FStar_Syntax_Subst.compress
                                             act_typ2 in
-                                        uu____7026.FStar_Syntax_Syntax.n in
-                                      match uu____7025 with
+                                        uu____7064.FStar_Syntax_Syntax.n in
+                                      match uu____7063 with
                                       | FStar_Syntax_Syntax.Tm_arrow
-                                          (bs, uu____7036) ->
+                                          (bs, uu____7074) ->
                                           let bs1 =
                                             FStar_Syntax_Subst.open_binders
                                               bs in
                                           let env2 =
                                             FStar_TypeChecker_Env.push_binders
                                               env1 bs1 in
-                                          let uu____7059 =
+                                          let uu____7097 =
                                             FStar_Syntax_Util.type_u () in
-                                          (match uu____7059 with
+                                          (match uu____7097 with
                                            | (t, u) ->
                                                let reason =
-                                                 let uu____7073 =
+                                                 let uu____7111 =
                                                    FStar_Ident.string_of_lid
                                                      ed.FStar_Syntax_Syntax.mname in
-                                                 let uu____7074 =
+                                                 let uu____7112 =
                                                    FStar_Ident.string_of_lid
                                                      act1.FStar_Syntax_Syntax.action_name in
                                                  FStar_Util.format2
                                                    "implicit for return type of action %s:%s"
-                                                   uu____7073 uu____7074 in
-                                               let uu____7075 =
+                                                   uu____7111 uu____7112 in
+                                               let uu____7113 =
                                                  FStar_TypeChecker_Util.new_implicit_var
                                                    reason r env2 t in
-                                               (match uu____7075 with
-                                                | (a_tm, uu____7095, g_tm) ->
-                                                    let uu____7109 =
+                                               (match uu____7113 with
+                                                | (a_tm, uu____7133, g_tm) ->
+                                                    let uu____7147 =
                                                       fresh_repr r env2 u
                                                         a_tm in
-                                                    (match uu____7109 with
+                                                    (match uu____7147 with
                                                      | (repr1, g) ->
-                                                         let uu____7122 =
-                                                           let uu____7125 =
-                                                             let uu____7128 =
-                                                               let uu____7131
+                                                         let uu____7160 =
+                                                           let uu____7163 =
+                                                             let uu____7166 =
+                                                               let uu____7169
                                                                  =
                                                                  FStar_TypeChecker_Env.new_u_univ
                                                                    () in
                                                                FStar_All.pipe_right
-                                                                 uu____7131
+                                                                 uu____7169
                                                                  (fun
-                                                                    uu____7134
+                                                                    uu____7172
                                                                     ->
                                                                     FStar_Pervasives_Native.Some
-                                                                    uu____7134) in
+                                                                    uu____7172) in
                                                              FStar_Syntax_Syntax.mk_Total'
                                                                repr1
-                                                               uu____7128 in
+                                                               uu____7166 in
                                                            FStar_Syntax_Util.arrow
-                                                             bs1 uu____7125 in
-                                                         let uu____7135 =
+                                                             bs1 uu____7163 in
+                                                         let uu____7173 =
                                                            FStar_TypeChecker_Env.conj_guard
                                                              g g_tm in
-                                                         (uu____7122,
-                                                           uu____7135))))
-                                      | uu____7138 ->
-                                          let uu____7139 =
-                                            let uu____7144 =
-                                              let uu____7145 =
+                                                         (uu____7160,
+                                                           uu____7173))))
+                                      | uu____7176 ->
+                                          let uu____7177 =
+                                            let uu____7182 =
+                                              let uu____7183 =
                                                 FStar_Ident.string_of_lid
                                                   ed.FStar_Syntax_Syntax.mname in
-                                              let uu____7146 =
+                                              let uu____7184 =
                                                 FStar_Ident.string_of_lid
                                                   act1.FStar_Syntax_Syntax.action_name in
-                                              let uu____7147 =
+                                              let uu____7185 =
                                                 FStar_Syntax_Print.term_to_string
                                                   act_typ2 in
                                               FStar_Util.format3
                                                 "Unexpected non-function type for action %s:%s (%s)"
-                                                uu____7145 uu____7146
-                                                uu____7147 in
+                                                uu____7183 uu____7184
+                                                uu____7185 in
                                             (FStar_Errors.Fatal_ActionMustHaveFunctionType,
-                                              uu____7144) in
-                                          FStar_Errors.raise_error uu____7139
+                                              uu____7182) in
+                                          FStar_Errors.raise_error uu____7177
                                             r in
-                                    match uu____7017 with
+                                    match uu____7055 with
                                     | (k, g_k) ->
-                                        ((let uu____7161 =
+                                        ((let uu____7199 =
                                             FStar_All.pipe_left
                                               (FStar_TypeChecker_Env.debug
                                                  env1)
                                               (FStar_Options.Other
                                                  "LayeredEffectsTc") in
-                                          if uu____7161
+                                          if uu____7199
                                           then
-                                            let uu____7162 =
+                                            let uu____7200 =
                                               FStar_Syntax_Print.term_to_string
                                                 k in
                                             FStar_Util.print1
                                               "Expected action type: %s\n"
-                                              uu____7162
+                                              uu____7200
                                           else ());
                                          (let g =
                                             FStar_TypeChecker_Rel.teq env1
@@ -2374,94 +2374,94 @@ let (tc_layered_eff_decl :
                                           FStar_List.iter
                                             (FStar_TypeChecker_Rel.force_trivial_guard
                                                env1) [g_t; g_d; g_k; g];
-                                          (let uu____7167 =
+                                          (let uu____7205 =
                                              FStar_All.pipe_left
                                                (FStar_TypeChecker_Env.debug
                                                   env1)
                                                (FStar_Options.Other
                                                   "LayeredEffectsTc") in
-                                           if uu____7167
+                                           if uu____7205
                                            then
-                                             let uu____7168 =
+                                             let uu____7206 =
                                                FStar_Syntax_Print.term_to_string
                                                  k in
                                              FStar_Util.print1
                                                "Expected action type after unification: %s\n"
-                                               uu____7168
+                                               uu____7206
                                            else ());
                                           (let act_typ2 =
                                              let err_msg t =
-                                               let uu____7177 =
+                                               let uu____7215 =
                                                  FStar_Ident.string_of_lid
                                                    ed.FStar_Syntax_Syntax.mname in
-                                               let uu____7178 =
+                                               let uu____7216 =
                                                  FStar_Ident.string_of_lid
                                                    act1.FStar_Syntax_Syntax.action_name in
-                                               let uu____7179 =
+                                               let uu____7217 =
                                                  FStar_Syntax_Print.term_to_string
                                                    t in
                                                FStar_Util.format3
                                                  "Unexpected (k-)type of action %s:%s, expected bs -> repr<u> i_1 ... i_n, found: %s"
-                                                 uu____7177 uu____7178
-                                                 uu____7179 in
+                                                 uu____7215 uu____7216
+                                                 uu____7217 in
                                              let repr_args t =
-                                               let uu____7198 =
-                                                 let uu____7199 =
+                                               let uu____7236 =
+                                                 let uu____7237 =
                                                    FStar_Syntax_Subst.compress
                                                      t in
-                                                 uu____7199.FStar_Syntax_Syntax.n in
-                                               match uu____7198 with
+                                                 uu____7237.FStar_Syntax_Syntax.n in
+                                               match uu____7236 with
                                                | FStar_Syntax_Syntax.Tm_app
                                                    (head, a::is) ->
-                                                   let uu____7251 =
-                                                     let uu____7252 =
+                                                   let uu____7289 =
+                                                     let uu____7290 =
                                                        FStar_Syntax_Subst.compress
                                                          head in
-                                                     uu____7252.FStar_Syntax_Syntax.n in
-                                                   (match uu____7251 with
+                                                     uu____7290.FStar_Syntax_Syntax.n in
+                                                   (match uu____7289 with
                                                     | FStar_Syntax_Syntax.Tm_uinst
-                                                        (uu____7261, us) ->
+                                                        (uu____7299, us) ->
                                                         (us,
                                                           (FStar_Pervasives_Native.fst
                                                              a), is)
-                                                    | uu____7271 ->
-                                                        let uu____7272 =
-                                                          let uu____7277 =
+                                                    | uu____7309 ->
+                                                        let uu____7310 =
+                                                          let uu____7315 =
                                                             err_msg t in
                                                           (FStar_Errors.Fatal_ActionMustHaveFunctionType,
-                                                            uu____7277) in
+                                                            uu____7315) in
                                                         FStar_Errors.raise_error
-                                                          uu____7272 r)
-                                               | uu____7284 ->
-                                                   let uu____7285 =
-                                                     let uu____7290 =
+                                                          uu____7310 r)
+                                               | uu____7322 ->
+                                                   let uu____7323 =
+                                                     let uu____7328 =
                                                        err_msg t in
                                                      (FStar_Errors.Fatal_ActionMustHaveFunctionType,
-                                                       uu____7290) in
+                                                       uu____7328) in
                                                    FStar_Errors.raise_error
-                                                     uu____7285 r in
+                                                     uu____7323 r in
                                              let k1 =
                                                FStar_TypeChecker_Normalize.normalize
                                                  [FStar_TypeChecker_Env.Beta]
                                                  env1 k in
-                                             let uu____7298 =
-                                               let uu____7299 =
+                                             let uu____7336 =
+                                               let uu____7337 =
                                                  FStar_Syntax_Subst.compress
                                                    k1 in
-                                               uu____7299.FStar_Syntax_Syntax.n in
-                                             match uu____7298 with
+                                               uu____7337.FStar_Syntax_Syntax.n in
+                                             match uu____7336 with
                                              | FStar_Syntax_Syntax.Tm_arrow
                                                  (bs, c) ->
-                                                 let uu____7324 =
+                                                 let uu____7362 =
                                                    FStar_Syntax_Subst.open_comp
                                                      bs c in
-                                                 (match uu____7324 with
+                                                 (match uu____7362 with
                                                   | (bs1, c1) ->
-                                                      let uu____7331 =
+                                                      let uu____7369 =
                                                         repr_args
                                                           (FStar_Syntax_Util.comp_result
                                                              c1) in
-                                                      (match uu____7331 with
+                                                      (match uu____7369 with
                                                        | (us, a, is) ->
                                                            let ct =
                                                              {
@@ -2477,67 +2477,67 @@ let (tc_layered_eff_decl :
                                                                FStar_Syntax_Syntax.flags
                                                                  = []
                                                              } in
-                                                           let uu____7342 =
+                                                           let uu____7380 =
                                                              FStar_Syntax_Syntax.mk_Comp
                                                                ct in
                                                            FStar_Syntax_Util.arrow
-                                                             bs1 uu____7342))
-                                             | uu____7345 ->
-                                                 let uu____7346 =
-                                                   let uu____7351 =
+                                                             bs1 uu____7380))
+                                             | uu____7383 ->
+                                                 let uu____7384 =
+                                                   let uu____7389 =
                                                      err_msg k1 in
                                                    (FStar_Errors.Fatal_ActionMustHaveFunctionType,
-                                                     uu____7351) in
+                                                     uu____7389) in
                                                  FStar_Errors.raise_error
-                                                   uu____7346 r in
-                                           (let uu____7353 =
+                                                   uu____7384 r in
+                                           (let uu____7391 =
                                               FStar_All.pipe_left
                                                 (FStar_TypeChecker_Env.debug
                                                    env1)
                                                 (FStar_Options.Other
                                                    "LayeredEffectsTc") in
-                                            if uu____7353
+                                            if uu____7391
                                             then
-                                              let uu____7354 =
+                                              let uu____7392 =
                                                 FStar_Syntax_Print.term_to_string
                                                   act_typ2 in
                                               FStar_Util.print1
                                                 "Action type after injecting it into the monad: %s\n"
-                                                uu____7354
+                                                uu____7392
                                             else ());
                                            (let act2 =
-                                              let uu____7357 =
+                                              let uu____7395 =
                                                 FStar_TypeChecker_Generalize.generalize_universes
                                                   env1 act_defn in
-                                              match uu____7357 with
+                                              match uu____7395 with
                                               | (us, act_defn1) ->
                                                   if
                                                     act1.FStar_Syntax_Syntax.action_univs
                                                       = []
                                                   then
-                                                    let uu___749_7370 = act1 in
-                                                    let uu____7371 =
+                                                    let uu___749_7408 = act1 in
+                                                    let uu____7409 =
                                                       FStar_Syntax_Subst.close_univ_vars
                                                         us act_typ2 in
                                                     {
                                                       FStar_Syntax_Syntax.action_name
                                                         =
-                                                        (uu___749_7370.FStar_Syntax_Syntax.action_name);
+                                                        (uu___749_7408.FStar_Syntax_Syntax.action_name);
                                                       FStar_Syntax_Syntax.action_unqualified_name
                                                         =
-                                                        (uu___749_7370.FStar_Syntax_Syntax.action_unqualified_name);
+                                                        (uu___749_7408.FStar_Syntax_Syntax.action_unqualified_name);
                                                       FStar_Syntax_Syntax.action_univs
                                                         = us;
                                                       FStar_Syntax_Syntax.action_params
                                                         =
-                                                        (uu___749_7370.FStar_Syntax_Syntax.action_params);
+                                                        (uu___749_7408.FStar_Syntax_Syntax.action_params);
                                                       FStar_Syntax_Syntax.action_defn
                                                         = act_defn1;
                                                       FStar_Syntax_Syntax.action_typ
-                                                        = uu____7371
+                                                        = uu____7409
                                                     }
                                                   else
-                                                    (let uu____7373 =
+                                                    (let uu____7411 =
                                                        ((FStar_List.length us)
                                                           =
                                                           (FStar_List.length
@@ -2546,103 +2546,103 @@ let (tc_layered_eff_decl :
                                                          (FStar_List.forall2
                                                             (fun u1 ->
                                                                fun u2 ->
-                                                                 let uu____7379
+                                                                 let uu____7417
                                                                    =
                                                                    FStar_Syntax_Syntax.order_univ_name
                                                                     u1 u2 in
-                                                                 uu____7379 =
+                                                                 uu____7417 =
                                                                    Prims.int_zero)
                                                             us
                                                             act1.FStar_Syntax_Syntax.action_univs) in
-                                                     if uu____7373
+                                                     if uu____7411
                                                      then
-                                                       let uu___754_7380 =
+                                                       let uu___754_7418 =
                                                          act1 in
-                                                       let uu____7381 =
+                                                       let uu____7419 =
                                                          FStar_Syntax_Subst.close_univ_vars
                                                            act1.FStar_Syntax_Syntax.action_univs
                                                            act_typ2 in
                                                        {
                                                          FStar_Syntax_Syntax.action_name
                                                            =
-                                                           (uu___754_7380.FStar_Syntax_Syntax.action_name);
+                                                           (uu___754_7418.FStar_Syntax_Syntax.action_name);
                                                          FStar_Syntax_Syntax.action_unqualified_name
                                                            =
-                                                           (uu___754_7380.FStar_Syntax_Syntax.action_unqualified_name);
+                                                           (uu___754_7418.FStar_Syntax_Syntax.action_unqualified_name);
                                                          FStar_Syntax_Syntax.action_univs
                                                            =
-                                                           (uu___754_7380.FStar_Syntax_Syntax.action_univs);
+                                                           (uu___754_7418.FStar_Syntax_Syntax.action_univs);
                                                          FStar_Syntax_Syntax.action_params
                                                            =
-                                                           (uu___754_7380.FStar_Syntax_Syntax.action_params);
+                                                           (uu___754_7418.FStar_Syntax_Syntax.action_params);
                                                          FStar_Syntax_Syntax.action_defn
                                                            = act_defn1;
                                                          FStar_Syntax_Syntax.action_typ
-                                                           = uu____7381
+                                                           = uu____7419
                                                        }
                                                      else
-                                                       (let uu____7383 =
-                                                          let uu____7388 =
-                                                            let uu____7389 =
+                                                       (let uu____7421 =
+                                                          let uu____7426 =
+                                                            let uu____7427 =
                                                               FStar_Ident.string_of_lid
                                                                 ed.FStar_Syntax_Syntax.mname in
-                                                            let uu____7390 =
+                                                            let uu____7428 =
                                                               FStar_Ident.string_of_lid
                                                                 act1.FStar_Syntax_Syntax.action_name in
-                                                            let uu____7391 =
+                                                            let uu____7429 =
                                                               FStar_Syntax_Print.univ_names_to_string
                                                                 us in
-                                                            let uu____7392 =
+                                                            let uu____7430 =
                                                               FStar_Syntax_Print.univ_names_to_string
                                                                 act1.FStar_Syntax_Syntax.action_univs in
                                                             FStar_Util.format4
                                                               "Expected and generalized universes in the declaration for %s:%s are different, input: %s, but after gen: %s"
-                                                              uu____7389
-                                                              uu____7390
-                                                              uu____7391
-                                                              uu____7392 in
+                                                              uu____7427
+                                                              uu____7428
+                                                              uu____7429
+                                                              uu____7430 in
                                                           (FStar_Errors.Fatal_UnexpectedNumberOfUniverse,
-                                                            uu____7388) in
+                                                            uu____7426) in
                                                         FStar_Errors.raise_error
-                                                          uu____7383 r)) in
+                                                          uu____7421 r)) in
                                             act2))))))))) in
-                 let tschemes_of uu____7414 =
-                   match uu____7414 with | (us, t, ty) -> ((us, t), (us, ty)) in
+                 let tschemes_of uu____7452 =
+                   match uu____7452 with | (us, t, ty) -> ((us, t), (us, ty)) in
                  let combinators =
-                   let uu____7459 =
-                     let uu____7460 = tschemes_of repr in
-                     let uu____7465 = tschemes_of return_repr in
-                     let uu____7470 = tschemes_of bind_repr in
-                     let uu____7475 = tschemes_of stronger_repr in
-                     let uu____7480 = tschemes_of if_then_else in
+                   let uu____7497 =
+                     let uu____7498 = tschemes_of repr in
+                     let uu____7503 = tschemes_of return_repr in
+                     let uu____7508 = tschemes_of bind_repr in
+                     let uu____7513 = tschemes_of stronger_repr in
+                     let uu____7518 = tschemes_of if_then_else in
                      {
-                       FStar_Syntax_Syntax.l_repr = uu____7460;
-                       FStar_Syntax_Syntax.l_return = uu____7465;
-                       FStar_Syntax_Syntax.l_bind = uu____7470;
-                       FStar_Syntax_Syntax.l_subcomp = uu____7475;
-                       FStar_Syntax_Syntax.l_if_then_else = uu____7480
+                       FStar_Syntax_Syntax.l_repr = uu____7498;
+                       FStar_Syntax_Syntax.l_return = uu____7503;
+                       FStar_Syntax_Syntax.l_bind = uu____7508;
+                       FStar_Syntax_Syntax.l_subcomp = uu____7513;
+                       FStar_Syntax_Syntax.l_if_then_else = uu____7518
                      } in
-                   FStar_Syntax_Syntax.Layered_eff uu____7459 in
-                 let uu___763_7485 = ed in
-                 let uu____7486 =
+                   FStar_Syntax_Syntax.Layered_eff uu____7497 in
+                 let uu___763_7523 = ed in
+                 let uu____7524 =
                    FStar_List.map (tc_action env0)
                      ed.FStar_Syntax_Syntax.actions in
                  {
                    FStar_Syntax_Syntax.mname =
-                     (uu___763_7485.FStar_Syntax_Syntax.mname);
+                     (uu___763_7523.FStar_Syntax_Syntax.mname);
                    FStar_Syntax_Syntax.cattributes =
-                     (uu___763_7485.FStar_Syntax_Syntax.cattributes);
+                     (uu___763_7523.FStar_Syntax_Syntax.cattributes);
                    FStar_Syntax_Syntax.univs =
-                     (uu___763_7485.FStar_Syntax_Syntax.univs);
+                     (uu___763_7523.FStar_Syntax_Syntax.univs);
                    FStar_Syntax_Syntax.binders =
-                     (uu___763_7485.FStar_Syntax_Syntax.binders);
+                     (uu___763_7523.FStar_Syntax_Syntax.binders);
                    FStar_Syntax_Syntax.signature =
-                     (let uu____7493 = signature in
-                      match uu____7493 with | (us, t, uu____7508) -> (us, t));
+                     (let uu____7531 = signature in
+                      match uu____7531 with | (us, t, uu____7546) -> (us, t));
                    FStar_Syntax_Syntax.combinators = combinators;
-                   FStar_Syntax_Syntax.actions = uu____7486;
+                   FStar_Syntax_Syntax.actions = uu____7524;
                    FStar_Syntax_Syntax.eff_attrs =
-                     (uu___763_7485.FStar_Syntax_Syntax.eff_attrs)
+                     (uu___763_7523.FStar_Syntax_Syntax.eff_attrs)
                  })))))))
 let (tc_non_layered_eff_decl :
   FStar_TypeChecker_Env.env ->
@@ -2655,216 +2655,216 @@ let (tc_non_layered_eff_decl :
     fun ed ->
       fun _quals ->
         fun _attrs ->
-          (let uu____7554 =
+          (let uu____7592 =
              FStar_All.pipe_left (FStar_TypeChecker_Env.debug env0)
                (FStar_Options.Other "ED") in
-           if uu____7554
+           if uu____7592
            then
-             let uu____7555 = FStar_Syntax_Print.eff_decl_to_string false ed in
-             FStar_Util.print1 "Typechecking eff_decl: \n\t%s\n" uu____7555
+             let uu____7593 = FStar_Syntax_Print.eff_decl_to_string false ed in
+             FStar_Util.print1 "Typechecking eff_decl: \n\t%s\n" uu____7593
            else ());
-          (let uu____7557 =
-             let uu____7562 =
+          (let uu____7595 =
+             let uu____7600 =
                FStar_Syntax_Subst.univ_var_opening
                  ed.FStar_Syntax_Syntax.univs in
-             match uu____7562 with
+             match uu____7600 with
              | (ed_univs_subst, ed_univs) ->
                  let bs =
-                   let uu____7586 =
+                   let uu____7624 =
                      FStar_Syntax_Subst.subst_binders ed_univs_subst
                        ed.FStar_Syntax_Syntax.binders in
-                   FStar_Syntax_Subst.open_binders uu____7586 in
-                 let uu____7587 =
-                   let uu____7594 =
+                   FStar_Syntax_Subst.open_binders uu____7624 in
+                 let uu____7625 =
+                   let uu____7632 =
                      FStar_TypeChecker_Env.push_univ_vars env0 ed_univs in
-                   FStar_TypeChecker_TcTerm.tc_tparams uu____7594 bs in
-                 (match uu____7587 with
-                  | (bs1, uu____7600, uu____7601) ->
-                      let uu____7602 =
+                   FStar_TypeChecker_TcTerm.tc_tparams uu____7632 bs in
+                 (match uu____7625 with
+                  | (bs1, uu____7638, uu____7639) ->
+                      let uu____7640 =
                         let tmp_t =
-                          let uu____7612 =
-                            let uu____7615 =
+                          let uu____7650 =
+                            let uu____7653 =
                               FStar_All.pipe_right FStar_Syntax_Syntax.U_zero
-                                (fun uu____7620 ->
-                                   FStar_Pervasives_Native.Some uu____7620) in
+                                (fun uu____7658 ->
+                                   FStar_Pervasives_Native.Some uu____7658) in
                             FStar_Syntax_Syntax.mk_Total'
-                              FStar_Syntax_Syntax.t_unit uu____7615 in
-                          FStar_Syntax_Util.arrow bs1 uu____7612 in
-                        let uu____7621 =
+                              FStar_Syntax_Syntax.t_unit uu____7653 in
+                          FStar_Syntax_Util.arrow bs1 uu____7650 in
+                        let uu____7659 =
                           FStar_TypeChecker_Generalize.generalize_universes
                             env0 tmp_t in
-                        match uu____7621 with
+                        match uu____7659 with
                         | (us, tmp_t1) ->
-                            let uu____7638 =
-                              let uu____7639 =
-                                let uu____7640 =
+                            let uu____7676 =
+                              let uu____7677 =
+                                let uu____7678 =
                                   FStar_All.pipe_right tmp_t1
                                     FStar_Syntax_Util.arrow_formals in
-                                FStar_All.pipe_right uu____7640
+                                FStar_All.pipe_right uu____7678
                                   FStar_Pervasives_Native.fst in
-                              FStar_All.pipe_right uu____7639
+                              FStar_All.pipe_right uu____7677
                                 FStar_Syntax_Subst.close_binders in
-                            (us, uu____7638) in
-                      (match uu____7602 with
+                            (us, uu____7676) in
+                      (match uu____7640 with
                        | (us, bs2) ->
                            (match ed_univs with
                             | [] -> (us, bs2)
-                            | uu____7677 ->
-                                let uu____7680 =
+                            | uu____7715 ->
+                                let uu____7718 =
                                   ((FStar_List.length ed_univs) =
                                      (FStar_List.length us))
                                     &&
                                     (FStar_List.forall2
                                        (fun u1 ->
                                           fun u2 ->
-                                            let uu____7686 =
+                                            let uu____7724 =
                                               FStar_Syntax_Syntax.order_univ_name
                                                 u1 u2 in
-                                            uu____7686 = Prims.int_zero)
+                                            uu____7724 = Prims.int_zero)
                                        ed_univs us) in
-                                if uu____7680
+                                if uu____7718
                                 then (us, bs2)
                                 else
-                                  (let uu____7692 =
-                                     let uu____7697 =
-                                       let uu____7698 =
+                                  (let uu____7730 =
+                                     let uu____7735 =
+                                       let uu____7736 =
                                          FStar_Ident.string_of_lid
                                            ed.FStar_Syntax_Syntax.mname in
-                                       let uu____7699 =
+                                       let uu____7737 =
                                          FStar_Util.string_of_int
                                            (FStar_List.length ed_univs) in
-                                       let uu____7700 =
+                                       let uu____7738 =
                                          FStar_Util.string_of_int
                                            (FStar_List.length us) in
                                        FStar_Util.format3
                                          "Expected and generalized universes in effect declaration for %s are different, expected: %s, but found %s"
-                                         uu____7698 uu____7699 uu____7700 in
+                                         uu____7736 uu____7737 uu____7738 in
                                      (FStar_Errors.Fatal_UnexpectedNumberOfUniverse,
-                                       uu____7697) in
-                                   let uu____7701 =
+                                       uu____7735) in
+                                   let uu____7739 =
                                      FStar_Ident.range_of_lid
                                        ed.FStar_Syntax_Syntax.mname in
-                                   FStar_Errors.raise_error uu____7692
-                                     uu____7701)))) in
-           match uu____7557 with
+                                   FStar_Errors.raise_error uu____7730
+                                     uu____7739)))) in
+           match uu____7595 with
            | (us, bs) ->
                let ed1 =
-                 let uu___798_7709 = ed in
+                 let uu___798_7747 = ed in
                  {
                    FStar_Syntax_Syntax.mname =
-                     (uu___798_7709.FStar_Syntax_Syntax.mname);
+                     (uu___798_7747.FStar_Syntax_Syntax.mname);
                    FStar_Syntax_Syntax.cattributes =
-                     (uu___798_7709.FStar_Syntax_Syntax.cattributes);
+                     (uu___798_7747.FStar_Syntax_Syntax.cattributes);
                    FStar_Syntax_Syntax.univs = us;
                    FStar_Syntax_Syntax.binders = bs;
                    FStar_Syntax_Syntax.signature =
-                     (uu___798_7709.FStar_Syntax_Syntax.signature);
+                     (uu___798_7747.FStar_Syntax_Syntax.signature);
                    FStar_Syntax_Syntax.combinators =
-                     (uu___798_7709.FStar_Syntax_Syntax.combinators);
+                     (uu___798_7747.FStar_Syntax_Syntax.combinators);
                    FStar_Syntax_Syntax.actions =
-                     (uu___798_7709.FStar_Syntax_Syntax.actions);
+                     (uu___798_7747.FStar_Syntax_Syntax.actions);
                    FStar_Syntax_Syntax.eff_attrs =
-                     (uu___798_7709.FStar_Syntax_Syntax.eff_attrs)
+                     (uu___798_7747.FStar_Syntax_Syntax.eff_attrs)
                  } in
-               let uu____7710 = FStar_Syntax_Subst.univ_var_opening us in
-               (match uu____7710 with
+               let uu____7748 = FStar_Syntax_Subst.univ_var_opening us in
+               (match uu____7748 with
                 | (ed_univs_subst, ed_univs) ->
-                    let uu____7729 =
-                      let uu____7734 =
+                    let uu____7767 =
+                      let uu____7772 =
                         FStar_Syntax_Subst.subst_binders ed_univs_subst bs in
-                      FStar_Syntax_Subst.open_binders' uu____7734 in
-                    (match uu____7729 with
+                      FStar_Syntax_Subst.open_binders' uu____7772 in
+                    (match uu____7767 with
                      | (ed_bs, ed_bs_subst) ->
                          let ed2 =
-                           let op uu____7755 =
-                             match uu____7755 with
+                           let op uu____7793 =
+                             match uu____7793 with
                              | (us1, t) ->
                                  let t1 =
-                                   let uu____7775 =
+                                   let uu____7813 =
                                      FStar_Syntax_Subst.shift_subst
                                        ((FStar_List.length ed_bs) +
                                           (FStar_List.length us1))
                                        ed_univs_subst in
-                                   FStar_Syntax_Subst.subst uu____7775 t in
-                                 let uu____7784 =
-                                   let uu____7785 =
+                                   FStar_Syntax_Subst.subst uu____7813 t in
+                                 let uu____7822 =
+                                   let uu____7823 =
                                      FStar_Syntax_Subst.shift_subst
                                        (FStar_List.length us1) ed_bs_subst in
-                                   FStar_Syntax_Subst.subst uu____7785 t1 in
-                                 (us1, uu____7784) in
-                           let uu___812_7790 = ed1 in
-                           let uu____7791 =
+                                   FStar_Syntax_Subst.subst uu____7823 t1 in
+                                 (us1, uu____7822) in
+                           let uu___812_7828 = ed1 in
+                           let uu____7829 =
                              op ed1.FStar_Syntax_Syntax.signature in
-                           let uu____7792 =
+                           let uu____7830 =
                              FStar_Syntax_Util.apply_eff_combinators op
                                ed1.FStar_Syntax_Syntax.combinators in
-                           let uu____7793 =
+                           let uu____7831 =
                              FStar_List.map
                                (fun a ->
-                                  let uu___815_7801 = a in
-                                  let uu____7802 =
-                                    let uu____7803 =
+                                  let uu___815_7839 = a in
+                                  let uu____7840 =
+                                    let uu____7841 =
                                       op
                                         ((a.FStar_Syntax_Syntax.action_univs),
                                           (a.FStar_Syntax_Syntax.action_defn)) in
-                                    FStar_Pervasives_Native.snd uu____7803 in
-                                  let uu____7814 =
-                                    let uu____7815 =
+                                    FStar_Pervasives_Native.snd uu____7841 in
+                                  let uu____7852 =
+                                    let uu____7853 =
                                       op
                                         ((a.FStar_Syntax_Syntax.action_univs),
                                           (a.FStar_Syntax_Syntax.action_typ)) in
-                                    FStar_Pervasives_Native.snd uu____7815 in
+                                    FStar_Pervasives_Native.snd uu____7853 in
                                   {
                                     FStar_Syntax_Syntax.action_name =
-                                      (uu___815_7801.FStar_Syntax_Syntax.action_name);
+                                      (uu___815_7839.FStar_Syntax_Syntax.action_name);
                                     FStar_Syntax_Syntax.action_unqualified_name
                                       =
-                                      (uu___815_7801.FStar_Syntax_Syntax.action_unqualified_name);
+                                      (uu___815_7839.FStar_Syntax_Syntax.action_unqualified_name);
                                     FStar_Syntax_Syntax.action_univs =
-                                      (uu___815_7801.FStar_Syntax_Syntax.action_univs);
+                                      (uu___815_7839.FStar_Syntax_Syntax.action_univs);
                                     FStar_Syntax_Syntax.action_params =
-                                      (uu___815_7801.FStar_Syntax_Syntax.action_params);
+                                      (uu___815_7839.FStar_Syntax_Syntax.action_params);
                                     FStar_Syntax_Syntax.action_defn =
-                                      uu____7802;
+                                      uu____7840;
                                     FStar_Syntax_Syntax.action_typ =
-                                      uu____7814
+                                      uu____7852
                                   }) ed1.FStar_Syntax_Syntax.actions in
                            {
                              FStar_Syntax_Syntax.mname =
-                               (uu___812_7790.FStar_Syntax_Syntax.mname);
+                               (uu___812_7828.FStar_Syntax_Syntax.mname);
                              FStar_Syntax_Syntax.cattributes =
-                               (uu___812_7790.FStar_Syntax_Syntax.cattributes);
+                               (uu___812_7828.FStar_Syntax_Syntax.cattributes);
                              FStar_Syntax_Syntax.univs =
-                               (uu___812_7790.FStar_Syntax_Syntax.univs);
+                               (uu___812_7828.FStar_Syntax_Syntax.univs);
                              FStar_Syntax_Syntax.binders =
-                               (uu___812_7790.FStar_Syntax_Syntax.binders);
-                             FStar_Syntax_Syntax.signature = uu____7791;
-                             FStar_Syntax_Syntax.combinators = uu____7792;
-                             FStar_Syntax_Syntax.actions = uu____7793;
+                               (uu___812_7828.FStar_Syntax_Syntax.binders);
+                             FStar_Syntax_Syntax.signature = uu____7829;
+                             FStar_Syntax_Syntax.combinators = uu____7830;
+                             FStar_Syntax_Syntax.actions = uu____7831;
                              FStar_Syntax_Syntax.eff_attrs =
-                               (uu___812_7790.FStar_Syntax_Syntax.eff_attrs)
+                               (uu___812_7828.FStar_Syntax_Syntax.eff_attrs)
                            } in
-                         ((let uu____7827 =
+                         ((let uu____7865 =
                              FStar_All.pipe_left
                                (FStar_TypeChecker_Env.debug env0)
                                (FStar_Options.Other "ED") in
-                           if uu____7827
+                           if uu____7865
                            then
-                             let uu____7828 =
+                             let uu____7866 =
                                FStar_Syntax_Print.eff_decl_to_string false
                                  ed2 in
                              FStar_Util.print1
                                "After typechecking binders eff_decl: \n\t%s\n"
-                               uu____7828
+                               uu____7866
                            else ());
                           (let env =
-                             let uu____7831 =
+                             let uu____7869 =
                                FStar_TypeChecker_Env.push_univ_vars env0
                                  ed_univs in
-                             FStar_TypeChecker_Env.push_binders uu____7831
+                             FStar_TypeChecker_Env.push_binders uu____7869
                                ed_bs in
-                           let check_and_gen' comb n env_opt uu____7864 k =
-                             match uu____7864 with
+                           let check_and_gen' comb n env_opt uu____7902 k =
+                             match uu____7902 with
                              | (us1, t) ->
                                  let env1 =
                                    if FStar_Util.is_some env_opt
@@ -2872,54 +2872,54 @@ let (tc_non_layered_eff_decl :
                                      FStar_All.pipe_right env_opt
                                        FStar_Util.must
                                    else env in
-                                 let uu____7880 =
+                                 let uu____7918 =
                                    FStar_Syntax_Subst.open_univ_vars us1 t in
-                                 (match uu____7880 with
+                                 (match uu____7918 with
                                   | (us2, t1) ->
                                       let t2 =
                                         match k with
                                         | FStar_Pervasives_Native.Some k1 ->
-                                            let uu____7889 =
+                                            let uu____7927 =
                                               FStar_TypeChecker_Env.push_univ_vars
                                                 env1 us2 in
                                             FStar_TypeChecker_TcTerm.tc_check_trivial_guard
-                                              uu____7889 t1 k1
+                                              uu____7927 t1 k1
                                         | FStar_Pervasives_Native.None ->
-                                            let uu____7890 =
-                                              let uu____7897 =
+                                            let uu____7928 =
+                                              let uu____7935 =
                                                 FStar_TypeChecker_Env.push_univ_vars
                                                   env1 us2 in
                                               FStar_TypeChecker_TcTerm.tc_tot_or_gtot_term
-                                                uu____7897 t1 in
-                                            (match uu____7890 with
-                                             | (t2, uu____7899, g) ->
+                                                uu____7935 t1 in
+                                            (match uu____7928 with
+                                             | (t2, uu____7937, g) ->
                                                  (FStar_TypeChecker_Rel.force_trivial_guard
                                                     env1 g;
                                                   t2)) in
-                                      let uu____7902 =
+                                      let uu____7940 =
                                         FStar_TypeChecker_Generalize.generalize_universes
                                           env1 t2 in
-                                      (match uu____7902 with
+                                      (match uu____7940 with
                                        | (g_us, t3) ->
                                            (if (FStar_List.length g_us) <> n
                                             then
                                               (let error =
-                                                 let uu____7915 =
+                                                 let uu____7953 =
                                                    FStar_Ident.string_of_lid
                                                      ed2.FStar_Syntax_Syntax.mname in
-                                                 let uu____7916 =
+                                                 let uu____7954 =
                                                    FStar_Util.string_of_int n in
-                                                 let uu____7917 =
-                                                   let uu____7918 =
+                                                 let uu____7955 =
+                                                   let uu____7956 =
                                                      FStar_All.pipe_right
                                                        g_us FStar_List.length in
                                                    FStar_All.pipe_right
-                                                     uu____7918
+                                                     uu____7956
                                                      FStar_Util.string_of_int in
                                                  FStar_Util.format4
                                                    "Expected %s:%s to be universe-polymorphic in %s universes, found %s"
-                                                   uu____7915 comb uu____7916
-                                                   uu____7917 in
+                                                   uu____7953 comb uu____7954
+                                                   uu____7955 in
                                                FStar_Errors.raise_error
                                                  (FStar_Errors.Fatal_MismatchUniversePolymorphic,
                                                    error)
@@ -2927,602 +2927,602 @@ let (tc_non_layered_eff_decl :
                                             else ();
                                             (match us2 with
                                              | [] -> (g_us, t3)
-                                             | uu____7926 ->
-                                                 let uu____7927 =
+                                             | uu____7964 ->
+                                                 let uu____7965 =
                                                    ((FStar_List.length us2) =
                                                       (FStar_List.length g_us))
                                                      &&
                                                      (FStar_List.forall2
                                                         (fun u1 ->
                                                            fun u2 ->
-                                                             let uu____7933 =
+                                                             let uu____7971 =
                                                                FStar_Syntax_Syntax.order_univ_name
                                                                  u1 u2 in
-                                                             uu____7933 =
+                                                             uu____7971 =
                                                                Prims.int_zero)
                                                         us2 g_us) in
-                                                 if uu____7927
+                                                 if uu____7965
                                                  then (g_us, t3)
                                                  else
-                                                   (let uu____7939 =
-                                                      let uu____7944 =
-                                                        let uu____7945 =
+                                                   (let uu____7977 =
+                                                      let uu____7982 =
+                                                        let uu____7983 =
                                                           FStar_Ident.string_of_lid
                                                             ed2.FStar_Syntax_Syntax.mname in
-                                                        let uu____7946 =
+                                                        let uu____7984 =
                                                           FStar_Util.string_of_int
                                                             (FStar_List.length
                                                                us2) in
-                                                        let uu____7947 =
+                                                        let uu____7985 =
                                                           FStar_Util.string_of_int
                                                             (FStar_List.length
                                                                g_us) in
                                                         FStar_Util.format4
                                                           "Expected and generalized universes in the declaration for %s:%s are different, expected: %s, but found %s"
-                                                          uu____7945 comb
-                                                          uu____7946
-                                                          uu____7947 in
+                                                          uu____7983 comb
+                                                          uu____7984
+                                                          uu____7985 in
                                                       (FStar_Errors.Fatal_UnexpectedNumberOfUniverse,
-                                                        uu____7944) in
+                                                        uu____7982) in
                                                     FStar_Errors.raise_error
-                                                      uu____7939
+                                                      uu____7977
                                                       t3.FStar_Syntax_Syntax.pos))))) in
                            let signature =
                              check_and_gen' "signature" Prims.int_one
                                FStar_Pervasives_Native.None
                                ed2.FStar_Syntax_Syntax.signature
                                FStar_Pervasives_Native.None in
-                           (let uu____7950 =
+                           (let uu____7988 =
                               FStar_All.pipe_left
                                 (FStar_TypeChecker_Env.debug env0)
                                 (FStar_Options.Other "ED") in
-                            if uu____7950
+                            if uu____7988
                             then
-                              let uu____7951 =
+                              let uu____7989 =
                                 FStar_Syntax_Print.tscheme_to_string
                                   signature in
                               FStar_Util.print1 "Typechecked signature: %s\n"
-                                uu____7951
+                                uu____7989
                             else ());
-                           (let fresh_a_and_wp uu____7964 =
+                           (let fresh_a_and_wp uu____8002 =
                               let fail t =
-                                let uu____7977 =
+                                let uu____8015 =
                                   FStar_TypeChecker_Err.unexpected_signature_for_monad
                                     env ed2.FStar_Syntax_Syntax.mname t in
-                                FStar_Errors.raise_error uu____7977
+                                FStar_Errors.raise_error uu____8015
                                   (FStar_Pervasives_Native.snd
                                      ed2.FStar_Syntax_Syntax.signature).FStar_Syntax_Syntax.pos in
-                              let uu____7992 =
+                              let uu____8030 =
                                 FStar_TypeChecker_Env.inst_tscheme signature in
-                              match uu____7992 with
-                              | (uu____8003, signature1) ->
-                                  let uu____8005 =
-                                    let uu____8006 =
+                              match uu____8030 with
+                              | (uu____8041, signature1) ->
+                                  let uu____8043 =
+                                    let uu____8044 =
                                       FStar_Syntax_Subst.compress signature1 in
-                                    uu____8006.FStar_Syntax_Syntax.n in
-                                  (match uu____8005 with
+                                    uu____8044.FStar_Syntax_Syntax.n in
+                                  (match uu____8043 with
                                    | FStar_Syntax_Syntax.Tm_arrow
-                                       (bs1, uu____8016) ->
+                                       (bs1, uu____8054) ->
                                        let bs2 =
                                          FStar_Syntax_Subst.open_binders bs1 in
                                        (match bs2 with
-                                        | (a, uu____8045)::(wp, uu____8047)::[]
+                                        | (a, uu____8083)::(wp, uu____8085)::[]
                                             ->
                                             (a,
                                               (wp.FStar_Syntax_Syntax.sort))
-                                        | uu____8076 -> fail signature1)
-                                   | uu____8077 -> fail signature1) in
+                                        | uu____8114 -> fail signature1)
+                                   | uu____8115 -> fail signature1) in
                             let log_combinator s ts =
-                              let uu____8089 =
+                              let uu____8127 =
                                 FStar_All.pipe_left
                                   (FStar_TypeChecker_Env.debug env)
                                   (FStar_Options.Other "ED") in
-                              if uu____8089
+                              if uu____8127
                               then
-                                let uu____8090 =
+                                let uu____8128 =
                                   FStar_Ident.string_of_lid
                                     ed2.FStar_Syntax_Syntax.mname in
-                                let uu____8091 =
+                                let uu____8129 =
                                   FStar_Syntax_Print.tscheme_to_string ts in
                                 FStar_Util.print3 "Typechecked %s:%s = %s\n"
-                                  uu____8090 s uu____8091
+                                  uu____8128 s uu____8129
                               else () in
                             let ret_wp =
-                              let uu____8094 = fresh_a_and_wp () in
-                              match uu____8094 with
+                              let uu____8132 = fresh_a_and_wp () in
+                              match uu____8132 with
                               | (a, wp_sort) ->
                                   let k =
-                                    let uu____8110 =
-                                      let uu____8119 =
+                                    let uu____8148 =
+                                      let uu____8157 =
                                         FStar_Syntax_Syntax.mk_binder a in
-                                      let uu____8126 =
-                                        let uu____8135 =
-                                          let uu____8142 =
+                                      let uu____8164 =
+                                        let uu____8173 =
+                                          let uu____8180 =
                                             FStar_Syntax_Syntax.bv_to_name a in
                                           FStar_Syntax_Syntax.null_binder
-                                            uu____8142 in
-                                        [uu____8135] in
-                                      uu____8119 :: uu____8126 in
-                                    let uu____8161 =
+                                            uu____8180 in
+                                        [uu____8173] in
+                                      uu____8157 :: uu____8164 in
+                                    let uu____8199 =
                                       FStar_Syntax_Syntax.mk_GTotal wp_sort in
-                                    FStar_Syntax_Util.arrow uu____8110
-                                      uu____8161 in
-                                  let uu____8164 =
+                                    FStar_Syntax_Util.arrow uu____8148
+                                      uu____8199 in
+                                  let uu____8202 =
                                     FStar_All.pipe_right ed2
                                       FStar_Syntax_Util.get_return_vc_combinator in
                                   check_and_gen' "ret_wp" Prims.int_one
-                                    FStar_Pervasives_Native.None uu____8164
+                                    FStar_Pervasives_Native.None uu____8202
                                     (FStar_Pervasives_Native.Some k) in
                             log_combinator "ret_wp" ret_wp;
                             (let bind_wp =
-                               let uu____8175 = fresh_a_and_wp () in
-                               match uu____8175 with
+                               let uu____8213 = fresh_a_and_wp () in
+                               match uu____8213 with
                                | (a, wp_sort_a) ->
-                                   let uu____8188 = fresh_a_and_wp () in
-                                   (match uu____8188 with
+                                   let uu____8226 = fresh_a_and_wp () in
+                                   (match uu____8226 with
                                     | (b, wp_sort_b) ->
                                         let wp_sort_a_b =
-                                          let uu____8204 =
-                                            let uu____8213 =
-                                              let uu____8220 =
+                                          let uu____8242 =
+                                            let uu____8251 =
+                                              let uu____8258 =
                                                 FStar_Syntax_Syntax.bv_to_name
                                                   a in
                                               FStar_Syntax_Syntax.null_binder
-                                                uu____8220 in
-                                            [uu____8213] in
-                                          let uu____8233 =
+                                                uu____8258 in
+                                            [uu____8251] in
+                                          let uu____8271 =
                                             FStar_Syntax_Syntax.mk_Total
                                               wp_sort_b in
-                                          FStar_Syntax_Util.arrow uu____8204
-                                            uu____8233 in
+                                          FStar_Syntax_Util.arrow uu____8242
+                                            uu____8271 in
                                         let k =
-                                          let uu____8239 =
-                                            let uu____8248 =
+                                          let uu____8277 =
+                                            let uu____8286 =
                                               FStar_Syntax_Syntax.null_binder
                                                 FStar_Syntax_Syntax.t_range in
-                                            let uu____8255 =
-                                              let uu____8264 =
+                                            let uu____8293 =
+                                              let uu____8302 =
                                                 FStar_Syntax_Syntax.mk_binder
                                                   a in
-                                              let uu____8271 =
-                                                let uu____8280 =
+                                              let uu____8309 =
+                                                let uu____8318 =
                                                   FStar_Syntax_Syntax.mk_binder
                                                     b in
-                                                let uu____8287 =
-                                                  let uu____8296 =
+                                                let uu____8325 =
+                                                  let uu____8334 =
                                                     FStar_Syntax_Syntax.null_binder
                                                       wp_sort_a in
-                                                  let uu____8303 =
-                                                    let uu____8312 =
+                                                  let uu____8341 =
+                                                    let uu____8350 =
                                                       FStar_Syntax_Syntax.null_binder
                                                         wp_sort_a_b in
-                                                    [uu____8312] in
-                                                  uu____8296 :: uu____8303 in
-                                                uu____8280 :: uu____8287 in
-                                              uu____8264 :: uu____8271 in
-                                            uu____8248 :: uu____8255 in
-                                          let uu____8355 =
+                                                    [uu____8350] in
+                                                  uu____8334 :: uu____8341 in
+                                                uu____8318 :: uu____8325 in
+                                              uu____8302 :: uu____8309 in
+                                            uu____8286 :: uu____8293 in
+                                          let uu____8393 =
                                             FStar_Syntax_Syntax.mk_Total
                                               wp_sort_b in
-                                          FStar_Syntax_Util.arrow uu____8239
-                                            uu____8355 in
-                                        let uu____8358 =
+                                          FStar_Syntax_Util.arrow uu____8277
+                                            uu____8393 in
+                                        let uu____8396 =
                                           FStar_All.pipe_right ed2
                                             FStar_Syntax_Util.get_bind_vc_combinator in
                                         check_and_gen' "bind_wp"
                                           (Prims.of_int (2))
                                           FStar_Pervasives_Native.None
-                                          uu____8358
+                                          uu____8396
                                           (FStar_Pervasives_Native.Some k)) in
                              log_combinator "bind_wp" bind_wp;
                              (let stronger =
-                                let uu____8369 = fresh_a_and_wp () in
-                                match uu____8369 with
+                                let uu____8407 = fresh_a_and_wp () in
+                                match uu____8407 with
                                 | (a, wp_sort_a) ->
-                                    let uu____8382 =
+                                    let uu____8420 =
                                       FStar_Syntax_Util.type_u () in
-                                    (match uu____8382 with
-                                     | (t, uu____8388) ->
+                                    (match uu____8420 with
+                                     | (t, uu____8426) ->
                                          let k =
-                                           let uu____8392 =
-                                             let uu____8401 =
+                                           let uu____8430 =
+                                             let uu____8439 =
                                                FStar_Syntax_Syntax.mk_binder
                                                  a in
-                                             let uu____8408 =
-                                               let uu____8417 =
+                                             let uu____8446 =
+                                               let uu____8455 =
                                                  FStar_Syntax_Syntax.null_binder
                                                    wp_sort_a in
-                                               let uu____8424 =
-                                                 let uu____8433 =
+                                               let uu____8462 =
+                                                 let uu____8471 =
                                                    FStar_Syntax_Syntax.null_binder
                                                      wp_sort_a in
-                                                 [uu____8433] in
-                                               uu____8417 :: uu____8424 in
-                                             uu____8401 :: uu____8408 in
-                                           let uu____8464 =
+                                                 [uu____8471] in
+                                               uu____8455 :: uu____8462 in
+                                             uu____8439 :: uu____8446 in
+                                           let uu____8502 =
                                              FStar_Syntax_Syntax.mk_Total t in
-                                           FStar_Syntax_Util.arrow uu____8392
-                                             uu____8464 in
-                                         let uu____8467 =
+                                           FStar_Syntax_Util.arrow uu____8430
+                                             uu____8502 in
+                                         let uu____8505 =
                                            FStar_All.pipe_right ed2
                                              FStar_Syntax_Util.get_stronger_vc_combinator in
                                          check_and_gen' "stronger"
                                            Prims.int_one
                                            FStar_Pervasives_Native.None
-                                           uu____8467
+                                           uu____8505
                                            (FStar_Pervasives_Native.Some k)) in
                               log_combinator "stronger" stronger;
                               (let if_then_else =
-                                 let uu____8478 = fresh_a_and_wp () in
-                                 match uu____8478 with
+                                 let uu____8516 = fresh_a_and_wp () in
+                                 match uu____8516 with
                                  | (a, wp_sort_a) ->
                                      let p =
-                                       let uu____8492 =
-                                         let uu____8495 =
+                                       let uu____8530 =
+                                         let uu____8533 =
                                            FStar_Ident.range_of_lid
                                              ed2.FStar_Syntax_Syntax.mname in
                                          FStar_Pervasives_Native.Some
-                                           uu____8495 in
-                                       let uu____8496 =
-                                         let uu____8497 =
+                                           uu____8533 in
+                                       let uu____8534 =
+                                         let uu____8535 =
                                            FStar_Syntax_Util.type_u () in
-                                         FStar_All.pipe_right uu____8497
+                                         FStar_All.pipe_right uu____8535
                                            FStar_Pervasives_Native.fst in
-                                       FStar_Syntax_Syntax.new_bv uu____8492
-                                         uu____8496 in
+                                       FStar_Syntax_Syntax.new_bv uu____8530
+                                         uu____8534 in
                                      let k =
-                                       let uu____8509 =
-                                         let uu____8518 =
+                                       let uu____8547 =
+                                         let uu____8556 =
                                            FStar_Syntax_Syntax.mk_binder a in
-                                         let uu____8525 =
-                                           let uu____8534 =
+                                         let uu____8563 =
+                                           let uu____8572 =
                                              FStar_Syntax_Syntax.mk_binder p in
-                                           let uu____8541 =
-                                             let uu____8550 =
+                                           let uu____8579 =
+                                             let uu____8588 =
                                                FStar_Syntax_Syntax.null_binder
                                                  wp_sort_a in
-                                             let uu____8557 =
-                                               let uu____8566 =
+                                             let uu____8595 =
+                                               let uu____8604 =
                                                  FStar_Syntax_Syntax.null_binder
                                                    wp_sort_a in
-                                               [uu____8566] in
-                                             uu____8550 :: uu____8557 in
-                                           uu____8534 :: uu____8541 in
-                                         uu____8518 :: uu____8525 in
-                                       let uu____8603 =
+                                               [uu____8604] in
+                                             uu____8588 :: uu____8595 in
+                                           uu____8572 :: uu____8579 in
+                                         uu____8556 :: uu____8563 in
+                                       let uu____8641 =
                                          FStar_Syntax_Syntax.mk_Total
                                            wp_sort_a in
-                                       FStar_Syntax_Util.arrow uu____8509
-                                         uu____8603 in
-                                     let uu____8606 =
-                                       let uu____8611 =
+                                       FStar_Syntax_Util.arrow uu____8547
+                                         uu____8641 in
+                                     let uu____8644 =
+                                       let uu____8649 =
                                          FStar_All.pipe_right ed2
                                            FStar_Syntax_Util.get_wp_if_then_else_combinator in
-                                       FStar_All.pipe_right uu____8611
+                                       FStar_All.pipe_right uu____8649
                                          FStar_Util.must in
                                      check_and_gen' "if_then_else"
                                        Prims.int_one
                                        FStar_Pervasives_Native.None
-                                       uu____8606
+                                       uu____8644
                                        (FStar_Pervasives_Native.Some k) in
                                log_combinator "if_then_else" if_then_else;
                                (let ite_wp =
-                                  let uu____8640 = fresh_a_and_wp () in
-                                  match uu____8640 with
+                                  let uu____8678 = fresh_a_and_wp () in
+                                  match uu____8678 with
                                   | (a, wp_sort_a) ->
                                       let k =
-                                        let uu____8656 =
-                                          let uu____8665 =
+                                        let uu____8694 =
+                                          let uu____8703 =
                                             FStar_Syntax_Syntax.mk_binder a in
-                                          let uu____8672 =
-                                            let uu____8681 =
+                                          let uu____8710 =
+                                            let uu____8719 =
                                               FStar_Syntax_Syntax.null_binder
                                                 wp_sort_a in
-                                            [uu____8681] in
-                                          uu____8665 :: uu____8672 in
-                                        let uu____8706 =
+                                            [uu____8719] in
+                                          uu____8703 :: uu____8710 in
+                                        let uu____8744 =
                                           FStar_Syntax_Syntax.mk_Total
                                             wp_sort_a in
-                                        FStar_Syntax_Util.arrow uu____8656
-                                          uu____8706 in
-                                      let uu____8709 =
-                                        let uu____8714 =
+                                        FStar_Syntax_Util.arrow uu____8694
+                                          uu____8744 in
+                                      let uu____8747 =
+                                        let uu____8752 =
                                           FStar_All.pipe_right ed2
                                             FStar_Syntax_Util.get_wp_ite_combinator in
-                                        FStar_All.pipe_right uu____8714
+                                        FStar_All.pipe_right uu____8752
                                           FStar_Util.must in
                                       check_and_gen' "ite_wp" Prims.int_one
                                         FStar_Pervasives_Native.None
-                                        uu____8709
+                                        uu____8747
                                         (FStar_Pervasives_Native.Some k) in
                                 log_combinator "ite_wp" ite_wp;
                                 (let close_wp =
-                                   let uu____8727 = fresh_a_and_wp () in
-                                   match uu____8727 with
+                                   let uu____8781 = fresh_a_and_wp () in
+                                   match uu____8781 with
                                    | (a, wp_sort_a) ->
                                        let b =
-                                         let uu____8741 =
-                                           let uu____8744 =
+                                         let uu____8795 =
+                                           let uu____8798 =
                                              FStar_Ident.range_of_lid
                                                ed2.FStar_Syntax_Syntax.mname in
                                            FStar_Pervasives_Native.Some
-                                             uu____8744 in
-                                         let uu____8745 =
-                                           let uu____8746 =
+                                             uu____8798 in
+                                         let uu____8799 =
+                                           let uu____8800 =
                                              FStar_Syntax_Util.type_u () in
-                                           FStar_All.pipe_right uu____8746
+                                           FStar_All.pipe_right uu____8800
                                              FStar_Pervasives_Native.fst in
                                          FStar_Syntax_Syntax.new_bv
-                                           uu____8741 uu____8745 in
+                                           uu____8795 uu____8799 in
                                        let wp_sort_b_a =
-                                         let uu____8758 =
-                                           let uu____8767 =
-                                             let uu____8774 =
+                                         let uu____8812 =
+                                           let uu____8821 =
+                                             let uu____8828 =
                                                FStar_Syntax_Syntax.bv_to_name
                                                  b in
                                              FStar_Syntax_Syntax.null_binder
-                                               uu____8774 in
-                                           [uu____8767] in
-                                         let uu____8787 =
+                                               uu____8828 in
+                                           [uu____8821] in
+                                         let uu____8841 =
                                            FStar_Syntax_Syntax.mk_Total
                                              wp_sort_a in
-                                         FStar_Syntax_Util.arrow uu____8758
-                                           uu____8787 in
+                                         FStar_Syntax_Util.arrow uu____8812
+                                           uu____8841 in
                                        let k =
-                                         let uu____8793 =
-                                           let uu____8802 =
+                                         let uu____8847 =
+                                           let uu____8856 =
                                              FStar_Syntax_Syntax.mk_binder a in
-                                           let uu____8809 =
-                                             let uu____8818 =
+                                           let uu____8863 =
+                                             let uu____8872 =
                                                FStar_Syntax_Syntax.mk_binder
                                                  b in
-                                             let uu____8825 =
-                                               let uu____8834 =
+                                             let uu____8879 =
+                                               let uu____8888 =
                                                  FStar_Syntax_Syntax.null_binder
                                                    wp_sort_b_a in
-                                               [uu____8834] in
-                                             uu____8818 :: uu____8825 in
-                                           uu____8802 :: uu____8809 in
-                                         let uu____8865 =
+                                               [uu____8888] in
+                                             uu____8872 :: uu____8879 in
+                                           uu____8856 :: uu____8863 in
+                                         let uu____8919 =
                                            FStar_Syntax_Syntax.mk_Total
                                              wp_sort_a in
-                                         FStar_Syntax_Util.arrow uu____8793
-                                           uu____8865 in
-                                       let uu____8868 =
-                                         let uu____8873 =
+                                         FStar_Syntax_Util.arrow uu____8847
+                                           uu____8919 in
+                                       let uu____8922 =
+                                         let uu____8927 =
                                            FStar_All.pipe_right ed2
                                              FStar_Syntax_Util.get_wp_close_combinator in
-                                         FStar_All.pipe_right uu____8873
+                                         FStar_All.pipe_right uu____8927
                                            FStar_Util.must in
                                        check_and_gen' "close_wp"
                                          (Prims.of_int (2))
                                          FStar_Pervasives_Native.None
-                                         uu____8868
+                                         uu____8922
                                          (FStar_Pervasives_Native.Some k) in
                                  log_combinator "close_wp" close_wp;
                                  (let trivial =
-                                    let uu____8886 = fresh_a_and_wp () in
-                                    match uu____8886 with
+                                    let uu____8940 = fresh_a_and_wp () in
+                                    match uu____8940 with
                                     | (a, wp_sort_a) ->
-                                        let uu____8899 =
+                                        let uu____8953 =
                                           FStar_Syntax_Util.type_u () in
-                                        (match uu____8899 with
-                                         | (t, uu____8905) ->
+                                        (match uu____8953 with
+                                         | (t, uu____8959) ->
                                              let k =
-                                               let uu____8909 =
-                                                 let uu____8918 =
+                                               let uu____8963 =
+                                                 let uu____8972 =
                                                    FStar_Syntax_Syntax.mk_binder
                                                      a in
-                                                 let uu____8925 =
-                                                   let uu____8934 =
+                                                 let uu____8979 =
+                                                   let uu____8988 =
                                                      FStar_Syntax_Syntax.null_binder
                                                        wp_sort_a in
-                                                   [uu____8934] in
-                                                 uu____8918 :: uu____8925 in
-                                               let uu____8959 =
+                                                   [uu____8988] in
+                                                 uu____8972 :: uu____8979 in
+                                               let uu____9013 =
                                                  FStar_Syntax_Syntax.mk_GTotal
                                                    t in
                                                FStar_Syntax_Util.arrow
-                                                 uu____8909 uu____8959 in
+                                                 uu____8963 uu____9013 in
                                              let trivial =
-                                               let uu____8963 =
-                                                 let uu____8968 =
+                                               let uu____9017 =
+                                                 let uu____9022 =
                                                    FStar_All.pipe_right ed2
                                                      FStar_Syntax_Util.get_wp_trivial_combinator in
                                                  FStar_All.pipe_right
-                                                   uu____8968 FStar_Util.must in
+                                                   uu____9022 FStar_Util.must in
                                                check_and_gen' "trivial"
                                                  Prims.int_one
                                                  FStar_Pervasives_Native.None
-                                                 uu____8963
+                                                 uu____9017
                                                  (FStar_Pervasives_Native.Some
                                                     k) in
                                              (log_combinator "trivial"
                                                 trivial;
                                               trivial)) in
-                                  let uu____8980 =
-                                    let uu____8997 =
+                                  let uu____9050 =
+                                    let uu____9067 =
                                       FStar_All.pipe_right ed2
                                         FStar_Syntax_Util.get_eff_repr in
-                                    match uu____8997 with
+                                    match uu____9067 with
                                     | FStar_Pervasives_Native.None ->
                                         (FStar_Pervasives_Native.None,
                                           FStar_Pervasives_Native.None,
                                           FStar_Pervasives_Native.None,
                                           (ed2.FStar_Syntax_Syntax.actions))
-                                    | uu____9026 ->
+                                    | uu____9096 ->
                                         let repr =
-                                          let uu____9030 = fresh_a_and_wp () in
-                                          match uu____9030 with
+                                          let uu____9100 = fresh_a_and_wp () in
+                                          match uu____9100 with
                                           | (a, wp_sort_a) ->
-                                              let uu____9043 =
+                                              let uu____9113 =
                                                 FStar_Syntax_Util.type_u () in
-                                              (match uu____9043 with
-                                               | (t, uu____9049) ->
+                                              (match uu____9113 with
+                                               | (t, uu____9119) ->
                                                    let k =
-                                                     let uu____9053 =
-                                                       let uu____9062 =
+                                                     let uu____9123 =
+                                                       let uu____9132 =
                                                          FStar_Syntax_Syntax.mk_binder
                                                            a in
-                                                       let uu____9069 =
-                                                         let uu____9078 =
+                                                       let uu____9139 =
+                                                         let uu____9148 =
                                                            FStar_Syntax_Syntax.null_binder
                                                              wp_sort_a in
-                                                         [uu____9078] in
-                                                       uu____9062 ::
-                                                         uu____9069 in
-                                                     let uu____9103 =
+                                                         [uu____9148] in
+                                                       uu____9132 ::
+                                                         uu____9139 in
+                                                     let uu____9173 =
                                                        FStar_Syntax_Syntax.mk_GTotal
                                                          t in
                                                      FStar_Syntax_Util.arrow
-                                                       uu____9053 uu____9103 in
-                                                   let uu____9106 =
-                                                     let uu____9111 =
+                                                       uu____9123 uu____9173 in
+                                                   let uu____9176 =
+                                                     let uu____9181 =
                                                        FStar_All.pipe_right
                                                          ed2
                                                          FStar_Syntax_Util.get_eff_repr in
                                                      FStar_All.pipe_right
-                                                       uu____9111
+                                                       uu____9181
                                                        FStar_Util.must in
                                                    check_and_gen' "repr"
                                                      Prims.int_one
                                                      FStar_Pervasives_Native.None
-                                                     uu____9106
+                                                     uu____9176
                                                      (FStar_Pervasives_Native.Some
                                                         k)) in
                                         (log_combinator "repr" repr;
                                          (let mk_repr' t wp =
-                                            let uu____9152 =
+                                            let uu____9222 =
                                               FStar_TypeChecker_Env.inst_tscheme
                                                 repr in
-                                            match uu____9152 with
-                                            | (uu____9159, repr1) ->
+                                            match uu____9222 with
+                                            | (uu____9229, repr1) ->
                                                 let repr2 =
                                                   FStar_TypeChecker_Normalize.normalize
                                                     [FStar_TypeChecker_Env.EraseUniverses;
                                                     FStar_TypeChecker_Env.AllowUnboundUniverses]
                                                     env repr1 in
-                                                let uu____9162 =
-                                                  let uu____9163 =
-                                                    let uu____9180 =
-                                                      let uu____9191 =
+                                                let uu____9232 =
+                                                  let uu____9233 =
+                                                    let uu____9250 =
+                                                      let uu____9261 =
                                                         FStar_All.pipe_right
                                                           t
                                                           FStar_Syntax_Syntax.as_arg in
-                                                      let uu____9208 =
-                                                        let uu____9219 =
+                                                      let uu____9278 =
+                                                        let uu____9289 =
                                                           FStar_All.pipe_right
                                                             wp
                                                             FStar_Syntax_Syntax.as_arg in
-                                                        [uu____9219] in
-                                                      uu____9191 ::
-                                                        uu____9208 in
-                                                    (repr2, uu____9180) in
+                                                        [uu____9289] in
+                                                      uu____9261 ::
+                                                        uu____9278 in
+                                                    (repr2, uu____9250) in
                                                   FStar_Syntax_Syntax.Tm_app
-                                                    uu____9163 in
+                                                    uu____9233 in
                                                 FStar_Syntax_Syntax.mk
-                                                  uu____9162
+                                                  uu____9232
                                                   FStar_Range.dummyRange in
                                           let mk_repr a wp =
-                                            let uu____9285 =
+                                            let uu____9355 =
                                               FStar_Syntax_Syntax.bv_to_name
                                                 a in
-                                            mk_repr' uu____9285 wp in
+                                            mk_repr' uu____9355 wp in
                                           let destruct_repr t =
-                                            let uu____9300 =
-                                              let uu____9301 =
+                                            let uu____9370 =
+                                              let uu____9371 =
                                                 FStar_Syntax_Subst.compress t in
-                                              uu____9301.FStar_Syntax_Syntax.n in
-                                            match uu____9300 with
+                                              uu____9371.FStar_Syntax_Syntax.n in
+                                            match uu____9370 with
                                             | FStar_Syntax_Syntax.Tm_app
-                                                (uu____9312,
-                                                 (t1, uu____9314)::(wp,
-                                                                    uu____9316)::[])
+                                                (uu____9382,
+                                                 (t1, uu____9384)::(wp,
+                                                                    uu____9386)::[])
                                                 -> (t1, wp)
-                                            | uu____9375 ->
+                                            | uu____9445 ->
                                                 failwith
                                                   "Unexpected repr type" in
                                           let return_repr =
                                             let return_repr_ts =
-                                              let uu____9390 =
+                                              let uu____9460 =
                                                 FStar_All.pipe_right ed2
                                                   FStar_Syntax_Util.get_return_repr in
-                                              FStar_All.pipe_right uu____9390
+                                              FStar_All.pipe_right uu____9460
                                                 FStar_Util.must in
-                                            let uu____9417 =
+                                            let uu____9487 =
                                               fresh_a_and_wp () in
-                                            match uu____9417 with
-                                            | (a, uu____9425) ->
+                                            match uu____9487 with
+                                            | (a, uu____9495) ->
                                                 let x_a =
-                                                  let uu____9431 =
+                                                  let uu____9501 =
                                                     FStar_Syntax_Syntax.bv_to_name
                                                       a in
                                                   FStar_Syntax_Syntax.gen_bv
                                                     "x_a"
                                                     FStar_Pervasives_Native.None
-                                                    uu____9431 in
+                                                    uu____9501 in
                                                 let res =
                                                   let wp =
-                                                    let uu____9436 =
-                                                      let uu____9437 =
+                                                    let uu____9506 =
+                                                      let uu____9507 =
                                                         FStar_TypeChecker_Env.inst_tscheme
                                                           ret_wp in
                                                       FStar_All.pipe_right
-                                                        uu____9437
+                                                        uu____9507
                                                         FStar_Pervasives_Native.snd in
-                                                    let uu____9446 =
-                                                      let uu____9447 =
-                                                        let uu____9456 =
+                                                    let uu____9516 =
+                                                      let uu____9517 =
+                                                        let uu____9526 =
                                                           FStar_Syntax_Syntax.bv_to_name
                                                             a in
                                                         FStar_All.pipe_right
-                                                          uu____9456
+                                                          uu____9526
                                                           FStar_Syntax_Syntax.as_arg in
-                                                      let uu____9465 =
-                                                        let uu____9476 =
-                                                          let uu____9485 =
+                                                      let uu____9535 =
+                                                        let uu____9546 =
+                                                          let uu____9555 =
                                                             FStar_Syntax_Syntax.bv_to_name
                                                               x_a in
                                                           FStar_All.pipe_right
-                                                            uu____9485
+                                                            uu____9555
                                                             FStar_Syntax_Syntax.as_arg in
-                                                        [uu____9476] in
-                                                      uu____9447 ::
-                                                        uu____9465 in
+                                                        [uu____9546] in
+                                                      uu____9517 ::
+                                                        uu____9535 in
                                                     FStar_Syntax_Syntax.mk_Tm_app
-                                                      uu____9436 uu____9446
+                                                      uu____9506 uu____9516
                                                       FStar_Range.dummyRange in
                                                   mk_repr a wp in
                                                 let k =
-                                                  let uu____9521 =
-                                                    let uu____9530 =
+                                                  let uu____9591 =
+                                                    let uu____9600 =
                                                       FStar_Syntax_Syntax.mk_binder
                                                         a in
-                                                    let uu____9537 =
-                                                      let uu____9546 =
+                                                    let uu____9607 =
+                                                      let uu____9616 =
                                                         FStar_Syntax_Syntax.mk_binder
                                                           x_a in
-                                                      [uu____9546] in
-                                                    uu____9530 :: uu____9537 in
-                                                  let uu____9571 =
+                                                      [uu____9616] in
+                                                    uu____9600 :: uu____9607 in
+                                                  let uu____9641 =
                                                     FStar_Syntax_Syntax.mk_Total
                                                       res in
                                                   FStar_Syntax_Util.arrow
-                                                    uu____9521 uu____9571 in
-                                                let uu____9574 =
+                                                    uu____9591 uu____9641 in
+                                                let uu____9644 =
                                                   FStar_TypeChecker_TcTerm.tc_tot_or_gtot_term
                                                     env k in
-                                                (match uu____9574 with
-                                                 | (k1, uu____9582,
-                                                    uu____9583) ->
+                                                (match uu____9644 with
+                                                 | (k1, uu____9652,
+                                                    uu____9653) ->
                                                      let env1 =
-                                                       let uu____9587 =
+                                                       let uu____9657 =
                                                          FStar_TypeChecker_Env.set_range
                                                            env
                                                            (FStar_Pervasives_Native.snd
                                                               return_repr_ts).FStar_Syntax_Syntax.pos in
                                                        FStar_Pervasives_Native.Some
-                                                         uu____9587 in
+                                                         uu____9657 in
                                                      check_and_gen'
                                                        "return_repr"
                                                        Prims.int_one env1
@@ -3533,43 +3533,43 @@ let (tc_non_layered_eff_decl :
                                             return_repr;
                                           (let bind_repr =
                                              let bind_repr_ts =
-                                               let uu____9597 =
+                                               let uu____9667 =
                                                  FStar_All.pipe_right ed2
                                                    FStar_Syntax_Util.get_bind_repr in
                                                FStar_All.pipe_right
-                                                 uu____9597 FStar_Util.must in
+                                                 uu____9667 FStar_Util.must in
                                              let r =
-                                               let uu____9635 =
+                                               let uu____9681 =
                                                  FStar_Syntax_Syntax.lid_as_fv
                                                    FStar_Parser_Const.range_0
                                                    FStar_Syntax_Syntax.delta_constant
                                                    FStar_Pervasives_Native.None in
                                                FStar_All.pipe_right
-                                                 uu____9635
+                                                 uu____9681
                                                  FStar_Syntax_Syntax.fv_to_tm in
-                                             let uu____9636 =
+                                             let uu____9682 =
                                                fresh_a_and_wp () in
-                                             match uu____9636 with
+                                             match uu____9682 with
                                              | (a, wp_sort_a) ->
-                                                 let uu____9649 =
+                                                 let uu____9695 =
                                                    fresh_a_and_wp () in
-                                                 (match uu____9649 with
+                                                 (match uu____9695 with
                                                   | (b, wp_sort_b) ->
                                                       let wp_sort_a_b =
-                                                        let uu____9665 =
-                                                          let uu____9674 =
-                                                            let uu____9681 =
+                                                        let uu____9711 =
+                                                          let uu____9720 =
+                                                            let uu____9727 =
                                                               FStar_Syntax_Syntax.bv_to_name
                                                                 a in
                                                             FStar_Syntax_Syntax.null_binder
-                                                              uu____9681 in
-                                                          [uu____9674] in
-                                                        let uu____9694 =
+                                                              uu____9727 in
+                                                          [uu____9720] in
+                                                        let uu____9740 =
                                                           FStar_Syntax_Syntax.mk_Total
                                                             wp_sort_b in
                                                         FStar_Syntax_Util.arrow
-                                                          uu____9665
-                                                          uu____9694 in
+                                                          uu____9711
+                                                          uu____9740 in
                                                       let wp_f =
                                                         FStar_Syntax_Syntax.gen_bv
                                                           "wp_f"
@@ -3581,195 +3581,195 @@ let (tc_non_layered_eff_decl :
                                                           FStar_Pervasives_Native.None
                                                           wp_sort_a_b in
                                                       let x_a =
-                                                        let uu____9700 =
+                                                        let uu____9746 =
                                                           FStar_Syntax_Syntax.bv_to_name
                                                             a in
                                                         FStar_Syntax_Syntax.gen_bv
                                                           "x_a"
                                                           FStar_Pervasives_Native.None
-                                                          uu____9700 in
+                                                          uu____9746 in
                                                       let wp_g_x =
-                                                        let uu____9702 =
+                                                        let uu____9748 =
                                                           FStar_Syntax_Syntax.bv_to_name
                                                             wp_g in
-                                                        let uu____9703 =
-                                                          let uu____9704 =
-                                                            let uu____9713 =
+                                                        let uu____9749 =
+                                                          let uu____9750 =
+                                                            let uu____9759 =
                                                               FStar_Syntax_Syntax.bv_to_name
                                                                 x_a in
                                                             FStar_All.pipe_right
-                                                              uu____9713
+                                                              uu____9759
                                                               FStar_Syntax_Syntax.as_arg in
-                                                          [uu____9704] in
+                                                          [uu____9750] in
                                                         FStar_Syntax_Syntax.mk_Tm_app
-                                                          uu____9702
-                                                          uu____9703
+                                                          uu____9748
+                                                          uu____9749
                                                           FStar_Range.dummyRange in
                                                       let res =
                                                         let wp =
-                                                          let uu____9742 =
-                                                            let uu____9743 =
+                                                          let uu____9788 =
+                                                            let uu____9789 =
                                                               FStar_TypeChecker_Env.inst_tscheme
                                                                 bind_wp in
                                                             FStar_All.pipe_right
-                                                              uu____9743
+                                                              uu____9789
                                                               FStar_Pervasives_Native.snd in
-                                                          let uu____9752 =
-                                                            let uu____9753 =
-                                                              let uu____9756
+                                                          let uu____9798 =
+                                                            let uu____9799 =
+                                                              let uu____9802
                                                                 =
-                                                                let uu____9759
+                                                                let uu____9805
                                                                   =
                                                                   FStar_Syntax_Syntax.bv_to_name
                                                                     a in
-                                                                let uu____9760
+                                                                let uu____9806
                                                                   =
-                                                                  let uu____9763
+                                                                  let uu____9809
                                                                     =
                                                                     FStar_Syntax_Syntax.bv_to_name
                                                                     b in
-                                                                  let uu____9764
+                                                                  let uu____9810
                                                                     =
-                                                                    let uu____9767
+                                                                    let uu____9813
                                                                     =
                                                                     FStar_Syntax_Syntax.bv_to_name
                                                                     wp_f in
-                                                                    let uu____9768
+                                                                    let uu____9814
                                                                     =
-                                                                    let uu____9771
+                                                                    let uu____9817
                                                                     =
                                                                     FStar_Syntax_Syntax.bv_to_name
                                                                     wp_g in
-                                                                    [uu____9771] in
-                                                                    uu____9767
+                                                                    [uu____9817] in
+                                                                    uu____9813
                                                                     ::
-                                                                    uu____9768 in
-                                                                  uu____9763
+                                                                    uu____9814 in
+                                                                  uu____9809
                                                                     ::
-                                                                    uu____9764 in
-                                                                uu____9759 ::
-                                                                  uu____9760 in
-                                                              r :: uu____9756 in
+                                                                    uu____9810 in
+                                                                uu____9805 ::
+                                                                  uu____9806 in
+                                                              r :: uu____9802 in
                                                             FStar_List.map
                                                               FStar_Syntax_Syntax.as_arg
-                                                              uu____9753 in
+                                                              uu____9799 in
                                                           FStar_Syntax_Syntax.mk_Tm_app
-                                                            uu____9742
-                                                            uu____9752
+                                                            uu____9788
+                                                            uu____9798
                                                             FStar_Range.dummyRange in
                                                         mk_repr b wp in
                                                       let maybe_range_arg =
-                                                        let uu____9789 =
+                                                        let uu____9835 =
                                                           FStar_Util.for_some
                                                             (FStar_Syntax_Util.attr_eq
                                                                FStar_Syntax_Util.dm4f_bind_range_attr)
                                                             ed2.FStar_Syntax_Syntax.eff_attrs in
-                                                        if uu____9789
+                                                        if uu____9835
                                                         then
-                                                          let uu____9798 =
+                                                          let uu____9844 =
                                                             FStar_Syntax_Syntax.null_binder
                                                               FStar_Syntax_Syntax.t_range in
-                                                          let uu____9805 =
-                                                            let uu____9814 =
+                                                          let uu____9851 =
+                                                            let uu____9860 =
                                                               FStar_Syntax_Syntax.null_binder
                                                                 FStar_Syntax_Syntax.t_range in
-                                                            [uu____9814] in
-                                                          uu____9798 ::
-                                                            uu____9805
+                                                            [uu____9860] in
+                                                          uu____9844 ::
+                                                            uu____9851
                                                         else [] in
                                                       let k =
-                                                        let uu____9849 =
-                                                          let uu____9858 =
-                                                            let uu____9867 =
+                                                        let uu____9895 =
+                                                          let uu____9904 =
+                                                            let uu____9913 =
                                                               FStar_Syntax_Syntax.mk_binder
                                                                 a in
-                                                            let uu____9874 =
-                                                              let uu____9883
+                                                            let uu____9920 =
+                                                              let uu____9929
                                                                 =
                                                                 FStar_Syntax_Syntax.mk_binder
                                                                   b in
-                                                              [uu____9883] in
-                                                            uu____9867 ::
-                                                              uu____9874 in
-                                                          let uu____9908 =
-                                                            let uu____9917 =
-                                                              let uu____9926
+                                                              [uu____9929] in
+                                                            uu____9913 ::
+                                                              uu____9920 in
+                                                          let uu____9954 =
+                                                            let uu____9963 =
+                                                              let uu____9972
                                                                 =
                                                                 FStar_Syntax_Syntax.mk_binder
                                                                   wp_f in
-                                                              let uu____9933
+                                                              let uu____9979
                                                                 =
-                                                                let uu____9942
+                                                                let uu____9988
                                                                   =
-                                                                  let uu____9949
+                                                                  let uu____9995
                                                                     =
-                                                                    let uu____9950
+                                                                    let uu____9996
                                                                     =
                                                                     FStar_Syntax_Syntax.bv_to_name
                                                                     wp_f in
                                                                     mk_repr a
-                                                                    uu____9950 in
+                                                                    uu____9996 in
                                                                   FStar_Syntax_Syntax.null_binder
-                                                                    uu____9949 in
-                                                                let uu____9951
+                                                                    uu____9995 in
+                                                                let uu____9997
                                                                   =
-                                                                  let uu____9960
+                                                                  let uu____10006
                                                                     =
                                                                     FStar_Syntax_Syntax.mk_binder
                                                                     wp_g in
-                                                                  let uu____9967
+                                                                  let uu____10013
                                                                     =
-                                                                    let uu____9976
+                                                                    let uu____10022
                                                                     =
-                                                                    let uu____9983
+                                                                    let uu____10029
                                                                     =
-                                                                    let uu____9984
+                                                                    let uu____10030
                                                                     =
-                                                                    let uu____9993
+                                                                    let uu____10039
                                                                     =
                                                                     FStar_Syntax_Syntax.mk_binder
                                                                     x_a in
-                                                                    [uu____9993] in
-                                                                    let uu____10012
+                                                                    [uu____10039] in
+                                                                    let uu____10058
                                                                     =
-                                                                    let uu____10015
+                                                                    let uu____10061
                                                                     =
                                                                     mk_repr b
                                                                     wp_g_x in
                                                                     FStar_All.pipe_left
                                                                     FStar_Syntax_Syntax.mk_Total
-                                                                    uu____10015 in
+                                                                    uu____10061 in
                                                                     FStar_Syntax_Util.arrow
-                                                                    uu____9984
-                                                                    uu____10012 in
+                                                                    uu____10030
+                                                                    uu____10058 in
                                                                     FStar_Syntax_Syntax.null_binder
-                                                                    uu____9983 in
-                                                                    [uu____9976] in
-                                                                  uu____9960
+                                                                    uu____10029 in
+                                                                    [uu____10022] in
+                                                                  uu____10006
                                                                     ::
-                                                                    uu____9967 in
-                                                                uu____9942 ::
-                                                                  uu____9951 in
-                                                              uu____9926 ::
-                                                                uu____9933 in
+                                                                    uu____10013 in
+                                                                uu____9988 ::
+                                                                  uu____9997 in
+                                                              uu____9972 ::
+                                                                uu____9979 in
                                                             FStar_List.append
                                                               maybe_range_arg
-                                                              uu____9917 in
+                                                              uu____9963 in
                                                           FStar_List.append
-                                                            uu____9858
-                                                            uu____9908 in
-                                                        let uu____10060 =
+                                                            uu____9904
+                                                            uu____9954 in
+                                                        let uu____10106 =
                                                           FStar_Syntax_Syntax.mk_Total
                                                             res in
                                                         FStar_Syntax_Util.arrow
-                                                          uu____9849
-                                                          uu____10060 in
-                                                      let uu____10063 =
+                                                          uu____9895
+                                                          uu____10106 in
+                                                      let uu____10109 =
                                                         FStar_TypeChecker_TcTerm.tc_tot_or_gtot_term
                                                           env k in
-                                                      (match uu____10063 with
-                                                       | (k1, uu____10071,
-                                                          uu____10072) ->
+                                                      (match uu____10109 with
+                                                       | (k1, uu____10117,
+                                                          uu____10118) ->
                                                            let env1 =
                                                              FStar_TypeChecker_Env.set_range
                                                                env
@@ -3777,201 +3777,201 @@ let (tc_non_layered_eff_decl :
                                                                   bind_repr_ts).FStar_Syntax_Syntax.pos in
                                                            let env2 =
                                                              FStar_All.pipe_right
-                                                               (let uu___1010_10082
+                                                               (let uu___1010_10128
                                                                   = env1 in
                                                                 {
                                                                   FStar_TypeChecker_Env.solver
                                                                     =
                                                                     (
-                                                                    uu___1010_10082.FStar_TypeChecker_Env.solver);
+                                                                    uu___1010_10128.FStar_TypeChecker_Env.solver);
                                                                   FStar_TypeChecker_Env.range
                                                                     =
                                                                     (
-                                                                    uu___1010_10082.FStar_TypeChecker_Env.range);
+                                                                    uu___1010_10128.FStar_TypeChecker_Env.range);
                                                                   FStar_TypeChecker_Env.curmodule
                                                                     =
                                                                     (
-                                                                    uu___1010_10082.FStar_TypeChecker_Env.curmodule);
+                                                                    uu___1010_10128.FStar_TypeChecker_Env.curmodule);
                                                                   FStar_TypeChecker_Env.gamma
                                                                     =
                                                                     (
-                                                                    uu___1010_10082.FStar_TypeChecker_Env.gamma);
+                                                                    uu___1010_10128.FStar_TypeChecker_Env.gamma);
                                                                   FStar_TypeChecker_Env.gamma_sig
                                                                     =
                                                                     (
-                                                                    uu___1010_10082.FStar_TypeChecker_Env.gamma_sig);
+                                                                    uu___1010_10128.FStar_TypeChecker_Env.gamma_sig);
                                                                   FStar_TypeChecker_Env.gamma_cache
                                                                     =
                                                                     (
-                                                                    uu___1010_10082.FStar_TypeChecker_Env.gamma_cache);
+                                                                    uu___1010_10128.FStar_TypeChecker_Env.gamma_cache);
                                                                   FStar_TypeChecker_Env.modules
                                                                     =
                                                                     (
-                                                                    uu___1010_10082.FStar_TypeChecker_Env.modules);
+                                                                    uu___1010_10128.FStar_TypeChecker_Env.modules);
                                                                   FStar_TypeChecker_Env.expected_typ
                                                                     =
                                                                     (
-                                                                    uu___1010_10082.FStar_TypeChecker_Env.expected_typ);
+                                                                    uu___1010_10128.FStar_TypeChecker_Env.expected_typ);
                                                                   FStar_TypeChecker_Env.sigtab
                                                                     =
                                                                     (
-                                                                    uu___1010_10082.FStar_TypeChecker_Env.sigtab);
+                                                                    uu___1010_10128.FStar_TypeChecker_Env.sigtab);
                                                                   FStar_TypeChecker_Env.attrtab
                                                                     =
                                                                     (
-                                                                    uu___1010_10082.FStar_TypeChecker_Env.attrtab);
+                                                                    uu___1010_10128.FStar_TypeChecker_Env.attrtab);
                                                                   FStar_TypeChecker_Env.instantiate_imp
                                                                     =
                                                                     (
-                                                                    uu___1010_10082.FStar_TypeChecker_Env.instantiate_imp);
+                                                                    uu___1010_10128.FStar_TypeChecker_Env.instantiate_imp);
                                                                   FStar_TypeChecker_Env.effects
                                                                     =
                                                                     (
-                                                                    uu___1010_10082.FStar_TypeChecker_Env.effects);
+                                                                    uu___1010_10128.FStar_TypeChecker_Env.effects);
                                                                   FStar_TypeChecker_Env.generalize
                                                                     =
                                                                     (
-                                                                    uu___1010_10082.FStar_TypeChecker_Env.generalize);
+                                                                    uu___1010_10128.FStar_TypeChecker_Env.generalize);
                                                                   FStar_TypeChecker_Env.letrecs
                                                                     =
                                                                     (
-                                                                    uu___1010_10082.FStar_TypeChecker_Env.letrecs);
+                                                                    uu___1010_10128.FStar_TypeChecker_Env.letrecs);
                                                                   FStar_TypeChecker_Env.top_level
                                                                     =
                                                                     (
-                                                                    uu___1010_10082.FStar_TypeChecker_Env.top_level);
+                                                                    uu___1010_10128.FStar_TypeChecker_Env.top_level);
                                                                   FStar_TypeChecker_Env.check_uvars
                                                                     =
                                                                     (
-                                                                    uu___1010_10082.FStar_TypeChecker_Env.check_uvars);
+                                                                    uu___1010_10128.FStar_TypeChecker_Env.check_uvars);
                                                                   FStar_TypeChecker_Env.use_eq
                                                                     =
                                                                     (
-                                                                    uu___1010_10082.FStar_TypeChecker_Env.use_eq);
+                                                                    uu___1010_10128.FStar_TypeChecker_Env.use_eq);
                                                                   FStar_TypeChecker_Env.use_eq_strict
                                                                     =
                                                                     (
-                                                                    uu___1010_10082.FStar_TypeChecker_Env.use_eq_strict);
+                                                                    uu___1010_10128.FStar_TypeChecker_Env.use_eq_strict);
                                                                   FStar_TypeChecker_Env.is_iface
                                                                     =
                                                                     (
-                                                                    uu___1010_10082.FStar_TypeChecker_Env.is_iface);
+                                                                    uu___1010_10128.FStar_TypeChecker_Env.is_iface);
                                                                   FStar_TypeChecker_Env.admit
                                                                     =
                                                                     (
-                                                                    uu___1010_10082.FStar_TypeChecker_Env.admit);
+                                                                    uu___1010_10128.FStar_TypeChecker_Env.admit);
                                                                   FStar_TypeChecker_Env.lax
                                                                     = true;
                                                                   FStar_TypeChecker_Env.lax_universes
                                                                     =
                                                                     (
-                                                                    uu___1010_10082.FStar_TypeChecker_Env.lax_universes);
+                                                                    uu___1010_10128.FStar_TypeChecker_Env.lax_universes);
                                                                   FStar_TypeChecker_Env.phase1
                                                                     =
                                                                     (
-                                                                    uu___1010_10082.FStar_TypeChecker_Env.phase1);
+                                                                    uu___1010_10128.FStar_TypeChecker_Env.phase1);
                                                                   FStar_TypeChecker_Env.failhard
                                                                     =
                                                                     (
-                                                                    uu___1010_10082.FStar_TypeChecker_Env.failhard);
+                                                                    uu___1010_10128.FStar_TypeChecker_Env.failhard);
                                                                   FStar_TypeChecker_Env.nosynth
                                                                     =
                                                                     (
-                                                                    uu___1010_10082.FStar_TypeChecker_Env.nosynth);
+                                                                    uu___1010_10128.FStar_TypeChecker_Env.nosynth);
                                                                   FStar_TypeChecker_Env.uvar_subtyping
                                                                     =
                                                                     (
-                                                                    uu___1010_10082.FStar_TypeChecker_Env.uvar_subtyping);
+                                                                    uu___1010_10128.FStar_TypeChecker_Env.uvar_subtyping);
                                                                   FStar_TypeChecker_Env.tc_term
                                                                     =
                                                                     (
-                                                                    uu___1010_10082.FStar_TypeChecker_Env.tc_term);
+                                                                    uu___1010_10128.FStar_TypeChecker_Env.tc_term);
                                                                   FStar_TypeChecker_Env.type_of
                                                                     =
                                                                     (
-                                                                    uu___1010_10082.FStar_TypeChecker_Env.type_of);
+                                                                    uu___1010_10128.FStar_TypeChecker_Env.type_of);
                                                                   FStar_TypeChecker_Env.universe_of
                                                                     =
                                                                     (
-                                                                    uu___1010_10082.FStar_TypeChecker_Env.universe_of);
+                                                                    uu___1010_10128.FStar_TypeChecker_Env.universe_of);
                                                                   FStar_TypeChecker_Env.check_type_of
                                                                     =
                                                                     (
-                                                                    uu___1010_10082.FStar_TypeChecker_Env.check_type_of);
+                                                                    uu___1010_10128.FStar_TypeChecker_Env.check_type_of);
                                                                   FStar_TypeChecker_Env.use_bv_sorts
                                                                     =
                                                                     (
-                                                                    uu___1010_10082.FStar_TypeChecker_Env.use_bv_sorts);
+                                                                    uu___1010_10128.FStar_TypeChecker_Env.use_bv_sorts);
                                                                   FStar_TypeChecker_Env.qtbl_name_and_index
                                                                     =
                                                                     (
-                                                                    uu___1010_10082.FStar_TypeChecker_Env.qtbl_name_and_index);
+                                                                    uu___1010_10128.FStar_TypeChecker_Env.qtbl_name_and_index);
                                                                   FStar_TypeChecker_Env.normalized_eff_names
                                                                     =
                                                                     (
-                                                                    uu___1010_10082.FStar_TypeChecker_Env.normalized_eff_names);
+                                                                    uu___1010_10128.FStar_TypeChecker_Env.normalized_eff_names);
                                                                   FStar_TypeChecker_Env.fv_delta_depths
                                                                     =
                                                                     (
-                                                                    uu___1010_10082.FStar_TypeChecker_Env.fv_delta_depths);
+                                                                    uu___1010_10128.FStar_TypeChecker_Env.fv_delta_depths);
                                                                   FStar_TypeChecker_Env.proof_ns
                                                                     =
                                                                     (
-                                                                    uu___1010_10082.FStar_TypeChecker_Env.proof_ns);
+                                                                    uu___1010_10128.FStar_TypeChecker_Env.proof_ns);
                                                                   FStar_TypeChecker_Env.synth_hook
                                                                     =
                                                                     (
-                                                                    uu___1010_10082.FStar_TypeChecker_Env.synth_hook);
+                                                                    uu___1010_10128.FStar_TypeChecker_Env.synth_hook);
                                                                   FStar_TypeChecker_Env.try_solve_implicits_hook
                                                                     =
                                                                     (
-                                                                    uu___1010_10082.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                                                                    uu___1010_10128.FStar_TypeChecker_Env.try_solve_implicits_hook);
                                                                   FStar_TypeChecker_Env.splice
                                                                     =
                                                                     (
-                                                                    uu___1010_10082.FStar_TypeChecker_Env.splice);
+                                                                    uu___1010_10128.FStar_TypeChecker_Env.splice);
                                                                   FStar_TypeChecker_Env.mpreprocess
                                                                     =
                                                                     (
-                                                                    uu___1010_10082.FStar_TypeChecker_Env.mpreprocess);
+                                                                    uu___1010_10128.FStar_TypeChecker_Env.mpreprocess);
                                                                   FStar_TypeChecker_Env.postprocess
                                                                     =
                                                                     (
-                                                                    uu___1010_10082.FStar_TypeChecker_Env.postprocess);
+                                                                    uu___1010_10128.FStar_TypeChecker_Env.postprocess);
                                                                   FStar_TypeChecker_Env.identifier_info
                                                                     =
                                                                     (
-                                                                    uu___1010_10082.FStar_TypeChecker_Env.identifier_info);
+                                                                    uu___1010_10128.FStar_TypeChecker_Env.identifier_info);
                                                                   FStar_TypeChecker_Env.tc_hooks
                                                                     =
                                                                     (
-                                                                    uu___1010_10082.FStar_TypeChecker_Env.tc_hooks);
+                                                                    uu___1010_10128.FStar_TypeChecker_Env.tc_hooks);
                                                                   FStar_TypeChecker_Env.dsenv
                                                                     =
                                                                     (
-                                                                    uu___1010_10082.FStar_TypeChecker_Env.dsenv);
+                                                                    uu___1010_10128.FStar_TypeChecker_Env.dsenv);
                                                                   FStar_TypeChecker_Env.nbe
                                                                     =
                                                                     (
-                                                                    uu___1010_10082.FStar_TypeChecker_Env.nbe);
+                                                                    uu___1010_10128.FStar_TypeChecker_Env.nbe);
                                                                   FStar_TypeChecker_Env.strict_args_tab
                                                                     =
                                                                     (
-                                                                    uu___1010_10082.FStar_TypeChecker_Env.strict_args_tab);
+                                                                    uu___1010_10128.FStar_TypeChecker_Env.strict_args_tab);
                                                                   FStar_TypeChecker_Env.erasable_types_tab
                                                                     =
                                                                     (
-                                                                    uu___1010_10082.FStar_TypeChecker_Env.erasable_types_tab);
+                                                                    uu___1010_10128.FStar_TypeChecker_Env.erasable_types_tab);
                                                                   FStar_TypeChecker_Env.enable_defer_to_tac
                                                                     =
                                                                     (
-                                                                    uu___1010_10082.FStar_TypeChecker_Env.enable_defer_to_tac)
+                                                                    uu___1010_10128.FStar_TypeChecker_Env.enable_defer_to_tac)
                                                                 })
                                                                (fun
-                                                                  uu____10083
+                                                                  uu____10129
                                                                   ->
                                                                   FStar_Pervasives_Native.Some
-                                                                    uu____10083) in
+                                                                    uu____10129) in
                                                            check_and_gen'
                                                              "bind_repr"
                                                              (Prims.of_int (2))
@@ -3991,280 +3991,280 @@ let (tc_non_layered_eff_decl :
                                                   failwith
                                                     "tc_eff_decl: expected action_params to be empty"
                                                 else ();
-                                                (let uu____10102 =
+                                                (let uu____10148 =
                                                    if
                                                      act.FStar_Syntax_Syntax.action_univs
                                                        = []
                                                    then (env, act)
                                                    else
-                                                     (let uu____10114 =
+                                                     (let uu____10160 =
                                                         FStar_Syntax_Subst.univ_var_opening
                                                           act.FStar_Syntax_Syntax.action_univs in
-                                                      match uu____10114 with
+                                                      match uu____10160 with
                                                       | (usubst, uvs) ->
-                                                          let uu____10137 =
+                                                          let uu____10183 =
                                                             FStar_TypeChecker_Env.push_univ_vars
                                                               env uvs in
-                                                          let uu____10138 =
-                                                            let uu___1023_10139
+                                                          let uu____10184 =
+                                                            let uu___1023_10185
                                                               = act in
-                                                            let uu____10140 =
+                                                            let uu____10186 =
                                                               FStar_Syntax_Subst.subst
                                                                 usubst
                                                                 act.FStar_Syntax_Syntax.action_defn in
-                                                            let uu____10141 =
+                                                            let uu____10187 =
                                                               FStar_Syntax_Subst.subst
                                                                 usubst
                                                                 act.FStar_Syntax_Syntax.action_typ in
                                                             {
                                                               FStar_Syntax_Syntax.action_name
                                                                 =
-                                                                (uu___1023_10139.FStar_Syntax_Syntax.action_name);
+                                                                (uu___1023_10185.FStar_Syntax_Syntax.action_name);
                                                               FStar_Syntax_Syntax.action_unqualified_name
                                                                 =
-                                                                (uu___1023_10139.FStar_Syntax_Syntax.action_unqualified_name);
+                                                                (uu___1023_10185.FStar_Syntax_Syntax.action_unqualified_name);
                                                               FStar_Syntax_Syntax.action_univs
                                                                 = uvs;
                                                               FStar_Syntax_Syntax.action_params
                                                                 =
-                                                                (uu___1023_10139.FStar_Syntax_Syntax.action_params);
+                                                                (uu___1023_10185.FStar_Syntax_Syntax.action_params);
                                                               FStar_Syntax_Syntax.action_defn
-                                                                = uu____10140;
+                                                                = uu____10186;
                                                               FStar_Syntax_Syntax.action_typ
-                                                                = uu____10141
+                                                                = uu____10187
                                                             } in
-                                                          (uu____10137,
-                                                            uu____10138)) in
-                                                 match uu____10102 with
+                                                          (uu____10183,
+                                                            uu____10184)) in
+                                                 match uu____10148 with
                                                  | (env1, act1) ->
                                                      let act_typ =
-                                                       let uu____10145 =
-                                                         let uu____10146 =
+                                                       let uu____10191 =
+                                                         let uu____10192 =
                                                            FStar_Syntax_Subst.compress
                                                              act1.FStar_Syntax_Syntax.action_typ in
-                                                         uu____10146.FStar_Syntax_Syntax.n in
-                                                       match uu____10145 with
+                                                         uu____10192.FStar_Syntax_Syntax.n in
+                                                       match uu____10191 with
                                                        | FStar_Syntax_Syntax.Tm_arrow
                                                            (bs1, c) ->
                                                            let c1 =
                                                              FStar_Syntax_Util.comp_to_comp_typ
                                                                c in
-                                                           let uu____10172 =
+                                                           let uu____10218 =
                                                              FStar_Ident.lid_equals
                                                                c1.FStar_Syntax_Syntax.effect_name
                                                                ed2.FStar_Syntax_Syntax.mname in
-                                                           if uu____10172
+                                                           if uu____10218
                                                            then
-                                                             let uu____10173
+                                                             let uu____10219
                                                                =
-                                                               let uu____10176
+                                                               let uu____10222
                                                                  =
-                                                                 let uu____10177
+                                                                 let uu____10223
                                                                    =
-                                                                   let uu____10178
+                                                                   let uu____10224
                                                                     =
                                                                     FStar_List.hd
                                                                     c1.FStar_Syntax_Syntax.effect_args in
                                                                    FStar_Pervasives_Native.fst
-                                                                    uu____10178 in
+                                                                    uu____10224 in
                                                                  mk_repr'
                                                                    c1.FStar_Syntax_Syntax.result_typ
-                                                                   uu____10177 in
+                                                                   uu____10223 in
                                                                FStar_Syntax_Syntax.mk_Total
-                                                                 uu____10176 in
+                                                                 uu____10222 in
                                                              FStar_Syntax_Util.arrow
                                                                bs1
-                                                               uu____10173
+                                                               uu____10219
                                                            else
                                                              act1.FStar_Syntax_Syntax.action_typ
-                                                       | uu____10200 ->
+                                                       | uu____10246 ->
                                                            act1.FStar_Syntax_Syntax.action_typ in
-                                                     let uu____10201 =
+                                                     let uu____10247 =
                                                        FStar_TypeChecker_TcTerm.tc_tot_or_gtot_term
                                                          env1 act_typ in
-                                                     (match uu____10201 with
+                                                     (match uu____10247 with
                                                       | (act_typ1,
-                                                         uu____10209, g_t) ->
+                                                         uu____10255, g_t) ->
                                                           let env' =
-                                                            let uu___1040_10212
+                                                            let uu___1040_10258
                                                               =
                                                               FStar_TypeChecker_Env.set_expected_typ
                                                                 env1 act_typ1 in
                                                             {
                                                               FStar_TypeChecker_Env.solver
                                                                 =
-                                                                (uu___1040_10212.FStar_TypeChecker_Env.solver);
+                                                                (uu___1040_10258.FStar_TypeChecker_Env.solver);
                                                               FStar_TypeChecker_Env.range
                                                                 =
-                                                                (uu___1040_10212.FStar_TypeChecker_Env.range);
+                                                                (uu___1040_10258.FStar_TypeChecker_Env.range);
                                                               FStar_TypeChecker_Env.curmodule
                                                                 =
-                                                                (uu___1040_10212.FStar_TypeChecker_Env.curmodule);
+                                                                (uu___1040_10258.FStar_TypeChecker_Env.curmodule);
                                                               FStar_TypeChecker_Env.gamma
                                                                 =
-                                                                (uu___1040_10212.FStar_TypeChecker_Env.gamma);
+                                                                (uu___1040_10258.FStar_TypeChecker_Env.gamma);
                                                               FStar_TypeChecker_Env.gamma_sig
                                                                 =
-                                                                (uu___1040_10212.FStar_TypeChecker_Env.gamma_sig);
+                                                                (uu___1040_10258.FStar_TypeChecker_Env.gamma_sig);
                                                               FStar_TypeChecker_Env.gamma_cache
                                                                 =
-                                                                (uu___1040_10212.FStar_TypeChecker_Env.gamma_cache);
+                                                                (uu___1040_10258.FStar_TypeChecker_Env.gamma_cache);
                                                               FStar_TypeChecker_Env.modules
                                                                 =
-                                                                (uu___1040_10212.FStar_TypeChecker_Env.modules);
+                                                                (uu___1040_10258.FStar_TypeChecker_Env.modules);
                                                               FStar_TypeChecker_Env.expected_typ
                                                                 =
-                                                                (uu___1040_10212.FStar_TypeChecker_Env.expected_typ);
+                                                                (uu___1040_10258.FStar_TypeChecker_Env.expected_typ);
                                                               FStar_TypeChecker_Env.sigtab
                                                                 =
-                                                                (uu___1040_10212.FStar_TypeChecker_Env.sigtab);
+                                                                (uu___1040_10258.FStar_TypeChecker_Env.sigtab);
                                                               FStar_TypeChecker_Env.attrtab
                                                                 =
-                                                                (uu___1040_10212.FStar_TypeChecker_Env.attrtab);
+                                                                (uu___1040_10258.FStar_TypeChecker_Env.attrtab);
                                                               FStar_TypeChecker_Env.instantiate_imp
                                                                 = false;
                                                               FStar_TypeChecker_Env.effects
                                                                 =
-                                                                (uu___1040_10212.FStar_TypeChecker_Env.effects);
+                                                                (uu___1040_10258.FStar_TypeChecker_Env.effects);
                                                               FStar_TypeChecker_Env.generalize
                                                                 =
-                                                                (uu___1040_10212.FStar_TypeChecker_Env.generalize);
+                                                                (uu___1040_10258.FStar_TypeChecker_Env.generalize);
                                                               FStar_TypeChecker_Env.letrecs
                                                                 =
-                                                                (uu___1040_10212.FStar_TypeChecker_Env.letrecs);
+                                                                (uu___1040_10258.FStar_TypeChecker_Env.letrecs);
                                                               FStar_TypeChecker_Env.top_level
                                                                 =
-                                                                (uu___1040_10212.FStar_TypeChecker_Env.top_level);
+                                                                (uu___1040_10258.FStar_TypeChecker_Env.top_level);
                                                               FStar_TypeChecker_Env.check_uvars
                                                                 =
-                                                                (uu___1040_10212.FStar_TypeChecker_Env.check_uvars);
+                                                                (uu___1040_10258.FStar_TypeChecker_Env.check_uvars);
                                                               FStar_TypeChecker_Env.use_eq
                                                                 =
-                                                                (uu___1040_10212.FStar_TypeChecker_Env.use_eq);
+                                                                (uu___1040_10258.FStar_TypeChecker_Env.use_eq);
                                                               FStar_TypeChecker_Env.use_eq_strict
                                                                 =
-                                                                (uu___1040_10212.FStar_TypeChecker_Env.use_eq_strict);
+                                                                (uu___1040_10258.FStar_TypeChecker_Env.use_eq_strict);
                                                               FStar_TypeChecker_Env.is_iface
                                                                 =
-                                                                (uu___1040_10212.FStar_TypeChecker_Env.is_iface);
+                                                                (uu___1040_10258.FStar_TypeChecker_Env.is_iface);
                                                               FStar_TypeChecker_Env.admit
                                                                 =
-                                                                (uu___1040_10212.FStar_TypeChecker_Env.admit);
+                                                                (uu___1040_10258.FStar_TypeChecker_Env.admit);
                                                               FStar_TypeChecker_Env.lax
                                                                 =
-                                                                (uu___1040_10212.FStar_TypeChecker_Env.lax);
+                                                                (uu___1040_10258.FStar_TypeChecker_Env.lax);
                                                               FStar_TypeChecker_Env.lax_universes
                                                                 =
-                                                                (uu___1040_10212.FStar_TypeChecker_Env.lax_universes);
+                                                                (uu___1040_10258.FStar_TypeChecker_Env.lax_universes);
                                                               FStar_TypeChecker_Env.phase1
                                                                 =
-                                                                (uu___1040_10212.FStar_TypeChecker_Env.phase1);
+                                                                (uu___1040_10258.FStar_TypeChecker_Env.phase1);
                                                               FStar_TypeChecker_Env.failhard
                                                                 =
-                                                                (uu___1040_10212.FStar_TypeChecker_Env.failhard);
+                                                                (uu___1040_10258.FStar_TypeChecker_Env.failhard);
                                                               FStar_TypeChecker_Env.nosynth
                                                                 =
-                                                                (uu___1040_10212.FStar_TypeChecker_Env.nosynth);
+                                                                (uu___1040_10258.FStar_TypeChecker_Env.nosynth);
                                                               FStar_TypeChecker_Env.uvar_subtyping
                                                                 =
-                                                                (uu___1040_10212.FStar_TypeChecker_Env.uvar_subtyping);
+                                                                (uu___1040_10258.FStar_TypeChecker_Env.uvar_subtyping);
                                                               FStar_TypeChecker_Env.tc_term
                                                                 =
-                                                                (uu___1040_10212.FStar_TypeChecker_Env.tc_term);
+                                                                (uu___1040_10258.FStar_TypeChecker_Env.tc_term);
                                                               FStar_TypeChecker_Env.type_of
                                                                 =
-                                                                (uu___1040_10212.FStar_TypeChecker_Env.type_of);
+                                                                (uu___1040_10258.FStar_TypeChecker_Env.type_of);
                                                               FStar_TypeChecker_Env.universe_of
                                                                 =
-                                                                (uu___1040_10212.FStar_TypeChecker_Env.universe_of);
+                                                                (uu___1040_10258.FStar_TypeChecker_Env.universe_of);
                                                               FStar_TypeChecker_Env.check_type_of
                                                                 =
-                                                                (uu___1040_10212.FStar_TypeChecker_Env.check_type_of);
+                                                                (uu___1040_10258.FStar_TypeChecker_Env.check_type_of);
                                                               FStar_TypeChecker_Env.use_bv_sorts
                                                                 =
-                                                                (uu___1040_10212.FStar_TypeChecker_Env.use_bv_sorts);
+                                                                (uu___1040_10258.FStar_TypeChecker_Env.use_bv_sorts);
                                                               FStar_TypeChecker_Env.qtbl_name_and_index
                                                                 =
-                                                                (uu___1040_10212.FStar_TypeChecker_Env.qtbl_name_and_index);
+                                                                (uu___1040_10258.FStar_TypeChecker_Env.qtbl_name_and_index);
                                                               FStar_TypeChecker_Env.normalized_eff_names
                                                                 =
-                                                                (uu___1040_10212.FStar_TypeChecker_Env.normalized_eff_names);
+                                                                (uu___1040_10258.FStar_TypeChecker_Env.normalized_eff_names);
                                                               FStar_TypeChecker_Env.fv_delta_depths
                                                                 =
-                                                                (uu___1040_10212.FStar_TypeChecker_Env.fv_delta_depths);
+                                                                (uu___1040_10258.FStar_TypeChecker_Env.fv_delta_depths);
                                                               FStar_TypeChecker_Env.proof_ns
                                                                 =
-                                                                (uu___1040_10212.FStar_TypeChecker_Env.proof_ns);
+                                                                (uu___1040_10258.FStar_TypeChecker_Env.proof_ns);
                                                               FStar_TypeChecker_Env.synth_hook
                                                                 =
-                                                                (uu___1040_10212.FStar_TypeChecker_Env.synth_hook);
+                                                                (uu___1040_10258.FStar_TypeChecker_Env.synth_hook);
                                                               FStar_TypeChecker_Env.try_solve_implicits_hook
                                                                 =
-                                                                (uu___1040_10212.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                                                                (uu___1040_10258.FStar_TypeChecker_Env.try_solve_implicits_hook);
                                                               FStar_TypeChecker_Env.splice
                                                                 =
-                                                                (uu___1040_10212.FStar_TypeChecker_Env.splice);
+                                                                (uu___1040_10258.FStar_TypeChecker_Env.splice);
                                                               FStar_TypeChecker_Env.mpreprocess
                                                                 =
-                                                                (uu___1040_10212.FStar_TypeChecker_Env.mpreprocess);
+                                                                (uu___1040_10258.FStar_TypeChecker_Env.mpreprocess);
                                                               FStar_TypeChecker_Env.postprocess
                                                                 =
-                                                                (uu___1040_10212.FStar_TypeChecker_Env.postprocess);
+                                                                (uu___1040_10258.FStar_TypeChecker_Env.postprocess);
                                                               FStar_TypeChecker_Env.identifier_info
                                                                 =
-                                                                (uu___1040_10212.FStar_TypeChecker_Env.identifier_info);
+                                                                (uu___1040_10258.FStar_TypeChecker_Env.identifier_info);
                                                               FStar_TypeChecker_Env.tc_hooks
                                                                 =
-                                                                (uu___1040_10212.FStar_TypeChecker_Env.tc_hooks);
+                                                                (uu___1040_10258.FStar_TypeChecker_Env.tc_hooks);
                                                               FStar_TypeChecker_Env.dsenv
                                                                 =
-                                                                (uu___1040_10212.FStar_TypeChecker_Env.dsenv);
+                                                                (uu___1040_10258.FStar_TypeChecker_Env.dsenv);
                                                               FStar_TypeChecker_Env.nbe
                                                                 =
-                                                                (uu___1040_10212.FStar_TypeChecker_Env.nbe);
+                                                                (uu___1040_10258.FStar_TypeChecker_Env.nbe);
                                                               FStar_TypeChecker_Env.strict_args_tab
                                                                 =
-                                                                (uu___1040_10212.FStar_TypeChecker_Env.strict_args_tab);
+                                                                (uu___1040_10258.FStar_TypeChecker_Env.strict_args_tab);
                                                               FStar_TypeChecker_Env.erasable_types_tab
                                                                 =
-                                                                (uu___1040_10212.FStar_TypeChecker_Env.erasable_types_tab);
+                                                                (uu___1040_10258.FStar_TypeChecker_Env.erasable_types_tab);
                                                               FStar_TypeChecker_Env.enable_defer_to_tac
                                                                 =
-                                                                (uu___1040_10212.FStar_TypeChecker_Env.enable_defer_to_tac)
+                                                                (uu___1040_10258.FStar_TypeChecker_Env.enable_defer_to_tac)
                                                             } in
-                                                          ((let uu____10214 =
+                                                          ((let uu____10260 =
                                                               FStar_TypeChecker_Env.debug
                                                                 env1
                                                                 (FStar_Options.Other
                                                                    "ED") in
-                                                            if uu____10214
+                                                            if uu____10260
                                                             then
-                                                              let uu____10215
+                                                              let uu____10261
                                                                 =
                                                                 FStar_Ident.string_of_lid
                                                                   act1.FStar_Syntax_Syntax.action_name in
-                                                              let uu____10216
+                                                              let uu____10262
                                                                 =
                                                                 FStar_Syntax_Print.term_to_string
                                                                   act1.FStar_Syntax_Syntax.action_defn in
-                                                              let uu____10217
+                                                              let uu____10263
                                                                 =
                                                                 FStar_Syntax_Print.term_to_string
                                                                   act_typ1 in
                                                               FStar_Util.print3
                                                                 "Checking action %s:\n[definition]: %s\n[cps'd type]: %s\n"
-                                                                uu____10215
-                                                                uu____10216
-                                                                uu____10217
+                                                                uu____10261
+                                                                uu____10262
+                                                                uu____10263
                                                             else ());
-                                                           (let uu____10219 =
+                                                           (let uu____10265 =
                                                               FStar_TypeChecker_TcTerm.tc_tot_or_gtot_term
                                                                 env'
                                                                 act1.FStar_Syntax_Syntax.action_defn in
-                                                            match uu____10219
+                                                            match uu____10265
                                                             with
                                                             | (act_defn,
-                                                               uu____10227,
+                                                               uu____10273,
                                                                g_a) ->
                                                                 let act_defn1
                                                                   =
@@ -4284,7 +4284,7 @@ let (tc_non_layered_eff_decl :
                                                                     FStar_TypeChecker_Env.Beta]
                                                                     env1
                                                                     act_typ1 in
-                                                                let uu____10231
+                                                                let uu____10277
                                                                   =
                                                                   let act_typ3
                                                                     =
@@ -4296,63 +4296,63 @@ let (tc_non_layered_eff_decl :
                                                                   | FStar_Syntax_Syntax.Tm_arrow
                                                                     (bs1, c)
                                                                     ->
-                                                                    let uu____10267
+                                                                    let uu____10313
                                                                     =
                                                                     FStar_Syntax_Subst.open_comp
                                                                     bs1 c in
-                                                                    (match uu____10267
+                                                                    (match uu____10313
                                                                     with
                                                                     | 
                                                                     (bs2,
-                                                                    uu____10279)
+                                                                    uu____10325)
                                                                     ->
                                                                     let res =
                                                                     mk_repr'
                                                                     FStar_Syntax_Syntax.tun
                                                                     FStar_Syntax_Syntax.tun in
                                                                     let k =
-                                                                    let uu____10286
+                                                                    let uu____10332
                                                                     =
                                                                     FStar_Syntax_Syntax.mk_Total
                                                                     res in
                                                                     FStar_Syntax_Util.arrow
                                                                     bs2
-                                                                    uu____10286 in
-                                                                    let uu____10289
+                                                                    uu____10332 in
+                                                                    let uu____10335
                                                                     =
                                                                     FStar_TypeChecker_TcTerm.tc_tot_or_gtot_term
                                                                     env1 k in
-                                                                    (match uu____10289
+                                                                    (match uu____10335
                                                                     with
                                                                     | 
                                                                     (k1,
-                                                                    uu____10303,
+                                                                    uu____10349,
                                                                     g) ->
                                                                     (k1, g)))
-                                                                  | uu____10307
+                                                                  | uu____10353
                                                                     ->
-                                                                    let uu____10308
+                                                                    let uu____10354
                                                                     =
-                                                                    let uu____10313
+                                                                    let uu____10359
                                                                     =
-                                                                    let uu____10314
+                                                                    let uu____10360
                                                                     =
                                                                     FStar_Syntax_Print.term_to_string
                                                                     act_typ3 in
-                                                                    let uu____10315
+                                                                    let uu____10361
                                                                     =
                                                                     FStar_Syntax_Print.tag_of_term
                                                                     act_typ3 in
                                                                     FStar_Util.format2
                                                                     "Actions must have function types (not: %s, a.k.a. %s)"
-                                                                    uu____10314
-                                                                    uu____10315 in
+                                                                    uu____10360
+                                                                    uu____10361 in
                                                                     (FStar_Errors.Fatal_ActionMustHaveFunctionType,
-                                                                    uu____10313) in
+                                                                    uu____10359) in
                                                                     FStar_Errors.raise_error
-                                                                    uu____10308
+                                                                    uu____10354
                                                                     act_defn1.FStar_Syntax_Syntax.pos in
-                                                                (match uu____10231
+                                                                (match uu____10277
                                                                  with
                                                                  | (expected_k,
                                                                     g_k) ->
@@ -4362,76 +4362,76 @@ let (tc_non_layered_eff_decl :
                                                                     act_typ2
                                                                     expected_k in
                                                                     ((
-                                                                    let uu____10330
+                                                                    let uu____10376
                                                                     =
-                                                                    let uu____10331
+                                                                    let uu____10377
                                                                     =
-                                                                    let uu____10332
+                                                                    let uu____10378
                                                                     =
                                                                     FStar_TypeChecker_Env.conj_guard
                                                                     g_t g in
                                                                     FStar_TypeChecker_Env.conj_guard
                                                                     g_k
-                                                                    uu____10332 in
+                                                                    uu____10378 in
                                                                     FStar_TypeChecker_Env.conj_guard
                                                                     g_a
-                                                                    uu____10331 in
+                                                                    uu____10377 in
                                                                     FStar_TypeChecker_Rel.force_trivial_guard
                                                                     env1
-                                                                    uu____10330);
+                                                                    uu____10376);
                                                                     (let act_typ3
                                                                     =
-                                                                    let uu____10334
+                                                                    let uu____10380
                                                                     =
-                                                                    let uu____10335
+                                                                    let uu____10381
                                                                     =
                                                                     FStar_Syntax_Subst.compress
                                                                     expected_k in
-                                                                    uu____10335.FStar_Syntax_Syntax.n in
-                                                                    match uu____10334
+                                                                    uu____10381.FStar_Syntax_Syntax.n in
+                                                                    match uu____10380
                                                                     with
                                                                     | 
                                                                     FStar_Syntax_Syntax.Tm_arrow
                                                                     (bs1, c)
                                                                     ->
-                                                                    let uu____10360
+                                                                    let uu____10406
                                                                     =
                                                                     FStar_Syntax_Subst.open_comp
                                                                     bs1 c in
-                                                                    (match uu____10360
+                                                                    (match uu____10406
                                                                     with
                                                                     | 
                                                                     (bs2, c1)
                                                                     ->
-                                                                    let uu____10367
+                                                                    let uu____10413
                                                                     =
                                                                     destruct_repr
                                                                     (FStar_Syntax_Util.comp_result
                                                                     c1) in
-                                                                    (match uu____10367
+                                                                    (match uu____10413
                                                                     with
                                                                     | 
                                                                     (a, wp)
                                                                     ->
                                                                     let c2 =
-                                                                    let uu____10387
+                                                                    let uu____10433
                                                                     =
-                                                                    let uu____10388
+                                                                    let uu____10434
                                                                     =
                                                                     env1.FStar_TypeChecker_Env.universe_of
                                                                     env1 a in
-                                                                    [uu____10388] in
-                                                                    let uu____10389
+                                                                    [uu____10434] in
+                                                                    let uu____10435
                                                                     =
-                                                                    let uu____10400
+                                                                    let uu____10446
                                                                     =
                                                                     FStar_Syntax_Syntax.as_arg
                                                                     wp in
-                                                                    [uu____10400] in
+                                                                    [uu____10446] in
                                                                     {
                                                                     FStar_Syntax_Syntax.comp_univs
                                                                     =
-                                                                    uu____10387;
+                                                                    uu____10433;
                                                                     FStar_Syntax_Syntax.effect_name
                                                                     =
                                                                     (ed2.FStar_Syntax_Syntax.mname);
@@ -4439,23 +4439,23 @@ let (tc_non_layered_eff_decl :
                                                                     = a;
                                                                     FStar_Syntax_Syntax.effect_args
                                                                     =
-                                                                    uu____10389;
+                                                                    uu____10435;
                                                                     FStar_Syntax_Syntax.flags
                                                                     = []
                                                                     } in
-                                                                    let uu____10425
+                                                                    let uu____10471
                                                                     =
                                                                     FStar_Syntax_Syntax.mk_Comp
                                                                     c2 in
                                                                     FStar_Syntax_Util.arrow
                                                                     bs2
-                                                                    uu____10425))
+                                                                    uu____10471))
                                                                     | 
-                                                                    uu____10428
+                                                                    uu____10474
                                                                     ->
                                                                     failwith
                                                                     "Impossible (expected_k is an arrow)" in
-                                                                    let uu____10429
+                                                                    let uu____10475
                                                                     =
                                                                     if
                                                                     act1.FStar_Syntax_Syntax.action_univs
@@ -4465,14 +4465,14 @@ let (tc_non_layered_eff_decl :
                                                                     env1
                                                                     act_defn1
                                                                     else
-                                                                    (let uu____10449
+                                                                    (let uu____10495
                                                                     =
                                                                     FStar_Syntax_Subst.close_univ_vars
                                                                     act1.FStar_Syntax_Syntax.action_univs
                                                                     act_defn1 in
                                                                     ((act1.FStar_Syntax_Syntax.action_univs),
-                                                                    uu____10449)) in
-                                                                    match uu____10429
+                                                                    uu____10495)) in
+                                                                    match uu____10475
                                                                     with
                                                                     | 
                                                                     (univs,
@@ -4489,20 +4489,20 @@ let (tc_non_layered_eff_decl :
                                                                     FStar_Syntax_Subst.close_univ_vars
                                                                     univs
                                                                     act_typ4 in
-                                                                    let uu___1090_10468
+                                                                    let uu___1090_10514
                                                                     = act1 in
                                                                     {
                                                                     FStar_Syntax_Syntax.action_name
                                                                     =
-                                                                    (uu___1090_10468.FStar_Syntax_Syntax.action_name);
+                                                                    (uu___1090_10514.FStar_Syntax_Syntax.action_name);
                                                                     FStar_Syntax_Syntax.action_unqualified_name
                                                                     =
-                                                                    (uu___1090_10468.FStar_Syntax_Syntax.action_unqualified_name);
+                                                                    (uu___1090_10514.FStar_Syntax_Syntax.action_unqualified_name);
                                                                     FStar_Syntax_Syntax.action_univs
                                                                     = univs;
                                                                     FStar_Syntax_Syntax.action_params
                                                                     =
-                                                                    (uu___1090_10468.FStar_Syntax_Syntax.action_params);
+                                                                    (uu___1090_10514.FStar_Syntax_Syntax.action_params);
                                                                     FStar_Syntax_Syntax.action_defn
                                                                     =
                                                                     act_defn2;
@@ -4519,7 +4519,7 @@ let (tc_non_layered_eff_decl :
                                                  return_repr),
                                               (FStar_Pervasives_Native.Some
                                                  bind_repr), actions))))) in
-                                  match uu____8980 with
+                                  match uu____9050 with
                                   | (repr, return_repr, bind_repr, actions)
                                       ->
                                       let cl ts =
@@ -4529,12 +4529,12 @@ let (tc_non_layered_eff_decl :
                                         let ed_univs_closing =
                                           FStar_Syntax_Subst.univ_var_closing
                                             ed_univs in
-                                        let uu____10511 =
+                                        let uu____10557 =
                                           FStar_Syntax_Subst.shift_subst
                                             (FStar_List.length ed_bs)
                                             ed_univs_closing in
                                         FStar_Syntax_Subst.subst_tscheme
-                                          uu____10511 ts1 in
+                                          uu____10557 ts1 in
                                       let combinators =
                                         {
                                           FStar_Syntax_Syntax.ret_wp = ret_wp;
@@ -4562,87 +4562,87 @@ let (tc_non_layered_eff_decl :
                                         match ed2.FStar_Syntax_Syntax.combinators
                                         with
                                         | FStar_Syntax_Syntax.Primitive_eff
-                                            uu____10523 ->
+                                            uu____10569 ->
                                             FStar_Syntax_Syntax.Primitive_eff
                                               combinators1
                                         | FStar_Syntax_Syntax.DM4F_eff
-                                            uu____10524 ->
+                                            uu____10570 ->
                                             FStar_Syntax_Syntax.DM4F_eff
                                               combinators1
-                                        | uu____10525 ->
+                                        | uu____10571 ->
                                             failwith
                                               "Impossible! tc_eff_decl on a layered effect is not expected" in
                                       let ed3 =
-                                        let uu___1110_10527 = ed2 in
-                                        let uu____10528 = cl signature in
-                                        let uu____10529 =
+                                        let uu___1110_10573 = ed2 in
+                                        let uu____10574 = cl signature in
+                                        let uu____10575 =
                                           FStar_List.map
                                             (fun a ->
-                                               let uu___1113_10537 = a in
-                                               let uu____10538 =
-                                                 let uu____10539 =
+                                               let uu___1113_10583 = a in
+                                               let uu____10584 =
+                                                 let uu____10585 =
                                                    cl
                                                      ((a.FStar_Syntax_Syntax.action_univs),
                                                        (a.FStar_Syntax_Syntax.action_defn)) in
                                                  FStar_All.pipe_right
-                                                   uu____10539
+                                                   uu____10585
                                                    FStar_Pervasives_Native.snd in
-                                               let uu____10564 =
-                                                 let uu____10565 =
+                                               let uu____10610 =
+                                                 let uu____10611 =
                                                    cl
                                                      ((a.FStar_Syntax_Syntax.action_univs),
                                                        (a.FStar_Syntax_Syntax.action_typ)) in
                                                  FStar_All.pipe_right
-                                                   uu____10565
+                                                   uu____10611
                                                    FStar_Pervasives_Native.snd in
                                                {
                                                  FStar_Syntax_Syntax.action_name
                                                    =
-                                                   (uu___1113_10537.FStar_Syntax_Syntax.action_name);
+                                                   (uu___1113_10583.FStar_Syntax_Syntax.action_name);
                                                  FStar_Syntax_Syntax.action_unqualified_name
                                                    =
-                                                   (uu___1113_10537.FStar_Syntax_Syntax.action_unqualified_name);
+                                                   (uu___1113_10583.FStar_Syntax_Syntax.action_unqualified_name);
                                                  FStar_Syntax_Syntax.action_univs
                                                    =
-                                                   (uu___1113_10537.FStar_Syntax_Syntax.action_univs);
+                                                   (uu___1113_10583.FStar_Syntax_Syntax.action_univs);
                                                  FStar_Syntax_Syntax.action_params
                                                    =
-                                                   (uu___1113_10537.FStar_Syntax_Syntax.action_params);
+                                                   (uu___1113_10583.FStar_Syntax_Syntax.action_params);
                                                  FStar_Syntax_Syntax.action_defn
-                                                   = uu____10538;
+                                                   = uu____10584;
                                                  FStar_Syntax_Syntax.action_typ
-                                                   = uu____10564
+                                                   = uu____10610
                                                }) actions in
                                         {
                                           FStar_Syntax_Syntax.mname =
-                                            (uu___1110_10527.FStar_Syntax_Syntax.mname);
+                                            (uu___1110_10573.FStar_Syntax_Syntax.mname);
                                           FStar_Syntax_Syntax.cattributes =
-                                            (uu___1110_10527.FStar_Syntax_Syntax.cattributes);
+                                            (uu___1110_10573.FStar_Syntax_Syntax.cattributes);
                                           FStar_Syntax_Syntax.univs =
-                                            (uu___1110_10527.FStar_Syntax_Syntax.univs);
+                                            (uu___1110_10573.FStar_Syntax_Syntax.univs);
                                           FStar_Syntax_Syntax.binders =
-                                            (uu___1110_10527.FStar_Syntax_Syntax.binders);
+                                            (uu___1110_10573.FStar_Syntax_Syntax.binders);
                                           FStar_Syntax_Syntax.signature =
-                                            uu____10528;
+                                            uu____10574;
                                           FStar_Syntax_Syntax.combinators =
                                             combinators2;
                                           FStar_Syntax_Syntax.actions =
-                                            uu____10529;
+                                            uu____10575;
                                           FStar_Syntax_Syntax.eff_attrs =
-                                            (uu___1110_10527.FStar_Syntax_Syntax.eff_attrs)
+                                            (uu___1110_10573.FStar_Syntax_Syntax.eff_attrs)
                                         } in
-                                      ((let uu____10591 =
+                                      ((let uu____10637 =
                                           FStar_All.pipe_left
                                             (FStar_TypeChecker_Env.debug env)
                                             (FStar_Options.Other "ED") in
-                                        if uu____10591
+                                        if uu____10637
                                         then
-                                          let uu____10592 =
+                                          let uu____10638 =
                                             FStar_Syntax_Print.eff_decl_to_string
                                               false ed3 in
                                           FStar_Util.print1
                                             "Typechecked effect declaration:\n\t%s\n"
-                                            uu____10592
+                                            uu____10638
                                         else ());
                                        ed3)))))))))))))
 let (tc_eff_decl :
@@ -4656,13 +4656,13 @@ let (tc_eff_decl :
     fun ed ->
       fun quals ->
         fun attrs ->
-          let uu____10622 =
-            let uu____10643 =
+          let uu____10668 =
+            let uu____10689 =
               FStar_All.pipe_right ed FStar_Syntax_Util.is_layered in
-            if uu____10643
+            if uu____10689
             then tc_layered_eff_decl
             else tc_non_layered_eff_decl in
-          uu____10622 env ed quals attrs
+          uu____10668 env ed quals attrs
 let (monad_signature :
   FStar_TypeChecker_Env.env ->
     FStar_Ident.lident ->
@@ -4673,256 +4673,256 @@ let (monad_signature :
   fun env ->
     fun m ->
       fun s ->
-        let fail uu____10693 =
-          let uu____10694 =
+        let fail uu____10739 =
+          let uu____10740 =
             FStar_TypeChecker_Err.unexpected_signature_for_monad env m s in
-          let uu____10699 = FStar_Ident.range_of_lid m in
-          FStar_Errors.raise_error uu____10694 uu____10699 in
+          let uu____10745 = FStar_Ident.range_of_lid m in
+          FStar_Errors.raise_error uu____10740 uu____10745 in
         let s1 = FStar_Syntax_Subst.compress s in
         match s1.FStar_Syntax_Syntax.n with
         | FStar_Syntax_Syntax.Tm_arrow (bs, c) ->
             let bs1 = FStar_Syntax_Subst.open_binders bs in
             (match bs1 with
-             | (a, uu____10743)::(wp, uu____10745)::[] ->
+             | (a, uu____10789)::(wp, uu____10791)::[] ->
                  (a, (wp.FStar_Syntax_Syntax.sort))
-             | uu____10774 -> fail ())
-        | uu____10775 -> fail ()
+             | uu____10820 -> fail ())
+        | uu____10821 -> fail ()
 let (tc_layered_lift :
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.sub_eff -> FStar_Syntax_Syntax.sub_eff)
   =
   fun env0 ->
     fun sub ->
-      (let uu____10787 =
+      (let uu____10833 =
          FStar_All.pipe_left (FStar_TypeChecker_Env.debug env0)
            (FStar_Options.Other "LayeredEffectsTc") in
-       if uu____10787
+       if uu____10833
        then
-         let uu____10788 = FStar_Syntax_Print.sub_eff_to_string sub in
-         FStar_Util.print1 "Typechecking sub_effect: %s\n" uu____10788
+         let uu____10834 = FStar_Syntax_Print.sub_eff_to_string sub in
+         FStar_Util.print1 "Typechecking sub_effect: %s\n" uu____10834
        else ());
       (let lift_ts =
          FStar_All.pipe_right sub.FStar_Syntax_Syntax.lift FStar_Util.must in
        let r =
-         let uu____10802 =
+         let uu____10848 =
            FStar_All.pipe_right lift_ts FStar_Pervasives_Native.snd in
-         uu____10802.FStar_Syntax_Syntax.pos in
-       let uu____10811 = check_and_gen env0 "" "lift" Prims.int_one lift_ts in
-       match uu____10811 with
+         uu____10848.FStar_Syntax_Syntax.pos in
+       let uu____10857 = check_and_gen env0 "" "lift" Prims.int_one lift_ts in
+       match uu____10857 with
        | (us, lift, lift_ty) ->
-           ((let uu____10822 =
+           ((let uu____10868 =
                FStar_All.pipe_left (FStar_TypeChecker_Env.debug env0)
                  (FStar_Options.Other "LayeredEffectsTc") in
-             if uu____10822
+             if uu____10868
              then
-               let uu____10823 =
+               let uu____10869 =
                  FStar_Syntax_Print.tscheme_to_string (us, lift) in
-               let uu____10828 =
+               let uu____10874 =
                  FStar_Syntax_Print.tscheme_to_string (us, lift_ty) in
                FStar_Util.print2 "Typechecked lift: %s and lift_ty: %s\n"
-                 uu____10823 uu____10828
+                 uu____10869 uu____10874
              else ());
-            (let uu____10834 = FStar_Syntax_Subst.open_univ_vars us lift_ty in
-             match uu____10834 with
+            (let uu____10880 = FStar_Syntax_Subst.open_univ_vars us lift_ty in
+             match uu____10880 with
              | (us1, lift_ty1) ->
                  let env = FStar_TypeChecker_Env.push_univ_vars env0 us1 in
                  (check_no_subtyping_for_layered_combinator env lift_ty1
                     FStar_Pervasives_Native.None;
                   (let lift_t_shape_error s =
-                     let uu____10849 =
+                     let uu____10895 =
                        FStar_Ident.string_of_lid
                          sub.FStar_Syntax_Syntax.source in
-                     let uu____10850 =
+                     let uu____10896 =
                        FStar_Ident.string_of_lid
                          sub.FStar_Syntax_Syntax.target in
-                     let uu____10851 =
+                     let uu____10897 =
                        FStar_Syntax_Print.term_to_string lift_ty1 in
                      FStar_Util.format4
                        "Unexpected shape of lift %s~>%s, reason:%s (t:%s)"
-                       uu____10849 uu____10850 s uu____10851 in
-                   let uu____10852 =
-                     let uu____10859 =
-                       let uu____10864 = FStar_Syntax_Util.type_u () in
-                       FStar_All.pipe_right uu____10864
-                         (fun uu____10881 ->
-                            match uu____10881 with
+                       uu____10895 uu____10896 s uu____10897 in
+                   let uu____10898 =
+                     let uu____10905 =
+                       let uu____10910 = FStar_Syntax_Util.type_u () in
+                       FStar_All.pipe_right uu____10910
+                         (fun uu____10927 ->
+                            match uu____10927 with
                             | (t, u) ->
-                                let uu____10892 =
-                                  let uu____10893 =
+                                let uu____10938 =
+                                  let uu____10939 =
                                     FStar_Syntax_Syntax.gen_bv "a"
                                       FStar_Pervasives_Native.None t in
-                                  FStar_All.pipe_right uu____10893
+                                  FStar_All.pipe_right uu____10939
                                     FStar_Syntax_Syntax.mk_binder in
-                                (uu____10892, u)) in
-                     match uu____10859 with
+                                (uu____10938, u)) in
+                     match uu____10905 with
                      | (a, u_a) ->
                          let rest_bs =
-                           let uu____10911 =
-                             let uu____10912 =
+                           let uu____10957 =
+                             let uu____10958 =
                                FStar_Syntax_Subst.compress lift_ty1 in
-                             uu____10912.FStar_Syntax_Syntax.n in
-                           match uu____10911 with
-                           | FStar_Syntax_Syntax.Tm_arrow (bs, uu____10924)
+                             uu____10958.FStar_Syntax_Syntax.n in
+                           match uu____10957 with
+                           | FStar_Syntax_Syntax.Tm_arrow (bs, uu____10970)
                                when
                                (FStar_List.length bs) >= (Prims.of_int (2))
                                ->
-                               let uu____10951 =
+                               let uu____10997 =
                                  FStar_Syntax_Subst.open_binders bs in
-                               (match uu____10951 with
-                                | (a', uu____10961)::bs1 ->
-                                    let uu____10981 =
-                                      let uu____10982 =
+                               (match uu____10997 with
+                                | (a', uu____11007)::bs1 ->
+                                    let uu____11027 =
+                                      let uu____11028 =
                                         FStar_All.pipe_right bs1
                                           (FStar_List.splitAt
                                              ((FStar_List.length bs1) -
                                                 Prims.int_one)) in
-                                      FStar_All.pipe_right uu____10982
+                                      FStar_All.pipe_right uu____11028
                                         FStar_Pervasives_Native.fst in
-                                    let uu____11047 =
-                                      let uu____11060 =
-                                        let uu____11063 =
-                                          let uu____11064 =
-                                            let uu____11071 =
+                                    let uu____11093 =
+                                      let uu____11106 =
+                                        let uu____11109 =
+                                          let uu____11110 =
+                                            let uu____11117 =
                                               FStar_Syntax_Syntax.bv_to_name
                                                 (FStar_Pervasives_Native.fst
                                                    a) in
-                                            (a', uu____11071) in
-                                          FStar_Syntax_Syntax.NT uu____11064 in
-                                        [uu____11063] in
+                                            (a', uu____11117) in
+                                          FStar_Syntax_Syntax.NT uu____11110 in
+                                        [uu____11109] in
                                       FStar_Syntax_Subst.subst_binders
-                                        uu____11060 in
-                                    FStar_All.pipe_right uu____10981
-                                      uu____11047)
-                           | uu____11086 ->
-                               let uu____11087 =
-                                 let uu____11092 =
+                                        uu____11106 in
+                                    FStar_All.pipe_right uu____11027
+                                      uu____11093)
+                           | uu____11132 ->
+                               let uu____11133 =
+                                 let uu____11138 =
                                    lift_t_shape_error
                                      "either not an arrow, or not enough binders" in
                                  (FStar_Errors.Fatal_UnexpectedExpressionType,
-                                   uu____11092) in
-                               FStar_Errors.raise_error uu____11087 r in
-                         let uu____11101 =
-                           let uu____11112 =
-                             let uu____11117 =
+                                   uu____11138) in
+                               FStar_Errors.raise_error uu____11133 r in
+                         let uu____11147 =
+                           let uu____11158 =
+                             let uu____11163 =
                                FStar_TypeChecker_Env.push_binders env (a ::
                                  rest_bs) in
-                             let uu____11124 =
-                               let uu____11125 =
+                             let uu____11170 =
+                               let uu____11171 =
                                  FStar_All.pipe_right a
                                    FStar_Pervasives_Native.fst in
-                               FStar_All.pipe_right uu____11125
+                               FStar_All.pipe_right uu____11171
                                  FStar_Syntax_Syntax.bv_to_name in
                              FStar_TypeChecker_Util.fresh_effect_repr_en
-                               uu____11117 r sub.FStar_Syntax_Syntax.source
-                               u_a uu____11124 in
-                           match uu____11112 with
+                               uu____11163 r sub.FStar_Syntax_Syntax.source
+                               u_a uu____11170 in
+                           match uu____11158 with
                            | (f_sort, g) ->
-                               let uu____11146 =
-                                 let uu____11153 =
+                               let uu____11192 =
+                                 let uu____11199 =
                                    FStar_Syntax_Syntax.gen_bv "f"
                                      FStar_Pervasives_Native.None f_sort in
-                                 FStar_All.pipe_right uu____11153
+                                 FStar_All.pipe_right uu____11199
                                    FStar_Syntax_Syntax.mk_binder in
-                               (uu____11146, g) in
-                         (match uu____11101 with
+                               (uu____11192, g) in
+                         (match uu____11147 with
                           | (f_b, g_f_b) ->
                               let bs = a :: (FStar_List.append rest_bs [f_b]) in
-                              let uu____11219 =
-                                let uu____11224 =
+                              let uu____11265 =
+                                let uu____11270 =
                                   FStar_TypeChecker_Env.push_binders env bs in
-                                let uu____11225 =
-                                  let uu____11226 =
+                                let uu____11271 =
+                                  let uu____11272 =
                                     FStar_All.pipe_right a
                                       FStar_Pervasives_Native.fst in
-                                  FStar_All.pipe_right uu____11226
+                                  FStar_All.pipe_right uu____11272
                                     FStar_Syntax_Syntax.bv_to_name in
                                 FStar_TypeChecker_Util.fresh_effect_repr_en
-                                  uu____11224 r
+                                  uu____11270 r
                                   sub.FStar_Syntax_Syntax.target u_a
-                                  uu____11225 in
-                              (match uu____11219 with
+                                  uu____11271 in
+                              (match uu____11265 with
                                | (repr, g_repr) ->
-                                   let uu____11243 =
-                                     let uu____11248 =
+                                   let uu____11289 =
+                                     let uu____11294 =
                                        FStar_TypeChecker_Env.push_binders env
                                          bs in
-                                     let uu____11249 =
-                                       let uu____11250 =
+                                     let uu____11295 =
+                                       let uu____11296 =
                                          FStar_Ident.string_of_lid
                                            sub.FStar_Syntax_Syntax.source in
-                                       let uu____11251 =
+                                       let uu____11297 =
                                          FStar_Ident.string_of_lid
                                            sub.FStar_Syntax_Syntax.target in
                                        FStar_Util.format2
                                          "implicit for pure_wp in typechecking lift %s~>%s"
-                                         uu____11250 uu____11251 in
-                                     pure_wp_uvar uu____11248 repr
-                                       uu____11249 r in
-                                   (match uu____11243 with
+                                         uu____11296 uu____11297 in
+                                     pure_wp_uvar uu____11294 repr
+                                       uu____11295 r in
+                                   (match uu____11289 with
                                     | (pure_wp_uvar1, guard_wp) ->
                                         let c =
-                                          let uu____11261 =
-                                            let uu____11262 =
-                                              let uu____11263 =
+                                          let uu____11307 =
+                                            let uu____11308 =
+                                              let uu____11309 =
                                                 FStar_TypeChecker_Env.new_u_univ
                                                   () in
-                                              [uu____11263] in
-                                            let uu____11264 =
-                                              let uu____11275 =
+                                              [uu____11309] in
+                                            let uu____11310 =
+                                              let uu____11321 =
                                                 FStar_All.pipe_right
                                                   pure_wp_uvar1
                                                   FStar_Syntax_Syntax.as_arg in
-                                              [uu____11275] in
+                                              [uu____11321] in
                                             {
                                               FStar_Syntax_Syntax.comp_univs
-                                                = uu____11262;
+                                                = uu____11308;
                                               FStar_Syntax_Syntax.effect_name
                                                 =
                                                 FStar_Parser_Const.effect_PURE_lid;
                                               FStar_Syntax_Syntax.result_typ
                                                 = repr;
                                               FStar_Syntax_Syntax.effect_args
-                                                = uu____11264;
+                                                = uu____11310;
                                               FStar_Syntax_Syntax.flags = []
                                             } in
                                           FStar_Syntax_Syntax.mk_Comp
-                                            uu____11261 in
-                                        let uu____11308 =
+                                            uu____11307 in
+                                        let uu____11354 =
                                           FStar_Syntax_Util.arrow bs c in
-                                        let uu____11311 =
-                                          let uu____11312 =
+                                        let uu____11357 =
+                                          let uu____11358 =
                                             FStar_TypeChecker_Env.conj_guard
                                               g_f_b g_repr in
                                           FStar_TypeChecker_Env.conj_guard
-                                            uu____11312 guard_wp in
-                                        (uu____11308, uu____11311)))) in
-                   match uu____10852 with
+                                            uu____11358 guard_wp in
+                                        (uu____11354, uu____11357)))) in
+                   match uu____10898 with
                    | (k, g_k) ->
-                       ((let uu____11322 =
+                       ((let uu____11368 =
                            FStar_All.pipe_left
                              (FStar_TypeChecker_Env.debug env)
                              (FStar_Options.Other "LayeredEffectsTc") in
-                         if uu____11322
+                         if uu____11368
                          then
-                           let uu____11323 =
+                           let uu____11369 =
                              FStar_Syntax_Print.term_to_string k in
                            FStar_Util.print1
                              "tc_layered_lift: before unification k: %s\n"
-                             uu____11323
+                             uu____11369
                          else ());
                         (let g = FStar_TypeChecker_Rel.teq env lift_ty1 k in
                          FStar_TypeChecker_Rel.force_trivial_guard env g_k;
                          FStar_TypeChecker_Rel.force_trivial_guard env g;
-                         (let uu____11329 =
+                         (let uu____11375 =
                             FStar_All.pipe_left
                               (FStar_TypeChecker_Env.debug env0)
                               (FStar_Options.Other "LayeredEffectsTc") in
-                          if uu____11329
+                          if uu____11375
                           then
-                            let uu____11330 =
+                            let uu____11376 =
                               FStar_Syntax_Print.term_to_string k in
                             FStar_Util.print1 "After unification k: %s\n"
-                              uu____11330
+                              uu____11376
                           else ());
                          (let k1 =
                             FStar_All.pipe_right k
@@ -4932,35 +4932,35 @@ let (tc_layered_lift :
                             (FStar_TypeChecker_Env.is_reifiable_effect env
                                sub.FStar_Syntax_Syntax.target)
                               &&
-                              (let uu____11335 =
+                              (let uu____11381 =
                                  FStar_TypeChecker_Env.fv_with_lid_has_attr
                                    env sub.FStar_Syntax_Syntax.target
                                    FStar_Parser_Const.allow_informative_binders_attr in
-                               Prims.op_Negation uu____11335) in
-                          (let uu____11337 =
-                             let uu____11338 = FStar_Syntax_Subst.compress k1 in
-                             uu____11338.FStar_Syntax_Syntax.n in
-                           match uu____11337 with
+                               Prims.op_Negation uu____11381) in
+                          (let uu____11383 =
+                             let uu____11384 = FStar_Syntax_Subst.compress k1 in
+                             uu____11384.FStar_Syntax_Syntax.n in
+                           match uu____11383 with
                            | FStar_Syntax_Syntax.Tm_arrow (bs, c) ->
-                               let uu____11363 =
+                               let uu____11409 =
                                  FStar_Syntax_Subst.open_comp bs c in
-                               (match uu____11363 with
+                               (match uu____11409 with
                                 | (a::bs1, c1) ->
                                     let res_t =
                                       FStar_Syntax_Util.comp_result c1 in
-                                    let uu____11394 =
-                                      let uu____11413 =
+                                    let uu____11440 =
+                                      let uu____11459 =
                                         FStar_List.splitAt
                                           ((FStar_List.length bs1) -
                                              Prims.int_one) bs1 in
-                                      FStar_All.pipe_right uu____11413
-                                        (fun uu____11488 ->
-                                           match uu____11488 with
+                                      FStar_All.pipe_right uu____11459
+                                        (fun uu____11534 ->
+                                           match uu____11534 with
                                            | (l1, l2) ->
-                                               let uu____11561 =
+                                               let uu____11607 =
                                                  FStar_List.hd l2 in
-                                               (l1, uu____11561)) in
-                                    (match uu____11394 with
+                                               (l1, uu____11607)) in
+                                    (match uu____11440 with
                                      | (bs2, f_b) ->
                                          let env1 =
                                            FStar_TypeChecker_Env.push_binders
@@ -4971,33 +4971,33 @@ let (tc_layered_lift :
                                            res_t]
                                            check_non_informative_binders r)));
                           (let sub1 =
-                             let uu___1223_11634 = sub in
-                             let uu____11635 =
-                               let uu____11638 =
-                                 let uu____11639 =
+                             let uu___1223_11680 = sub in
+                             let uu____11681 =
+                               let uu____11684 =
+                                 let uu____11685 =
                                    FStar_All.pipe_right k1
                                      (FStar_Syntax_Subst.close_univ_vars us1) in
-                                 (us1, uu____11639) in
-                               FStar_Pervasives_Native.Some uu____11638 in
+                                 (us1, uu____11685) in
+                               FStar_Pervasives_Native.Some uu____11684 in
                              {
                                FStar_Syntax_Syntax.source =
-                                 (uu___1223_11634.FStar_Syntax_Syntax.source);
+                                 (uu___1223_11680.FStar_Syntax_Syntax.source);
                                FStar_Syntax_Syntax.target =
-                                 (uu___1223_11634.FStar_Syntax_Syntax.target);
-                               FStar_Syntax_Syntax.lift_wp = uu____11635;
+                                 (uu___1223_11680.FStar_Syntax_Syntax.target);
+                               FStar_Syntax_Syntax.lift_wp = uu____11681;
                                FStar_Syntax_Syntax.lift =
                                  (FStar_Pervasives_Native.Some (us1, lift))
                              } in
-                           (let uu____11653 =
+                           (let uu____11699 =
                               FStar_All.pipe_left
                                 (FStar_TypeChecker_Env.debug env0)
                                 (FStar_Options.Other "LayeredEffectsTc") in
-                            if uu____11653
+                            if uu____11699
                             then
-                              let uu____11654 =
+                              let uu____11700 =
                                 FStar_Syntax_Print.sub_eff_to_string sub1 in
                               FStar_Util.print1 "Final sub_effect: %s\n"
-                                uu____11654
+                                uu____11700
                             else ());
                            sub1)))))))))
 let (tc_lift :
@@ -5009,109 +5009,109 @@ let (tc_lift :
     fun sub ->
       fun r ->
         let check_and_gen1 env1 t k =
-          let uu____11687 =
+          let uu____11733 =
             FStar_TypeChecker_TcTerm.tc_check_trivial_guard env1 t k in
-          FStar_TypeChecker_Generalize.generalize_universes env1 uu____11687 in
+          FStar_TypeChecker_Generalize.generalize_universes env1 uu____11733 in
         let ed_src =
           FStar_TypeChecker_Env.get_effect_decl env
             sub.FStar_Syntax_Syntax.source in
         let ed_tgt =
           FStar_TypeChecker_Env.get_effect_decl env
             sub.FStar_Syntax_Syntax.target in
-        let uu____11690 =
+        let uu____11736 =
           (FStar_All.pipe_right ed_src FStar_Syntax_Util.is_layered) ||
             (FStar_All.pipe_right ed_tgt FStar_Syntax_Util.is_layered) in
-        if uu____11690
+        if uu____11736
         then tc_layered_lift env sub
         else
-          (let uu____11692 =
-             let uu____11699 =
+          (let uu____11738 =
+             let uu____11745 =
                FStar_TypeChecker_Env.lookup_effect_lid env
                  sub.FStar_Syntax_Syntax.source in
-             monad_signature env sub.FStar_Syntax_Syntax.source uu____11699 in
-           match uu____11692 with
+             monad_signature env sub.FStar_Syntax_Syntax.source uu____11745 in
+           match uu____11738 with
            | (a, wp_a_src) ->
-               let uu____11706 =
-                 let uu____11713 =
+               let uu____11752 =
+                 let uu____11759 =
                    FStar_TypeChecker_Env.lookup_effect_lid env
                      sub.FStar_Syntax_Syntax.target in
                  monad_signature env sub.FStar_Syntax_Syntax.target
-                   uu____11713 in
-               (match uu____11706 with
+                   uu____11759 in
+               (match uu____11752 with
                 | (b, wp_b_tgt) ->
                     let wp_a_tgt =
-                      let uu____11721 =
-                        let uu____11724 =
-                          let uu____11725 =
-                            let uu____11732 =
+                      let uu____11767 =
+                        let uu____11770 =
+                          let uu____11771 =
+                            let uu____11778 =
                               FStar_Syntax_Syntax.bv_to_name a in
-                            (b, uu____11732) in
-                          FStar_Syntax_Syntax.NT uu____11725 in
-                        [uu____11724] in
-                      FStar_Syntax_Subst.subst uu____11721 wp_b_tgt in
+                            (b, uu____11778) in
+                          FStar_Syntax_Syntax.NT uu____11771 in
+                        [uu____11770] in
+                      FStar_Syntax_Subst.subst uu____11767 wp_b_tgt in
                     let expected_k =
-                      let uu____11740 =
-                        let uu____11749 = FStar_Syntax_Syntax.mk_binder a in
-                        let uu____11756 =
-                          let uu____11765 =
+                      let uu____11786 =
+                        let uu____11795 = FStar_Syntax_Syntax.mk_binder a in
+                        let uu____11802 =
+                          let uu____11811 =
                             FStar_Syntax_Syntax.null_binder wp_a_src in
-                          [uu____11765] in
-                        uu____11749 :: uu____11756 in
-                      let uu____11790 = FStar_Syntax_Syntax.mk_Total wp_a_tgt in
-                      FStar_Syntax_Util.arrow uu____11740 uu____11790 in
+                          [uu____11811] in
+                        uu____11795 :: uu____11802 in
+                      let uu____11836 = FStar_Syntax_Syntax.mk_Total wp_a_tgt in
+                      FStar_Syntax_Util.arrow uu____11786 uu____11836 in
                     let repr_type eff_name a1 wp =
-                      (let uu____11812 =
-                         let uu____11813 =
+                      (let uu____11858 =
+                         let uu____11859 =
                            FStar_TypeChecker_Env.is_reifiable_effect env
                              eff_name in
-                         Prims.op_Negation uu____11813 in
-                       if uu____11812
+                         Prims.op_Negation uu____11859 in
+                       if uu____11858
                        then
-                         let uu____11814 =
-                           let uu____11819 =
-                             let uu____11820 =
+                         let uu____11860 =
+                           let uu____11865 =
+                             let uu____11866 =
                                FStar_Ident.string_of_lid eff_name in
                              FStar_Util.format1 "Effect %s cannot be reified"
-                               uu____11820 in
+                               uu____11866 in
                            (FStar_Errors.Fatal_EffectCannotBeReified,
-                             uu____11819) in
-                         let uu____11821 =
+                             uu____11865) in
+                         let uu____11867 =
                            FStar_TypeChecker_Env.get_range env in
-                         FStar_Errors.raise_error uu____11814 uu____11821
+                         FStar_Errors.raise_error uu____11860 uu____11867
                        else ());
-                      (let uu____11823 =
+                      (let uu____11869 =
                          FStar_TypeChecker_Env.effect_decl_opt env eff_name in
-                       match uu____11823 with
+                       match uu____11869 with
                        | FStar_Pervasives_Native.None ->
                            failwith
                              "internal error: reifiable effect has no decl?"
                        | FStar_Pervasives_Native.Some (ed, qualifiers) ->
                            let repr =
-                             let uu____11855 =
-                               let uu____11856 =
+                             let uu____11901 =
+                               let uu____11902 =
                                  FStar_All.pipe_right ed
                                    FStar_Syntax_Util.get_eff_repr in
-                               FStar_All.pipe_right uu____11856
+                               FStar_All.pipe_right uu____11902
                                  FStar_Util.must in
                              FStar_TypeChecker_Env.inst_effect_fun_with
                                [FStar_Syntax_Syntax.U_unknown] env ed
-                               uu____11855 in
-                           let uu____11863 =
-                             let uu____11864 =
-                               let uu____11881 =
-                                 let uu____11892 =
+                               uu____11901 in
+                           let uu____11909 =
+                             let uu____11910 =
+                               let uu____11927 =
+                                 let uu____11938 =
                                    FStar_Syntax_Syntax.as_arg a1 in
-                                 let uu____11901 =
-                                   let uu____11912 =
+                                 let uu____11947 =
+                                   let uu____11958 =
                                      FStar_Syntax_Syntax.as_arg wp in
-                                   [uu____11912] in
-                                 uu____11892 :: uu____11901 in
-                               (repr, uu____11881) in
-                             FStar_Syntax_Syntax.Tm_app uu____11864 in
-                           let uu____11957 =
+                                   [uu____11958] in
+                                 uu____11938 :: uu____11947 in
+                               (repr, uu____11927) in
+                             FStar_Syntax_Syntax.Tm_app uu____11910 in
+                           let uu____12003 =
                              FStar_TypeChecker_Env.get_range env in
-                           FStar_Syntax_Syntax.mk uu____11863 uu____11957) in
-                    let uu____11958 =
+                           FStar_Syntax_Syntax.mk uu____11909 uu____12003) in
+                    let uu____12004 =
                       match ((sub.FStar_Syntax_Syntax.lift),
                               (sub.FStar_Syntax_Syntax.lift_wp))
                       with
@@ -5120,21 +5120,21 @@ let (tc_lift :
                           failwith "Impossible (parser)"
                       | (lift, FStar_Pervasives_Native.Some (uvs, lift_wp))
                           ->
-                          let uu____12130 =
+                          let uu____12176 =
                             if (FStar_List.length uvs) > Prims.int_zero
                             then
-                              let uu____12139 =
+                              let uu____12185 =
                                 FStar_Syntax_Subst.univ_var_opening uvs in
-                              match uu____12139 with
+                              match uu____12185 with
                               | (usubst, uvs1) ->
-                                  let uu____12162 =
+                                  let uu____12208 =
                                     FStar_TypeChecker_Env.push_univ_vars env
                                       uvs1 in
-                                  let uu____12163 =
+                                  let uu____12209 =
                                     FStar_Syntax_Subst.subst usubst lift_wp in
-                                  (uu____12162, uu____12163)
+                                  (uu____12208, uu____12209)
                             else (env, lift_wp) in
-                          (match uu____12130 with
+                          (match uu____12176 with
                            | (env1, lift_wp1) ->
                                let lift_wp2 =
                                  if (FStar_List.length uvs) = Prims.int_zero
@@ -5143,53 +5143,53 @@ let (tc_lift :
                                    (let lift_wp2 =
                                       FStar_TypeChecker_TcTerm.tc_check_trivial_guard
                                         env1 lift_wp1 expected_k in
-                                    let uu____12208 =
+                                    let uu____12254 =
                                       FStar_Syntax_Subst.close_univ_vars uvs
                                         lift_wp2 in
-                                    (uvs, uu____12208)) in
+                                    (uvs, uu____12254)) in
                                (lift, lift_wp2))
                       | (FStar_Pervasives_Native.Some (what, lift),
                          FStar_Pervasives_Native.None) ->
-                          let uu____12279 =
+                          let uu____12325 =
                             if (FStar_List.length what) > Prims.int_zero
                             then
-                              let uu____12292 =
+                              let uu____12338 =
                                 FStar_Syntax_Subst.univ_var_opening what in
-                              match uu____12292 with
+                              match uu____12338 with
                               | (usubst, uvs) ->
-                                  let uu____12317 =
+                                  let uu____12363 =
                                     FStar_Syntax_Subst.subst usubst lift in
-                                  (uvs, uu____12317)
+                                  (uvs, uu____12363)
                             else ([], lift) in
-                          (match uu____12279 with
+                          (match uu____12325 with
                            | (uvs, lift1) ->
-                               ((let uu____12352 =
+                               ((let uu____12398 =
                                    FStar_TypeChecker_Env.debug env
                                      (FStar_Options.Other "ED") in
-                                 if uu____12352
+                                 if uu____12398
                                  then
-                                   let uu____12353 =
+                                   let uu____12399 =
                                      FStar_Syntax_Print.term_to_string lift1 in
                                    FStar_Util.print1 "Lift for free : %s\n"
-                                     uu____12353
+                                     uu____12399
                                  else ());
                                 (let dmff_env =
                                    FStar_TypeChecker_DMFF.empty env
                                      (FStar_TypeChecker_TcTerm.tc_constant
                                         env FStar_Range.dummyRange) in
-                                 let uu____12356 =
-                                   let uu____12363 =
+                                 let uu____12402 =
+                                   let uu____12409 =
                                      FStar_TypeChecker_Env.push_univ_vars env
                                        uvs in
                                    FStar_TypeChecker_TcTerm.tc_term
-                                     uu____12363 lift1 in
-                                 match uu____12356 with
-                                 | (lift2, comp, uu____12388) ->
-                                     let uu____12389 =
+                                     uu____12409 lift1 in
+                                 match uu____12402 with
+                                 | (lift2, comp, uu____12434) ->
+                                     let uu____12435 =
                                        FStar_TypeChecker_DMFF.star_expr
                                          dmff_env lift2 in
-                                     (match uu____12389 with
-                                      | (uu____12418, lift_wp, lift_elab) ->
+                                     (match uu____12435 with
+                                      | (uu____12464, lift_wp, lift_elab) ->
                                           let lift_wp1 =
                                             FStar_TypeChecker_DMFF.recheck_debug
                                               "lift-wp" env lift_wp in
@@ -5200,156 +5200,156 @@ let (tc_lift :
                                             (FStar_List.length uvs) =
                                               Prims.int_zero
                                           then
-                                            let uu____12445 =
-                                              let uu____12456 =
+                                            let uu____12491 =
+                                              let uu____12502 =
                                                 FStar_TypeChecker_Generalize.generalize_universes
                                                   env lift_elab1 in
                                               FStar_Pervasives_Native.Some
-                                                uu____12456 in
-                                            let uu____12473 =
+                                                uu____12502 in
+                                            let uu____12519 =
                                               FStar_TypeChecker_Generalize.generalize_universes
                                                 env lift_wp1 in
-                                            (uu____12445, uu____12473)
+                                            (uu____12491, uu____12519)
                                           else
-                                            (let uu____12501 =
-                                               let uu____12512 =
-                                                 let uu____12521 =
+                                            (let uu____12547 =
+                                               let uu____12558 =
+                                                 let uu____12567 =
                                                    FStar_Syntax_Subst.close_univ_vars
                                                      uvs lift_elab1 in
-                                                 (uvs, uu____12521) in
+                                                 (uvs, uu____12567) in
                                                FStar_Pervasives_Native.Some
-                                                 uu____12512 in
-                                             let uu____12536 =
-                                               let uu____12545 =
+                                                 uu____12558 in
+                                             let uu____12582 =
+                                               let uu____12591 =
                                                  FStar_Syntax_Subst.close_univ_vars
                                                    uvs lift_wp1 in
-                                               (uvs, uu____12545) in
-                                             (uu____12501, uu____12536)))))) in
-                    (match uu____11958 with
+                                               (uvs, uu____12591) in
+                                             (uu____12547, uu____12582)))))) in
+                    (match uu____12004 with
                      | (lift, lift_wp) ->
                          let env1 =
-                           let uu___1307_12609 = env in
+                           let uu___1307_12655 = env in
                            {
                              FStar_TypeChecker_Env.solver =
-                               (uu___1307_12609.FStar_TypeChecker_Env.solver);
+                               (uu___1307_12655.FStar_TypeChecker_Env.solver);
                              FStar_TypeChecker_Env.range =
-                               (uu___1307_12609.FStar_TypeChecker_Env.range);
+                               (uu___1307_12655.FStar_TypeChecker_Env.range);
                              FStar_TypeChecker_Env.curmodule =
-                               (uu___1307_12609.FStar_TypeChecker_Env.curmodule);
+                               (uu___1307_12655.FStar_TypeChecker_Env.curmodule);
                              FStar_TypeChecker_Env.gamma =
-                               (uu___1307_12609.FStar_TypeChecker_Env.gamma);
+                               (uu___1307_12655.FStar_TypeChecker_Env.gamma);
                              FStar_TypeChecker_Env.gamma_sig =
-                               (uu___1307_12609.FStar_TypeChecker_Env.gamma_sig);
+                               (uu___1307_12655.FStar_TypeChecker_Env.gamma_sig);
                              FStar_TypeChecker_Env.gamma_cache =
-                               (uu___1307_12609.FStar_TypeChecker_Env.gamma_cache);
+                               (uu___1307_12655.FStar_TypeChecker_Env.gamma_cache);
                              FStar_TypeChecker_Env.modules =
-                               (uu___1307_12609.FStar_TypeChecker_Env.modules);
+                               (uu___1307_12655.FStar_TypeChecker_Env.modules);
                              FStar_TypeChecker_Env.expected_typ =
-                               (uu___1307_12609.FStar_TypeChecker_Env.expected_typ);
+                               (uu___1307_12655.FStar_TypeChecker_Env.expected_typ);
                              FStar_TypeChecker_Env.sigtab =
-                               (uu___1307_12609.FStar_TypeChecker_Env.sigtab);
+                               (uu___1307_12655.FStar_TypeChecker_Env.sigtab);
                              FStar_TypeChecker_Env.attrtab =
-                               (uu___1307_12609.FStar_TypeChecker_Env.attrtab);
+                               (uu___1307_12655.FStar_TypeChecker_Env.attrtab);
                              FStar_TypeChecker_Env.instantiate_imp =
-                               (uu___1307_12609.FStar_TypeChecker_Env.instantiate_imp);
+                               (uu___1307_12655.FStar_TypeChecker_Env.instantiate_imp);
                              FStar_TypeChecker_Env.effects =
-                               (uu___1307_12609.FStar_TypeChecker_Env.effects);
+                               (uu___1307_12655.FStar_TypeChecker_Env.effects);
                              FStar_TypeChecker_Env.generalize =
-                               (uu___1307_12609.FStar_TypeChecker_Env.generalize);
+                               (uu___1307_12655.FStar_TypeChecker_Env.generalize);
                              FStar_TypeChecker_Env.letrecs =
-                               (uu___1307_12609.FStar_TypeChecker_Env.letrecs);
+                               (uu___1307_12655.FStar_TypeChecker_Env.letrecs);
                              FStar_TypeChecker_Env.top_level =
-                               (uu___1307_12609.FStar_TypeChecker_Env.top_level);
+                               (uu___1307_12655.FStar_TypeChecker_Env.top_level);
                              FStar_TypeChecker_Env.check_uvars =
-                               (uu___1307_12609.FStar_TypeChecker_Env.check_uvars);
+                               (uu___1307_12655.FStar_TypeChecker_Env.check_uvars);
                              FStar_TypeChecker_Env.use_eq =
-                               (uu___1307_12609.FStar_TypeChecker_Env.use_eq);
+                               (uu___1307_12655.FStar_TypeChecker_Env.use_eq);
                              FStar_TypeChecker_Env.use_eq_strict =
-                               (uu___1307_12609.FStar_TypeChecker_Env.use_eq_strict);
+                               (uu___1307_12655.FStar_TypeChecker_Env.use_eq_strict);
                              FStar_TypeChecker_Env.is_iface =
-                               (uu___1307_12609.FStar_TypeChecker_Env.is_iface);
+                               (uu___1307_12655.FStar_TypeChecker_Env.is_iface);
                              FStar_TypeChecker_Env.admit =
-                               (uu___1307_12609.FStar_TypeChecker_Env.admit);
+                               (uu___1307_12655.FStar_TypeChecker_Env.admit);
                              FStar_TypeChecker_Env.lax = true;
                              FStar_TypeChecker_Env.lax_universes =
-                               (uu___1307_12609.FStar_TypeChecker_Env.lax_universes);
+                               (uu___1307_12655.FStar_TypeChecker_Env.lax_universes);
                              FStar_TypeChecker_Env.phase1 =
-                               (uu___1307_12609.FStar_TypeChecker_Env.phase1);
+                               (uu___1307_12655.FStar_TypeChecker_Env.phase1);
                              FStar_TypeChecker_Env.failhard =
-                               (uu___1307_12609.FStar_TypeChecker_Env.failhard);
+                               (uu___1307_12655.FStar_TypeChecker_Env.failhard);
                              FStar_TypeChecker_Env.nosynth =
-                               (uu___1307_12609.FStar_TypeChecker_Env.nosynth);
+                               (uu___1307_12655.FStar_TypeChecker_Env.nosynth);
                              FStar_TypeChecker_Env.uvar_subtyping =
-                               (uu___1307_12609.FStar_TypeChecker_Env.uvar_subtyping);
+                               (uu___1307_12655.FStar_TypeChecker_Env.uvar_subtyping);
                              FStar_TypeChecker_Env.tc_term =
-                               (uu___1307_12609.FStar_TypeChecker_Env.tc_term);
+                               (uu___1307_12655.FStar_TypeChecker_Env.tc_term);
                              FStar_TypeChecker_Env.type_of =
-                               (uu___1307_12609.FStar_TypeChecker_Env.type_of);
+                               (uu___1307_12655.FStar_TypeChecker_Env.type_of);
                              FStar_TypeChecker_Env.universe_of =
-                               (uu___1307_12609.FStar_TypeChecker_Env.universe_of);
+                               (uu___1307_12655.FStar_TypeChecker_Env.universe_of);
                              FStar_TypeChecker_Env.check_type_of =
-                               (uu___1307_12609.FStar_TypeChecker_Env.check_type_of);
+                               (uu___1307_12655.FStar_TypeChecker_Env.check_type_of);
                              FStar_TypeChecker_Env.use_bv_sorts =
-                               (uu___1307_12609.FStar_TypeChecker_Env.use_bv_sorts);
+                               (uu___1307_12655.FStar_TypeChecker_Env.use_bv_sorts);
                              FStar_TypeChecker_Env.qtbl_name_and_index =
-                               (uu___1307_12609.FStar_TypeChecker_Env.qtbl_name_and_index);
+                               (uu___1307_12655.FStar_TypeChecker_Env.qtbl_name_and_index);
                              FStar_TypeChecker_Env.normalized_eff_names =
-                               (uu___1307_12609.FStar_TypeChecker_Env.normalized_eff_names);
+                               (uu___1307_12655.FStar_TypeChecker_Env.normalized_eff_names);
                              FStar_TypeChecker_Env.fv_delta_depths =
-                               (uu___1307_12609.FStar_TypeChecker_Env.fv_delta_depths);
+                               (uu___1307_12655.FStar_TypeChecker_Env.fv_delta_depths);
                              FStar_TypeChecker_Env.proof_ns =
-                               (uu___1307_12609.FStar_TypeChecker_Env.proof_ns);
+                               (uu___1307_12655.FStar_TypeChecker_Env.proof_ns);
                              FStar_TypeChecker_Env.synth_hook =
-                               (uu___1307_12609.FStar_TypeChecker_Env.synth_hook);
+                               (uu___1307_12655.FStar_TypeChecker_Env.synth_hook);
                              FStar_TypeChecker_Env.try_solve_implicits_hook =
-                               (uu___1307_12609.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                               (uu___1307_12655.FStar_TypeChecker_Env.try_solve_implicits_hook);
                              FStar_TypeChecker_Env.splice =
-                               (uu___1307_12609.FStar_TypeChecker_Env.splice);
+                               (uu___1307_12655.FStar_TypeChecker_Env.splice);
                              FStar_TypeChecker_Env.mpreprocess =
-                               (uu___1307_12609.FStar_TypeChecker_Env.mpreprocess);
+                               (uu___1307_12655.FStar_TypeChecker_Env.mpreprocess);
                              FStar_TypeChecker_Env.postprocess =
-                               (uu___1307_12609.FStar_TypeChecker_Env.postprocess);
+                               (uu___1307_12655.FStar_TypeChecker_Env.postprocess);
                              FStar_TypeChecker_Env.identifier_info =
-                               (uu___1307_12609.FStar_TypeChecker_Env.identifier_info);
+                               (uu___1307_12655.FStar_TypeChecker_Env.identifier_info);
                              FStar_TypeChecker_Env.tc_hooks =
-                               (uu___1307_12609.FStar_TypeChecker_Env.tc_hooks);
+                               (uu___1307_12655.FStar_TypeChecker_Env.tc_hooks);
                              FStar_TypeChecker_Env.dsenv =
-                               (uu___1307_12609.FStar_TypeChecker_Env.dsenv);
+                               (uu___1307_12655.FStar_TypeChecker_Env.dsenv);
                              FStar_TypeChecker_Env.nbe =
-                               (uu___1307_12609.FStar_TypeChecker_Env.nbe);
+                               (uu___1307_12655.FStar_TypeChecker_Env.nbe);
                              FStar_TypeChecker_Env.strict_args_tab =
-                               (uu___1307_12609.FStar_TypeChecker_Env.strict_args_tab);
+                               (uu___1307_12655.FStar_TypeChecker_Env.strict_args_tab);
                              FStar_TypeChecker_Env.erasable_types_tab =
-                               (uu___1307_12609.FStar_TypeChecker_Env.erasable_types_tab);
+                               (uu___1307_12655.FStar_TypeChecker_Env.erasable_types_tab);
                              FStar_TypeChecker_Env.enable_defer_to_tac =
-                               (uu___1307_12609.FStar_TypeChecker_Env.enable_defer_to_tac)
+                               (uu___1307_12655.FStar_TypeChecker_Env.enable_defer_to_tac)
                            } in
                          let lift1 =
                            match lift with
                            | FStar_Pervasives_Native.None ->
                                FStar_Pervasives_Native.None
                            | FStar_Pervasives_Native.Some (uvs, lift1) ->
-                               let uu____12641 =
-                                 let uu____12646 =
+                               let uu____12687 =
+                                 let uu____12692 =
                                    FStar_Syntax_Subst.univ_var_opening uvs in
-                                 match uu____12646 with
+                                 match uu____12692 with
                                  | (usubst, uvs1) ->
-                                     let uu____12669 =
+                                     let uu____12715 =
                                        FStar_TypeChecker_Env.push_univ_vars
                                          env1 uvs1 in
-                                     let uu____12670 =
+                                     let uu____12716 =
                                        FStar_Syntax_Subst.subst usubst lift1 in
-                                     (uu____12669, uu____12670) in
-                               (match uu____12641 with
+                                     (uu____12715, uu____12716) in
+                               (match uu____12687 with
                                 | (env2, lift2) ->
-                                    let uu____12675 =
-                                      let uu____12682 =
+                                    let uu____12721 =
+                                      let uu____12728 =
                                         FStar_TypeChecker_Env.lookup_effect_lid
                                           env2 sub.FStar_Syntax_Syntax.source in
                                       monad_signature env2
                                         sub.FStar_Syntax_Syntax.source
-                                        uu____12682 in
-                                    (match uu____12675 with
+                                        uu____12728 in
+                                    (match uu____12721 with
                                      | (a1, wp_a_src1) ->
                                          let wp_a =
                                            FStar_Syntax_Syntax.new_bv
@@ -5373,56 +5373,56 @@ let (tc_lift :
                                                (FStar_Pervasives_Native.snd
                                                   lift_wp) in
                                            let lift_wp_a =
-                                             let uu____12708 =
-                                               let uu____12709 =
-                                                 let uu____12726 =
-                                                   let uu____12737 =
+                                             let uu____12754 =
+                                               let uu____12755 =
+                                                 let uu____12772 =
+                                                   let uu____12783 =
                                                      FStar_Syntax_Syntax.as_arg
                                                        a_typ in
-                                                   let uu____12746 =
-                                                     let uu____12757 =
+                                                   let uu____12792 =
+                                                     let uu____12803 =
                                                        FStar_Syntax_Syntax.as_arg
                                                          wp_a_typ in
-                                                     [uu____12757] in
-                                                   uu____12737 :: uu____12746 in
-                                                 (lift_wp1, uu____12726) in
+                                                     [uu____12803] in
+                                                   uu____12783 :: uu____12792 in
+                                                 (lift_wp1, uu____12772) in
                                                FStar_Syntax_Syntax.Tm_app
-                                                 uu____12709 in
-                                             let uu____12802 =
+                                                 uu____12755 in
+                                             let uu____12848 =
                                                FStar_TypeChecker_Env.get_range
                                                  env2 in
                                              FStar_Syntax_Syntax.mk
-                                               uu____12708 uu____12802 in
+                                               uu____12754 uu____12848 in
                                            repr_type
                                              sub.FStar_Syntax_Syntax.target
                                              a_typ lift_wp_a in
                                          let expected_k1 =
-                                           let uu____12806 =
-                                             let uu____12815 =
+                                           let uu____12852 =
+                                             let uu____12861 =
                                                FStar_Syntax_Syntax.mk_binder
                                                  a1 in
-                                             let uu____12822 =
-                                               let uu____12831 =
+                                             let uu____12868 =
+                                               let uu____12877 =
                                                  FStar_Syntax_Syntax.mk_binder
                                                    wp_a in
-                                               let uu____12838 =
-                                                 let uu____12847 =
+                                               let uu____12884 =
+                                                 let uu____12893 =
                                                    FStar_Syntax_Syntax.null_binder
                                                      repr_f in
-                                                 [uu____12847] in
-                                               uu____12831 :: uu____12838 in
-                                             uu____12815 :: uu____12822 in
-                                           let uu____12878 =
+                                                 [uu____12893] in
+                                               uu____12877 :: uu____12884 in
+                                             uu____12861 :: uu____12868 in
+                                           let uu____12924 =
                                              FStar_Syntax_Syntax.mk_Total
                                                repr_result in
                                            FStar_Syntax_Util.arrow
-                                             uu____12806 uu____12878 in
-                                         let uu____12881 =
+                                             uu____12852 uu____12924 in
+                                         let uu____12927 =
                                            FStar_TypeChecker_TcTerm.tc_tot_or_gtot_term
                                              env2 expected_k1 in
-                                         (match uu____12881 with
-                                          | (expected_k2, uu____12891,
-                                             uu____12892) ->
+                                         (match uu____12927 with
+                                          | (expected_k2, uu____12937,
+                                             uu____12938) ->
                                               let lift3 =
                                                 if
                                                   (FStar_List.length uvs) =
@@ -5434,93 +5434,93 @@ let (tc_lift :
                                                   (let lift3 =
                                                      FStar_TypeChecker_TcTerm.tc_check_trivial_guard
                                                        env2 lift2 expected_k2 in
-                                                   let uu____12896 =
+                                                   let uu____12942 =
                                                      FStar_Syntax_Subst.close_univ_vars
                                                        uvs lift3 in
-                                                   (uvs, uu____12896)) in
+                                                   (uvs, uu____12942)) in
                                               FStar_Pervasives_Native.Some
                                                 lift3))) in
-                         ((let uu____12904 =
-                             let uu____12905 =
-                               let uu____12906 =
+                         ((let uu____12950 =
+                             let uu____12951 =
+                               let uu____12952 =
                                  FStar_All.pipe_right lift_wp
                                    FStar_Pervasives_Native.fst in
-                               FStar_All.pipe_right uu____12906
+                               FStar_All.pipe_right uu____12952
                                  FStar_List.length in
-                             uu____12905 <> Prims.int_one in
-                           if uu____12904
+                             uu____12951 <> Prims.int_one in
+                           if uu____12950
                            then
-                             let uu____12925 =
-                               let uu____12930 =
-                                 let uu____12931 =
+                             let uu____12971 =
+                               let uu____12976 =
+                                 let uu____12977 =
                                    FStar_Syntax_Print.lid_to_string
                                      sub.FStar_Syntax_Syntax.source in
-                                 let uu____12932 =
+                                 let uu____12978 =
                                    FStar_Syntax_Print.lid_to_string
                                      sub.FStar_Syntax_Syntax.target in
-                                 let uu____12933 =
-                                   let uu____12934 =
-                                     let uu____12935 =
+                                 let uu____12979 =
+                                   let uu____12980 =
+                                     let uu____12981 =
                                        FStar_All.pipe_right lift_wp
                                          FStar_Pervasives_Native.fst in
-                                     FStar_All.pipe_right uu____12935
+                                     FStar_All.pipe_right uu____12981
                                        FStar_List.length in
-                                   FStar_All.pipe_right uu____12934
+                                   FStar_All.pipe_right uu____12980
                                      FStar_Util.string_of_int in
                                  FStar_Util.format3
                                    "Sub effect wp must be polymorphic in exactly 1 universe; %s ~> %s has %s universes"
-                                   uu____12931 uu____12932 uu____12933 in
+                                   uu____12977 uu____12978 uu____12979 in
                                (FStar_Errors.Fatal_TooManyUniverse,
-                                 uu____12930) in
-                             FStar_Errors.raise_error uu____12925 r
+                                 uu____12976) in
+                             FStar_Errors.raise_error uu____12971 r
                            else ());
-                          (let uu____12956 =
+                          (let uu____13002 =
                              (FStar_Util.is_some lift1) &&
-                               (let uu____12958 =
-                                  let uu____12959 =
-                                    let uu____12962 =
+                               (let uu____13004 =
+                                  let uu____13005 =
+                                    let uu____13008 =
                                       FStar_All.pipe_right lift1
                                         FStar_Util.must in
-                                    FStar_All.pipe_right uu____12962
+                                    FStar_All.pipe_right uu____13008
                                       FStar_Pervasives_Native.fst in
-                                  FStar_All.pipe_right uu____12959
+                                  FStar_All.pipe_right uu____13005
                                     FStar_List.length in
-                                uu____12958 <> Prims.int_one) in
-                           if uu____12956
+                                uu____13004 <> Prims.int_one) in
+                           if uu____13002
                            then
-                             let uu____12997 =
-                               let uu____13002 =
-                                 let uu____13003 =
+                             let uu____13043 =
+                               let uu____13048 =
+                                 let uu____13049 =
                                    FStar_Syntax_Print.lid_to_string
                                      sub.FStar_Syntax_Syntax.source in
-                                 let uu____13004 =
+                                 let uu____13050 =
                                    FStar_Syntax_Print.lid_to_string
                                      sub.FStar_Syntax_Syntax.target in
-                                 let uu____13005 =
-                                   let uu____13006 =
-                                     let uu____13007 =
-                                       let uu____13010 =
+                                 let uu____13051 =
+                                   let uu____13052 =
+                                     let uu____13053 =
+                                       let uu____13056 =
                                          FStar_All.pipe_right lift1
                                            FStar_Util.must in
-                                       FStar_All.pipe_right uu____13010
+                                       FStar_All.pipe_right uu____13056
                                          FStar_Pervasives_Native.fst in
-                                     FStar_All.pipe_right uu____13007
+                                     FStar_All.pipe_right uu____13053
                                        FStar_List.length in
-                                   FStar_All.pipe_right uu____13006
+                                   FStar_All.pipe_right uu____13052
                                      FStar_Util.string_of_int in
                                  FStar_Util.format3
                                    "Sub effect lift must be polymorphic in exactly 1 universe; %s ~> %s has %s universes"
-                                   uu____13003 uu____13004 uu____13005 in
+                                   uu____13049 uu____13050 uu____13051 in
                                (FStar_Errors.Fatal_TooManyUniverse,
-                                 uu____13002) in
-                             FStar_Errors.raise_error uu____12997 r
+                                 uu____13048) in
+                             FStar_Errors.raise_error uu____13043 r
                            else ());
-                          (let uu___1344_13046 = sub in
+                          (let uu___1344_13092 = sub in
                            {
                              FStar_Syntax_Syntax.source =
-                               (uu___1344_13046.FStar_Syntax_Syntax.source);
+                               (uu___1344_13092.FStar_Syntax_Syntax.source);
                              FStar_Syntax_Syntax.target =
-                               (uu___1344_13046.FStar_Syntax_Syntax.target);
+                               (uu___1344_13092.FStar_Syntax_Syntax.target);
                              FStar_Syntax_Syntax.lift_wp =
                                (FStar_Pervasives_Native.Some lift_wp);
                              FStar_Syntax_Syntax.lift = lift1
@@ -5534,139 +5534,139 @@ let (tc_effect_abbrev :
           FStar_Syntax_Syntax.binders * FStar_Syntax_Syntax.comp))
   =
   fun env ->
-    fun uu____13076 ->
+    fun uu____13122 ->
       fun r ->
-        match uu____13076 with
+        match uu____13122 with
         | (lid, uvs, tps, c) ->
             let env0 = env in
-            let uu____13099 =
+            let uu____13145 =
               if (FStar_List.length uvs) = Prims.int_zero
               then (env, uvs, tps, c)
               else
-                (let uu____13123 = FStar_Syntax_Subst.univ_var_opening uvs in
-                 match uu____13123 with
+                (let uu____13169 = FStar_Syntax_Subst.univ_var_opening uvs in
+                 match uu____13169 with
                  | (usubst, uvs1) ->
                      let tps1 = FStar_Syntax_Subst.subst_binders usubst tps in
                      let c1 =
-                       let uu____13154 =
+                       let uu____13200 =
                          FStar_Syntax_Subst.shift_subst
                            (FStar_List.length tps1) usubst in
-                       FStar_Syntax_Subst.subst_comp uu____13154 c in
-                     let uu____13163 =
+                       FStar_Syntax_Subst.subst_comp uu____13200 c in
+                     let uu____13209 =
                        FStar_TypeChecker_Env.push_univ_vars env uvs1 in
-                     (uu____13163, uvs1, tps1, c1)) in
-            (match uu____13099 with
+                     (uu____13209, uvs1, tps1, c1)) in
+            (match uu____13145 with
              | (env1, uvs1, tps1, c1) ->
                  let env2 = FStar_TypeChecker_Env.set_range env1 r in
-                 let uu____13183 = FStar_Syntax_Subst.open_comp tps1 c1 in
-                 (match uu____13183 with
+                 let uu____13229 = FStar_Syntax_Subst.open_comp tps1 c1 in
+                 (match uu____13229 with
                   | (tps2, c2) ->
-                      let uu____13198 =
+                      let uu____13244 =
                         FStar_TypeChecker_TcTerm.tc_tparams env2 tps2 in
-                      (match uu____13198 with
+                      (match uu____13244 with
                        | (tps3, env3, us) ->
-                           let uu____13216 =
+                           let uu____13262 =
                              FStar_TypeChecker_TcTerm.tc_comp env3 c2 in
-                           (match uu____13216 with
+                           (match uu____13262 with
                             | (c3, u, g) ->
                                 (FStar_TypeChecker_Rel.force_trivial_guard
                                    env3 g;
                                  (let expected_result_typ =
                                     match tps3 with
-                                    | (x, uu____13242)::uu____13243 ->
+                                    | (x, uu____13288)::uu____13289 ->
                                         FStar_Syntax_Syntax.bv_to_name x
-                                    | uu____13262 ->
+                                    | uu____13308 ->
                                         FStar_Errors.raise_error
                                           (FStar_Errors.Fatal_NotEnoughArgumentsForEffect,
                                             "Effect abbreviations must bind at least the result type")
                                           r in
                                   let def_result_typ =
                                     FStar_Syntax_Util.comp_result c3 in
-                                  let uu____13268 =
-                                    let uu____13269 =
+                                  let uu____13314 =
+                                    let uu____13315 =
                                       FStar_TypeChecker_Rel.teq_nosmt_force
                                         env3 expected_result_typ
                                         def_result_typ in
-                                    Prims.op_Negation uu____13269 in
-                                  if uu____13268
+                                    Prims.op_Negation uu____13315 in
+                                  if uu____13314
                                   then
-                                    let uu____13270 =
-                                      let uu____13275 =
-                                        let uu____13276 =
+                                    let uu____13316 =
+                                      let uu____13321 =
+                                        let uu____13322 =
                                           FStar_Syntax_Print.term_to_string
                                             expected_result_typ in
-                                        let uu____13277 =
+                                        let uu____13323 =
                                           FStar_Syntax_Print.term_to_string
                                             def_result_typ in
                                         FStar_Util.format2
                                           "Result type of effect abbreviation `%s` does not match the result type of its definition `%s`"
-                                          uu____13276 uu____13277 in
+                                          uu____13322 uu____13323 in
                                       (FStar_Errors.Fatal_EffectAbbreviationResultTypeMismatch,
-                                        uu____13275) in
-                                    FStar_Errors.raise_error uu____13270 r
+                                        uu____13321) in
+                                    FStar_Errors.raise_error uu____13316 r
                                   else ());
                                  (let tps4 =
                                     FStar_Syntax_Subst.close_binders tps3 in
                                   let c4 =
                                     FStar_Syntax_Subst.close_comp tps4 c3 in
-                                  let uu____13281 =
-                                    let uu____13282 =
+                                  let uu____13327 =
+                                    let uu____13328 =
                                       FStar_Syntax_Syntax.mk
                                         (FStar_Syntax_Syntax.Tm_arrow
                                            (tps4, c4)) r in
                                     FStar_TypeChecker_Generalize.generalize_universes
-                                      env0 uu____13282 in
-                                  match uu____13281 with
+                                      env0 uu____13328 in
+                                  match uu____13327 with
                                   | (uvs2, t) ->
-                                      let uu____13311 =
-                                        let uu____13316 =
-                                          let uu____13329 =
-                                            let uu____13330 =
+                                      let uu____13357 =
+                                        let uu____13362 =
+                                          let uu____13375 =
+                                            let uu____13376 =
                                               FStar_Syntax_Subst.compress t in
-                                            uu____13330.FStar_Syntax_Syntax.n in
-                                          (tps4, uu____13329) in
-                                        match uu____13316 with
+                                            uu____13376.FStar_Syntax_Syntax.n in
+                                          (tps4, uu____13375) in
+                                        match uu____13362 with
                                         | ([], FStar_Syntax_Syntax.Tm_arrow
-                                           (uu____13345, c5)) -> ([], c5)
-                                        | (uu____13387,
+                                           (uu____13391, c5)) -> ([], c5)
+                                        | (uu____13433,
                                            FStar_Syntax_Syntax.Tm_arrow
                                            (tps5, c5)) -> (tps5, c5)
-                                        | uu____13426 ->
+                                        | uu____13472 ->
                                             failwith
                                               "Impossible (t is an arrow)" in
-                                      (match uu____13311 with
+                                      (match uu____13357 with
                                        | (tps5, c5) ->
                                            (if
                                               (FStar_List.length uvs2) <>
                                                 Prims.int_one
                                             then
-                                              (let uu____13454 =
+                                              (let uu____13500 =
                                                  FStar_Syntax_Subst.open_univ_vars
                                                    uvs2 t in
-                                               match uu____13454 with
-                                               | (uu____13459, t1) ->
-                                                   let uu____13461 =
-                                                     let uu____13466 =
-                                                       let uu____13467 =
+                                               match uu____13500 with
+                                               | (uu____13505, t1) ->
+                                                   let uu____13507 =
+                                                     let uu____13512 =
+                                                       let uu____13513 =
                                                          FStar_Syntax_Print.lid_to_string
                                                            lid in
-                                                       let uu____13468 =
+                                                       let uu____13514 =
                                                          FStar_All.pipe_right
                                                            (FStar_List.length
                                                               uvs2)
                                                            FStar_Util.string_of_int in
-                                                       let uu____13469 =
+                                                       let uu____13515 =
                                                          FStar_Syntax_Print.term_to_string
                                                            t1 in
                                                        FStar_Util.format3
                                                          "Effect abbreviations must be polymorphic in exactly 1 universe; %s has %s universes (%s)"
-                                                         uu____13467
-                                                         uu____13468
-                                                         uu____13469 in
+                                                         uu____13513
+                                                         uu____13514
+                                                         uu____13515 in
                                                      (FStar_Errors.Fatal_TooManyUniverse,
-                                                       uu____13466) in
+                                                       uu____13512) in
                                                    FStar_Errors.raise_error
-                                                     uu____13461 r)
+                                                     uu____13507 r)
                                             else ();
                                             (lid, uvs2, tps5, c5)))))))))
 let (tc_polymonadic_bind :
@@ -5683,272 +5683,272 @@ let (tc_polymonadic_bind :
         fun p ->
           fun ts ->
             let eff_name =
-              let uu____13505 =
-                let uu____13506 =
+              let uu____13551 =
+                let uu____13552 =
                   FStar_All.pipe_right m FStar_Ident.ident_of_lid in
-                FStar_All.pipe_right uu____13506 FStar_Ident.string_of_id in
-              let uu____13507 =
-                let uu____13508 =
+                FStar_All.pipe_right uu____13552 FStar_Ident.string_of_id in
+              let uu____13553 =
+                let uu____13554 =
                   FStar_All.pipe_right n FStar_Ident.ident_of_lid in
-                FStar_All.pipe_right uu____13508 FStar_Ident.string_of_id in
-              let uu____13509 =
-                let uu____13510 =
+                FStar_All.pipe_right uu____13554 FStar_Ident.string_of_id in
+              let uu____13555 =
+                let uu____13556 =
                   FStar_All.pipe_right p FStar_Ident.ident_of_lid in
-                FStar_All.pipe_right uu____13510 FStar_Ident.string_of_id in
-              FStar_Util.format3 "(%s, %s) |> %s)" uu____13505 uu____13507
-                uu____13509 in
+                FStar_All.pipe_right uu____13556 FStar_Ident.string_of_id in
+              FStar_Util.format3 "(%s, %s) |> %s)" uu____13551 uu____13553
+                uu____13555 in
             let r = (FStar_Pervasives_Native.snd ts).FStar_Syntax_Syntax.pos in
-            let uu____13516 =
+            let uu____13562 =
               check_and_gen env eff_name "polymonadic_bind"
                 (Prims.of_int (2)) ts in
-            match uu____13516 with
+            match uu____13562 with
             | (us, t, ty) ->
-                let uu____13530 = FStar_Syntax_Subst.open_univ_vars us ty in
-                (match uu____13530 with
+                let uu____13576 = FStar_Syntax_Subst.open_univ_vars us ty in
+                (match uu____13576 with
                  | (us1, ty1) ->
                      let env1 = FStar_TypeChecker_Env.push_univ_vars env us1 in
                      (check_no_subtyping_for_layered_combinator env1 ty1
                         FStar_Pervasives_Native.None;
-                      (let uu____13543 =
-                         let uu____13548 = FStar_Syntax_Util.type_u () in
-                         FStar_All.pipe_right uu____13548
-                           (fun uu____13565 ->
-                              match uu____13565 with
+                      (let uu____13589 =
+                         let uu____13594 = FStar_Syntax_Util.type_u () in
+                         FStar_All.pipe_right uu____13594
+                           (fun uu____13611 ->
+                              match uu____13611 with
                               | (t1, u) ->
-                                  let uu____13576 =
-                                    let uu____13577 =
+                                  let uu____13622 =
+                                    let uu____13623 =
                                       FStar_Syntax_Syntax.gen_bv "a"
                                         FStar_Pervasives_Native.None t1 in
-                                    FStar_All.pipe_right uu____13577
+                                    FStar_All.pipe_right uu____13623
                                       FStar_Syntax_Syntax.mk_binder in
-                                  (uu____13576, u)) in
-                       match uu____13543 with
+                                  (uu____13622, u)) in
+                       match uu____13589 with
                        | (a, u_a) ->
-                           let uu____13584 =
-                             let uu____13589 = FStar_Syntax_Util.type_u () in
-                             FStar_All.pipe_right uu____13589
-                               (fun uu____13606 ->
-                                  match uu____13606 with
+                           let uu____13630 =
+                             let uu____13635 = FStar_Syntax_Util.type_u () in
+                             FStar_All.pipe_right uu____13635
+                               (fun uu____13652 ->
+                                  match uu____13652 with
                                   | (t1, u) ->
-                                      let uu____13617 =
-                                        let uu____13618 =
+                                      let uu____13663 =
+                                        let uu____13664 =
                                           FStar_Syntax_Syntax.gen_bv "b"
                                             FStar_Pervasives_Native.None t1 in
-                                        FStar_All.pipe_right uu____13618
+                                        FStar_All.pipe_right uu____13664
                                           FStar_Syntax_Syntax.mk_binder in
-                                      (uu____13617, u)) in
-                           (match uu____13584 with
+                                      (uu____13663, u)) in
+                           (match uu____13630 with
                             | (b, u_b) ->
                                 let rest_bs =
-                                  let uu____13634 =
-                                    let uu____13635 =
+                                  let uu____13680 =
+                                    let uu____13681 =
                                       FStar_Syntax_Subst.compress ty1 in
-                                    uu____13635.FStar_Syntax_Syntax.n in
-                                  match uu____13634 with
+                                    uu____13681.FStar_Syntax_Syntax.n in
+                                  match uu____13680 with
                                   | FStar_Syntax_Syntax.Tm_arrow
-                                      (bs, uu____13647) when
+                                      (bs, uu____13693) when
                                       (FStar_List.length bs) >=
                                         (Prims.of_int (4))
                                       ->
-                                      let uu____13674 =
+                                      let uu____13720 =
                                         FStar_Syntax_Subst.open_binders bs in
-                                      (match uu____13674 with
-                                       | (a', uu____13684)::(b', uu____13686)::bs1
+                                      (match uu____13720 with
+                                       | (a', uu____13730)::(b', uu____13732)::bs1
                                            ->
-                                           let uu____13716 =
-                                             let uu____13717 =
+                                           let uu____13762 =
+                                             let uu____13763 =
                                                FStar_All.pipe_right bs1
                                                  (FStar_List.splitAt
                                                     ((FStar_List.length bs1)
                                                        - (Prims.of_int (2)))) in
-                                             FStar_All.pipe_right uu____13717
+                                             FStar_All.pipe_right uu____13763
                                                FStar_Pervasives_Native.fst in
-                                           let uu____13782 =
-                                             let uu____13795 =
-                                               let uu____13798 =
-                                                 let uu____13799 =
-                                                   let uu____13806 =
-                                                     let uu____13809 =
+                                           let uu____13860 =
+                                             let uu____13873 =
+                                               let uu____13876 =
+                                                 let uu____13877 =
+                                                   let uu____13884 =
+                                                     let uu____13887 =
                                                        FStar_All.pipe_right a
                                                          FStar_Pervasives_Native.fst in
                                                      FStar_All.pipe_right
-                                                       uu____13809
+                                                       uu____13887
                                                        FStar_Syntax_Syntax.bv_to_name in
-                                                   (a', uu____13806) in
+                                                   (a', uu____13884) in
                                                  FStar_Syntax_Syntax.NT
-                                                   uu____13799 in
-                                               let uu____13822 =
-                                                 let uu____13825 =
-                                                   let uu____13826 =
-                                                     let uu____13833 =
-                                                       let uu____13836 =
+                                                   uu____13877 in
+                                               let uu____13900 =
+                                                 let uu____13903 =
+                                                   let uu____13904 =
+                                                     let uu____13911 =
+                                                       let uu____13914 =
                                                          FStar_All.pipe_right
                                                            b
                                                            FStar_Pervasives_Native.fst in
                                                        FStar_All.pipe_right
-                                                         uu____13836
+                                                         uu____13914
                                                          FStar_Syntax_Syntax.bv_to_name in
-                                                     (b', uu____13833) in
+                                                     (b', uu____13911) in
                                                    FStar_Syntax_Syntax.NT
-                                                     uu____13826 in
-                                                 [uu____13825] in
-                                               uu____13798 :: uu____13822 in
+                                                     uu____13904 in
+                                                 [uu____13903] in
+                                               uu____13876 :: uu____13900 in
                                              FStar_Syntax_Subst.subst_binders
-                                               uu____13795 in
-                                           FStar_All.pipe_right uu____13716
-                                             uu____13782)
-                                  | uu____13857 ->
-                                      let uu____13858 =
-                                        let uu____13863 =
-                                          let uu____13864 =
+                                               uu____13873 in
+                                           FStar_All.pipe_right uu____13762
+                                             uu____13860)
+                                  | uu____13935 ->
+                                      let uu____13936 =
+                                        let uu____13941 =
+                                          let uu____13942 =
                                             FStar_Syntax_Print.tag_of_term
                                               ty1 in
-                                          let uu____13865 =
+                                          let uu____13943 =
                                             FStar_Syntax_Print.term_to_string
                                               ty1 in
                                           FStar_Util.format3
                                             "Type of %s is not an arrow with >= 4 binders (%s::%s)"
-                                            eff_name uu____13864 uu____13865 in
+                                            eff_name uu____13942 uu____13943 in
                                         (FStar_Errors.Fatal_UnexpectedEffect,
-                                          uu____13863) in
-                                      FStar_Errors.raise_error uu____13858 r in
+                                          uu____13941) in
+                                      FStar_Errors.raise_error uu____13936 r in
                                 let bs = a :: b :: rest_bs in
-                                let uu____13895 =
-                                  let uu____13906 =
-                                    let uu____13911 =
+                                let uu____13973 =
+                                  let uu____13984 =
+                                    let uu____13989 =
                                       FStar_TypeChecker_Env.push_binders env1
                                         bs in
-                                    let uu____13912 =
-                                      let uu____13913 =
+                                    let uu____13990 =
+                                      let uu____13991 =
                                         FStar_All.pipe_right a
                                           FStar_Pervasives_Native.fst in
-                                      FStar_All.pipe_right uu____13913
+                                      FStar_All.pipe_right uu____13991
                                         FStar_Syntax_Syntax.bv_to_name in
                                     FStar_TypeChecker_Util.fresh_effect_repr_en
-                                      uu____13911 r m u_a uu____13912 in
-                                  match uu____13906 with
+                                      uu____13989 r m u_a uu____13990 in
+                                  match uu____13984 with
                                   | (repr, g) ->
-                                      let uu____13934 =
-                                        let uu____13941 =
+                                      let uu____14012 =
+                                        let uu____14019 =
                                           FStar_Syntax_Syntax.gen_bv "f"
                                             FStar_Pervasives_Native.None repr in
-                                        FStar_All.pipe_right uu____13941
+                                        FStar_All.pipe_right uu____14019
                                           FStar_Syntax_Syntax.mk_binder in
-                                      (uu____13934, g) in
-                                (match uu____13895 with
+                                      (uu____14012, g) in
+                                (match uu____13973 with
                                  | (f, guard_f) ->
-                                     let uu____13972 =
+                                     let uu____14050 =
                                        let x_a =
-                                         let uu____13990 =
-                                           let uu____13991 =
-                                             let uu____13992 =
+                                         let uu____14068 =
+                                           let uu____14069 =
+                                             let uu____14070 =
                                                FStar_All.pipe_right a
                                                  FStar_Pervasives_Native.fst in
-                                             FStar_All.pipe_right uu____13992
+                                             FStar_All.pipe_right uu____14070
                                                FStar_Syntax_Syntax.bv_to_name in
                                            FStar_Syntax_Syntax.gen_bv "x"
                                              FStar_Pervasives_Native.None
-                                             uu____13991 in
-                                         FStar_All.pipe_right uu____13990
+                                             uu____14069 in
+                                         FStar_All.pipe_right uu____14068
                                            FStar_Syntax_Syntax.mk_binder in
-                                       let uu____14007 =
-                                         let uu____14012 =
+                                       let uu____14085 =
+                                         let uu____14090 =
                                            FStar_TypeChecker_Env.push_binders
                                              env1
                                              (FStar_List.append bs [x_a]) in
-                                         let uu____14031 =
-                                           let uu____14032 =
+                                         let uu____14109 =
+                                           let uu____14110 =
                                              FStar_All.pipe_right b
                                                FStar_Pervasives_Native.fst in
-                                           FStar_All.pipe_right uu____14032
+                                           FStar_All.pipe_right uu____14110
                                              FStar_Syntax_Syntax.bv_to_name in
                                          FStar_TypeChecker_Util.fresh_effect_repr_en
-                                           uu____14012 r n u_b uu____14031 in
-                                       match uu____14007 with
+                                           uu____14090 r n u_b uu____14109 in
+                                       match uu____14085 with
                                        | (repr, g) ->
-                                           let uu____14053 =
-                                             let uu____14060 =
-                                               let uu____14061 =
-                                                 let uu____14062 =
-                                                   let uu____14065 =
-                                                     let uu____14068 =
+                                           let uu____14131 =
+                                             let uu____14138 =
+                                               let uu____14139 =
+                                                 let uu____14140 =
+                                                   let uu____14143 =
+                                                     let uu____14146 =
                                                        FStar_TypeChecker_Env.new_u_univ
                                                          () in
                                                      FStar_Pervasives_Native.Some
-                                                       uu____14068 in
+                                                       uu____14146 in
                                                    FStar_Syntax_Syntax.mk_Total'
-                                                     repr uu____14065 in
+                                                     repr uu____14143 in
                                                  FStar_Syntax_Util.arrow
-                                                   [x_a] uu____14062 in
+                                                   [x_a] uu____14140 in
                                                FStar_Syntax_Syntax.gen_bv "g"
                                                  FStar_Pervasives_Native.None
-                                                 uu____14061 in
-                                             FStar_All.pipe_right uu____14060
+                                                 uu____14139 in
+                                             FStar_All.pipe_right uu____14138
                                                FStar_Syntax_Syntax.mk_binder in
-                                           (uu____14053, g) in
-                                     (match uu____13972 with
+                                           (uu____14131, g) in
+                                     (match uu____14050 with
                                       | (g, guard_g) ->
-                                          let uu____14111 =
-                                            let uu____14116 =
+                                          let uu____14189 =
+                                            let uu____14194 =
                                               FStar_TypeChecker_Env.push_binders
                                                 env1 bs in
-                                            let uu____14117 =
-                                              let uu____14118 =
+                                            let uu____14195 =
+                                              let uu____14196 =
                                                 FStar_All.pipe_right b
                                                   FStar_Pervasives_Native.fst in
                                               FStar_All.pipe_right
-                                                uu____14118
+                                                uu____14196
                                                 FStar_Syntax_Syntax.bv_to_name in
                                             FStar_TypeChecker_Util.fresh_effect_repr_en
-                                              uu____14116 r p u_b uu____14117 in
-                                          (match uu____14111 with
+                                              uu____14194 r p u_b uu____14195 in
+                                          (match uu____14189 with
                                            | (repr, guard_repr) ->
-                                               let uu____14133 =
-                                                 let uu____14138 =
+                                               let uu____14211 =
+                                                 let uu____14216 =
                                                    FStar_TypeChecker_Env.push_binders
                                                      env1 bs in
-                                                 let uu____14139 =
+                                                 let uu____14217 =
                                                    FStar_Util.format1
                                                      "implicit for pure_wp in checking %s"
                                                      eff_name in
-                                                 pure_wp_uvar uu____14138
-                                                   repr uu____14139 r in
-                                               (match uu____14133 with
+                                                 pure_wp_uvar uu____14216
+                                                   repr uu____14217 r in
+                                               (match uu____14211 with
                                                 | (pure_wp_uvar1,
                                                    g_pure_wp_uvar) ->
                                                     let k =
-                                                      let uu____14149 =
-                                                        let uu____14152 =
-                                                          let uu____14153 =
-                                                            let uu____14154 =
+                                                      let uu____14227 =
+                                                        let uu____14230 =
+                                                          let uu____14231 =
+                                                            let uu____14232 =
                                                               FStar_TypeChecker_Env.new_u_univ
                                                                 () in
-                                                            [uu____14154] in
-                                                          let uu____14155 =
-                                                            let uu____14166 =
+                                                            [uu____14232] in
+                                                          let uu____14233 =
+                                                            let uu____14244 =
                                                               FStar_All.pipe_right
                                                                 pure_wp_uvar1
                                                                 FStar_Syntax_Syntax.as_arg in
-                                                            [uu____14166] in
+                                                            [uu____14244] in
                                                           {
                                                             FStar_Syntax_Syntax.comp_univs
-                                                              = uu____14153;
+                                                              = uu____14231;
                                                             FStar_Syntax_Syntax.effect_name
                                                               =
                                                               FStar_Parser_Const.effect_PURE_lid;
                                                             FStar_Syntax_Syntax.result_typ
                                                               = repr;
                                                             FStar_Syntax_Syntax.effect_args
-                                                              = uu____14155;
+                                                              = uu____14233;
                                                             FStar_Syntax_Syntax.flags
                                                               = []
                                                           } in
                                                         FStar_Syntax_Syntax.mk_Comp
-                                                          uu____14152 in
+                                                          uu____14230 in
                                                       FStar_Syntax_Util.arrow
                                                         (FStar_List.append bs
                                                            [f; g])
-                                                        uu____14149 in
+                                                        uu____14227 in
                                                     let guard_eq =
                                                       FStar_TypeChecker_Rel.teq
                                                         env1 ty1 k in
@@ -5960,24 +5960,24 @@ let (tc_polymonadic_bind :
                                                        guard_repr;
                                                        g_pure_wp_uvar;
                                                        guard_eq];
-                                                     (let uu____14226 =
+                                                     (let uu____14304 =
                                                         FStar_All.pipe_left
                                                           (FStar_TypeChecker_Env.debug
                                                              env1)
                                                           FStar_Options.Extreme in
-                                                      if uu____14226
+                                                      if uu____14304
                                                       then
-                                                        let uu____14227 =
+                                                        let uu____14305 =
                                                           FStar_Syntax_Print.tscheme_to_string
                                                             (us1, t) in
-                                                        let uu____14232 =
+                                                        let uu____14310 =
                                                           FStar_Syntax_Print.tscheme_to_string
                                                             (us1, k) in
                                                         FStar_Util.print3
                                                           "Polymonadic bind %s after typechecking (%s::%s)\n"
                                                           eff_name
-                                                          uu____14227
-                                                          uu____14232
+                                                          uu____14305
+                                                          uu____14310
                                                       else ());
                                                      (let k1 =
                                                         FStar_All.pipe_right
@@ -5989,33 +5989,33 @@ let (tc_polymonadic_bind :
                                                         (FStar_TypeChecker_Env.is_reifiable_effect
                                                            env1 p)
                                                           &&
-                                                          (let uu____14241 =
+                                                          (let uu____14319 =
                                                              FStar_TypeChecker_Env.fv_with_lid_has_attr
                                                                env1 p
                                                                FStar_Parser_Const.allow_informative_binders_attr in
                                                            Prims.op_Negation
-                                                             uu____14241) in
-                                                      (let uu____14243 =
-                                                         let uu____14244 =
+                                                             uu____14319) in
+                                                      (let uu____14321 =
+                                                         let uu____14322 =
                                                            FStar_Syntax_Subst.compress
                                                              k1 in
-                                                         uu____14244.FStar_Syntax_Syntax.n in
-                                                       match uu____14243 with
+                                                         uu____14322.FStar_Syntax_Syntax.n in
+                                                       match uu____14321 with
                                                        | FStar_Syntax_Syntax.Tm_arrow
                                                            (bs1, c) ->
-                                                           let uu____14269 =
+                                                           let uu____14347 =
                                                              FStar_Syntax_Subst.open_comp
                                                                bs1 c in
-                                                           (match uu____14269
+                                                           (match uu____14347
                                                             with
                                                             | (a1::b1::bs2,
                                                                c1) ->
                                                                 let res_t =
                                                                   FStar_Syntax_Util.comp_result
                                                                     c1 in
-                                                                let uu____14313
+                                                                let uu____14391
                                                                   =
-                                                                  let uu____14340
+                                                                  let uu____14418
                                                                     =
                                                                     FStar_List.splitAt
                                                                     ((FStar_List.length
@@ -6023,53 +6023,53 @@ let (tc_polymonadic_bind :
                                                                     (Prims.of_int (2)))
                                                                     bs2 in
                                                                   FStar_All.pipe_right
-                                                                    uu____14340
+                                                                    uu____14418
                                                                     (
                                                                     fun
-                                                                    uu____14424
+                                                                    uu____14502
                                                                     ->
-                                                                    match uu____14424
+                                                                    match uu____14502
                                                                     with
                                                                     | 
                                                                     (l1, l2)
                                                                     ->
-                                                                    let uu____14505
+                                                                    let uu____14583
                                                                     =
                                                                     FStar_All.pipe_right
                                                                     l2
                                                                     FStar_List.hd in
-                                                                    let uu____14532
+                                                                    let uu____14610
                                                                     =
-                                                                    let uu____14539
+                                                                    let uu____14617
                                                                     =
                                                                     FStar_All.pipe_right
                                                                     l2
                                                                     FStar_List.tl in
                                                                     FStar_All.pipe_right
-                                                                    uu____14539
+                                                                    uu____14617
                                                                     FStar_List.hd in
                                                                     (l1,
-                                                                    uu____14505,
-                                                                    uu____14532)) in
-                                                                (match uu____14313
+                                                                    uu____14583,
+                                                                    uu____14610)) in
+                                                                (match uu____14391
                                                                  with
                                                                  | (bs3, f_b,
                                                                     g_b) ->
                                                                     let g_sort
                                                                     =
-                                                                    let uu____14654
+                                                                    let uu____14732
                                                                     =
-                                                                    let uu____14655
+                                                                    let uu____14733
                                                                     =
                                                                     FStar_Syntax_Subst.compress
                                                                     (FStar_Pervasives_Native.fst
                                                                     g_b).FStar_Syntax_Syntax.sort in
-                                                                    uu____14655.FStar_Syntax_Syntax.n in
-                                                                    match uu____14654
+                                                                    uu____14733.FStar_Syntax_Syntax.n in
+                                                                    match uu____14732
                                                                     with
                                                                     | 
                                                                     FStar_Syntax_Syntax.Tm_arrow
-                                                                    (uu____14660,
+                                                                    (uu____14738,
                                                                     c2) ->
                                                                     FStar_Syntax_Util.comp_result
                                                                     c2 in
@@ -6087,24 +6087,24 @@ let (tc_polymonadic_bind :
                                                                     res_t]
                                                                     check_non_informative_binders
                                                                     r)));
-                                                      (let uu____14704 =
-                                                         let uu____14709 =
+                                                      (let uu____14782 =
+                                                         let uu____14787 =
                                                            FStar_Util.format1
                                                              "Polymonadic binds (%s in this case) is an experimental feature;it is subject to some redesign in the future. Please keep us informed (on github etc.) about how you are using it"
                                                              eff_name in
                                                          (FStar_Errors.Warning_BleedingEdge_Feature,
-                                                           uu____14709) in
+                                                           uu____14787) in
                                                        FStar_Errors.log_issue
-                                                         r uu____14704);
-                                                      (let uu____14710 =
-                                                         let uu____14711 =
+                                                         r uu____14782);
+                                                      (let uu____14788 =
+                                                         let uu____14789 =
                                                            FStar_All.pipe_right
                                                              k1
                                                              (FStar_Syntax_Subst.close_univ_vars
                                                                 us1) in
-                                                         (us1, uu____14711) in
+                                                         (us1, uu____14789) in
                                                        ((us1, t),
-                                                         uu____14710))))))))))))
+                                                         uu____14788))))))))))))
 let (tc_polymonadic_subcomp :
   FStar_TypeChecker_Env.env ->
     FStar_Ident.lident ->
@@ -6118,186 +6118,186 @@ let (tc_polymonadic_subcomp :
         fun ts ->
           let r = (FStar_Pervasives_Native.snd ts).FStar_Syntax_Syntax.pos in
           let combinator_name =
-            let uu____14758 =
-              let uu____14759 =
+            let uu____14836 =
+              let uu____14837 =
                 FStar_All.pipe_right m FStar_Ident.ident_of_lid in
-              FStar_All.pipe_right uu____14759 FStar_Ident.string_of_id in
-            let uu____14760 =
-              let uu____14761 =
-                let uu____14762 =
+              FStar_All.pipe_right uu____14837 FStar_Ident.string_of_id in
+            let uu____14838 =
+              let uu____14839 =
+                let uu____14840 =
                   FStar_All.pipe_right n FStar_Ident.ident_of_lid in
-                FStar_All.pipe_right uu____14762 FStar_Ident.string_of_id in
-              Prims.op_Hat " <: " uu____14761 in
-            Prims.op_Hat uu____14758 uu____14760 in
-          let uu____14763 =
+                FStar_All.pipe_right uu____14840 FStar_Ident.string_of_id in
+              Prims.op_Hat " <: " uu____14839 in
+            Prims.op_Hat uu____14836 uu____14838 in
+          let uu____14841 =
             check_and_gen env0 combinator_name "polymonadic_subcomp"
               Prims.int_one ts in
-          match uu____14763 with
+          match uu____14841 with
           | (us, t, ty) ->
-              let uu____14777 = FStar_Syntax_Subst.open_univ_vars us ty in
-              (match uu____14777 with
+              let uu____14855 = FStar_Syntax_Subst.open_univ_vars us ty in
+              (match uu____14855 with
                | (us1, ty1) ->
                    let env = FStar_TypeChecker_Env.push_univ_vars env0 us1 in
                    (check_no_subtyping_for_layered_combinator env ty1
                       FStar_Pervasives_Native.None;
-                    (let uu____14790 =
-                       let uu____14795 = FStar_Syntax_Util.type_u () in
-                       FStar_All.pipe_right uu____14795
-                         (fun uu____14812 ->
-                            match uu____14812 with
+                    (let uu____14868 =
+                       let uu____14873 = FStar_Syntax_Util.type_u () in
+                       FStar_All.pipe_right uu____14873
+                         (fun uu____14890 ->
+                            match uu____14890 with
                             | (t1, u) ->
-                                let uu____14823 =
-                                  let uu____14824 =
+                                let uu____14901 =
+                                  let uu____14902 =
                                     FStar_Syntax_Syntax.gen_bv "a"
                                       FStar_Pervasives_Native.None t1 in
-                                  FStar_All.pipe_right uu____14824
+                                  FStar_All.pipe_right uu____14902
                                     FStar_Syntax_Syntax.mk_binder in
-                                (uu____14823, u)) in
-                     match uu____14790 with
+                                (uu____14901, u)) in
+                     match uu____14868 with
                      | (a, u) ->
                          let rest_bs =
-                           let uu____14840 =
-                             let uu____14841 =
+                           let uu____14918 =
+                             let uu____14919 =
                                FStar_Syntax_Subst.compress ty1 in
-                             uu____14841.FStar_Syntax_Syntax.n in
-                           match uu____14840 with
-                           | FStar_Syntax_Syntax.Tm_arrow (bs, uu____14853)
+                             uu____14919.FStar_Syntax_Syntax.n in
+                           match uu____14918 with
+                           | FStar_Syntax_Syntax.Tm_arrow (bs, uu____14931)
                                when
                                (FStar_List.length bs) >= (Prims.of_int (2))
                                ->
-                               let uu____14880 =
+                               let uu____14958 =
                                  FStar_Syntax_Subst.open_binders bs in
-                               (match uu____14880 with
-                                | (a', uu____14890)::bs1 ->
-                                    let uu____14910 =
-                                      let uu____14911 =
+                               (match uu____14958 with
+                                | (a', uu____14968)::bs1 ->
+                                    let uu____14988 =
+                                      let uu____14989 =
                                         FStar_All.pipe_right bs1
                                           (FStar_List.splitAt
                                              ((FStar_List.length bs1) -
                                                 Prims.int_one)) in
-                                      FStar_All.pipe_right uu____14911
+                                      FStar_All.pipe_right uu____14989
                                         FStar_Pervasives_Native.fst in
-                                    let uu____15008 =
-                                      let uu____15021 =
-                                        let uu____15024 =
-                                          let uu____15025 =
-                                            let uu____15032 =
+                                    let uu____15054 =
+                                      let uu____15067 =
+                                        let uu____15070 =
+                                          let uu____15071 =
+                                            let uu____15078 =
                                               FStar_Syntax_Syntax.bv_to_name
                                                 (FStar_Pervasives_Native.fst
                                                    a) in
-                                            (a', uu____15032) in
-                                          FStar_Syntax_Syntax.NT uu____15025 in
-                                        [uu____15024] in
+                                            (a', uu____15078) in
+                                          FStar_Syntax_Syntax.NT uu____15071 in
+                                        [uu____15070] in
                                       FStar_Syntax_Subst.subst_binders
-                                        uu____15021 in
-                                    FStar_All.pipe_right uu____14910
-                                      uu____15008)
-                           | uu____15047 ->
-                               let uu____15048 =
-                                 let uu____15053 =
-                                   let uu____15054 =
+                                        uu____15067 in
+                                    FStar_All.pipe_right uu____14988
+                                      uu____15054)
+                           | uu____15093 ->
+                               let uu____15094 =
+                                 let uu____15099 =
+                                   let uu____15100 =
                                      FStar_Syntax_Print.tag_of_term t in
-                                   let uu____15055 =
+                                   let uu____15101 =
                                      FStar_Syntax_Print.term_to_string t in
                                    FStar_Util.format3
                                      "Type of polymonadic subcomp %s is not an arrow with >= 2 binders (%s::%s)"
-                                     combinator_name uu____15054 uu____15055 in
+                                     combinator_name uu____15100 uu____15101 in
                                  (FStar_Errors.Fatal_UnexpectedEffect,
-                                   uu____15053) in
-                               FStar_Errors.raise_error uu____15048 r in
+                                   uu____15099) in
+                               FStar_Errors.raise_error uu____15094 r in
                          let bs = a :: rest_bs in
-                         let uu____15079 =
-                           let uu____15090 =
-                             let uu____15095 =
+                         let uu____15125 =
+                           let uu____15136 =
+                             let uu____15141 =
                                FStar_TypeChecker_Env.push_binders env bs in
-                             let uu____15096 =
-                               let uu____15097 =
+                             let uu____15142 =
+                               let uu____15143 =
                                  FStar_All.pipe_right a
                                    FStar_Pervasives_Native.fst in
-                               FStar_All.pipe_right uu____15097
+                               FStar_All.pipe_right uu____15143
                                  FStar_Syntax_Syntax.bv_to_name in
                              FStar_TypeChecker_Util.fresh_effect_repr_en
-                               uu____15095 r m u uu____15096 in
-                           match uu____15090 with
+                               uu____15141 r m u uu____15142 in
+                           match uu____15136 with
                            | (repr, g) ->
-                               let uu____15118 =
-                                 let uu____15125 =
+                               let uu____15164 =
+                                 let uu____15171 =
                                    FStar_Syntax_Syntax.gen_bv "f"
                                      FStar_Pervasives_Native.None repr in
-                                 FStar_All.pipe_right uu____15125
+                                 FStar_All.pipe_right uu____15171
                                    FStar_Syntax_Syntax.mk_binder in
-                               (uu____15118, g) in
-                         (match uu____15079 with
+                               (uu____15164, g) in
+                         (match uu____15125 with
                           | (f, guard_f) ->
-                              let uu____15156 =
-                                let uu____15161 =
+                              let uu____15202 =
+                                let uu____15207 =
                                   FStar_TypeChecker_Env.push_binders env bs in
-                                let uu____15162 =
-                                  let uu____15163 =
+                                let uu____15208 =
+                                  let uu____15209 =
                                     FStar_All.pipe_right a
                                       FStar_Pervasives_Native.fst in
-                                  FStar_All.pipe_right uu____15163
+                                  FStar_All.pipe_right uu____15209
                                     FStar_Syntax_Syntax.bv_to_name in
                                 FStar_TypeChecker_Util.fresh_effect_repr_en
-                                  uu____15161 r n u uu____15162 in
-                              (match uu____15156 with
+                                  uu____15207 r n u uu____15208 in
+                              (match uu____15202 with
                                | (ret_t, guard_ret_t) ->
-                                   let uu____15178 =
-                                     let uu____15183 =
+                                   let uu____15224 =
+                                     let uu____15229 =
                                        FStar_TypeChecker_Env.push_binders env
                                          bs in
-                                     let uu____15184 =
+                                     let uu____15230 =
                                        FStar_Util.format1
                                          "implicit for pure_wp in checking polymonadic subcomp %s"
                                          combinator_name in
-                                     pure_wp_uvar uu____15183 ret_t
-                                       uu____15184 r in
-                                   (match uu____15178 with
+                                     pure_wp_uvar uu____15229 ret_t
+                                       uu____15230 r in
+                                   (match uu____15224 with
                                     | (pure_wp_uvar1, guard_wp) ->
                                         let c =
-                                          let uu____15192 =
-                                            let uu____15193 =
-                                              let uu____15194 =
+                                          let uu____15238 =
+                                            let uu____15239 =
+                                              let uu____15240 =
                                                 FStar_TypeChecker_Env.new_u_univ
                                                   () in
-                                              [uu____15194] in
-                                            let uu____15195 =
-                                              let uu____15206 =
+                                              [uu____15240] in
+                                            let uu____15241 =
+                                              let uu____15252 =
                                                 FStar_All.pipe_right
                                                   pure_wp_uvar1
                                                   FStar_Syntax_Syntax.as_arg in
-                                              [uu____15206] in
+                                              [uu____15252] in
                                             {
                                               FStar_Syntax_Syntax.comp_univs
-                                                = uu____15193;
+                                                = uu____15239;
                                               FStar_Syntax_Syntax.effect_name
                                                 =
                                                 FStar_Parser_Const.effect_PURE_lid;
                                               FStar_Syntax_Syntax.result_typ
                                                 = ret_t;
                                               FStar_Syntax_Syntax.effect_args
-                                                = uu____15195;
+                                                = uu____15241;
                                               FStar_Syntax_Syntax.flags = []
                                             } in
                                           FStar_Syntax_Syntax.mk_Comp
-                                            uu____15192 in
+                                            uu____15238 in
                                         let k =
                                           FStar_Syntax_Util.arrow
                                             (FStar_List.append bs [f]) c in
-                                        ((let uu____15261 =
+                                        ((let uu____15307 =
                                             FStar_All.pipe_left
                                               (FStar_TypeChecker_Env.debug
                                                  env)
                                               (FStar_Options.Other
                                                  "LayeredEffectsTc") in
-                                          if uu____15261
+                                          if uu____15307
                                           then
-                                            let uu____15262 =
+                                            let uu____15308 =
                                               FStar_Syntax_Print.term_to_string
                                                 k in
                                             FStar_Util.print2
                                               "Expected type of polymonadic subcomp %s before unification: %s\n"
-                                              combinator_name uu____15262
+                                              combinator_name uu____15308
                                           else ());
                                          (let guard_eq =
                                             FStar_TypeChecker_Rel.teq env ty1
@@ -6310,59 +6310,59 @@ let (tc_polymonadic_subcomp :
                                             guard_wp;
                                             guard_eq];
                                           (let k1 =
-                                             let uu____15269 =
+                                             let uu____15315 =
                                                FStar_All.pipe_right k
                                                  (FStar_TypeChecker_Normalize.remove_uvar_solutions
                                                     env) in
-                                             FStar_All.pipe_right uu____15269
+                                             FStar_All.pipe_right uu____15315
                                                (FStar_TypeChecker_Normalize.normalize
                                                   [FStar_TypeChecker_Env.Beta;
                                                   FStar_TypeChecker_Env.Eager_unfolding]
                                                   env) in
-                                           (let uu____15273 =
+                                           (let uu____15319 =
                                               FStar_All.pipe_left
                                                 (FStar_TypeChecker_Env.debug
                                                    env)
                                                 (FStar_Options.Other
                                                    "LayeredEffectsTc") in
-                                            if uu____15273
+                                            if uu____15319
                                             then
-                                              let uu____15274 =
+                                              let uu____15320 =
                                                 FStar_Syntax_Print.tscheme_to_string
                                                   (us1, k1) in
                                               FStar_Util.print2
                                                 "Polymonadic subcomp %s type after unification : %s\n"
-                                                combinator_name uu____15274
+                                                combinator_name uu____15320
                                             else ());
                                            (let check_non_informative_binders
                                               =
                                               (FStar_TypeChecker_Env.is_reifiable_effect
                                                  env n)
                                                 &&
-                                                (let uu____15282 =
+                                                (let uu____15328 =
                                                    FStar_TypeChecker_Env.fv_with_lid_has_attr
                                                      env n
                                                      FStar_Parser_Const.allow_informative_binders_attr in
                                                  Prims.op_Negation
-                                                   uu____15282) in
-                                            (let uu____15284 =
-                                               let uu____15285 =
+                                                   uu____15328) in
+                                            (let uu____15330 =
+                                               let uu____15331 =
                                                  FStar_Syntax_Subst.compress
                                                    k1 in
-                                               uu____15285.FStar_Syntax_Syntax.n in
-                                             match uu____15284 with
+                                               uu____15331.FStar_Syntax_Syntax.n in
+                                             match uu____15330 with
                                              | FStar_Syntax_Syntax.Tm_arrow
                                                  (bs1, c1) ->
-                                                 let uu____15310 =
+                                                 let uu____15356 =
                                                    FStar_Syntax_Subst.open_comp
                                                      bs1 c1 in
-                                                 (match uu____15310 with
+                                                 (match uu____15356 with
                                                   | (a1::bs2, c2) ->
                                                       let res_t =
                                                         FStar_Syntax_Util.comp_result
                                                           c2 in
-                                                      let uu____15341 =
-                                                        let uu____15360 =
+                                                      let uu____15387 =
+                                                        let uu____15406 =
                                                           FStar_List.splitAt
                                                             ((FStar_List.length
                                                                 bs2)
@@ -6370,18 +6370,18 @@ let (tc_polymonadic_subcomp :
                                                                Prims.int_one)
                                                             bs2 in
                                                         FStar_All.pipe_right
-                                                          uu____15360
-                                                          (fun uu____15435 ->
-                                                             match uu____15435
+                                                          uu____15406
+                                                          (fun uu____15481 ->
+                                                             match uu____15481
                                                              with
                                                              | (l1, l2) ->
-                                                                 let uu____15508
+                                                                 let uu____15554
                                                                    =
                                                                    FStar_List.hd
                                                                     l2 in
                                                                  (l1,
-                                                                   uu____15508)) in
-                                                      (match uu____15341 with
+                                                                   uu____15554)) in
+                                                      (match uu____15387 with
                                                        | (bs3, f_b) ->
                                                            let env1 =
                                                              FStar_TypeChecker_Env.push_binders
@@ -6393,19 +6393,19 @@ let (tc_polymonadic_subcomp :
                                                              res_t]
                                                              check_non_informative_binders
                                                              r)));
-                                            (let uu____15581 =
-                                               let uu____15586 =
+                                            (let uu____15627 =
+                                               let uu____15632 =
                                                  FStar_Util.format1
                                                    "Polymonadic subcomp (%s in this case) is an experimental feature;it is subject to some redesign in the future. Please keep us informed (on github etc.) about how you are using it"
                                                    combinator_name in
                                                (FStar_Errors.Warning_BleedingEdge_Feature,
-                                                 uu____15586) in
+                                                 uu____15632) in
                                              FStar_Errors.log_issue r
-                                               uu____15581);
-                                            (let uu____15587 =
-                                               let uu____15588 =
+                                               uu____15627);
+                                            (let uu____15633 =
+                                               let uu____15634 =
                                                  FStar_All.pipe_right k1
                                                    (FStar_Syntax_Subst.close_univ_vars
                                                       us1) in
-                                               (us1, uu____15588) in
-                                             ((us1, t), uu____15587))))))))))))
+                                               (us1, uu____15634) in
+                                             ((us1, t), uu____15633))))))))))))

--- a/src/ocaml-output/FStar_TypeChecker_TcTerm.ml
+++ b/src/ocaml-output/FStar_TypeChecker_TcTerm.ml
@@ -1911,60 +1911,60 @@ and (tc_maybe_toplevel_term :
            let uu____5243 = FStar_All.pipe_right top is_comp_ascribed_reflect in
            FStar_All.pipe_right uu____5243 FStar_Util.is_some ->
            let uu____5274 =
-             let uu____5285 =
+             let uu____5283 =
                FStar_All.pipe_right top is_comp_ascribed_reflect in
-             FStar_All.pipe_right uu____5285 FStar_Util.must in
+             FStar_All.pipe_right uu____5283 FStar_Util.must in
            (match uu____5274 with
             | (effect_lid, e1, aqual) ->
-                let uu____5359 =
+                let uu____5335 =
                   FStar_TypeChecker_Env.clear_expected_typ env1 in
-                (match uu____5359 with
-                 | (env0, uu____5373) ->
-                     let uu____5378 = tc_comp env0 expected_c in
-                     (match uu____5378 with
-                      | (expected_c1, uu____5392, g_c) ->
+                (match uu____5335 with
+                 | (env0, uu____5349) ->
+                     let uu____5354 = tc_comp env0 expected_c in
+                     (match uu____5354 with
+                      | (expected_c1, uu____5368, g_c) ->
                           let expected_ct =
                             FStar_TypeChecker_Env.unfold_effect_abbrev env0
                               expected_c1 in
-                          ((let uu____5396 =
-                              let uu____5397 =
+                          ((let uu____5372 =
+                              let uu____5373 =
                                 FStar_Ident.lid_equals effect_lid
                                   expected_ct.FStar_Syntax_Syntax.effect_name in
-                              Prims.op_Negation uu____5397 in
-                            if uu____5396
+                              Prims.op_Negation uu____5373 in
+                            if uu____5372
                             then
-                              let uu____5398 =
-                                let uu____5403 =
-                                  let uu____5404 =
+                              let uu____5374 =
+                                let uu____5379 =
+                                  let uu____5380 =
                                     FStar_Ident.string_of_lid effect_lid in
-                                  let uu____5405 =
+                                  let uu____5381 =
                                     FStar_Ident.string_of_lid
                                       expected_ct.FStar_Syntax_Syntax.effect_name in
                                   FStar_Util.format2
                                     "The effect on reflect %s does not match with the annotation %s\n"
-                                    uu____5404 uu____5405 in
+                                    uu____5380 uu____5381 in
                                 (FStar_Errors.Fatal_UnexpectedEffect,
-                                  uu____5403) in
-                              FStar_Errors.raise_error uu____5398
+                                  uu____5379) in
+                              FStar_Errors.raise_error uu____5374
                                 top.FStar_Syntax_Syntax.pos
                             else ());
-                           (let uu____5408 =
-                              let uu____5409 =
+                           (let uu____5384 =
+                              let uu____5385 =
                                 FStar_TypeChecker_Env.is_user_reflectable_effect
                                   env1 effect_lid in
-                              Prims.op_Negation uu____5409 in
-                            if uu____5408
+                              Prims.op_Negation uu____5385 in
+                            if uu____5384
                             then
-                              let uu____5410 =
-                                let uu____5415 =
-                                  let uu____5416 =
+                              let uu____5386 =
+                                let uu____5391 =
+                                  let uu____5392 =
                                     FStar_Ident.string_of_lid effect_lid in
                                   FStar_Util.format1
                                     "Effect %s cannot be reflected"
-                                    uu____5416 in
+                                    uu____5392 in
                                 (FStar_Errors.Fatal_EffectCannotBeReified,
-                                  uu____5415) in
-                              FStar_Errors.raise_error uu____5410
+                                  uu____5391) in
+                              FStar_Errors.raise_error uu____5386
                                 top.FStar_Syntax_Syntax.pos
                             else ());
                            (let u_c =
@@ -1972,59 +1972,59 @@ and (tc_maybe_toplevel_term :
                                 expected_ct.FStar_Syntax_Syntax.comp_univs
                                 FStar_List.hd in
                             let repr =
-                              let uu____5422 =
-                                let uu____5425 =
+                              let uu____5398 =
+                                let uu____5401 =
                                   FStar_All.pipe_right expected_ct
                                     FStar_Syntax_Syntax.mk_Comp in
                                 FStar_TypeChecker_Env.effect_repr env0
-                                  uu____5425 u_c in
-                              FStar_All.pipe_right uu____5422 FStar_Util.must in
+                                  uu____5401 u_c in
+                              FStar_All.pipe_right uu____5398 FStar_Util.must in
                             let e2 =
-                              let uu____5431 =
-                                let uu____5432 =
-                                  let uu____5459 =
-                                    let uu____5476 =
-                                      let uu____5485 =
+                              let uu____5407 =
+                                let uu____5408 =
+                                  let uu____5435 =
+                                    let uu____5452 =
+                                      let uu____5461 =
                                         FStar_Syntax_Syntax.mk_Total' repr
                                           (FStar_Pervasives_Native.Some u_c) in
-                                      FStar_Util.Inr uu____5485 in
-                                    (uu____5476,
+                                      FStar_Util.Inr uu____5461 in
+                                    (uu____5452,
                                       FStar_Pervasives_Native.None) in
-                                  (e1, uu____5459,
+                                  (e1, uu____5435,
                                     FStar_Pervasives_Native.None) in
-                                FStar_Syntax_Syntax.Tm_ascribed uu____5432 in
-                              FStar_Syntax_Syntax.mk uu____5431
+                                FStar_Syntax_Syntax.Tm_ascribed uu____5408 in
+                              FStar_Syntax_Syntax.mk uu____5407
                                 e1.FStar_Syntax_Syntax.pos in
-                            (let uu____5527 =
+                            (let uu____5503 =
                                FStar_All.pipe_left
                                  (FStar_TypeChecker_Env.debug env0)
                                  FStar_Options.Extreme in
-                             if uu____5527
+                             if uu____5503
                              then
-                               let uu____5528 =
+                               let uu____5504 =
                                  FStar_Syntax_Print.term_to_string e2 in
                                FStar_Util.print1
                                  "Typechecking ascribed reflect, inner ascribed term: %s\n"
-                                 uu____5528
+                                 uu____5504
                              else ());
-                            (let uu____5530 = tc_tot_or_gtot_term env0 e2 in
-                             match uu____5530 with
-                             | (e3, uu____5544, g_e) ->
+                            (let uu____5506 = tc_tot_or_gtot_term env0 e2 in
+                             match uu____5506 with
+                             | (e3, uu____5520, g_e) ->
                                  let e4 = FStar_Syntax_Util.unascribe e3 in
-                                 ((let uu____5548 =
+                                 ((let uu____5524 =
                                      FStar_All.pipe_left
                                        (FStar_TypeChecker_Env.debug env0)
                                        FStar_Options.Extreme in
-                                   if uu____5548
+                                   if uu____5524
                                    then
-                                     let uu____5549 =
+                                     let uu____5525 =
                                        FStar_Syntax_Print.term_to_string e4 in
-                                     let uu____5550 =
+                                     let uu____5526 =
                                        FStar_TypeChecker_Rel.guard_to_string
                                          env0 g_e in
                                      FStar_Util.print2
                                        "Typechecking ascribed reflect, after typechecking inner ascribed term: %s and guard: %s\n"
-                                       uu____5549 uu____5550
+                                       uu____5525 uu____5526
                                    else ());
                                   (let top1 =
                                      let r = top.FStar_Syntax_Syntax.pos in
@@ -2037,69 +2037,69 @@ and (tc_maybe_toplevel_term :
                                        FStar_Syntax_Syntax.mk
                                          (FStar_Syntax_Syntax.Tm_app
                                             (tm, [(e4, aqual)])) r in
-                                     let uu____5594 =
-                                       let uu____5595 =
-                                         let uu____5622 =
-                                           let uu____5625 =
+                                     let uu____5570 =
+                                       let uu____5571 =
+                                         let uu____5598 =
+                                           let uu____5601 =
                                              FStar_All.pipe_right expected_c1
                                                FStar_Syntax_Util.comp_effect_name in
-                                           FStar_All.pipe_right uu____5625
-                                             (fun uu____5630 ->
+                                           FStar_All.pipe_right uu____5601
+                                             (fun uu____5606 ->
                                                 FStar_Pervasives_Native.Some
-                                                  uu____5630) in
+                                                  uu____5606) in
                                          (tm1,
                                            ((FStar_Util.Inr expected_c1),
                                              FStar_Pervasives_Native.None),
-                                           uu____5622) in
+                                           uu____5598) in
                                        FStar_Syntax_Syntax.Tm_ascribed
-                                         uu____5595 in
-                                     FStar_Syntax_Syntax.mk uu____5594 r in
-                                   let uu____5669 =
-                                     let uu____5676 =
+                                         uu____5571 in
+                                     FStar_Syntax_Syntax.mk uu____5570 r in
+                                   let uu____5645 =
+                                     let uu____5652 =
                                        FStar_All.pipe_right expected_c1
                                          FStar_TypeChecker_Common.lcomp_of_comp in
                                      comp_check_expected_typ env1 top1
-                                       uu____5676 in
-                                   match uu____5669 with
+                                       uu____5652 in
+                                   match uu____5645 with
                                    | (top2, c, g_env) ->
-                                       let uu____5686 =
+                                       let uu____5662 =
                                          FStar_TypeChecker_Env.conj_guards
                                            [g_c; g_e; g_env] in
-                                       (top2, c, uu____5686)))))))))
+                                       (top2, c, uu____5662)))))))))
        | FStar_Syntax_Syntax.Tm_ascribed
            (e1, (FStar_Util.Inr expected_c, FStar_Pervasives_Native.None),
-            uu____5689)
+            uu____5665)
            ->
-           let uu____5734 = FStar_TypeChecker_Env.clear_expected_typ env1 in
-           (match uu____5734 with
-            | (env0, uu____5748) ->
-                let uu____5753 = tc_comp env0 expected_c in
-                (match uu____5753 with
-                 | (expected_c1, uu____5767, g) ->
-                     let uu____5769 =
-                       let uu____5776 =
+           let uu____5710 = FStar_TypeChecker_Env.clear_expected_typ env1 in
+           (match uu____5710 with
+            | (env0, uu____5724) ->
+                let uu____5729 = tc_comp env0 expected_c in
+                (match uu____5729 with
+                 | (expected_c1, uu____5743, g) ->
+                     let uu____5745 =
+                       let uu____5752 =
                          FStar_All.pipe_right
                            (FStar_Syntax_Util.comp_result expected_c1)
                            (FStar_TypeChecker_Env.set_expected_typ env0) in
-                       tc_term uu____5776 e1 in
-                     (match uu____5769 with
+                       tc_term uu____5752 e1 in
+                     (match uu____5745 with
                       | (e2, c', g') ->
-                          let uu____5786 =
-                            let uu____5797 =
+                          let uu____5762 =
+                            let uu____5773 =
                               FStar_TypeChecker_Common.lcomp_comp c' in
-                            match uu____5797 with
+                            match uu____5773 with
                             | (c'1, g_c') ->
-                                let uu____5814 =
+                                let uu____5790 =
                                   check_expected_effect env0
                                     (FStar_Pervasives_Native.Some expected_c1)
                                     (e2, c'1) in
-                                (match uu____5814 with
+                                (match uu____5790 with
                                  | (e3, expected_c2, g'') ->
-                                     let uu____5834 =
+                                     let uu____5810 =
                                        FStar_TypeChecker_Env.conj_guard g_c'
                                          g'' in
-                                     (e3, expected_c2, uu____5834)) in
-                          (match uu____5786 with
+                                     (e3, expected_c2, uu____5810)) in
+                          (match uu____5762 with
                            | (e3, expected_c2, g'') ->
                                let e4 =
                                  FStar_Syntax_Syntax.mk
@@ -2115,46 +2115,46 @@ and (tc_maybe_toplevel_term :
                                  FStar_TypeChecker_Common.lcomp_of_comp
                                    expected_c2 in
                                let f =
-                                 let uu____5899 =
+                                 let uu____5875 =
                                    FStar_TypeChecker_Env.conj_guard g' g'' in
                                  FStar_TypeChecker_Env.conj_guard g
-                                   uu____5899 in
-                               let uu____5900 =
+                                   uu____5875 in
+                               let uu____5876 =
                                  comp_check_expected_typ env1 e4 lc in
-                               (match uu____5900 with
+                               (match uu____5876 with
                                 | (e5, c, f2) ->
-                                    let uu____5916 =
+                                    let uu____5892 =
                                       FStar_TypeChecker_Env.conj_guard f f2 in
-                                    (e5, c, uu____5916))))))
+                                    (e5, c, uu____5892))))))
        | FStar_Syntax_Syntax.Tm_ascribed
-           (e1, (FStar_Util.Inl t, FStar_Pervasives_Native.None), uu____5919)
+           (e1, (FStar_Util.Inl t, FStar_Pervasives_Native.None), uu____5895)
            ->
-           let uu____5964 = FStar_Syntax_Util.type_u () in
-           (match uu____5964 with
+           let uu____5940 = FStar_Syntax_Util.type_u () in
+           (match uu____5940 with
             | (k, u) ->
-                let uu____5977 = tc_check_tot_or_gtot_term env1 t k "" in
-                (match uu____5977 with
-                 | (t1, uu____5991, f) ->
-                     let uu____5993 =
-                       let uu____6000 =
+                let uu____5953 = tc_check_tot_or_gtot_term env1 t k "" in
+                (match uu____5953 with
+                 | (t1, uu____5967, f) ->
+                     let uu____5969 =
+                       let uu____5976 =
                          FStar_TypeChecker_Env.set_expected_typ env1 t1 in
-                       tc_term uu____6000 e1 in
-                     (match uu____5993 with
+                       tc_term uu____5976 e1 in
+                     (match uu____5969 with
                       | (e2, c, g) ->
-                          let uu____6010 =
-                            let uu____6015 =
+                          let uu____5986 =
+                            let uu____5991 =
                               FStar_TypeChecker_Env.set_range env1
                                 t1.FStar_Syntax_Syntax.pos in
                             FStar_TypeChecker_Util.strengthen_precondition
                               (FStar_Pervasives_Native.Some
-                                 (fun uu____6020 ->
+                                 (fun uu____5996 ->
                                     FStar_Util.return_all
                                       FStar_TypeChecker_Err.ill_kinded_type))
-                              uu____6015 e2 c f in
-                          (match uu____6010 with
+                              uu____5991 e2 c f in
+                          (match uu____5986 with
                            | (c1, f1) ->
-                               let uu____6029 =
-                                 let uu____6036 =
+                               let uu____6005 =
+                                 let uu____6012 =
                                    FStar_Syntax_Syntax.mk
                                      (FStar_Syntax_Syntax.Tm_ascribed
                                         (e2,
@@ -2163,33 +2163,33 @@ and (tc_maybe_toplevel_term :
                                           (FStar_Pervasives_Native.Some
                                              (c1.FStar_TypeChecker_Common.eff_name))))
                                      top.FStar_Syntax_Syntax.pos in
-                                 comp_check_expected_typ env1 uu____6036 c1 in
-                               (match uu____6029 with
+                                 comp_check_expected_typ env1 uu____6012 c1 in
+                               (match uu____6005 with
                                 | (e3, c2, f2) ->
-                                    let uu____6084 =
-                                      let uu____6085 =
+                                    let uu____6060 =
+                                      let uu____6061 =
                                         FStar_TypeChecker_Env.conj_guard g f2 in
                                       FStar_TypeChecker_Env.conj_guard f1
-                                        uu____6085 in
-                                    (e3, c2, uu____6084))))))
+                                        uu____6061 in
+                                    (e3, c2, uu____6060))))))
        | FStar_Syntax_Syntax.Tm_app
            ({
               FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
                 (FStar_Const.Const_range_of);
-              FStar_Syntax_Syntax.pos = uu____6086;
-              FStar_Syntax_Syntax.vars = uu____6087;_},
+              FStar_Syntax_Syntax.pos = uu____6062;
+              FStar_Syntax_Syntax.vars = uu____6063;_},
             a::hd::rest)
            ->
            let rest1 = hd :: rest in
-           let uu____6166 = FStar_Syntax_Util.head_and_args top in
-           (match uu____6166 with
-            | (unary_op, uu____6190) ->
+           let uu____6142 = FStar_Syntax_Util.head_and_args top in
+           (match uu____6142 with
+            | (unary_op, uu____6166) ->
                 let head =
-                  let uu____6218 =
+                  let uu____6194 =
                     FStar_Range.union_ranges unary_op.FStar_Syntax_Syntax.pos
                       (FStar_Pervasives_Native.fst a).FStar_Syntax_Syntax.pos in
                   FStar_Syntax_Syntax.mk
-                    (FStar_Syntax_Syntax.Tm_app (unary_op, [a])) uu____6218 in
+                    (FStar_Syntax_Syntax.Tm_app (unary_op, [a])) uu____6194 in
                 let t =
                   FStar_Syntax_Syntax.mk
                     (FStar_Syntax_Syntax.Tm_app (head, rest1))
@@ -2199,20 +2199,20 @@ and (tc_maybe_toplevel_term :
            ({
               FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
                 (FStar_Const.Const_reify);
-              FStar_Syntax_Syntax.pos = uu____6266;
-              FStar_Syntax_Syntax.vars = uu____6267;_},
+              FStar_Syntax_Syntax.pos = uu____6242;
+              FStar_Syntax_Syntax.vars = uu____6243;_},
             a::hd::rest)
            ->
            let rest1 = hd :: rest in
-           let uu____6346 = FStar_Syntax_Util.head_and_args top in
-           (match uu____6346 with
-            | (unary_op, uu____6370) ->
+           let uu____6322 = FStar_Syntax_Util.head_and_args top in
+           (match uu____6322 with
+            | (unary_op, uu____6346) ->
                 let head =
-                  let uu____6398 =
+                  let uu____6374 =
                     FStar_Range.union_ranges unary_op.FStar_Syntax_Syntax.pos
                       (FStar_Pervasives_Native.fst a).FStar_Syntax_Syntax.pos in
                   FStar_Syntax_Syntax.mk
-                    (FStar_Syntax_Syntax.Tm_app (unary_op, [a])) uu____6398 in
+                    (FStar_Syntax_Syntax.Tm_app (unary_op, [a])) uu____6374 in
                 let t =
                   FStar_Syntax_Syntax.mk
                     (FStar_Syntax_Syntax.Tm_app (head, rest1))
@@ -2221,21 +2221,21 @@ and (tc_maybe_toplevel_term :
        | FStar_Syntax_Syntax.Tm_app
            ({
               FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
-                (FStar_Const.Const_reflect uu____6446);
-              FStar_Syntax_Syntax.pos = uu____6447;
-              FStar_Syntax_Syntax.vars = uu____6448;_},
+                (FStar_Const.Const_reflect uu____6422);
+              FStar_Syntax_Syntax.pos = uu____6423;
+              FStar_Syntax_Syntax.vars = uu____6424;_},
             a::hd::rest)
            ->
            let rest1 = hd :: rest in
-           let uu____6527 = FStar_Syntax_Util.head_and_args top in
-           (match uu____6527 with
-            | (unary_op, uu____6551) ->
+           let uu____6503 = FStar_Syntax_Util.head_and_args top in
+           (match uu____6503 with
+            | (unary_op, uu____6527) ->
                 let head =
-                  let uu____6579 =
+                  let uu____6555 =
                     FStar_Range.union_ranges unary_op.FStar_Syntax_Syntax.pos
                       (FStar_Pervasives_Native.fst a).FStar_Syntax_Syntax.pos in
                   FStar_Syntax_Syntax.mk
-                    (FStar_Syntax_Syntax.Tm_app (unary_op, [a])) uu____6579 in
+                    (FStar_Syntax_Syntax.Tm_app (unary_op, [a])) uu____6555 in
                 let t =
                   FStar_Syntax_Syntax.mk
                     (FStar_Syntax_Syntax.Tm_app (head, rest1))
@@ -2245,21 +2245,21 @@ and (tc_maybe_toplevel_term :
            ({
               FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
                 (FStar_Const.Const_set_range_of);
-              FStar_Syntax_Syntax.pos = uu____6627;
-              FStar_Syntax_Syntax.vars = uu____6628;_},
+              FStar_Syntax_Syntax.pos = uu____6603;
+              FStar_Syntax_Syntax.vars = uu____6604;_},
             a1::a2::hd::rest)
            ->
            let rest1 = hd :: rest in
-           let uu____6724 = FStar_Syntax_Util.head_and_args top in
-           (match uu____6724 with
-            | (unary_op, uu____6748) ->
+           let uu____6700 = FStar_Syntax_Util.head_and_args top in
+           (match uu____6700 with
+            | (unary_op, uu____6724) ->
                 let head =
-                  let uu____6776 =
+                  let uu____6752 =
                     FStar_Range.union_ranges unary_op.FStar_Syntax_Syntax.pos
                       (FStar_Pervasives_Native.fst a1).FStar_Syntax_Syntax.pos in
                   FStar_Syntax_Syntax.mk
                     (FStar_Syntax_Syntax.Tm_app (unary_op, [a1; a2]))
-                    uu____6776 in
+                    uu____6752 in
                 let t =
                   FStar_Syntax_Syntax.mk
                     (FStar_Syntax_Syntax.Tm_app (head, rest1))
@@ -2269,101 +2269,101 @@ and (tc_maybe_toplevel_term :
            ({
               FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
                 (FStar_Const.Const_range_of);
-              FStar_Syntax_Syntax.pos = uu____6832;
-              FStar_Syntax_Syntax.vars = uu____6833;_},
+              FStar_Syntax_Syntax.pos = uu____6808;
+              FStar_Syntax_Syntax.vars = uu____6809;_},
             (e1, FStar_Pervasives_Native.None)::[])
            ->
-           let uu____6871 =
-             let uu____6878 =
-               let uu____6879 = FStar_TypeChecker_Env.clear_expected_typ env1 in
-               FStar_All.pipe_left FStar_Pervasives_Native.fst uu____6879 in
-             tc_term uu____6878 e1 in
-           (match uu____6871 with
+           let uu____6847 =
+             let uu____6854 =
+               let uu____6855 = FStar_TypeChecker_Env.clear_expected_typ env1 in
+               FStar_All.pipe_left FStar_Pervasives_Native.fst uu____6855 in
+             tc_term uu____6854 e1 in
+           (match uu____6847 with
             | (e2, c, g) ->
-                let uu____6903 = FStar_Syntax_Util.head_and_args top in
-                (match uu____6903 with
-                 | (head, uu____6927) ->
-                     let uu____6952 =
+                let uu____6879 = FStar_Syntax_Util.head_and_args top in
+                (match uu____6879 with
+                 | (head, uu____6903) ->
+                     let uu____6928 =
                        FStar_Syntax_Syntax.mk
                          (FStar_Syntax_Syntax.Tm_app
                             (head, [(e2, FStar_Pervasives_Native.None)]))
                          top.FStar_Syntax_Syntax.pos in
-                     let uu____6985 =
-                       let uu____6986 =
-                         let uu____6987 =
+                     let uu____6961 =
+                       let uu____6962 =
+                         let uu____6963 =
                            FStar_Syntax_Syntax.tabbrev
                              FStar_Parser_Const.range_lid in
-                         FStar_Syntax_Syntax.mk_Total uu____6987 in
+                         FStar_Syntax_Syntax.mk_Total uu____6963 in
                        FStar_All.pipe_left
-                         FStar_TypeChecker_Common.lcomp_of_comp uu____6986 in
-                     (uu____6952, uu____6985, g)))
+                         FStar_TypeChecker_Common.lcomp_of_comp uu____6962 in
+                     (uu____6928, uu____6961, g)))
        | FStar_Syntax_Syntax.Tm_app
            ({
               FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
                 (FStar_Const.Const_set_range_of);
-              FStar_Syntax_Syntax.pos = uu____6988;
-              FStar_Syntax_Syntax.vars = uu____6989;_},
+              FStar_Syntax_Syntax.pos = uu____6964;
+              FStar_Syntax_Syntax.vars = uu____6965;_},
             (t, FStar_Pervasives_Native.None)::(r,
                                                 FStar_Pervasives_Native.None)::[])
            ->
-           let uu____7042 = FStar_Syntax_Util.head_and_args top in
-           (match uu____7042 with
-            | (head, uu____7066) ->
+           let uu____7018 = FStar_Syntax_Util.head_and_args top in
+           (match uu____7018 with
+            | (head, uu____7042) ->
                 let env' =
-                  let uu____7092 =
+                  let uu____7068 =
                     FStar_Syntax_Syntax.tabbrev FStar_Parser_Const.range_lid in
-                  FStar_TypeChecker_Env.set_expected_typ env1 uu____7092 in
-                let uu____7093 = tc_term env' r in
-                (match uu____7093 with
-                 | (er, uu____7107, gr) ->
-                     let uu____7109 = tc_term env1 t in
-                     (match uu____7109 with
+                  FStar_TypeChecker_Env.set_expected_typ env1 uu____7068 in
+                let uu____7069 = tc_term env' r in
+                (match uu____7069 with
+                 | (er, uu____7083, gr) ->
+                     let uu____7085 = tc_term env1 t in
+                     (match uu____7085 with
                       | (t1, tt, gt) ->
                           let g = FStar_TypeChecker_Env.conj_guard gr gt in
-                          let uu____7126 =
-                            let uu____7127 =
-                              let uu____7128 = FStar_Syntax_Syntax.as_arg t1 in
-                              let uu____7137 =
-                                let uu____7148 = FStar_Syntax_Syntax.as_arg r in
-                                [uu____7148] in
-                              uu____7128 :: uu____7137 in
-                            FStar_Syntax_Syntax.mk_Tm_app head uu____7127
+                          let uu____7102 =
+                            let uu____7103 =
+                              let uu____7104 = FStar_Syntax_Syntax.as_arg t1 in
+                              let uu____7113 =
+                                let uu____7124 = FStar_Syntax_Syntax.as_arg r in
+                                [uu____7124] in
+                              uu____7104 :: uu____7113 in
+                            FStar_Syntax_Syntax.mk_Tm_app head uu____7103
                               top.FStar_Syntax_Syntax.pos in
-                          (uu____7126, tt, g))))
+                          (uu____7102, tt, g))))
        | FStar_Syntax_Syntax.Tm_app
            ({
               FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
                 (FStar_Const.Const_range_of);
-              FStar_Syntax_Syntax.pos = uu____7181;
-              FStar_Syntax_Syntax.vars = uu____7182;_},
-            uu____7183)
+              FStar_Syntax_Syntax.pos = uu____7157;
+              FStar_Syntax_Syntax.vars = uu____7158;_},
+            uu____7159)
            ->
-           let uu____7208 =
-             let uu____7213 =
-               let uu____7214 = FStar_Syntax_Print.term_to_string top in
-               FStar_Util.format1 "Ill-applied constant %s" uu____7214 in
-             (FStar_Errors.Fatal_IllAppliedConstant, uu____7213) in
-           FStar_Errors.raise_error uu____7208 e.FStar_Syntax_Syntax.pos
+           let uu____7184 =
+             let uu____7189 =
+               let uu____7190 = FStar_Syntax_Print.term_to_string top in
+               FStar_Util.format1 "Ill-applied constant %s" uu____7190 in
+             (FStar_Errors.Fatal_IllAppliedConstant, uu____7189) in
+           FStar_Errors.raise_error uu____7184 e.FStar_Syntax_Syntax.pos
        | FStar_Syntax_Syntax.Tm_app
            ({
               FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
                 (FStar_Const.Const_set_range_of);
-              FStar_Syntax_Syntax.pos = uu____7221;
-              FStar_Syntax_Syntax.vars = uu____7222;_},
-            uu____7223)
+              FStar_Syntax_Syntax.pos = uu____7197;
+              FStar_Syntax_Syntax.vars = uu____7198;_},
+            uu____7199)
            ->
-           let uu____7248 =
-             let uu____7253 =
-               let uu____7254 = FStar_Syntax_Print.term_to_string top in
-               FStar_Util.format1 "Ill-applied constant %s" uu____7254 in
-             (FStar_Errors.Fatal_IllAppliedConstant, uu____7253) in
-           FStar_Errors.raise_error uu____7248 e.FStar_Syntax_Syntax.pos
+           let uu____7224 =
+             let uu____7229 =
+               let uu____7230 = FStar_Syntax_Print.term_to_string top in
+               FStar_Util.format1 "Ill-applied constant %s" uu____7230 in
+             (FStar_Errors.Fatal_IllAppliedConstant, uu____7229) in
+           FStar_Errors.raise_error uu____7224 e.FStar_Syntax_Syntax.pos
        | FStar_Syntax_Syntax.Tm_app
            ({
               FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
                 (FStar_Const.Const_reify);
-              FStar_Syntax_Syntax.pos = uu____7261;
-              FStar_Syntax_Syntax.vars = uu____7262;_},
+              FStar_Syntax_Syntax.pos = uu____7237;
+              FStar_Syntax_Syntax.vars = uu____7238;_},
             (e1, aqual)::[])
            ->
            (if FStar_Option.isSome aqual
@@ -2372,41 +2372,41 @@ and (tc_maybe_toplevel_term :
                 (FStar_Errors.Warning_IrrelevantQualifierOnArgumentToReify,
                   "Qualifier on argument to reify is irrelevant and will be ignored")
             else ();
-            (let uu____7305 = FStar_TypeChecker_Env.clear_expected_typ env1 in
-             match uu____7305 with
-             | (env0, uu____7319) ->
-                 let uu____7324 = tc_term env0 e1 in
-                 (match uu____7324 with
+            (let uu____7281 = FStar_TypeChecker_Env.clear_expected_typ env1 in
+             match uu____7281 with
+             | (env0, uu____7295) ->
+                 let uu____7300 = tc_term env0 e1 in
+                 (match uu____7300 with
                   | (e2, c, g) ->
-                      let uu____7340 = FStar_Syntax_Util.head_and_args top in
-                      (match uu____7340 with
-                       | (reify_op, uu____7364) ->
+                      let uu____7316 = FStar_Syntax_Util.head_and_args top in
+                      (match uu____7316 with
+                       | (reify_op, uu____7340) ->
                            let u_c =
                              env1.FStar_TypeChecker_Env.universe_of env1
                                c.FStar_TypeChecker_Common.res_typ in
-                           let uu____7390 =
+                           let uu____7366 =
                              FStar_TypeChecker_Common.lcomp_comp c in
-                           (match uu____7390 with
+                           (match uu____7366 with
                             | (c1, g_c) ->
                                 let ef =
                                   FStar_Syntax_Util.comp_effect_name c1 in
-                                ((let uu____7405 =
-                                    let uu____7406 =
+                                ((let uu____7381 =
+                                    let uu____7382 =
                                       FStar_TypeChecker_Env.is_user_reifiable_effect
                                         env1 ef in
-                                    Prims.op_Negation uu____7406 in
-                                  if uu____7405
+                                    Prims.op_Negation uu____7382 in
+                                  if uu____7381
                                   then
-                                    let uu____7407 =
-                                      let uu____7412 =
-                                        let uu____7413 =
+                                    let uu____7383 =
+                                      let uu____7388 =
+                                        let uu____7389 =
                                           FStar_Ident.string_of_lid ef in
                                         FStar_Util.format1
                                           "Effect %s cannot be reified"
-                                          uu____7413 in
+                                          uu____7389 in
                                       (FStar_Errors.Fatal_EffectCannotBeReified,
-                                        uu____7412) in
-                                    FStar_Errors.raise_error uu____7407
+                                        uu____7388) in
+                                    FStar_Errors.raise_error uu____7383
                                       e2.FStar_Syntax_Syntax.pos
                                   else ());
                                  (let repr =
@@ -2418,14 +2418,14 @@ and (tc_maybe_toplevel_term :
                                          (reify_op, [(e2, aqual)]))
                                       top.FStar_Syntax_Syntax.pos in
                                   let c2 =
-                                    let uu____7452 =
+                                    let uu____7428 =
                                       FStar_TypeChecker_Env.is_total_effect
                                         env1 ef in
-                                    if uu____7452
+                                    if uu____7428
                                     then
-                                      let uu____7453 =
+                                      let uu____7429 =
                                         FStar_Syntax_Syntax.mk_Total repr in
-                                      FStar_All.pipe_right uu____7453
+                                      FStar_All.pipe_right uu____7429
                                         FStar_TypeChecker_Common.lcomp_of_comp
                                     else
                                       (let ct =
@@ -2440,27 +2440,27 @@ and (tc_maybe_toplevel_term :
                                              [];
                                            FStar_Syntax_Syntax.flags = []
                                          } in
-                                       let uu____7464 =
+                                       let uu____7440 =
                                          FStar_Syntax_Syntax.mk_Comp ct in
-                                       FStar_All.pipe_right uu____7464
+                                       FStar_All.pipe_right uu____7440
                                          FStar_TypeChecker_Common.lcomp_of_comp) in
-                                  let uu____7465 =
+                                  let uu____7441 =
                                     comp_check_expected_typ env1 e3 c2 in
-                                  match uu____7465 with
+                                  match uu____7441 with
                                   | (e4, c3, g') ->
-                                      let uu____7481 =
-                                        let uu____7482 =
+                                      let uu____7457 =
+                                        let uu____7458 =
                                           FStar_TypeChecker_Env.conj_guard
                                             g_c g' in
                                         FStar_TypeChecker_Env.conj_guard g
-                                          uu____7482 in
-                                      (e4, c3, uu____7481))))))))
+                                          uu____7458 in
+                                      (e4, c3, uu____7457))))))))
        | FStar_Syntax_Syntax.Tm_app
            ({
               FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
                 (FStar_Const.Const_reflect l);
-              FStar_Syntax_Syntax.pos = uu____7484;
-              FStar_Syntax_Syntax.vars = uu____7485;_},
+              FStar_Syntax_Syntax.pos = uu____7460;
+              FStar_Syntax_Syntax.vars = uu____7461;_},
             (e1, aqual)::[])
            ->
            (if FStar_Option.isSome aqual
@@ -2469,52 +2469,52 @@ and (tc_maybe_toplevel_term :
                 (FStar_Errors.Warning_IrrelevantQualifierOnArgumentToReflect,
                   "Qualifier on argument to reflect is irrelevant and will be ignored")
             else ();
-            (let uu____7529 =
-               let uu____7530 =
+            (let uu____7505 =
+               let uu____7506 =
                  FStar_TypeChecker_Env.is_user_reflectable_effect env1 l in
-               Prims.op_Negation uu____7530 in
-             if uu____7529
+               Prims.op_Negation uu____7506 in
+             if uu____7505
              then
-               let uu____7531 =
-                 let uu____7536 =
-                   let uu____7537 = FStar_Ident.string_of_lid l in
+               let uu____7507 =
+                 let uu____7512 =
+                   let uu____7513 = FStar_Ident.string_of_lid l in
                    FStar_Util.format1 "Effect %s cannot be reflected"
-                     uu____7537 in
-                 (FStar_Errors.Fatal_EffectCannotBeReified, uu____7536) in
-               FStar_Errors.raise_error uu____7531 e1.FStar_Syntax_Syntax.pos
+                     uu____7513 in
+                 (FStar_Errors.Fatal_EffectCannotBeReified, uu____7512) in
+               FStar_Errors.raise_error uu____7507 e1.FStar_Syntax_Syntax.pos
              else ());
-            (let uu____7539 = FStar_Syntax_Util.head_and_args top in
-             match uu____7539 with
-             | (reflect_op, uu____7563) ->
-                 let uu____7588 =
+            (let uu____7515 = FStar_Syntax_Util.head_and_args top in
+             match uu____7515 with
+             | (reflect_op, uu____7539) ->
+                 let uu____7564 =
                    FStar_TypeChecker_Env.effect_decl_opt env1 l in
-                 (match uu____7588 with
+                 (match uu____7564 with
                   | FStar_Pervasives_Native.None ->
-                      let uu____7609 =
-                        let uu____7614 =
-                          let uu____7615 = FStar_Ident.string_of_lid l in
+                      let uu____7585 =
+                        let uu____7590 =
+                          let uu____7591 = FStar_Ident.string_of_lid l in
                           FStar_Util.format1
-                            "Effect %s not found (for reflect)" uu____7615 in
-                        (FStar_Errors.Fatal_EffectNotFound, uu____7614) in
-                      FStar_Errors.raise_error uu____7609
+                            "Effect %s not found (for reflect)" uu____7591 in
+                        (FStar_Errors.Fatal_EffectNotFound, uu____7590) in
+                      FStar_Errors.raise_error uu____7585
                         e1.FStar_Syntax_Syntax.pos
                   | FStar_Pervasives_Native.Some (ed, qualifiers) ->
-                      let uu____7634 =
+                      let uu____7610 =
                         FStar_TypeChecker_Env.clear_expected_typ env1 in
-                      (match uu____7634 with
-                       | (env_no_ex, uu____7648) ->
-                           let uu____7653 =
-                             let uu____7662 =
+                      (match uu____7610 with
+                       | (env_no_ex, uu____7624) ->
+                           let uu____7629 =
+                             let uu____7638 =
                                tc_tot_or_gtot_term env_no_ex e1 in
-                             match uu____7662 with
+                             match uu____7638 with
                              | (e2, c, g) ->
-                                 ((let uu____7681 =
-                                     let uu____7682 =
+                                 ((let uu____7657 =
+                                     let uu____7658 =
                                        FStar_TypeChecker_Common.is_total_lcomp
                                          c in
                                      FStar_All.pipe_left Prims.op_Negation
-                                       uu____7682 in
-                                   if uu____7681
+                                       uu____7658 in
+                                   if uu____7657
                                    then
                                      FStar_TypeChecker_Err.add_errors env1
                                        [(FStar_Errors.Error_UnexpectedGTotComputation,
@@ -2522,26 +2522,26 @@ and (tc_maybe_toplevel_term :
                                           (e2.FStar_Syntax_Syntax.pos))]
                                    else ());
                                   (e2, c, g)) in
-                           (match uu____7653 with
+                           (match uu____7629 with
                             | (e2, c_e, g_e) ->
-                                let uu____7711 =
-                                  let uu____7726 =
+                                let uu____7687 =
+                                  let uu____7702 =
                                     FStar_Syntax_Util.type_u () in
-                                  match uu____7726 with
+                                  match uu____7702 with
                                   | (a, u_a) ->
-                                      let uu____7747 =
+                                      let uu____7723 =
                                         FStar_TypeChecker_Util.new_implicit_var
                                           "" e2.FStar_Syntax_Syntax.pos
                                           env_no_ex a in
-                                      (match uu____7747 with
-                                       | (a_uvar, uu____7775, g_a) ->
-                                           let uu____7789 =
+                                      (match uu____7723 with
+                                       | (a_uvar, uu____7751, g_a) ->
+                                           let uu____7765 =
                                              FStar_TypeChecker_Util.fresh_effect_repr_en
                                                env_no_ex
                                                e2.FStar_Syntax_Syntax.pos l
                                                u_a a_uvar in
-                                           (uu____7789, u_a, a_uvar, g_a)) in
-                                (match uu____7711 with
+                                           (uu____7765, u_a, a_uvar, g_a)) in
+                                (match uu____7687 with
                                  | ((expected_repr_typ, g_repr), u_a, a, g_a)
                                      ->
                                      let g_eq =
@@ -2549,37 +2549,37 @@ and (tc_maybe_toplevel_term :
                                          c_e.FStar_TypeChecker_Common.res_typ
                                          expected_repr_typ in
                                      let eff_args =
-                                       let uu____7831 =
-                                         let uu____7832 =
+                                       let uu____7807 =
+                                         let uu____7808 =
                                            FStar_Syntax_Subst.compress
                                              expected_repr_typ in
-                                         uu____7832.FStar_Syntax_Syntax.n in
-                                       match uu____7831 with
+                                         uu____7808.FStar_Syntax_Syntax.n in
+                                       match uu____7807 with
                                        | FStar_Syntax_Syntax.Tm_app
-                                           (uu____7845, uu____7846::args) ->
+                                           (uu____7821, uu____7822::args) ->
                                            args
-                                       | uu____7888 ->
-                                           let uu____7889 =
-                                             let uu____7894 =
-                                               let uu____7895 =
+                                       | uu____7864 ->
+                                           let uu____7865 =
+                                             let uu____7870 =
+                                               let uu____7871 =
                                                  FStar_Ident.string_of_lid l in
-                                               let uu____7896 =
+                                               let uu____7872 =
                                                  FStar_Syntax_Print.tag_of_term
                                                    expected_repr_typ in
-                                               let uu____7897 =
+                                               let uu____7873 =
                                                  FStar_Syntax_Print.term_to_string
                                                    expected_repr_typ in
                                                FStar_Util.format3
                                                  "Expected repr type for %s is not an application node (%s:%s)"
-                                                 uu____7895 uu____7896
-                                                 uu____7897 in
+                                                 uu____7871 uu____7872
+                                                 uu____7873 in
                                              (FStar_Errors.Fatal_UnexpectedEffect,
-                                               uu____7894) in
+                                               uu____7870) in
                                            FStar_Errors.raise_error
-                                             uu____7889
+                                             uu____7865
                                              top.FStar_Syntax_Syntax.pos in
                                      let c =
-                                       let uu____7909 =
+                                       let uu____7885 =
                                          FStar_Syntax_Syntax.mk_Comp
                                            {
                                              FStar_Syntax_Syntax.comp_univs =
@@ -2593,16 +2593,16 @@ and (tc_maybe_toplevel_term :
                                                = eff_args;
                                              FStar_Syntax_Syntax.flags = []
                                            } in
-                                       FStar_All.pipe_right uu____7909
+                                       FStar_All.pipe_right uu____7885
                                          FStar_TypeChecker_Common.lcomp_of_comp in
                                      let e3 =
                                        FStar_Syntax_Syntax.mk
                                          (FStar_Syntax_Syntax.Tm_app
                                             (reflect_op, [(e2, aqual)]))
                                          top.FStar_Syntax_Syntax.pos in
-                                     let uu____7945 =
+                                     let uu____7921 =
                                        comp_check_expected_typ env1 e3 c in
-                                     (match uu____7945 with
+                                     (match uu____7921 with
                                       | (e4, c1, g') ->
                                           let e5 =
                                             FStar_Syntax_Syntax.mk
@@ -2612,37 +2612,37 @@ and (tc_maybe_toplevel_term :
                                                       ((c1.FStar_TypeChecker_Common.eff_name),
                                                         (c1.FStar_TypeChecker_Common.res_typ)))))
                                               e4.FStar_Syntax_Syntax.pos in
-                                          let uu____7968 =
+                                          let uu____7944 =
                                             FStar_TypeChecker_Env.conj_guards
                                               [g_e; g_repr; g_a; g_eq; g'] in
-                                          (e5, c1, uu____7968))))))))
+                                          (e5, c1, uu____7944))))))))
        | FStar_Syntax_Syntax.Tm_app
            (head, (tau, FStar_Pervasives_Native.None)::[]) when
            (FStar_Syntax_Util.is_synth_by_tactic head) &&
              (Prims.op_Negation env1.FStar_TypeChecker_Env.phase1)
            ->
-           let uu____8007 = FStar_Syntax_Util.head_and_args top in
-           (match uu____8007 with
+           let uu____7983 = FStar_Syntax_Util.head_and_args top in
+           (match uu____7983 with
             | (head1, args) ->
                 tc_synth head1 env1 args top.FStar_Syntax_Syntax.pos)
        | FStar_Syntax_Syntax.Tm_app
            (head,
-            (uu____8057, FStar_Pervasives_Native.Some
-             (FStar_Syntax_Syntax.Implicit uu____8058))::(tau,
+            (uu____8033, FStar_Pervasives_Native.Some
+             (FStar_Syntax_Syntax.Implicit uu____8034))::(tau,
                                                           FStar_Pervasives_Native.None)::[])
            when
            (FStar_Syntax_Util.is_synth_by_tactic head) &&
              (Prims.op_Negation env1.FStar_TypeChecker_Env.phase1)
            ->
-           let uu____8110 = FStar_Syntax_Util.head_and_args top in
-           (match uu____8110 with
+           let uu____8086 = FStar_Syntax_Util.head_and_args top in
+           (match uu____8086 with
             | (head1, args) ->
                 tc_synth head1 env1 args top.FStar_Syntax_Syntax.pos)
        | FStar_Syntax_Syntax.Tm_app (head, args) when
            (FStar_Syntax_Util.is_synth_by_tactic head) &&
              (Prims.op_Negation env1.FStar_TypeChecker_Env.phase1)
            ->
-           let uu____8185 =
+           let uu____8161 =
              match args with
              | (tau, FStar_Pervasives_Native.None)::rest ->
                  ([(tau, FStar_Pervasives_Native.None)], rest)
@@ -2652,160 +2652,160 @@ and (tc_maybe_toplevel_term :
                      (FStar_Pervasives_Native.Some
                         (FStar_Syntax_Syntax.Implicit b)));
                   (tau, FStar_Pervasives_Native.None)], rest)
-             | uu____8394 ->
+             | uu____8370 ->
                  FStar_Errors.raise_error
                    (FStar_Errors.Fatal_SynthByTacticError,
                      "synth_by_tactic: bad application")
                    top.FStar_Syntax_Syntax.pos in
-           (match uu____8185 with
+           (match uu____8161 with
             | (args1, args2) ->
                 let t1 = FStar_Syntax_Util.mk_app head args1 in
                 let t2 = FStar_Syntax_Util.mk_app t1 args2 in tc_term env1 t2)
        | FStar_Syntax_Syntax.Tm_app (head, args) ->
            let env0 = env1 in
            let env2 =
-             let uu____8511 =
-               let uu____8512 = FStar_TypeChecker_Env.clear_expected_typ env1 in
-               FStar_All.pipe_right uu____8512 FStar_Pervasives_Native.fst in
-             FStar_All.pipe_right uu____8511 instantiate_both in
-           ((let uu____8528 =
+             let uu____8487 =
+               let uu____8488 = FStar_TypeChecker_Env.clear_expected_typ env1 in
+               FStar_All.pipe_right uu____8488 FStar_Pervasives_Native.fst in
+             FStar_All.pipe_right uu____8487 instantiate_both in
+           ((let uu____8504 =
                FStar_TypeChecker_Env.debug env2 FStar_Options.High in
-             if uu____8528
+             if uu____8504
              then
-               let uu____8529 =
+               let uu____8505 =
                  FStar_Range.string_of_range top.FStar_Syntax_Syntax.pos in
-               let uu____8530 = FStar_Syntax_Print.term_to_string top in
-               let uu____8531 =
-                 let uu____8532 = FStar_TypeChecker_Env.expected_typ env0 in
-                 FStar_All.pipe_right uu____8532
-                   (fun uu___3_8538 ->
-                      match uu___3_8538 with
+               let uu____8506 = FStar_Syntax_Print.term_to_string top in
+               let uu____8507 =
+                 let uu____8508 = FStar_TypeChecker_Env.expected_typ env0 in
+                 FStar_All.pipe_right uu____8508
+                   (fun uu___3_8514 ->
+                      match uu___3_8514 with
                       | FStar_Pervasives_Native.None -> "none"
                       | FStar_Pervasives_Native.Some t ->
                           FStar_Syntax_Print.term_to_string t) in
                FStar_Util.print3
-                 "(%s) Checking app %s, expected type is %s\n" uu____8529
-                 uu____8530 uu____8531
+                 "(%s) Checking app %s, expected type is %s\n" uu____8505
+                 uu____8506 uu____8507
              else ());
-            (let uu____8543 = tc_term (no_inst env2) head in
-             match uu____8543 with
+            (let uu____8519 = tc_term (no_inst env2) head in
+             match uu____8519 with
              | (head1, chead, g_head) ->
-                 let uu____8559 =
-                   let uu____8564 = FStar_TypeChecker_Common.lcomp_comp chead in
-                   FStar_All.pipe_right uu____8564
-                     (fun uu____8581 ->
-                        match uu____8581 with
+                 let uu____8535 =
+                   let uu____8540 = FStar_TypeChecker_Common.lcomp_comp chead in
+                   FStar_All.pipe_right uu____8540
+                     (fun uu____8557 ->
+                        match uu____8557 with
                         | (c, g) ->
-                            let uu____8592 =
+                            let uu____8568 =
                               FStar_TypeChecker_Env.conj_guard g_head g in
-                            (c, uu____8592)) in
-                 (match uu____8559 with
+                            (c, uu____8568)) in
+                 (match uu____8535 with
                   | (chead1, g_head1) ->
-                      let uu____8601 =
-                        let uu____8608 =
+                      let uu____8577 =
+                        let uu____8584 =
                           ((Prims.op_Negation env2.FStar_TypeChecker_Env.lax)
                              &&
-                             (let uu____8610 = FStar_Options.lax () in
-                              Prims.op_Negation uu____8610))
+                             (let uu____8586 = FStar_Options.lax () in
+                              Prims.op_Negation uu____8586))
                             &&
                             (FStar_TypeChecker_Util.short_circuit_head head1) in
-                        if uu____8608
+                        if uu____8584
                         then
-                          let uu____8617 =
-                            let uu____8624 =
+                          let uu____8593 =
+                            let uu____8600 =
                               FStar_TypeChecker_Env.expected_typ env0 in
                             check_short_circuit_args env2 head1 chead1
-                              g_head1 args uu____8624 in
-                          match uu____8617 with | (e1, c, g) -> (e1, c, g)
+                              g_head1 args uu____8600 in
+                          match uu____8593 with | (e1, c, g) -> (e1, c, g)
                         else
-                          (let uu____8637 =
+                          (let uu____8613 =
                              FStar_TypeChecker_Env.expected_typ env0 in
                            check_application_args env2 head1 chead1 g_head1
-                             args uu____8637) in
-                      (match uu____8601 with
+                             args uu____8613) in
+                      (match uu____8577 with
                        | (e1, c, g) ->
-                           let uu____8649 =
-                             let uu____8656 =
+                           let uu____8625 =
+                             let uu____8632 =
                                FStar_TypeChecker_Common.is_tot_or_gtot_lcomp
                                  c in
-                             if uu____8656
+                             if uu____8632
                              then
-                               let uu____8663 =
+                               let uu____8639 =
                                  FStar_TypeChecker_Util.maybe_instantiate
                                    env0 e1 c.FStar_TypeChecker_Common.res_typ in
-                               match uu____8663 with
+                               match uu____8639 with
                                | (e2, res_typ, implicits) ->
-                                   let uu____8679 =
+                                   let uu____8655 =
                                      FStar_TypeChecker_Common.set_result_typ_lc
                                        c res_typ in
-                                   (e2, uu____8679, implicits)
+                                   (e2, uu____8655, implicits)
                              else
                                (e1, c, FStar_TypeChecker_Env.trivial_guard) in
-                           (match uu____8649 with
+                           (match uu____8625 with
                             | (e2, c1, implicits) ->
-                                ((let uu____8691 =
+                                ((let uu____8667 =
                                     FStar_TypeChecker_Env.debug env2
                                       FStar_Options.Extreme in
-                                  if uu____8691
+                                  if uu____8667
                                   then
-                                    let uu____8692 =
+                                    let uu____8668 =
                                       FStar_TypeChecker_Rel.print_pending_implicits
                                         g in
                                     FStar_Util.print1
                                       "Introduced {%s} implicits in application\n"
-                                      uu____8692
+                                      uu____8668
                                   else ());
-                                 (let uu____8694 =
+                                 (let uu____8670 =
                                     comp_check_expected_typ env0 e2 c1 in
-                                  match uu____8694 with
+                                  match uu____8670 with
                                   | (e3, c2, g') ->
                                       let gres =
                                         FStar_TypeChecker_Env.conj_guard g g' in
                                       let gres1 =
                                         FStar_TypeChecker_Env.conj_guard gres
                                           implicits in
-                                      ((let uu____8713 =
+                                      ((let uu____8689 =
                                           FStar_TypeChecker_Env.debug env2
                                             FStar_Options.Extreme in
-                                        if uu____8713
+                                        if uu____8689
                                         then
-                                          let uu____8714 =
+                                          let uu____8690 =
                                             FStar_Syntax_Print.term_to_string
                                               e3 in
-                                          let uu____8715 =
+                                          let uu____8691 =
                                             FStar_TypeChecker_Rel.guard_to_string
                                               env2 gres1 in
                                           FStar_Util.print2
                                             "Guard from application node %s is %s\n"
-                                            uu____8714 uu____8715
+                                            uu____8690 uu____8691
                                         else ());
                                        (e3, c2, gres1)))))))))
-       | FStar_Syntax_Syntax.Tm_match uu____8717 -> tc_match env1 top
+       | FStar_Syntax_Syntax.Tm_match uu____8693 -> tc_match env1 top
        | FStar_Syntax_Syntax.Tm_let
            ((false,
-             { FStar_Syntax_Syntax.lbname = FStar_Util.Inr uu____8740;
-               FStar_Syntax_Syntax.lbunivs = uu____8741;
-               FStar_Syntax_Syntax.lbtyp = uu____8742;
-               FStar_Syntax_Syntax.lbeff = uu____8743;
-               FStar_Syntax_Syntax.lbdef = uu____8744;
-               FStar_Syntax_Syntax.lbattrs = uu____8745;
-               FStar_Syntax_Syntax.lbpos = uu____8746;_}::[]),
-            uu____8747)
+             { FStar_Syntax_Syntax.lbname = FStar_Util.Inr uu____8716;
+               FStar_Syntax_Syntax.lbunivs = uu____8717;
+               FStar_Syntax_Syntax.lbtyp = uu____8718;
+               FStar_Syntax_Syntax.lbeff = uu____8719;
+               FStar_Syntax_Syntax.lbdef = uu____8720;
+               FStar_Syntax_Syntax.lbattrs = uu____8721;
+               FStar_Syntax_Syntax.lbpos = uu____8722;_}::[]),
+            uu____8723)
            -> check_top_level_let env1 top
-       | FStar_Syntax_Syntax.Tm_let ((false, uu____8770), uu____8771) ->
+       | FStar_Syntax_Syntax.Tm_let ((false, uu____8746), uu____8747) ->
            check_inner_let env1 top
        | FStar_Syntax_Syntax.Tm_let
            ((true,
-             { FStar_Syntax_Syntax.lbname = FStar_Util.Inr uu____8786;
-               FStar_Syntax_Syntax.lbunivs = uu____8787;
-               FStar_Syntax_Syntax.lbtyp = uu____8788;
-               FStar_Syntax_Syntax.lbeff = uu____8789;
-               FStar_Syntax_Syntax.lbdef = uu____8790;
-               FStar_Syntax_Syntax.lbattrs = uu____8791;
-               FStar_Syntax_Syntax.lbpos = uu____8792;_}::uu____8793),
-            uu____8794)
+             { FStar_Syntax_Syntax.lbname = FStar_Util.Inr uu____8762;
+               FStar_Syntax_Syntax.lbunivs = uu____8763;
+               FStar_Syntax_Syntax.lbtyp = uu____8764;
+               FStar_Syntax_Syntax.lbeff = uu____8765;
+               FStar_Syntax_Syntax.lbdef = uu____8766;
+               FStar_Syntax_Syntax.lbattrs = uu____8767;
+               FStar_Syntax_Syntax.lbpos = uu____8768;_}::uu____8769),
+            uu____8770)
            -> check_top_level_let_rec env1 top
-       | FStar_Syntax_Syntax.Tm_let ((true, uu____8819), uu____8820) ->
+       | FStar_Syntax_Syntax.Tm_let ((true, uu____8795), uu____8796) ->
            check_inner_let_rec env1 top)
 and (tc_match :
   FStar_TypeChecker_Env.env ->
@@ -2815,60 +2815,60 @@ and (tc_match :
   =
   fun env ->
     fun top ->
-      let uu____8843 =
-        let uu____8844 = FStar_Syntax_Subst.compress top in
-        uu____8844.FStar_Syntax_Syntax.n in
-      match uu____8843 with
+      let uu____8819 =
+        let uu____8820 = FStar_Syntax_Subst.compress top in
+        uu____8820.FStar_Syntax_Syntax.n in
+      match uu____8819 with
       | FStar_Syntax_Syntax.Tm_match (e1, eqns) ->
-          let uu____8891 = FStar_TypeChecker_Env.clear_expected_typ env in
-          (match uu____8891 with
+          let uu____8867 = FStar_TypeChecker_Env.clear_expected_typ env in
+          (match uu____8867 with
            | (env1, topt) ->
                let env11 = instantiate_both env1 in
-               let uu____8911 = tc_term env11 e1 in
-               (match uu____8911 with
+               let uu____8887 = tc_term env11 e1 in
+               (match uu____8887 with
                 | (e11, c1, g1) ->
-                    let uu____8927 =
-                      let uu____8938 =
+                    let uu____8903 =
+                      let uu____8914 =
                         FStar_TypeChecker_Util.coerce_views env e11 c1 in
-                      match uu____8938 with
+                      match uu____8914 with
                       | FStar_Pervasives_Native.Some (e12, c11) ->
                           (e12, c11, eqns)
                       | FStar_Pervasives_Native.None -> (e11, c1, eqns) in
-                    (match uu____8927 with
+                    (match uu____8903 with
                      | (e12, c11, eqns1) ->
                          let eqns2 = eqns1 in
-                         let uu____8993 =
+                         let uu____8969 =
                            match topt with
                            | FStar_Pervasives_Native.Some t -> (env, t, g1)
                            | FStar_Pervasives_Native.None ->
-                               let uu____9007 = FStar_Syntax_Util.type_u () in
-                               (match uu____9007 with
-                                | (k, uu____9019) ->
-                                    let uu____9020 =
+                               let uu____8983 = FStar_Syntax_Util.type_u () in
+                               (match uu____8983 with
+                                | (k, uu____8995) ->
+                                    let uu____8996 =
                                       FStar_TypeChecker_Util.new_implicit_var
                                         "match result"
                                         e12.FStar_Syntax_Syntax.pos env k in
-                                    (match uu____9020 with
-                                     | (res_t, uu____9040, g) ->
-                                         let uu____9054 =
+                                    (match uu____8996 with
+                                     | (res_t, uu____9016, g) ->
+                                         let uu____9030 =
                                            FStar_TypeChecker_Env.set_expected_typ
                                              env res_t in
-                                         let uu____9055 =
+                                         let uu____9031 =
                                            FStar_TypeChecker_Env.conj_guard
                                              g1 g in
-                                         (uu____9054, res_t, uu____9055))) in
-                         (match uu____8993 with
+                                         (uu____9030, res_t, uu____9031))) in
+                         (match uu____8969 with
                           | (env_branches, res_t, g11) ->
-                              ((let uu____9066 =
+                              ((let uu____9042 =
                                   FStar_TypeChecker_Env.debug env
                                     FStar_Options.Extreme in
-                                if uu____9066
+                                if uu____9042
                                 then
-                                  let uu____9067 =
+                                  let uu____9043 =
                                     FStar_Syntax_Print.term_to_string res_t in
                                   FStar_Util.print1
                                     "Tm_match: expected type of branches is %s\n"
-                                    uu____9067
+                                    uu____9043
                                 else ());
                                (let guard_x =
                                   FStar_Syntax_Syntax.new_bv
@@ -2879,33 +2879,33 @@ and (tc_match :
                                   FStar_All.pipe_right eqns2
                                     (FStar_List.map
                                        (tc_eqn guard_x env_branches)) in
-                                let uu____9166 =
-                                  let uu____9173 =
+                                let uu____9142 =
+                                  let uu____9149 =
                                     FStar_List.fold_right
-                                      (fun uu____9260 ->
-                                         fun uu____9261 ->
-                                           match (uu____9260, uu____9261)
+                                      (fun uu____9236 ->
+                                         fun uu____9237 ->
+                                           match (uu____9236, uu____9237)
                                            with
                                            | ((branch, f, eff_label, cflags,
                                                c, g, erasable_branch),
                                               (caccum, gaccum, erasable)) ->
-                                               let uu____9511 =
+                                               let uu____9487 =
                                                  FStar_TypeChecker_Env.conj_guard
                                                    g gaccum in
                                                (((f, eff_label, cflags, c) ::
-                                                 caccum), uu____9511,
+                                                 caccum), uu____9487,
                                                  (erasable || erasable_branch)))
                                       t_eqns
                                       ([],
                                         FStar_TypeChecker_Env.trivial_guard,
                                         false) in
-                                  match uu____9173 with
+                                  match uu____9149 with
                                   | (cases, g, erasable) ->
-                                      let uu____9612 =
+                                      let uu____9588 =
                                         FStar_TypeChecker_Util.bind_cases env
                                           res_t cases guard_x in
-                                      (uu____9612, g, erasable) in
-                                match uu____9166 with
+                                      (uu____9588, g, erasable) in
+                                match uu____9142 with
                                 | (c_branches, g_branches, erasable) ->
                                     let cres =
                                       FStar_TypeChecker_Util.bind
@@ -2924,13 +2924,13 @@ and (tc_match :
                                             FStar_Syntax_Util.t_bool
                                             (FStar_Pervasives_Native.Some
                                                FStar_Syntax_Syntax.U_zero) in
-                                        let uu____9628 =
+                                        let uu____9604 =
                                           FStar_TypeChecker_Common.lcomp_of_comp
                                             c in
                                         FStar_TypeChecker_Util.bind
                                           e.FStar_Syntax_Syntax.pos env
                                           (FStar_Pervasives_Native.Some e)
-                                          uu____9628
+                                          uu____9604
                                           (FStar_Pervasives_Native.None,
                                             cres)
                                       else cres in
@@ -2939,19 +2939,19 @@ and (tc_match :
                                         let branches =
                                           FStar_All.pipe_right t_eqns
                                             (FStar_List.map
-                                               (fun uu____9765 ->
-                                                  match uu____9765 with
+                                               (fun uu____9741 ->
+                                                  match uu____9741 with
                                                   | ((pat, wopt, br),
-                                                     uu____9811, eff_label,
-                                                     uu____9813, uu____9814,
-                                                     uu____9815, uu____9816)
+                                                     uu____9787, eff_label,
+                                                     uu____9789, uu____9790,
+                                                     uu____9791, uu____9792)
                                                       ->
-                                                      let uu____9851 =
+                                                      let uu____9827 =
                                                         FStar_TypeChecker_Util.maybe_lift
                                                           env br eff_label
                                                           cres1.FStar_TypeChecker_Common.eff_name
                                                           res_t in
-                                                      (pat, wopt, uu____9851))) in
+                                                      (pat, wopt, uu____9827))) in
                                         let e =
                                           FStar_Syntax_Syntax.mk
                                             (FStar_Syntax_Syntax.Tm_match
@@ -2971,72 +2971,72 @@ and (tc_match :
                                                (FStar_Pervasives_Native.Some
                                                   (cres1.FStar_TypeChecker_Common.eff_name))))
                                           e2.FStar_Syntax_Syntax.pos in
-                                      let uu____9918 =
+                                      let uu____9894 =
                                         FStar_TypeChecker_Util.is_pure_or_ghost_effect
                                           env
                                           c11.FStar_TypeChecker_Common.eff_name in
-                                      if uu____9918
+                                      if uu____9894
                                       then mk_match e12
                                       else
                                         (let e_match =
-                                           let uu____9923 =
+                                           let uu____9899 =
                                              FStar_Syntax_Syntax.bv_to_name
                                                guard_x in
-                                           mk_match uu____9923 in
+                                           mk_match uu____9899 in
                                          let lb =
-                                           let uu____9927 =
+                                           let uu____9903 =
                                              FStar_TypeChecker_Env.norm_eff_name
                                                env
                                                c11.FStar_TypeChecker_Common.eff_name in
                                            FStar_Syntax_Util.mk_letbinding
                                              (FStar_Util.Inl guard_x) []
                                              c11.FStar_TypeChecker_Common.res_typ
-                                             uu____9927 e12 []
+                                             uu____9903 e12 []
                                              e12.FStar_Syntax_Syntax.pos in
                                          let e =
-                                           let uu____9933 =
-                                             let uu____9934 =
-                                               let uu____9947 =
-                                                 let uu____9950 =
-                                                   let uu____9951 =
+                                           let uu____9909 =
+                                             let uu____9910 =
+                                               let uu____9923 =
+                                                 let uu____9926 =
+                                                   let uu____9927 =
                                                      FStar_Syntax_Syntax.mk_binder
                                                        guard_x in
-                                                   [uu____9951] in
+                                                   [uu____9927] in
                                                  FStar_Syntax_Subst.close
-                                                   uu____9950 e_match in
-                                               ((false, [lb]), uu____9947) in
+                                                   uu____9926 e_match in
+                                               ((false, [lb]), uu____9923) in
                                              FStar_Syntax_Syntax.Tm_let
-                                               uu____9934 in
-                                           FStar_Syntax_Syntax.mk uu____9933
+                                               uu____9910 in
+                                           FStar_Syntax_Syntax.mk uu____9909
                                              top.FStar_Syntax_Syntax.pos in
                                          FStar_TypeChecker_Util.maybe_monadic
                                            env e
                                            cres1.FStar_TypeChecker_Common.eff_name
                                            cres1.FStar_TypeChecker_Common.res_typ) in
-                                    ((let uu____9981 =
+                                    ((let uu____9957 =
                                         FStar_TypeChecker_Env.debug env
                                           FStar_Options.Extreme in
-                                      if uu____9981
+                                      if uu____9957
                                       then
-                                        let uu____9982 =
+                                        let uu____9958 =
                                           FStar_Range.string_of_range
                                             top.FStar_Syntax_Syntax.pos in
-                                        let uu____9983 =
+                                        let uu____9959 =
                                           FStar_TypeChecker_Common.lcomp_to_string
                                             cres1 in
                                         FStar_Util.print2
                                           "(%s) Typechecked Tm_match, comp type = %s\n"
-                                          uu____9982 uu____9983
+                                          uu____9958 uu____9959
                                       else ());
-                                     (let uu____9985 =
+                                     (let uu____9961 =
                                         FStar_TypeChecker_Env.conj_guard g11
                                           g_branches in
-                                      (e, cres1, uu____9985)))))))))
-      | uu____9986 ->
-          let uu____9987 =
-            let uu____9988 = FStar_Syntax_Print.tag_of_term top in
-            FStar_Util.format1 "tc_match called on %s\n" uu____9988 in
-          failwith uu____9987
+                                      (e, cres1, uu____9961)))))))))
+      | uu____9962 ->
+          let uu____9963 =
+            let uu____9964 = FStar_Syntax_Print.tag_of_term top in
+            FStar_Util.format1 "tc_match called on %s\n" uu____9964 in
+          failwith uu____9963
 and (tc_synth :
   FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
     FStar_TypeChecker_Env.env ->
@@ -3051,79 +3051,79 @@ and (tc_synth :
     fun env ->
       fun args ->
         fun rng ->
-          let uu____10011 =
+          let uu____9987 =
             match args with
             | (tau, FStar_Pervasives_Native.None)::[] ->
                 (tau, FStar_Pervasives_Native.None)
             | (a, FStar_Pervasives_Native.Some (FStar_Syntax_Syntax.Implicit
-               uu____10050))::(tau, FStar_Pervasives_Native.None)::[] ->
+               uu____10026))::(tau, FStar_Pervasives_Native.None)::[] ->
                 (tau, (FStar_Pervasives_Native.Some a))
-            | uu____10090 ->
+            | uu____10066 ->
                 FStar_Errors.raise_error
                   (FStar_Errors.Fatal_SynthByTacticError,
                     "synth_by_tactic: bad application") rng in
-          match uu____10011 with
+          match uu____9987 with
           | (tau, atyp) ->
               let typ =
                 match atyp with
                 | FStar_Pervasives_Native.Some t -> t
                 | FStar_Pervasives_Native.None ->
-                    let uu____10121 = FStar_TypeChecker_Env.expected_typ env in
-                    (match uu____10121 with
+                    let uu____10097 = FStar_TypeChecker_Env.expected_typ env in
+                    (match uu____10097 with
                      | FStar_Pervasives_Native.Some t -> t
                      | FStar_Pervasives_Native.None ->
-                         let uu____10125 =
+                         let uu____10101 =
                            FStar_TypeChecker_Env.get_range env in
                          FStar_Errors.raise_error
                            (FStar_Errors.Fatal_SynthByTacticError,
                              "synth_by_tactic: need a type annotation when no expected type is present")
-                           uu____10125) in
-              let uu____10126 =
-                let uu____10133 =
-                  let uu____10134 =
-                    let uu____10135 = FStar_Syntax_Util.type_u () in
+                           uu____10101) in
+              let uu____10102 =
+                let uu____10109 =
+                  let uu____10110 =
+                    let uu____10111 = FStar_Syntax_Util.type_u () in
                     FStar_All.pipe_left FStar_Pervasives_Native.fst
-                      uu____10135 in
-                  FStar_TypeChecker_Env.set_expected_typ env uu____10134 in
-                tc_term uu____10133 typ in
-              (match uu____10126 with
-               | (typ1, uu____10151, g1) ->
+                      uu____10111 in
+                  FStar_TypeChecker_Env.set_expected_typ env uu____10110 in
+                tc_term uu____10109 typ in
+              (match uu____10102 with
+               | (typ1, uu____10127, g1) ->
                    (FStar_TypeChecker_Rel.force_trivial_guard env g1;
-                    (let uu____10154 =
+                    (let uu____10130 =
                        tc_tactic FStar_Syntax_Syntax.t_unit
                          FStar_Syntax_Syntax.t_unit env tau in
-                     match uu____10154 with
-                     | (tau1, uu____10168, g2) ->
+                     match uu____10130 with
+                     | (tau1, uu____10144, g2) ->
                          (FStar_TypeChecker_Rel.force_trivial_guard env g2;
                           (let t =
                              env.FStar_TypeChecker_Env.synth_hook env typ1
-                               (let uu___1360_10173 = tau1 in
+                               (let uu___1360_10149 = tau1 in
                                 {
                                   FStar_Syntax_Syntax.n =
-                                    (uu___1360_10173.FStar_Syntax_Syntax.n);
+                                    (uu___1360_10149.FStar_Syntax_Syntax.n);
                                   FStar_Syntax_Syntax.pos = rng;
                                   FStar_Syntax_Syntax.vars =
-                                    (uu___1360_10173.FStar_Syntax_Syntax.vars)
+                                    (uu___1360_10149.FStar_Syntax_Syntax.vars)
                                 }) in
-                           (let uu____10175 =
+                           (let uu____10151 =
                               FStar_All.pipe_left
                                 (FStar_TypeChecker_Env.debug env)
                                 (FStar_Options.Other "Tac") in
-                            if uu____10175
+                            if uu____10151
                             then
-                              let uu____10176 =
+                              let uu____10152 =
                                 FStar_Syntax_Print.term_to_string t in
-                              FStar_Util.print1 "Got %s\n" uu____10176
+                              FStar_Util.print1 "Got %s\n" uu____10152
                             else ());
                            FStar_TypeChecker_Util.check_uvars
                              tau1.FStar_Syntax_Syntax.pos t;
-                           (let uu____10179 =
-                              let uu____10180 =
+                           (let uu____10155 =
+                              let uu____10156 =
                                 FStar_Syntax_Syntax.mk_Total typ1 in
                               FStar_All.pipe_left
                                 FStar_TypeChecker_Common.lcomp_of_comp
-                                uu____10180 in
-                            (t, uu____10179,
+                                uu____10156 in
+                            (t, uu____10155,
                               FStar_TypeChecker_Env.trivial_guard)))))))
 and (tc_tactic :
   FStar_Syntax_Syntax.typ ->
@@ -3138,104 +3138,104 @@ and (tc_tactic :
       fun env ->
         fun tau ->
           let env1 =
-            let uu___1370_10186 = env in
+            let uu___1370_10162 = env in
             {
               FStar_TypeChecker_Env.solver =
-                (uu___1370_10186.FStar_TypeChecker_Env.solver);
+                (uu___1370_10162.FStar_TypeChecker_Env.solver);
               FStar_TypeChecker_Env.range =
-                (uu___1370_10186.FStar_TypeChecker_Env.range);
+                (uu___1370_10162.FStar_TypeChecker_Env.range);
               FStar_TypeChecker_Env.curmodule =
-                (uu___1370_10186.FStar_TypeChecker_Env.curmodule);
+                (uu___1370_10162.FStar_TypeChecker_Env.curmodule);
               FStar_TypeChecker_Env.gamma =
-                (uu___1370_10186.FStar_TypeChecker_Env.gamma);
+                (uu___1370_10162.FStar_TypeChecker_Env.gamma);
               FStar_TypeChecker_Env.gamma_sig =
-                (uu___1370_10186.FStar_TypeChecker_Env.gamma_sig);
+                (uu___1370_10162.FStar_TypeChecker_Env.gamma_sig);
               FStar_TypeChecker_Env.gamma_cache =
-                (uu___1370_10186.FStar_TypeChecker_Env.gamma_cache);
+                (uu___1370_10162.FStar_TypeChecker_Env.gamma_cache);
               FStar_TypeChecker_Env.modules =
-                (uu___1370_10186.FStar_TypeChecker_Env.modules);
+                (uu___1370_10162.FStar_TypeChecker_Env.modules);
               FStar_TypeChecker_Env.expected_typ =
-                (uu___1370_10186.FStar_TypeChecker_Env.expected_typ);
+                (uu___1370_10162.FStar_TypeChecker_Env.expected_typ);
               FStar_TypeChecker_Env.sigtab =
-                (uu___1370_10186.FStar_TypeChecker_Env.sigtab);
+                (uu___1370_10162.FStar_TypeChecker_Env.sigtab);
               FStar_TypeChecker_Env.attrtab =
-                (uu___1370_10186.FStar_TypeChecker_Env.attrtab);
+                (uu___1370_10162.FStar_TypeChecker_Env.attrtab);
               FStar_TypeChecker_Env.instantiate_imp =
-                (uu___1370_10186.FStar_TypeChecker_Env.instantiate_imp);
+                (uu___1370_10162.FStar_TypeChecker_Env.instantiate_imp);
               FStar_TypeChecker_Env.effects =
-                (uu___1370_10186.FStar_TypeChecker_Env.effects);
+                (uu___1370_10162.FStar_TypeChecker_Env.effects);
               FStar_TypeChecker_Env.generalize =
-                (uu___1370_10186.FStar_TypeChecker_Env.generalize);
+                (uu___1370_10162.FStar_TypeChecker_Env.generalize);
               FStar_TypeChecker_Env.letrecs =
-                (uu___1370_10186.FStar_TypeChecker_Env.letrecs);
+                (uu___1370_10162.FStar_TypeChecker_Env.letrecs);
               FStar_TypeChecker_Env.top_level =
-                (uu___1370_10186.FStar_TypeChecker_Env.top_level);
+                (uu___1370_10162.FStar_TypeChecker_Env.top_level);
               FStar_TypeChecker_Env.check_uvars =
-                (uu___1370_10186.FStar_TypeChecker_Env.check_uvars);
+                (uu___1370_10162.FStar_TypeChecker_Env.check_uvars);
               FStar_TypeChecker_Env.use_eq =
-                (uu___1370_10186.FStar_TypeChecker_Env.use_eq);
+                (uu___1370_10162.FStar_TypeChecker_Env.use_eq);
               FStar_TypeChecker_Env.use_eq_strict =
-                (uu___1370_10186.FStar_TypeChecker_Env.use_eq_strict);
+                (uu___1370_10162.FStar_TypeChecker_Env.use_eq_strict);
               FStar_TypeChecker_Env.is_iface =
-                (uu___1370_10186.FStar_TypeChecker_Env.is_iface);
+                (uu___1370_10162.FStar_TypeChecker_Env.is_iface);
               FStar_TypeChecker_Env.admit =
-                (uu___1370_10186.FStar_TypeChecker_Env.admit);
+                (uu___1370_10162.FStar_TypeChecker_Env.admit);
               FStar_TypeChecker_Env.lax =
-                (uu___1370_10186.FStar_TypeChecker_Env.lax);
+                (uu___1370_10162.FStar_TypeChecker_Env.lax);
               FStar_TypeChecker_Env.lax_universes =
-                (uu___1370_10186.FStar_TypeChecker_Env.lax_universes);
+                (uu___1370_10162.FStar_TypeChecker_Env.lax_universes);
               FStar_TypeChecker_Env.phase1 =
-                (uu___1370_10186.FStar_TypeChecker_Env.phase1);
+                (uu___1370_10162.FStar_TypeChecker_Env.phase1);
               FStar_TypeChecker_Env.failhard = true;
               FStar_TypeChecker_Env.nosynth =
-                (uu___1370_10186.FStar_TypeChecker_Env.nosynth);
+                (uu___1370_10162.FStar_TypeChecker_Env.nosynth);
               FStar_TypeChecker_Env.uvar_subtyping =
-                (uu___1370_10186.FStar_TypeChecker_Env.uvar_subtyping);
+                (uu___1370_10162.FStar_TypeChecker_Env.uvar_subtyping);
               FStar_TypeChecker_Env.tc_term =
-                (uu___1370_10186.FStar_TypeChecker_Env.tc_term);
+                (uu___1370_10162.FStar_TypeChecker_Env.tc_term);
               FStar_TypeChecker_Env.type_of =
-                (uu___1370_10186.FStar_TypeChecker_Env.type_of);
+                (uu___1370_10162.FStar_TypeChecker_Env.type_of);
               FStar_TypeChecker_Env.universe_of =
-                (uu___1370_10186.FStar_TypeChecker_Env.universe_of);
+                (uu___1370_10162.FStar_TypeChecker_Env.universe_of);
               FStar_TypeChecker_Env.check_type_of =
-                (uu___1370_10186.FStar_TypeChecker_Env.check_type_of);
+                (uu___1370_10162.FStar_TypeChecker_Env.check_type_of);
               FStar_TypeChecker_Env.use_bv_sorts =
-                (uu___1370_10186.FStar_TypeChecker_Env.use_bv_sorts);
+                (uu___1370_10162.FStar_TypeChecker_Env.use_bv_sorts);
               FStar_TypeChecker_Env.qtbl_name_and_index =
-                (uu___1370_10186.FStar_TypeChecker_Env.qtbl_name_and_index);
+                (uu___1370_10162.FStar_TypeChecker_Env.qtbl_name_and_index);
               FStar_TypeChecker_Env.normalized_eff_names =
-                (uu___1370_10186.FStar_TypeChecker_Env.normalized_eff_names);
+                (uu___1370_10162.FStar_TypeChecker_Env.normalized_eff_names);
               FStar_TypeChecker_Env.fv_delta_depths =
-                (uu___1370_10186.FStar_TypeChecker_Env.fv_delta_depths);
+                (uu___1370_10162.FStar_TypeChecker_Env.fv_delta_depths);
               FStar_TypeChecker_Env.proof_ns =
-                (uu___1370_10186.FStar_TypeChecker_Env.proof_ns);
+                (uu___1370_10162.FStar_TypeChecker_Env.proof_ns);
               FStar_TypeChecker_Env.synth_hook =
-                (uu___1370_10186.FStar_TypeChecker_Env.synth_hook);
+                (uu___1370_10162.FStar_TypeChecker_Env.synth_hook);
               FStar_TypeChecker_Env.try_solve_implicits_hook =
-                (uu___1370_10186.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                (uu___1370_10162.FStar_TypeChecker_Env.try_solve_implicits_hook);
               FStar_TypeChecker_Env.splice =
-                (uu___1370_10186.FStar_TypeChecker_Env.splice);
+                (uu___1370_10162.FStar_TypeChecker_Env.splice);
               FStar_TypeChecker_Env.mpreprocess =
-                (uu___1370_10186.FStar_TypeChecker_Env.mpreprocess);
+                (uu___1370_10162.FStar_TypeChecker_Env.mpreprocess);
               FStar_TypeChecker_Env.postprocess =
-                (uu___1370_10186.FStar_TypeChecker_Env.postprocess);
+                (uu___1370_10162.FStar_TypeChecker_Env.postprocess);
               FStar_TypeChecker_Env.identifier_info =
-                (uu___1370_10186.FStar_TypeChecker_Env.identifier_info);
+                (uu___1370_10162.FStar_TypeChecker_Env.identifier_info);
               FStar_TypeChecker_Env.tc_hooks =
-                (uu___1370_10186.FStar_TypeChecker_Env.tc_hooks);
+                (uu___1370_10162.FStar_TypeChecker_Env.tc_hooks);
               FStar_TypeChecker_Env.dsenv =
-                (uu___1370_10186.FStar_TypeChecker_Env.dsenv);
+                (uu___1370_10162.FStar_TypeChecker_Env.dsenv);
               FStar_TypeChecker_Env.nbe =
-                (uu___1370_10186.FStar_TypeChecker_Env.nbe);
+                (uu___1370_10162.FStar_TypeChecker_Env.nbe);
               FStar_TypeChecker_Env.strict_args_tab =
-                (uu___1370_10186.FStar_TypeChecker_Env.strict_args_tab);
+                (uu___1370_10162.FStar_TypeChecker_Env.strict_args_tab);
               FStar_TypeChecker_Env.erasable_types_tab =
-                (uu___1370_10186.FStar_TypeChecker_Env.erasable_types_tab);
+                (uu___1370_10162.FStar_TypeChecker_Env.erasable_types_tab);
               FStar_TypeChecker_Env.enable_defer_to_tac =
-                (uu___1370_10186.FStar_TypeChecker_Env.enable_defer_to_tac)
+                (uu___1370_10162.FStar_TypeChecker_Env.enable_defer_to_tac)
             } in
-          let uu____10187 = FStar_Syntax_Syntax.t_tac_of a b in
-          tc_check_tot_or_gtot_term env1 tau uu____10187 ""
+          let uu____10163 = FStar_Syntax_Syntax.t_tac_of a b in
+          tc_check_tot_or_gtot_term env1 tau uu____10163 ""
 and (tc_tactic_opt :
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.term FStar_Pervasives_Native.option ->
@@ -3248,11 +3248,11 @@ and (tc_tactic_opt :
       | FStar_Pervasives_Native.None ->
           (FStar_Pervasives_Native.None, FStar_TypeChecker_Env.trivial_guard)
       | FStar_Pervasives_Native.Some tactic ->
-          let uu____10201 =
+          let uu____10177 =
             tc_tactic FStar_Syntax_Syntax.t_unit FStar_Syntax_Syntax.t_unit
               env tactic in
-          (match uu____10201 with
-           | (tactic1, uu____10215, g) ->
+          (match uu____10177 with
+           | (tactic1, uu____10191, g) ->
                ((FStar_Pervasives_Native.Some tactic1), g))
 and (tc_value :
   FStar_TypeChecker_Env.env ->
@@ -3264,180 +3264,180 @@ and (tc_value :
     fun e ->
       let check_instantiated_fvar env1 v dc e1 t0 =
         let t = FStar_Syntax_Util.remove_inacc t0 in
-        let uu____10268 = FStar_TypeChecker_Util.maybe_instantiate env1 e1 t in
-        match uu____10268 with
+        let uu____10244 = FStar_TypeChecker_Util.maybe_instantiate env1 e1 t in
+        match uu____10244 with
         | (e2, t1, implicits) ->
             let tc =
-              let uu____10289 = FStar_TypeChecker_Env.should_verify env1 in
-              if uu____10289
+              let uu____10265 = FStar_TypeChecker_Env.should_verify env1 in
+              if uu____10265
               then FStar_Util.Inl t1
               else
-                (let uu____10295 =
-                   let uu____10296 = FStar_Syntax_Syntax.mk_Total t1 in
+                (let uu____10271 =
+                   let uu____10272 = FStar_Syntax_Syntax.mk_Total t1 in
                    FStar_All.pipe_left FStar_TypeChecker_Common.lcomp_of_comp
-                     uu____10296 in
-                 FStar_Util.Inr uu____10295) in
-            let is_data_ctor uu___4_10304 =
-              match uu___4_10304 with
+                     uu____10272 in
+                 FStar_Util.Inr uu____10271) in
+            let is_data_ctor uu___4_10280 =
+              match uu___4_10280 with
               | FStar_Pervasives_Native.Some (FStar_Syntax_Syntax.Data_ctor)
                   -> true
               | FStar_Pervasives_Native.Some (FStar_Syntax_Syntax.Record_ctor
-                  uu____10307) -> true
-              | uu____10314 -> false in
-            let uu____10317 =
+                  uu____10283) -> true
+              | uu____10290 -> false in
+            let uu____10293 =
               (is_data_ctor dc) &&
-                (let uu____10319 =
+                (let uu____10295 =
                    FStar_TypeChecker_Env.is_datacon env1
                      v.FStar_Syntax_Syntax.v in
-                 Prims.op_Negation uu____10319) in
-            if uu____10317
+                 Prims.op_Negation uu____10295) in
+            if uu____10293
             then
-              let uu____10326 =
-                let uu____10331 =
-                  let uu____10332 =
+              let uu____10302 =
+                let uu____10307 =
+                  let uu____10308 =
                     FStar_Ident.string_of_lid v.FStar_Syntax_Syntax.v in
                   FStar_Util.format1 "Expected a data constructor; got %s"
-                    uu____10332 in
-                (FStar_Errors.Fatal_MissingDataConstructor, uu____10331) in
-              let uu____10333 = FStar_TypeChecker_Env.get_range env1 in
-              FStar_Errors.raise_error uu____10326 uu____10333
+                    uu____10308 in
+                (FStar_Errors.Fatal_MissingDataConstructor, uu____10307) in
+              let uu____10309 = FStar_TypeChecker_Env.get_range env1 in
+              FStar_Errors.raise_error uu____10302 uu____10309
             else value_check_expected_typ env1 e2 tc implicits in
       let env1 =
         FStar_TypeChecker_Env.set_range env e.FStar_Syntax_Syntax.pos in
       let top = FStar_Syntax_Subst.compress e in
       match top.FStar_Syntax_Syntax.n with
       | FStar_Syntax_Syntax.Tm_bvar x ->
-          let uu____10350 =
-            let uu____10355 =
-              let uu____10356 = FStar_Syntax_Print.term_to_string top in
+          let uu____10326 =
+            let uu____10331 =
+              let uu____10332 = FStar_Syntax_Print.term_to_string top in
               FStar_Util.format1
-                "Violation of locally nameless convention: %s" uu____10356 in
-            (FStar_Errors.Error_IllScopedTerm, uu____10355) in
-          FStar_Errors.raise_error uu____10350 top.FStar_Syntax_Syntax.pos
+                "Violation of locally nameless convention: %s" uu____10332 in
+            (FStar_Errors.Error_IllScopedTerm, uu____10331) in
+          FStar_Errors.raise_error uu____10326 top.FStar_Syntax_Syntax.pos
       | FStar_Syntax_Syntax.Tm_uvar (u, s) ->
-          let uu____10381 =
-            let uu____10386 =
+          let uu____10357 =
+            let uu____10362 =
               FStar_Syntax_Subst.subst' s u.FStar_Syntax_Syntax.ctx_uvar_typ in
-            FStar_Util.Inl uu____10386 in
-          value_check_expected_typ env1 e uu____10381
+            FStar_Util.Inl uu____10362 in
+          value_check_expected_typ env1 e uu____10357
             FStar_TypeChecker_Env.trivial_guard
       | FStar_Syntax_Syntax.Tm_unknown ->
           let r = FStar_TypeChecker_Env.get_range env1 in
-          let uu____10388 =
-            let uu____10401 = FStar_TypeChecker_Env.expected_typ env1 in
-            match uu____10401 with
+          let uu____10364 =
+            let uu____10377 = FStar_TypeChecker_Env.expected_typ env1 in
+            match uu____10377 with
             | FStar_Pervasives_Native.None ->
-                let uu____10416 = FStar_Syntax_Util.type_u () in
-                (match uu____10416 with
+                let uu____10392 = FStar_Syntax_Util.type_u () in
+                (match uu____10392 with
                  | (k, u) ->
                      FStar_TypeChecker_Util.new_implicit_var
                        "type of user-provided implicit term" r env1 k)
             | FStar_Pervasives_Native.Some t ->
                 (t, [], FStar_TypeChecker_Env.trivial_guard) in
-          (match uu____10388 with
-           | (t, uu____10453, g0) ->
-               let uu____10467 =
-                 let uu____10480 =
-                   let uu____10481 = FStar_Range.string_of_range r in
-                   Prims.op_Hat "user-provided implicit term at " uu____10481 in
-                 FStar_TypeChecker_Util.new_implicit_var uu____10480 r env1 t in
-               (match uu____10467 with
-                | (e1, uu____10489, g1) ->
-                    let uu____10503 =
-                      let uu____10504 = FStar_Syntax_Syntax.mk_Total t in
-                      FStar_All.pipe_right uu____10504
+          (match uu____10364 with
+           | (t, uu____10429, g0) ->
+               let uu____10443 =
+                 let uu____10456 =
+                   let uu____10457 = FStar_Range.string_of_range r in
+                   Prims.op_Hat "user-provided implicit term at " uu____10457 in
+                 FStar_TypeChecker_Util.new_implicit_var uu____10456 r env1 t in
+               (match uu____10443 with
+                | (e1, uu____10465, g1) ->
+                    let uu____10479 =
+                      let uu____10480 = FStar_Syntax_Syntax.mk_Total t in
+                      FStar_All.pipe_right uu____10480
                         FStar_TypeChecker_Common.lcomp_of_comp in
-                    let uu____10505 = FStar_TypeChecker_Env.conj_guard g0 g1 in
-                    (e1, uu____10503, uu____10505)))
+                    let uu____10481 = FStar_TypeChecker_Env.conj_guard g0 g1 in
+                    (e1, uu____10479, uu____10481)))
       | FStar_Syntax_Syntax.Tm_name x ->
-          let uu____10507 =
+          let uu____10483 =
             if env1.FStar_TypeChecker_Env.use_bv_sorts
             then
-              let uu____10516 = FStar_Syntax_Syntax.range_of_bv x in
-              ((x.FStar_Syntax_Syntax.sort), uu____10516)
+              let uu____10492 = FStar_Syntax_Syntax.range_of_bv x in
+              ((x.FStar_Syntax_Syntax.sort), uu____10492)
             else FStar_TypeChecker_Env.lookup_bv env1 x in
-          (match uu____10507 with
+          (match uu____10483 with
            | (t, rng) ->
                let x1 =
                  FStar_Syntax_Syntax.set_range_of_bv
-                   (let uu___1436_10529 = x in
+                   (let uu___1436_10505 = x in
                     {
                       FStar_Syntax_Syntax.ppname =
-                        (uu___1436_10529.FStar_Syntax_Syntax.ppname);
+                        (uu___1436_10505.FStar_Syntax_Syntax.ppname);
                       FStar_Syntax_Syntax.index =
-                        (uu___1436_10529.FStar_Syntax_Syntax.index);
+                        (uu___1436_10505.FStar_Syntax_Syntax.index);
                       FStar_Syntax_Syntax.sort = t
                     }) rng in
                (FStar_TypeChecker_Env.insert_bv_info env1 x1 t;
                 (let e1 = FStar_Syntax_Syntax.bv_to_name x1 in
-                 let uu____10532 =
+                 let uu____10508 =
                    FStar_TypeChecker_Util.maybe_instantiate env1 e1 t in
-                 match uu____10532 with
+                 match uu____10508 with
                  | (e2, t1, implicits) ->
                      let tc =
-                       let uu____10553 =
+                       let uu____10529 =
                          FStar_TypeChecker_Env.should_verify env1 in
-                       if uu____10553
+                       if uu____10529
                        then FStar_Util.Inl t1
                        else
-                         (let uu____10559 =
-                            let uu____10560 = FStar_Syntax_Syntax.mk_Total t1 in
+                         (let uu____10535 =
+                            let uu____10536 = FStar_Syntax_Syntax.mk_Total t1 in
                             FStar_All.pipe_left
                               FStar_TypeChecker_Common.lcomp_of_comp
-                              uu____10560 in
-                          FStar_Util.Inr uu____10559) in
+                              uu____10536 in
+                          FStar_Util.Inr uu____10535) in
                      value_check_expected_typ env1 e2 tc implicits)))
       | FStar_Syntax_Syntax.Tm_uinst
           ({ FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar fv;
-             FStar_Syntax_Syntax.pos = uu____10562;
-             FStar_Syntax_Syntax.vars = uu____10563;_},
-           uu____10564)
+             FStar_Syntax_Syntax.pos = uu____10538;
+             FStar_Syntax_Syntax.vars = uu____10539;_},
+           uu____10540)
           when
           (FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.synth_lid) &&
             (Prims.op_Negation env1.FStar_TypeChecker_Env.phase1)
           ->
-          let uu____10569 = FStar_TypeChecker_Env.get_range env1 in
+          let uu____10545 = FStar_TypeChecker_Env.get_range env1 in
           FStar_Errors.raise_error
             (FStar_Errors.Fatal_BadlyInstantiatedSynthByTactic,
-              "Badly instantiated synth_by_tactic") uu____10569
+              "Badly instantiated synth_by_tactic") uu____10545
       | FStar_Syntax_Syntax.Tm_fvar fv when
           (FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.synth_lid) &&
             (Prims.op_Negation env1.FStar_TypeChecker_Env.phase1)
           ->
-          let uu____10577 = FStar_TypeChecker_Env.get_range env1 in
+          let uu____10553 = FStar_TypeChecker_Env.get_range env1 in
           FStar_Errors.raise_error
             (FStar_Errors.Fatal_BadlyInstantiatedSynthByTactic,
-              "Badly instantiated synth_by_tactic") uu____10577
+              "Badly instantiated synth_by_tactic") uu____10553
       | FStar_Syntax_Syntax.Tm_uinst
           ({ FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar fv;
-             FStar_Syntax_Syntax.pos = uu____10585;
-             FStar_Syntax_Syntax.vars = uu____10586;_},
+             FStar_Syntax_Syntax.pos = uu____10561;
+             FStar_Syntax_Syntax.vars = uu____10562;_},
            us)
           ->
           let us1 = FStar_List.map (tc_universe env1) us in
-          let uu____10595 =
+          let uu____10571 =
             FStar_TypeChecker_Env.lookup_lid env1
               (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-          (match uu____10595 with
+          (match uu____10571 with
            | ((us', t), range) ->
                let fv1 = FStar_Syntax_Syntax.set_range_of_fv fv range in
                (maybe_warn_on_use env1 fv1;
                 if (FStar_List.length us1) <> (FStar_List.length us')
                 then
-                  (let uu____10620 =
-                     let uu____10625 =
-                       let uu____10626 = FStar_Syntax_Print.fv_to_string fv1 in
-                       let uu____10627 =
+                  (let uu____10596 =
+                     let uu____10601 =
+                       let uu____10602 = FStar_Syntax_Print.fv_to_string fv1 in
+                       let uu____10603 =
                          FStar_Util.string_of_int (FStar_List.length us1) in
-                       let uu____10628 =
+                       let uu____10604 =
                          FStar_Util.string_of_int (FStar_List.length us') in
                        FStar_Util.format3
                          "Unexpected number of universe instantiations for \"%s\" (%s vs %s)"
-                         uu____10626 uu____10627 uu____10628 in
+                         uu____10602 uu____10603 uu____10604 in
                      (FStar_Errors.Fatal_UnexpectedNumberOfUniverse,
-                       uu____10625) in
-                   let uu____10629 = FStar_TypeChecker_Env.get_range env1 in
-                   FStar_Errors.raise_error uu____10620 uu____10629)
+                       uu____10601) in
+                   let uu____10605 = FStar_TypeChecker_Env.get_range env1 in
+                   FStar_Errors.raise_error uu____10596 uu____10605)
                 else
                   FStar_List.iter2
                     (fun u' ->
@@ -3445,53 +3445,53 @@ and (tc_value :
                          match u' with
                          | FStar_Syntax_Syntax.U_unif u'' ->
                              FStar_Syntax_Unionfind.univ_change u'' u
-                         | uu____10647 -> failwith "Impossible") us' us1;
+                         | uu____10623 -> failwith "Impossible") us' us1;
                 FStar_TypeChecker_Env.insert_fv_info env1 fv1 t;
                 (let e1 =
-                   let uu____10650 =
+                   let uu____10626 =
                      FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_fvar fv1)
                        e.FStar_Syntax_Syntax.pos in
-                   FStar_Syntax_Syntax.mk_Tm_uinst uu____10650 us1 in
+                   FStar_Syntax_Syntax.mk_Tm_uinst uu____10626 us1 in
                  check_instantiated_fvar env1 fv1.FStar_Syntax_Syntax.fv_name
                    fv1.FStar_Syntax_Syntax.fv_qual e1 t)))
-      | FStar_Syntax_Syntax.Tm_uinst (uu____10651, us) ->
-          let uu____10657 = FStar_TypeChecker_Env.get_range env1 in
+      | FStar_Syntax_Syntax.Tm_uinst (uu____10627, us) ->
+          let uu____10633 = FStar_TypeChecker_Env.get_range env1 in
           FStar_Errors.raise_error
             (FStar_Errors.Fatal_UnexpectedNumberOfUniverse,
               "Universe applications are only allowed on top-level identifiers")
-            uu____10657
+            uu____10633
       | FStar_Syntax_Syntax.Tm_fvar fv ->
-          let uu____10665 =
+          let uu____10641 =
             FStar_TypeChecker_Env.lookup_lid env1
               (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-          (match uu____10665 with
+          (match uu____10641 with
            | ((us, t), range) ->
                let fv1 = FStar_Syntax_Syntax.set_range_of_fv fv range in
                (maybe_warn_on_use env1 fv1;
-                (let uu____10690 =
+                (let uu____10666 =
                    FStar_All.pipe_left (FStar_TypeChecker_Env.debug env1)
                      (FStar_Options.Other "Range") in
-                 if uu____10690
+                 if uu____10666
                  then
-                   let uu____10691 =
-                     let uu____10692 = FStar_Syntax_Syntax.lid_of_fv fv1 in
-                     FStar_Syntax_Print.lid_to_string uu____10692 in
-                   let uu____10693 =
+                   let uu____10667 =
+                     let uu____10668 = FStar_Syntax_Syntax.lid_of_fv fv1 in
+                     FStar_Syntax_Print.lid_to_string uu____10668 in
+                   let uu____10669 =
                      FStar_Range.string_of_range e.FStar_Syntax_Syntax.pos in
-                   let uu____10694 = FStar_Range.string_of_range range in
-                   let uu____10695 = FStar_Range.string_of_use_range range in
-                   let uu____10696 = FStar_Syntax_Print.term_to_string t in
+                   let uu____10670 = FStar_Range.string_of_range range in
+                   let uu____10671 = FStar_Range.string_of_use_range range in
+                   let uu____10672 = FStar_Syntax_Print.term_to_string t in
                    FStar_Util.print5
                      "Lookup up fvar %s at location %s (lid range = defined at %s, used at %s); got universes type %s"
-                     uu____10691 uu____10693 uu____10694 uu____10695
-                     uu____10696
+                     uu____10667 uu____10669 uu____10670 uu____10671
+                     uu____10672
                  else ());
                 FStar_TypeChecker_Env.insert_fv_info env1 fv1 t;
                 (let e1 =
-                   let uu____10700 =
+                   let uu____10676 =
                      FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_fvar fv1)
                        e.FStar_Syntax_Syntax.pos in
-                   FStar_Syntax_Syntax.mk_Tm_uinst uu____10700 us in
+                   FStar_Syntax_Syntax.mk_Tm_uinst uu____10676 us in
                  check_instantiated_fvar env1 fv1.FStar_Syntax_Syntax.fv_name
                    fv1.FStar_Syntax_Syntax.fv_qual e1 t)))
       | FStar_Syntax_Syntax.Tm_constant c ->
@@ -3502,30 +3502,30 @@ and (tc_value :
           value_check_expected_typ env1 e1 (FStar_Util.Inl t)
             FStar_TypeChecker_Env.trivial_guard
       | FStar_Syntax_Syntax.Tm_arrow (bs, c) ->
-          let uu____10728 = FStar_Syntax_Subst.open_comp bs c in
-          (match uu____10728 with
+          let uu____10704 = FStar_Syntax_Subst.open_comp bs c in
+          (match uu____10704 with
            | (bs1, c1) ->
                let env0 = env1 in
-               let uu____10742 =
+               let uu____10718 =
                  FStar_TypeChecker_Env.clear_expected_typ env1 in
-               (match uu____10742 with
-                | (env2, uu____10756) ->
-                    let uu____10761 = tc_binders env2 bs1 in
-                    (match uu____10761 with
+               (match uu____10718 with
+                | (env2, uu____10732) ->
+                    let uu____10737 = tc_binders env2 bs1 in
+                    (match uu____10737 with
                      | (bs2, env3, g, us) ->
-                         let uu____10780 = tc_comp env3 c1 in
-                         (match uu____10780 with
+                         let uu____10756 = tc_comp env3 c1 in
+                         (match uu____10756 with
                           | (c2, uc, f) ->
                               let e1 =
-                                let uu___1522_10799 =
+                                let uu___1522_10775 =
                                   FStar_Syntax_Util.arrow bs2 c2 in
                                 {
                                   FStar_Syntax_Syntax.n =
-                                    (uu___1522_10799.FStar_Syntax_Syntax.n);
+                                    (uu___1522_10775.FStar_Syntax_Syntax.n);
                                   FStar_Syntax_Syntax.pos =
                                     (top.FStar_Syntax_Syntax.pos);
                                   FStar_Syntax_Syntax.vars =
-                                    (uu___1522_10799.FStar_Syntax_Syntax.vars)
+                                    (uu___1522_10775.FStar_Syntax_Syntax.vars)
                                 } in
                               (check_smt_pat env3 e1 bs2 c2;
                                (let u = FStar_Syntax_Syntax.U_max (uc :: us) in
@@ -3534,11 +3534,11 @@ and (tc_value :
                                     (FStar_Syntax_Syntax.Tm_type u)
                                     top.FStar_Syntax_Syntax.pos in
                                 let g1 =
-                                  let uu____10810 =
+                                  let uu____10786 =
                                     FStar_TypeChecker_Env.close_guard_univs
                                       us bs2 f in
                                   FStar_TypeChecker_Env.conj_guard g
-                                    uu____10810 in
+                                    uu____10786 in
                                 let g2 =
                                   FStar_TypeChecker_Util.close_guard_implicits
                                     env3 false bs2 g1 in
@@ -3556,106 +3556,106 @@ and (tc_value :
           value_check_expected_typ env1 e1 (FStar_Util.Inl t)
             FStar_TypeChecker_Env.trivial_guard
       | FStar_Syntax_Syntax.Tm_refine (x, phi) ->
-          let uu____10826 =
-            let uu____10831 =
-              let uu____10832 = FStar_Syntax_Syntax.mk_binder x in
-              [uu____10832] in
-            FStar_Syntax_Subst.open_term uu____10831 phi in
-          (match uu____10826 with
+          let uu____10802 =
+            let uu____10807 =
+              let uu____10808 = FStar_Syntax_Syntax.mk_binder x in
+              [uu____10808] in
+            FStar_Syntax_Subst.open_term uu____10807 phi in
+          (match uu____10802 with
            | (x1, phi1) ->
                let env0 = env1 in
-               let uu____10860 =
+               let uu____10836 =
                  FStar_TypeChecker_Env.clear_expected_typ env1 in
-               (match uu____10860 with
-                | (env2, uu____10874) ->
-                    let uu____10879 =
-                      let uu____10894 = FStar_List.hd x1 in
-                      tc_binder env2 uu____10894 in
-                    (match uu____10879 with
+               (match uu____10836 with
+                | (env2, uu____10850) ->
+                    let uu____10855 =
+                      let uu____10870 = FStar_List.hd x1 in
+                      tc_binder env2 uu____10870 in
+                    (match uu____10855 with
                      | (x2, env3, f1, u) ->
-                         ((let uu____10930 =
+                         ((let uu____10906 =
                              FStar_TypeChecker_Env.debug env3
                                FStar_Options.High in
-                           if uu____10930
+                           if uu____10906
                            then
-                             let uu____10931 =
+                             let uu____10907 =
                                FStar_Range.string_of_range
                                  top.FStar_Syntax_Syntax.pos in
-                             let uu____10932 =
+                             let uu____10908 =
                                FStar_Syntax_Print.term_to_string phi1 in
-                             let uu____10933 =
+                             let uu____10909 =
                                FStar_Syntax_Print.bv_to_string
                                  (FStar_Pervasives_Native.fst x2) in
                              FStar_Util.print3
                                "(%s) Checking refinement formula %s; binder is %s\n"
-                               uu____10931 uu____10932 uu____10933
+                               uu____10907 uu____10908 uu____10909
                            else ());
-                          (let uu____10937 = FStar_Syntax_Util.type_u () in
-                           match uu____10937 with
-                           | (t_phi, uu____10949) ->
-                               let uu____10950 =
+                          (let uu____10913 = FStar_Syntax_Util.type_u () in
+                           match uu____10913 with
+                           | (t_phi, uu____10925) ->
+                               let uu____10926 =
                                  tc_check_tot_or_gtot_term env3 phi1 t_phi
                                    "refinement formula must be pure or ghost" in
-                               (match uu____10950 with
-                                | (phi2, uu____10964, f2) ->
+                               (match uu____10926 with
+                                | (phi2, uu____10940, f2) ->
                                     let e1 =
-                                      let uu___1560_10969 =
+                                      let uu___1560_10945 =
                                         FStar_Syntax_Util.refine
                                           (FStar_Pervasives_Native.fst x2)
                                           phi2 in
                                       {
                                         FStar_Syntax_Syntax.n =
-                                          (uu___1560_10969.FStar_Syntax_Syntax.n);
+                                          (uu___1560_10945.FStar_Syntax_Syntax.n);
                                         FStar_Syntax_Syntax.pos =
                                           (top.FStar_Syntax_Syntax.pos);
                                         FStar_Syntax_Syntax.vars =
-                                          (uu___1560_10969.FStar_Syntax_Syntax.vars)
+                                          (uu___1560_10945.FStar_Syntax_Syntax.vars)
                                       } in
                                     let t =
                                       FStar_Syntax_Syntax.mk
                                         (FStar_Syntax_Syntax.Tm_type u)
                                         top.FStar_Syntax_Syntax.pos in
                                     let g =
-                                      let uu____10978 =
+                                      let uu____10954 =
                                         FStar_TypeChecker_Env.close_guard_univs
                                           [u] [x2] f2 in
                                       FStar_TypeChecker_Env.conj_guard f1
-                                        uu____10978 in
+                                        uu____10954 in
                                     let g1 =
                                       FStar_TypeChecker_Util.close_guard_implicits
                                         env3 false [x2] g in
                                     value_check_expected_typ env0 e1
                                       (FStar_Util.Inl t) g1))))))
-      | FStar_Syntax_Syntax.Tm_abs (bs, body, uu____11006) ->
+      | FStar_Syntax_Syntax.Tm_abs (bs, body, uu____10982) ->
           let bs1 = FStar_TypeChecker_Util.maybe_add_implicit_binders env1 bs in
-          ((let uu____11033 =
+          ((let uu____11009 =
               FStar_TypeChecker_Env.debug env1 FStar_Options.Medium in
-            if uu____11033
+            if uu____11009
             then
-              let uu____11034 =
+              let uu____11010 =
                 FStar_Syntax_Print.term_to_string
-                  (let uu___1573_11037 = top in
+                  (let uu___1573_11013 = top in
                    {
                      FStar_Syntax_Syntax.n =
                        (FStar_Syntax_Syntax.Tm_abs
                           (bs1, body, FStar_Pervasives_Native.None));
                      FStar_Syntax_Syntax.pos =
-                       (uu___1573_11037.FStar_Syntax_Syntax.pos);
+                       (uu___1573_11013.FStar_Syntax_Syntax.pos);
                      FStar_Syntax_Syntax.vars =
-                       (uu___1573_11037.FStar_Syntax_Syntax.vars)
+                       (uu___1573_11013.FStar_Syntax_Syntax.vars)
                    }) in
-              FStar_Util.print1 "Abstraction is: %s\n" uu____11034
+              FStar_Util.print1 "Abstraction is: %s\n" uu____11010
             else ());
-           (let uu____11051 = FStar_Syntax_Subst.open_term bs1 body in
-            match uu____11051 with
+           (let uu____11027 = FStar_Syntax_Subst.open_term bs1 body in
+            match uu____11027 with
             | (bs2, body1) -> tc_abs env1 top bs2 body1))
-      | uu____11064 ->
-          let uu____11065 =
-            let uu____11066 = FStar_Syntax_Print.term_to_string top in
-            let uu____11067 = FStar_Syntax_Print.tag_of_term top in
-            FStar_Util.format2 "Unexpected value: %s (%s)" uu____11066
-              uu____11067 in
-          failwith uu____11065
+      | uu____11040 ->
+          let uu____11041 =
+            let uu____11042 = FStar_Syntax_Print.term_to_string top in
+            let uu____11043 = FStar_Syntax_Print.tag_of_term top in
+            FStar_Util.format2 "Unexpected value: %s (%s)" uu____11042
+              uu____11043 in
+          failwith uu____11041
 and (tc_constant :
   FStar_TypeChecker_Env.env ->
     FStar_Range.range -> FStar_Const.sconst -> FStar_Syntax_Syntax.typ)
@@ -3666,11 +3666,11 @@ and (tc_constant :
         let res =
           match c with
           | FStar_Const.Const_unit -> FStar_Syntax_Syntax.t_unit
-          | FStar_Const.Const_bool uu____11078 -> FStar_Syntax_Util.t_bool
-          | FStar_Const.Const_int (uu____11079, FStar_Pervasives_Native.None)
+          | FStar_Const.Const_bool uu____11054 -> FStar_Syntax_Util.t_bool
+          | FStar_Const.Const_int (uu____11055, FStar_Pervasives_Native.None)
               -> FStar_Syntax_Syntax.t_int
           | FStar_Const.Const_int
-              (uu____11090, FStar_Pervasives_Native.Some msize) ->
+              (uu____11066, FStar_Pervasives_Native.Some msize) ->
               FStar_Syntax_Syntax.tconst
                 (match msize with
                  | (FStar_Const.Signed, FStar_Const.Int8) ->
@@ -3689,56 +3689,56 @@ and (tc_constant :
                      FStar_Parser_Const.uint32_lid
                  | (FStar_Const.Unsigned, FStar_Const.Int64) ->
                      FStar_Parser_Const.uint64_lid)
-          | FStar_Const.Const_string uu____11106 ->
+          | FStar_Const.Const_string uu____11082 ->
               FStar_Syntax_Syntax.t_string
-          | FStar_Const.Const_real uu____11111 -> FStar_Syntax_Syntax.t_real
-          | FStar_Const.Const_float uu____11112 ->
+          | FStar_Const.Const_real uu____11087 -> FStar_Syntax_Syntax.t_real
+          | FStar_Const.Const_float uu____11088 ->
               FStar_Syntax_Syntax.t_float
-          | FStar_Const.Const_char uu____11113 ->
-              let uu____11114 =
+          | FStar_Const.Const_char uu____11089 ->
+              let uu____11090 =
                 FStar_Syntax_DsEnv.try_lookup_lid
                   env.FStar_TypeChecker_Env.dsenv FStar_Parser_Const.char_lid in
-              FStar_All.pipe_right uu____11114 FStar_Util.must
+              FStar_All.pipe_right uu____11090 FStar_Util.must
           | FStar_Const.Const_effect -> FStar_Syntax_Util.ktype0
-          | FStar_Const.Const_range uu____11119 ->
+          | FStar_Const.Const_range uu____11095 ->
               FStar_Syntax_Syntax.t_range
           | FStar_Const.Const_range_of ->
-              let uu____11120 =
-                let uu____11125 =
-                  let uu____11126 = FStar_Parser_Const.const_to_string c in
+              let uu____11096 =
+                let uu____11101 =
+                  let uu____11102 = FStar_Parser_Const.const_to_string c in
                   FStar_Util.format1
                     "Ill-typed %s: this constant must be fully applied"
-                    uu____11126 in
-                (FStar_Errors.Fatal_IllTyped, uu____11125) in
-              FStar_Errors.raise_error uu____11120 r
+                    uu____11102 in
+                (FStar_Errors.Fatal_IllTyped, uu____11101) in
+              FStar_Errors.raise_error uu____11096 r
           | FStar_Const.Const_set_range_of ->
-              let uu____11127 =
-                let uu____11132 =
-                  let uu____11133 = FStar_Parser_Const.const_to_string c in
+              let uu____11103 =
+                let uu____11108 =
+                  let uu____11109 = FStar_Parser_Const.const_to_string c in
                   FStar_Util.format1
                     "Ill-typed %s: this constant must be fully applied"
-                    uu____11133 in
-                (FStar_Errors.Fatal_IllTyped, uu____11132) in
-              FStar_Errors.raise_error uu____11127 r
+                    uu____11109 in
+                (FStar_Errors.Fatal_IllTyped, uu____11108) in
+              FStar_Errors.raise_error uu____11103 r
           | FStar_Const.Const_reify ->
-              let uu____11134 =
-                let uu____11139 =
-                  let uu____11140 = FStar_Parser_Const.const_to_string c in
+              let uu____11110 =
+                let uu____11115 =
+                  let uu____11116 = FStar_Parser_Const.const_to_string c in
                   FStar_Util.format1
                     "Ill-typed %s: this constant must be fully applied"
-                    uu____11140 in
-                (FStar_Errors.Fatal_IllTyped, uu____11139) in
-              FStar_Errors.raise_error uu____11134 r
-          | FStar_Const.Const_reflect uu____11141 ->
-              let uu____11142 =
-                let uu____11147 =
-                  let uu____11148 = FStar_Parser_Const.const_to_string c in
+                    uu____11116 in
+                (FStar_Errors.Fatal_IllTyped, uu____11115) in
+              FStar_Errors.raise_error uu____11110 r
+          | FStar_Const.Const_reflect uu____11117 ->
+              let uu____11118 =
+                let uu____11123 =
+                  let uu____11124 = FStar_Parser_Const.const_to_string c in
                   FStar_Util.format1
                     "Ill-typed %s: this constant must be fully applied"
-                    uu____11148 in
-                (FStar_Errors.Fatal_IllTyped, uu____11147) in
-              FStar_Errors.raise_error uu____11142 r
-          | uu____11149 ->
+                    uu____11124 in
+                (FStar_Errors.Fatal_IllTyped, uu____11123) in
+              FStar_Errors.raise_error uu____11118 r
+          | uu____11125 ->
               FStar_Errors.raise_error
                 (FStar_Errors.Fatal_UnsupportedConstant,
                   "Unsupported constant") r in
@@ -3753,28 +3753,28 @@ and (tc_comp :
     fun c ->
       let c0 = c in
       match c.FStar_Syntax_Syntax.n with
-      | FStar_Syntax_Syntax.Total (t, uu____11166) ->
-          let uu____11175 = FStar_Syntax_Util.type_u () in
-          (match uu____11175 with
+      | FStar_Syntax_Syntax.Total (t, uu____11142) ->
+          let uu____11151 = FStar_Syntax_Util.type_u () in
+          (match uu____11151 with
            | (k, u) ->
-               let uu____11188 = tc_check_tot_or_gtot_term env t k "" in
-               (match uu____11188 with
-                | (t1, uu____11202, g) ->
-                    let uu____11204 =
+               let uu____11164 = tc_check_tot_or_gtot_term env t k "" in
+               (match uu____11164 with
+                | (t1, uu____11178, g) ->
+                    let uu____11180 =
                       FStar_Syntax_Syntax.mk_Total' t1
                         (FStar_Pervasives_Native.Some u) in
-                    (uu____11204, u, g)))
-      | FStar_Syntax_Syntax.GTotal (t, uu____11206) ->
-          let uu____11215 = FStar_Syntax_Util.type_u () in
-          (match uu____11215 with
+                    (uu____11180, u, g)))
+      | FStar_Syntax_Syntax.GTotal (t, uu____11182) ->
+          let uu____11191 = FStar_Syntax_Util.type_u () in
+          (match uu____11191 with
            | (k, u) ->
-               let uu____11228 = tc_check_tot_or_gtot_term env t k "" in
-               (match uu____11228 with
-                | (t1, uu____11242, g) ->
-                    let uu____11244 =
+               let uu____11204 = tc_check_tot_or_gtot_term env t k "" in
+               (match uu____11204 with
+                | (t1, uu____11218, g) ->
+                    let uu____11220 =
                       FStar_Syntax_Syntax.mk_GTotal' t1
                         (FStar_Pervasives_Native.Some u) in
-                    (uu____11244, u, g)))
+                    (uu____11220, u, g)))
       | FStar_Syntax_Syntax.Comp c1 ->
           let head =
             FStar_Syntax_Syntax.fvar c1.FStar_Syntax_Syntax.effect_name
@@ -3787,74 +3787,74 @@ and (tc_comp :
                   (FStar_Syntax_Syntax.Tm_uinst (head, us))
                   c0.FStar_Syntax_Syntax.pos in
           let tc =
-            let uu____11252 =
-              let uu____11253 =
+            let uu____11228 =
+              let uu____11229 =
                 FStar_Syntax_Syntax.as_arg c1.FStar_Syntax_Syntax.result_typ in
-              uu____11253 :: (c1.FStar_Syntax_Syntax.effect_args) in
-            FStar_Syntax_Syntax.mk_Tm_app head1 uu____11252
+              uu____11229 :: (c1.FStar_Syntax_Syntax.effect_args) in
+            FStar_Syntax_Syntax.mk_Tm_app head1 uu____11228
               (c1.FStar_Syntax_Syntax.result_typ).FStar_Syntax_Syntax.pos in
-          let uu____11270 =
+          let uu____11246 =
             tc_check_tot_or_gtot_term env tc FStar_Syntax_Syntax.teff "" in
-          (match uu____11270 with
-           | (tc1, uu____11284, f) ->
-               let uu____11286 = FStar_Syntax_Util.head_and_args tc1 in
-               (match uu____11286 with
+          (match uu____11246 with
+           | (tc1, uu____11260, f) ->
+               let uu____11262 = FStar_Syntax_Util.head_and_args tc1 in
+               (match uu____11262 with
                 | (head2, args) ->
                     let comp_univs =
-                      let uu____11336 =
-                        let uu____11337 = FStar_Syntax_Subst.compress head2 in
-                        uu____11337.FStar_Syntax_Syntax.n in
-                      match uu____11336 with
-                      | FStar_Syntax_Syntax.Tm_uinst (uu____11340, us) -> us
-                      | uu____11346 -> [] in
-                    let uu____11347 = FStar_Syntax_Util.head_and_args tc1 in
-                    (match uu____11347 with
-                     | (uu____11370, args1) ->
-                         let uu____11396 =
-                           let uu____11419 = FStar_List.hd args1 in
-                           let uu____11436 = FStar_List.tl args1 in
-                           (uu____11419, uu____11436) in
-                         (match uu____11396 with
+                      let uu____11312 =
+                        let uu____11313 = FStar_Syntax_Subst.compress head2 in
+                        uu____11313.FStar_Syntax_Syntax.n in
+                      match uu____11312 with
+                      | FStar_Syntax_Syntax.Tm_uinst (uu____11316, us) -> us
+                      | uu____11322 -> [] in
+                    let uu____11323 = FStar_Syntax_Util.head_and_args tc1 in
+                    (match uu____11323 with
+                     | (uu____11346, args1) ->
+                         let uu____11372 =
+                           let uu____11395 = FStar_List.hd args1 in
+                           let uu____11412 = FStar_List.tl args1 in
+                           (uu____11395, uu____11412) in
+                         (match uu____11372 with
                           | (res, args2) ->
-                              let uu____11517 =
-                                let uu____11526 =
+                              let uu____11493 =
+                                let uu____11502 =
                                   FStar_All.pipe_right
                                     c1.FStar_Syntax_Syntax.flags
                                     (FStar_List.map
-                                       (fun uu___5_11554 ->
-                                          match uu___5_11554 with
+                                       (fun uu___5_11530 ->
+                                          match uu___5_11530 with
                                           | FStar_Syntax_Syntax.DECREASES e
                                               ->
-                                              let uu____11562 =
+                                              let uu____11538 =
                                                 FStar_TypeChecker_Env.clear_expected_typ
                                                   env in
-                                              (match uu____11562 with
-                                               | (env1, uu____11574) ->
-                                                   let uu____11579 =
+                                              (match uu____11538 with
+                                               | (env1, uu____11550) ->
+                                                   let uu____11555 =
                                                      tc_tot_or_gtot_term env1
                                                        e in
-                                                   (match uu____11579 with
-                                                    | (e1, uu____11591, g) ->
+                                                   (match uu____11555 with
+                                                    | (e1, uu____11567, g) ->
                                                         ((FStar_Syntax_Syntax.DECREASES
                                                             e1), g)))
                                           | f1 ->
                                               (f1,
                                                 FStar_TypeChecker_Env.trivial_guard))) in
-                                FStar_All.pipe_right uu____11526
+                                FStar_All.pipe_right uu____11502
                                   FStar_List.unzip in
-                              (match uu____11517 with
+                              (match uu____11493 with
                                | (flags, guards) ->
                                    let u =
                                      env.FStar_TypeChecker_Env.universe_of
                                        env (FStar_Pervasives_Native.fst res) in
                                    let c2 =
                                      FStar_Syntax_Syntax.mk_Comp
-                                       (let uu___1703_11632 = c1 in
+                                       (let uu___1703_11608 = c1 in
                                         {
                                           FStar_Syntax_Syntax.comp_univs =
                                             comp_univs;
                                           FStar_Syntax_Syntax.effect_name =
-                                            (uu___1703_11632.FStar_Syntax_Syntax.effect_name);
+                                            (uu___1703_11608.FStar_Syntax_Syntax.effect_name);
                                           FStar_Syntax_Syntax.result_typ =
                                             (FStar_Pervasives_Native.fst res);
                                           FStar_Syntax_Syntax.effect_args =
@@ -3865,11 +3865,11 @@ and (tc_comp :
                                      FStar_All.pipe_right c2
                                        (FStar_TypeChecker_Util.universe_of_comp
                                           env u) in
-                                   let uu____11638 =
+                                   let uu____11614 =
                                      FStar_List.fold_left
                                        FStar_TypeChecker_Env.conj_guard f
                                        guards in
-                                   (c2, u_c, uu____11638))))))
+                                   (c2, u_c, uu____11614))))))
 and (tc_universe :
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.universe -> FStar_Syntax_Syntax.universe)
@@ -3879,38 +3879,38 @@ and (tc_universe :
       let rec aux u1 =
         let u2 = FStar_Syntax_Subst.compress_univ u1 in
         match u2 with
-        | FStar_Syntax_Syntax.U_bvar uu____11648 ->
+        | FStar_Syntax_Syntax.U_bvar uu____11624 ->
             failwith "Impossible: locally nameless"
         | FStar_Syntax_Syntax.U_unknown -> failwith "Unknown universe"
-        | FStar_Syntax_Syntax.U_unif uu____11649 -> u2
+        | FStar_Syntax_Syntax.U_unif uu____11625 -> u2
         | FStar_Syntax_Syntax.U_zero -> u2
         | FStar_Syntax_Syntax.U_succ u3 ->
-            let uu____11661 = aux u3 in
-            FStar_Syntax_Syntax.U_succ uu____11661
+            let uu____11637 = aux u3 in
+            FStar_Syntax_Syntax.U_succ uu____11637
         | FStar_Syntax_Syntax.U_max us ->
-            let uu____11665 = FStar_List.map aux us in
-            FStar_Syntax_Syntax.U_max uu____11665
+            let uu____11641 = FStar_List.map aux us in
+            FStar_Syntax_Syntax.U_max uu____11641
         | FStar_Syntax_Syntax.U_name x ->
-            let uu____11669 =
+            let uu____11645 =
               env.FStar_TypeChecker_Env.use_bv_sorts ||
                 (FStar_TypeChecker_Env.lookup_univ env x) in
-            if uu____11669
+            if uu____11645
             then u2
             else
-              (let uu____11671 =
-                 let uu____11672 =
-                   let uu____11673 = FStar_Syntax_Print.univ_to_string u2 in
-                   Prims.op_Hat uu____11673 " not found" in
-                 Prims.op_Hat "Universe variable " uu____11672 in
-               failwith uu____11671) in
+              (let uu____11647 =
+                 let uu____11648 =
+                   let uu____11649 = FStar_Syntax_Print.univ_to_string u2 in
+                   Prims.op_Hat uu____11649 " not found" in
+                 Prims.op_Hat "Universe variable " uu____11648 in
+               failwith uu____11647) in
       if env.FStar_TypeChecker_Env.lax_universes
       then FStar_Syntax_Syntax.U_zero
       else
         (match u with
          | FStar_Syntax_Syntax.U_unknown ->
-             let uu____11675 = FStar_Syntax_Util.type_u () in
-             FStar_All.pipe_right uu____11675 FStar_Pervasives_Native.snd
-         | uu____11684 -> aux u)
+             let uu____11651 = FStar_Syntax_Util.type_u () in
+             FStar_All.pipe_right uu____11651 FStar_Pervasives_Native.snd
+         | uu____11660 -> aux u)
 and (tc_abs_expected_function_typ :
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.binders ->
@@ -3930,103 +3930,103 @@ and (tc_abs_expected_function_typ :
           | FStar_Pervasives_Native.None ->
               ((match env.FStar_TypeChecker_Env.letrecs with
                 | [] -> ()
-                | uu____11718 ->
+                | uu____11694 ->
                     failwith
                       "Impossible: Can't have a let rec annotation but no expected type");
-               (let uu____11729 = tc_binders env bs in
-                match uu____11729 with
-                | (bs1, envbody, g_env, uu____11759) ->
+               (let uu____11705 = tc_binders env bs in
+                match uu____11705 with
+                | (bs1, envbody, g_env, uu____11735) ->
                     (FStar_Pervasives_Native.None, bs1, [],
                       FStar_Pervasives_Native.None, envbody, body, g_env)))
           | FStar_Pervasives_Native.Some t ->
               let t1 = FStar_Syntax_Subst.compress t in
               let rec as_function_typ norm1 t2 =
-                let uu____11803 =
-                  let uu____11804 = FStar_Syntax_Subst.compress t2 in
-                  uu____11804.FStar_Syntax_Syntax.n in
-                match uu____11803 with
-                | FStar_Syntax_Syntax.Tm_uvar uu____11827 ->
+                let uu____11779 =
+                  let uu____11780 = FStar_Syntax_Subst.compress t2 in
+                  uu____11780.FStar_Syntax_Syntax.n in
+                match uu____11779 with
+                | FStar_Syntax_Syntax.Tm_uvar uu____11803 ->
                     ((match env.FStar_TypeChecker_Env.letrecs with
                       | [] -> ()
-                      | uu____11849 -> failwith "Impossible");
-                     (let uu____11860 = tc_binders env bs in
-                      match uu____11860 with
-                      | (bs1, envbody, g_env, uu____11892) ->
-                          let uu____11893 =
+                      | uu____11825 -> failwith "Impossible");
+                     (let uu____11836 = tc_binders env bs in
+                      match uu____11836 with
+                      | (bs1, envbody, g_env, uu____11868) ->
+                          let uu____11869 =
                             FStar_TypeChecker_Env.clear_expected_typ envbody in
-                          (match uu____11893 with
-                           | (envbody1, uu____11921) ->
+                          (match uu____11869 with
+                           | (envbody1, uu____11897) ->
                                ((FStar_Pervasives_Native.Some t2), bs1, [],
                                  FStar_Pervasives_Native.None, envbody1,
                                  body, g_env))))
                 | FStar_Syntax_Syntax.Tm_app
                     ({
                        FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_uvar
-                         uu____11932;
-                       FStar_Syntax_Syntax.pos = uu____11933;
-                       FStar_Syntax_Syntax.vars = uu____11934;_},
-                     uu____11935)
+                         uu____11908;
+                       FStar_Syntax_Syntax.pos = uu____11909;
+                       FStar_Syntax_Syntax.vars = uu____11910;_},
+                     uu____11911)
                     ->
                     ((match env.FStar_TypeChecker_Env.letrecs with
                       | [] -> ()
-                      | uu____11981 -> failwith "Impossible");
-                     (let uu____11992 = tc_binders env bs in
-                      match uu____11992 with
-                      | (bs1, envbody, g_env, uu____12024) ->
-                          let uu____12025 =
+                      | uu____11957 -> failwith "Impossible");
+                     (let uu____11968 = tc_binders env bs in
+                      match uu____11968 with
+                      | (bs1, envbody, g_env, uu____12000) ->
+                          let uu____12001 =
                             FStar_TypeChecker_Env.clear_expected_typ envbody in
-                          (match uu____12025 with
-                           | (envbody1, uu____12053) ->
+                          (match uu____12001 with
+                           | (envbody1, uu____12029) ->
                                ((FStar_Pervasives_Native.Some t2), bs1, [],
                                  FStar_Pervasives_Native.None, envbody1,
                                  body, g_env))))
-                | FStar_Syntax_Syntax.Tm_refine (b, uu____12065) ->
-                    let uu____12070 =
+                | FStar_Syntax_Syntax.Tm_refine (b, uu____12041) ->
+                    let uu____12046 =
                       as_function_typ norm1 b.FStar_Syntax_Syntax.sort in
-                    (match uu____12070 with
-                     | (uu____12111, bs1, bs', copt, env_body, body1, g_env)
+                    (match uu____12046 with
+                     | (uu____12087, bs1, bs', copt, env_body, body1, g_env)
                          ->
                          ((FStar_Pervasives_Native.Some t2), bs1, bs', copt,
                            env_body, body1, g_env))
                 | FStar_Syntax_Syntax.Tm_arrow (bs_expected, c_expected) ->
-                    let uu____12158 =
+                    let uu____12134 =
                       FStar_Syntax_Subst.open_comp bs_expected c_expected in
-                    (match uu____12158 with
+                    (match uu____12134 with
                      | (bs_expected1, c_expected1) ->
                          let check_actuals_against_formals env1 bs1
                            bs_expected2 body1 =
-                           let rec handle_more uu____12293 c_expected2 body2
+                           let rec handle_more uu____12269 c_expected2 body2
                              =
-                             match uu____12293 with
+                             match uu____12269 with
                              | (env_bs, bs2, more, guard_env, subst) ->
                                  (match more with
                                   | FStar_Pervasives_Native.None ->
-                                      let uu____12407 =
+                                      let uu____12383 =
                                         FStar_Syntax_Subst.subst_comp subst
                                           c_expected2 in
-                                      (env_bs, bs2, guard_env, uu____12407,
+                                      (env_bs, bs2, guard_env, uu____12383,
                                         body2)
                                   | FStar_Pervasives_Native.Some
                                       (FStar_Util.Inr more_bs_expected) ->
                                       let c =
-                                        let uu____12424 =
+                                        let uu____12400 =
                                           FStar_Syntax_Util.arrow
                                             more_bs_expected c_expected2 in
                                         FStar_Syntax_Syntax.mk_Total
-                                          uu____12424 in
-                                      let uu____12425 =
+                                          uu____12400 in
+                                      let uu____12401 =
                                         FStar_Syntax_Subst.subst_comp subst c in
-                                      (env_bs, bs2, guard_env, uu____12425,
+                                      (env_bs, bs2, guard_env, uu____12401,
                                         body2)
                                   | FStar_Pervasives_Native.Some
                                       (FStar_Util.Inl more_bs) ->
                                       let c =
                                         FStar_Syntax_Subst.subst_comp subst
                                           c_expected2 in
-                                      let uu____12442 =
+                                      let uu____12418 =
                                         (FStar_Options.ml_ish ()) ||
                                           (FStar_Syntax_Util.is_named_tot c) in
-                                      if uu____12442
+                                      if uu____12418
                                       then
                                         let t3 =
                                           FStar_TypeChecker_Normalize.unfold_whnf
@@ -4035,17 +4035,17 @@ and (tc_abs_expected_function_typ :
                                         (match t3.FStar_Syntax_Syntax.n with
                                          | FStar_Syntax_Syntax.Tm_arrow
                                              (bs_expected3, c_expected3) ->
-                                             let uu____12506 =
+                                             let uu____12482 =
                                                FStar_Syntax_Subst.open_comp
                                                  bs_expected3 c_expected3 in
-                                             (match uu____12506 with
+                                             (match uu____12482 with
                                               | (bs_expected4, c_expected4)
                                                   ->
-                                                  let uu____12533 =
+                                                  let uu____12509 =
                                                     tc_abs_check_binders
                                                       env_bs more_bs
                                                       bs_expected4 in
-                                                  (match uu____12533 with
+                                                  (match uu____12509 with
                                                    | (env_bs_bs', bs', more1,
                                                       guard'_env_bs, subst1)
                                                        ->
@@ -4053,8 +4053,8 @@ and (tc_abs_expected_function_typ :
                                                          FStar_TypeChecker_Env.close_guard
                                                            env_bs bs2
                                                            guard'_env_bs in
-                                                       let uu____12588 =
-                                                         let uu____12615 =
+                                                       let uu____12564 =
+                                                         let uu____12591 =
                                                            FStar_TypeChecker_Env.conj_guard
                                                              guard_env
                                                              guard'_env in
@@ -4062,12 +4062,12 @@ and (tc_abs_expected_function_typ :
                                                            (FStar_List.append
                                                               bs2 bs'),
                                                            more1,
-                                                           uu____12615,
+                                                           uu____12591,
                                                            subst1) in
                                                        handle_more
-                                                         uu____12588
+                                                         uu____12564
                                                          c_expected4 body2))
-                                         | uu____12638 ->
+                                         | uu____12614 ->
                                              let body3 =
                                                FStar_Syntax_Util.abs more_bs
                                                  body2
@@ -4080,396 +4080,396 @@ and (tc_abs_expected_function_typ :
                                              body2
                                              FStar_Pervasives_Native.None in
                                          (env_bs, bs2, guard_env, c, body3))) in
-                           let uu____12666 =
+                           let uu____12642 =
                              tc_abs_check_binders env1 bs1 bs_expected2 in
-                           handle_more uu____12666 c_expected1 body1 in
+                           handle_more uu____12642 c_expected1 body1 in
                          let mk_letrec_env envbody bs1 c =
                            let letrecs = guard_letrecs envbody bs1 c in
                            let envbody1 =
-                             let uu___1834_12731 = envbody in
+                             let uu___1834_12707 = envbody in
                              {
                                FStar_TypeChecker_Env.solver =
-                                 (uu___1834_12731.FStar_TypeChecker_Env.solver);
+                                 (uu___1834_12707.FStar_TypeChecker_Env.solver);
                                FStar_TypeChecker_Env.range =
-                                 (uu___1834_12731.FStar_TypeChecker_Env.range);
+                                 (uu___1834_12707.FStar_TypeChecker_Env.range);
                                FStar_TypeChecker_Env.curmodule =
-                                 (uu___1834_12731.FStar_TypeChecker_Env.curmodule);
+                                 (uu___1834_12707.FStar_TypeChecker_Env.curmodule);
                                FStar_TypeChecker_Env.gamma =
-                                 (uu___1834_12731.FStar_TypeChecker_Env.gamma);
+                                 (uu___1834_12707.FStar_TypeChecker_Env.gamma);
                                FStar_TypeChecker_Env.gamma_sig =
-                                 (uu___1834_12731.FStar_TypeChecker_Env.gamma_sig);
+                                 (uu___1834_12707.FStar_TypeChecker_Env.gamma_sig);
                                FStar_TypeChecker_Env.gamma_cache =
-                                 (uu___1834_12731.FStar_TypeChecker_Env.gamma_cache);
+                                 (uu___1834_12707.FStar_TypeChecker_Env.gamma_cache);
                                FStar_TypeChecker_Env.modules =
-                                 (uu___1834_12731.FStar_TypeChecker_Env.modules);
+                                 (uu___1834_12707.FStar_TypeChecker_Env.modules);
                                FStar_TypeChecker_Env.expected_typ =
-                                 (uu___1834_12731.FStar_TypeChecker_Env.expected_typ);
+                                 (uu___1834_12707.FStar_TypeChecker_Env.expected_typ);
                                FStar_TypeChecker_Env.sigtab =
-                                 (uu___1834_12731.FStar_TypeChecker_Env.sigtab);
+                                 (uu___1834_12707.FStar_TypeChecker_Env.sigtab);
                                FStar_TypeChecker_Env.attrtab =
-                                 (uu___1834_12731.FStar_TypeChecker_Env.attrtab);
+                                 (uu___1834_12707.FStar_TypeChecker_Env.attrtab);
                                FStar_TypeChecker_Env.instantiate_imp =
-                                 (uu___1834_12731.FStar_TypeChecker_Env.instantiate_imp);
+                                 (uu___1834_12707.FStar_TypeChecker_Env.instantiate_imp);
                                FStar_TypeChecker_Env.effects =
-                                 (uu___1834_12731.FStar_TypeChecker_Env.effects);
+                                 (uu___1834_12707.FStar_TypeChecker_Env.effects);
                                FStar_TypeChecker_Env.generalize =
-                                 (uu___1834_12731.FStar_TypeChecker_Env.generalize);
+                                 (uu___1834_12707.FStar_TypeChecker_Env.generalize);
                                FStar_TypeChecker_Env.letrecs = [];
                                FStar_TypeChecker_Env.top_level =
-                                 (uu___1834_12731.FStar_TypeChecker_Env.top_level);
+                                 (uu___1834_12707.FStar_TypeChecker_Env.top_level);
                                FStar_TypeChecker_Env.check_uvars =
-                                 (uu___1834_12731.FStar_TypeChecker_Env.check_uvars);
+                                 (uu___1834_12707.FStar_TypeChecker_Env.check_uvars);
                                FStar_TypeChecker_Env.use_eq =
-                                 (uu___1834_12731.FStar_TypeChecker_Env.use_eq);
+                                 (uu___1834_12707.FStar_TypeChecker_Env.use_eq);
                                FStar_TypeChecker_Env.use_eq_strict =
-                                 (uu___1834_12731.FStar_TypeChecker_Env.use_eq_strict);
+                                 (uu___1834_12707.FStar_TypeChecker_Env.use_eq_strict);
                                FStar_TypeChecker_Env.is_iface =
-                                 (uu___1834_12731.FStar_TypeChecker_Env.is_iface);
+                                 (uu___1834_12707.FStar_TypeChecker_Env.is_iface);
                                FStar_TypeChecker_Env.admit =
-                                 (uu___1834_12731.FStar_TypeChecker_Env.admit);
+                                 (uu___1834_12707.FStar_TypeChecker_Env.admit);
                                FStar_TypeChecker_Env.lax =
-                                 (uu___1834_12731.FStar_TypeChecker_Env.lax);
+                                 (uu___1834_12707.FStar_TypeChecker_Env.lax);
                                FStar_TypeChecker_Env.lax_universes =
-                                 (uu___1834_12731.FStar_TypeChecker_Env.lax_universes);
+                                 (uu___1834_12707.FStar_TypeChecker_Env.lax_universes);
                                FStar_TypeChecker_Env.phase1 =
-                                 (uu___1834_12731.FStar_TypeChecker_Env.phase1);
+                                 (uu___1834_12707.FStar_TypeChecker_Env.phase1);
                                FStar_TypeChecker_Env.failhard =
-                                 (uu___1834_12731.FStar_TypeChecker_Env.failhard);
+                                 (uu___1834_12707.FStar_TypeChecker_Env.failhard);
                                FStar_TypeChecker_Env.nosynth =
-                                 (uu___1834_12731.FStar_TypeChecker_Env.nosynth);
+                                 (uu___1834_12707.FStar_TypeChecker_Env.nosynth);
                                FStar_TypeChecker_Env.uvar_subtyping =
-                                 (uu___1834_12731.FStar_TypeChecker_Env.uvar_subtyping);
+                                 (uu___1834_12707.FStar_TypeChecker_Env.uvar_subtyping);
                                FStar_TypeChecker_Env.tc_term =
-                                 (uu___1834_12731.FStar_TypeChecker_Env.tc_term);
+                                 (uu___1834_12707.FStar_TypeChecker_Env.tc_term);
                                FStar_TypeChecker_Env.type_of =
-                                 (uu___1834_12731.FStar_TypeChecker_Env.type_of);
+                                 (uu___1834_12707.FStar_TypeChecker_Env.type_of);
                                FStar_TypeChecker_Env.universe_of =
-                                 (uu___1834_12731.FStar_TypeChecker_Env.universe_of);
+                                 (uu___1834_12707.FStar_TypeChecker_Env.universe_of);
                                FStar_TypeChecker_Env.check_type_of =
-                                 (uu___1834_12731.FStar_TypeChecker_Env.check_type_of);
+                                 (uu___1834_12707.FStar_TypeChecker_Env.check_type_of);
                                FStar_TypeChecker_Env.use_bv_sorts =
-                                 (uu___1834_12731.FStar_TypeChecker_Env.use_bv_sorts);
+                                 (uu___1834_12707.FStar_TypeChecker_Env.use_bv_sorts);
                                FStar_TypeChecker_Env.qtbl_name_and_index =
-                                 (uu___1834_12731.FStar_TypeChecker_Env.qtbl_name_and_index);
+                                 (uu___1834_12707.FStar_TypeChecker_Env.qtbl_name_and_index);
                                FStar_TypeChecker_Env.normalized_eff_names =
-                                 (uu___1834_12731.FStar_TypeChecker_Env.normalized_eff_names);
+                                 (uu___1834_12707.FStar_TypeChecker_Env.normalized_eff_names);
                                FStar_TypeChecker_Env.fv_delta_depths =
-                                 (uu___1834_12731.FStar_TypeChecker_Env.fv_delta_depths);
+                                 (uu___1834_12707.FStar_TypeChecker_Env.fv_delta_depths);
                                FStar_TypeChecker_Env.proof_ns =
-                                 (uu___1834_12731.FStar_TypeChecker_Env.proof_ns);
+                                 (uu___1834_12707.FStar_TypeChecker_Env.proof_ns);
                                FStar_TypeChecker_Env.synth_hook =
-                                 (uu___1834_12731.FStar_TypeChecker_Env.synth_hook);
+                                 (uu___1834_12707.FStar_TypeChecker_Env.synth_hook);
                                FStar_TypeChecker_Env.try_solve_implicits_hook
                                  =
-                                 (uu___1834_12731.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                                 (uu___1834_12707.FStar_TypeChecker_Env.try_solve_implicits_hook);
                                FStar_TypeChecker_Env.splice =
-                                 (uu___1834_12731.FStar_TypeChecker_Env.splice);
+                                 (uu___1834_12707.FStar_TypeChecker_Env.splice);
                                FStar_TypeChecker_Env.mpreprocess =
-                                 (uu___1834_12731.FStar_TypeChecker_Env.mpreprocess);
+                                 (uu___1834_12707.FStar_TypeChecker_Env.mpreprocess);
                                FStar_TypeChecker_Env.postprocess =
-                                 (uu___1834_12731.FStar_TypeChecker_Env.postprocess);
+                                 (uu___1834_12707.FStar_TypeChecker_Env.postprocess);
                                FStar_TypeChecker_Env.identifier_info =
-                                 (uu___1834_12731.FStar_TypeChecker_Env.identifier_info);
+                                 (uu___1834_12707.FStar_TypeChecker_Env.identifier_info);
                                FStar_TypeChecker_Env.tc_hooks =
-                                 (uu___1834_12731.FStar_TypeChecker_Env.tc_hooks);
+                                 (uu___1834_12707.FStar_TypeChecker_Env.tc_hooks);
                                FStar_TypeChecker_Env.dsenv =
-                                 (uu___1834_12731.FStar_TypeChecker_Env.dsenv);
+                                 (uu___1834_12707.FStar_TypeChecker_Env.dsenv);
                                FStar_TypeChecker_Env.nbe =
-                                 (uu___1834_12731.FStar_TypeChecker_Env.nbe);
+                                 (uu___1834_12707.FStar_TypeChecker_Env.nbe);
                                FStar_TypeChecker_Env.strict_args_tab =
-                                 (uu___1834_12731.FStar_TypeChecker_Env.strict_args_tab);
+                                 (uu___1834_12707.FStar_TypeChecker_Env.strict_args_tab);
                                FStar_TypeChecker_Env.erasable_types_tab =
-                                 (uu___1834_12731.FStar_TypeChecker_Env.erasable_types_tab);
+                                 (uu___1834_12707.FStar_TypeChecker_Env.erasable_types_tab);
                                FStar_TypeChecker_Env.enable_defer_to_tac =
-                                 (uu___1834_12731.FStar_TypeChecker_Env.enable_defer_to_tac)
+                                 (uu___1834_12707.FStar_TypeChecker_Env.enable_defer_to_tac)
                              } in
-                           let uu____12740 =
+                           let uu____12716 =
                              FStar_All.pipe_right letrecs
                                (FStar_List.fold_left
-                                  (fun uu____12806 ->
-                                     fun uu____12807 ->
-                                       match (uu____12806, uu____12807) with
+                                  (fun uu____12782 ->
+                                     fun uu____12783 ->
+                                       match (uu____12782, uu____12783) with
                                        | ((env1, letrec_binders, g),
                                           (l, t3, u_names)) ->
-                                           let uu____12898 =
-                                             let uu____12905 =
-                                               let uu____12906 =
+                                           let uu____12874 =
+                                             let uu____12881 =
+                                               let uu____12882 =
                                                  FStar_TypeChecker_Env.clear_expected_typ
                                                    env1 in
                                                FStar_All.pipe_right
-                                                 uu____12906
+                                                 uu____12882
                                                  FStar_Pervasives_Native.fst in
-                                             tc_term uu____12905 t3 in
-                                           (match uu____12898 with
-                                            | (t4, uu____12930, g') ->
+                                             tc_term uu____12881 t3 in
+                                           (match uu____12874 with
+                                            | (t4, uu____12906, g') ->
                                                 let env2 =
                                                   FStar_TypeChecker_Env.push_let_binding
                                                     env1 l (u_names, t4) in
                                                 let lb =
                                                   match l with
                                                   | FStar_Util.Inl x ->
-                                                      let uu____12943 =
+                                                      let uu____12919 =
                                                         FStar_Syntax_Syntax.mk_binder
-                                                          (let uu___1852_12946
+                                                          (let uu___1852_12922
                                                              = x in
                                                            {
                                                              FStar_Syntax_Syntax.ppname
                                                                =
-                                                               (uu___1852_12946.FStar_Syntax_Syntax.ppname);
+                                                               (uu___1852_12922.FStar_Syntax_Syntax.ppname);
                                                              FStar_Syntax_Syntax.index
                                                                =
-                                                               (uu___1852_12946.FStar_Syntax_Syntax.index);
+                                                               (uu___1852_12922.FStar_Syntax_Syntax.index);
                                                              FStar_Syntax_Syntax.sort
                                                                = t4
                                                            }) in
-                                                      uu____12943 ::
+                                                      uu____12919 ::
                                                         letrec_binders
-                                                  | uu____12947 ->
+                                                  | uu____12923 ->
                                                       letrec_binders in
-                                                let uu____12952 =
+                                                let uu____12928 =
                                                   FStar_TypeChecker_Env.conj_guard
                                                     g g' in
-                                                (env2, lb, uu____12952)))
+                                                (env2, lb, uu____12928)))
                                   (envbody1, [],
                                     FStar_TypeChecker_Env.trivial_guard)) in
-                           match uu____12740 with
+                           match uu____12716 with
                            | (envbody2, letrec_binders, g) ->
-                               let uu____12972 =
+                               let uu____12948 =
                                  FStar_TypeChecker_Env.close_guard envbody2
                                    bs1 g in
-                               (envbody2, letrec_binders, uu____12972) in
+                               (envbody2, letrec_binders, uu____12948) in
                          let envbody =
-                           let uu___1860_12976 = env in
+                           let uu___1860_12952 = env in
                            {
                              FStar_TypeChecker_Env.solver =
-                               (uu___1860_12976.FStar_TypeChecker_Env.solver);
+                               (uu___1860_12952.FStar_TypeChecker_Env.solver);
                              FStar_TypeChecker_Env.range =
-                               (uu___1860_12976.FStar_TypeChecker_Env.range);
+                               (uu___1860_12952.FStar_TypeChecker_Env.range);
                              FStar_TypeChecker_Env.curmodule =
-                               (uu___1860_12976.FStar_TypeChecker_Env.curmodule);
+                               (uu___1860_12952.FStar_TypeChecker_Env.curmodule);
                              FStar_TypeChecker_Env.gamma =
-                               (uu___1860_12976.FStar_TypeChecker_Env.gamma);
+                               (uu___1860_12952.FStar_TypeChecker_Env.gamma);
                              FStar_TypeChecker_Env.gamma_sig =
-                               (uu___1860_12976.FStar_TypeChecker_Env.gamma_sig);
+                               (uu___1860_12952.FStar_TypeChecker_Env.gamma_sig);
                              FStar_TypeChecker_Env.gamma_cache =
-                               (uu___1860_12976.FStar_TypeChecker_Env.gamma_cache);
+                               (uu___1860_12952.FStar_TypeChecker_Env.gamma_cache);
                              FStar_TypeChecker_Env.modules =
-                               (uu___1860_12976.FStar_TypeChecker_Env.modules);
+                               (uu___1860_12952.FStar_TypeChecker_Env.modules);
                              FStar_TypeChecker_Env.expected_typ =
-                               (uu___1860_12976.FStar_TypeChecker_Env.expected_typ);
+                               (uu___1860_12952.FStar_TypeChecker_Env.expected_typ);
                              FStar_TypeChecker_Env.sigtab =
-                               (uu___1860_12976.FStar_TypeChecker_Env.sigtab);
+                               (uu___1860_12952.FStar_TypeChecker_Env.sigtab);
                              FStar_TypeChecker_Env.attrtab =
-                               (uu___1860_12976.FStar_TypeChecker_Env.attrtab);
+                               (uu___1860_12952.FStar_TypeChecker_Env.attrtab);
                              FStar_TypeChecker_Env.instantiate_imp =
-                               (uu___1860_12976.FStar_TypeChecker_Env.instantiate_imp);
+                               (uu___1860_12952.FStar_TypeChecker_Env.instantiate_imp);
                              FStar_TypeChecker_Env.effects =
-                               (uu___1860_12976.FStar_TypeChecker_Env.effects);
+                               (uu___1860_12952.FStar_TypeChecker_Env.effects);
                              FStar_TypeChecker_Env.generalize =
-                               (uu___1860_12976.FStar_TypeChecker_Env.generalize);
+                               (uu___1860_12952.FStar_TypeChecker_Env.generalize);
                              FStar_TypeChecker_Env.letrecs = [];
                              FStar_TypeChecker_Env.top_level =
-                               (uu___1860_12976.FStar_TypeChecker_Env.top_level);
+                               (uu___1860_12952.FStar_TypeChecker_Env.top_level);
                              FStar_TypeChecker_Env.check_uvars =
-                               (uu___1860_12976.FStar_TypeChecker_Env.check_uvars);
+                               (uu___1860_12952.FStar_TypeChecker_Env.check_uvars);
                              FStar_TypeChecker_Env.use_eq =
-                               (uu___1860_12976.FStar_TypeChecker_Env.use_eq);
+                               (uu___1860_12952.FStar_TypeChecker_Env.use_eq);
                              FStar_TypeChecker_Env.use_eq_strict =
-                               (uu___1860_12976.FStar_TypeChecker_Env.use_eq_strict);
+                               (uu___1860_12952.FStar_TypeChecker_Env.use_eq_strict);
                              FStar_TypeChecker_Env.is_iface =
-                               (uu___1860_12976.FStar_TypeChecker_Env.is_iface);
+                               (uu___1860_12952.FStar_TypeChecker_Env.is_iface);
                              FStar_TypeChecker_Env.admit =
-                               (uu___1860_12976.FStar_TypeChecker_Env.admit);
+                               (uu___1860_12952.FStar_TypeChecker_Env.admit);
                              FStar_TypeChecker_Env.lax =
-                               (uu___1860_12976.FStar_TypeChecker_Env.lax);
+                               (uu___1860_12952.FStar_TypeChecker_Env.lax);
                              FStar_TypeChecker_Env.lax_universes =
-                               (uu___1860_12976.FStar_TypeChecker_Env.lax_universes);
+                               (uu___1860_12952.FStar_TypeChecker_Env.lax_universes);
                              FStar_TypeChecker_Env.phase1 =
-                               (uu___1860_12976.FStar_TypeChecker_Env.phase1);
+                               (uu___1860_12952.FStar_TypeChecker_Env.phase1);
                              FStar_TypeChecker_Env.failhard =
-                               (uu___1860_12976.FStar_TypeChecker_Env.failhard);
+                               (uu___1860_12952.FStar_TypeChecker_Env.failhard);
                              FStar_TypeChecker_Env.nosynth =
-                               (uu___1860_12976.FStar_TypeChecker_Env.nosynth);
+                               (uu___1860_12952.FStar_TypeChecker_Env.nosynth);
                              FStar_TypeChecker_Env.uvar_subtyping =
-                               (uu___1860_12976.FStar_TypeChecker_Env.uvar_subtyping);
+                               (uu___1860_12952.FStar_TypeChecker_Env.uvar_subtyping);
                              FStar_TypeChecker_Env.tc_term =
-                               (uu___1860_12976.FStar_TypeChecker_Env.tc_term);
+                               (uu___1860_12952.FStar_TypeChecker_Env.tc_term);
                              FStar_TypeChecker_Env.type_of =
-                               (uu___1860_12976.FStar_TypeChecker_Env.type_of);
+                               (uu___1860_12952.FStar_TypeChecker_Env.type_of);
                              FStar_TypeChecker_Env.universe_of =
-                               (uu___1860_12976.FStar_TypeChecker_Env.universe_of);
+                               (uu___1860_12952.FStar_TypeChecker_Env.universe_of);
                              FStar_TypeChecker_Env.check_type_of =
-                               (uu___1860_12976.FStar_TypeChecker_Env.check_type_of);
+                               (uu___1860_12952.FStar_TypeChecker_Env.check_type_of);
                              FStar_TypeChecker_Env.use_bv_sorts =
-                               (uu___1860_12976.FStar_TypeChecker_Env.use_bv_sorts);
+                               (uu___1860_12952.FStar_TypeChecker_Env.use_bv_sorts);
                              FStar_TypeChecker_Env.qtbl_name_and_index =
-                               (uu___1860_12976.FStar_TypeChecker_Env.qtbl_name_and_index);
+                               (uu___1860_12952.FStar_TypeChecker_Env.qtbl_name_and_index);
                              FStar_TypeChecker_Env.normalized_eff_names =
-                               (uu___1860_12976.FStar_TypeChecker_Env.normalized_eff_names);
+                               (uu___1860_12952.FStar_TypeChecker_Env.normalized_eff_names);
                              FStar_TypeChecker_Env.fv_delta_depths =
-                               (uu___1860_12976.FStar_TypeChecker_Env.fv_delta_depths);
+                               (uu___1860_12952.FStar_TypeChecker_Env.fv_delta_depths);
                              FStar_TypeChecker_Env.proof_ns =
-                               (uu___1860_12976.FStar_TypeChecker_Env.proof_ns);
+                               (uu___1860_12952.FStar_TypeChecker_Env.proof_ns);
                              FStar_TypeChecker_Env.synth_hook =
-                               (uu___1860_12976.FStar_TypeChecker_Env.synth_hook);
+                               (uu___1860_12952.FStar_TypeChecker_Env.synth_hook);
                              FStar_TypeChecker_Env.try_solve_implicits_hook =
-                               (uu___1860_12976.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                               (uu___1860_12952.FStar_TypeChecker_Env.try_solve_implicits_hook);
                              FStar_TypeChecker_Env.splice =
-                               (uu___1860_12976.FStar_TypeChecker_Env.splice);
+                               (uu___1860_12952.FStar_TypeChecker_Env.splice);
                              FStar_TypeChecker_Env.mpreprocess =
-                               (uu___1860_12976.FStar_TypeChecker_Env.mpreprocess);
+                               (uu___1860_12952.FStar_TypeChecker_Env.mpreprocess);
                              FStar_TypeChecker_Env.postprocess =
-                               (uu___1860_12976.FStar_TypeChecker_Env.postprocess);
+                               (uu___1860_12952.FStar_TypeChecker_Env.postprocess);
                              FStar_TypeChecker_Env.identifier_info =
-                               (uu___1860_12976.FStar_TypeChecker_Env.identifier_info);
+                               (uu___1860_12952.FStar_TypeChecker_Env.identifier_info);
                              FStar_TypeChecker_Env.tc_hooks =
-                               (uu___1860_12976.FStar_TypeChecker_Env.tc_hooks);
+                               (uu___1860_12952.FStar_TypeChecker_Env.tc_hooks);
                              FStar_TypeChecker_Env.dsenv =
-                               (uu___1860_12976.FStar_TypeChecker_Env.dsenv);
+                               (uu___1860_12952.FStar_TypeChecker_Env.dsenv);
                              FStar_TypeChecker_Env.nbe =
-                               (uu___1860_12976.FStar_TypeChecker_Env.nbe);
+                               (uu___1860_12952.FStar_TypeChecker_Env.nbe);
                              FStar_TypeChecker_Env.strict_args_tab =
-                               (uu___1860_12976.FStar_TypeChecker_Env.strict_args_tab);
+                               (uu___1860_12952.FStar_TypeChecker_Env.strict_args_tab);
                              FStar_TypeChecker_Env.erasable_types_tab =
-                               (uu___1860_12976.FStar_TypeChecker_Env.erasable_types_tab);
+                               (uu___1860_12952.FStar_TypeChecker_Env.erasable_types_tab);
                              FStar_TypeChecker_Env.enable_defer_to_tac =
-                               (uu___1860_12976.FStar_TypeChecker_Env.enable_defer_to_tac)
+                               (uu___1860_12952.FStar_TypeChecker_Env.enable_defer_to_tac)
                            } in
-                         let uu____12985 =
+                         let uu____12961 =
                            check_actuals_against_formals envbody bs
                              bs_expected1 body in
-                         (match uu____12985 with
+                         (match uu____12961 with
                           | (envbody1, bs1, g_env, c, body1) ->
                               let envbody2 =
-                                let uu___1869_13022 = envbody1 in
+                                let uu___1869_12998 = envbody1 in
                                 {
                                   FStar_TypeChecker_Env.solver =
-                                    (uu___1869_13022.FStar_TypeChecker_Env.solver);
+                                    (uu___1869_12998.FStar_TypeChecker_Env.solver);
                                   FStar_TypeChecker_Env.range =
-                                    (uu___1869_13022.FStar_TypeChecker_Env.range);
+                                    (uu___1869_12998.FStar_TypeChecker_Env.range);
                                   FStar_TypeChecker_Env.curmodule =
-                                    (uu___1869_13022.FStar_TypeChecker_Env.curmodule);
+                                    (uu___1869_12998.FStar_TypeChecker_Env.curmodule);
                                   FStar_TypeChecker_Env.gamma =
-                                    (uu___1869_13022.FStar_TypeChecker_Env.gamma);
+                                    (uu___1869_12998.FStar_TypeChecker_Env.gamma);
                                   FStar_TypeChecker_Env.gamma_sig =
-                                    (uu___1869_13022.FStar_TypeChecker_Env.gamma_sig);
+                                    (uu___1869_12998.FStar_TypeChecker_Env.gamma_sig);
                                   FStar_TypeChecker_Env.gamma_cache =
-                                    (uu___1869_13022.FStar_TypeChecker_Env.gamma_cache);
+                                    (uu___1869_12998.FStar_TypeChecker_Env.gamma_cache);
                                   FStar_TypeChecker_Env.modules =
-                                    (uu___1869_13022.FStar_TypeChecker_Env.modules);
+                                    (uu___1869_12998.FStar_TypeChecker_Env.modules);
                                   FStar_TypeChecker_Env.expected_typ =
-                                    (uu___1869_13022.FStar_TypeChecker_Env.expected_typ);
+                                    (uu___1869_12998.FStar_TypeChecker_Env.expected_typ);
                                   FStar_TypeChecker_Env.sigtab =
-                                    (uu___1869_13022.FStar_TypeChecker_Env.sigtab);
+                                    (uu___1869_12998.FStar_TypeChecker_Env.sigtab);
                                   FStar_TypeChecker_Env.attrtab =
-                                    (uu___1869_13022.FStar_TypeChecker_Env.attrtab);
+                                    (uu___1869_12998.FStar_TypeChecker_Env.attrtab);
                                   FStar_TypeChecker_Env.instantiate_imp =
-                                    (uu___1869_13022.FStar_TypeChecker_Env.instantiate_imp);
+                                    (uu___1869_12998.FStar_TypeChecker_Env.instantiate_imp);
                                   FStar_TypeChecker_Env.effects =
-                                    (uu___1869_13022.FStar_TypeChecker_Env.effects);
+                                    (uu___1869_12998.FStar_TypeChecker_Env.effects);
                                   FStar_TypeChecker_Env.generalize =
-                                    (uu___1869_13022.FStar_TypeChecker_Env.generalize);
+                                    (uu___1869_12998.FStar_TypeChecker_Env.generalize);
                                   FStar_TypeChecker_Env.letrecs =
                                     (env.FStar_TypeChecker_Env.letrecs);
                                   FStar_TypeChecker_Env.top_level =
-                                    (uu___1869_13022.FStar_TypeChecker_Env.top_level);
+                                    (uu___1869_12998.FStar_TypeChecker_Env.top_level);
                                   FStar_TypeChecker_Env.check_uvars =
-                                    (uu___1869_13022.FStar_TypeChecker_Env.check_uvars);
+                                    (uu___1869_12998.FStar_TypeChecker_Env.check_uvars);
                                   FStar_TypeChecker_Env.use_eq =
-                                    (uu___1869_13022.FStar_TypeChecker_Env.use_eq);
+                                    (uu___1869_12998.FStar_TypeChecker_Env.use_eq);
                                   FStar_TypeChecker_Env.use_eq_strict =
-                                    (uu___1869_13022.FStar_TypeChecker_Env.use_eq_strict);
+                                    (uu___1869_12998.FStar_TypeChecker_Env.use_eq_strict);
                                   FStar_TypeChecker_Env.is_iface =
-                                    (uu___1869_13022.FStar_TypeChecker_Env.is_iface);
+                                    (uu___1869_12998.FStar_TypeChecker_Env.is_iface);
                                   FStar_TypeChecker_Env.admit =
-                                    (uu___1869_13022.FStar_TypeChecker_Env.admit);
+                                    (uu___1869_12998.FStar_TypeChecker_Env.admit);
                                   FStar_TypeChecker_Env.lax =
-                                    (uu___1869_13022.FStar_TypeChecker_Env.lax);
+                                    (uu___1869_12998.FStar_TypeChecker_Env.lax);
                                   FStar_TypeChecker_Env.lax_universes =
-                                    (uu___1869_13022.FStar_TypeChecker_Env.lax_universes);
+                                    (uu___1869_12998.FStar_TypeChecker_Env.lax_universes);
                                   FStar_TypeChecker_Env.phase1 =
-                                    (uu___1869_13022.FStar_TypeChecker_Env.phase1);
+                                    (uu___1869_12998.FStar_TypeChecker_Env.phase1);
                                   FStar_TypeChecker_Env.failhard =
-                                    (uu___1869_13022.FStar_TypeChecker_Env.failhard);
+                                    (uu___1869_12998.FStar_TypeChecker_Env.failhard);
                                   FStar_TypeChecker_Env.nosynth =
-                                    (uu___1869_13022.FStar_TypeChecker_Env.nosynth);
+                                    (uu___1869_12998.FStar_TypeChecker_Env.nosynth);
                                   FStar_TypeChecker_Env.uvar_subtyping =
-                                    (uu___1869_13022.FStar_TypeChecker_Env.uvar_subtyping);
+                                    (uu___1869_12998.FStar_TypeChecker_Env.uvar_subtyping);
                                   FStar_TypeChecker_Env.tc_term =
-                                    (uu___1869_13022.FStar_TypeChecker_Env.tc_term);
+                                    (uu___1869_12998.FStar_TypeChecker_Env.tc_term);
                                   FStar_TypeChecker_Env.type_of =
-                                    (uu___1869_13022.FStar_TypeChecker_Env.type_of);
+                                    (uu___1869_12998.FStar_TypeChecker_Env.type_of);
                                   FStar_TypeChecker_Env.universe_of =
-                                    (uu___1869_13022.FStar_TypeChecker_Env.universe_of);
+                                    (uu___1869_12998.FStar_TypeChecker_Env.universe_of);
                                   FStar_TypeChecker_Env.check_type_of =
-                                    (uu___1869_13022.FStar_TypeChecker_Env.check_type_of);
+                                    (uu___1869_12998.FStar_TypeChecker_Env.check_type_of);
                                   FStar_TypeChecker_Env.use_bv_sorts =
-                                    (uu___1869_13022.FStar_TypeChecker_Env.use_bv_sorts);
+                                    (uu___1869_12998.FStar_TypeChecker_Env.use_bv_sorts);
                                   FStar_TypeChecker_Env.qtbl_name_and_index =
-                                    (uu___1869_13022.FStar_TypeChecker_Env.qtbl_name_and_index);
+                                    (uu___1869_12998.FStar_TypeChecker_Env.qtbl_name_and_index);
                                   FStar_TypeChecker_Env.normalized_eff_names
                                     =
-                                    (uu___1869_13022.FStar_TypeChecker_Env.normalized_eff_names);
+                                    (uu___1869_12998.FStar_TypeChecker_Env.normalized_eff_names);
                                   FStar_TypeChecker_Env.fv_delta_depths =
-                                    (uu___1869_13022.FStar_TypeChecker_Env.fv_delta_depths);
+                                    (uu___1869_12998.FStar_TypeChecker_Env.fv_delta_depths);
                                   FStar_TypeChecker_Env.proof_ns =
-                                    (uu___1869_13022.FStar_TypeChecker_Env.proof_ns);
+                                    (uu___1869_12998.FStar_TypeChecker_Env.proof_ns);
                                   FStar_TypeChecker_Env.synth_hook =
-                                    (uu___1869_13022.FStar_TypeChecker_Env.synth_hook);
+                                    (uu___1869_12998.FStar_TypeChecker_Env.synth_hook);
                                   FStar_TypeChecker_Env.try_solve_implicits_hook
                                     =
-                                    (uu___1869_13022.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                                    (uu___1869_12998.FStar_TypeChecker_Env.try_solve_implicits_hook);
                                   FStar_TypeChecker_Env.splice =
-                                    (uu___1869_13022.FStar_TypeChecker_Env.splice);
+                                    (uu___1869_12998.FStar_TypeChecker_Env.splice);
                                   FStar_TypeChecker_Env.mpreprocess =
-                                    (uu___1869_13022.FStar_TypeChecker_Env.mpreprocess);
+                                    (uu___1869_12998.FStar_TypeChecker_Env.mpreprocess);
                                   FStar_TypeChecker_Env.postprocess =
-                                    (uu___1869_13022.FStar_TypeChecker_Env.postprocess);
+                                    (uu___1869_12998.FStar_TypeChecker_Env.postprocess);
                                   FStar_TypeChecker_Env.identifier_info =
-                                    (uu___1869_13022.FStar_TypeChecker_Env.identifier_info);
+                                    (uu___1869_12998.FStar_TypeChecker_Env.identifier_info);
                                   FStar_TypeChecker_Env.tc_hooks =
-                                    (uu___1869_13022.FStar_TypeChecker_Env.tc_hooks);
+                                    (uu___1869_12998.FStar_TypeChecker_Env.tc_hooks);
                                   FStar_TypeChecker_Env.dsenv =
-                                    (uu___1869_13022.FStar_TypeChecker_Env.dsenv);
+                                    (uu___1869_12998.FStar_TypeChecker_Env.dsenv);
                                   FStar_TypeChecker_Env.nbe =
-                                    (uu___1869_13022.FStar_TypeChecker_Env.nbe);
+                                    (uu___1869_12998.FStar_TypeChecker_Env.nbe);
                                   FStar_TypeChecker_Env.strict_args_tab =
-                                    (uu___1869_13022.FStar_TypeChecker_Env.strict_args_tab);
+                                    (uu___1869_12998.FStar_TypeChecker_Env.strict_args_tab);
                                   FStar_TypeChecker_Env.erasable_types_tab =
-                                    (uu___1869_13022.FStar_TypeChecker_Env.erasable_types_tab);
+                                    (uu___1869_12998.FStar_TypeChecker_Env.erasable_types_tab);
                                   FStar_TypeChecker_Env.enable_defer_to_tac =
-                                    (uu___1869_13022.FStar_TypeChecker_Env.enable_defer_to_tac)
+                                    (uu___1869_12998.FStar_TypeChecker_Env.enable_defer_to_tac)
                                 } in
-                              let uu____13023 = mk_letrec_env envbody2 bs1 c in
-                              (match uu____13023 with
+                              let uu____12999 = mk_letrec_env envbody2 bs1 c in
+                              (match uu____12999 with
                                | (envbody3, letrecs, g_annots) ->
                                    let envbody4 =
                                      FStar_TypeChecker_Env.set_expected_typ
                                        envbody3
                                        (FStar_Syntax_Util.comp_result c) in
-                                   let uu____13060 =
+                                   let uu____13036 =
                                      FStar_TypeChecker_Env.conj_guard g_env
                                        g_annots in
                                    ((FStar_Pervasives_Native.Some t2), bs1,
                                      letrecs,
                                      (FStar_Pervasives_Native.Some c),
-                                     envbody4, body1, uu____13060))))
-                | uu____13067 ->
+                                     envbody4, body1, uu____13036))))
+                | uu____13043 ->
                     if Prims.op_Negation norm1
                     then
-                      let uu____13088 =
-                        let uu____13089 =
+                      let uu____13064 =
+                        let uu____13065 =
                           FStar_All.pipe_right t2
                             (FStar_TypeChecker_Normalize.unfold_whnf env) in
-                        FStar_All.pipe_right uu____13089
+                        FStar_All.pipe_right uu____13065
                           FStar_Syntax_Util.unascribe in
-                      as_function_typ true uu____13088
+                      as_function_typ true uu____13064
                     else
-                      (let uu____13091 =
+                      (let uu____13067 =
                          tc_abs_expected_function_typ env bs
                            FStar_Pervasives_Native.None body in
-                       match uu____13091 with
-                       | (uu____13130, bs1, uu____13132, c_opt, envbody,
+                       match uu____13067 with
+                       | (uu____13106, bs1, uu____13108, c_opt, envbody,
                           body1, g_env) ->
                            ((FStar_Pervasives_Native.Some t2), bs1, [],
                              c_opt, envbody, body1, g_env)) in
@@ -4486,152 +4486,152 @@ and (tc_abs_check_binders :
   fun env ->
     fun bs ->
       fun bs_expected ->
-        let rec aux uu____13205 bs1 bs_expected1 =
-          match uu____13205 with
+        let rec aux uu____13181 bs1 bs_expected1 =
+          match uu____13181 with
           | (env1, subst) ->
               (match (bs1, bs_expected1) with
                | ([], []) ->
                    (env1, [], FStar_Pervasives_Native.None,
                      FStar_TypeChecker_Env.trivial_guard, subst)
-               | ((uu____13312, FStar_Pervasives_Native.None)::uu____13313,
-                  (hd_e, q)::uu____13316) when
+               | ((uu____13288, FStar_Pervasives_Native.None)::uu____13289,
+                  (hd_e, q)::uu____13292) when
                    FStar_Syntax_Syntax.is_implicit_or_meta q ->
                    let bv =
-                     let uu____13368 =
-                       let uu____13371 =
+                     let uu____13344 =
+                       let uu____13347 =
                          FStar_Ident.range_of_id
                            hd_e.FStar_Syntax_Syntax.ppname in
-                       FStar_Pervasives_Native.Some uu____13371 in
-                     let uu____13372 =
+                       FStar_Pervasives_Native.Some uu____13347 in
+                     let uu____13348 =
                        FStar_Syntax_Subst.subst subst
                          hd_e.FStar_Syntax_Syntax.sort in
-                     FStar_Syntax_Syntax.new_bv uu____13368 uu____13372 in
+                     FStar_Syntax_Syntax.new_bv uu____13344 uu____13348 in
                    aux (env1, subst) ((bv, q) :: bs1) bs_expected1
                | ((hd, imp)::bs2, (hd_expected, imp')::bs_expected2) ->
                    ((let special q1 q2 =
                        match (q1, q2) with
                        | (FStar_Pervasives_Native.Some
-                          (FStar_Syntax_Syntax.Meta uu____13465),
+                          (FStar_Syntax_Syntax.Meta uu____13441),
                           FStar_Pervasives_Native.Some
-                          (FStar_Syntax_Syntax.Meta uu____13466)) -> true
+                          (FStar_Syntax_Syntax.Meta uu____13442)) -> true
                        | (FStar_Pervasives_Native.None,
                           FStar_Pervasives_Native.Some
                           (FStar_Syntax_Syntax.Equality)) -> true
                        | (FStar_Pervasives_Native.Some
-                          (FStar_Syntax_Syntax.Implicit uu____13475),
+                          (FStar_Syntax_Syntax.Implicit uu____13451),
                           FStar_Pervasives_Native.Some
-                          (FStar_Syntax_Syntax.Meta uu____13476)) -> true
-                       | uu____13481 -> false in
-                     let uu____13490 =
+                          (FStar_Syntax_Syntax.Meta uu____13452)) -> true
+                       | uu____13457 -> false in
+                     let uu____13466 =
                        (Prims.op_Negation (special imp imp')) &&
-                         (let uu____13492 =
+                         (let uu____13468 =
                             FStar_Syntax_Util.eq_aqual imp imp' in
-                          uu____13492 <> FStar_Syntax_Util.Equal) in
-                     if uu____13490
+                          uu____13468 <> FStar_Syntax_Util.Equal) in
+                     if uu____13466
                      then
-                       let uu____13493 =
-                         let uu____13498 =
-                           let uu____13499 =
+                       let uu____13469 =
+                         let uu____13474 =
+                           let uu____13475 =
                              FStar_Syntax_Print.bv_to_string hd in
                            FStar_Util.format1
                              "Inconsistent implicit argument annotation on argument %s"
-                             uu____13499 in
+                             uu____13475 in
                          (FStar_Errors.Fatal_InconsistentImplicitArgumentAnnotation,
-                           uu____13498) in
-                       let uu____13500 = FStar_Syntax_Syntax.range_of_bv hd in
-                       FStar_Errors.raise_error uu____13493 uu____13500
+                           uu____13474) in
+                       let uu____13476 = FStar_Syntax_Syntax.range_of_bv hd in
+                       FStar_Errors.raise_error uu____13469 uu____13476
                      else ());
                     (let expected_t =
                        FStar_Syntax_Subst.subst subst
                          hd_expected.FStar_Syntax_Syntax.sort in
-                     let uu____13503 =
-                       let uu____13510 =
-                         let uu____13511 =
+                     let uu____13479 =
+                       let uu____13486 =
+                         let uu____13487 =
                            FStar_Syntax_Util.unmeta
                              hd.FStar_Syntax_Syntax.sort in
-                         uu____13511.FStar_Syntax_Syntax.n in
-                       match uu____13510 with
+                         uu____13487.FStar_Syntax_Syntax.n in
+                       match uu____13486 with
                        | FStar_Syntax_Syntax.Tm_unknown ->
                            (expected_t, FStar_TypeChecker_Env.trivial_guard)
-                       | uu____13522 ->
-                           ((let uu____13524 =
+                       | uu____13498 ->
+                           ((let uu____13500 =
                                FStar_TypeChecker_Env.debug env1
                                  FStar_Options.High in
-                             if uu____13524
+                             if uu____13500
                              then
-                               let uu____13525 =
+                               let uu____13501 =
                                  FStar_Syntax_Print.bv_to_string hd in
                                FStar_Util.print1 "Checking binder %s\n"
-                                 uu____13525
+                                 uu____13501
                              else ());
-                            (let uu____13527 =
+                            (let uu____13503 =
                                tc_tot_or_gtot_term env1
                                  hd.FStar_Syntax_Syntax.sort in
-                             match uu____13527 with
-                             | (t, uu____13541, g1_env) ->
+                             match uu____13503 with
+                             | (t, uu____13517, g1_env) ->
                                  let g2_env =
-                                   let uu____13544 =
+                                   let uu____13520 =
                                      FStar_TypeChecker_Rel.teq_nosmt env1 t
                                        expected_t in
-                                   match uu____13544 with
+                                   match uu____13520 with
                                    | FStar_Pervasives_Native.Some g ->
                                        FStar_All.pipe_right g
                                          (FStar_TypeChecker_Rel.resolve_implicits
                                             env1)
                                    | FStar_Pervasives_Native.None ->
-                                       let uu____13548 =
+                                       let uu____13524 =
                                          FStar_TypeChecker_Rel.get_subtyping_prop
                                            env1 expected_t t in
-                                       (match uu____13548 with
+                                       (match uu____13524 with
                                         | FStar_Pervasives_Native.None ->
-                                            let uu____13551 =
+                                            let uu____13527 =
                                               FStar_TypeChecker_Err.basic_type_error
                                                 env1
                                                 FStar_Pervasives_Native.None
                                                 expected_t t in
-                                            let uu____13556 =
+                                            let uu____13532 =
                                               FStar_TypeChecker_Env.get_range
                                                 env1 in
                                             FStar_Errors.raise_error
-                                              uu____13551 uu____13556
+                                              uu____13527 uu____13532
                                         | FStar_Pervasives_Native.Some g_env
                                             ->
                                             FStar_TypeChecker_Util.label_guard
                                               (hd.FStar_Syntax_Syntax.sort).FStar_Syntax_Syntax.pos
                                               "Type annotation on parameter incompatible with the expected type"
                                               g_env) in
-                                 let uu____13558 =
+                                 let uu____13534 =
                                    FStar_TypeChecker_Env.conj_guard g1_env
                                      g2_env in
-                                 (t, uu____13558))) in
-                     match uu____13503 with
+                                 (t, uu____13534))) in
+                     match uu____13479 with
                      | (t, g_env) ->
                          let hd1 =
-                           let uu___1965_13584 = hd in
+                           let uu___1965_13560 = hd in
                            {
                              FStar_Syntax_Syntax.ppname =
-                               (uu___1965_13584.FStar_Syntax_Syntax.ppname);
+                               (uu___1965_13560.FStar_Syntax_Syntax.ppname);
                              FStar_Syntax_Syntax.index =
-                               (uu___1965_13584.FStar_Syntax_Syntax.index);
+                               (uu___1965_13560.FStar_Syntax_Syntax.index);
                              FStar_Syntax_Syntax.sort = t
                            } in
                          let b = (hd1, imp) in
                          let b_expected = (hd_expected, imp') in
                          let env_b = push_binding env1 b in
                          let subst1 =
-                           let uu____13607 =
+                           let uu____13583 =
                              FStar_Syntax_Syntax.bv_to_name hd1 in
-                           maybe_extend_subst subst b_expected uu____13607 in
-                         let uu____13610 =
+                           maybe_extend_subst subst b_expected uu____13583 in
+                         let uu____13586 =
                            aux (env_b, subst1) bs2 bs_expected2 in
-                         (match uu____13610 with
+                         (match uu____13586 with
                           | (env_bs, bs3, rest, g'_env_b, subst2) ->
                               let g'_env =
                                 FStar_TypeChecker_Env.close_guard env_bs 
                                   [b] g'_env_b in
-                              let uu____13675 =
+                              let uu____13651 =
                                 FStar_TypeChecker_Env.conj_guard g_env g'_env in
-                              (env_bs, (b :: bs3), rest, uu____13675, subst2))))
+                              (env_bs, (b :: bs3), rest, uu____13651, subst2))))
                | (rest, []) ->
                    (env1, [],
                      (FStar_Pervasives_Native.Some (FStar_Util.Inl rest)),
@@ -4654,437 +4654,437 @@ and (tc_abs :
       fun bs ->
         fun body ->
           let fail msg t =
-            let uu____13812 =
+            let uu____13788 =
               FStar_TypeChecker_Err.expected_a_term_of_type_t_got_a_function
                 env msg t top in
-            FStar_Errors.raise_error uu____13812 top.FStar_Syntax_Syntax.pos in
+            FStar_Errors.raise_error uu____13788 top.FStar_Syntax_Syntax.pos in
           let use_eq = env.FStar_TypeChecker_Env.use_eq in
-          let uu____13818 = FStar_TypeChecker_Env.clear_expected_typ env in
-          match uu____13818 with
+          let uu____13794 = FStar_TypeChecker_Env.clear_expected_typ env in
+          match uu____13794 with
           | (env1, topt) ->
-              ((let uu____13838 =
+              ((let uu____13814 =
                   FStar_TypeChecker_Env.debug env1 FStar_Options.High in
-                if uu____13838
+                if uu____13814
                 then
-                  let uu____13839 =
+                  let uu____13815 =
                     match topt with
                     | FStar_Pervasives_Native.None -> "None"
                     | FStar_Pervasives_Native.Some t ->
                         FStar_Syntax_Print.term_to_string t in
                   FStar_Util.print2
                     "!!!!!!!!!!!!!!!Expected type is %s, top_level=%s\n"
-                    uu____13839
+                    uu____13815
                     (if env1.FStar_TypeChecker_Env.top_level
                      then "true"
                      else "false")
                 else ());
-               (let uu____13843 =
+               (let uu____13819 =
                   tc_abs_expected_function_typ env1 bs topt body in
-                match uu____13843 with
+                match uu____13819 with
                 | (tfun_opt, bs1, letrec_binders, c_opt, envbody, body1,
                    g_env) ->
-                    ((let uu____13884 =
+                    ((let uu____13860 =
                         FStar_TypeChecker_Env.debug env1
                           FStar_Options.Extreme in
-                      if uu____13884
+                      if uu____13860
                       then
-                        let uu____13885 =
+                        let uu____13861 =
                           match tfun_opt with
                           | FStar_Pervasives_Native.None -> "None"
                           | FStar_Pervasives_Native.Some t ->
                               FStar_Syntax_Print.term_to_string t in
-                        let uu____13887 =
+                        let uu____13863 =
                           match c_opt with
                           | FStar_Pervasives_Native.None -> "None"
                           | FStar_Pervasives_Native.Some t ->
                               FStar_Syntax_Print.comp_to_string t in
-                        let uu____13889 =
-                          let uu____13890 =
+                        let uu____13865 =
+                          let uu____13866 =
                             FStar_TypeChecker_Env.expected_typ envbody in
-                          match uu____13890 with
+                          match uu____13866 with
                           | FStar_Pervasives_Native.None -> "None"
                           | FStar_Pervasives_Native.Some t ->
                               FStar_Syntax_Print.term_to_string t in
                         FStar_Util.print3
                           "After expected_function_typ, tfun_opt: %s, c_opt: %s, and expected type in envbody: %s\n"
-                          uu____13885 uu____13887 uu____13889
+                          uu____13861 uu____13863 uu____13865
                       else ());
-                     (let uu____13896 =
+                     (let uu____13872 =
                         FStar_All.pipe_left
                           (FStar_TypeChecker_Env.debug env1)
                           (FStar_Options.Other "NYC") in
-                      if uu____13896
+                      if uu____13872
                       then
-                        let uu____13897 =
+                        let uu____13873 =
                           FStar_Syntax_Print.binders_to_string ", " bs1 in
-                        let uu____13898 =
+                        let uu____13874 =
                           FStar_TypeChecker_Rel.guard_to_string env1 g_env in
                         FStar_Util.print2
                           "!!!!!!!!!!!!!!!Guard for function with binders %s is %s\n"
-                          uu____13897 uu____13898
+                          uu____13873 uu____13874
                       else ());
                      (let envbody1 =
                         FStar_TypeChecker_Env.set_range envbody
                           body1.FStar_Syntax_Syntax.pos in
-                      let uu____13901 =
-                        let uu____13912 =
-                          let uu____13919 =
+                      let uu____13877 =
+                        let uu____13888 =
+                          let uu____13895 =
                             (FStar_All.pipe_right c_opt FStar_Util.is_some)
                               &&
-                              (let uu____13927 =
-                                 let uu____13928 =
+                              (let uu____13903 =
+                                 let uu____13904 =
                                    FStar_Syntax_Subst.compress body1 in
-                                 uu____13928.FStar_Syntax_Syntax.n in
-                               match uu____13927 with
+                                 uu____13904.FStar_Syntax_Syntax.n in
+                               match uu____13903 with
                                | FStar_Syntax_Syntax.Tm_app (head, args) when
                                    (FStar_List.length args) = Prims.int_one
                                    ->
-                                   let uu____13965 =
-                                     let uu____13966 =
+                                   let uu____13941 =
+                                     let uu____13942 =
                                        FStar_Syntax_Subst.compress head in
-                                     uu____13966.FStar_Syntax_Syntax.n in
-                                   (match uu____13965 with
+                                     uu____13942.FStar_Syntax_Syntax.n in
+                                   (match uu____13941 with
                                     | FStar_Syntax_Syntax.Tm_constant
                                         (FStar_Const.Const_reflect
-                                        uu____13969) -> true
-                                    | uu____13970 -> false)
-                               | uu____13971 -> false) in
-                          if uu____13919
+                                        uu____13945) -> true
+                                    | uu____13946 -> false)
+                               | uu____13947 -> false) in
+                          if uu____13895
                           then
-                            let uu____13978 =
-                              let uu____13979 =
+                            let uu____13954 =
+                              let uu____13955 =
                                 FStar_TypeChecker_Env.clear_expected_typ
                                   envbody1 in
-                              FStar_All.pipe_right uu____13979
+                              FStar_All.pipe_right uu____13955
                                 FStar_Pervasives_Native.fst in
-                            let uu____13994 =
-                              let uu____13995 =
-                                let uu____13996 =
-                                  let uu____14023 =
-                                    let uu____14040 =
-                                      let uu____14049 =
+                            let uu____13970 =
+                              let uu____13971 =
+                                let uu____13972 =
+                                  let uu____13999 =
+                                    let uu____14016 =
+                                      let uu____14025 =
                                         FStar_All.pipe_right c_opt
                                           FStar_Util.must in
-                                      FStar_Util.Inr uu____14049 in
-                                    (uu____14040,
+                                      FStar_Util.Inr uu____14025 in
+                                    (uu____14016,
                                       FStar_Pervasives_Native.None) in
-                                  (body1, uu____14023,
+                                  (body1, uu____13999,
                                     FStar_Pervasives_Native.None) in
-                                FStar_Syntax_Syntax.Tm_ascribed uu____13996 in
-                              FStar_Syntax_Syntax.mk uu____13995
+                                FStar_Syntax_Syntax.Tm_ascribed uu____13972 in
+                              FStar_Syntax_Syntax.mk uu____13971
                                 FStar_Range.dummyRange in
-                            (uu____13978, uu____13994, false)
+                            (uu____13954, uu____13970, false)
                           else
-                            (let uu____14095 =
-                               let uu____14096 =
-                                 let uu____14103 =
-                                   let uu____14104 =
+                            (let uu____14075 =
+                               let uu____14076 =
+                                 let uu____14083 =
+                                   let uu____14084 =
                                      FStar_Syntax_Subst.compress body1 in
-                                   uu____14104.FStar_Syntax_Syntax.n in
-                                 (c_opt, uu____14103) in
-                               match uu____14096 with
+                                   uu____14084.FStar_Syntax_Syntax.n in
+                                 (c_opt, uu____14083) in
+                               match uu____14076 with
                                | (FStar_Pervasives_Native.None,
                                   FStar_Syntax_Syntax.Tm_ascribed
-                                  (uu____14109,
-                                   (FStar_Util.Inr expected_c, uu____14111),
-                                   uu____14112)) -> false
-                               | uu____14161 -> true in
-                             (envbody1, body1, uu____14095)) in
-                        match uu____13912 with
+                                  (uu____14089,
+                                   (FStar_Util.Inr expected_c, uu____14091),
+                                   uu____14092)) -> false
+                               | uu____14141 -> true in
+                             (envbody1, body1, uu____14075)) in
+                        match uu____13888 with
                         | (envbody2, body2, should_check_expected_effect) ->
-                            let uu____14181 =
+                            let uu____14161 =
                               tc_term
-                                (let uu___2050_14190 = envbody2 in
+                                (let uu___2050_14170 = envbody2 in
                                  {
                                    FStar_TypeChecker_Env.solver =
-                                     (uu___2050_14190.FStar_TypeChecker_Env.solver);
+                                     (uu___2050_14170.FStar_TypeChecker_Env.solver);
                                    FStar_TypeChecker_Env.range =
-                                     (uu___2050_14190.FStar_TypeChecker_Env.range);
+                                     (uu___2050_14170.FStar_TypeChecker_Env.range);
                                    FStar_TypeChecker_Env.curmodule =
-                                     (uu___2050_14190.FStar_TypeChecker_Env.curmodule);
+                                     (uu___2050_14170.FStar_TypeChecker_Env.curmodule);
                                    FStar_TypeChecker_Env.gamma =
-                                     (uu___2050_14190.FStar_TypeChecker_Env.gamma);
+                                     (uu___2050_14170.FStar_TypeChecker_Env.gamma);
                                    FStar_TypeChecker_Env.gamma_sig =
-                                     (uu___2050_14190.FStar_TypeChecker_Env.gamma_sig);
+                                     (uu___2050_14170.FStar_TypeChecker_Env.gamma_sig);
                                    FStar_TypeChecker_Env.gamma_cache =
-                                     (uu___2050_14190.FStar_TypeChecker_Env.gamma_cache);
+                                     (uu___2050_14170.FStar_TypeChecker_Env.gamma_cache);
                                    FStar_TypeChecker_Env.modules =
-                                     (uu___2050_14190.FStar_TypeChecker_Env.modules);
+                                     (uu___2050_14170.FStar_TypeChecker_Env.modules);
                                    FStar_TypeChecker_Env.expected_typ =
-                                     (uu___2050_14190.FStar_TypeChecker_Env.expected_typ);
+                                     (uu___2050_14170.FStar_TypeChecker_Env.expected_typ);
                                    FStar_TypeChecker_Env.sigtab =
-                                     (uu___2050_14190.FStar_TypeChecker_Env.sigtab);
+                                     (uu___2050_14170.FStar_TypeChecker_Env.sigtab);
                                    FStar_TypeChecker_Env.attrtab =
-                                     (uu___2050_14190.FStar_TypeChecker_Env.attrtab);
+                                     (uu___2050_14170.FStar_TypeChecker_Env.attrtab);
                                    FStar_TypeChecker_Env.instantiate_imp =
-                                     (uu___2050_14190.FStar_TypeChecker_Env.instantiate_imp);
+                                     (uu___2050_14170.FStar_TypeChecker_Env.instantiate_imp);
                                    FStar_TypeChecker_Env.effects =
-                                     (uu___2050_14190.FStar_TypeChecker_Env.effects);
+                                     (uu___2050_14170.FStar_TypeChecker_Env.effects);
                                    FStar_TypeChecker_Env.generalize =
-                                     (uu___2050_14190.FStar_TypeChecker_Env.generalize);
+                                     (uu___2050_14170.FStar_TypeChecker_Env.generalize);
                                    FStar_TypeChecker_Env.letrecs =
-                                     (uu___2050_14190.FStar_TypeChecker_Env.letrecs);
+                                     (uu___2050_14170.FStar_TypeChecker_Env.letrecs);
                                    FStar_TypeChecker_Env.top_level = false;
                                    FStar_TypeChecker_Env.check_uvars =
-                                     (uu___2050_14190.FStar_TypeChecker_Env.check_uvars);
+                                     (uu___2050_14170.FStar_TypeChecker_Env.check_uvars);
                                    FStar_TypeChecker_Env.use_eq = use_eq;
                                    FStar_TypeChecker_Env.use_eq_strict =
-                                     (uu___2050_14190.FStar_TypeChecker_Env.use_eq_strict);
+                                     (uu___2050_14170.FStar_TypeChecker_Env.use_eq_strict);
                                    FStar_TypeChecker_Env.is_iface =
-                                     (uu___2050_14190.FStar_TypeChecker_Env.is_iface);
+                                     (uu___2050_14170.FStar_TypeChecker_Env.is_iface);
                                    FStar_TypeChecker_Env.admit =
-                                     (uu___2050_14190.FStar_TypeChecker_Env.admit);
+                                     (uu___2050_14170.FStar_TypeChecker_Env.admit);
                                    FStar_TypeChecker_Env.lax =
-                                     (uu___2050_14190.FStar_TypeChecker_Env.lax);
+                                     (uu___2050_14170.FStar_TypeChecker_Env.lax);
                                    FStar_TypeChecker_Env.lax_universes =
-                                     (uu___2050_14190.FStar_TypeChecker_Env.lax_universes);
+                                     (uu___2050_14170.FStar_TypeChecker_Env.lax_universes);
                                    FStar_TypeChecker_Env.phase1 =
-                                     (uu___2050_14190.FStar_TypeChecker_Env.phase1);
+                                     (uu___2050_14170.FStar_TypeChecker_Env.phase1);
                                    FStar_TypeChecker_Env.failhard =
-                                     (uu___2050_14190.FStar_TypeChecker_Env.failhard);
+                                     (uu___2050_14170.FStar_TypeChecker_Env.failhard);
                                    FStar_TypeChecker_Env.nosynth =
-                                     (uu___2050_14190.FStar_TypeChecker_Env.nosynth);
+                                     (uu___2050_14170.FStar_TypeChecker_Env.nosynth);
                                    FStar_TypeChecker_Env.uvar_subtyping =
-                                     (uu___2050_14190.FStar_TypeChecker_Env.uvar_subtyping);
+                                     (uu___2050_14170.FStar_TypeChecker_Env.uvar_subtyping);
                                    FStar_TypeChecker_Env.tc_term =
-                                     (uu___2050_14190.FStar_TypeChecker_Env.tc_term);
+                                     (uu___2050_14170.FStar_TypeChecker_Env.tc_term);
                                    FStar_TypeChecker_Env.type_of =
-                                     (uu___2050_14190.FStar_TypeChecker_Env.type_of);
+                                     (uu___2050_14170.FStar_TypeChecker_Env.type_of);
                                    FStar_TypeChecker_Env.universe_of =
-                                     (uu___2050_14190.FStar_TypeChecker_Env.universe_of);
+                                     (uu___2050_14170.FStar_TypeChecker_Env.universe_of);
                                    FStar_TypeChecker_Env.check_type_of =
-                                     (uu___2050_14190.FStar_TypeChecker_Env.check_type_of);
+                                     (uu___2050_14170.FStar_TypeChecker_Env.check_type_of);
                                    FStar_TypeChecker_Env.use_bv_sorts =
-                                     (uu___2050_14190.FStar_TypeChecker_Env.use_bv_sorts);
+                                     (uu___2050_14170.FStar_TypeChecker_Env.use_bv_sorts);
                                    FStar_TypeChecker_Env.qtbl_name_and_index
                                      =
-                                     (uu___2050_14190.FStar_TypeChecker_Env.qtbl_name_and_index);
+                                     (uu___2050_14170.FStar_TypeChecker_Env.qtbl_name_and_index);
                                    FStar_TypeChecker_Env.normalized_eff_names
                                      =
-                                     (uu___2050_14190.FStar_TypeChecker_Env.normalized_eff_names);
+                                     (uu___2050_14170.FStar_TypeChecker_Env.normalized_eff_names);
                                    FStar_TypeChecker_Env.fv_delta_depths =
-                                     (uu___2050_14190.FStar_TypeChecker_Env.fv_delta_depths);
+                                     (uu___2050_14170.FStar_TypeChecker_Env.fv_delta_depths);
                                    FStar_TypeChecker_Env.proof_ns =
-                                     (uu___2050_14190.FStar_TypeChecker_Env.proof_ns);
+                                     (uu___2050_14170.FStar_TypeChecker_Env.proof_ns);
                                    FStar_TypeChecker_Env.synth_hook =
-                                     (uu___2050_14190.FStar_TypeChecker_Env.synth_hook);
+                                     (uu___2050_14170.FStar_TypeChecker_Env.synth_hook);
                                    FStar_TypeChecker_Env.try_solve_implicits_hook
                                      =
-                                     (uu___2050_14190.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                                     (uu___2050_14170.FStar_TypeChecker_Env.try_solve_implicits_hook);
                                    FStar_TypeChecker_Env.splice =
-                                     (uu___2050_14190.FStar_TypeChecker_Env.splice);
+                                     (uu___2050_14170.FStar_TypeChecker_Env.splice);
                                    FStar_TypeChecker_Env.mpreprocess =
-                                     (uu___2050_14190.FStar_TypeChecker_Env.mpreprocess);
+                                     (uu___2050_14170.FStar_TypeChecker_Env.mpreprocess);
                                    FStar_TypeChecker_Env.postprocess =
-                                     (uu___2050_14190.FStar_TypeChecker_Env.postprocess);
+                                     (uu___2050_14170.FStar_TypeChecker_Env.postprocess);
                                    FStar_TypeChecker_Env.identifier_info =
-                                     (uu___2050_14190.FStar_TypeChecker_Env.identifier_info);
+                                     (uu___2050_14170.FStar_TypeChecker_Env.identifier_info);
                                    FStar_TypeChecker_Env.tc_hooks =
-                                     (uu___2050_14190.FStar_TypeChecker_Env.tc_hooks);
+                                     (uu___2050_14170.FStar_TypeChecker_Env.tc_hooks);
                                    FStar_TypeChecker_Env.dsenv =
-                                     (uu___2050_14190.FStar_TypeChecker_Env.dsenv);
+                                     (uu___2050_14170.FStar_TypeChecker_Env.dsenv);
                                    FStar_TypeChecker_Env.nbe =
-                                     (uu___2050_14190.FStar_TypeChecker_Env.nbe);
+                                     (uu___2050_14170.FStar_TypeChecker_Env.nbe);
                                    FStar_TypeChecker_Env.strict_args_tab =
-                                     (uu___2050_14190.FStar_TypeChecker_Env.strict_args_tab);
+                                     (uu___2050_14170.FStar_TypeChecker_Env.strict_args_tab);
                                    FStar_TypeChecker_Env.erasable_types_tab =
-                                     (uu___2050_14190.FStar_TypeChecker_Env.erasable_types_tab);
+                                     (uu___2050_14170.FStar_TypeChecker_Env.erasable_types_tab);
                                    FStar_TypeChecker_Env.enable_defer_to_tac
                                      =
-                                     (uu___2050_14190.FStar_TypeChecker_Env.enable_defer_to_tac)
+                                     (uu___2050_14170.FStar_TypeChecker_Env.enable_defer_to_tac)
                                  }) body2 in
-                            (match uu____14181 with
+                            (match uu____14161 with
                              | (body3, cbody, guard_body) ->
                                  let guard_body1 =
                                    FStar_TypeChecker_Rel.solve_deferred_constraints
                                      envbody2 guard_body in
                                  if should_check_expected_effect
                                  then
-                                   let uu____14215 =
+                                   let uu____14195 =
                                      FStar_TypeChecker_Common.lcomp_comp
                                        cbody in
-                                   (match uu____14215 with
+                                   (match uu____14195 with
                                     | (cbody1, g_lc) ->
-                                        let uu____14232 =
+                                        let uu____14212 =
                                           check_expected_effect
-                                            (let uu___2061_14241 = envbody2 in
+                                            (let uu___2061_14221 = envbody2 in
                                              {
                                                FStar_TypeChecker_Env.solver =
-                                                 (uu___2061_14241.FStar_TypeChecker_Env.solver);
+                                                 (uu___2061_14221.FStar_TypeChecker_Env.solver);
                                                FStar_TypeChecker_Env.range =
-                                                 (uu___2061_14241.FStar_TypeChecker_Env.range);
+                                                 (uu___2061_14221.FStar_TypeChecker_Env.range);
                                                FStar_TypeChecker_Env.curmodule
                                                  =
-                                                 (uu___2061_14241.FStar_TypeChecker_Env.curmodule);
+                                                 (uu___2061_14221.FStar_TypeChecker_Env.curmodule);
                                                FStar_TypeChecker_Env.gamma =
-                                                 (uu___2061_14241.FStar_TypeChecker_Env.gamma);
+                                                 (uu___2061_14221.FStar_TypeChecker_Env.gamma);
                                                FStar_TypeChecker_Env.gamma_sig
                                                  =
-                                                 (uu___2061_14241.FStar_TypeChecker_Env.gamma_sig);
+                                                 (uu___2061_14221.FStar_TypeChecker_Env.gamma_sig);
                                                FStar_TypeChecker_Env.gamma_cache
                                                  =
-                                                 (uu___2061_14241.FStar_TypeChecker_Env.gamma_cache);
+                                                 (uu___2061_14221.FStar_TypeChecker_Env.gamma_cache);
                                                FStar_TypeChecker_Env.modules
                                                  =
-                                                 (uu___2061_14241.FStar_TypeChecker_Env.modules);
+                                                 (uu___2061_14221.FStar_TypeChecker_Env.modules);
                                                FStar_TypeChecker_Env.expected_typ
                                                  =
-                                                 (uu___2061_14241.FStar_TypeChecker_Env.expected_typ);
+                                                 (uu___2061_14221.FStar_TypeChecker_Env.expected_typ);
                                                FStar_TypeChecker_Env.sigtab =
-                                                 (uu___2061_14241.FStar_TypeChecker_Env.sigtab);
+                                                 (uu___2061_14221.FStar_TypeChecker_Env.sigtab);
                                                FStar_TypeChecker_Env.attrtab
                                                  =
-                                                 (uu___2061_14241.FStar_TypeChecker_Env.attrtab);
+                                                 (uu___2061_14221.FStar_TypeChecker_Env.attrtab);
                                                FStar_TypeChecker_Env.instantiate_imp
                                                  =
-                                                 (uu___2061_14241.FStar_TypeChecker_Env.instantiate_imp);
+                                                 (uu___2061_14221.FStar_TypeChecker_Env.instantiate_imp);
                                                FStar_TypeChecker_Env.effects
                                                  =
-                                                 (uu___2061_14241.FStar_TypeChecker_Env.effects);
+                                                 (uu___2061_14221.FStar_TypeChecker_Env.effects);
                                                FStar_TypeChecker_Env.generalize
                                                  =
-                                                 (uu___2061_14241.FStar_TypeChecker_Env.generalize);
+                                                 (uu___2061_14221.FStar_TypeChecker_Env.generalize);
                                                FStar_TypeChecker_Env.letrecs
                                                  =
-                                                 (uu___2061_14241.FStar_TypeChecker_Env.letrecs);
+                                                 (uu___2061_14221.FStar_TypeChecker_Env.letrecs);
                                                FStar_TypeChecker_Env.top_level
                                                  =
-                                                 (uu___2061_14241.FStar_TypeChecker_Env.top_level);
+                                                 (uu___2061_14221.FStar_TypeChecker_Env.top_level);
                                                FStar_TypeChecker_Env.check_uvars
                                                  =
-                                                 (uu___2061_14241.FStar_TypeChecker_Env.check_uvars);
+                                                 (uu___2061_14221.FStar_TypeChecker_Env.check_uvars);
                                                FStar_TypeChecker_Env.use_eq =
                                                  use_eq;
                                                FStar_TypeChecker_Env.use_eq_strict
                                                  =
-                                                 (uu___2061_14241.FStar_TypeChecker_Env.use_eq_strict);
+                                                 (uu___2061_14221.FStar_TypeChecker_Env.use_eq_strict);
                                                FStar_TypeChecker_Env.is_iface
                                                  =
-                                                 (uu___2061_14241.FStar_TypeChecker_Env.is_iface);
+                                                 (uu___2061_14221.FStar_TypeChecker_Env.is_iface);
                                                FStar_TypeChecker_Env.admit =
-                                                 (uu___2061_14241.FStar_TypeChecker_Env.admit);
+                                                 (uu___2061_14221.FStar_TypeChecker_Env.admit);
                                                FStar_TypeChecker_Env.lax =
-                                                 (uu___2061_14241.FStar_TypeChecker_Env.lax);
+                                                 (uu___2061_14221.FStar_TypeChecker_Env.lax);
                                                FStar_TypeChecker_Env.lax_universes
                                                  =
-                                                 (uu___2061_14241.FStar_TypeChecker_Env.lax_universes);
+                                                 (uu___2061_14221.FStar_TypeChecker_Env.lax_universes);
                                                FStar_TypeChecker_Env.phase1 =
-                                                 (uu___2061_14241.FStar_TypeChecker_Env.phase1);
+                                                 (uu___2061_14221.FStar_TypeChecker_Env.phase1);
                                                FStar_TypeChecker_Env.failhard
                                                  =
-                                                 (uu___2061_14241.FStar_TypeChecker_Env.failhard);
+                                                 (uu___2061_14221.FStar_TypeChecker_Env.failhard);
                                                FStar_TypeChecker_Env.nosynth
                                                  =
-                                                 (uu___2061_14241.FStar_TypeChecker_Env.nosynth);
+                                                 (uu___2061_14221.FStar_TypeChecker_Env.nosynth);
                                                FStar_TypeChecker_Env.uvar_subtyping
                                                  =
-                                                 (uu___2061_14241.FStar_TypeChecker_Env.uvar_subtyping);
+                                                 (uu___2061_14221.FStar_TypeChecker_Env.uvar_subtyping);
                                                FStar_TypeChecker_Env.tc_term
                                                  =
-                                                 (uu___2061_14241.FStar_TypeChecker_Env.tc_term);
+                                                 (uu___2061_14221.FStar_TypeChecker_Env.tc_term);
                                                FStar_TypeChecker_Env.type_of
                                                  =
-                                                 (uu___2061_14241.FStar_TypeChecker_Env.type_of);
+                                                 (uu___2061_14221.FStar_TypeChecker_Env.type_of);
                                                FStar_TypeChecker_Env.universe_of
                                                  =
-                                                 (uu___2061_14241.FStar_TypeChecker_Env.universe_of);
+                                                 (uu___2061_14221.FStar_TypeChecker_Env.universe_of);
                                                FStar_TypeChecker_Env.check_type_of
                                                  =
-                                                 (uu___2061_14241.FStar_TypeChecker_Env.check_type_of);
+                                                 (uu___2061_14221.FStar_TypeChecker_Env.check_type_of);
                                                FStar_TypeChecker_Env.use_bv_sorts
                                                  =
-                                                 (uu___2061_14241.FStar_TypeChecker_Env.use_bv_sorts);
+                                                 (uu___2061_14221.FStar_TypeChecker_Env.use_bv_sorts);
                                                FStar_TypeChecker_Env.qtbl_name_and_index
                                                  =
-                                                 (uu___2061_14241.FStar_TypeChecker_Env.qtbl_name_and_index);
+                                                 (uu___2061_14221.FStar_TypeChecker_Env.qtbl_name_and_index);
                                                FStar_TypeChecker_Env.normalized_eff_names
                                                  =
-                                                 (uu___2061_14241.FStar_TypeChecker_Env.normalized_eff_names);
+                                                 (uu___2061_14221.FStar_TypeChecker_Env.normalized_eff_names);
                                                FStar_TypeChecker_Env.fv_delta_depths
                                                  =
-                                                 (uu___2061_14241.FStar_TypeChecker_Env.fv_delta_depths);
+                                                 (uu___2061_14221.FStar_TypeChecker_Env.fv_delta_depths);
                                                FStar_TypeChecker_Env.proof_ns
                                                  =
-                                                 (uu___2061_14241.FStar_TypeChecker_Env.proof_ns);
+                                                 (uu___2061_14221.FStar_TypeChecker_Env.proof_ns);
                                                FStar_TypeChecker_Env.synth_hook
                                                  =
-                                                 (uu___2061_14241.FStar_TypeChecker_Env.synth_hook);
+                                                 (uu___2061_14221.FStar_TypeChecker_Env.synth_hook);
                                                FStar_TypeChecker_Env.try_solve_implicits_hook
                                                  =
-                                                 (uu___2061_14241.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                                                 (uu___2061_14221.FStar_TypeChecker_Env.try_solve_implicits_hook);
                                                FStar_TypeChecker_Env.splice =
-                                                 (uu___2061_14241.FStar_TypeChecker_Env.splice);
+                                                 (uu___2061_14221.FStar_TypeChecker_Env.splice);
                                                FStar_TypeChecker_Env.mpreprocess
                                                  =
-                                                 (uu___2061_14241.FStar_TypeChecker_Env.mpreprocess);
+                                                 (uu___2061_14221.FStar_TypeChecker_Env.mpreprocess);
                                                FStar_TypeChecker_Env.postprocess
                                                  =
-                                                 (uu___2061_14241.FStar_TypeChecker_Env.postprocess);
+                                                 (uu___2061_14221.FStar_TypeChecker_Env.postprocess);
                                                FStar_TypeChecker_Env.identifier_info
                                                  =
-                                                 (uu___2061_14241.FStar_TypeChecker_Env.identifier_info);
+                                                 (uu___2061_14221.FStar_TypeChecker_Env.identifier_info);
                                                FStar_TypeChecker_Env.tc_hooks
                                                  =
-                                                 (uu___2061_14241.FStar_TypeChecker_Env.tc_hooks);
+                                                 (uu___2061_14221.FStar_TypeChecker_Env.tc_hooks);
                                                FStar_TypeChecker_Env.dsenv =
-                                                 (uu___2061_14241.FStar_TypeChecker_Env.dsenv);
+                                                 (uu___2061_14221.FStar_TypeChecker_Env.dsenv);
                                                FStar_TypeChecker_Env.nbe =
-                                                 (uu___2061_14241.FStar_TypeChecker_Env.nbe);
+                                                 (uu___2061_14221.FStar_TypeChecker_Env.nbe);
                                                FStar_TypeChecker_Env.strict_args_tab
                                                  =
-                                                 (uu___2061_14241.FStar_TypeChecker_Env.strict_args_tab);
+                                                 (uu___2061_14221.FStar_TypeChecker_Env.strict_args_tab);
                                                FStar_TypeChecker_Env.erasable_types_tab
                                                  =
-                                                 (uu___2061_14241.FStar_TypeChecker_Env.erasable_types_tab);
+                                                 (uu___2061_14221.FStar_TypeChecker_Env.erasable_types_tab);
                                                FStar_TypeChecker_Env.enable_defer_to_tac
                                                  =
-                                                 (uu___2061_14241.FStar_TypeChecker_Env.enable_defer_to_tac)
+                                                 (uu___2061_14221.FStar_TypeChecker_Env.enable_defer_to_tac)
                                              }) c_opt (body3, cbody1) in
-                                        (match uu____14232 with
+                                        (match uu____14212 with
                                          | (body4, cbody2, guard) ->
-                                             let uu____14255 =
-                                               let uu____14256 =
+                                             let uu____14235 =
+                                               let uu____14236 =
                                                  FStar_TypeChecker_Env.conj_guard
                                                    g_lc guard in
                                                FStar_TypeChecker_Env.conj_guard
-                                                 guard_body1 uu____14256 in
-                                             (body4, cbody2, uu____14255)))
+                                                 guard_body1 uu____14236 in
+                                             (body4, cbody2, uu____14235)))
                                  else
-                                   (let uu____14262 =
+                                   (let uu____14242 =
                                       FStar_TypeChecker_Common.lcomp_comp
                                         cbody in
-                                    match uu____14262 with
+                                    match uu____14242 with
                                     | (cbody1, g_lc) ->
-                                        let uu____14279 =
+                                        let uu____14259 =
                                           FStar_TypeChecker_Env.conj_guard
                                             guard_body1 g_lc in
-                                        (body3, cbody1, uu____14279))) in
-                      match uu____13901 with
+                                        (body3, cbody1, uu____14259))) in
+                      match uu____13877 with
                       | (body2, cbody, guard_body) ->
                           let guard =
-                            let uu____14302 =
+                            let uu____14282 =
                               env1.FStar_TypeChecker_Env.top_level ||
-                                (let uu____14304 =
+                                (let uu____14284 =
                                    FStar_TypeChecker_Env.should_verify env1 in
-                                 Prims.op_Negation uu____14304) in
-                            if uu____14302
+                                 Prims.op_Negation uu____14284) in
+                            if uu____14282
                             then
-                              let uu____14305 =
+                              let uu____14285 =
                                 FStar_TypeChecker_Rel.discharge_guard env1
                                   g_env in
-                              let uu____14306 =
+                              let uu____14286 =
                                 FStar_TypeChecker_Rel.discharge_guard
                                   envbody1 guard_body in
-                              FStar_TypeChecker_Env.conj_guard uu____14305
-                                uu____14306
+                              FStar_TypeChecker_Env.conj_guard uu____14285
+                                uu____14286
                             else
                               (let guard =
-                                 let uu____14309 =
+                                 let uu____14289 =
                                    FStar_TypeChecker_Env.close_guard env1
                                      (FStar_List.append bs1 letrec_binders)
                                      guard_body in
                                  FStar_TypeChecker_Env.conj_guard g_env
-                                   uu____14309 in
+                                   uu____14289 in
                                guard) in
                           let guard1 =
                             FStar_TypeChecker_Util.close_guard_implicits env1
@@ -5096,7 +5096,7 @@ and (tc_abs :
                               (FStar_Pervasives_Native.Some
                                  (FStar_Syntax_Util.residual_comp_of_comp
                                     (FStar_Util.dflt cbody c_opt))) in
-                          let uu____14323 =
+                          let uu____14303 =
                             match tfun_opt with
                             | FStar_Pervasives_Native.Some t ->
                                 let t1 = FStar_Syntax_Subst.compress t in
@@ -5107,36 +5107,36 @@ and (tc_abs :
                                       failwith
                                         "Impossible! tc_abs: if tfun_computed is Some, expected topt to also be Some" in
                                 (match t1.FStar_Syntax_Syntax.n with
-                                 | FStar_Syntax_Syntax.Tm_arrow uu____14346
+                                 | FStar_Syntax_Syntax.Tm_arrow uu____14326
                                      -> (e, t_annot, guard1)
-                                 | uu____14361 ->
+                                 | uu____14341 ->
                                      let lc =
-                                       let uu____14363 =
+                                       let uu____14343 =
                                          FStar_Syntax_Syntax.mk_Total
                                            tfun_computed in
-                                       FStar_All.pipe_right uu____14363
+                                       FStar_All.pipe_right uu____14343
                                          FStar_TypeChecker_Common.lcomp_of_comp in
-                                     let uu____14364 =
+                                     let uu____14344 =
                                        FStar_TypeChecker_Util.check_has_type
                                          env1 e lc t1 in
-                                     (match uu____14364 with
-                                      | (e1, uu____14378, guard') ->
-                                          let uu____14380 =
+                                     (match uu____14344 with
+                                      | (e1, uu____14358, guard') ->
+                                          let uu____14360 =
                                             FStar_TypeChecker_Env.conj_guard
                                               guard1 guard' in
-                                          (e1, t_annot, uu____14380)))
+                                          (e1, t_annot, uu____14360)))
                             | FStar_Pervasives_Native.None ->
                                 (e, tfun_computed, guard1) in
-                          (match uu____14323 with
+                          (match uu____14303 with
                            | (e1, tfun, guard2) ->
                                let c = FStar_Syntax_Syntax.mk_Total tfun in
-                               let uu____14391 =
-                                 let uu____14396 =
+                               let uu____14371 =
+                                 let uu____14376 =
                                    FStar_TypeChecker_Common.lcomp_of_comp c in
                                  FStar_TypeChecker_Util.strengthen_precondition
                                    FStar_Pervasives_Native.None env1 e1
-                                   uu____14396 guard2 in
-                               (match uu____14391 with
+                                   uu____14376 guard2 in
+                               (match uu____14371 with
                                 | (c1, g) -> (e1, c1, g)))))))
 and (check_application_args :
   FStar_TypeChecker_Env.env ->
@@ -5159,82 +5159,82 @@ and (check_application_args :
               let n_args = FStar_List.length args in
               let r = FStar_TypeChecker_Env.get_range env in
               let thead = FStar_Syntax_Util.comp_result chead in
-              (let uu____14446 =
+              (let uu____14426 =
                  FStar_TypeChecker_Env.debug env FStar_Options.High in
-               if uu____14446
+               if uu____14426
                then
-                 let uu____14447 =
+                 let uu____14427 =
                    FStar_Range.string_of_range head.FStar_Syntax_Syntax.pos in
-                 let uu____14448 = FStar_Syntax_Print.term_to_string thead in
-                 FStar_Util.print2 "(%s) Type of head is %s\n" uu____14447
-                   uu____14448
+                 let uu____14428 = FStar_Syntax_Print.term_to_string thead in
+                 FStar_Util.print2 "(%s) Type of head is %s\n" uu____14427
+                   uu____14428
                else ());
-              (let monadic_application uu____14527 subst arg_comps_rev
+              (let monadic_application uu____14507 subst arg_comps_rev
                  arg_rets_rev guard fvs bs =
-                 match uu____14527 with
+                 match uu____14507 with
                  | (head1, chead1, ghead1, cres) ->
-                     let uu____14596 =
+                     let uu____14576 =
                        check_no_escape (FStar_Pervasives_Native.Some head1)
                          env fvs (FStar_Syntax_Util.comp_result cres) in
-                     (match uu____14596 with
+                     (match uu____14576 with
                       | (rt, g0) ->
                           let cres1 =
                             FStar_Syntax_Util.set_result_typ cres rt in
-                          let uu____14610 =
+                          let uu____14590 =
                             match bs with
                             | [] ->
                                 let g =
-                                  let uu____14626 =
+                                  let uu____14606 =
                                     FStar_TypeChecker_Env.conj_guard ghead1
                                       guard in
                                   FStar_All.pipe_left
                                     (FStar_TypeChecker_Env.conj_guard g0)
-                                    uu____14626 in
+                                    uu____14606 in
                                 (cres1, g)
-                            | uu____14627 ->
+                            | uu____14607 ->
                                 let g =
-                                  let uu____14637 =
-                                    let uu____14638 =
+                                  let uu____14617 =
+                                    let uu____14618 =
                                       FStar_TypeChecker_Env.conj_guard ghead1
                                         guard in
-                                    FStar_All.pipe_right uu____14638
+                                    FStar_All.pipe_right uu____14618
                                       (FStar_TypeChecker_Rel.solve_deferred_constraints
                                          env) in
                                   FStar_TypeChecker_Env.conj_guard g0
-                                    uu____14637 in
-                                let uu____14639 =
-                                  let uu____14640 =
+                                    uu____14617 in
+                                let uu____14619 =
+                                  let uu____14620 =
                                     FStar_Syntax_Util.arrow bs cres1 in
-                                  FStar_Syntax_Syntax.mk_Total uu____14640 in
-                                (uu____14639, g) in
-                          (match uu____14610 with
+                                  FStar_Syntax_Syntax.mk_Total uu____14620 in
+                                (uu____14619, g) in
+                          (match uu____14590 with
                            | (cres2, guard1) ->
-                               ((let uu____14650 =
+                               ((let uu____14630 =
                                    FStar_TypeChecker_Env.debug env
                                      FStar_Options.Medium in
-                                 if uu____14650
+                                 if uu____14630
                                  then
-                                   let uu____14651 =
+                                   let uu____14631 =
                                      FStar_Syntax_Print.comp_to_string cres2 in
                                    FStar_Util.print1
                                      "\t Type of result cres is %s\n"
-                                     uu____14651
+                                     uu____14631
                                  else ());
-                                (let uu____14653 =
-                                   let uu____14658 =
-                                     let uu____14659 =
+                                (let uu____14633 =
+                                   let uu____14638 =
+                                     let uu____14639 =
                                        FStar_Syntax_Subst.subst_comp subst
                                          chead1 in
-                                     FStar_All.pipe_right uu____14659
+                                     FStar_All.pipe_right uu____14639
                                        FStar_TypeChecker_Common.lcomp_of_comp in
-                                   let uu____14660 =
-                                     let uu____14661 =
+                                   let uu____14640 =
+                                     let uu____14641 =
                                        FStar_Syntax_Subst.subst_comp subst
                                          cres2 in
-                                     FStar_All.pipe_right uu____14661
+                                     FStar_All.pipe_right uu____14641
                                        FStar_TypeChecker_Common.lcomp_of_comp in
-                                   (uu____14658, uu____14660) in
-                                 match uu____14653 with
+                                   (uu____14638, uu____14640) in
+                                 match uu____14633 with
                                  | (chead2, cres3) ->
                                      let cres4 =
                                        let head_is_pure_and_some_arg_is_effectful
@@ -5243,15 +5243,15 @@ and (check_application_args :
                                             chead2)
                                            &&
                                            (FStar_Util.for_some
-                                              (fun uu____14684 ->
-                                                 match uu____14684 with
-                                                 | (uu____14693, uu____14694,
+                                              (fun uu____14664 ->
+                                                 match uu____14664 with
+                                                 | (uu____14673, uu____14674,
                                                     lc) ->
-                                                     (let uu____14702 =
+                                                     (let uu____14682 =
                                                         FStar_TypeChecker_Common.is_pure_or_ghost_lcomp
                                                           lc in
                                                       Prims.op_Negation
-                                                        uu____14702)
+                                                        uu____14682)
                                                        ||
                                                        (FStar_TypeChecker_Util.should_not_inline_lc
                                                           lc)) arg_comps_rev) in
@@ -5259,54 +5259,54 @@ and (check_application_args :
                                          FStar_Syntax_Syntax.mk_Tm_app head1
                                            (FStar_List.rev arg_rets_rev)
                                            head1.FStar_Syntax_Syntax.pos in
-                                       let uu____14712 =
+                                       let uu____14692 =
                                          (FStar_TypeChecker_Common.is_pure_or_ghost_lcomp
                                             cres3)
                                            &&
                                            head_is_pure_and_some_arg_is_effectful in
-                                       if uu____14712
+                                       if uu____14692
                                        then
-                                         ((let uu____14714 =
+                                         ((let uu____14694 =
                                              FStar_TypeChecker_Env.debug env
                                                FStar_Options.Extreme in
-                                           if uu____14714
+                                           if uu____14694
                                            then
-                                             let uu____14715 =
+                                             let uu____14695 =
                                                FStar_Syntax_Print.term_to_string
                                                  term in
                                              FStar_Util.print1
                                                "(a) Monadic app: Return inserted in monadic application: %s\n"
-                                               uu____14715
+                                               uu____14695
                                            else ());
                                           FStar_TypeChecker_Util.maybe_assume_result_eq_pure_term
                                             env term cres3)
                                        else
-                                         ((let uu____14719 =
+                                         ((let uu____14699 =
                                              FStar_TypeChecker_Env.debug env
                                                FStar_Options.Extreme in
-                                           if uu____14719
+                                           if uu____14699
                                            then
-                                             let uu____14720 =
+                                             let uu____14700 =
                                                FStar_Syntax_Print.term_to_string
                                                  term in
                                              FStar_Util.print1
                                                "(a) Monadic app: No return inserted in monadic application: %s\n"
-                                               uu____14720
+                                               uu____14700
                                            else ());
                                           cres3) in
                                      let comp =
                                        FStar_List.fold_left
                                          (fun out_c ->
-                                            fun uu____14748 ->
-                                              match uu____14748 with
+                                            fun uu____14728 ->
+                                              match uu____14728 with
                                               | ((e, q), x, c) ->
-                                                  ((let uu____14790 =
+                                                  ((let uu____14770 =
                                                       FStar_TypeChecker_Env.debug
                                                         env
                                                         FStar_Options.Extreme in
-                                                    if uu____14790
+                                                    if uu____14770
                                                     then
-                                                      let uu____14791 =
+                                                      let uu____14771 =
                                                         match x with
                                                         | FStar_Pervasives_Native.None
                                                             -> "_"
@@ -5314,22 +5314,22 @@ and (check_application_args :
                                                             x1 ->
                                                             FStar_Syntax_Print.bv_to_string
                                                               x1 in
-                                                      let uu____14793 =
+                                                      let uu____14773 =
                                                         FStar_Syntax_Print.term_to_string
                                                           e in
-                                                      let uu____14794 =
+                                                      let uu____14774 =
                                                         FStar_TypeChecker_Common.lcomp_to_string
                                                           c in
                                                       FStar_Util.print3
                                                         "(b) Monadic app: Binding argument %s : %s of type (%s)\n"
-                                                        uu____14791
-                                                        uu____14793
-                                                        uu____14794
+                                                        uu____14771
+                                                        uu____14773
+                                                        uu____14774
                                                     else ());
-                                                   (let uu____14796 =
+                                                   (let uu____14776 =
                                                       FStar_TypeChecker_Common.is_pure_or_ghost_lcomp
                                                         c in
-                                                    if uu____14796
+                                                    if uu____14776
                                                     then
                                                       FStar_TypeChecker_Util.bind
                                                         e.FStar_Syntax_Syntax.pos
@@ -5344,22 +5344,22 @@ and (check_application_args :
                                                         c (x, out_c)))) cres4
                                          arg_comps_rev in
                                      let comp1 =
-                                       (let uu____14804 =
+                                       (let uu____14784 =
                                           FStar_TypeChecker_Env.debug env
                                             FStar_Options.Extreme in
-                                        if uu____14804
+                                        if uu____14784
                                         then
-                                          let uu____14805 =
+                                          let uu____14785 =
                                             FStar_Syntax_Print.term_to_string
                                               head1 in
                                           FStar_Util.print1
                                             "(c) Monadic app: Binding head %s\n"
-                                            uu____14805
+                                            uu____14785
                                         else ());
-                                       (let uu____14807 =
+                                       (let uu____14787 =
                                           FStar_TypeChecker_Common.is_pure_or_ghost_lcomp
                                             chead2 in
-                                        if uu____14807
+                                        if uu____14787
                                         then
                                           FStar_TypeChecker_Util.bind
                                             head1.FStar_Syntax_Syntax.pos env
@@ -5375,28 +5375,28 @@ and (check_application_args :
                                             (FStar_Pervasives_Native.None,
                                               comp)) in
                                      let shortcuts_evaluation_order =
-                                       let uu____14814 =
-                                         let uu____14815 =
+                                       let uu____14794 =
+                                         let uu____14795 =
                                            FStar_Syntax_Subst.compress head1 in
-                                         uu____14815.FStar_Syntax_Syntax.n in
-                                       match uu____14814 with
+                                         uu____14795.FStar_Syntax_Syntax.n in
+                                       match uu____14794 with
                                        | FStar_Syntax_Syntax.Tm_fvar fv ->
                                            (FStar_Syntax_Syntax.fv_eq_lid fv
                                               FStar_Parser_Const.op_And)
                                              ||
                                              (FStar_Syntax_Syntax.fv_eq_lid
                                                 fv FStar_Parser_Const.op_Or)
-                                       | uu____14819 -> false in
+                                       | uu____14799 -> false in
                                      let app =
                                        if shortcuts_evaluation_order
                                        then
                                          let args1 =
                                            FStar_List.fold_left
                                              (fun args1 ->
-                                                fun uu____14840 ->
-                                                  match uu____14840 with
-                                                  | (arg, uu____14854,
-                                                     uu____14855) -> arg ::
+                                                fun uu____14820 ->
+                                                  match uu____14820 with
+                                                  | (arg, uu____14834,
+                                                     uu____14835) -> arg ::
                                                       args1) [] arg_comps_rev in
                                          let app =
                                            FStar_Syntax_Syntax.mk_Tm_app
@@ -5412,37 +5412,37 @@ and (check_application_args :
                                            comp1.FStar_TypeChecker_Common.eff_name
                                            comp1.FStar_TypeChecker_Common.res_typ
                                        else
-                                         (let uu____14863 =
-                                            let map_fun uu____14929 =
-                                              match uu____14929 with
-                                              | ((e, q), uu____14970, c) ->
-                                                  ((let uu____14993 =
+                                         (let uu____14843 =
+                                            let map_fun uu____14909 =
+                                              match uu____14909 with
+                                              | ((e, q), uu____14950, c) ->
+                                                  ((let uu____14973 =
                                                       FStar_TypeChecker_Env.debug
                                                         env
                                                         FStar_Options.Extreme in
-                                                    if uu____14993
+                                                    if uu____14973
                                                     then
-                                                      let uu____14994 =
+                                                      let uu____14974 =
                                                         FStar_Syntax_Print.term_to_string
                                                           e in
-                                                      let uu____14995 =
+                                                      let uu____14975 =
                                                         FStar_TypeChecker_Common.lcomp_to_string
                                                           c in
                                                       FStar_Util.print2
                                                         "For arg e=(%s) c=(%s)... "
-                                                        uu____14994
-                                                        uu____14995
+                                                        uu____14974
+                                                        uu____14975
                                                     else ());
-                                                   (let uu____14997 =
+                                                   (let uu____14977 =
                                                       FStar_TypeChecker_Common.is_pure_or_ghost_lcomp
                                                         c in
-                                                    if uu____14997
+                                                    if uu____14977
                                                     then
-                                                      ((let uu____15021 =
+                                                      ((let uu____15001 =
                                                           FStar_TypeChecker_Env.debug
                                                             env
                                                             FStar_Options.Extreme in
-                                                        if uu____15021
+                                                        if uu____15001
                                                         then
                                                           FStar_Util.print_string
                                                             "... not lifting\n"
@@ -5456,61 +5456,61 @@ and (check_application_args :
                                                             env
                                                             chead2.FStar_TypeChecker_Common.res_typ)
                                                            &&
-                                                           (let uu____15056 =
-                                                              let uu____15057
+                                                           (let uu____15036 =
+                                                              let uu____15037
                                                                 =
-                                                                let uu____15058
+                                                                let uu____15038
                                                                   =
                                                                   FStar_Syntax_Util.un_uinst
                                                                     head1 in
-                                                                uu____15058.FStar_Syntax_Syntax.n in
-                                                              match uu____15057
+                                                                uu____15038.FStar_Syntax_Syntax.n in
+                                                              match uu____15037
                                                               with
                                                               | FStar_Syntax_Syntax.Tm_fvar
                                                                   fv ->
-                                                                  let uu____15062
+                                                                  let uu____15042
                                                                     =
                                                                     FStar_Parser_Const.psconst
                                                                     "ignore" in
                                                                   FStar_Syntax_Syntax.fv_eq_lid
                                                                     fv
-                                                                    uu____15062
-                                                              | uu____15063
+                                                                    uu____15042
+                                                              | uu____15043
                                                                   -> true in
                                                             Prims.op_Negation
-                                                              uu____15056) in
+                                                              uu____15036) in
                                                        if warn_effectful_args
                                                        then
-                                                         (let uu____15065 =
-                                                            let uu____15070 =
-                                                              let uu____15071
+                                                         (let uu____15045 =
+                                                            let uu____15050 =
+                                                              let uu____15051
                                                                 =
                                                                 FStar_Syntax_Print.term_to_string
                                                                   e in
-                                                              let uu____15072
+                                                              let uu____15052
                                                                 =
                                                                 FStar_Ident.string_of_lid
                                                                   c.FStar_TypeChecker_Common.eff_name in
-                                                              let uu____15073
+                                                              let uu____15053
                                                                 =
                                                                 FStar_Syntax_Print.term_to_string
                                                                   head1 in
                                                               FStar_Util.format3
                                                                 "Effectful argument %s (%s) to erased function %s, consider let binding it"
-                                                                uu____15071
-                                                                uu____15072
-                                                                uu____15073 in
+                                                                uu____15051
+                                                                uu____15052
+                                                                uu____15053 in
                                                             (FStar_Errors.Warning_EffectfulArgumentToErasedFunction,
-                                                              uu____15070) in
+                                                              uu____15050) in
                                                           FStar_Errors.log_issue
                                                             e.FStar_Syntax_Syntax.pos
-                                                            uu____15065)
+                                                            uu____15045)
                                                        else ();
-                                                       (let uu____15076 =
+                                                       (let uu____15056 =
                                                           FStar_TypeChecker_Env.debug
                                                             env
                                                             FStar_Options.Extreme in
-                                                        if uu____15076
+                                                        if uu____15056
                                                         then
                                                           FStar_Util.print_string
                                                             "... lifting!\n"
@@ -5525,49 +5525,49 @@ and (check_application_args :
                                                             c.FStar_TypeChecker_Common.eff_name
                                                             comp1.FStar_TypeChecker_Common.eff_name
                                                             c.FStar_TypeChecker_Common.res_typ in
-                                                        let uu____15080 =
-                                                          let uu____15089 =
+                                                        let uu____15060 =
+                                                          let uu____15069 =
                                                             FStar_Syntax_Syntax.bv_to_name
                                                               x in
-                                                          (uu____15089, q) in
+                                                          (uu____15069, q) in
                                                         ((FStar_Pervasives_Native.Some
                                                             (x,
                                                               (c.FStar_TypeChecker_Common.eff_name),
                                                               (c.FStar_TypeChecker_Common.res_typ),
                                                               e1)),
-                                                          uu____15080))))) in
-                                            let uu____15118 =
-                                              let uu____15149 =
-                                                let uu____15178 =
-                                                  let uu____15189 =
-                                                    let uu____15198 =
+                                                          uu____15060))))) in
+                                            let uu____15098 =
+                                              let uu____15129 =
+                                                let uu____15158 =
+                                                  let uu____15169 =
+                                                    let uu____15178 =
                                                       FStar_Syntax_Syntax.as_arg
                                                         head1 in
-                                                    (uu____15198,
+                                                    (uu____15178,
                                                       FStar_Pervasives_Native.None,
                                                       chead2) in
-                                                  uu____15189 ::
+                                                  uu____15169 ::
                                                     arg_comps_rev in
                                                 FStar_List.map map_fun
-                                                  uu____15178 in
+                                                  uu____15158 in
                                               FStar_All.pipe_left
-                                                FStar_List.split uu____15149 in
-                                            match uu____15118 with
+                                                FStar_List.split uu____15129 in
+                                            match uu____15098 with
                                             | (lifted_args, reverse_args) ->
-                                                let uu____15399 =
-                                                  let uu____15400 =
+                                                let uu____15379 =
+                                                  let uu____15380 =
                                                     FStar_List.hd
                                                       reverse_args in
                                                   FStar_Pervasives_Native.fst
-                                                    uu____15400 in
-                                                let uu____15421 =
-                                                  let uu____15422 =
+                                                    uu____15380 in
+                                                let uu____15401 =
+                                                  let uu____15402 =
                                                     FStar_List.tl
                                                       reverse_args in
-                                                  FStar_List.rev uu____15422 in
-                                                (lifted_args, uu____15399,
-                                                  uu____15421) in
-                                          match uu____14863 with
+                                                  FStar_List.rev uu____15402 in
+                                                (lifted_args, uu____15379,
+                                                  uu____15401) in
+                                          match uu____14843 with
                                           | (lifted_args, head2, args1) ->
                                               let app =
                                                 FStar_Syntax_Syntax.mk_Tm_app
@@ -5584,8 +5584,8 @@ and (check_application_args :
                                                   comp1.FStar_TypeChecker_Common.eff_name
                                                   comp1.FStar_TypeChecker_Common.res_typ in
                                               let bind_lifted_args e
-                                                uu___6_15531 =
-                                                match uu___6_15531 with
+                                                uu___6_15511 =
+                                                match uu___6_15511 with
                                                 | FStar_Pervasives_Native.None
                                                     -> e
                                                 | FStar_Pervasives_Native.Some
@@ -5596,23 +5596,23 @@ and (check_application_args :
                                                         t m e1 []
                                                         e1.FStar_Syntax_Syntax.pos in
                                                     let letbinding =
-                                                      let uu____15592 =
-                                                        let uu____15593 =
-                                                          let uu____15606 =
-                                                            let uu____15609 =
-                                                              let uu____15610
+                                                      let uu____15572 =
+                                                        let uu____15573 =
+                                                          let uu____15586 =
+                                                            let uu____15589 =
+                                                              let uu____15590
                                                                 =
                                                                 FStar_Syntax_Syntax.mk_binder
                                                                   x in
-                                                              [uu____15610] in
+                                                              [uu____15590] in
                                                             FStar_Syntax_Subst.close
-                                                              uu____15609 e in
+                                                              uu____15589 e in
                                                           ((false, [lb]),
-                                                            uu____15606) in
+                                                            uu____15586) in
                                                         FStar_Syntax_Syntax.Tm_let
-                                                          uu____15593 in
+                                                          uu____15573 in
                                                       FStar_Syntax_Syntax.mk
-                                                        uu____15592
+                                                        uu____15572
                                                         e.FStar_Syntax_Syntax.pos in
                                                     FStar_Syntax_Syntax.mk
                                                       (FStar_Syntax_Syntax.Tm_meta
@@ -5624,237 +5624,237 @@ and (check_application_args :
                                               FStar_List.fold_left
                                                 bind_lifted_args app2
                                                 lifted_args) in
-                                     let uu____15659 =
+                                     let uu____15639 =
                                        FStar_TypeChecker_Util.strengthen_precondition
                                          FStar_Pervasives_Native.None env app
                                          comp1 guard1 in
-                                     (match uu____15659 with
+                                     (match uu____15639 with
                                       | (comp2, g) ->
-                                          ((let uu____15676 =
+                                          ((let uu____15656 =
                                               FStar_TypeChecker_Env.debug env
                                                 FStar_Options.Extreme in
-                                            if uu____15676
+                                            if uu____15656
                                             then
-                                              let uu____15677 =
+                                              let uu____15657 =
                                                 FStar_Syntax_Print.term_to_string
                                                   app in
-                                              let uu____15678 =
+                                              let uu____15658 =
                                                 FStar_TypeChecker_Common.lcomp_to_string
                                                   comp2 in
                                               FStar_Util.print2
                                                 "(d) Monadic app: type of app\n\t(%s)\n\t: %s\n"
-                                                uu____15677 uu____15678
+                                                uu____15657 uu____15658
                                             else ());
                                            (app, comp2, g))))))) in
-               let rec tc_args head_info uu____15764 bs args1 =
-                 match uu____15764 with
+               let rec tc_args head_info uu____15744 bs args1 =
+                 match uu____15744 with
                  | (subst, outargs, arg_rets, g, fvs) ->
                      (match (bs, args1) with
                       | ((x, FStar_Pervasives_Native.Some
-                          (FStar_Syntax_Syntax.Implicit uu____15927))::rest,
-                         (uu____15929, FStar_Pervasives_Native.None)::uu____15930)
+                          (FStar_Syntax_Syntax.Implicit uu____15907))::rest,
+                         (uu____15909, FStar_Pervasives_Native.None)::uu____15910)
                           ->
                           let t =
                             FStar_Syntax_Subst.subst subst
                               x.FStar_Syntax_Syntax.sort in
-                          let uu____15990 =
+                          let uu____15970 =
                             check_no_escape
                               (FStar_Pervasives_Native.Some head) env fvs t in
-                          (match uu____15990 with
+                          (match uu____15970 with
                            | (t1, g_ex) ->
                                let r1 =
                                  match outargs with
                                  | [] -> head.FStar_Syntax_Syntax.pos
-                                 | ((t2, uu____16021), uu____16022,
-                                    uu____16023)::uu____16024 ->
-                                     let uu____16079 =
+                                 | ((t2, uu____16001), uu____16002,
+                                    uu____16003)::uu____16004 ->
+                                     let uu____16059 =
                                        FStar_Range.def_range
                                          head.FStar_Syntax_Syntax.pos in
-                                     let uu____16080 =
-                                       let uu____16081 =
+                                     let uu____16060 =
+                                       let uu____16061 =
                                          FStar_Range.use_range
                                            head.FStar_Syntax_Syntax.pos in
-                                       let uu____16082 =
+                                       let uu____16062 =
                                          FStar_Range.use_range
                                            t2.FStar_Syntax_Syntax.pos in
-                                       FStar_Range.union_rng uu____16081
-                                         uu____16082 in
-                                     FStar_Range.range_of_rng uu____16079
-                                       uu____16080 in
-                               let uu____16083 =
+                                       FStar_Range.union_rng uu____16061
+                                         uu____16062 in
+                                     FStar_Range.range_of_rng uu____16059
+                                       uu____16060 in
+                               let uu____16063 =
                                  FStar_TypeChecker_Util.new_implicit_var
                                    "Instantiating implicit argument in application"
                                    r1 env t1 in
-                               (match uu____16083 with
-                                | (varg, uu____16103, implicits) ->
+                               (match uu____16063 with
+                                | (varg, uu____16083, implicits) ->
                                     let subst1 =
                                       (FStar_Syntax_Syntax.NT (x, varg)) ::
                                       subst in
                                     let arg =
-                                      let uu____16131 =
+                                      let uu____16111 =
                                         FStar_Syntax_Syntax.as_implicit true in
-                                      (varg, uu____16131) in
+                                      (varg, uu____16111) in
                                     let guard =
                                       FStar_List.fold_right
                                         FStar_TypeChecker_Env.conj_guard
                                         [g_ex; g] implicits in
-                                    let uu____16139 =
-                                      let uu____16182 =
-                                        let uu____16201 =
-                                          let uu____16218 =
-                                            let uu____16219 =
+                                    let uu____16119 =
+                                      let uu____16162 =
+                                        let uu____16181 =
+                                          let uu____16198 =
+                                            let uu____16199 =
                                               FStar_Syntax_Syntax.mk_Total t1 in
-                                            FStar_All.pipe_right uu____16219
+                                            FStar_All.pipe_right uu____16199
                                               FStar_TypeChecker_Common.lcomp_of_comp in
                                           (arg, FStar_Pervasives_Native.None,
-                                            uu____16218) in
-                                        uu____16201 :: outargs in
-                                      (subst1, uu____16182, (arg ::
+                                            uu____16198) in
+                                        uu____16181 :: outargs in
+                                      (subst1, uu____16162, (arg ::
                                         arg_rets), guard, fvs) in
-                                    tc_args head_info uu____16139 rest args1))
+                                    tc_args head_info uu____16119 rest args1))
                       | ((x, FStar_Pervasives_Native.Some
                           (FStar_Syntax_Syntax.Meta tau_or_attr))::rest,
-                         (uu____16289, FStar_Pervasives_Native.None)::uu____16290)
+                         (uu____16269, FStar_Pervasives_Native.None)::uu____16270)
                           ->
-                          let uu____16349 =
+                          let uu____16329 =
                             match tau_or_attr with
                             | FStar_Syntax_Syntax.Arg_qualifier_meta_tac tau
                                 ->
                                 let tau1 = FStar_Syntax_Subst.subst subst tau in
-                                let uu____16362 =
+                                let uu____16342 =
                                   tc_tactic FStar_Syntax_Syntax.t_unit
                                     FStar_Syntax_Syntax.t_unit env tau1 in
-                                (match uu____16362 with
-                                 | (tau2, uu____16374, g_tau) ->
-                                     let uu____16376 =
-                                       let uu____16377 =
-                                         let uu____16384 =
+                                (match uu____16342 with
+                                 | (tau2, uu____16354, g_tau) ->
+                                     let uu____16356 =
+                                       let uu____16357 =
+                                         let uu____16364 =
                                            FStar_Dyn.mkdyn env in
-                                         (uu____16384, tau2) in
+                                         (uu____16364, tau2) in
                                        FStar_Syntax_Syntax.Ctx_uvar_meta_tac
-                                         uu____16377 in
-                                     (uu____16376, g_tau))
+                                         uu____16357 in
+                                     (uu____16356, g_tau))
                             | FStar_Syntax_Syntax.Arg_qualifier_meta_attr
                                 attr ->
                                 let attr1 =
                                   FStar_Syntax_Subst.subst subst attr in
-                                let uu____16391 =
+                                let uu____16371 =
                                   tc_tot_or_gtot_term env attr1 in
-                                (match uu____16391 with
-                                 | (attr2, uu____16403, g_attr) ->
+                                (match uu____16371 with
+                                 | (attr2, uu____16383, g_attr) ->
                                      ((FStar_Syntax_Syntax.Ctx_uvar_meta_attr
                                          attr2), g_attr)) in
-                          (match uu____16349 with
+                          (match uu____16329 with
                            | (ctx_uvar_meta, g_tau_or_attr) ->
                                let t =
                                  FStar_Syntax_Subst.subst subst
                                    x.FStar_Syntax_Syntax.sort in
-                               let uu____16414 =
+                               let uu____16394 =
                                  check_no_escape
                                    (FStar_Pervasives_Native.Some head) env
                                    fvs t in
-                               (match uu____16414 with
+                               (match uu____16394 with
                                 | (t1, g_ex) ->
                                     let r1 =
                                       match outargs with
                                       | [] -> head.FStar_Syntax_Syntax.pos
-                                      | ((t2, uu____16445), uu____16446,
-                                         uu____16447)::uu____16448 ->
-                                          let uu____16503 =
+                                      | ((t2, uu____16425), uu____16426,
+                                         uu____16427)::uu____16428 ->
+                                          let uu____16483 =
                                             FStar_Range.def_range
                                               head.FStar_Syntax_Syntax.pos in
-                                          let uu____16504 =
-                                            let uu____16505 =
+                                          let uu____16484 =
+                                            let uu____16485 =
                                               FStar_Range.use_range
                                                 head.FStar_Syntax_Syntax.pos in
-                                            let uu____16506 =
+                                            let uu____16486 =
                                               FStar_Range.use_range
                                                 t2.FStar_Syntax_Syntax.pos in
-                                            FStar_Range.union_rng uu____16505
-                                              uu____16506 in
+                                            FStar_Range.union_rng uu____16485
+                                              uu____16486 in
                                           FStar_Range.range_of_rng
-                                            uu____16503 uu____16504 in
-                                    let uu____16507 =
+                                            uu____16483 uu____16484 in
+                                    let uu____16487 =
                                       FStar_TypeChecker_Env.new_implicit_var_aux
                                         "Instantiating meta argument in application"
                                         r1 env t1 FStar_Syntax_Syntax.Strict
                                         (FStar_Pervasives_Native.Some
                                            ctx_uvar_meta) in
-                                    (match uu____16507 with
-                                     | (varg, uu____16527, implicits) ->
+                                    (match uu____16487 with
+                                     | (varg, uu____16507, implicits) ->
                                          let subst1 =
                                            (FStar_Syntax_Syntax.NT (x, varg))
                                            :: subst in
                                          let arg =
-                                           let uu____16555 =
+                                           let uu____16535 =
                                              FStar_Syntax_Syntax.as_implicit
                                                true in
-                                           (varg, uu____16555) in
+                                           (varg, uu____16535) in
                                          let guard =
                                            FStar_List.fold_right
                                              FStar_TypeChecker_Env.conj_guard
                                              [g_ex; g; g_tau_or_attr]
                                              implicits in
-                                         let uu____16563 =
-                                           let uu____16606 =
-                                             let uu____16625 =
-                                               let uu____16642 =
-                                                 let uu____16643 =
+                                         let uu____16543 =
+                                           let uu____16586 =
+                                             let uu____16605 =
+                                               let uu____16622 =
+                                                 let uu____16623 =
                                                    FStar_Syntax_Syntax.mk_Total
                                                      t1 in
                                                  FStar_All.pipe_right
-                                                   uu____16643
+                                                   uu____16623
                                                    FStar_TypeChecker_Common.lcomp_of_comp in
                                                (arg,
                                                  FStar_Pervasives_Native.None,
-                                                 uu____16642) in
-                                             uu____16625 :: outargs in
-                                           (subst1, uu____16606, (arg ::
+                                                 uu____16622) in
+                                             uu____16605 :: outargs in
+                                           (subst1, uu____16586, (arg ::
                                              arg_rets), guard, fvs) in
-                                         tc_args head_info uu____16563 rest
+                                         tc_args head_info uu____16543 rest
                                            args1)))
                       | ((x, aqual)::rest, (e, aq)::rest') ->
                           ((match (aqual, aq) with
-                            | (uu____16783, FStar_Pervasives_Native.Some
-                               (FStar_Syntax_Syntax.Meta uu____16784)) ->
+                            | (uu____16763, FStar_Pervasives_Native.Some
+                               (FStar_Syntax_Syntax.Meta uu____16764)) ->
                                 FStar_Errors.raise_error
                                   (FStar_Errors.Fatal_InconsistentImplicitQualifier,
                                     "Inconsistent implicit qualifier; cannot apply meta arguments, just use #")
                                   e.FStar_Syntax_Syntax.pos
                             | (FStar_Pervasives_Native.Some
-                               (FStar_Syntax_Syntax.Meta uu____16791),
+                               (FStar_Syntax_Syntax.Meta uu____16771),
                                FStar_Pervasives_Native.Some
-                               (FStar_Syntax_Syntax.Implicit uu____16792)) ->
+                               (FStar_Syntax_Syntax.Implicit uu____16772)) ->
                                 ()
                             | (FStar_Pervasives_Native.Some
-                               (FStar_Syntax_Syntax.Implicit uu____16797),
+                               (FStar_Syntax_Syntax.Implicit uu____16777),
                                FStar_Pervasives_Native.Some
-                               (FStar_Syntax_Syntax.Implicit uu____16798)) ->
+                               (FStar_Syntax_Syntax.Implicit uu____16778)) ->
                                 ()
                             | (FStar_Pervasives_Native.None,
                                FStar_Pervasives_Native.None) -> ()
                             | (FStar_Pervasives_Native.Some
                                (FStar_Syntax_Syntax.Equality),
                                FStar_Pervasives_Native.None) -> ()
-                            | uu____16811 ->
-                                let uu____16820 =
-                                  let uu____16825 =
-                                    let uu____16826 =
+                            | uu____16791 ->
+                                let uu____16800 =
+                                  let uu____16805 =
+                                    let uu____16806 =
                                       FStar_Syntax_Print.aqual_to_string
                                         aqual in
-                                    let uu____16827 =
+                                    let uu____16807 =
                                       FStar_Syntax_Print.aqual_to_string aq in
-                                    let uu____16828 =
+                                    let uu____16808 =
                                       FStar_Syntax_Print.bv_to_string x in
-                                    let uu____16829 =
+                                    let uu____16809 =
                                       FStar_Syntax_Print.term_to_string e in
                                     FStar_Util.format4
                                       "Inconsistent implicit qualifier; %s vs %s\nfor bvar %s and term %s"
-                                      uu____16826 uu____16827 uu____16828
-                                      uu____16829 in
+                                      uu____16806 uu____16807 uu____16808
+                                      uu____16809 in
                                   (FStar_Errors.Fatal_InconsistentImplicitQualifier,
-                                    uu____16825) in
-                                FStar_Errors.raise_error uu____16820
+                                    uu____16805) in
+                                FStar_Errors.raise_error uu____16800
                                   e.FStar_Syntax_Syntax.pos);
                            (let targ =
                               FStar_Syntax_Subst.subst subst
@@ -5862,202 +5862,202 @@ and (check_application_args :
                             let aqual1 =
                               FStar_Syntax_Subst.subst_imp subst aqual in
                             let x1 =
-                              let uu___2372_16833 = x in
+                              let uu___2372_16813 = x in
                               {
                                 FStar_Syntax_Syntax.ppname =
-                                  (uu___2372_16833.FStar_Syntax_Syntax.ppname);
+                                  (uu___2372_16813.FStar_Syntax_Syntax.ppname);
                                 FStar_Syntax_Syntax.index =
-                                  (uu___2372_16833.FStar_Syntax_Syntax.index);
+                                  (uu___2372_16813.FStar_Syntax_Syntax.index);
                                 FStar_Syntax_Syntax.sort = targ
                               } in
-                            (let uu____16835 =
+                            (let uu____16815 =
                                FStar_TypeChecker_Env.debug env
                                  FStar_Options.Extreme in
-                             if uu____16835
+                             if uu____16815
                              then
-                               let uu____16836 =
+                               let uu____16816 =
                                  FStar_Syntax_Print.bv_to_string x1 in
-                               let uu____16837 =
+                               let uu____16817 =
                                  FStar_Syntax_Print.term_to_string
                                    x1.FStar_Syntax_Syntax.sort in
-                               let uu____16838 =
+                               let uu____16818 =
                                  FStar_Syntax_Print.term_to_string e in
-                               let uu____16839 =
+                               let uu____16819 =
                                  FStar_Syntax_Print.subst_to_string subst in
-                               let uu____16840 =
+                               let uu____16820 =
                                  FStar_Syntax_Print.term_to_string targ in
                                FStar_Util.print5
                                  "\tFormal is %s : %s\tType of arg %s (after subst %s) = %s\n"
-                                 uu____16836 uu____16837 uu____16838
-                                 uu____16839 uu____16840
+                                 uu____16816 uu____16817 uu____16818
+                                 uu____16819 uu____16820
                              else ());
-                            (let uu____16842 =
+                            (let uu____16822 =
                                check_no_escape
                                  (FStar_Pervasives_Native.Some head) env fvs
                                  targ in
-                             match uu____16842 with
+                             match uu____16822 with
                              | (targ1, g_ex) ->
                                  let env1 =
                                    FStar_TypeChecker_Env.set_expected_typ env
                                      targ1 in
                                  let env2 =
-                                   let uu___2381_16857 = env1 in
+                                   let uu___2381_16837 = env1 in
                                    {
                                      FStar_TypeChecker_Env.solver =
-                                       (uu___2381_16857.FStar_TypeChecker_Env.solver);
+                                       (uu___2381_16837.FStar_TypeChecker_Env.solver);
                                      FStar_TypeChecker_Env.range =
-                                       (uu___2381_16857.FStar_TypeChecker_Env.range);
+                                       (uu___2381_16837.FStar_TypeChecker_Env.range);
                                      FStar_TypeChecker_Env.curmodule =
-                                       (uu___2381_16857.FStar_TypeChecker_Env.curmodule);
+                                       (uu___2381_16837.FStar_TypeChecker_Env.curmodule);
                                      FStar_TypeChecker_Env.gamma =
-                                       (uu___2381_16857.FStar_TypeChecker_Env.gamma);
+                                       (uu___2381_16837.FStar_TypeChecker_Env.gamma);
                                      FStar_TypeChecker_Env.gamma_sig =
-                                       (uu___2381_16857.FStar_TypeChecker_Env.gamma_sig);
+                                       (uu___2381_16837.FStar_TypeChecker_Env.gamma_sig);
                                      FStar_TypeChecker_Env.gamma_cache =
-                                       (uu___2381_16857.FStar_TypeChecker_Env.gamma_cache);
+                                       (uu___2381_16837.FStar_TypeChecker_Env.gamma_cache);
                                      FStar_TypeChecker_Env.modules =
-                                       (uu___2381_16857.FStar_TypeChecker_Env.modules);
+                                       (uu___2381_16837.FStar_TypeChecker_Env.modules);
                                      FStar_TypeChecker_Env.expected_typ =
-                                       (uu___2381_16857.FStar_TypeChecker_Env.expected_typ);
+                                       (uu___2381_16837.FStar_TypeChecker_Env.expected_typ);
                                      FStar_TypeChecker_Env.sigtab =
-                                       (uu___2381_16857.FStar_TypeChecker_Env.sigtab);
+                                       (uu___2381_16837.FStar_TypeChecker_Env.sigtab);
                                      FStar_TypeChecker_Env.attrtab =
-                                       (uu___2381_16857.FStar_TypeChecker_Env.attrtab);
+                                       (uu___2381_16837.FStar_TypeChecker_Env.attrtab);
                                      FStar_TypeChecker_Env.instantiate_imp =
-                                       (uu___2381_16857.FStar_TypeChecker_Env.instantiate_imp);
+                                       (uu___2381_16837.FStar_TypeChecker_Env.instantiate_imp);
                                      FStar_TypeChecker_Env.effects =
-                                       (uu___2381_16857.FStar_TypeChecker_Env.effects);
+                                       (uu___2381_16837.FStar_TypeChecker_Env.effects);
                                      FStar_TypeChecker_Env.generalize =
-                                       (uu___2381_16857.FStar_TypeChecker_Env.generalize);
+                                       (uu___2381_16837.FStar_TypeChecker_Env.generalize);
                                      FStar_TypeChecker_Env.letrecs =
-                                       (uu___2381_16857.FStar_TypeChecker_Env.letrecs);
+                                       (uu___2381_16837.FStar_TypeChecker_Env.letrecs);
                                      FStar_TypeChecker_Env.top_level =
-                                       (uu___2381_16857.FStar_TypeChecker_Env.top_level);
+                                       (uu___2381_16837.FStar_TypeChecker_Env.top_level);
                                      FStar_TypeChecker_Env.check_uvars =
-                                       (uu___2381_16857.FStar_TypeChecker_Env.check_uvars);
+                                       (uu___2381_16837.FStar_TypeChecker_Env.check_uvars);
                                      FStar_TypeChecker_Env.use_eq =
                                        (is_eq aqual1);
                                      FStar_TypeChecker_Env.use_eq_strict =
-                                       (uu___2381_16857.FStar_TypeChecker_Env.use_eq_strict);
+                                       (uu___2381_16837.FStar_TypeChecker_Env.use_eq_strict);
                                      FStar_TypeChecker_Env.is_iface =
-                                       (uu___2381_16857.FStar_TypeChecker_Env.is_iface);
+                                       (uu___2381_16837.FStar_TypeChecker_Env.is_iface);
                                      FStar_TypeChecker_Env.admit =
-                                       (uu___2381_16857.FStar_TypeChecker_Env.admit);
+                                       (uu___2381_16837.FStar_TypeChecker_Env.admit);
                                      FStar_TypeChecker_Env.lax =
-                                       (uu___2381_16857.FStar_TypeChecker_Env.lax);
+                                       (uu___2381_16837.FStar_TypeChecker_Env.lax);
                                      FStar_TypeChecker_Env.lax_universes =
-                                       (uu___2381_16857.FStar_TypeChecker_Env.lax_universes);
+                                       (uu___2381_16837.FStar_TypeChecker_Env.lax_universes);
                                      FStar_TypeChecker_Env.phase1 =
-                                       (uu___2381_16857.FStar_TypeChecker_Env.phase1);
+                                       (uu___2381_16837.FStar_TypeChecker_Env.phase1);
                                      FStar_TypeChecker_Env.failhard =
-                                       (uu___2381_16857.FStar_TypeChecker_Env.failhard);
+                                       (uu___2381_16837.FStar_TypeChecker_Env.failhard);
                                      FStar_TypeChecker_Env.nosynth =
-                                       (uu___2381_16857.FStar_TypeChecker_Env.nosynth);
+                                       (uu___2381_16837.FStar_TypeChecker_Env.nosynth);
                                      FStar_TypeChecker_Env.uvar_subtyping =
-                                       (uu___2381_16857.FStar_TypeChecker_Env.uvar_subtyping);
+                                       (uu___2381_16837.FStar_TypeChecker_Env.uvar_subtyping);
                                      FStar_TypeChecker_Env.tc_term =
-                                       (uu___2381_16857.FStar_TypeChecker_Env.tc_term);
+                                       (uu___2381_16837.FStar_TypeChecker_Env.tc_term);
                                      FStar_TypeChecker_Env.type_of =
-                                       (uu___2381_16857.FStar_TypeChecker_Env.type_of);
+                                       (uu___2381_16837.FStar_TypeChecker_Env.type_of);
                                      FStar_TypeChecker_Env.universe_of =
-                                       (uu___2381_16857.FStar_TypeChecker_Env.universe_of);
+                                       (uu___2381_16837.FStar_TypeChecker_Env.universe_of);
                                      FStar_TypeChecker_Env.check_type_of =
-                                       (uu___2381_16857.FStar_TypeChecker_Env.check_type_of);
+                                       (uu___2381_16837.FStar_TypeChecker_Env.check_type_of);
                                      FStar_TypeChecker_Env.use_bv_sorts =
-                                       (uu___2381_16857.FStar_TypeChecker_Env.use_bv_sorts);
+                                       (uu___2381_16837.FStar_TypeChecker_Env.use_bv_sorts);
                                      FStar_TypeChecker_Env.qtbl_name_and_index
                                        =
-                                       (uu___2381_16857.FStar_TypeChecker_Env.qtbl_name_and_index);
+                                       (uu___2381_16837.FStar_TypeChecker_Env.qtbl_name_and_index);
                                      FStar_TypeChecker_Env.normalized_eff_names
                                        =
-                                       (uu___2381_16857.FStar_TypeChecker_Env.normalized_eff_names);
+                                       (uu___2381_16837.FStar_TypeChecker_Env.normalized_eff_names);
                                      FStar_TypeChecker_Env.fv_delta_depths =
-                                       (uu___2381_16857.FStar_TypeChecker_Env.fv_delta_depths);
+                                       (uu___2381_16837.FStar_TypeChecker_Env.fv_delta_depths);
                                      FStar_TypeChecker_Env.proof_ns =
-                                       (uu___2381_16857.FStar_TypeChecker_Env.proof_ns);
+                                       (uu___2381_16837.FStar_TypeChecker_Env.proof_ns);
                                      FStar_TypeChecker_Env.synth_hook =
-                                       (uu___2381_16857.FStar_TypeChecker_Env.synth_hook);
+                                       (uu___2381_16837.FStar_TypeChecker_Env.synth_hook);
                                      FStar_TypeChecker_Env.try_solve_implicits_hook
                                        =
-                                       (uu___2381_16857.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                                       (uu___2381_16837.FStar_TypeChecker_Env.try_solve_implicits_hook);
                                      FStar_TypeChecker_Env.splice =
-                                       (uu___2381_16857.FStar_TypeChecker_Env.splice);
+                                       (uu___2381_16837.FStar_TypeChecker_Env.splice);
                                      FStar_TypeChecker_Env.mpreprocess =
-                                       (uu___2381_16857.FStar_TypeChecker_Env.mpreprocess);
+                                       (uu___2381_16837.FStar_TypeChecker_Env.mpreprocess);
                                      FStar_TypeChecker_Env.postprocess =
-                                       (uu___2381_16857.FStar_TypeChecker_Env.postprocess);
+                                       (uu___2381_16837.FStar_TypeChecker_Env.postprocess);
                                      FStar_TypeChecker_Env.identifier_info =
-                                       (uu___2381_16857.FStar_TypeChecker_Env.identifier_info);
+                                       (uu___2381_16837.FStar_TypeChecker_Env.identifier_info);
                                      FStar_TypeChecker_Env.tc_hooks =
-                                       (uu___2381_16857.FStar_TypeChecker_Env.tc_hooks);
+                                       (uu___2381_16837.FStar_TypeChecker_Env.tc_hooks);
                                      FStar_TypeChecker_Env.dsenv =
-                                       (uu___2381_16857.FStar_TypeChecker_Env.dsenv);
+                                       (uu___2381_16837.FStar_TypeChecker_Env.dsenv);
                                      FStar_TypeChecker_Env.nbe =
-                                       (uu___2381_16857.FStar_TypeChecker_Env.nbe);
+                                       (uu___2381_16837.FStar_TypeChecker_Env.nbe);
                                      FStar_TypeChecker_Env.strict_args_tab =
-                                       (uu___2381_16857.FStar_TypeChecker_Env.strict_args_tab);
+                                       (uu___2381_16837.FStar_TypeChecker_Env.strict_args_tab);
                                      FStar_TypeChecker_Env.erasable_types_tab
                                        =
-                                       (uu___2381_16857.FStar_TypeChecker_Env.erasable_types_tab);
+                                       (uu___2381_16837.FStar_TypeChecker_Env.erasable_types_tab);
                                      FStar_TypeChecker_Env.enable_defer_to_tac
                                        =
-                                       (uu___2381_16857.FStar_TypeChecker_Env.enable_defer_to_tac)
+                                       (uu___2381_16837.FStar_TypeChecker_Env.enable_defer_to_tac)
                                    } in
-                                 ((let uu____16859 =
+                                 ((let uu____16839 =
                                      FStar_TypeChecker_Env.debug env2
                                        FStar_Options.High in
-                                   if uu____16859
+                                   if uu____16839
                                    then
-                                     let uu____16860 =
+                                     let uu____16840 =
                                        FStar_Syntax_Print.tag_of_term e in
-                                     let uu____16861 =
+                                     let uu____16841 =
                                        FStar_Syntax_Print.term_to_string e in
-                                     let uu____16862 =
+                                     let uu____16842 =
                                        FStar_Syntax_Print.term_to_string
                                          targ1 in
-                                     let uu____16863 =
+                                     let uu____16843 =
                                        FStar_Util.string_of_bool
                                          env2.FStar_TypeChecker_Env.use_eq in
                                      FStar_Util.print4
                                        "Checking arg (%s) %s at type %s with use_eq:%s\n"
-                                       uu____16860 uu____16861 uu____16862
-                                       uu____16863
+                                       uu____16840 uu____16841 uu____16842
+                                       uu____16843
                                    else ());
-                                  (let uu____16865 = tc_term env2 e in
-                                   match uu____16865 with
+                                  (let uu____16845 = tc_term env2 e in
+                                   match uu____16845 with
                                    | (e1, c, g_e) ->
                                        let g1 =
-                                         let uu____16882 =
+                                         let uu____16862 =
                                            FStar_TypeChecker_Env.conj_guard g
                                              g_e in
                                          FStar_All.pipe_left
                                            (FStar_TypeChecker_Env.conj_guard
-                                              g_ex) uu____16882 in
+                                              g_ex) uu____16862 in
                                        let arg = (e1, aq) in
                                        let xterm =
-                                         let uu____16905 =
-                                           let uu____16908 =
-                                             let uu____16917 =
+                                         let uu____16885 =
+                                           let uu____16888 =
+                                             let uu____16897 =
                                                FStar_Syntax_Syntax.bv_to_name
                                                  x1 in
                                              FStar_Syntax_Syntax.as_arg
-                                               uu____16917 in
+                                               uu____16897 in
                                            FStar_Pervasives_Native.fst
-                                             uu____16908 in
-                                         (uu____16905, aq) in
-                                       let uu____16926 =
+                                             uu____16888 in
+                                         (uu____16885, aq) in
+                                       let uu____16906 =
                                          (FStar_TypeChecker_Common.is_tot_or_gtot_lcomp
                                             c)
                                            ||
                                            (FStar_TypeChecker_Util.is_pure_or_ghost_effect
                                               env2
                                               c.FStar_TypeChecker_Common.eff_name) in
-                                       if uu____16926
+                                       if uu____16906
                                        then
                                          let subst1 =
-                                           let uu____16934 = FStar_List.hd bs in
+                                           let uu____16914 = FStar_List.hd bs in
                                            maybe_extend_subst subst
-                                             uu____16934 e1 in
+                                             uu____16914 e1 in
                                          tc_args head_info
                                            (subst1,
                                              ((arg,
@@ -6073,49 +6073,49 @@ and (check_application_args :
                                                    x1), c) :: outargs),
                                              (xterm :: arg_rets), g1, (x1 ::
                                              fvs)) rest rest')))))
-                      | (uu____17080, []) ->
+                      | (uu____17060, []) ->
                           monadic_application head_info subst outargs
                             arg_rets g fvs bs
-                      | ([], arg::uu____17116) ->
-                          let uu____17167 =
+                      | ([], arg::uu____17096) ->
+                          let uu____17147 =
                             monadic_application head_info subst outargs
                               arg_rets g fvs [] in
-                          (match uu____17167 with
+                          (match uu____17147 with
                            | (head1, chead1, ghead1) ->
-                               let uu____17189 =
-                                 let uu____17194 =
+                               let uu____17169 =
+                                 let uu____17174 =
                                    FStar_TypeChecker_Common.lcomp_comp chead1 in
-                                 FStar_All.pipe_right uu____17194
-                                   (fun uu____17211 ->
-                                      match uu____17211 with
+                                 FStar_All.pipe_right uu____17174
+                                   (fun uu____17191 ->
+                                      match uu____17191 with
                                       | (c, g1) ->
-                                          let uu____17222 =
+                                          let uu____17202 =
                                             FStar_TypeChecker_Env.conj_guard
                                               ghead1 g1 in
-                                          (c, uu____17222)) in
-                               (match uu____17189 with
+                                          (c, uu____17202)) in
+                               (match uu____17169 with
                                 | (chead2, ghead2) ->
                                     let rec aux norm1 solve ghead3 tres =
                                       let tres1 =
-                                        let uu____17261 =
+                                        let uu____17241 =
                                           FStar_Syntax_Subst.compress tres in
-                                        FStar_All.pipe_right uu____17261
+                                        FStar_All.pipe_right uu____17241
                                           FStar_Syntax_Util.unrefine in
                                       match tres1.FStar_Syntax_Syntax.n with
                                       | FStar_Syntax_Syntax.Tm_arrow
                                           (bs1, cres') ->
-                                          let uu____17292 =
+                                          let uu____17272 =
                                             FStar_Syntax_Subst.open_comp bs1
                                               cres' in
-                                          (match uu____17292 with
+                                          (match uu____17272 with
                                            | (bs2, cres'1) ->
                                                let head_info1 =
                                                  (head1, chead2, ghead3,
                                                    cres'1) in
-                                               ((let uu____17315 =
+                                               ((let uu____17295 =
                                                    FStar_TypeChecker_Env.debug
                                                      env FStar_Options.Low in
-                                                 if uu____17315
+                                                 if uu____17295
                                                  then
                                                    FStar_Errors.log_issue
                                                      tres1.FStar_Syntax_Syntax.pos
@@ -6126,280 +6126,280 @@ and (check_application_args :
                                                   ([], [], [],
                                                     FStar_TypeChecker_Env.trivial_guard,
                                                     []) bs2 args1))
-                                      | uu____17373 when
+                                      | uu____17353 when
                                           Prims.op_Negation norm1 ->
                                           let rec norm_tres tres2 =
                                             let tres3 =
-                                              let uu____17381 =
+                                              let uu____17361 =
                                                 FStar_All.pipe_right tres2
                                                   (FStar_TypeChecker_Normalize.unfold_whnf
                                                      env) in
                                               FStar_All.pipe_right
-                                                uu____17381
+                                                uu____17361
                                                 FStar_Syntax_Util.unascribe in
-                                            let uu____17382 =
-                                              let uu____17383 =
+                                            let uu____17362 =
+                                              let uu____17363 =
                                                 FStar_Syntax_Subst.compress
                                                   tres3 in
-                                              uu____17383.FStar_Syntax_Syntax.n in
-                                            match uu____17382 with
+                                              uu____17363.FStar_Syntax_Syntax.n in
+                                            match uu____17362 with
                                             | FStar_Syntax_Syntax.Tm_refine
                                                 ({
                                                    FStar_Syntax_Syntax.ppname
-                                                     = uu____17386;
+                                                     = uu____17366;
                                                    FStar_Syntax_Syntax.index
-                                                     = uu____17387;
+                                                     = uu____17367;
                                                    FStar_Syntax_Syntax.sort =
                                                      tres4;_},
-                                                 uu____17389)
+                                                 uu____17369)
                                                 -> norm_tres tres4
-                                            | uu____17396 -> tres3 in
-                                          let uu____17397 = norm_tres tres1 in
-                                          aux true solve ghead3 uu____17397
-                                      | uu____17398 when
+                                            | uu____17376 -> tres3 in
+                                          let uu____17377 = norm_tres tres1 in
+                                          aux true solve ghead3 uu____17377
+                                      | uu____17378 when
                                           Prims.op_Negation solve ->
                                           let ghead4 =
                                             FStar_TypeChecker_Rel.solve_deferred_constraints
                                               env ghead3 in
                                           aux norm1 true ghead4 tres1
-                                      | uu____17400 ->
-                                          let uu____17401 =
-                                            let uu____17406 =
-                                              let uu____17407 =
+                                      | uu____17380 ->
+                                          let uu____17381 =
+                                            let uu____17386 =
+                                              let uu____17387 =
                                                 FStar_TypeChecker_Normalize.term_to_string
                                                   env thead in
-                                              let uu____17408 =
+                                              let uu____17388 =
                                                 FStar_Util.string_of_int
                                                   n_args in
-                                              let uu____17409 =
+                                              let uu____17389 =
                                                 FStar_Syntax_Print.term_to_string
                                                   tres1 in
                                               FStar_Util.format3
                                                 "Too many arguments to function of type %s; got %s arguments, remaining type is %s"
-                                                uu____17407 uu____17408
-                                                uu____17409 in
+                                                uu____17387 uu____17388
+                                                uu____17389 in
                                             (FStar_Errors.Fatal_ToManyArgumentToFunction,
-                                              uu____17406) in
-                                          let uu____17410 =
+                                              uu____17386) in
+                                          let uu____17390 =
                                             FStar_Syntax_Syntax.argpos arg in
                                           FStar_Errors.raise_error
-                                            uu____17401 uu____17410 in
+                                            uu____17381 uu____17390 in
                                     aux false false ghead2
                                       (FStar_Syntax_Util.comp_result chead2)))) in
                let rec check_function_app tf guard =
-                 let uu____17438 =
-                   let uu____17439 =
+                 let uu____17418 =
+                   let uu____17419 =
                      FStar_TypeChecker_Normalize.unfold_whnf env tf in
-                   uu____17439.FStar_Syntax_Syntax.n in
-                 match uu____17438 with
-                 | FStar_Syntax_Syntax.Tm_uvar uu____17448 ->
-                     let uu____17461 =
+                   uu____17419.FStar_Syntax_Syntax.n in
+                 match uu____17418 with
+                 | FStar_Syntax_Syntax.Tm_uvar uu____17428 ->
+                     let uu____17441 =
                        FStar_List.fold_right
-                         (fun uu____17492 ->
-                            fun uu____17493 ->
-                              match uu____17493 with
+                         (fun uu____17472 ->
+                            fun uu____17473 ->
+                              match uu____17473 with
                               | (bs, guard1) ->
-                                  let uu____17520 =
-                                    let uu____17533 =
-                                      let uu____17534 =
+                                  let uu____17500 =
+                                    let uu____17513 =
+                                      let uu____17514 =
                                         FStar_Syntax_Util.type_u () in
-                                      FStar_All.pipe_right uu____17534
+                                      FStar_All.pipe_right uu____17514
                                         FStar_Pervasives_Native.fst in
                                     FStar_TypeChecker_Util.new_implicit_var
                                       "formal parameter"
                                       tf.FStar_Syntax_Syntax.pos env
-                                      uu____17533 in
-                                  (match uu____17520 with
-                                   | (t, uu____17550, g) ->
-                                       let uu____17564 =
-                                         let uu____17567 =
+                                      uu____17513 in
+                                  (match uu____17500 with
+                                   | (t, uu____17530, g) ->
+                                       let uu____17544 =
+                                         let uu____17547 =
                                            FStar_Syntax_Syntax.null_binder t in
-                                         uu____17567 :: bs in
-                                       let uu____17568 =
+                                         uu____17547 :: bs in
+                                       let uu____17548 =
                                          FStar_TypeChecker_Env.conj_guard g
                                            guard1 in
-                                       (uu____17564, uu____17568))) args
+                                       (uu____17544, uu____17548))) args
                          ([], guard) in
-                     (match uu____17461 with
+                     (match uu____17441 with
                       | (bs, guard1) ->
-                          let uu____17585 =
-                            let uu____17592 =
-                              let uu____17605 =
-                                let uu____17606 = FStar_Syntax_Util.type_u () in
-                                FStar_All.pipe_right uu____17606
+                          let uu____17565 =
+                            let uu____17572 =
+                              let uu____17585 =
+                                let uu____17586 = FStar_Syntax_Util.type_u () in
+                                FStar_All.pipe_right uu____17586
                                   FStar_Pervasives_Native.fst in
                               FStar_TypeChecker_Util.new_implicit_var
                                 "result type" tf.FStar_Syntax_Syntax.pos env
-                                uu____17605 in
-                            match uu____17592 with
-                            | (t, uu____17622, g) ->
-                                let uu____17636 = FStar_Options.ml_ish () in
-                                if uu____17636
+                                uu____17585 in
+                            match uu____17572 with
+                            | (t, uu____17602, g) ->
+                                let uu____17616 = FStar_Options.ml_ish () in
+                                if uu____17616
                                 then
-                                  let uu____17643 =
+                                  let uu____17623 =
                                     FStar_Syntax_Util.ml_comp t r in
-                                  let uu____17646 =
+                                  let uu____17626 =
                                     FStar_TypeChecker_Env.conj_guard guard1 g in
-                                  (uu____17643, uu____17646)
+                                  (uu____17623, uu____17626)
                                 else
-                                  (let uu____17650 =
+                                  (let uu____17630 =
                                      FStar_Syntax_Syntax.mk_Total t in
-                                   let uu____17653 =
+                                   let uu____17633 =
                                      FStar_TypeChecker_Env.conj_guard guard1
                                        g in
-                                   (uu____17650, uu____17653)) in
-                          (match uu____17585 with
+                                   (uu____17630, uu____17633)) in
+                          (match uu____17565 with
                            | (cres, guard2) ->
                                let bs_cres = FStar_Syntax_Util.arrow bs cres in
-                               ((let uu____17672 =
+                               ((let uu____17652 =
                                    FStar_All.pipe_left
                                      (FStar_TypeChecker_Env.debug env)
                                      FStar_Options.Extreme in
-                                 if uu____17672
+                                 if uu____17652
                                  then
-                                   let uu____17673 =
+                                   let uu____17653 =
                                      FStar_Syntax_Print.term_to_string head in
-                                   let uu____17674 =
+                                   let uu____17654 =
                                      FStar_Syntax_Print.term_to_string tf in
-                                   let uu____17675 =
+                                   let uu____17655 =
                                      FStar_Syntax_Print.term_to_string
                                        bs_cres in
                                    FStar_Util.print3
                                      "Forcing the type of %s from %s to %s\n"
-                                     uu____17673 uu____17674 uu____17675
+                                     uu____17653 uu____17654 uu____17655
                                  else ());
                                 (let g =
-                                   let uu____17678 =
+                                   let uu____17658 =
                                      FStar_TypeChecker_Rel.teq env tf bs_cres in
                                    FStar_TypeChecker_Rel.solve_deferred_constraints
-                                     env uu____17678 in
-                                 let uu____17679 =
+                                     env uu____17658 in
+                                 let uu____17659 =
                                    FStar_TypeChecker_Env.conj_guard g guard2 in
-                                 check_function_app bs_cres uu____17679))))
+                                 check_function_app bs_cres uu____17659))))
                  | FStar_Syntax_Syntax.Tm_app
                      ({
                         FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_uvar
-                          uu____17680;
-                        FStar_Syntax_Syntax.pos = uu____17681;
-                        FStar_Syntax_Syntax.vars = uu____17682;_},
-                      uu____17683)
+                          uu____17660;
+                        FStar_Syntax_Syntax.pos = uu____17661;
+                        FStar_Syntax_Syntax.vars = uu____17662;_},
+                      uu____17663)
                      ->
-                     let uu____17720 =
+                     let uu____17700 =
                        FStar_List.fold_right
-                         (fun uu____17751 ->
-                            fun uu____17752 ->
-                              match uu____17752 with
+                         (fun uu____17731 ->
+                            fun uu____17732 ->
+                              match uu____17732 with
                               | (bs, guard1) ->
-                                  let uu____17779 =
-                                    let uu____17792 =
-                                      let uu____17793 =
+                                  let uu____17759 =
+                                    let uu____17772 =
+                                      let uu____17773 =
                                         FStar_Syntax_Util.type_u () in
-                                      FStar_All.pipe_right uu____17793
+                                      FStar_All.pipe_right uu____17773
                                         FStar_Pervasives_Native.fst in
                                     FStar_TypeChecker_Util.new_implicit_var
                                       "formal parameter"
                                       tf.FStar_Syntax_Syntax.pos env
-                                      uu____17792 in
-                                  (match uu____17779 with
-                                   | (t, uu____17809, g) ->
-                                       let uu____17823 =
-                                         let uu____17826 =
+                                      uu____17772 in
+                                  (match uu____17759 with
+                                   | (t, uu____17789, g) ->
+                                       let uu____17803 =
+                                         let uu____17806 =
                                            FStar_Syntax_Syntax.null_binder t in
-                                         uu____17826 :: bs in
-                                       let uu____17827 =
+                                         uu____17806 :: bs in
+                                       let uu____17807 =
                                          FStar_TypeChecker_Env.conj_guard g
                                            guard1 in
-                                       (uu____17823, uu____17827))) args
+                                       (uu____17803, uu____17807))) args
                          ([], guard) in
-                     (match uu____17720 with
+                     (match uu____17700 with
                       | (bs, guard1) ->
-                          let uu____17844 =
-                            let uu____17851 =
-                              let uu____17864 =
-                                let uu____17865 = FStar_Syntax_Util.type_u () in
-                                FStar_All.pipe_right uu____17865
+                          let uu____17824 =
+                            let uu____17831 =
+                              let uu____17844 =
+                                let uu____17845 = FStar_Syntax_Util.type_u () in
+                                FStar_All.pipe_right uu____17845
                                   FStar_Pervasives_Native.fst in
                               FStar_TypeChecker_Util.new_implicit_var
                                 "result type" tf.FStar_Syntax_Syntax.pos env
-                                uu____17864 in
-                            match uu____17851 with
-                            | (t, uu____17881, g) ->
-                                let uu____17895 = FStar_Options.ml_ish () in
-                                if uu____17895
+                                uu____17844 in
+                            match uu____17831 with
+                            | (t, uu____17861, g) ->
+                                let uu____17875 = FStar_Options.ml_ish () in
+                                if uu____17875
                                 then
-                                  let uu____17902 =
+                                  let uu____17882 =
                                     FStar_Syntax_Util.ml_comp t r in
-                                  let uu____17905 =
+                                  let uu____17885 =
                                     FStar_TypeChecker_Env.conj_guard guard1 g in
-                                  (uu____17902, uu____17905)
+                                  (uu____17882, uu____17885)
                                 else
-                                  (let uu____17909 =
+                                  (let uu____17889 =
                                      FStar_Syntax_Syntax.mk_Total t in
-                                   let uu____17912 =
+                                   let uu____17892 =
                                      FStar_TypeChecker_Env.conj_guard guard1
                                        g in
-                                   (uu____17909, uu____17912)) in
-                          (match uu____17844 with
+                                   (uu____17889, uu____17892)) in
+                          (match uu____17824 with
                            | (cres, guard2) ->
                                let bs_cres = FStar_Syntax_Util.arrow bs cres in
-                               ((let uu____17931 =
+                               ((let uu____17911 =
                                    FStar_All.pipe_left
                                      (FStar_TypeChecker_Env.debug env)
                                      FStar_Options.Extreme in
-                                 if uu____17931
+                                 if uu____17911
                                  then
-                                   let uu____17932 =
+                                   let uu____17912 =
                                      FStar_Syntax_Print.term_to_string head in
-                                   let uu____17933 =
+                                   let uu____17913 =
                                      FStar_Syntax_Print.term_to_string tf in
-                                   let uu____17934 =
+                                   let uu____17914 =
                                      FStar_Syntax_Print.term_to_string
                                        bs_cres in
                                    FStar_Util.print3
                                      "Forcing the type of %s from %s to %s\n"
-                                     uu____17932 uu____17933 uu____17934
+                                     uu____17912 uu____17913 uu____17914
                                  else ());
                                 (let g =
-                                   let uu____17937 =
+                                   let uu____17917 =
                                      FStar_TypeChecker_Rel.teq env tf bs_cres in
                                    FStar_TypeChecker_Rel.solve_deferred_constraints
-                                     env uu____17937 in
-                                 let uu____17938 =
+                                     env uu____17917 in
+                                 let uu____17918 =
                                    FStar_TypeChecker_Env.conj_guard g guard2 in
-                                 check_function_app bs_cres uu____17938))))
+                                 check_function_app bs_cres uu____17918))))
                  | FStar_Syntax_Syntax.Tm_arrow (bs, c) ->
-                     let uu____17961 = FStar_Syntax_Subst.open_comp bs c in
-                     (match uu____17961 with
+                     let uu____17941 = FStar_Syntax_Subst.open_comp bs c in
+                     (match uu____17941 with
                       | (bs1, c1) ->
                           let head_info = (head, chead, ghead, c1) in
-                          ((let uu____17984 =
+                          ((let uu____17964 =
                               FStar_TypeChecker_Env.debug env
                                 FStar_Options.Extreme in
-                            if uu____17984
+                            if uu____17964
                             then
-                              let uu____17985 =
+                              let uu____17965 =
                                 FStar_Syntax_Print.term_to_string head in
-                              let uu____17986 =
+                              let uu____17966 =
                                 FStar_Syntax_Print.term_to_string tf in
-                              let uu____17987 =
+                              let uu____17967 =
                                 FStar_Syntax_Print.binders_to_string ", " bs1 in
-                              let uu____17988 =
+                              let uu____17968 =
                                 FStar_Syntax_Print.comp_to_string c1 in
                               FStar_Util.print4
                                 "######tc_args of head %s @ %s with formals=%s and result type=%s\n"
-                                uu____17985 uu____17986 uu____17987
-                                uu____17988
+                                uu____17965 uu____17966 uu____17967
+                                uu____17968
                             else ());
                            tc_args head_info ([], [], [], guard, []) bs1 args))
-                 | FStar_Syntax_Syntax.Tm_refine (bv, uu____18047) ->
+                 | FStar_Syntax_Syntax.Tm_refine (bv, uu____18027) ->
                      check_function_app bv.FStar_Syntax_Syntax.sort guard
                  | FStar_Syntax_Syntax.Tm_ascribed
-                     (t, uu____18053, uu____18054) ->
+                     (t, uu____18033, uu____18034) ->
                      check_function_app t guard
-                 | uu____18095 ->
-                     let uu____18096 =
+                 | uu____18075 ->
+                     let uu____18076 =
                        FStar_TypeChecker_Err.expected_function_typ env tf in
-                     FStar_Errors.raise_error uu____18096
+                     FStar_Errors.raise_error uu____18076
                        head.FStar_Syntax_Syntax.pos in
                check_function_app thead FStar_TypeChecker_Env.trivial_guard)
 and (check_short_circuit_args :
@@ -6430,79 +6430,79 @@ and (check_short_circuit_args :
                     ((FStar_List.length bs) = (FStar_List.length args))
                   ->
                   let res_t = FStar_Syntax_Util.comp_result c in
-                  let uu____18178 =
+                  let uu____18158 =
                     FStar_List.fold_left2
-                      (fun uu____18245 ->
-                         fun uu____18246 ->
-                           fun uu____18247 ->
-                             match (uu____18245, uu____18246, uu____18247)
+                      (fun uu____18225 ->
+                         fun uu____18226 ->
+                           fun uu____18227 ->
+                             match (uu____18225, uu____18226, uu____18227)
                              with
                              | ((seen, guard, ghost), (e, aq), (b, aq')) ->
-                                 ((let uu____18394 =
-                                     let uu____18395 =
+                                 ((let uu____18374 =
+                                     let uu____18375 =
                                        FStar_Syntax_Util.eq_aqual aq aq' in
-                                     uu____18395 <> FStar_Syntax_Util.Equal in
-                                   if uu____18394
+                                     uu____18375 <> FStar_Syntax_Util.Equal in
+                                   if uu____18374
                                    then
                                      FStar_Errors.raise_error
                                        (FStar_Errors.Fatal_InconsistentImplicitQualifier,
                                          "Inconsistent implicit qualifiers")
                                        e.FStar_Syntax_Syntax.pos
                                    else ());
-                                  (let uu____18397 =
+                                  (let uu____18377 =
                                      tc_check_tot_or_gtot_term env e
                                        b.FStar_Syntax_Syntax.sort
                                        "arguments to short circuiting operators must be pure or ghost" in
-                                   match uu____18397 with
+                                   match uu____18377 with
                                    | (e1, c1, g) ->
                                        let short =
                                          FStar_TypeChecker_Util.short_circuit
                                            head seen in
                                        let g1 =
-                                         let uu____18425 =
+                                         let uu____18405 =
                                            FStar_TypeChecker_Env.guard_of_guard_formula
                                              short in
                                          FStar_TypeChecker_Env.imp_guard
-                                           uu____18425 g in
+                                           uu____18405 g in
                                        let ghost1 =
                                          ghost ||
-                                           ((let uu____18429 =
+                                           ((let uu____18409 =
                                                FStar_TypeChecker_Common.is_total_lcomp
                                                  c1 in
-                                             Prims.op_Negation uu____18429)
+                                             Prims.op_Negation uu____18409)
                                               &&
-                                              (let uu____18431 =
+                                              (let uu____18411 =
                                                  FStar_TypeChecker_Util.is_pure_effect
                                                    env
                                                    c1.FStar_TypeChecker_Common.eff_name in
-                                               Prims.op_Negation uu____18431)) in
-                                       let uu____18432 =
-                                         let uu____18443 =
-                                           let uu____18454 =
+                                               Prims.op_Negation uu____18411)) in
+                                       let uu____18412 =
+                                         let uu____18423 =
+                                           let uu____18434 =
                                              FStar_Syntax_Syntax.as_arg e1 in
-                                           [uu____18454] in
-                                         FStar_List.append seen uu____18443 in
-                                       let uu____18487 =
+                                           [uu____18434] in
+                                         FStar_List.append seen uu____18423 in
+                                       let uu____18467 =
                                          FStar_TypeChecker_Env.conj_guard
                                            guard g1 in
-                                       (uu____18432, uu____18487, ghost1))))
+                                       (uu____18412, uu____18467, ghost1))))
                       ([], g_head, false) args bs in
-                  (match uu____18178 with
+                  (match uu____18158 with
                    | (args1, guard, ghost) ->
                        let e = FStar_Syntax_Syntax.mk_Tm_app head args1 r in
                        let c1 =
                          if ghost
                          then
-                           let uu____18547 =
+                           let uu____18527 =
                              FStar_Syntax_Syntax.mk_GTotal res_t in
-                           FStar_All.pipe_right uu____18547
+                           FStar_All.pipe_right uu____18527
                              FStar_TypeChecker_Common.lcomp_of_comp
                          else FStar_TypeChecker_Common.lcomp_of_comp c in
-                       let uu____18549 =
+                       let uu____18529 =
                          FStar_TypeChecker_Util.strengthen_precondition
                            FStar_Pervasives_Native.None env e c1 guard in
-                       (match uu____18549 with | (c2, g) -> (e, c2, g)))
-              | uu____18565 ->
+                       (match uu____18529 with | (c2, g) -> (e, c2, g)))
+              | uu____18545 ->
                   check_application_args env head chead g_head args
                     expected_topt
 and (tc_pat :
@@ -6524,52 +6524,52 @@ and (tc_pat :
         let expected_pat_typ env1 pos scrutinee_t =
           let rec aux norm1 t =
             let t1 = FStar_Syntax_Util.unrefine t in
-            let uu____18657 = FStar_Syntax_Util.head_and_args t1 in
-            match uu____18657 with
+            let uu____18637 = FStar_Syntax_Util.head_and_args t1 in
+            match uu____18637 with
             | (head, args) ->
-                let uu____18700 =
-                  let uu____18701 = FStar_Syntax_Subst.compress head in
-                  uu____18701.FStar_Syntax_Syntax.n in
-                (match uu____18700 with
+                let uu____18680 =
+                  let uu____18681 = FStar_Syntax_Subst.compress head in
+                  uu____18681.FStar_Syntax_Syntax.n in
+                (match uu____18680 with
                  | FStar_Syntax_Syntax.Tm_uinst
                      ({
                         FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar f;
-                        FStar_Syntax_Syntax.pos = uu____18705;
-                        FStar_Syntax_Syntax.vars = uu____18706;_},
+                        FStar_Syntax_Syntax.pos = uu____18685;
+                        FStar_Syntax_Syntax.vars = uu____18686;_},
                       us)
                      -> unfold_once t1 f us args
                  | FStar_Syntax_Syntax.Tm_fvar f -> unfold_once t1 f [] args
-                 | uu____18713 ->
+                 | uu____18693 ->
                      if norm1
                      then t1
                      else
-                       (let uu____18715 =
+                       (let uu____18695 =
                           FStar_TypeChecker_Normalize.normalize
                             [FStar_TypeChecker_Env.HNF;
                             FStar_TypeChecker_Env.Unmeta;
                             FStar_TypeChecker_Env.Unascribe;
                             FStar_TypeChecker_Env.UnfoldUntil
                               FStar_Syntax_Syntax.delta_constant] env1 t1 in
-                        aux true uu____18715))
+                        aux true uu____18695))
           and unfold_once t f us args =
-            let uu____18732 =
+            let uu____18712 =
               FStar_TypeChecker_Env.is_type_constructor env1
                 (f.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-            if uu____18732
+            if uu____18712
             then t
             else
-              (let uu____18734 =
+              (let uu____18714 =
                  FStar_TypeChecker_Env.lookup_definition
                    [FStar_TypeChecker_Env.Unfold
                       FStar_Syntax_Syntax.delta_constant] env1
                    (f.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-               match uu____18734 with
+               match uu____18714 with
                | FStar_Pervasives_Native.None -> t
                | FStar_Pervasives_Native.Some head_def_ts ->
-                   let uu____18754 =
+                   let uu____18734 =
                      FStar_TypeChecker_Env.inst_tscheme_with head_def_ts us in
-                   (match uu____18754 with
-                    | (uu____18759, head_def) ->
+                   (match uu____18734 with
+                    | (uu____18739, head_def) ->
                         let t' =
                           FStar_Syntax_Syntax.mk_Tm_app head_def args
                             t.FStar_Syntax_Syntax.pos in
@@ -6578,69 +6578,69 @@ and (tc_pat :
                             [FStar_TypeChecker_Env.Beta;
                             FStar_TypeChecker_Env.Iota] env1 t' in
                         aux false t'1)) in
-          let uu____18763 =
+          let uu____18743 =
             FStar_TypeChecker_Normalize.normalize
               [FStar_TypeChecker_Env.Beta; FStar_TypeChecker_Env.Iota] env1
               scrutinee_t in
-          aux false uu____18763 in
+          aux false uu____18743 in
         let pat_typ_ok env1 pat_t1 scrutinee_t =
-          (let uu____18781 =
+          (let uu____18761 =
              FStar_All.pipe_left (FStar_TypeChecker_Env.debug env1)
                (FStar_Options.Other "Patterns") in
-           if uu____18781
+           if uu____18761
            then
-             let uu____18782 = FStar_Syntax_Print.term_to_string pat_t1 in
-             let uu____18783 = FStar_Syntax_Print.term_to_string scrutinee_t in
+             let uu____18762 = FStar_Syntax_Print.term_to_string pat_t1 in
+             let uu____18763 = FStar_Syntax_Print.term_to_string scrutinee_t in
              FStar_Util.print2 "$$$$$$$$$$$$pat_typ_ok? %s vs. %s\n"
-               uu____18782 uu____18783
+               uu____18762 uu____18763
            else ());
           (let fail1 msg =
              let msg1 =
-               let uu____18797 = FStar_Syntax_Print.term_to_string pat_t1 in
-               let uu____18798 =
+               let uu____18777 = FStar_Syntax_Print.term_to_string pat_t1 in
+               let uu____18778 =
                  FStar_Syntax_Print.term_to_string scrutinee_t in
                FStar_Util.format3
                  "Type of pattern (%s) does not match type of scrutinee (%s)%s"
-                 uu____18797 uu____18798 msg in
+                 uu____18777 uu____18778 msg in
              FStar_Errors.raise_error
                (FStar_Errors.Fatal_MismatchedPatternType, msg1)
                p0.FStar_Syntax_Syntax.p in
-           let uu____18799 = FStar_Syntax_Util.head_and_args scrutinee_t in
-           match uu____18799 with
+           let uu____18779 = FStar_Syntax_Util.head_and_args scrutinee_t in
+           match uu____18779 with
            | (head_s, args_s) ->
                let pat_t2 =
                  FStar_TypeChecker_Normalize.normalize
                    [FStar_TypeChecker_Env.Beta] env1 pat_t1 in
-               let uu____18843 = FStar_Syntax_Util.un_uinst head_s in
-               (match uu____18843 with
+               let uu____18823 = FStar_Syntax_Util.un_uinst head_s in
+               (match uu____18823 with
                 | {
                     FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar
-                      uu____18844;
-                    FStar_Syntax_Syntax.pos = uu____18845;
-                    FStar_Syntax_Syntax.vars = uu____18846;_} ->
-                    let uu____18849 = FStar_Syntax_Util.head_and_args pat_t2 in
-                    (match uu____18849 with
+                      uu____18824;
+                    FStar_Syntax_Syntax.pos = uu____18825;
+                    FStar_Syntax_Syntax.vars = uu____18826;_} ->
+                    let uu____18829 = FStar_Syntax_Util.head_and_args pat_t2 in
+                    (match uu____18829 with
                      | (head_p, args_p) ->
-                         let uu____18892 =
+                         let uu____18872 =
                            FStar_TypeChecker_Rel.teq_nosmt_force env1 head_p
                              head_s in
-                         if uu____18892
+                         if uu____18872
                          then
-                           let uu____18893 =
-                             let uu____18894 =
+                           let uu____18873 =
+                             let uu____18874 =
                                FStar_Syntax_Util.un_uinst head_p in
-                             uu____18894.FStar_Syntax_Syntax.n in
-                           (match uu____18893 with
+                             uu____18874.FStar_Syntax_Syntax.n in
+                           (match uu____18873 with
                             | FStar_Syntax_Syntax.Tm_fvar f ->
-                                ((let uu____18899 =
-                                    let uu____18900 =
-                                      let uu____18901 =
+                                ((let uu____18879 =
+                                    let uu____18880 =
+                                      let uu____18881 =
                                         FStar_Syntax_Syntax.lid_of_fv f in
                                       FStar_TypeChecker_Env.is_type_constructor
-                                        env1 uu____18901 in
+                                        env1 uu____18881 in
                                     FStar_All.pipe_left Prims.op_Negation
-                                      uu____18900 in
-                                  if uu____18899
+                                      uu____18880 in
+                                  if uu____18879
                                   then
                                     fail1
                                       "Pattern matching a non-inductive type"
@@ -6650,54 +6650,54 @@ and (tc_pat :
                                      (FStar_List.length args_s)
                                  then fail1 ""
                                  else ();
-                                 (let uu____18921 =
-                                    let uu____18946 =
-                                      let uu____18949 =
+                                 (let uu____18901 =
+                                    let uu____18926 =
+                                      let uu____18929 =
                                         FStar_Syntax_Syntax.lid_of_fv f in
                                       FStar_TypeChecker_Env.num_inductive_ty_params
-                                        env1 uu____18949 in
-                                    match uu____18946 with
+                                        env1 uu____18929 in
+                                    match uu____18926 with
                                     | FStar_Pervasives_Native.None ->
                                         (args_p, args_s)
                                     | FStar_Pervasives_Native.Some n ->
-                                        let uu____18995 =
+                                        let uu____18975 =
                                           FStar_Util.first_N n args_p in
-                                        (match uu____18995 with
-                                         | (params_p, uu____19053) ->
-                                             let uu____19094 =
+                                        (match uu____18975 with
+                                         | (params_p, uu____19033) ->
+                                             let uu____19074 =
                                                FStar_Util.first_N n args_s in
-                                             (match uu____19094 with
-                                              | (params_s, uu____19152) ->
+                                             (match uu____19074 with
+                                              | (params_s, uu____19132) ->
                                                   (params_p, params_s))) in
-                                  match uu____18921 with
+                                  match uu____18901 with
                                   | (params_p, params_s) ->
                                       FStar_List.fold_left2
                                         (fun out ->
-                                           fun uu____19281 ->
-                                             fun uu____19282 ->
-                                               match (uu____19281,
-                                                       uu____19282)
+                                           fun uu____19261 ->
+                                             fun uu____19262 ->
+                                               match (uu____19261,
+                                                       uu____19262)
                                                with
-                                               | ((p, uu____19316),
-                                                  (s, uu____19318)) ->
-                                                   let uu____19351 =
+                                               | ((p, uu____19296),
+                                                  (s, uu____19298)) ->
+                                                   let uu____19331 =
                                                      FStar_TypeChecker_Rel.teq_nosmt
                                                        env1 p s in
-                                                   (match uu____19351 with
+                                                   (match uu____19331 with
                                                     | FStar_Pervasives_Native.None
                                                         ->
-                                                        let uu____19354 =
-                                                          let uu____19355 =
+                                                        let uu____19334 =
+                                                          let uu____19335 =
                                                             FStar_Syntax_Print.term_to_string
                                                               p in
-                                                          let uu____19356 =
+                                                          let uu____19336 =
                                                             FStar_Syntax_Print.term_to_string
                                                               s in
                                                           FStar_Util.format2
                                                             "; parameter %s <> parameter %s"
-                                                            uu____19355
-                                                            uu____19356 in
-                                                        fail1 uu____19354
+                                                            uu____19335
+                                                            uu____19336 in
+                                                        fail1 uu____19334
                                                     | FStar_Pervasives_Native.Some
                                                         g ->
                                                         let g1 =
@@ -6707,21 +6707,21 @@ and (tc_pat :
                                                           g1 out))
                                         FStar_TypeChecker_Env.trivial_guard
                                         params_p params_s))
-                            | uu____19359 ->
+                            | uu____19339 ->
                                 fail1 "Pattern matching a non-inductive type")
                          else
-                           (let uu____19361 =
-                              let uu____19362 =
+                           (let uu____19341 =
+                              let uu____19342 =
                                 FStar_Syntax_Print.term_to_string head_p in
-                              let uu____19363 =
+                              let uu____19343 =
                                 FStar_Syntax_Print.term_to_string head_s in
                               FStar_Util.format2 "; head mismatch %s vs %s"
-                                uu____19362 uu____19363 in
-                            fail1 uu____19361))
-                | uu____19364 ->
-                    let uu____19365 =
+                                uu____19342 uu____19343 in
+                            fail1 uu____19341))
+                | uu____19344 ->
+                    let uu____19345 =
                       FStar_TypeChecker_Rel.teq_nosmt env1 pat_t2 scrutinee_t in
-                    (match uu____19365 with
+                    (match uu____19345 with
                      | FStar_Pervasives_Native.None -> fail1 ""
                      | FStar_Pervasives_Native.Some g ->
                          let g1 =
@@ -6729,18 +6729,18 @@ and (tc_pat :
                              g in
                          g1))) in
         let type_of_simple_pat env1 e =
-          let uu____19405 = FStar_Syntax_Util.head_and_args e in
-          match uu____19405 with
+          let uu____19385 = FStar_Syntax_Util.head_and_args e in
+          match uu____19385 with
           | (head, args) ->
               (match head.FStar_Syntax_Syntax.n with
                | FStar_Syntax_Syntax.Tm_fvar f ->
-                   let uu____19473 =
+                   let uu____19453 =
                      FStar_TypeChecker_Env.lookup_datacon env1
                        (f.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-                   (match uu____19473 with
+                   (match uu____19453 with
                     | (us, t_f) ->
-                        let uu____19492 = FStar_Syntax_Util.arrow_formals t_f in
-                        (match uu____19492 with
+                        let uu____19472 = FStar_Syntax_Util.arrow_formals t_f in
+                        (match uu____19472 with
                          | (formals, t) ->
                              let erasable =
                                FStar_TypeChecker_Env.non_informative env1 t in
@@ -6751,8 +6751,8 @@ and (tc_pat :
                                 fail
                                   "Pattern is not a fully-applied data constructor"
                               else ();
-                              (let rec aux uu____19597 formals1 args1 =
-                                 match uu____19597 with
+                              (let rec aux uu____19577 formals1 args1 =
+                                 match uu____19577 with
                                  | (subst, args_out, bvs, guard) ->
                                      (match (formals1, args1) with
                                       | ([], []) ->
@@ -6763,32 +6763,32 @@ and (tc_pat :
                                             FStar_Syntax_Syntax.mk_Tm_app
                                               head1 args_out
                                               e.FStar_Syntax_Syntax.pos in
-                                          let uu____19740 =
+                                          let uu____19720 =
                                             FStar_Syntax_Subst.subst subst t in
-                                          (pat_e, uu____19740, bvs, guard,
+                                          (pat_e, uu____19720, bvs, guard,
                                             erasable)
-                                      | ((f1, uu____19744)::formals2,
+                                      | ((f1, uu____19724)::formals2,
                                          (a, imp_a)::args2) ->
                                           let t_f1 =
                                             FStar_Syntax_Subst.subst subst
                                               f1.FStar_Syntax_Syntax.sort in
-                                          let uu____19802 =
-                                            let uu____19823 =
-                                              let uu____19824 =
+                                          let uu____19782 =
+                                            let uu____19803 =
+                                              let uu____19804 =
                                                 FStar_Syntax_Subst.compress a in
-                                              uu____19824.FStar_Syntax_Syntax.n in
-                                            match uu____19823 with
+                                              uu____19804.FStar_Syntax_Syntax.n in
+                                            match uu____19803 with
                                             | FStar_Syntax_Syntax.Tm_name x
                                                 ->
                                                 let x1 =
-                                                  let uu___2688_19849 = x in
+                                                  let uu___2688_19829 = x in
                                                   {
                                                     FStar_Syntax_Syntax.ppname
                                                       =
-                                                      (uu___2688_19849.FStar_Syntax_Syntax.ppname);
+                                                      (uu___2688_19829.FStar_Syntax_Syntax.ppname);
                                                     FStar_Syntax_Syntax.index
                                                       =
-                                                      (uu___2688_19849.FStar_Syntax_Syntax.index);
+                                                      (uu___2688_19829.FStar_Syntax_Syntax.index);
                                                     FStar_Syntax_Syntax.sort
                                                       = t_f1
                                                   } in
@@ -6803,14 +6803,14 @@ and (tc_pat :
                                                   (FStar_List.append bvs [x1]),
                                                   FStar_TypeChecker_Env.trivial_guard)
                                             | FStar_Syntax_Syntax.Tm_uvar
-                                                uu____19872 ->
+                                                uu____19852 ->
                                                 let env2 =
                                                   FStar_TypeChecker_Env.set_expected_typ
                                                     env1 t_f1 in
-                                                let uu____19886 =
+                                                let uu____19866 =
                                                   tc_tot_or_gtot_term env2 a in
-                                                (match uu____19886 with
-                                                 | (a1, uu____19914, g) ->
+                                                (match uu____19866 with
+                                                 | (a1, uu____19894, g) ->
                                                      let g1 =
                                                        FStar_TypeChecker_Rel.discharge_guard_no_smt
                                                          env2 g in
@@ -6820,36 +6820,36 @@ and (tc_pat :
                                                        :: subst in
                                                      ((a1, imp_a), subst1,
                                                        bvs, g1))
-                                            | uu____19938 ->
+                                            | uu____19918 ->
                                                 fail "Not a simple pattern" in
-                                          (match uu____19802 with
+                                          (match uu____19782 with
                                            | (a1, subst1, bvs1, g) ->
-                                               let uu____19999 =
-                                                 let uu____20022 =
+                                               let uu____19979 =
+                                                 let uu____20002 =
                                                    FStar_TypeChecker_Env.conj_guard
                                                      g guard in
                                                  (subst1,
                                                    (FStar_List.append
                                                       args_out [a1]), bvs1,
-                                                   uu____20022) in
-                                               aux uu____19999 formals2 args2)
-                                      | uu____20061 ->
+                                                   uu____20002) in
+                                               aux uu____19979 formals2 args2)
+                                      | uu____20041 ->
                                           fail "Not a fully applued pattern") in
                                aux
                                  ([], [], [],
                                    FStar_TypeChecker_Env.trivial_guard)
                                  formals args))))
-               | uu____20116 -> fail "Not a simple pattern") in
+               | uu____20096 -> fail "Not a simple pattern") in
         let rec check_nested_pattern env1 p t =
-          (let uu____20178 =
+          (let uu____20158 =
              FStar_All.pipe_left (FStar_TypeChecker_Env.debug env1)
                (FStar_Options.Other "Patterns") in
-           if uu____20178
+           if uu____20158
            then
-             let uu____20179 = FStar_Syntax_Print.pat_to_string p in
-             let uu____20180 = FStar_Syntax_Print.term_to_string t in
-             FStar_Util.print2 "Checking pattern %s at type %s\n" uu____20179
-               uu____20180
+             let uu____20159 = FStar_Syntax_Print.pat_to_string p in
+             let uu____20160 = FStar_Syntax_Print.term_to_string t in
+             FStar_Util.print2 "Checking pattern %s at type %s\n" uu____20159
+               uu____20160
            else ());
           (let id =
              FStar_Syntax_Syntax.fvar FStar_Parser_Const.id_lid
@@ -6857,120 +6857,120 @@ and (tc_pat :
                FStar_Pervasives_Native.None in
            let mk_disc_t disc inner_t =
              let x_b =
-               let uu____20201 =
+               let uu____20181 =
                  FStar_Syntax_Syntax.gen_bv "x" FStar_Pervasives_Native.None
                    t in
-               FStar_All.pipe_right uu____20201 FStar_Syntax_Syntax.mk_binder in
+               FStar_All.pipe_right uu____20181 FStar_Syntax_Syntax.mk_binder in
              let tm =
-               let uu____20209 =
-                 let uu____20210 =
-                   let uu____20219 =
-                     let uu____20220 =
+               let uu____20189 =
+                 let uu____20190 =
+                   let uu____20199 =
+                     let uu____20200 =
                        FStar_All.pipe_right x_b FStar_Pervasives_Native.fst in
-                     FStar_All.pipe_right uu____20220
+                     FStar_All.pipe_right uu____20200
                        FStar_Syntax_Syntax.bv_to_name in
-                   FStar_All.pipe_right uu____20219
+                   FStar_All.pipe_right uu____20199
                      FStar_Syntax_Syntax.as_arg in
-                 [uu____20210] in
-               FStar_Syntax_Syntax.mk_Tm_app disc uu____20209
+                 [uu____20190] in
+               FStar_Syntax_Syntax.mk_Tm_app disc uu____20189
                  FStar_Range.dummyRange in
              let tm1 =
-               let uu____20254 =
-                 let uu____20255 =
+               let uu____20234 =
+                 let uu____20235 =
                    FStar_All.pipe_right tm FStar_Syntax_Syntax.as_arg in
-                 [uu____20255] in
-               FStar_Syntax_Syntax.mk_Tm_app inner_t uu____20254
+                 [uu____20235] in
+               FStar_Syntax_Syntax.mk_Tm_app inner_t uu____20234
                  FStar_Range.dummyRange in
              FStar_Syntax_Util.abs [x_b] tm1 FStar_Pervasives_Native.None in
            match p.FStar_Syntax_Syntax.v with
-           | FStar_Syntax_Syntax.Pat_dot_term uu____20316 ->
-               let uu____20323 =
-                 let uu____20324 = FStar_Syntax_Print.pat_to_string p in
+           | FStar_Syntax_Syntax.Pat_dot_term uu____20296 ->
+               let uu____20303 =
+                 let uu____20304 = FStar_Syntax_Print.pat_to_string p in
                  FStar_Util.format1
                    "Impossible: Expected an undecorated pattern, got %s"
-                   uu____20324 in
-               failwith uu____20323
+                   uu____20304 in
+               failwith uu____20303
            | FStar_Syntax_Syntax.Pat_wild x ->
                let x1 =
-                 let uu___2727_20343 = x in
+                 let uu___2727_20323 = x in
                  {
                    FStar_Syntax_Syntax.ppname =
-                     (uu___2727_20343.FStar_Syntax_Syntax.ppname);
+                     (uu___2727_20323.FStar_Syntax_Syntax.ppname);
                    FStar_Syntax_Syntax.index =
-                     (uu___2727_20343.FStar_Syntax_Syntax.index);
+                     (uu___2727_20323.FStar_Syntax_Syntax.index);
                    FStar_Syntax_Syntax.sort = t
                  } in
-               let uu____20344 = FStar_Syntax_Syntax.bv_to_name x1 in
-               ([x1], [id], uu____20344,
-                 (let uu___2730_20350 = p in
+               let uu____20324 = FStar_Syntax_Syntax.bv_to_name x1 in
+               ([x1], [id], uu____20324,
+                 (let uu___2730_20330 = p in
                   {
                     FStar_Syntax_Syntax.v = (FStar_Syntax_Syntax.Pat_wild x1);
                     FStar_Syntax_Syntax.p =
-                      (uu___2730_20350.FStar_Syntax_Syntax.p)
+                      (uu___2730_20330.FStar_Syntax_Syntax.p)
                   }), FStar_TypeChecker_Env.trivial_guard, false)
            | FStar_Syntax_Syntax.Pat_var x ->
                let x1 =
-                 let uu___2734_20353 = x in
+                 let uu___2734_20333 = x in
                  {
                    FStar_Syntax_Syntax.ppname =
-                     (uu___2734_20353.FStar_Syntax_Syntax.ppname);
+                     (uu___2734_20333.FStar_Syntax_Syntax.ppname);
                    FStar_Syntax_Syntax.index =
-                     (uu___2734_20353.FStar_Syntax_Syntax.index);
+                     (uu___2734_20333.FStar_Syntax_Syntax.index);
                    FStar_Syntax_Syntax.sort = t
                  } in
-               let uu____20354 = FStar_Syntax_Syntax.bv_to_name x1 in
-               ([x1], [id], uu____20354,
-                 (let uu___2737_20360 = p in
+               let uu____20334 = FStar_Syntax_Syntax.bv_to_name x1 in
+               ([x1], [id], uu____20334,
+                 (let uu___2737_20340 = p in
                   {
                     FStar_Syntax_Syntax.v = (FStar_Syntax_Syntax.Pat_var x1);
                     FStar_Syntax_Syntax.p =
-                      (uu___2737_20360.FStar_Syntax_Syntax.p)
+                      (uu___2737_20340.FStar_Syntax_Syntax.p)
                   }), FStar_TypeChecker_Env.trivial_guard, false)
            | FStar_Syntax_Syntax.Pat_constant c ->
                ((match c with
                  | FStar_Const.Const_unit -> ()
-                 | FStar_Const.Const_bool uu____20363 -> ()
-                 | FStar_Const.Const_int uu____20364 -> ()
-                 | FStar_Const.Const_char uu____20375 -> ()
-                 | FStar_Const.Const_float uu____20376 -> ()
-                 | FStar_Const.Const_string uu____20377 -> ()
-                 | uu____20382 ->
-                     let uu____20383 =
-                       let uu____20384 = FStar_Syntax_Print.const_to_string c in
+                 | FStar_Const.Const_bool uu____20343 -> ()
+                 | FStar_Const.Const_int uu____20344 -> ()
+                 | FStar_Const.Const_char uu____20355 -> ()
+                 | FStar_Const.Const_float uu____20356 -> ()
+                 | FStar_Const.Const_string uu____20357 -> ()
+                 | uu____20362 ->
+                     let uu____20363 =
+                       let uu____20364 = FStar_Syntax_Print.const_to_string c in
                        FStar_Util.format1
                          "Pattern matching a constant that does not have decidable equality: %s"
-                         uu____20384 in
-                     fail uu____20383);
-                (let uu____20385 =
+                         uu____20364 in
+                     fail uu____20363);
+                (let uu____20365 =
                    FStar_TypeChecker_PatternUtils.pat_as_exp false env1 p in
-                 match uu____20385 with
-                 | (uu____20412, e_c, uu____20414, uu____20415) ->
-                     let uu____20420 = tc_tot_or_gtot_term env1 e_c in
-                     (match uu____20420 with
+                 match uu____20365 with
+                 | (uu____20392, e_c, uu____20394, uu____20395) ->
+                     let uu____20400 = tc_tot_or_gtot_term env1 e_c in
+                     (match uu____20400 with
                       | (e_c1, lc, g) ->
                           (FStar_TypeChecker_Rel.force_trivial_guard env1 g;
                            (let expected_t =
                               expected_pat_typ env1 p0.FStar_Syntax_Syntax.p
                                 t in
-                            (let uu____20449 =
-                               let uu____20450 =
+                            (let uu____20429 =
+                               let uu____20430 =
                                  FStar_TypeChecker_Rel.teq_nosmt_force env1
                                    lc.FStar_TypeChecker_Common.res_typ
                                    expected_t in
-                               Prims.op_Negation uu____20450 in
-                             if uu____20449
+                               Prims.op_Negation uu____20430 in
+                             if uu____20429
                              then
-                               let uu____20451 =
-                                 let uu____20452 =
+                               let uu____20431 =
+                                 let uu____20432 =
                                    FStar_Syntax_Print.term_to_string
                                      lc.FStar_TypeChecker_Common.res_typ in
-                                 let uu____20453 =
+                                 let uu____20433 =
                                    FStar_Syntax_Print.term_to_string
                                      expected_t in
                                  FStar_Util.format2
                                    "Type of pattern (%s) does not match type of scrutinee (%s)"
-                                   uu____20452 uu____20453 in
-                               fail uu____20451
+                                   uu____20432 uu____20433 in
+                               fail uu____20431
                              else ());
                             ([], [], e_c1, p,
                               FStar_TypeChecker_Env.trivial_guard, false))))))
@@ -6978,141 +6978,141 @@ and (tc_pat :
                let simple_pat =
                  let simple_sub_pats =
                    FStar_List.map
-                     (fun uu____20505 ->
-                        match uu____20505 with
+                     (fun uu____20485 ->
+                        match uu____20485 with
                         | (p1, b) ->
                             (match p1.FStar_Syntax_Syntax.v with
-                             | FStar_Syntax_Syntax.Pat_dot_term uu____20530
+                             | FStar_Syntax_Syntax.Pat_dot_term uu____20510
                                  -> (p1, b)
-                             | uu____20539 ->
-                                 let uu____20540 =
-                                   let uu____20543 =
-                                     let uu____20544 =
+                             | uu____20519 ->
+                                 let uu____20520 =
+                                   let uu____20523 =
+                                     let uu____20524 =
                                        FStar_Syntax_Syntax.new_bv
                                          (FStar_Pervasives_Native.Some
                                             (p1.FStar_Syntax_Syntax.p))
                                          FStar_Syntax_Syntax.tun in
-                                     FStar_Syntax_Syntax.Pat_var uu____20544 in
-                                   FStar_Syntax_Syntax.withinfo uu____20543
+                                     FStar_Syntax_Syntax.Pat_var uu____20524 in
+                                   FStar_Syntax_Syntax.withinfo uu____20523
                                      p1.FStar_Syntax_Syntax.p in
-                                 (uu____20540, b))) sub_pats in
-                 let uu___2778_20547 = p in
+                                 (uu____20520, b))) sub_pats in
+                 let uu___2778_20527 = p in
                  {
                    FStar_Syntax_Syntax.v =
                      (FStar_Syntax_Syntax.Pat_cons (fv, simple_sub_pats));
                    FStar_Syntax_Syntax.p =
-                     (uu___2778_20547.FStar_Syntax_Syntax.p)
+                     (uu___2778_20527.FStar_Syntax_Syntax.p)
                  } in
                let sub_pats1 =
                  FStar_All.pipe_right sub_pats
                    (FStar_List.filter
-                      (fun uu____20587 ->
-                         match uu____20587 with
-                         | (x, uu____20595) ->
+                      (fun uu____20567 ->
+                         match uu____20567 with
+                         | (x, uu____20575) ->
                              (match x.FStar_Syntax_Syntax.v with
-                              | FStar_Syntax_Syntax.Pat_dot_term uu____20600
+                              | FStar_Syntax_Syntax.Pat_dot_term uu____20580
                                   -> false
-                              | uu____20607 -> true))) in
-               let uu____20608 =
+                              | uu____20587 -> true))) in
+               let uu____20588 =
                  FStar_TypeChecker_PatternUtils.pat_as_exp false env1
                    simple_pat in
-               (match uu____20608 with
+               (match uu____20588 with
                 | (simple_bvs, simple_pat_e, g0, simple_pat_elab) ->
                     (if
                        (FStar_List.length simple_bvs) <>
                          (FStar_List.length sub_pats1)
                      then
-                       (let uu____20648 =
-                          let uu____20649 =
+                       (let uu____20628 =
+                          let uu____20629 =
                             FStar_Range.string_of_range
                               p.FStar_Syntax_Syntax.p in
-                          let uu____20650 =
+                          let uu____20630 =
                             FStar_Syntax_Print.pat_to_string simple_pat in
-                          let uu____20651 =
+                          let uu____20631 =
                             FStar_Util.string_of_int
                               (FStar_List.length sub_pats1) in
-                          let uu____20656 =
+                          let uu____20636 =
                             FStar_Util.string_of_int
                               (FStar_List.length simple_bvs) in
                           FStar_Util.format4
                             "(%s) Impossible: pattern bvar mismatch: %s; expected %s sub pats; got %s"
-                            uu____20649 uu____20650 uu____20651 uu____20656 in
-                        failwith uu____20648)
+                            uu____20629 uu____20630 uu____20631 uu____20636 in
+                        failwith uu____20628)
                      else ();
-                     (let uu____20658 =
-                        let uu____20669 =
+                     (let uu____20638 =
+                        let uu____20649 =
                           type_of_simple_pat env1 simple_pat_e in
-                        match uu____20669 with
+                        match uu____20649 with
                         | (simple_pat_e1, simple_pat_t, simple_bvs1, guard,
                            erasable) ->
                             let g' =
-                              let uu____20702 =
+                              let uu____20682 =
                                 expected_pat_typ env1
                                   p0.FStar_Syntax_Syntax.p t in
-                              pat_typ_ok env1 simple_pat_t uu____20702 in
+                              pat_typ_ok env1 simple_pat_t uu____20682 in
                             let guard1 =
                               FStar_TypeChecker_Env.conj_guard guard g' in
-                            ((let uu____20705 =
+                            ((let uu____20685 =
                                 FStar_All.pipe_left
                                   (FStar_TypeChecker_Env.debug env1)
                                   (FStar_Options.Other "Patterns") in
-                              if uu____20705
+                              if uu____20685
                               then
-                                let uu____20706 =
+                                let uu____20686 =
                                   FStar_Syntax_Print.term_to_string
                                     simple_pat_e1 in
-                                let uu____20707 =
+                                let uu____20687 =
                                   FStar_Syntax_Print.term_to_string
                                     simple_pat_t in
-                                let uu____20708 =
-                                  let uu____20709 =
+                                let uu____20688 =
+                                  let uu____20689 =
                                     FStar_List.map
                                       (fun x ->
-                                         let uu____20715 =
-                                           let uu____20716 =
+                                         let uu____20695 =
+                                           let uu____20696 =
                                              FStar_Syntax_Print.bv_to_string
                                                x in
-                                           let uu____20717 =
-                                             let uu____20718 =
-                                               let uu____20719 =
+                                           let uu____20697 =
+                                             let uu____20698 =
+                                               let uu____20699 =
                                                  FStar_Syntax_Print.term_to_string
                                                    x.FStar_Syntax_Syntax.sort in
-                                               Prims.op_Hat uu____20719 ")" in
-                                             Prims.op_Hat " : " uu____20718 in
-                                           Prims.op_Hat uu____20716
-                                             uu____20717 in
-                                         Prims.op_Hat "(" uu____20715)
+                                               Prims.op_Hat uu____20699 ")" in
+                                             Prims.op_Hat " : " uu____20698 in
+                                           Prims.op_Hat uu____20696
+                                             uu____20697 in
+                                         Prims.op_Hat "(" uu____20695)
                                       simple_bvs1 in
-                                  FStar_All.pipe_right uu____20709
+                                  FStar_All.pipe_right uu____20689
                                     (FStar_String.concat " ") in
                                 FStar_Util.print3
                                   "$$$$$$$$$$$$Checked simple pattern %s at type %s with bvs=%s\n"
-                                  uu____20706 uu____20707 uu____20708
+                                  uu____20686 uu____20687 uu____20688
                               else ());
                              (simple_pat_e1, simple_bvs1, guard1, erasable)) in
-                      match uu____20658 with
+                      match uu____20638 with
                       | (simple_pat_e1, simple_bvs1, g1, erasable) ->
-                          let uu____20749 =
-                            let uu____20778 =
-                              let uu____20807 =
+                          let uu____20729 =
+                            let uu____20758 =
+                              let uu____20787 =
                                 FStar_TypeChecker_Env.conj_guard g0 g1 in
-                              (env1, [], [], [], [], uu____20807, erasable,
+                              (env1, [], [], [], [], uu____20787, erasable,
                                 Prims.int_zero) in
                             FStar_List.fold_left2
-                              (fun uu____20880 ->
-                                 fun uu____20881 ->
+                              (fun uu____20860 ->
+                                 fun uu____20861 ->
                                    fun x ->
-                                     match (uu____20880, uu____20881) with
+                                     match (uu____20860, uu____20861) with
                                      | ((env2, bvs, tms, pats, subst, g,
                                          erasable1, i),
                                         (p1, b)) ->
                                          let expected_t =
                                            FStar_Syntax_Subst.subst subst
                                              x.FStar_Syntax_Syntax.sort in
-                                         let uu____21042 =
+                                         let uu____21022 =
                                            check_nested_pattern env2 p1
                                              expected_t in
-                                         (match uu____21042 with
+                                         (match uu____21022 with
                                           | (bvs_p, tms_p, e_p, p2, g',
                                              erasable_p) ->
                                               let env3 =
@@ -7120,24 +7120,24 @@ and (tc_pat :
                                                   env2 bvs_p in
                                               let tms_p1 =
                                                 let disc_tm =
-                                                  let uu____21106 =
+                                                  let uu____21086 =
                                                     FStar_Syntax_Syntax.lid_of_fv
                                                       fv in
                                                   FStar_TypeChecker_Util.get_field_projector_name
-                                                    env3 uu____21106 i in
-                                                let uu____21107 =
-                                                  let uu____21116 =
-                                                    let uu____21121 =
+                                                    env3 uu____21086 i in
+                                                let uu____21087 =
+                                                  let uu____21096 =
+                                                    let uu____21101 =
                                                       FStar_Syntax_Syntax.fvar
                                                         disc_tm
                                                         (FStar_Syntax_Syntax.Delta_constant_at_level
                                                            Prims.int_one)
                                                         FStar_Pervasives_Native.None in
-                                                    mk_disc_t uu____21121 in
-                                                  FStar_List.map uu____21116 in
+                                                    mk_disc_t uu____21101 in
+                                                  FStar_List.map uu____21096 in
                                                 FStar_All.pipe_right tms_p
-                                                  uu____21107 in
-                                              let uu____21126 =
+                                                  uu____21087 in
+                                              let uu____21106 =
                                                 FStar_TypeChecker_Env.conj_guard
                                                   g g' in
                                               (env3,
@@ -7147,13 +7147,13 @@ and (tc_pat :
                                                    [(p2, b)]),
                                                 ((FStar_Syntax_Syntax.NT
                                                     (x, e_p)) :: subst),
-                                                uu____21126,
+                                                uu____21106,
                                                 (erasable1 || erasable_p),
                                                 (i + Prims.int_one))))
-                              uu____20778 sub_pats1 simple_bvs1 in
-                          (match uu____20749 with
+                              uu____20758 sub_pats1 simple_bvs1 in
+                          (match uu____20729 with
                            | (_env, bvs, tms, checked_sub_pats, subst, g,
-                              erasable1, uu____21176) ->
+                              erasable1, uu____21156) ->
                                let pat_e =
                                  FStar_Syntax_Subst.subst subst simple_pat_e1 in
                                let reconstruct_nested_pat pat =
@@ -7168,33 +7168,33 @@ and (tc_pat :
                                               FStar_Syntax_Subst.subst subst
                                                 e in
                                             let hd1 =
-                                              let uu___2862_21333 = hd in
+                                              let uu___2862_21313 = hd in
                                               {
                                                 FStar_Syntax_Syntax.v =
                                                   (FStar_Syntax_Syntax.Pat_dot_term
                                                      (x, e1));
                                                 FStar_Syntax_Syntax.p =
-                                                  (uu___2862_21333.FStar_Syntax_Syntax.p)
+                                                  (uu___2862_21313.FStar_Syntax_Syntax.p)
                                               } in
-                                            let uu____21338 =
+                                            let uu____21318 =
                                               aux simple_pats1 bvs1 sub_pats2 in
-                                            (hd1, b) :: uu____21338
+                                            (hd1, b) :: uu____21318
                                         | FStar_Syntax_Syntax.Pat_var x ->
                                             (match (bvs1, sub_pats2) with
                                              | (x'::bvs2,
-                                                (hd1, uu____21377)::sub_pats3)
+                                                (hd1, uu____21357)::sub_pats3)
                                                  when
                                                  FStar_Syntax_Syntax.bv_eq x
                                                    x'
                                                  ->
-                                                 let uu____21409 =
+                                                 let uu____21389 =
                                                    aux simple_pats1 bvs2
                                                      sub_pats3 in
-                                                 (hd1, b) :: uu____21409
-                                             | uu____21426 ->
+                                                 (hd1, b) :: uu____21389
+                                             | uu____21406 ->
                                                  failwith
                                                    "Impossible: simple pat variable mismatch")
-                                        | uu____21449 ->
+                                        | uu____21429 ->
                                             failwith
                                               "Impossible: expected a simple pattern") in
                                  match pat.FStar_Syntax_Syntax.v with
@@ -7203,147 +7203,147 @@ and (tc_pat :
                                      let nested_pats =
                                        aux simple_pats simple_bvs1
                                          checked_sub_pats in
-                                     let uu___2883_21487 = pat in
+                                     let uu___2883_21467 = pat in
                                      {
                                        FStar_Syntax_Syntax.v =
                                          (FStar_Syntax_Syntax.Pat_cons
                                             (fv1, nested_pats));
                                        FStar_Syntax_Syntax.p =
-                                         (uu___2883_21487.FStar_Syntax_Syntax.p)
+                                         (uu___2883_21467.FStar_Syntax_Syntax.p)
                                      }
-                                 | uu____21498 -> failwith "Impossible" in
-                               let uu____21501 =
+                                 | uu____21478 -> failwith "Impossible" in
+                               let uu____21481 =
                                  reconstruct_nested_pat simple_pat_elab in
-                               (bvs, tms, pat_e, uu____21501, g, erasable1)))))) in
-        (let uu____21507 =
+                               (bvs, tms, pat_e, uu____21481, g, erasable1)))))) in
+        (let uu____21487 =
            FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
              (FStar_Options.Other "Patterns") in
-         if uu____21507
+         if uu____21487
          then
-           let uu____21508 = FStar_Syntax_Print.pat_to_string p0 in
-           FStar_Util.print1 "Checking pattern: %s\n" uu____21508
+           let uu____21488 = FStar_Syntax_Print.pat_to_string p0 in
+           FStar_Util.print1 "Checking pattern: %s\n" uu____21488
          else ());
-        (let uu____21510 =
-           let uu____21527 =
-             let uu___2888_21528 =
-               let uu____21529 = FStar_TypeChecker_Env.clear_expected_typ env in
-               FStar_All.pipe_right uu____21529 FStar_Pervasives_Native.fst in
+        (let uu____21490 =
+           let uu____21507 =
+             let uu___2888_21508 =
+               let uu____21509 = FStar_TypeChecker_Env.clear_expected_typ env in
+               FStar_All.pipe_right uu____21509 FStar_Pervasives_Native.fst in
              {
                FStar_TypeChecker_Env.solver =
-                 (uu___2888_21528.FStar_TypeChecker_Env.solver);
+                 (uu___2888_21508.FStar_TypeChecker_Env.solver);
                FStar_TypeChecker_Env.range =
-                 (uu___2888_21528.FStar_TypeChecker_Env.range);
+                 (uu___2888_21508.FStar_TypeChecker_Env.range);
                FStar_TypeChecker_Env.curmodule =
-                 (uu___2888_21528.FStar_TypeChecker_Env.curmodule);
+                 (uu___2888_21508.FStar_TypeChecker_Env.curmodule);
                FStar_TypeChecker_Env.gamma =
-                 (uu___2888_21528.FStar_TypeChecker_Env.gamma);
+                 (uu___2888_21508.FStar_TypeChecker_Env.gamma);
                FStar_TypeChecker_Env.gamma_sig =
-                 (uu___2888_21528.FStar_TypeChecker_Env.gamma_sig);
+                 (uu___2888_21508.FStar_TypeChecker_Env.gamma_sig);
                FStar_TypeChecker_Env.gamma_cache =
-                 (uu___2888_21528.FStar_TypeChecker_Env.gamma_cache);
+                 (uu___2888_21508.FStar_TypeChecker_Env.gamma_cache);
                FStar_TypeChecker_Env.modules =
-                 (uu___2888_21528.FStar_TypeChecker_Env.modules);
+                 (uu___2888_21508.FStar_TypeChecker_Env.modules);
                FStar_TypeChecker_Env.expected_typ =
-                 (uu___2888_21528.FStar_TypeChecker_Env.expected_typ);
+                 (uu___2888_21508.FStar_TypeChecker_Env.expected_typ);
                FStar_TypeChecker_Env.sigtab =
-                 (uu___2888_21528.FStar_TypeChecker_Env.sigtab);
+                 (uu___2888_21508.FStar_TypeChecker_Env.sigtab);
                FStar_TypeChecker_Env.attrtab =
-                 (uu___2888_21528.FStar_TypeChecker_Env.attrtab);
+                 (uu___2888_21508.FStar_TypeChecker_Env.attrtab);
                FStar_TypeChecker_Env.instantiate_imp =
-                 (uu___2888_21528.FStar_TypeChecker_Env.instantiate_imp);
+                 (uu___2888_21508.FStar_TypeChecker_Env.instantiate_imp);
                FStar_TypeChecker_Env.effects =
-                 (uu___2888_21528.FStar_TypeChecker_Env.effects);
+                 (uu___2888_21508.FStar_TypeChecker_Env.effects);
                FStar_TypeChecker_Env.generalize =
-                 (uu___2888_21528.FStar_TypeChecker_Env.generalize);
+                 (uu___2888_21508.FStar_TypeChecker_Env.generalize);
                FStar_TypeChecker_Env.letrecs =
-                 (uu___2888_21528.FStar_TypeChecker_Env.letrecs);
+                 (uu___2888_21508.FStar_TypeChecker_Env.letrecs);
                FStar_TypeChecker_Env.top_level =
-                 (uu___2888_21528.FStar_TypeChecker_Env.top_level);
+                 (uu___2888_21508.FStar_TypeChecker_Env.top_level);
                FStar_TypeChecker_Env.check_uvars =
-                 (uu___2888_21528.FStar_TypeChecker_Env.check_uvars);
+                 (uu___2888_21508.FStar_TypeChecker_Env.check_uvars);
                FStar_TypeChecker_Env.use_eq = true;
                FStar_TypeChecker_Env.use_eq_strict =
-                 (uu___2888_21528.FStar_TypeChecker_Env.use_eq_strict);
+                 (uu___2888_21508.FStar_TypeChecker_Env.use_eq_strict);
                FStar_TypeChecker_Env.is_iface =
-                 (uu___2888_21528.FStar_TypeChecker_Env.is_iface);
+                 (uu___2888_21508.FStar_TypeChecker_Env.is_iface);
                FStar_TypeChecker_Env.admit =
-                 (uu___2888_21528.FStar_TypeChecker_Env.admit);
+                 (uu___2888_21508.FStar_TypeChecker_Env.admit);
                FStar_TypeChecker_Env.lax =
-                 (uu___2888_21528.FStar_TypeChecker_Env.lax);
+                 (uu___2888_21508.FStar_TypeChecker_Env.lax);
                FStar_TypeChecker_Env.lax_universes =
-                 (uu___2888_21528.FStar_TypeChecker_Env.lax_universes);
+                 (uu___2888_21508.FStar_TypeChecker_Env.lax_universes);
                FStar_TypeChecker_Env.phase1 =
-                 (uu___2888_21528.FStar_TypeChecker_Env.phase1);
+                 (uu___2888_21508.FStar_TypeChecker_Env.phase1);
                FStar_TypeChecker_Env.failhard =
-                 (uu___2888_21528.FStar_TypeChecker_Env.failhard);
+                 (uu___2888_21508.FStar_TypeChecker_Env.failhard);
                FStar_TypeChecker_Env.nosynth =
-                 (uu___2888_21528.FStar_TypeChecker_Env.nosynth);
+                 (uu___2888_21508.FStar_TypeChecker_Env.nosynth);
                FStar_TypeChecker_Env.uvar_subtyping =
-                 (uu___2888_21528.FStar_TypeChecker_Env.uvar_subtyping);
+                 (uu___2888_21508.FStar_TypeChecker_Env.uvar_subtyping);
                FStar_TypeChecker_Env.tc_term =
-                 (uu___2888_21528.FStar_TypeChecker_Env.tc_term);
+                 (uu___2888_21508.FStar_TypeChecker_Env.tc_term);
                FStar_TypeChecker_Env.type_of =
-                 (uu___2888_21528.FStar_TypeChecker_Env.type_of);
+                 (uu___2888_21508.FStar_TypeChecker_Env.type_of);
                FStar_TypeChecker_Env.universe_of =
-                 (uu___2888_21528.FStar_TypeChecker_Env.universe_of);
+                 (uu___2888_21508.FStar_TypeChecker_Env.universe_of);
                FStar_TypeChecker_Env.check_type_of =
-                 (uu___2888_21528.FStar_TypeChecker_Env.check_type_of);
+                 (uu___2888_21508.FStar_TypeChecker_Env.check_type_of);
                FStar_TypeChecker_Env.use_bv_sorts =
-                 (uu___2888_21528.FStar_TypeChecker_Env.use_bv_sorts);
+                 (uu___2888_21508.FStar_TypeChecker_Env.use_bv_sorts);
                FStar_TypeChecker_Env.qtbl_name_and_index =
-                 (uu___2888_21528.FStar_TypeChecker_Env.qtbl_name_and_index);
+                 (uu___2888_21508.FStar_TypeChecker_Env.qtbl_name_and_index);
                FStar_TypeChecker_Env.normalized_eff_names =
-                 (uu___2888_21528.FStar_TypeChecker_Env.normalized_eff_names);
+                 (uu___2888_21508.FStar_TypeChecker_Env.normalized_eff_names);
                FStar_TypeChecker_Env.fv_delta_depths =
-                 (uu___2888_21528.FStar_TypeChecker_Env.fv_delta_depths);
+                 (uu___2888_21508.FStar_TypeChecker_Env.fv_delta_depths);
                FStar_TypeChecker_Env.proof_ns =
-                 (uu___2888_21528.FStar_TypeChecker_Env.proof_ns);
+                 (uu___2888_21508.FStar_TypeChecker_Env.proof_ns);
                FStar_TypeChecker_Env.synth_hook =
-                 (uu___2888_21528.FStar_TypeChecker_Env.synth_hook);
+                 (uu___2888_21508.FStar_TypeChecker_Env.synth_hook);
                FStar_TypeChecker_Env.try_solve_implicits_hook =
-                 (uu___2888_21528.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                 (uu___2888_21508.FStar_TypeChecker_Env.try_solve_implicits_hook);
                FStar_TypeChecker_Env.splice =
-                 (uu___2888_21528.FStar_TypeChecker_Env.splice);
+                 (uu___2888_21508.FStar_TypeChecker_Env.splice);
                FStar_TypeChecker_Env.mpreprocess =
-                 (uu___2888_21528.FStar_TypeChecker_Env.mpreprocess);
+                 (uu___2888_21508.FStar_TypeChecker_Env.mpreprocess);
                FStar_TypeChecker_Env.postprocess =
-                 (uu___2888_21528.FStar_TypeChecker_Env.postprocess);
+                 (uu___2888_21508.FStar_TypeChecker_Env.postprocess);
                FStar_TypeChecker_Env.identifier_info =
-                 (uu___2888_21528.FStar_TypeChecker_Env.identifier_info);
+                 (uu___2888_21508.FStar_TypeChecker_Env.identifier_info);
                FStar_TypeChecker_Env.tc_hooks =
-                 (uu___2888_21528.FStar_TypeChecker_Env.tc_hooks);
+                 (uu___2888_21508.FStar_TypeChecker_Env.tc_hooks);
                FStar_TypeChecker_Env.dsenv =
-                 (uu___2888_21528.FStar_TypeChecker_Env.dsenv);
+                 (uu___2888_21508.FStar_TypeChecker_Env.dsenv);
                FStar_TypeChecker_Env.nbe =
-                 (uu___2888_21528.FStar_TypeChecker_Env.nbe);
+                 (uu___2888_21508.FStar_TypeChecker_Env.nbe);
                FStar_TypeChecker_Env.strict_args_tab =
-                 (uu___2888_21528.FStar_TypeChecker_Env.strict_args_tab);
+                 (uu___2888_21508.FStar_TypeChecker_Env.strict_args_tab);
                FStar_TypeChecker_Env.erasable_types_tab =
-                 (uu___2888_21528.FStar_TypeChecker_Env.erasable_types_tab);
+                 (uu___2888_21508.FStar_TypeChecker_Env.erasable_types_tab);
                FStar_TypeChecker_Env.enable_defer_to_tac =
-                 (uu___2888_21528.FStar_TypeChecker_Env.enable_defer_to_tac)
+                 (uu___2888_21508.FStar_TypeChecker_Env.enable_defer_to_tac)
              } in
-           let uu____21544 =
+           let uu____21524 =
              FStar_TypeChecker_PatternUtils.elaborate_pat env p0 in
-           check_nested_pattern uu____21527 uu____21544 pat_t in
-         match uu____21510 with
+           check_nested_pattern uu____21507 uu____21524 pat_t in
+         match uu____21490 with
          | (bvs, tms, pat_e, pat, g, erasable) ->
-             ((let uu____21580 =
+             ((let uu____21560 =
                  FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
                    (FStar_Options.Other "Patterns") in
-               if uu____21580
+               if uu____21560
                then
-                 let uu____21581 = FStar_Syntax_Print.pat_to_string pat in
-                 let uu____21582 = FStar_Syntax_Print.term_to_string pat_e in
+                 let uu____21561 = FStar_Syntax_Print.pat_to_string pat in
+                 let uu____21562 = FStar_Syntax_Print.term_to_string pat_e in
                  FStar_Util.print2
-                   "Done checking pattern %s as expression %s\n" uu____21581
-                   uu____21582
+                   "Done checking pattern %s as expression %s\n" uu____21561
+                   uu____21562
                else ());
-              (let uu____21584 = FStar_TypeChecker_Env.push_bvs env bvs in
-               let uu____21585 =
+              (let uu____21564 = FStar_TypeChecker_Env.push_bvs env bvs in
+               let uu____21565 =
                  FStar_TypeChecker_Normalize.normalize
                    [FStar_TypeChecker_Env.Beta] env pat_e in
-               (pat, bvs, tms, uu____21584, pat_e, uu____21585, g, erasable))))
+               (pat, bvs, tms, uu____21564, pat_e, uu____21565, g, erasable))))
 and (tc_eqn :
   FStar_Syntax_Syntax.bv ->
     FStar_TypeChecker_Env.env ->
@@ -7358,78 +7358,78 @@ and (tc_eqn :
   fun scrutinee ->
     fun env ->
       fun branch ->
-        let uu____21620 = FStar_Syntax_Subst.open_branch branch in
-        match uu____21620 with
+        let uu____21600 = FStar_Syntax_Subst.open_branch branch in
+        match uu____21600 with
         | (pattern, when_clause, branch_exp) ->
-            let uu____21667 = branch in
-            (match uu____21667 with
-             | (cpat, uu____21696, cbr) ->
+            let uu____21647 = branch in
+            (match uu____21647 with
+             | (cpat, uu____21676, cbr) ->
                  let pat_t = scrutinee.FStar_Syntax_Syntax.sort in
                  let scrutinee_tm = FStar_Syntax_Syntax.bv_to_name scrutinee in
-                 let uu____21718 =
-                   let uu____21725 =
+                 let uu____21698 =
+                   let uu____21705 =
                      FStar_TypeChecker_Env.push_bv env scrutinee in
-                   FStar_All.pipe_right uu____21725
+                   FStar_All.pipe_right uu____21705
                      FStar_TypeChecker_Env.clear_expected_typ in
-                 (match uu____21718 with
-                  | (scrutinee_env, uu____21760) ->
-                      let uu____21765 = tc_pat env pat_t pattern in
-                      (match uu____21765 with
+                 (match uu____21698 with
+                  | (scrutinee_env, uu____21740) ->
+                      let uu____21745 = tc_pat env pat_t pattern in
+                      (match uu____21745 with
                        | (pattern1, pat_bvs, pat_bv_tms, pat_env, pat_exp,
                           norm_pat_exp, guard_pat, erasable) ->
-                           ((let uu____21830 =
+                           ((let uu____21810 =
                                FStar_All.pipe_left
                                  (FStar_TypeChecker_Env.debug env)
                                  FStar_Options.Extreme in
-                             if uu____21830
+                             if uu____21810
                              then
-                               let uu____21831 =
+                               let uu____21811 =
                                  FStar_Syntax_Print.pat_to_string pattern1 in
-                               let uu____21832 =
+                               let uu____21812 =
                                  FStar_Syntax_Print.bvs_to_string ";" pat_bvs in
-                               let uu____21833 =
+                               let uu____21813 =
                                  FStar_List.fold_left
                                    (fun s ->
                                       fun t ->
-                                        let uu____21839 =
-                                          let uu____21840 =
+                                        let uu____21819 =
+                                          let uu____21820 =
                                             FStar_Syntax_Print.term_to_string
                                               t in
-                                          Prims.op_Hat ";" uu____21840 in
-                                        Prims.op_Hat s uu____21839) ""
+                                          Prims.op_Hat ";" uu____21820 in
+                                        Prims.op_Hat s uu____21819) ""
                                    pat_bv_tms in
                                FStar_Util.print3
                                  "tc_eqn: typechecked pattern %s with bvs %s and pat_bv_tms %s"
-                                 uu____21831 uu____21832 uu____21833
+                                 uu____21811 uu____21812 uu____21813
                              else ());
-                            (let uu____21842 =
+                            (let uu____21822 =
                                match when_clause with
                                | FStar_Pervasives_Native.None ->
                                    (FStar_Pervasives_Native.None,
                                      FStar_TypeChecker_Env.trivial_guard)
                                | FStar_Pervasives_Native.Some e ->
-                                   let uu____21872 =
+                                   let uu____21852 =
                                      FStar_TypeChecker_Env.should_verify env in
-                                   if uu____21872
+                                   if uu____21852
                                    then
                                      FStar_Errors.raise_error
                                        (FStar_Errors.Fatal_WhenClauseNotSupported,
                                          "When clauses are not yet supported in --verify mode; they will be some day")
                                        e.FStar_Syntax_Syntax.pos
                                    else
-                                     (let uu____21890 =
-                                        let uu____21897 =
+                                     (let uu____21870 =
+                                        let uu____21877 =
                                           FStar_TypeChecker_Env.set_expected_typ
                                             pat_env FStar_Syntax_Util.t_bool in
-                                        tc_term uu____21897 e in
-                                      match uu____21890 with
+                                        tc_term uu____21877 e in
+                                      match uu____21870 with
                                       | (e1, c, g) ->
                                           ((FStar_Pervasives_Native.Some e1),
                                             g)) in
-                             match uu____21842 with
+                             match uu____21822 with
                              | (when_clause1, g_when) ->
-                                 let uu____21952 = tc_term pat_env branch_exp in
-                                 (match uu____21952 with
+                                 let uu____21932 = tc_term pat_env branch_exp in
+                                 (match uu____21932 with
                                   | (branch_exp1, c, g_branch) ->
                                       (FStar_TypeChecker_Env.def_check_guard_wf
                                          cbr.FStar_Syntax_Syntax.pos
@@ -7439,22 +7439,22 @@ and (tc_eqn :
                                           | FStar_Pervasives_Native.None ->
                                               FStar_Pervasives_Native.None
                                           | FStar_Pervasives_Native.Some w ->
-                                              let uu____22008 =
+                                              let uu____21988 =
                                                 FStar_Syntax_Util.mk_eq2
                                                   FStar_Syntax_Syntax.U_zero
                                                   FStar_Syntax_Util.t_bool w
                                                   FStar_Syntax_Util.exp_true_bool in
                                               FStar_All.pipe_left
-                                                (fun uu____22019 ->
+                                                (fun uu____21999 ->
                                                    FStar_Pervasives_Native.Some
-                                                     uu____22019) uu____22008 in
+                                                     uu____21999) uu____21988 in
                                         let branch_guard =
-                                          let uu____22023 =
-                                            let uu____22024 =
+                                          let uu____22003 =
+                                            let uu____22004 =
                                               FStar_TypeChecker_Env.should_verify
                                                 env in
-                                            Prims.op_Negation uu____22024 in
-                                          if uu____22023
+                                            Prims.op_Negation uu____22004 in
+                                          if uu____22003
                                           then
                                             FStar_Syntax_Util.exp_true_bool
                                           else
@@ -7463,14 +7463,14 @@ and (tc_eqn :
                                                pat_exp1 =
                                                let discriminate scrutinee_tm2
                                                  f =
-                                                 let uu____22077 =
-                                                   let uu____22084 =
+                                                 let uu____22057 =
+                                                   let uu____22064 =
                                                      FStar_TypeChecker_Env.typ_of_datacon
                                                        env
                                                        f.FStar_Syntax_Syntax.v in
                                                    FStar_TypeChecker_Env.datacons_of_typ
-                                                     env uu____22084 in
-                                                 match uu____22077 with
+                                                     env uu____22064 in
+                                                 match uu____22057 with
                                                  | (is_induc, datacons) ->
                                                      if
                                                        (Prims.op_Negation
@@ -7483,50 +7483,50 @@ and (tc_eqn :
                                                        let discriminator =
                                                          FStar_Syntax_Util.mk_discriminator
                                                            f.FStar_Syntax_Syntax.v in
-                                                       let uu____22096 =
+                                                       let uu____22076 =
                                                          FStar_TypeChecker_Env.try_lookup_lid
                                                            env discriminator in
-                                                       (match uu____22096
+                                                       (match uu____22076
                                                         with
                                                         | FStar_Pervasives_Native.None
                                                             -> []
-                                                        | uu____22117 ->
+                                                        | uu____22097 ->
                                                             let disc =
                                                               FStar_Syntax_Syntax.fvar
                                                                 discriminator
                                                                 (FStar_Syntax_Syntax.Delta_equational_at_level
                                                                    Prims.int_one)
                                                                 FStar_Pervasives_Native.None in
-                                                            let uu____22129 =
-                                                              let uu____22130
+                                                            let uu____22109 =
+                                                              let uu____22110
                                                                 =
-                                                                let uu____22131
+                                                                let uu____22111
                                                                   =
                                                                   FStar_Syntax_Syntax.as_arg
                                                                     scrutinee_tm2 in
-                                                                [uu____22131] in
+                                                                [uu____22111] in
                                                               FStar_Syntax_Syntax.mk_Tm_app
                                                                 disc
-                                                                uu____22130
+                                                                uu____22110
                                                                 scrutinee_tm2.FStar_Syntax_Syntax.pos in
-                                                            [uu____22129])
+                                                            [uu____22109])
                                                      else [] in
-                                               let fail uu____22162 =
-                                                 let uu____22163 =
-                                                   let uu____22164 =
+                                               let fail uu____22142 =
+                                                 let uu____22143 =
+                                                   let uu____22144 =
                                                      FStar_Range.string_of_range
                                                        pat_exp1.FStar_Syntax_Syntax.pos in
-                                                   let uu____22165 =
+                                                   let uu____22145 =
                                                      FStar_Syntax_Print.term_to_string
                                                        pat_exp1 in
-                                                   let uu____22166 =
+                                                   let uu____22146 =
                                                      FStar_Syntax_Print.tag_of_term
                                                        pat_exp1 in
                                                    FStar_Util.format3
                                                      "tc_eqn: Impossible (%s) %s (%s)"
-                                                     uu____22164 uu____22165
-                                                     uu____22166 in
-                                                 failwith uu____22163 in
+                                                     uu____22144 uu____22145
+                                                     uu____22146 in
+                                                 failwith uu____22143 in
                                                let rec head_constructor t =
                                                  match t.FStar_Syntax_Syntax.n
                                                  with
@@ -7534,42 +7534,42 @@ and (tc_eqn :
                                                      fv ->
                                                      fv.FStar_Syntax_Syntax.fv_name
                                                  | FStar_Syntax_Syntax.Tm_uinst
-                                                     (t1, uu____22179) ->
+                                                     (t1, uu____22159) ->
                                                      head_constructor t1
-                                                 | uu____22184 -> fail () in
+                                                 | uu____22164 -> fail () in
                                                let force_scrutinee
-                                                 uu____22190 =
+                                                 uu____22170 =
                                                  match scrutinee_tm1 with
                                                  | FStar_Pervasives_Native.None
                                                      ->
-                                                     let uu____22191 =
-                                                       let uu____22192 =
+                                                     let uu____22171 =
+                                                       let uu____22172 =
                                                          FStar_Range.string_of_range
                                                            pattern2.FStar_Syntax_Syntax.p in
-                                                       let uu____22193 =
+                                                       let uu____22173 =
                                                          FStar_Syntax_Print.pat_to_string
                                                            pattern2 in
                                                        FStar_Util.format2
                                                          "Impossible (%s): scrutinee of match is not defined %s"
-                                                         uu____22192
-                                                         uu____22193 in
-                                                     failwith uu____22191
+                                                         uu____22172
+                                                         uu____22173 in
+                                                     failwith uu____22171
                                                  | FStar_Pervasives_Native.Some
                                                      t -> t in
                                                let pat_exp2 =
-                                                 let uu____22198 =
+                                                 let uu____22178 =
                                                    FStar_Syntax_Subst.compress
                                                      pat_exp1 in
                                                  FStar_All.pipe_right
-                                                   uu____22198
+                                                   uu____22178
                                                    FStar_Syntax_Util.unmeta in
                                                match ((pattern2.FStar_Syntax_Syntax.v),
                                                        (pat_exp2.FStar_Syntax_Syntax.n))
                                                with
-                                               | (uu____22203,
+                                               | (uu____22183,
                                                   FStar_Syntax_Syntax.Tm_name
-                                                  uu____22204) -> []
-                                               | (uu____22205,
+                                                  uu____22184) -> []
+                                               | (uu____22185,
                                                   FStar_Syntax_Syntax.Tm_constant
                                                   (FStar_Const.Const_unit))
                                                    -> []
@@ -7577,139 +7577,139 @@ and (tc_eqn :
                                                   _c,
                                                   FStar_Syntax_Syntax.Tm_constant
                                                   c1) ->
-                                                   let uu____22208 =
-                                                     let uu____22209 =
+                                                   let uu____22188 =
+                                                     let uu____22189 =
                                                        tc_constant env
                                                          pat_exp2.FStar_Syntax_Syntax.pos
                                                          c1 in
-                                                     let uu____22210 =
+                                                     let uu____22190 =
                                                        force_scrutinee () in
                                                      FStar_Syntax_Util.mk_decidable_eq
-                                                       uu____22209
-                                                       uu____22210 pat_exp2 in
-                                                   [uu____22208]
+                                                       uu____22189
+                                                       uu____22190 pat_exp2 in
+                                                   [uu____22188]
                                                | (FStar_Syntax_Syntax.Pat_constant
                                                   (FStar_Const.Const_int
-                                                  (uu____22213,
+                                                  (uu____22193,
                                                    FStar_Pervasives_Native.Some
-                                                   uu____22214)),
-                                                  uu____22215) ->
-                                                   let uu____22230 =
-                                                     let uu____22237 =
+                                                   uu____22194)),
+                                                  uu____22195) ->
+                                                   let uu____22210 =
+                                                     let uu____22217 =
                                                        FStar_TypeChecker_Env.clear_expected_typ
                                                          env in
-                                                     match uu____22237 with
-                                                     | (env1, uu____22251) ->
+                                                     match uu____22217 with
+                                                     | (env1, uu____22231) ->
                                                          env1.FStar_TypeChecker_Env.type_of
                                                            env1 pat_exp2 in
-                                                   (match uu____22230 with
-                                                    | (uu____22258, t,
-                                                       uu____22260) ->
-                                                        let uu____22261 =
-                                                          let uu____22262 =
+                                                   (match uu____22210 with
+                                                    | (uu____22238, t,
+                                                       uu____22240) ->
+                                                        let uu____22241 =
+                                                          let uu____22242 =
                                                             force_scrutinee
                                                               () in
                                                           FStar_Syntax_Util.mk_decidable_eq
-                                                            t uu____22262
+                                                            t uu____22242
                                                             pat_exp2 in
-                                                        [uu____22261])
+                                                        [uu____22241])
                                                | (FStar_Syntax_Syntax.Pat_cons
-                                                  (uu____22265, []),
+                                                  (uu____22245, []),
                                                   FStar_Syntax_Syntax.Tm_uinst
-                                                  uu____22266) ->
+                                                  uu____22246) ->
                                                    let f =
                                                      head_constructor
                                                        pat_exp2 in
-                                                   let uu____22288 =
-                                                     let uu____22289 =
+                                                   let uu____22268 =
+                                                     let uu____22269 =
                                                        FStar_TypeChecker_Env.is_datacon
                                                          env
                                                          f.FStar_Syntax_Syntax.v in
                                                      Prims.op_Negation
-                                                       uu____22289 in
-                                                   if uu____22288
+                                                       uu____22269 in
+                                                   if uu____22268
                                                    then
                                                      failwith
                                                        "Impossible: nullary patterns must be data constructors"
                                                    else
-                                                     (let uu____22295 =
+                                                     (let uu____22275 =
                                                         force_scrutinee () in
-                                                      let uu____22298 =
+                                                      let uu____22278 =
                                                         head_constructor
                                                           pat_exp2 in
                                                       discriminate
-                                                        uu____22295
-                                                        uu____22298)
+                                                        uu____22275
+                                                        uu____22278)
                                                | (FStar_Syntax_Syntax.Pat_cons
-                                                  (uu____22301, []),
+                                                  (uu____22281, []),
                                                   FStar_Syntax_Syntax.Tm_fvar
-                                                  uu____22302) ->
+                                                  uu____22282) ->
                                                    let f =
                                                      head_constructor
                                                        pat_exp2 in
-                                                   let uu____22318 =
-                                                     let uu____22319 =
+                                                   let uu____22298 =
+                                                     let uu____22299 =
                                                        FStar_TypeChecker_Env.is_datacon
                                                          env
                                                          f.FStar_Syntax_Syntax.v in
                                                      Prims.op_Negation
-                                                       uu____22319 in
-                                                   if uu____22318
+                                                       uu____22299 in
+                                                   if uu____22298
                                                    then
                                                      failwith
                                                        "Impossible: nullary patterns must be data constructors"
                                                    else
-                                                     (let uu____22325 =
+                                                     (let uu____22305 =
                                                         force_scrutinee () in
-                                                      let uu____22328 =
+                                                      let uu____22308 =
                                                         head_constructor
                                                           pat_exp2 in
                                                       discriminate
-                                                        uu____22325
-                                                        uu____22328)
+                                                        uu____22305
+                                                        uu____22308)
                                                | (FStar_Syntax_Syntax.Pat_cons
-                                                  (uu____22331, pat_args),
+                                                  (uu____22311, pat_args),
                                                   FStar_Syntax_Syntax.Tm_app
                                                   (head, args)) ->
                                                    let f =
                                                      head_constructor head in
-                                                   let uu____22376 =
-                                                     (let uu____22379 =
+                                                   let uu____22356 =
+                                                     (let uu____22359 =
                                                         FStar_TypeChecker_Env.is_datacon
                                                           env
                                                           f.FStar_Syntax_Syntax.v in
                                                       Prims.op_Negation
-                                                        uu____22379)
+                                                        uu____22359)
                                                        ||
                                                        ((FStar_List.length
                                                            pat_args)
                                                           <>
                                                           (FStar_List.length
                                                              args)) in
-                                                   if uu____22376
+                                                   if uu____22356
                                                    then
                                                      failwith
                                                        "Impossible: application patterns must be fully-applied data constructors"
                                                    else
                                                      (let sub_term_guards =
-                                                        let uu____22402 =
-                                                          let uu____22407 =
+                                                        let uu____22382 =
+                                                          let uu____22387 =
                                                             FStar_List.zip
                                                               pat_args args in
                                                           FStar_All.pipe_right
-                                                            uu____22407
+                                                            uu____22387
                                                             (FStar_List.mapi
                                                                (fun i ->
                                                                   fun
-                                                                    uu____22489
+                                                                    uu____22469
                                                                     ->
-                                                                    match uu____22489
+                                                                    match uu____22469
                                                                     with
                                                                     | 
                                                                     ((pi,
-                                                                    uu____22509),
+                                                                    uu____22489),
                                                                     (ei,
-                                                                    uu____22511))
+                                                                    uu____22491))
                                                                     ->
                                                                     let projector
                                                                     =
@@ -7719,109 +7719,109 @@ and (tc_eqn :
                                                                     i in
                                                                     let scrutinee_tm2
                                                                     =
-                                                                    let uu____22536
+                                                                    let uu____22516
                                                                     =
                                                                     FStar_TypeChecker_Env.try_lookup_lid
                                                                     env
                                                                     projector in
-                                                                    match uu____22536
+                                                                    match uu____22516
                                                                     with
                                                                     | 
                                                                     FStar_Pervasives_Native.None
                                                                     ->
                                                                     FStar_Pervasives_Native.None
                                                                     | 
-                                                                    uu____22557
+                                                                    uu____22537
                                                                     ->
                                                                     let proj
                                                                     =
-                                                                    let uu____22569
+                                                                    let uu____22549
                                                                     =
                                                                     FStar_Ident.set_lid_range
                                                                     projector
                                                                     f.FStar_Syntax_Syntax.p in
                                                                     FStar_Syntax_Syntax.fvar
-                                                                    uu____22569
+                                                                    uu____22549
                                                                     (FStar_Syntax_Syntax.Delta_equational_at_level
                                                                     Prims.int_one)
                                                                     FStar_Pervasives_Native.None in
-                                                                    let uu____22570
+                                                                    let uu____22550
                                                                     =
-                                                                    let uu____22571
+                                                                    let uu____22551
                                                                     =
-                                                                    let uu____22572
+                                                                    let uu____22552
                                                                     =
-                                                                    let uu____22581
+                                                                    let uu____22561
                                                                     =
                                                                     force_scrutinee
                                                                     () in
                                                                     FStar_Syntax_Syntax.as_arg
-                                                                    uu____22581 in
-                                                                    [uu____22572] in
+                                                                    uu____22561 in
+                                                                    [uu____22552] in
                                                                     FStar_Syntax_Syntax.mk_Tm_app
                                                                     proj
-                                                                    uu____22571
+                                                                    uu____22551
                                                                     f.FStar_Syntax_Syntax.p in
                                                                     FStar_Pervasives_Native.Some
-                                                                    uu____22570 in
+                                                                    uu____22550 in
                                                                     build_branch_guard
                                                                     scrutinee_tm2
                                                                     pi ei)) in
                                                         FStar_All.pipe_right
-                                                          uu____22402
+                                                          uu____22382
                                                           FStar_List.flatten in
-                                                      let uu____22604 =
-                                                        let uu____22607 =
+                                                      let uu____22584 =
+                                                        let uu____22587 =
                                                           force_scrutinee () in
                                                         discriminate
-                                                          uu____22607 f in
+                                                          uu____22587 f in
                                                       FStar_List.append
-                                                        uu____22604
+                                                        uu____22584
                                                         sub_term_guards)
                                                | (FStar_Syntax_Syntax.Pat_dot_term
-                                                  uu____22610, uu____22611)
+                                                  uu____22590, uu____22591)
                                                    -> []
-                                               | uu____22618 ->
-                                                   let uu____22623 =
-                                                     let uu____22624 =
+                                               | uu____22598 ->
+                                                   let uu____22603 =
+                                                     let uu____22604 =
                                                        FStar_Syntax_Print.pat_to_string
                                                          pattern2 in
-                                                     let uu____22625 =
+                                                     let uu____22605 =
                                                        FStar_Syntax_Print.term_to_string
                                                          pat_exp2 in
                                                      FStar_Util.format2
                                                        "Internal error: unexpected elaborated pattern: %s and pattern expression %s"
-                                                       uu____22624
-                                                       uu____22625 in
-                                                   failwith uu____22623 in
+                                                       uu____22604
+                                                       uu____22605 in
+                                                   failwith uu____22603 in
                                              let build_and_check_branch_guard
                                                scrutinee_tm1 pattern2 pat =
-                                               let uu____22652 =
-                                                 let uu____22653 =
+                                               let uu____22632 =
+                                                 let uu____22633 =
                                                    FStar_TypeChecker_Env.should_verify
                                                      env in
                                                  Prims.op_Negation
-                                                   uu____22653 in
-                                               if uu____22652
+                                                   uu____22633 in
+                                               if uu____22632
                                                then
                                                  FStar_Syntax_Util.exp_true_bool
                                                else
                                                  (let t =
-                                                    let uu____22656 =
+                                                    let uu____22636 =
                                                       build_branch_guard
                                                         scrutinee_tm1
                                                         pattern2 pat in
                                                     FStar_All.pipe_left
                                                       FStar_Syntax_Util.mk_and_l
-                                                      uu____22656 in
-                                                  let uu____22665 =
+                                                      uu____22636 in
+                                                  let uu____22645 =
                                                     tc_check_tot_or_gtot_term
                                                       scrutinee_env t
                                                       FStar_Syntax_Util.t_bool
                                                       "" in
-                                                  match uu____22665 with
-                                                  | (t1, uu____22673,
-                                                     uu____22674) -> t1) in
+                                                  match uu____22645 with
+                                                  | (t1, uu____22653,
+                                                     uu____22654) -> t1) in
                                              let branch_guard =
                                                build_and_check_branch_guard
                                                  (FStar_Pervasives_Native.Some
@@ -7836,92 +7836,92 @@ and (tc_eqn :
                                                    FStar_Syntax_Util.mk_and
                                                      branch_guard w in
                                              branch_guard1) in
-                                        (let uu____22689 =
+                                        (let uu____22669 =
                                            FStar_All.pipe_left
                                              (FStar_TypeChecker_Env.debug env)
                                              FStar_Options.Extreme in
-                                         if uu____22689
+                                         if uu____22669
                                          then
-                                           let uu____22690 =
+                                           let uu____22670 =
                                              FStar_Syntax_Print.term_to_string
                                                branch_guard in
                                            FStar_Util.print1
                                              "tc_eqn: branch guard : %s\n"
-                                             uu____22690
+                                             uu____22670
                                          else ());
-                                        (let uu____22692 =
+                                        (let uu____22672 =
                                            let eqs =
-                                             let uu____22711 =
-                                               let uu____22712 =
+                                             let uu____22691 =
+                                               let uu____22692 =
                                                  FStar_TypeChecker_Env.should_verify
                                                    env in
-                                               Prims.op_Negation uu____22712 in
-                                             if uu____22711
+                                               Prims.op_Negation uu____22692 in
+                                             if uu____22691
                                              then
                                                FStar_Pervasives_Native.None
                                              else
                                                (let e =
                                                   FStar_Syntax_Subst.compress
                                                     pat_exp in
-                                                let uu____22717 =
-                                                  let uu____22718 =
+                                                let uu____22697 =
+                                                  let uu____22698 =
                                                     env.FStar_TypeChecker_Env.universe_of
                                                       env pat_t in
                                                   FStar_Syntax_Util.mk_eq2
-                                                    uu____22718 pat_t
+                                                    uu____22698 pat_t
                                                     scrutinee_tm e in
                                                 FStar_Pervasives_Native.Some
-                                                  uu____22717) in
-                                           let uu____22719 =
+                                                  uu____22697) in
+                                           let uu____22699 =
                                              FStar_TypeChecker_Util.strengthen_precondition
                                                FStar_Pervasives_Native.None
                                                env branch_exp1 c g_branch in
-                                           match uu____22719 with
+                                           match uu____22699 with
                                            | (c1, g_branch1) ->
                                                let branch_has_layered_effect
                                                  =
-                                                 let uu____22745 =
+                                                 let uu____22725 =
                                                    FStar_All.pipe_right
                                                      c1.FStar_TypeChecker_Common.eff_name
                                                      (FStar_TypeChecker_Env.norm_eff_name
                                                         env) in
                                                  FStar_All.pipe_right
-                                                   uu____22745
+                                                   uu____22725
                                                    (FStar_TypeChecker_Env.is_layered_effect
                                                       env) in
-                                               let uu____22746 =
+                                               let uu____22726 =
                                                  let env1 =
-                                                   let uu____22752 =
+                                                   let uu____22732 =
                                                      FStar_All.pipe_right
                                                        pat_bvs
                                                        (FStar_List.map
                                                           FStar_Syntax_Syntax.mk_binder) in
                                                    FStar_TypeChecker_Env.push_binders
                                                      scrutinee_env
-                                                     uu____22752 in
+                                                     uu____22732 in
                                                  if branch_has_layered_effect
                                                  then
                                                    let c2 =
-                                                     let uu____22760 =
-                                                       let uu____22761 =
+                                                     let uu____22740 =
+                                                       let uu____22741 =
                                                          FStar_Syntax_Util.b2t
                                                            branch_guard in
                                                        FStar_TypeChecker_Common.NonTrivial
-                                                         uu____22761 in
+                                                         uu____22741 in
                                                      FStar_TypeChecker_Util.weaken_precondition
-                                                       env1 c1 uu____22760 in
+                                                       env1 c1 uu____22740 in
                                                    (c2,
                                                      FStar_TypeChecker_Env.trivial_guard)
                                                  else
                                                    (match (eqs,
                                                             when_condition)
                                                     with
-                                                    | uu____22773 when
-                                                        let uu____22784 =
+                                                    | uu____22753 when
+                                                        let uu____22764 =
                                                           FStar_TypeChecker_Env.should_verify
                                                             env1 in
                                                         Prims.op_Negation
-                                                          uu____22784
+                                                          uu____22764
                                                         -> (c1, g_when)
                                                     | (FStar_Pervasives_Native.None,
                                                        FStar_Pervasives_Native.None)
@@ -7936,14 +7936,14 @@ and (tc_eqn :
                                                         let g =
                                                           FStar_TypeChecker_Env.guard_of_guard_formula
                                                             gf in
-                                                        let uu____22804 =
+                                                        let uu____22784 =
                                                           FStar_TypeChecker_Util.weaken_precondition
                                                             env1 c1 gf in
-                                                        let uu____22805 =
+                                                        let uu____22785 =
                                                           FStar_TypeChecker_Env.imp_guard
                                                             g g_when in
-                                                        (uu____22804,
-                                                          uu____22805)
+                                                        (uu____22784,
+                                                          uu____22785)
                                                     | (FStar_Pervasives_Native.Some
                                                        f,
                                                        FStar_Pervasives_Native.Some
@@ -7952,23 +7952,23 @@ and (tc_eqn :
                                                           FStar_TypeChecker_Common.NonTrivial
                                                             f in
                                                         let g_fw =
-                                                          let uu____22820 =
+                                                          let uu____22800 =
                                                             FStar_Syntax_Util.mk_conj
                                                               f w in
                                                           FStar_TypeChecker_Common.NonTrivial
-                                                            uu____22820 in
-                                                        let uu____22821 =
+                                                            uu____22800 in
+                                                        let uu____22801 =
                                                           FStar_TypeChecker_Util.weaken_precondition
                                                             env1 c1 g_fw in
-                                                        let uu____22822 =
-                                                          let uu____22823 =
+                                                        let uu____22802 =
+                                                          let uu____22803 =
                                                             FStar_TypeChecker_Env.guard_of_guard_formula
                                                               g_f in
                                                           FStar_TypeChecker_Env.imp_guard
-                                                            uu____22823
+                                                            uu____22803
                                                             g_when in
-                                                        (uu____22821,
-                                                          uu____22822)
+                                                        (uu____22801,
+                                                          uu____22802)
                                                     | (FStar_Pervasives_Native.None,
                                                        FStar_Pervasives_Native.Some
                                                        w) ->
@@ -7978,11 +7978,11 @@ and (tc_eqn :
                                                         let g =
                                                           FStar_TypeChecker_Env.guard_of_guard_formula
                                                             g_w in
-                                                        let uu____22837 =
+                                                        let uu____22817 =
                                                           FStar_TypeChecker_Util.weaken_precondition
                                                             env1 c1 g_w in
-                                                        (uu____22837, g_when)) in
-                                               (match uu____22746 with
+                                                        (uu____22817, g_when)) in
+                                               (match uu____22726 with
                                                 | (c_weak, g_when_weak) ->
                                                     let binders =
                                                       FStar_List.map
@@ -7991,11 +7991,11 @@ and (tc_eqn :
                                                     let maybe_return_c_weak
                                                       should_return =
                                                       let c_weak1 =
-                                                        let uu____22877 =
+                                                        let uu____22857 =
                                                           should_return &&
                                                             (FStar_TypeChecker_Common.is_pure_or_ghost_lcomp
                                                                c_weak) in
-                                                        if uu____22877
+                                                        if uu____22857
                                                         then
                                                           FStar_TypeChecker_Util.maybe_assume_result_eq_pure_term
                                                             env branch_exp1
@@ -8004,13 +8004,13 @@ and (tc_eqn :
                                                       if
                                                         branch_has_layered_effect
                                                       then
-                                                        ((let uu____22880 =
+                                                        ((let uu____22860 =
                                                             FStar_All.pipe_left
                                                               (FStar_TypeChecker_Env.debug
                                                                  env)
                                                               (FStar_Options.Other
                                                                  "LayeredEffects") in
-                                                          if uu____22880
+                                                          if uu____22860
                                                           then
                                                             FStar_Util.print_string
                                                               "Typechecking pat_bv_tms ...\n"
@@ -8022,21 +8022,21 @@ and (tc_eqn :
                                                                  (fun
                                                                     pat_bv_tm
                                                                     ->
-                                                                    let uu____22892
+                                                                    let uu____22872
                                                                     =
-                                                                    let uu____22893
+                                                                    let uu____22873
                                                                     =
                                                                     FStar_All.pipe_right
                                                                     scrutinee_tm
                                                                     FStar_Syntax_Syntax.as_arg in
-                                                                    [uu____22893] in
+                                                                    [uu____22873] in
                                                                     FStar_Syntax_Syntax.mk_Tm_app
                                                                     pat_bv_tm
-                                                                    uu____22892
+                                                                    uu____22872
                                                                     FStar_Range.dummyRange)) in
                                                           let pat_bv_tms2 =
                                                             let env1 =
-                                                              let uu___3119_22930
+                                                              let uu___3119_22910
                                                                 =
                                                                 FStar_TypeChecker_Env.push_bv
                                                                   env
@@ -8044,157 +8044,157 @@ and (tc_eqn :
                                                               {
                                                                 FStar_TypeChecker_Env.solver
                                                                   =
-                                                                  (uu___3119_22930.FStar_TypeChecker_Env.solver);
+                                                                  (uu___3119_22910.FStar_TypeChecker_Env.solver);
                                                                 FStar_TypeChecker_Env.range
                                                                   =
-                                                                  (uu___3119_22930.FStar_TypeChecker_Env.range);
+                                                                  (uu___3119_22910.FStar_TypeChecker_Env.range);
                                                                 FStar_TypeChecker_Env.curmodule
                                                                   =
-                                                                  (uu___3119_22930.FStar_TypeChecker_Env.curmodule);
+                                                                  (uu___3119_22910.FStar_TypeChecker_Env.curmodule);
                                                                 FStar_TypeChecker_Env.gamma
                                                                   =
-                                                                  (uu___3119_22930.FStar_TypeChecker_Env.gamma);
+                                                                  (uu___3119_22910.FStar_TypeChecker_Env.gamma);
                                                                 FStar_TypeChecker_Env.gamma_sig
                                                                   =
-                                                                  (uu___3119_22930.FStar_TypeChecker_Env.gamma_sig);
+                                                                  (uu___3119_22910.FStar_TypeChecker_Env.gamma_sig);
                                                                 FStar_TypeChecker_Env.gamma_cache
                                                                   =
-                                                                  (uu___3119_22930.FStar_TypeChecker_Env.gamma_cache);
+                                                                  (uu___3119_22910.FStar_TypeChecker_Env.gamma_cache);
                                                                 FStar_TypeChecker_Env.modules
                                                                   =
-                                                                  (uu___3119_22930.FStar_TypeChecker_Env.modules);
+                                                                  (uu___3119_22910.FStar_TypeChecker_Env.modules);
                                                                 FStar_TypeChecker_Env.expected_typ
                                                                   =
-                                                                  (uu___3119_22930.FStar_TypeChecker_Env.expected_typ);
+                                                                  (uu___3119_22910.FStar_TypeChecker_Env.expected_typ);
                                                                 FStar_TypeChecker_Env.sigtab
                                                                   =
-                                                                  (uu___3119_22930.FStar_TypeChecker_Env.sigtab);
+                                                                  (uu___3119_22910.FStar_TypeChecker_Env.sigtab);
                                                                 FStar_TypeChecker_Env.attrtab
                                                                   =
-                                                                  (uu___3119_22930.FStar_TypeChecker_Env.attrtab);
+                                                                  (uu___3119_22910.FStar_TypeChecker_Env.attrtab);
                                                                 FStar_TypeChecker_Env.instantiate_imp
                                                                   =
-                                                                  (uu___3119_22930.FStar_TypeChecker_Env.instantiate_imp);
+                                                                  (uu___3119_22910.FStar_TypeChecker_Env.instantiate_imp);
                                                                 FStar_TypeChecker_Env.effects
                                                                   =
-                                                                  (uu___3119_22930.FStar_TypeChecker_Env.effects);
+                                                                  (uu___3119_22910.FStar_TypeChecker_Env.effects);
                                                                 FStar_TypeChecker_Env.generalize
                                                                   =
-                                                                  (uu___3119_22930.FStar_TypeChecker_Env.generalize);
+                                                                  (uu___3119_22910.FStar_TypeChecker_Env.generalize);
                                                                 FStar_TypeChecker_Env.letrecs
                                                                   =
-                                                                  (uu___3119_22930.FStar_TypeChecker_Env.letrecs);
+                                                                  (uu___3119_22910.FStar_TypeChecker_Env.letrecs);
                                                                 FStar_TypeChecker_Env.top_level
                                                                   =
-                                                                  (uu___3119_22930.FStar_TypeChecker_Env.top_level);
+                                                                  (uu___3119_22910.FStar_TypeChecker_Env.top_level);
                                                                 FStar_TypeChecker_Env.check_uvars
                                                                   =
-                                                                  (uu___3119_22930.FStar_TypeChecker_Env.check_uvars);
+                                                                  (uu___3119_22910.FStar_TypeChecker_Env.check_uvars);
                                                                 FStar_TypeChecker_Env.use_eq
                                                                   =
-                                                                  (uu___3119_22930.FStar_TypeChecker_Env.use_eq);
+                                                                  (uu___3119_22910.FStar_TypeChecker_Env.use_eq);
                                                                 FStar_TypeChecker_Env.use_eq_strict
                                                                   =
-                                                                  (uu___3119_22930.FStar_TypeChecker_Env.use_eq_strict);
+                                                                  (uu___3119_22910.FStar_TypeChecker_Env.use_eq_strict);
                                                                 FStar_TypeChecker_Env.is_iface
                                                                   =
-                                                                  (uu___3119_22930.FStar_TypeChecker_Env.is_iface);
+                                                                  (uu___3119_22910.FStar_TypeChecker_Env.is_iface);
                                                                 FStar_TypeChecker_Env.admit
                                                                   =
-                                                                  (uu___3119_22930.FStar_TypeChecker_Env.admit);
+                                                                  (uu___3119_22910.FStar_TypeChecker_Env.admit);
                                                                 FStar_TypeChecker_Env.lax
                                                                   = true;
                                                                 FStar_TypeChecker_Env.lax_universes
                                                                   =
-                                                                  (uu___3119_22930.FStar_TypeChecker_Env.lax_universes);
+                                                                  (uu___3119_22910.FStar_TypeChecker_Env.lax_universes);
                                                                 FStar_TypeChecker_Env.phase1
                                                                   =
-                                                                  (uu___3119_22930.FStar_TypeChecker_Env.phase1);
+                                                                  (uu___3119_22910.FStar_TypeChecker_Env.phase1);
                                                                 FStar_TypeChecker_Env.failhard
                                                                   =
-                                                                  (uu___3119_22930.FStar_TypeChecker_Env.failhard);
+                                                                  (uu___3119_22910.FStar_TypeChecker_Env.failhard);
                                                                 FStar_TypeChecker_Env.nosynth
                                                                   =
-                                                                  (uu___3119_22930.FStar_TypeChecker_Env.nosynth);
+                                                                  (uu___3119_22910.FStar_TypeChecker_Env.nosynth);
                                                                 FStar_TypeChecker_Env.uvar_subtyping
                                                                   =
-                                                                  (uu___3119_22930.FStar_TypeChecker_Env.uvar_subtyping);
+                                                                  (uu___3119_22910.FStar_TypeChecker_Env.uvar_subtyping);
                                                                 FStar_TypeChecker_Env.tc_term
                                                                   =
-                                                                  (uu___3119_22930.FStar_TypeChecker_Env.tc_term);
+                                                                  (uu___3119_22910.FStar_TypeChecker_Env.tc_term);
                                                                 FStar_TypeChecker_Env.type_of
                                                                   =
-                                                                  (uu___3119_22930.FStar_TypeChecker_Env.type_of);
+                                                                  (uu___3119_22910.FStar_TypeChecker_Env.type_of);
                                                                 FStar_TypeChecker_Env.universe_of
                                                                   =
-                                                                  (uu___3119_22930.FStar_TypeChecker_Env.universe_of);
+                                                                  (uu___3119_22910.FStar_TypeChecker_Env.universe_of);
                                                                 FStar_TypeChecker_Env.check_type_of
                                                                   =
-                                                                  (uu___3119_22930.FStar_TypeChecker_Env.check_type_of);
+                                                                  (uu___3119_22910.FStar_TypeChecker_Env.check_type_of);
                                                                 FStar_TypeChecker_Env.use_bv_sorts
                                                                   =
-                                                                  (uu___3119_22930.FStar_TypeChecker_Env.use_bv_sorts);
+                                                                  (uu___3119_22910.FStar_TypeChecker_Env.use_bv_sorts);
                                                                 FStar_TypeChecker_Env.qtbl_name_and_index
                                                                   =
-                                                                  (uu___3119_22930.FStar_TypeChecker_Env.qtbl_name_and_index);
+                                                                  (uu___3119_22910.FStar_TypeChecker_Env.qtbl_name_and_index);
                                                                 FStar_TypeChecker_Env.normalized_eff_names
                                                                   =
-                                                                  (uu___3119_22930.FStar_TypeChecker_Env.normalized_eff_names);
+                                                                  (uu___3119_22910.FStar_TypeChecker_Env.normalized_eff_names);
                                                                 FStar_TypeChecker_Env.fv_delta_depths
                                                                   =
-                                                                  (uu___3119_22930.FStar_TypeChecker_Env.fv_delta_depths);
+                                                                  (uu___3119_22910.FStar_TypeChecker_Env.fv_delta_depths);
                                                                 FStar_TypeChecker_Env.proof_ns
                                                                   =
-                                                                  (uu___3119_22930.FStar_TypeChecker_Env.proof_ns);
+                                                                  (uu___3119_22910.FStar_TypeChecker_Env.proof_ns);
                                                                 FStar_TypeChecker_Env.synth_hook
                                                                   =
-                                                                  (uu___3119_22930.FStar_TypeChecker_Env.synth_hook);
+                                                                  (uu___3119_22910.FStar_TypeChecker_Env.synth_hook);
                                                                 FStar_TypeChecker_Env.try_solve_implicits_hook
                                                                   =
-                                                                  (uu___3119_22930.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                                                                  (uu___3119_22910.FStar_TypeChecker_Env.try_solve_implicits_hook);
                                                                 FStar_TypeChecker_Env.splice
                                                                   =
-                                                                  (uu___3119_22930.FStar_TypeChecker_Env.splice);
+                                                                  (uu___3119_22910.FStar_TypeChecker_Env.splice);
                                                                 FStar_TypeChecker_Env.mpreprocess
                                                                   =
-                                                                  (uu___3119_22930.FStar_TypeChecker_Env.mpreprocess);
+                                                                  (uu___3119_22910.FStar_TypeChecker_Env.mpreprocess);
                                                                 FStar_TypeChecker_Env.postprocess
                                                                   =
-                                                                  (uu___3119_22930.FStar_TypeChecker_Env.postprocess);
+                                                                  (uu___3119_22910.FStar_TypeChecker_Env.postprocess);
                                                                 FStar_TypeChecker_Env.identifier_info
                                                                   =
-                                                                  (uu___3119_22930.FStar_TypeChecker_Env.identifier_info);
+                                                                  (uu___3119_22910.FStar_TypeChecker_Env.identifier_info);
                                                                 FStar_TypeChecker_Env.tc_hooks
                                                                   =
-                                                                  (uu___3119_22930.FStar_TypeChecker_Env.tc_hooks);
+                                                                  (uu___3119_22910.FStar_TypeChecker_Env.tc_hooks);
                                                                 FStar_TypeChecker_Env.dsenv
                                                                   =
-                                                                  (uu___3119_22930.FStar_TypeChecker_Env.dsenv);
+                                                                  (uu___3119_22910.FStar_TypeChecker_Env.dsenv);
                                                                 FStar_TypeChecker_Env.nbe
                                                                   =
-                                                                  (uu___3119_22930.FStar_TypeChecker_Env.nbe);
+                                                                  (uu___3119_22910.FStar_TypeChecker_Env.nbe);
                                                                 FStar_TypeChecker_Env.strict_args_tab
                                                                   =
-                                                                  (uu___3119_22930.FStar_TypeChecker_Env.strict_args_tab);
+                                                                  (uu___3119_22910.FStar_TypeChecker_Env.strict_args_tab);
                                                                 FStar_TypeChecker_Env.erasable_types_tab
                                                                   =
-                                                                  (uu___3119_22930.FStar_TypeChecker_Env.erasable_types_tab);
+                                                                  (uu___3119_22910.FStar_TypeChecker_Env.erasable_types_tab);
                                                                 FStar_TypeChecker_Env.enable_defer_to_tac
                                                                   =
-                                                                  (uu___3119_22930.FStar_TypeChecker_Env.enable_defer_to_tac)
+                                                                  (uu___3119_22910.FStar_TypeChecker_Env.enable_defer_to_tac)
                                                               } in
-                                                            let uu____22931 =
-                                                              let uu____22934
+                                                            let uu____22911 =
+                                                              let uu____22914
                                                                 =
                                                                 FStar_List.fold_left2
                                                                   (fun
-                                                                    uu____22962
+                                                                    uu____22942
                                                                     ->
                                                                     fun
                                                                     pat_bv_tm
                                                                     ->
                                                                     fun bv ->
-                                                                    match uu____22962
+                                                                    match uu____22942
                                                                     with
                                                                     | 
                                                                     (substs,
@@ -8206,28 +8206,28 @@ and (tc_eqn :
                                                                     bv.FStar_Syntax_Syntax.sort in
                                                                     let pat_bv_tm1
                                                                     =
-                                                                    let uu____23003
+                                                                    let uu____22983
                                                                     =
-                                                                    let uu____23010
+                                                                    let uu____22990
                                                                     =
                                                                     FStar_All.pipe_right
                                                                     pat_bv_tm
                                                                     (FStar_Syntax_Subst.subst
                                                                     substs) in
-                                                                    let uu____23011
+                                                                    let uu____22991
                                                                     =
-                                                                    let uu____23022
+                                                                    let uu____23002
                                                                     =
                                                                     FStar_TypeChecker_Env.set_expected_typ
                                                                     env1
                                                                     expected_t in
                                                                     tc_trivial_guard
-                                                                    uu____23022 in
+                                                                    uu____23002 in
                                                                     FStar_All.pipe_right
-                                                                    uu____23010
-                                                                    uu____23011 in
+                                                                    uu____22990
+                                                                    uu____22991 in
                                                                     FStar_All.pipe_right
-                                                                    uu____23003
+                                                                    uu____22983
                                                                     FStar_Pervasives_Native.fst in
                                                                     ((FStar_List.append
                                                                     substs
@@ -8242,65 +8242,65 @@ and (tc_eqn :
                                                                   pat_bv_tms1
                                                                   pat_bvs in
                                                               FStar_All.pipe_right
-                                                                uu____22934
+                                                                uu____22914
                                                                 FStar_Pervasives_Native.snd in
                                                             FStar_All.pipe_right
-                                                              uu____22931
+                                                              uu____22911
                                                               (FStar_List.map
                                                                  (FStar_TypeChecker_Normalize.normalize
                                                                     [FStar_TypeChecker_Env.Beta]
                                                                     env1)) in
-                                                          (let uu____23084 =
+                                                          (let uu____23064 =
                                                              FStar_All.pipe_left
                                                                (FStar_TypeChecker_Env.debug
                                                                   env)
                                                                (FStar_Options.Other
                                                                   "LayeredEffects") in
-                                                           if uu____23084
+                                                           if uu____23064
                                                            then
-                                                             let uu____23085
+                                                             let uu____23065
                                                                =
                                                                FStar_List.fold_left
                                                                  (fun s ->
                                                                     fun t ->
-                                                                    let uu____23091
+                                                                    let uu____23071
                                                                     =
-                                                                    let uu____23092
+                                                                    let uu____23072
                                                                     =
                                                                     FStar_Syntax_Print.term_to_string
                                                                     t in
                                                                     Prims.op_Hat
                                                                     ";"
-                                                                    uu____23092 in
+                                                                    uu____23072 in
                                                                     Prims.op_Hat
                                                                     s
-                                                                    uu____23091)
+                                                                    uu____23071)
                                                                  ""
                                                                  pat_bv_tms2 in
-                                                             let uu____23093
+                                                             let uu____23073
                                                                =
                                                                FStar_List.fold_left
                                                                  (fun s ->
                                                                     fun t ->
-                                                                    let uu____23099
+                                                                    let uu____23079
                                                                     =
-                                                                    let uu____23100
+                                                                    let uu____23080
                                                                     =
                                                                     FStar_Syntax_Print.bv_to_string
                                                                     t in
                                                                     Prims.op_Hat
                                                                     ";"
-                                                                    uu____23100 in
+                                                                    uu____23080 in
                                                                     Prims.op_Hat
                                                                     s
-                                                                    uu____23099)
+                                                                    uu____23079)
                                                                  "" pat_bvs in
                                                              FStar_Util.print2
                                                                "tc_eqn: typechecked pat_bv_tms %s (pat_bvs : %s)\n"
-                                                               uu____23085
-                                                               uu____23093
+                                                               uu____23065
+                                                               uu____23073
                                                            else ());
-                                                          (let uu____23102 =
+                                                          (let uu____23082 =
                                                              FStar_All.pipe_right
                                                                c_weak1
                                                                (FStar_TypeChecker_Common.apply_lcomp
@@ -8317,69 +8317,69 @@ and (tc_eqn :
                                                                     eqs1 ->
                                                                     FStar_TypeChecker_Common.weaken_guard_formula
                                                                     g eqs1)) in
-                                                           let uu____23109 =
-                                                             let uu____23114
+                                                           let uu____23089 =
+                                                             let uu____23094
                                                                =
                                                                FStar_TypeChecker_Env.push_bv
                                                                  env
                                                                  scrutinee in
                                                              FStar_TypeChecker_Util.close_layered_lcomp
-                                                               uu____23114
+                                                               uu____23094
                                                                pat_bvs
                                                                pat_bv_tms2 in
                                                            FStar_All.pipe_right
-                                                             uu____23102
-                                                             uu____23109)))
+                                                             uu____23082
+                                                             uu____23089)))
                                                       else
                                                         FStar_TypeChecker_Util.close_wp_lcomp
                                                           env pat_bvs c_weak1 in
-                                                    let uu____23116 =
+                                                    let uu____23096 =
                                                       FStar_TypeChecker_Env.close_guard
                                                         env binders
                                                         g_when_weak in
-                                                    let uu____23117 =
+                                                    let uu____23097 =
                                                       FStar_TypeChecker_Env.conj_guard
                                                         guard_pat g_branch1 in
                                                     ((c_weak.FStar_TypeChecker_Common.eff_name),
                                                       (c_weak.FStar_TypeChecker_Common.cflags),
                                                       maybe_return_c_weak,
-                                                      uu____23116,
-                                                      uu____23117)) in
-                                         match uu____22692 with
+                                                      uu____23096,
+                                                      uu____23097)) in
+                                         match uu____22672 with
                                          | (effect_label, cflags,
                                             maybe_return_c, g_when1,
                                             g_branch1) ->
                                              let guard =
                                                FStar_TypeChecker_Env.conj_guard
                                                  g_when1 g_branch1 in
-                                             ((let uu____23167 =
+                                             ((let uu____23147 =
                                                  FStar_TypeChecker_Env.debug
                                                    env FStar_Options.High in
-                                               if uu____23167
+                                               if uu____23147
                                                then
-                                                 let uu____23168 =
+                                                 let uu____23148 =
                                                    FStar_TypeChecker_Rel.guard_to_string
                                                      env guard in
                                                  FStar_All.pipe_left
                                                    (FStar_Util.print1
                                                       "Carrying guard from match: %s\n")
-                                                   uu____23168
+                                                   uu____23148
                                                else ());
-                                              (let uu____23170 =
+                                              (let uu____23150 =
                                                  FStar_Syntax_Subst.close_branch
                                                    (pattern1, when_clause1,
                                                      branch_exp1) in
-                                               let uu____23187 =
-                                                 let uu____23188 =
+                                               let uu____23167 =
+                                                 let uu____23168 =
                                                    FStar_List.map
                                                      FStar_Syntax_Syntax.mk_binder
                                                      pat_bvs in
                                                  FStar_TypeChecker_Util.close_guard_implicits
-                                                   env false uu____23188
+                                                   env false uu____23168
                                                    guard in
-                                               (uu____23170, branch_guard,
+                                               (uu____23150, branch_guard,
                                                  effect_label, cflags,
-                                                 maybe_return_c, uu____23187,
+                                                 maybe_return_c, uu____23167,
                                                  erasable))))))))))))
 and (check_top_level_let :
   FStar_TypeChecker_Env.env ->
@@ -8392,38 +8392,38 @@ and (check_top_level_let :
       let env1 = instantiate_both env in
       match e.FStar_Syntax_Syntax.n with
       | FStar_Syntax_Syntax.Tm_let ((false, lb::[]), e2) ->
-          let uu____23231 = check_let_bound_def true env1 lb in
-          (match uu____23231 with
+          let uu____23211 = check_let_bound_def true env1 lb in
+          (match uu____23211 with
            | (e1, univ_vars, c1, g1, annotated) ->
-               let uu____23253 =
+               let uu____23233 =
                  if
                    annotated &&
                      (Prims.op_Negation env1.FStar_TypeChecker_Env.generalize)
                  then
-                   let uu____23274 =
+                   let uu____23254 =
                      FStar_TypeChecker_Normalize.reduce_uvar_solutions env1
                        e1 in
-                   (g1, uu____23274, univ_vars, c1)
+                   (g1, uu____23254, univ_vars, c1)
                  else
                    (let g11 =
-                      let uu____23279 =
+                      let uu____23259 =
                         FStar_TypeChecker_Rel.solve_deferred_constraints env1
                           g1 in
-                      FStar_All.pipe_right uu____23279
+                      FStar_All.pipe_right uu____23259
                         (FStar_TypeChecker_Rel.resolve_implicits env1) in
-                    let uu____23280 = FStar_TypeChecker_Common.lcomp_comp c1 in
-                    match uu____23280 with
+                    let uu____23260 = FStar_TypeChecker_Common.lcomp_comp c1 in
+                    match uu____23260 with
                     | (comp1, g_comp1) ->
                         let g12 =
                           FStar_TypeChecker_Env.conj_guard g11 g_comp1 in
-                        let uu____23298 =
-                          let uu____23311 =
+                        let uu____23278 =
+                          let uu____23291 =
                             FStar_TypeChecker_Generalize.generalize env1
                               false
                               [((lb.FStar_Syntax_Syntax.lbname), e1, comp1)] in
-                          FStar_List.hd uu____23311 in
-                        (match uu____23298 with
-                         | (uu____23360, univs, e11, c11, gvs) ->
+                          FStar_List.hd uu____23291 in
+                        (match uu____23278 with
+                         | (uu____23340, univs, e11, c11, gvs) ->
                              let g13 =
                                FStar_All.pipe_left
                                  (FStar_TypeChecker_Env.map_guard g12)
@@ -8436,40 +8436,40 @@ and (check_top_level_let :
                                       FStar_TypeChecker_Env.Zeta] env1) in
                              let g14 =
                                FStar_TypeChecker_Env.abstract_guard_n gvs g13 in
-                             let uu____23374 =
+                             let uu____23354 =
                                FStar_TypeChecker_Common.lcomp_of_comp c11 in
-                             (g14, e11, univs, uu____23374))) in
-               (match uu____23253 with
+                             (g14, e11, univs, uu____23354))) in
+               (match uu____23233 with
                 | (g11, e11, univ_vars1, c11) ->
-                    let uu____23391 =
-                      let uu____23400 =
+                    let uu____23371 =
+                      let uu____23380 =
                         FStar_TypeChecker_Env.should_verify env1 in
-                      if uu____23400
+                      if uu____23380
                       then
-                        let uu____23409 =
+                        let uu____23389 =
                           FStar_TypeChecker_Util.check_top_level env1 g11 c11 in
-                        match uu____23409 with
+                        match uu____23389 with
                         | (ok, c12) ->
                             (if ok
                              then (e2, c12)
                              else
-                               ((let uu____23438 =
+                               ((let uu____23418 =
                                    FStar_TypeChecker_Env.get_range env1 in
-                                 FStar_Errors.log_issue uu____23438
+                                 FStar_Errors.log_issue uu____23418
                                    FStar_TypeChecker_Err.top_level_effect);
-                                (let uu____23439 =
+                                (let uu____23419 =
                                    FStar_Syntax_Syntax.mk
                                      (FStar_Syntax_Syntax.Tm_meta
                                         (e2,
                                           (FStar_Syntax_Syntax.Meta_desugared
                                              FStar_Syntax_Syntax.Masked_effect)))
                                      e2.FStar_Syntax_Syntax.pos in
-                                 (uu____23439, c12))))
+                                 (uu____23419, c12))))
                       else
                         (FStar_TypeChecker_Rel.force_trivial_guard env1 g11;
-                         (let uu____23450 =
+                         (let uu____23430 =
                             FStar_TypeChecker_Common.lcomp_comp c11 in
-                          match uu____23450 with
+                          match uu____23430 with
                           | (comp1, g_comp1) ->
                               (FStar_TypeChecker_Rel.force_trivial_guard env1
                                  g_comp1;
@@ -8481,14 +8481,14 @@ and (check_top_level_let :
                                        FStar_TypeChecker_Env.DoNotUnfoldPureLets]
                                        env1) in
                                 let e21 =
-                                  let uu____23474 =
+                                  let uu____23454 =
                                     FStar_Syntax_Util.is_pure_comp c in
-                                  if uu____23474
+                                  if uu____23454
                                   then e2
                                   else
-                                    ((let uu____23479 =
+                                    ((let uu____23459 =
                                         FStar_TypeChecker_Env.get_range env1 in
-                                      FStar_Errors.log_issue uu____23479
+                                      FStar_Errors.log_issue uu____23459
                                         FStar_TypeChecker_Err.top_level_effect);
                                      FStar_Syntax_Syntax.mk
                                        (FStar_Syntax_Syntax.Tm_meta
@@ -8497,21 +8497,21 @@ and (check_top_level_let :
                                                FStar_Syntax_Syntax.Masked_effect)))
                                        e2.FStar_Syntax_Syntax.pos) in
                                 (e21, c))))) in
-                    (match uu____23391 with
+                    (match uu____23371 with
                      | (e21, c12) ->
-                         ((let uu____23503 =
+                         ((let uu____23483 =
                              FStar_TypeChecker_Env.debug env1
                                FStar_Options.Medium in
-                           if uu____23503
+                           if uu____23483
                            then
-                             let uu____23504 =
+                             let uu____23484 =
                                FStar_Syntax_Print.term_to_string e11 in
                              FStar_Util.print1
-                               "Let binding BEFORE tcnorm: %s\n" uu____23504
+                               "Let binding BEFORE tcnorm: %s\n" uu____23484
                            else ());
                           (let e12 =
-                             let uu____23507 = FStar_Options.tcnorm () in
-                             if uu____23507
+                             let uu____23487 = FStar_Options.tcnorm () in
+                             if uu____23487
                              then
                                FStar_TypeChecker_Normalize.normalize
                                  [FStar_TypeChecker_Env.UnfoldAttr
@@ -8524,20 +8524,20 @@ and (check_top_level_let :
                                  FStar_TypeChecker_Env.DoNotUnfoldPureLets]
                                  env1 e11
                              else e11 in
-                           (let uu____23510 =
+                           (let uu____23490 =
                               FStar_TypeChecker_Env.debug env1
                                 FStar_Options.Medium in
-                            if uu____23510
+                            if uu____23490
                             then
-                              let uu____23511 =
+                              let uu____23491 =
                                 FStar_Syntax_Print.term_to_string e12 in
                               FStar_Util.print1
-                                "Let binding AFTER tcnorm: %s\n" uu____23511
+                                "Let binding AFTER tcnorm: %s\n" uu____23491
                             else ());
                            (let cres =
-                              let uu____23514 =
+                              let uu____23494 =
                                 FStar_Syntax_Util.is_pure_or_ghost_comp c12 in
-                              if uu____23514
+                              if uu____23494
                               then
                                 FStar_Syntax_Syntax.mk_Total'
                                   FStar_Syntax_Syntax.t_unit
@@ -8551,8 +8551,8 @@ and (check_top_level_let :
                                  let c1_wp =
                                    match c1_comp_typ.FStar_Syntax_Syntax.effect_args
                                    with
-                                   | (wp, uu____23519)::[] -> wp
-                                   | uu____23544 ->
+                                   | (wp, uu____23499)::[] -> wp
+                                   | uu____23524 ->
                                        failwith
                                          "Impossible! check_top_level_let: got unexpected effect args" in
                                  let c1_eff_decl =
@@ -8562,35 +8562,35 @@ and (check_top_level_let :
                                    let ret =
                                      FStar_All.pipe_right c1_eff_decl
                                        FStar_Syntax_Util.get_return_vc_combinator in
-                                   let uu____23558 =
+                                   let uu____23538 =
                                      FStar_TypeChecker_Env.inst_effect_fun_with
                                        [FStar_Syntax_Syntax.U_zero] env1
                                        c1_eff_decl ret in
-                                   let uu____23559 =
-                                     let uu____23560 =
+                                   let uu____23539 =
+                                     let uu____23540 =
                                        FStar_Syntax_Syntax.as_arg
                                          FStar_Syntax_Syntax.t_unit in
-                                     let uu____23569 =
-                                       let uu____23580 =
+                                     let uu____23549 =
+                                       let uu____23560 =
                                          FStar_Syntax_Syntax.as_arg
                                            FStar_Syntax_Syntax.unit_const in
-                                       [uu____23580] in
-                                     uu____23560 :: uu____23569 in
-                                   FStar_Syntax_Syntax.mk_Tm_app uu____23558
-                                     uu____23559 e21.FStar_Syntax_Syntax.pos in
+                                       [uu____23560] in
+                                     uu____23540 :: uu____23549 in
+                                   FStar_Syntax_Syntax.mk_Tm_app uu____23538
+                                     uu____23539 e21.FStar_Syntax_Syntax.pos in
                                  let wp =
                                    let bind =
                                      FStar_All.pipe_right c1_eff_decl
                                        FStar_Syntax_Util.get_bind_vc_combinator in
-                                   let uu____23615 =
+                                   let uu____23595 =
                                      FStar_TypeChecker_Env.inst_effect_fun_with
                                        (FStar_List.append
                                           c1_comp_typ.FStar_Syntax_Syntax.comp_univs
                                           [FStar_Syntax_Syntax.U_zero]) env1
                                        c1_eff_decl bind in
-                                   let uu____23616 =
-                                     let uu____23617 =
-                                       let uu____23626 =
+                                   let uu____23596 =
+                                     let uu____23597 =
+                                       let uu____23606 =
                                          FStar_Syntax_Syntax.mk
                                            (FStar_Syntax_Syntax.Tm_constant
                                               (FStar_Const.Const_range
@@ -8598,29 +8598,29 @@ and (check_top_level_let :
                                            lb.FStar_Syntax_Syntax.lbpos in
                                        FStar_All.pipe_left
                                          FStar_Syntax_Syntax.as_arg
-                                         uu____23626 in
-                                     let uu____23635 =
-                                       let uu____23646 =
+                                         uu____23606 in
+                                     let uu____23615 =
+                                       let uu____23626 =
                                          FStar_All.pipe_left
                                            FStar_Syntax_Syntax.as_arg
                                            c1_comp_typ.FStar_Syntax_Syntax.result_typ in
-                                       let uu____23663 =
-                                         let uu____23674 =
+                                       let uu____23643 =
+                                         let uu____23654 =
                                            FStar_Syntax_Syntax.as_arg
                                              FStar_Syntax_Syntax.t_unit in
-                                         let uu____23683 =
-                                           let uu____23694 =
+                                         let uu____23663 =
+                                           let uu____23674 =
                                              FStar_Syntax_Syntax.as_arg c1_wp in
-                                           let uu____23703 =
-                                             let uu____23714 =
-                                               let uu____23723 =
-                                                 let uu____23724 =
-                                                   let uu____23725 =
+                                           let uu____23683 =
+                                             let uu____23694 =
+                                               let uu____23703 =
+                                                 let uu____23704 =
+                                                   let uu____23705 =
                                                      FStar_Syntax_Syntax.null_binder
                                                        c1_comp_typ.FStar_Syntax_Syntax.result_typ in
-                                                   [uu____23725] in
+                                                   [uu____23705] in
                                                  FStar_Syntax_Util.abs
-                                                   uu____23724 wp2
+                                                   uu____23704 wp2
                                                    (FStar_Pervasives_Native.Some
                                                       (FStar_Syntax_Util.mk_residual_comp
                                                          FStar_Parser_Const.effect_Tot_lid
@@ -8628,19 +8628,19 @@ and (check_top_level_let :
                                                          [FStar_Syntax_Syntax.TOTAL])) in
                                                FStar_All.pipe_left
                                                  FStar_Syntax_Syntax.as_arg
-                                                 uu____23723 in
-                                             [uu____23714] in
-                                           uu____23694 :: uu____23703 in
-                                         uu____23674 :: uu____23683 in
-                                       uu____23646 :: uu____23663 in
-                                     uu____23617 :: uu____23635 in
-                                   FStar_Syntax_Syntax.mk_Tm_app uu____23615
-                                     uu____23616 lb.FStar_Syntax_Syntax.lbpos in
-                                 let uu____23802 =
-                                   let uu____23803 =
-                                     let uu____23814 =
+                                                 uu____23703 in
+                                             [uu____23694] in
+                                           uu____23674 :: uu____23683 in
+                                         uu____23654 :: uu____23663 in
+                                       uu____23626 :: uu____23643 in
+                                     uu____23597 :: uu____23615 in
+                                   FStar_Syntax_Syntax.mk_Tm_app uu____23595
+                                     uu____23596 lb.FStar_Syntax_Syntax.lbpos in
+                                 let uu____23782 =
+                                   let uu____23783 =
+                                     let uu____23794 =
                                        FStar_Syntax_Syntax.as_arg wp in
-                                     [uu____23814] in
+                                     [uu____23794] in
                                    {
                                      FStar_Syntax_Syntax.comp_univs =
                                        [FStar_Syntax_Syntax.U_zero];
@@ -8649,10 +8649,10 @@ and (check_top_level_let :
                                      FStar_Syntax_Syntax.result_typ =
                                        FStar_Syntax_Syntax.t_unit;
                                      FStar_Syntax_Syntax.effect_args =
-                                       uu____23803;
+                                       uu____23783;
                                      FStar_Syntax_Syntax.flags = []
                                    } in
-                                 FStar_Syntax_Syntax.mk_Comp uu____23802) in
+                                 FStar_Syntax_Syntax.mk_Comp uu____23782) in
                             let lb1 =
                               FStar_Syntax_Util.close_univs_and_mk_letbinding
                                 FStar_Pervasives_Native.None
@@ -8661,16 +8661,16 @@ and (check_top_level_let :
                                 (FStar_Syntax_Util.comp_effect_name c12) e12
                                 lb.FStar_Syntax_Syntax.lbattrs
                                 lb.FStar_Syntax_Syntax.lbpos in
-                            let uu____23842 =
+                            let uu____23822 =
                               FStar_Syntax_Syntax.mk
                                 (FStar_Syntax_Syntax.Tm_let
                                    ((false, [lb1]), e21))
                                 e.FStar_Syntax_Syntax.pos in
-                            let uu____23853 =
+                            let uu____23833 =
                               FStar_TypeChecker_Common.lcomp_of_comp cres in
-                            (uu____23842, uu____23853,
+                            (uu____23822, uu____23833,
                               FStar_TypeChecker_Env.trivial_guard)))))))
-      | uu____23854 -> failwith "Impossible"
+      | uu____23834 -> failwith "Impossible"
 and (maybe_intro_smt_lemma :
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.term ->
@@ -8679,15 +8679,15 @@ and (maybe_intro_smt_lemma :
   fun env ->
     fun lem_typ ->
       fun c2 ->
-        let uu____23864 = FStar_Syntax_Util.is_smt_lemma lem_typ in
-        if uu____23864
+        let uu____23844 = FStar_Syntax_Util.is_smt_lemma lem_typ in
+        if uu____23844
         then
           let universe_of_binders bs =
-            let uu____23889 =
+            let uu____23869 =
               FStar_List.fold_left
-                (fun uu____23914 ->
+                (fun uu____23894 ->
                    fun b ->
-                     match uu____23914 with
+                     match uu____23894 with
                      | (env1, us) ->
                          let u =
                            env1.FStar_TypeChecker_Env.universe_of env1
@@ -8695,7 +8695,7 @@ and (maybe_intro_smt_lemma :
                          let env2 =
                            FStar_TypeChecker_Env.push_binders env1 [b] in
                          (env2, (u :: us))) (env, []) bs in
-            match uu____23889 with | (uu____23962, us) -> FStar_List.rev us in
+            match uu____23869 with | (uu____23942, us) -> FStar_List.rev us in
           let quant =
             FStar_Syntax_Util.smt_lemma_as_forall lem_typ universe_of_binders in
           FStar_TypeChecker_Util.weaken_precondition env c2
@@ -8713,109 +8713,109 @@ and (check_inner_let :
       match e.FStar_Syntax_Syntax.n with
       | FStar_Syntax_Syntax.Tm_let ((false, lb::[]), e2) ->
           let env2 =
-            let uu___3251_23994 = env1 in
+            let uu___3251_23974 = env1 in
             {
               FStar_TypeChecker_Env.solver =
-                (uu___3251_23994.FStar_TypeChecker_Env.solver);
+                (uu___3251_23974.FStar_TypeChecker_Env.solver);
               FStar_TypeChecker_Env.range =
-                (uu___3251_23994.FStar_TypeChecker_Env.range);
+                (uu___3251_23974.FStar_TypeChecker_Env.range);
               FStar_TypeChecker_Env.curmodule =
-                (uu___3251_23994.FStar_TypeChecker_Env.curmodule);
+                (uu___3251_23974.FStar_TypeChecker_Env.curmodule);
               FStar_TypeChecker_Env.gamma =
-                (uu___3251_23994.FStar_TypeChecker_Env.gamma);
+                (uu___3251_23974.FStar_TypeChecker_Env.gamma);
               FStar_TypeChecker_Env.gamma_sig =
-                (uu___3251_23994.FStar_TypeChecker_Env.gamma_sig);
+                (uu___3251_23974.FStar_TypeChecker_Env.gamma_sig);
               FStar_TypeChecker_Env.gamma_cache =
-                (uu___3251_23994.FStar_TypeChecker_Env.gamma_cache);
+                (uu___3251_23974.FStar_TypeChecker_Env.gamma_cache);
               FStar_TypeChecker_Env.modules =
-                (uu___3251_23994.FStar_TypeChecker_Env.modules);
+                (uu___3251_23974.FStar_TypeChecker_Env.modules);
               FStar_TypeChecker_Env.expected_typ =
-                (uu___3251_23994.FStar_TypeChecker_Env.expected_typ);
+                (uu___3251_23974.FStar_TypeChecker_Env.expected_typ);
               FStar_TypeChecker_Env.sigtab =
-                (uu___3251_23994.FStar_TypeChecker_Env.sigtab);
+                (uu___3251_23974.FStar_TypeChecker_Env.sigtab);
               FStar_TypeChecker_Env.attrtab =
-                (uu___3251_23994.FStar_TypeChecker_Env.attrtab);
+                (uu___3251_23974.FStar_TypeChecker_Env.attrtab);
               FStar_TypeChecker_Env.instantiate_imp =
-                (uu___3251_23994.FStar_TypeChecker_Env.instantiate_imp);
+                (uu___3251_23974.FStar_TypeChecker_Env.instantiate_imp);
               FStar_TypeChecker_Env.effects =
-                (uu___3251_23994.FStar_TypeChecker_Env.effects);
+                (uu___3251_23974.FStar_TypeChecker_Env.effects);
               FStar_TypeChecker_Env.generalize =
-                (uu___3251_23994.FStar_TypeChecker_Env.generalize);
+                (uu___3251_23974.FStar_TypeChecker_Env.generalize);
               FStar_TypeChecker_Env.letrecs =
-                (uu___3251_23994.FStar_TypeChecker_Env.letrecs);
+                (uu___3251_23974.FStar_TypeChecker_Env.letrecs);
               FStar_TypeChecker_Env.top_level = false;
               FStar_TypeChecker_Env.check_uvars =
-                (uu___3251_23994.FStar_TypeChecker_Env.check_uvars);
+                (uu___3251_23974.FStar_TypeChecker_Env.check_uvars);
               FStar_TypeChecker_Env.use_eq =
-                (uu___3251_23994.FStar_TypeChecker_Env.use_eq);
+                (uu___3251_23974.FStar_TypeChecker_Env.use_eq);
               FStar_TypeChecker_Env.use_eq_strict =
-                (uu___3251_23994.FStar_TypeChecker_Env.use_eq_strict);
+                (uu___3251_23974.FStar_TypeChecker_Env.use_eq_strict);
               FStar_TypeChecker_Env.is_iface =
-                (uu___3251_23994.FStar_TypeChecker_Env.is_iface);
+                (uu___3251_23974.FStar_TypeChecker_Env.is_iface);
               FStar_TypeChecker_Env.admit =
-                (uu___3251_23994.FStar_TypeChecker_Env.admit);
+                (uu___3251_23974.FStar_TypeChecker_Env.admit);
               FStar_TypeChecker_Env.lax =
-                (uu___3251_23994.FStar_TypeChecker_Env.lax);
+                (uu___3251_23974.FStar_TypeChecker_Env.lax);
               FStar_TypeChecker_Env.lax_universes =
-                (uu___3251_23994.FStar_TypeChecker_Env.lax_universes);
+                (uu___3251_23974.FStar_TypeChecker_Env.lax_universes);
               FStar_TypeChecker_Env.phase1 =
-                (uu___3251_23994.FStar_TypeChecker_Env.phase1);
+                (uu___3251_23974.FStar_TypeChecker_Env.phase1);
               FStar_TypeChecker_Env.failhard =
-                (uu___3251_23994.FStar_TypeChecker_Env.failhard);
+                (uu___3251_23974.FStar_TypeChecker_Env.failhard);
               FStar_TypeChecker_Env.nosynth =
-                (uu___3251_23994.FStar_TypeChecker_Env.nosynth);
+                (uu___3251_23974.FStar_TypeChecker_Env.nosynth);
               FStar_TypeChecker_Env.uvar_subtyping =
-                (uu___3251_23994.FStar_TypeChecker_Env.uvar_subtyping);
+                (uu___3251_23974.FStar_TypeChecker_Env.uvar_subtyping);
               FStar_TypeChecker_Env.tc_term =
-                (uu___3251_23994.FStar_TypeChecker_Env.tc_term);
+                (uu___3251_23974.FStar_TypeChecker_Env.tc_term);
               FStar_TypeChecker_Env.type_of =
-                (uu___3251_23994.FStar_TypeChecker_Env.type_of);
+                (uu___3251_23974.FStar_TypeChecker_Env.type_of);
               FStar_TypeChecker_Env.universe_of =
-                (uu___3251_23994.FStar_TypeChecker_Env.universe_of);
+                (uu___3251_23974.FStar_TypeChecker_Env.universe_of);
               FStar_TypeChecker_Env.check_type_of =
-                (uu___3251_23994.FStar_TypeChecker_Env.check_type_of);
+                (uu___3251_23974.FStar_TypeChecker_Env.check_type_of);
               FStar_TypeChecker_Env.use_bv_sorts =
-                (uu___3251_23994.FStar_TypeChecker_Env.use_bv_sorts);
+                (uu___3251_23974.FStar_TypeChecker_Env.use_bv_sorts);
               FStar_TypeChecker_Env.qtbl_name_and_index =
-                (uu___3251_23994.FStar_TypeChecker_Env.qtbl_name_and_index);
+                (uu___3251_23974.FStar_TypeChecker_Env.qtbl_name_and_index);
               FStar_TypeChecker_Env.normalized_eff_names =
-                (uu___3251_23994.FStar_TypeChecker_Env.normalized_eff_names);
+                (uu___3251_23974.FStar_TypeChecker_Env.normalized_eff_names);
               FStar_TypeChecker_Env.fv_delta_depths =
-                (uu___3251_23994.FStar_TypeChecker_Env.fv_delta_depths);
+                (uu___3251_23974.FStar_TypeChecker_Env.fv_delta_depths);
               FStar_TypeChecker_Env.proof_ns =
-                (uu___3251_23994.FStar_TypeChecker_Env.proof_ns);
+                (uu___3251_23974.FStar_TypeChecker_Env.proof_ns);
               FStar_TypeChecker_Env.synth_hook =
-                (uu___3251_23994.FStar_TypeChecker_Env.synth_hook);
+                (uu___3251_23974.FStar_TypeChecker_Env.synth_hook);
               FStar_TypeChecker_Env.try_solve_implicits_hook =
-                (uu___3251_23994.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                (uu___3251_23974.FStar_TypeChecker_Env.try_solve_implicits_hook);
               FStar_TypeChecker_Env.splice =
-                (uu___3251_23994.FStar_TypeChecker_Env.splice);
+                (uu___3251_23974.FStar_TypeChecker_Env.splice);
               FStar_TypeChecker_Env.mpreprocess =
-                (uu___3251_23994.FStar_TypeChecker_Env.mpreprocess);
+                (uu___3251_23974.FStar_TypeChecker_Env.mpreprocess);
               FStar_TypeChecker_Env.postprocess =
-                (uu___3251_23994.FStar_TypeChecker_Env.postprocess);
+                (uu___3251_23974.FStar_TypeChecker_Env.postprocess);
               FStar_TypeChecker_Env.identifier_info =
-                (uu___3251_23994.FStar_TypeChecker_Env.identifier_info);
+                (uu___3251_23974.FStar_TypeChecker_Env.identifier_info);
               FStar_TypeChecker_Env.tc_hooks =
-                (uu___3251_23994.FStar_TypeChecker_Env.tc_hooks);
+                (uu___3251_23974.FStar_TypeChecker_Env.tc_hooks);
               FStar_TypeChecker_Env.dsenv =
-                (uu___3251_23994.FStar_TypeChecker_Env.dsenv);
+                (uu___3251_23974.FStar_TypeChecker_Env.dsenv);
               FStar_TypeChecker_Env.nbe =
-                (uu___3251_23994.FStar_TypeChecker_Env.nbe);
+                (uu___3251_23974.FStar_TypeChecker_Env.nbe);
               FStar_TypeChecker_Env.strict_args_tab =
-                (uu___3251_23994.FStar_TypeChecker_Env.strict_args_tab);
+                (uu___3251_23974.FStar_TypeChecker_Env.strict_args_tab);
               FStar_TypeChecker_Env.erasable_types_tab =
-                (uu___3251_23994.FStar_TypeChecker_Env.erasable_types_tab);
+                (uu___3251_23974.FStar_TypeChecker_Env.erasable_types_tab);
               FStar_TypeChecker_Env.enable_defer_to_tac =
-                (uu___3251_23994.FStar_TypeChecker_Env.enable_defer_to_tac)
+                (uu___3251_23974.FStar_TypeChecker_Env.enable_defer_to_tac)
             } in
-          let uu____23995 =
-            let uu____24006 =
-              let uu____24007 = FStar_TypeChecker_Env.clear_expected_typ env2 in
-              FStar_All.pipe_right uu____24007 FStar_Pervasives_Native.fst in
-            check_let_bound_def false uu____24006 lb in
-          (match uu____23995 with
-           | (e1, uu____24029, c1, g1, annotated) ->
+          let uu____23975 =
+            let uu____23986 =
+              let uu____23987 = FStar_TypeChecker_Env.clear_expected_typ env2 in
+              FStar_All.pipe_right uu____23987 FStar_Pervasives_Native.fst in
+            check_let_bound_def false uu____23986 lb in
+          (match uu____23975 with
+           | (e1, uu____24009, c1, g1, annotated) ->
                let pure_or_ghost =
                  FStar_TypeChecker_Common.is_pure_or_ghost_lcomp c1 in
                let is_inline_let =
@@ -8825,68 +8825,68 @@ and (check_inner_let :
                    lb.FStar_Syntax_Syntax.lbattrs in
                (if is_inline_let && (Prims.op_Negation pure_or_ghost)
                 then
-                  (let uu____24038 =
-                     let uu____24043 =
-                       let uu____24044 = FStar_Syntax_Print.term_to_string e1 in
-                       let uu____24045 =
+                  (let uu____24018 =
+                     let uu____24023 =
+                       let uu____24024 = FStar_Syntax_Print.term_to_string e1 in
+                       let uu____24025 =
                          FStar_Syntax_Print.lid_to_string
                            c1.FStar_TypeChecker_Common.eff_name in
                        FStar_Util.format2
                          "Definitions marked @inline_let are expected to be pure or ghost; got an expression \"%s\" with effect \"%s\""
-                         uu____24044 uu____24045 in
-                     (FStar_Errors.Fatal_ExpectedPureExpression, uu____24043) in
-                   FStar_Errors.raise_error uu____24038
+                         uu____24024 uu____24025 in
+                     (FStar_Errors.Fatal_ExpectedPureExpression, uu____24023) in
+                   FStar_Errors.raise_error uu____24018
                      e1.FStar_Syntax_Syntax.pos)
                 else ();
                 (let attrs =
-                   let uu____24052 =
+                   let uu____24032 =
                      (pure_or_ghost && (Prims.op_Negation is_inline_let)) &&
                        (FStar_Syntax_Util.is_unit
                           c1.FStar_TypeChecker_Common.res_typ) in
-                   if uu____24052
+                   if uu____24032
                    then FStar_Syntax_Util.inline_let_attr ::
                      (lb.FStar_Syntax_Syntax.lbattrs)
                    else lb.FStar_Syntax_Syntax.lbattrs in
                  let x =
-                   let uu___3266_24061 =
+                   let uu___3266_24041 =
                      FStar_Util.left lb.FStar_Syntax_Syntax.lbname in
                    {
                      FStar_Syntax_Syntax.ppname =
-                       (uu___3266_24061.FStar_Syntax_Syntax.ppname);
+                       (uu___3266_24041.FStar_Syntax_Syntax.ppname);
                      FStar_Syntax_Syntax.index =
-                       (uu___3266_24061.FStar_Syntax_Syntax.index);
+                       (uu___3266_24041.FStar_Syntax_Syntax.index);
                      FStar_Syntax_Syntax.sort =
                        (c1.FStar_TypeChecker_Common.res_typ)
                    } in
-                 let uu____24062 =
-                   let uu____24067 =
-                     let uu____24068 = FStar_Syntax_Syntax.mk_binder x in
-                     [uu____24068] in
-                   FStar_Syntax_Subst.open_term uu____24067 e2 in
-                 match uu____24062 with
+                 let uu____24042 =
+                   let uu____24047 =
+                     let uu____24048 = FStar_Syntax_Syntax.mk_binder x in
+                     [uu____24048] in
+                   FStar_Syntax_Subst.open_term uu____24047 e2 in
+                 match uu____24042 with
                  | (xb, e21) ->
                      let xbinder = FStar_List.hd xb in
                      let x1 = FStar_Pervasives_Native.fst xbinder in
                      let env_x = FStar_TypeChecker_Env.push_bv env2 x1 in
-                     let uu____24112 =
-                       let uu____24119 = tc_term env_x e21 in
-                       FStar_All.pipe_right uu____24119
-                         (fun uu____24145 ->
-                            match uu____24145 with
+                     let uu____24092 =
+                       let uu____24099 = tc_term env_x e21 in
+                       FStar_All.pipe_right uu____24099
+                         (fun uu____24125 ->
+                            match uu____24125 with
                             | (e22, c2, g2) ->
-                                let uu____24161 =
-                                  let uu____24166 =
+                                let uu____24141 =
+                                  let uu____24146 =
                                     FStar_All.pipe_right
-                                      (fun uu____24181 ->
+                                      (fun uu____24161 ->
                                          "folding guard g2 of e2 in the lcomp")
-                                      (fun uu____24185 ->
+                                      (fun uu____24165 ->
                                          FStar_Pervasives_Native.Some
-                                           uu____24185) in
+                                           uu____24165) in
                                   FStar_TypeChecker_Util.strengthen_precondition
-                                    uu____24166 env_x e22 c2 g2 in
-                                (match uu____24161 with
+                                    uu____24146 env_x e22 c2 g2 in
+                                (match uu____24141 with
                                  | (c21, g21) -> (e22, c21, g21))) in
-                     (match uu____24112 with
+                     (match uu____24092 with
                       | (e22, c2, g2) ->
                           let c21 =
                             maybe_intro_smt_lemma env_x
@@ -8913,93 +8913,93 @@ and (check_inner_let :
                               cres.FStar_TypeChecker_Common.eff_name e11
                               attrs lb.FStar_Syntax_Syntax.lbpos in
                           let e3 =
-                            let uu____24213 =
-                              let uu____24214 =
-                                let uu____24227 =
+                            let uu____24193 =
+                              let uu____24194 =
+                                let uu____24207 =
                                   FStar_Syntax_Subst.close xb e23 in
-                                ((false, [lb1]), uu____24227) in
-                              FStar_Syntax_Syntax.Tm_let uu____24214 in
-                            FStar_Syntax_Syntax.mk uu____24213
+                                ((false, [lb1]), uu____24207) in
+                              FStar_Syntax_Syntax.Tm_let uu____24194 in
+                            FStar_Syntax_Syntax.mk uu____24193
                               e.FStar_Syntax_Syntax.pos in
                           let e4 =
                             FStar_TypeChecker_Util.maybe_monadic env2 e3
                               cres.FStar_TypeChecker_Common.eff_name
                               cres.FStar_TypeChecker_Common.res_typ in
                           let g21 =
-                            let uu____24242 =
-                              let uu____24243 =
+                            let uu____24222 =
+                              let uu____24223 =
                                 FStar_All.pipe_right
                                   cres.FStar_TypeChecker_Common.eff_name
                                   (FStar_TypeChecker_Env.norm_eff_name env2) in
-                              FStar_All.pipe_right uu____24243
+                              FStar_All.pipe_right uu____24223
                                 (FStar_TypeChecker_Env.is_layered_effect env2) in
                             FStar_TypeChecker_Util.close_guard_implicits env2
-                              uu____24242 xb g2 in
+                              uu____24222 xb g2 in
                           let guard = FStar_TypeChecker_Env.conj_guard g1 g21 in
-                          let uu____24245 =
-                            let uu____24246 =
+                          let uu____24225 =
+                            let uu____24226 =
                               FStar_TypeChecker_Env.expected_typ env2 in
-                            FStar_Option.isSome uu____24246 in
-                          if uu____24245
+                            FStar_Option.isSome uu____24226 in
+                          if uu____24225
                           then
                             let tt =
-                              let uu____24256 =
+                              let uu____24236 =
                                 FStar_TypeChecker_Env.expected_typ env2 in
-                              FStar_All.pipe_right uu____24256
+                              FStar_All.pipe_right uu____24236
                                 FStar_Option.get in
-                            ((let uu____24262 =
+                            ((let uu____24242 =
                                 FStar_All.pipe_left
                                   (FStar_TypeChecker_Env.debug env2)
                                   (FStar_Options.Other "Exports") in
-                              if uu____24262
+                              if uu____24242
                               then
-                                let uu____24263 =
+                                let uu____24243 =
                                   FStar_Syntax_Print.term_to_string tt in
-                                let uu____24264 =
+                                let uu____24244 =
                                   FStar_Syntax_Print.term_to_string
                                     cres.FStar_TypeChecker_Common.res_typ in
                                 FStar_Util.print2
                                   "Got expected type from env %s\ncres.res_typ=%s\n"
-                                  uu____24263 uu____24264
+                                  uu____24243 uu____24244
                               else ());
                              (e4, cres, guard))
                           else
-                            (let uu____24267 =
+                            (let uu____24247 =
                                check_no_escape FStar_Pervasives_Native.None
                                  env2 [x1]
                                  cres.FStar_TypeChecker_Common.res_typ in
-                             match uu____24267 with
+                             match uu____24247 with
                              | (t, g_ex) ->
-                                 ((let uu____24281 =
+                                 ((let uu____24261 =
                                      FStar_All.pipe_left
                                        (FStar_TypeChecker_Env.debug env2)
                                        (FStar_Options.Other "Exports") in
-                                   if uu____24281
+                                   if uu____24261
                                    then
-                                     let uu____24282 =
+                                     let uu____24262 =
                                        FStar_Syntax_Print.term_to_string
                                          cres.FStar_TypeChecker_Common.res_typ in
-                                     let uu____24283 =
+                                     let uu____24263 =
                                        FStar_Syntax_Print.term_to_string t in
                                      FStar_Util.print2
                                        "Checked %s has no escaping types; normalized to %s\n"
-                                       uu____24282 uu____24283
+                                       uu____24262 uu____24263
                                    else ());
-                                  (let uu____24285 =
+                                  (let uu____24265 =
                                      FStar_TypeChecker_Env.conj_guard g_ex
                                        guard in
                                    (e4,
-                                     (let uu___3305_24287 = cres in
+                                     (let uu___3305_24267 = cres in
                                       {
                                         FStar_TypeChecker_Common.eff_name =
-                                          (uu___3305_24287.FStar_TypeChecker_Common.eff_name);
+                                          (uu___3305_24267.FStar_TypeChecker_Common.eff_name);
                                         FStar_TypeChecker_Common.res_typ = t;
                                         FStar_TypeChecker_Common.cflags =
-                                          (uu___3305_24287.FStar_TypeChecker_Common.cflags);
+                                          (uu___3305_24267.FStar_TypeChecker_Common.cflags);
                                         FStar_TypeChecker_Common.comp_thunk =
-                                          (uu___3305_24287.FStar_TypeChecker_Common.comp_thunk)
-                                      }), uu____24285))))))))
-      | uu____24288 ->
+                                          (uu___3305_24267.FStar_TypeChecker_Common.comp_thunk)
+                                      }), uu____24265))))))))
+      | uu____24268 ->
           failwith "Impossible (inner let with more than one lb)"
 and (check_top_level_let_rec :
   FStar_TypeChecker_Env.env ->
@@ -9012,40 +9012,40 @@ and (check_top_level_let_rec :
       let env1 = instantiate_both env in
       match top.FStar_Syntax_Syntax.n with
       | FStar_Syntax_Syntax.Tm_let ((true, lbs), e2) ->
-          let uu____24320 = FStar_Syntax_Subst.open_let_rec lbs e2 in
-          (match uu____24320 with
+          let uu____24300 = FStar_Syntax_Subst.open_let_rec lbs e2 in
+          (match uu____24300 with
            | (lbs1, e21) ->
-               let uu____24339 =
+               let uu____24319 =
                  FStar_TypeChecker_Env.clear_expected_typ env1 in
-               (match uu____24339 with
+               (match uu____24319 with
                 | (env0, topt) ->
-                    let uu____24358 = build_let_rec_env true env0 lbs1 in
-                    (match uu____24358 with
+                    let uu____24338 = build_let_rec_env true env0 lbs1 in
+                    (match uu____24338 with
                      | (lbs2, rec_env, g_t) ->
-                         let uu____24380 = check_let_recs rec_env lbs2 in
-                         (match uu____24380 with
+                         let uu____24360 = check_let_recs rec_env lbs2 in
+                         (match uu____24360 with
                           | (lbs3, g_lbs) ->
                               let g_lbs1 =
-                                let uu____24400 =
-                                  let uu____24401 =
+                                let uu____24380 =
+                                  let uu____24381 =
                                     FStar_TypeChecker_Env.conj_guard g_t
                                       g_lbs in
-                                  FStar_All.pipe_right uu____24401
+                                  FStar_All.pipe_right uu____24381
                                     (FStar_TypeChecker_Rel.solve_deferred_constraints
                                        env1) in
-                                FStar_All.pipe_right uu____24400
+                                FStar_All.pipe_right uu____24380
                                   (FStar_TypeChecker_Rel.resolve_implicits
                                      env1) in
                               let all_lb_names =
-                                let uu____24407 =
+                                let uu____24387 =
                                   FStar_All.pipe_right lbs3
                                     (FStar_List.map
                                        (fun lb ->
                                           FStar_Util.right
                                             lb.FStar_Syntax_Syntax.lbname)) in
-                                FStar_All.pipe_right uu____24407
-                                  (fun uu____24424 ->
-                                     FStar_Pervasives_Native.Some uu____24424) in
+                                FStar_All.pipe_right uu____24387
+                                  (fun uu____24404 ->
+                                     FStar_Pervasives_Native.Some uu____24404) in
                               let lbs4 =
                                 if
                                   Prims.op_Negation
@@ -9074,22 +9074,22 @@ and (check_top_level_let_rec :
                                               lb.FStar_Syntax_Syntax.lbpos))
                                 else
                                   (let ecs =
-                                     let uu____24457 =
+                                     let uu____24437 =
                                        FStar_All.pipe_right lbs3
                                          (FStar_List.map
                                             (fun lb ->
-                                               let uu____24491 =
+                                               let uu____24471 =
                                                  FStar_Syntax_Syntax.mk_Total
                                                    lb.FStar_Syntax_Syntax.lbtyp in
                                                ((lb.FStar_Syntax_Syntax.lbname),
                                                  (lb.FStar_Syntax_Syntax.lbdef),
-                                                 uu____24491))) in
+                                                 uu____24471))) in
                                      FStar_TypeChecker_Generalize.generalize
-                                       env1 true uu____24457 in
+                                       env1 true uu____24437 in
                                    FStar_List.map2
-                                     (fun uu____24525 ->
+                                     (fun uu____24505 ->
                                         fun lb ->
-                                          match uu____24525 with
+                                          match uu____24505 with
                                           | (x, uvs, e, c, gvs) ->
                                               FStar_Syntax_Util.close_univs_and_mk_letbinding
                                                 all_lb_names x uvs
@@ -9101,30 +9101,30 @@ and (check_top_level_let_rec :
                                                 lb.FStar_Syntax_Syntax.lbpos)
                                      ecs lbs3) in
                               let cres =
-                                let uu____24573 =
+                                let uu____24553 =
                                   FStar_Syntax_Syntax.mk_Total
                                     FStar_Syntax_Syntax.t_unit in
                                 FStar_All.pipe_left
                                   FStar_TypeChecker_Common.lcomp_of_comp
-                                  uu____24573 in
-                              let uu____24574 =
+                                  uu____24553 in
+                              let uu____24554 =
                                 FStar_Syntax_Subst.close_let_rec lbs4 e21 in
-                              (match uu____24574 with
+                              (match uu____24554 with
                                | (lbs5, e22) ->
-                                   ((let uu____24594 =
+                                   ((let uu____24574 =
                                        FStar_TypeChecker_Rel.discharge_guard
                                          env1 g_lbs1 in
-                                     FStar_All.pipe_right uu____24594
+                                     FStar_All.pipe_right uu____24574
                                        (FStar_TypeChecker_Rel.force_trivial_guard
                                           env1));
-                                    (let uu____24595 =
+                                    (let uu____24575 =
                                        FStar_Syntax_Syntax.mk
                                          (FStar_Syntax_Syntax.Tm_let
                                             ((true, lbs5), e22))
                                          top.FStar_Syntax_Syntax.pos in
-                                     (uu____24595, cres,
+                                     (uu____24575, cres,
                                        FStar_TypeChecker_Env.trivial_guard))))))))
-      | uu____24606 -> failwith "Impossible"
+      | uu____24586 -> failwith "Impossible"
 and (check_inner_let_rec :
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.term ->
@@ -9136,61 +9136,61 @@ and (check_inner_let_rec :
       let env1 = instantiate_both env in
       match top.FStar_Syntax_Syntax.n with
       | FStar_Syntax_Syntax.Tm_let ((true, lbs), e2) ->
-          let uu____24638 = FStar_Syntax_Subst.open_let_rec lbs e2 in
-          (match uu____24638 with
+          let uu____24618 = FStar_Syntax_Subst.open_let_rec lbs e2 in
+          (match uu____24618 with
            | (lbs1, e21) ->
-               let uu____24657 =
+               let uu____24637 =
                  FStar_TypeChecker_Env.clear_expected_typ env1 in
-               (match uu____24657 with
+               (match uu____24637 with
                 | (env0, topt) ->
-                    let uu____24676 = build_let_rec_env false env0 lbs1 in
-                    (match uu____24676 with
+                    let uu____24656 = build_let_rec_env false env0 lbs1 in
+                    (match uu____24656 with
                      | (lbs2, rec_env, g_t) ->
-                         let uu____24698 =
-                           let uu____24705 = check_let_recs rec_env lbs2 in
-                           FStar_All.pipe_right uu____24705
-                             (fun uu____24728 ->
-                                match uu____24728 with
+                         let uu____24678 =
+                           let uu____24685 = check_let_recs rec_env lbs2 in
+                           FStar_All.pipe_right uu____24685
+                             (fun uu____24708 ->
+                                match uu____24708 with
                                 | (lbs3, g) ->
-                                    let uu____24747 =
+                                    let uu____24727 =
                                       FStar_TypeChecker_Env.conj_guard g_t g in
-                                    (lbs3, uu____24747)) in
-                         (match uu____24698 with
+                                    (lbs3, uu____24727)) in
+                         (match uu____24678 with
                           | (lbs3, g_lbs) ->
-                              let uu____24762 =
+                              let uu____24742 =
                                 FStar_All.pipe_right lbs3
                                   (FStar_Util.fold_map
                                      (fun env2 ->
                                         fun lb ->
                                           let x =
-                                            let uu___3380_24785 =
+                                            let uu___3380_24765 =
                                               FStar_Util.left
                                                 lb.FStar_Syntax_Syntax.lbname in
                                             {
                                               FStar_Syntax_Syntax.ppname =
-                                                (uu___3380_24785.FStar_Syntax_Syntax.ppname);
+                                                (uu___3380_24765.FStar_Syntax_Syntax.ppname);
                                               FStar_Syntax_Syntax.index =
-                                                (uu___3380_24785.FStar_Syntax_Syntax.index);
+                                                (uu___3380_24765.FStar_Syntax_Syntax.index);
                                               FStar_Syntax_Syntax.sort =
                                                 (lb.FStar_Syntax_Syntax.lbtyp)
                                             } in
                                           let lb1 =
-                                            let uu___3383_24787 = lb in
+                                            let uu___3383_24767 = lb in
                                             {
                                               FStar_Syntax_Syntax.lbname =
                                                 (FStar_Util.Inl x);
                                               FStar_Syntax_Syntax.lbunivs =
-                                                (uu___3383_24787.FStar_Syntax_Syntax.lbunivs);
+                                                (uu___3383_24767.FStar_Syntax_Syntax.lbunivs);
                                               FStar_Syntax_Syntax.lbtyp =
-                                                (uu___3383_24787.FStar_Syntax_Syntax.lbtyp);
+                                                (uu___3383_24767.FStar_Syntax_Syntax.lbtyp);
                                               FStar_Syntax_Syntax.lbeff =
-                                                (uu___3383_24787.FStar_Syntax_Syntax.lbeff);
+                                                (uu___3383_24767.FStar_Syntax_Syntax.lbeff);
                                               FStar_Syntax_Syntax.lbdef =
-                                                (uu___3383_24787.FStar_Syntax_Syntax.lbdef);
+                                                (uu___3383_24767.FStar_Syntax_Syntax.lbdef);
                                               FStar_Syntax_Syntax.lbattrs =
-                                                (uu___3383_24787.FStar_Syntax_Syntax.lbattrs);
+                                                (uu___3383_24767.FStar_Syntax_Syntax.lbattrs);
                                               FStar_Syntax_Syntax.lbpos =
-                                                (uu___3383_24787.FStar_Syntax_Syntax.lbpos)
+                                                (uu___3383_24767.FStar_Syntax_Syntax.lbpos)
                                             } in
                                           let env3 =
                                             FStar_TypeChecker_Env.push_let_binding
@@ -9199,7 +9199,7 @@ and (check_inner_let_rec :
                                               ([],
                                                 (lb1.FStar_Syntax_Syntax.lbtyp)) in
                                           (env3, lb1)) env1) in
-                              (match uu____24762 with
+                              (match uu____24742 with
                                | (env2, lbs4) ->
                                    let bvs =
                                      FStar_All.pipe_right lbs4
@@ -9207,8 +9207,8 @@ and (check_inner_let_rec :
                                           (fun lb ->
                                              FStar_Util.left
                                                lb.FStar_Syntax_Syntax.lbname)) in
-                                   let uu____24814 = tc_term env2 e21 in
-                                   (match uu____24814 with
+                                   let uu____24794 = tc_term env2 e21 in
+                                   (match uu____24794 with
                                     | (e22, cres, g2) ->
                                         let cres1 =
                                           FStar_List.fold_right
@@ -9225,15 +9225,15 @@ and (check_inner_let_rec :
                                             cres2
                                             [FStar_Syntax_Syntax.SHOULD_NOT_INLINE] in
                                         let guard =
-                                          let uu____24838 =
-                                            let uu____24839 =
+                                          let uu____24818 =
+                                            let uu____24819 =
                                               FStar_List.map
                                                 FStar_Syntax_Syntax.mk_binder
                                                 bvs in
                                             FStar_TypeChecker_Env.close_guard
-                                              env2 uu____24839 g2 in
+                                              env2 uu____24819 g2 in
                                           FStar_TypeChecker_Env.conj_guard
-                                            g_lbs uu____24838 in
+                                            g_lbs uu____24818 in
                                         let cres4 =
                                           FStar_TypeChecker_Util.close_wp_lcomp
                                             env2 bvs cres3 in
@@ -9241,35 +9241,35 @@ and (check_inner_let_rec :
                                           norm env2
                                             cres4.FStar_TypeChecker_Common.res_typ in
                                         let cres5 =
-                                          let uu___3404_24849 = cres4 in
+                                          let uu___3404_24829 = cres4 in
                                           {
                                             FStar_TypeChecker_Common.eff_name
                                               =
-                                              (uu___3404_24849.FStar_TypeChecker_Common.eff_name);
+                                              (uu___3404_24829.FStar_TypeChecker_Common.eff_name);
                                             FStar_TypeChecker_Common.res_typ
                                               = tres;
                                             FStar_TypeChecker_Common.cflags =
-                                              (uu___3404_24849.FStar_TypeChecker_Common.cflags);
+                                              (uu___3404_24829.FStar_TypeChecker_Common.cflags);
                                             FStar_TypeChecker_Common.comp_thunk
                                               =
-                                              (uu___3404_24849.FStar_TypeChecker_Common.comp_thunk)
+                                              (uu___3404_24829.FStar_TypeChecker_Common.comp_thunk)
                                           } in
                                         let guard1 =
                                           let bs =
                                             FStar_All.pipe_right lbs4
                                               (FStar_List.map
                                                  (fun lb ->
-                                                    let uu____24857 =
+                                                    let uu____24837 =
                                                       FStar_Util.left
                                                         lb.FStar_Syntax_Syntax.lbname in
                                                     FStar_Syntax_Syntax.mk_binder
-                                                      uu____24857)) in
+                                                      uu____24837)) in
                                           FStar_TypeChecker_Util.close_guard_implicits
                                             env2 false bs guard in
-                                        let uu____24858 =
+                                        let uu____24838 =
                                           FStar_Syntax_Subst.close_let_rec
                                             lbs4 e22 in
-                                        (match uu____24858 with
+                                        (match uu____24838 with
                                          | (lbs5, e23) ->
                                              let e =
                                                FStar_Syntax_Syntax.mk
@@ -9278,38 +9278,38 @@ and (check_inner_let_rec :
                                                  top.FStar_Syntax_Syntax.pos in
                                              (match topt with
                                               | FStar_Pervasives_Native.Some
-                                                  uu____24896 ->
+                                                  uu____24876 ->
                                                   (e, cres5, guard1)
                                               | FStar_Pervasives_Native.None
                                                   ->
-                                                  let uu____24897 =
+                                                  let uu____24877 =
                                                     check_no_escape
                                                       FStar_Pervasives_Native.None
                                                       env2 bvs tres in
-                                                  (match uu____24897 with
+                                                  (match uu____24877 with
                                                    | (tres1, g_ex) ->
                                                        let cres6 =
-                                                         let uu___3420_24911
+                                                         let uu___3420_24891
                                                            = cres5 in
                                                          {
                                                            FStar_TypeChecker_Common.eff_name
                                                              =
-                                                             (uu___3420_24911.FStar_TypeChecker_Common.eff_name);
+                                                             (uu___3420_24891.FStar_TypeChecker_Common.eff_name);
                                                            FStar_TypeChecker_Common.res_typ
                                                              = tres1;
                                                            FStar_TypeChecker_Common.cflags
                                                              =
-                                                             (uu___3420_24911.FStar_TypeChecker_Common.cflags);
+                                                             (uu___3420_24891.FStar_TypeChecker_Common.cflags);
                                                            FStar_TypeChecker_Common.comp_thunk
                                                              =
-                                                             (uu___3420_24911.FStar_TypeChecker_Common.comp_thunk)
+                                                             (uu___3420_24891.FStar_TypeChecker_Common.comp_thunk)
                                                          } in
-                                                       let uu____24912 =
+                                                       let uu____24892 =
                                                          FStar_TypeChecker_Env.conj_guard
                                                            g_ex guard1 in
                                                        (e, cres6,
-                                                         uu____24912))))))))))
-      | uu____24913 -> failwith "Impossible"
+                                                         uu____24892))))))))))
+      | uu____24893 -> failwith "Impossible"
 and (build_let_rec_env :
   Prims.bool ->
     FStar_TypeChecker_Env.env ->
@@ -9322,70 +9322,70 @@ and (build_let_rec_env :
       fun lbs ->
         let env0 = env in
         let termination_check_enabled lbname lbdef lbtyp =
-          let uu____24962 = FStar_Options.ml_ish () in
-          if uu____24962
+          let uu____24942 = FStar_Options.ml_ish () in
+          if uu____24942
           then FStar_Pervasives_Native.None
           else
             (let lbtyp0 = lbtyp in
-             let uu____24975 = FStar_Syntax_Util.abs_formals lbdef in
-             match uu____24975 with
+             let uu____24955 = FStar_Syntax_Util.abs_formals lbdef in
+             match uu____24955 with
              | (actuals, body, body_lc) ->
                  let actuals1 =
-                   let uu____24998 =
+                   let uu____24978 =
                      FStar_TypeChecker_Env.set_expected_typ env lbtyp in
                    FStar_TypeChecker_Util.maybe_add_implicit_binders
-                     uu____24998 actuals in
+                     uu____24978 actuals in
                  let nactuals = FStar_List.length actuals1 in
-                 let uu____25006 =
+                 let uu____24986 =
                    FStar_TypeChecker_Normalize.get_n_binders env nactuals
                      lbtyp in
-                 (match uu____25006 with
+                 (match uu____24986 with
                   | (formals, c) ->
                       (if
                          (FStar_List.isEmpty formals) ||
                            (FStar_List.isEmpty actuals1)
                        then
-                         (let uu____25032 =
-                            let uu____25037 =
-                              let uu____25038 =
+                         (let uu____25012 =
+                            let uu____25017 =
+                              let uu____25018 =
                                 FStar_Syntax_Print.term_to_string lbdef in
-                              let uu____25039 =
+                              let uu____25019 =
                                 FStar_Syntax_Print.term_to_string lbtyp in
                               FStar_Util.format2
                                 "Only function literals with arrow types can be defined recursively; got %s : %s"
-                                uu____25038 uu____25039 in
+                                uu____25018 uu____25019 in
                             (FStar_Errors.Fatal_RecursiveFunctionLiteral,
-                              uu____25037) in
-                          FStar_Errors.raise_error uu____25032
+                              uu____25017) in
+                          FStar_Errors.raise_error uu____25012
                             lbtyp.FStar_Syntax_Syntax.pos)
                        else ();
                        (let nformals = FStar_List.length formals in
-                        let uu____25042 =
-                          let uu____25043 =
+                        let uu____25022 =
+                          let uu____25023 =
                             FStar_All.pipe_right
                               (FStar_Syntax_Util.comp_effect_name c)
                               (FStar_TypeChecker_Env.lookup_effect_quals env) in
-                          FStar_All.pipe_right uu____25043
+                          FStar_All.pipe_right uu____25023
                             (FStar_List.contains
                                FStar_Syntax_Syntax.TotalEffect) in
-                        if uu____25042
+                        if uu____25022
                         then
-                          let uu____25056 =
-                            let uu____25061 =
+                          let uu____25036 =
+                            let uu____25041 =
                               FStar_Syntax_Util.abs actuals1 body body_lc in
-                            (nformals, uu____25061) in
-                          FStar_Pervasives_Native.Some uu____25056
+                            (nformals, uu____25041) in
+                          FStar_Pervasives_Native.Some uu____25036
                         else FStar_Pervasives_Native.None)))) in
-        let uu____25071 =
+        let uu____25051 =
           FStar_List.fold_left
-            (fun uu____25105 ->
+            (fun uu____25085 ->
                fun lb ->
-                 match uu____25105 with
+                 match uu____25085 with
                  | (lbs1, env1, g_acc) ->
-                     let uu____25130 =
+                     let uu____25110 =
                        FStar_TypeChecker_Util.extract_let_rec_annotation env1
                          lb in
-                     (match uu____25130 with
+                     (match uu____25110 with
                       | (univ_vars, t, check_t) ->
                           let env2 =
                             FStar_TypeChecker_Env.push_univ_vars env1
@@ -9393,302 +9393,302 @@ and (build_let_rec_env :
                           let e =
                             FStar_Syntax_Util.unascribe
                               lb.FStar_Syntax_Syntax.lbdef in
-                          let uu____25150 =
+                          let uu____25130 =
                             if Prims.op_Negation check_t
                             then (g_acc, t)
                             else
                               (let env01 =
                                  FStar_TypeChecker_Env.push_univ_vars env0
                                    univ_vars in
-                               let uu____25167 =
-                                 let uu____25174 =
-                                   let uu____25175 =
+                               let uu____25147 =
+                                 let uu____25154 =
+                                   let uu____25155 =
                                      FStar_Syntax_Util.type_u () in
                                    FStar_All.pipe_left
-                                     FStar_Pervasives_Native.fst uu____25175 in
+                                     FStar_Pervasives_Native.fst uu____25155 in
                                  tc_check_tot_or_gtot_term
-                                   (let uu___3460_25186 = env01 in
+                                   (let uu___3460_25166 = env01 in
                                     {
                                       FStar_TypeChecker_Env.solver =
-                                        (uu___3460_25186.FStar_TypeChecker_Env.solver);
+                                        (uu___3460_25166.FStar_TypeChecker_Env.solver);
                                       FStar_TypeChecker_Env.range =
-                                        (uu___3460_25186.FStar_TypeChecker_Env.range);
+                                        (uu___3460_25166.FStar_TypeChecker_Env.range);
                                       FStar_TypeChecker_Env.curmodule =
-                                        (uu___3460_25186.FStar_TypeChecker_Env.curmodule);
+                                        (uu___3460_25166.FStar_TypeChecker_Env.curmodule);
                                       FStar_TypeChecker_Env.gamma =
-                                        (uu___3460_25186.FStar_TypeChecker_Env.gamma);
+                                        (uu___3460_25166.FStar_TypeChecker_Env.gamma);
                                       FStar_TypeChecker_Env.gamma_sig =
-                                        (uu___3460_25186.FStar_TypeChecker_Env.gamma_sig);
+                                        (uu___3460_25166.FStar_TypeChecker_Env.gamma_sig);
                                       FStar_TypeChecker_Env.gamma_cache =
-                                        (uu___3460_25186.FStar_TypeChecker_Env.gamma_cache);
+                                        (uu___3460_25166.FStar_TypeChecker_Env.gamma_cache);
                                       FStar_TypeChecker_Env.modules =
-                                        (uu___3460_25186.FStar_TypeChecker_Env.modules);
+                                        (uu___3460_25166.FStar_TypeChecker_Env.modules);
                                       FStar_TypeChecker_Env.expected_typ =
-                                        (uu___3460_25186.FStar_TypeChecker_Env.expected_typ);
+                                        (uu___3460_25166.FStar_TypeChecker_Env.expected_typ);
                                       FStar_TypeChecker_Env.sigtab =
-                                        (uu___3460_25186.FStar_TypeChecker_Env.sigtab);
+                                        (uu___3460_25166.FStar_TypeChecker_Env.sigtab);
                                       FStar_TypeChecker_Env.attrtab =
-                                        (uu___3460_25186.FStar_TypeChecker_Env.attrtab);
+                                        (uu___3460_25166.FStar_TypeChecker_Env.attrtab);
                                       FStar_TypeChecker_Env.instantiate_imp =
-                                        (uu___3460_25186.FStar_TypeChecker_Env.instantiate_imp);
+                                        (uu___3460_25166.FStar_TypeChecker_Env.instantiate_imp);
                                       FStar_TypeChecker_Env.effects =
-                                        (uu___3460_25186.FStar_TypeChecker_Env.effects);
+                                        (uu___3460_25166.FStar_TypeChecker_Env.effects);
                                       FStar_TypeChecker_Env.generalize =
-                                        (uu___3460_25186.FStar_TypeChecker_Env.generalize);
+                                        (uu___3460_25166.FStar_TypeChecker_Env.generalize);
                                       FStar_TypeChecker_Env.letrecs =
-                                        (uu___3460_25186.FStar_TypeChecker_Env.letrecs);
+                                        (uu___3460_25166.FStar_TypeChecker_Env.letrecs);
                                       FStar_TypeChecker_Env.top_level =
-                                        (uu___3460_25186.FStar_TypeChecker_Env.top_level);
+                                        (uu___3460_25166.FStar_TypeChecker_Env.top_level);
                                       FStar_TypeChecker_Env.check_uvars =
                                         true;
                                       FStar_TypeChecker_Env.use_eq =
-                                        (uu___3460_25186.FStar_TypeChecker_Env.use_eq);
+                                        (uu___3460_25166.FStar_TypeChecker_Env.use_eq);
                                       FStar_TypeChecker_Env.use_eq_strict =
-                                        (uu___3460_25186.FStar_TypeChecker_Env.use_eq_strict);
+                                        (uu___3460_25166.FStar_TypeChecker_Env.use_eq_strict);
                                       FStar_TypeChecker_Env.is_iface =
-                                        (uu___3460_25186.FStar_TypeChecker_Env.is_iface);
+                                        (uu___3460_25166.FStar_TypeChecker_Env.is_iface);
                                       FStar_TypeChecker_Env.admit =
-                                        (uu___3460_25186.FStar_TypeChecker_Env.admit);
+                                        (uu___3460_25166.FStar_TypeChecker_Env.admit);
                                       FStar_TypeChecker_Env.lax =
-                                        (uu___3460_25186.FStar_TypeChecker_Env.lax);
+                                        (uu___3460_25166.FStar_TypeChecker_Env.lax);
                                       FStar_TypeChecker_Env.lax_universes =
-                                        (uu___3460_25186.FStar_TypeChecker_Env.lax_universes);
+                                        (uu___3460_25166.FStar_TypeChecker_Env.lax_universes);
                                       FStar_TypeChecker_Env.phase1 =
-                                        (uu___3460_25186.FStar_TypeChecker_Env.phase1);
+                                        (uu___3460_25166.FStar_TypeChecker_Env.phase1);
                                       FStar_TypeChecker_Env.failhard =
-                                        (uu___3460_25186.FStar_TypeChecker_Env.failhard);
+                                        (uu___3460_25166.FStar_TypeChecker_Env.failhard);
                                       FStar_TypeChecker_Env.nosynth =
-                                        (uu___3460_25186.FStar_TypeChecker_Env.nosynth);
+                                        (uu___3460_25166.FStar_TypeChecker_Env.nosynth);
                                       FStar_TypeChecker_Env.uvar_subtyping =
-                                        (uu___3460_25186.FStar_TypeChecker_Env.uvar_subtyping);
+                                        (uu___3460_25166.FStar_TypeChecker_Env.uvar_subtyping);
                                       FStar_TypeChecker_Env.tc_term =
-                                        (uu___3460_25186.FStar_TypeChecker_Env.tc_term);
+                                        (uu___3460_25166.FStar_TypeChecker_Env.tc_term);
                                       FStar_TypeChecker_Env.type_of =
-                                        (uu___3460_25186.FStar_TypeChecker_Env.type_of);
+                                        (uu___3460_25166.FStar_TypeChecker_Env.type_of);
                                       FStar_TypeChecker_Env.universe_of =
-                                        (uu___3460_25186.FStar_TypeChecker_Env.universe_of);
+                                        (uu___3460_25166.FStar_TypeChecker_Env.universe_of);
                                       FStar_TypeChecker_Env.check_type_of =
-                                        (uu___3460_25186.FStar_TypeChecker_Env.check_type_of);
+                                        (uu___3460_25166.FStar_TypeChecker_Env.check_type_of);
                                       FStar_TypeChecker_Env.use_bv_sorts =
-                                        (uu___3460_25186.FStar_TypeChecker_Env.use_bv_sorts);
+                                        (uu___3460_25166.FStar_TypeChecker_Env.use_bv_sorts);
                                       FStar_TypeChecker_Env.qtbl_name_and_index
                                         =
-                                        (uu___3460_25186.FStar_TypeChecker_Env.qtbl_name_and_index);
+                                        (uu___3460_25166.FStar_TypeChecker_Env.qtbl_name_and_index);
                                       FStar_TypeChecker_Env.normalized_eff_names
                                         =
-                                        (uu___3460_25186.FStar_TypeChecker_Env.normalized_eff_names);
+                                        (uu___3460_25166.FStar_TypeChecker_Env.normalized_eff_names);
                                       FStar_TypeChecker_Env.fv_delta_depths =
-                                        (uu___3460_25186.FStar_TypeChecker_Env.fv_delta_depths);
+                                        (uu___3460_25166.FStar_TypeChecker_Env.fv_delta_depths);
                                       FStar_TypeChecker_Env.proof_ns =
-                                        (uu___3460_25186.FStar_TypeChecker_Env.proof_ns);
+                                        (uu___3460_25166.FStar_TypeChecker_Env.proof_ns);
                                       FStar_TypeChecker_Env.synth_hook =
-                                        (uu___3460_25186.FStar_TypeChecker_Env.synth_hook);
+                                        (uu___3460_25166.FStar_TypeChecker_Env.synth_hook);
                                       FStar_TypeChecker_Env.try_solve_implicits_hook
                                         =
-                                        (uu___3460_25186.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                                        (uu___3460_25166.FStar_TypeChecker_Env.try_solve_implicits_hook);
                                       FStar_TypeChecker_Env.splice =
-                                        (uu___3460_25186.FStar_TypeChecker_Env.splice);
+                                        (uu___3460_25166.FStar_TypeChecker_Env.splice);
                                       FStar_TypeChecker_Env.mpreprocess =
-                                        (uu___3460_25186.FStar_TypeChecker_Env.mpreprocess);
+                                        (uu___3460_25166.FStar_TypeChecker_Env.mpreprocess);
                                       FStar_TypeChecker_Env.postprocess =
-                                        (uu___3460_25186.FStar_TypeChecker_Env.postprocess);
+                                        (uu___3460_25166.FStar_TypeChecker_Env.postprocess);
                                       FStar_TypeChecker_Env.identifier_info =
-                                        (uu___3460_25186.FStar_TypeChecker_Env.identifier_info);
+                                        (uu___3460_25166.FStar_TypeChecker_Env.identifier_info);
                                       FStar_TypeChecker_Env.tc_hooks =
-                                        (uu___3460_25186.FStar_TypeChecker_Env.tc_hooks);
+                                        (uu___3460_25166.FStar_TypeChecker_Env.tc_hooks);
                                       FStar_TypeChecker_Env.dsenv =
-                                        (uu___3460_25186.FStar_TypeChecker_Env.dsenv);
+                                        (uu___3460_25166.FStar_TypeChecker_Env.dsenv);
                                       FStar_TypeChecker_Env.nbe =
-                                        (uu___3460_25186.FStar_TypeChecker_Env.nbe);
+                                        (uu___3460_25166.FStar_TypeChecker_Env.nbe);
                                       FStar_TypeChecker_Env.strict_args_tab =
-                                        (uu___3460_25186.FStar_TypeChecker_Env.strict_args_tab);
+                                        (uu___3460_25166.FStar_TypeChecker_Env.strict_args_tab);
                                       FStar_TypeChecker_Env.erasable_types_tab
                                         =
-                                        (uu___3460_25186.FStar_TypeChecker_Env.erasable_types_tab);
+                                        (uu___3460_25166.FStar_TypeChecker_Env.erasable_types_tab);
                                       FStar_TypeChecker_Env.enable_defer_to_tac
                                         =
-                                        (uu___3460_25186.FStar_TypeChecker_Env.enable_defer_to_tac)
-                                    }) t uu____25174 "" in
-                               match uu____25167 with
-                               | (t1, uu____25194, g) ->
-                                   let uu____25196 =
-                                     let uu____25197 =
-                                       let uu____25198 =
+                                        (uu___3460_25166.FStar_TypeChecker_Env.enable_defer_to_tac)
+                                    }) t uu____25154 "" in
+                               match uu____25147 with
+                               | (t1, uu____25174, g) ->
+                                   let uu____25176 =
+                                     let uu____25177 =
+                                       let uu____25178 =
                                          FStar_All.pipe_right g
                                            (FStar_TypeChecker_Rel.resolve_implicits
                                               env2) in
-                                       FStar_All.pipe_right uu____25198
+                                       FStar_All.pipe_right uu____25178
                                          (FStar_TypeChecker_Rel.discharge_guard
                                             env2) in
                                      FStar_TypeChecker_Env.conj_guard g_acc
-                                       uu____25197 in
-                                   let uu____25199 = norm env01 t1 in
-                                   (uu____25196, uu____25199)) in
-                          (match uu____25150 with
+                                       uu____25177 in
+                                   let uu____25179 = norm env01 t1 in
+                                   (uu____25176, uu____25179)) in
+                          (match uu____25130 with
                            | (g, t1) ->
-                               let uu____25218 =
-                                 let uu____25223 =
+                               let uu____25198 =
+                                 let uu____25203 =
                                    termination_check_enabled
                                      lb.FStar_Syntax_Syntax.lbname e t1 in
-                                 match uu____25223 with
+                                 match uu____25203 with
                                  | FStar_Pervasives_Native.Some (arity, def)
                                      ->
                                      let lb1 =
-                                       let uu___3473_25241 = lb in
+                                       let uu___3473_25221 = lb in
                                        {
                                          FStar_Syntax_Syntax.lbname =
-                                           (uu___3473_25241.FStar_Syntax_Syntax.lbname);
+                                           (uu___3473_25221.FStar_Syntax_Syntax.lbname);
                                          FStar_Syntax_Syntax.lbunivs =
                                            univ_vars;
                                          FStar_Syntax_Syntax.lbtyp = t1;
                                          FStar_Syntax_Syntax.lbeff =
-                                           (uu___3473_25241.FStar_Syntax_Syntax.lbeff);
+                                           (uu___3473_25221.FStar_Syntax_Syntax.lbeff);
                                          FStar_Syntax_Syntax.lbdef = def;
                                          FStar_Syntax_Syntax.lbattrs =
-                                           (uu___3473_25241.FStar_Syntax_Syntax.lbattrs);
+                                           (uu___3473_25221.FStar_Syntax_Syntax.lbattrs);
                                          FStar_Syntax_Syntax.lbpos =
-                                           (uu___3473_25241.FStar_Syntax_Syntax.lbpos)
+                                           (uu___3473_25221.FStar_Syntax_Syntax.lbpos)
                                        } in
                                      let env3 =
-                                       let uu___3476_25243 = env2 in
+                                       let uu___3476_25223 = env2 in
                                        {
                                          FStar_TypeChecker_Env.solver =
-                                           (uu___3476_25243.FStar_TypeChecker_Env.solver);
+                                           (uu___3476_25223.FStar_TypeChecker_Env.solver);
                                          FStar_TypeChecker_Env.range =
-                                           (uu___3476_25243.FStar_TypeChecker_Env.range);
+                                           (uu___3476_25223.FStar_TypeChecker_Env.range);
                                          FStar_TypeChecker_Env.curmodule =
-                                           (uu___3476_25243.FStar_TypeChecker_Env.curmodule);
+                                           (uu___3476_25223.FStar_TypeChecker_Env.curmodule);
                                          FStar_TypeChecker_Env.gamma =
-                                           (uu___3476_25243.FStar_TypeChecker_Env.gamma);
+                                           (uu___3476_25223.FStar_TypeChecker_Env.gamma);
                                          FStar_TypeChecker_Env.gamma_sig =
-                                           (uu___3476_25243.FStar_TypeChecker_Env.gamma_sig);
+                                           (uu___3476_25223.FStar_TypeChecker_Env.gamma_sig);
                                          FStar_TypeChecker_Env.gamma_cache =
-                                           (uu___3476_25243.FStar_TypeChecker_Env.gamma_cache);
+                                           (uu___3476_25223.FStar_TypeChecker_Env.gamma_cache);
                                          FStar_TypeChecker_Env.modules =
-                                           (uu___3476_25243.FStar_TypeChecker_Env.modules);
+                                           (uu___3476_25223.FStar_TypeChecker_Env.modules);
                                          FStar_TypeChecker_Env.expected_typ =
-                                           (uu___3476_25243.FStar_TypeChecker_Env.expected_typ);
+                                           (uu___3476_25223.FStar_TypeChecker_Env.expected_typ);
                                          FStar_TypeChecker_Env.sigtab =
-                                           (uu___3476_25243.FStar_TypeChecker_Env.sigtab);
+                                           (uu___3476_25223.FStar_TypeChecker_Env.sigtab);
                                          FStar_TypeChecker_Env.attrtab =
-                                           (uu___3476_25243.FStar_TypeChecker_Env.attrtab);
+                                           (uu___3476_25223.FStar_TypeChecker_Env.attrtab);
                                          FStar_TypeChecker_Env.instantiate_imp
                                            =
-                                           (uu___3476_25243.FStar_TypeChecker_Env.instantiate_imp);
+                                           (uu___3476_25223.FStar_TypeChecker_Env.instantiate_imp);
                                          FStar_TypeChecker_Env.effects =
-                                           (uu___3476_25243.FStar_TypeChecker_Env.effects);
+                                           (uu___3476_25223.FStar_TypeChecker_Env.effects);
                                          FStar_TypeChecker_Env.generalize =
-                                           (uu___3476_25243.FStar_TypeChecker_Env.generalize);
+                                           (uu___3476_25223.FStar_TypeChecker_Env.generalize);
                                          FStar_TypeChecker_Env.letrecs =
                                            (((lb1.FStar_Syntax_Syntax.lbname),
                                               arity, t1, univ_vars) ::
                                            (env2.FStar_TypeChecker_Env.letrecs));
                                          FStar_TypeChecker_Env.top_level =
-                                           (uu___3476_25243.FStar_TypeChecker_Env.top_level);
+                                           (uu___3476_25223.FStar_TypeChecker_Env.top_level);
                                          FStar_TypeChecker_Env.check_uvars =
-                                           (uu___3476_25243.FStar_TypeChecker_Env.check_uvars);
+                                           (uu___3476_25223.FStar_TypeChecker_Env.check_uvars);
                                          FStar_TypeChecker_Env.use_eq =
-                                           (uu___3476_25243.FStar_TypeChecker_Env.use_eq);
+                                           (uu___3476_25223.FStar_TypeChecker_Env.use_eq);
                                          FStar_TypeChecker_Env.use_eq_strict
                                            =
-                                           (uu___3476_25243.FStar_TypeChecker_Env.use_eq_strict);
+                                           (uu___3476_25223.FStar_TypeChecker_Env.use_eq_strict);
                                          FStar_TypeChecker_Env.is_iface =
-                                           (uu___3476_25243.FStar_TypeChecker_Env.is_iface);
+                                           (uu___3476_25223.FStar_TypeChecker_Env.is_iface);
                                          FStar_TypeChecker_Env.admit =
-                                           (uu___3476_25243.FStar_TypeChecker_Env.admit);
+                                           (uu___3476_25223.FStar_TypeChecker_Env.admit);
                                          FStar_TypeChecker_Env.lax =
-                                           (uu___3476_25243.FStar_TypeChecker_Env.lax);
+                                           (uu___3476_25223.FStar_TypeChecker_Env.lax);
                                          FStar_TypeChecker_Env.lax_universes
                                            =
-                                           (uu___3476_25243.FStar_TypeChecker_Env.lax_universes);
+                                           (uu___3476_25223.FStar_TypeChecker_Env.lax_universes);
                                          FStar_TypeChecker_Env.phase1 =
-                                           (uu___3476_25243.FStar_TypeChecker_Env.phase1);
+                                           (uu___3476_25223.FStar_TypeChecker_Env.phase1);
                                          FStar_TypeChecker_Env.failhard =
-                                           (uu___3476_25243.FStar_TypeChecker_Env.failhard);
+                                           (uu___3476_25223.FStar_TypeChecker_Env.failhard);
                                          FStar_TypeChecker_Env.nosynth =
-                                           (uu___3476_25243.FStar_TypeChecker_Env.nosynth);
+                                           (uu___3476_25223.FStar_TypeChecker_Env.nosynth);
                                          FStar_TypeChecker_Env.uvar_subtyping
                                            =
-                                           (uu___3476_25243.FStar_TypeChecker_Env.uvar_subtyping);
+                                           (uu___3476_25223.FStar_TypeChecker_Env.uvar_subtyping);
                                          FStar_TypeChecker_Env.tc_term =
-                                           (uu___3476_25243.FStar_TypeChecker_Env.tc_term);
+                                           (uu___3476_25223.FStar_TypeChecker_Env.tc_term);
                                          FStar_TypeChecker_Env.type_of =
-                                           (uu___3476_25243.FStar_TypeChecker_Env.type_of);
+                                           (uu___3476_25223.FStar_TypeChecker_Env.type_of);
                                          FStar_TypeChecker_Env.universe_of =
-                                           (uu___3476_25243.FStar_TypeChecker_Env.universe_of);
+                                           (uu___3476_25223.FStar_TypeChecker_Env.universe_of);
                                          FStar_TypeChecker_Env.check_type_of
                                            =
-                                           (uu___3476_25243.FStar_TypeChecker_Env.check_type_of);
+                                           (uu___3476_25223.FStar_TypeChecker_Env.check_type_of);
                                          FStar_TypeChecker_Env.use_bv_sorts =
-                                           (uu___3476_25243.FStar_TypeChecker_Env.use_bv_sorts);
+                                           (uu___3476_25223.FStar_TypeChecker_Env.use_bv_sorts);
                                          FStar_TypeChecker_Env.qtbl_name_and_index
                                            =
-                                           (uu___3476_25243.FStar_TypeChecker_Env.qtbl_name_and_index);
+                                           (uu___3476_25223.FStar_TypeChecker_Env.qtbl_name_and_index);
                                          FStar_TypeChecker_Env.normalized_eff_names
                                            =
-                                           (uu___3476_25243.FStar_TypeChecker_Env.normalized_eff_names);
+                                           (uu___3476_25223.FStar_TypeChecker_Env.normalized_eff_names);
                                          FStar_TypeChecker_Env.fv_delta_depths
                                            =
-                                           (uu___3476_25243.FStar_TypeChecker_Env.fv_delta_depths);
+                                           (uu___3476_25223.FStar_TypeChecker_Env.fv_delta_depths);
                                          FStar_TypeChecker_Env.proof_ns =
-                                           (uu___3476_25243.FStar_TypeChecker_Env.proof_ns);
+                                           (uu___3476_25223.FStar_TypeChecker_Env.proof_ns);
                                          FStar_TypeChecker_Env.synth_hook =
-                                           (uu___3476_25243.FStar_TypeChecker_Env.synth_hook);
+                                           (uu___3476_25223.FStar_TypeChecker_Env.synth_hook);
                                          FStar_TypeChecker_Env.try_solve_implicits_hook
                                            =
-                                           (uu___3476_25243.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                                           (uu___3476_25223.FStar_TypeChecker_Env.try_solve_implicits_hook);
                                          FStar_TypeChecker_Env.splice =
-                                           (uu___3476_25243.FStar_TypeChecker_Env.splice);
+                                           (uu___3476_25223.FStar_TypeChecker_Env.splice);
                                          FStar_TypeChecker_Env.mpreprocess =
-                                           (uu___3476_25243.FStar_TypeChecker_Env.mpreprocess);
+                                           (uu___3476_25223.FStar_TypeChecker_Env.mpreprocess);
                                          FStar_TypeChecker_Env.postprocess =
-                                           (uu___3476_25243.FStar_TypeChecker_Env.postprocess);
+                                           (uu___3476_25223.FStar_TypeChecker_Env.postprocess);
                                          FStar_TypeChecker_Env.identifier_info
                                            =
-                                           (uu___3476_25243.FStar_TypeChecker_Env.identifier_info);
+                                           (uu___3476_25223.FStar_TypeChecker_Env.identifier_info);
                                          FStar_TypeChecker_Env.tc_hooks =
-                                           (uu___3476_25243.FStar_TypeChecker_Env.tc_hooks);
+                                           (uu___3476_25223.FStar_TypeChecker_Env.tc_hooks);
                                          FStar_TypeChecker_Env.dsenv =
-                                           (uu___3476_25243.FStar_TypeChecker_Env.dsenv);
+                                           (uu___3476_25223.FStar_TypeChecker_Env.dsenv);
                                          FStar_TypeChecker_Env.nbe =
-                                           (uu___3476_25243.FStar_TypeChecker_Env.nbe);
+                                           (uu___3476_25223.FStar_TypeChecker_Env.nbe);
                                          FStar_TypeChecker_Env.strict_args_tab
                                            =
-                                           (uu___3476_25243.FStar_TypeChecker_Env.strict_args_tab);
+                                           (uu___3476_25223.FStar_TypeChecker_Env.strict_args_tab);
                                          FStar_TypeChecker_Env.erasable_types_tab
                                            =
-                                           (uu___3476_25243.FStar_TypeChecker_Env.erasable_types_tab);
+                                           (uu___3476_25223.FStar_TypeChecker_Env.erasable_types_tab);
                                          FStar_TypeChecker_Env.enable_defer_to_tac
                                            =
-                                           (uu___3476_25243.FStar_TypeChecker_Env.enable_defer_to_tac)
+                                           (uu___3476_25223.FStar_TypeChecker_Env.enable_defer_to_tac)
                                        } in
                                      (lb1, env3)
                                  | FStar_Pervasives_Native.None ->
                                      let lb1 =
-                                       let uu___3480_25257 = lb in
+                                       let uu___3480_25237 = lb in
                                        {
                                          FStar_Syntax_Syntax.lbname =
-                                           (uu___3480_25257.FStar_Syntax_Syntax.lbname);
+                                           (uu___3480_25237.FStar_Syntax_Syntax.lbname);
                                          FStar_Syntax_Syntax.lbunivs =
                                            univ_vars;
                                          FStar_Syntax_Syntax.lbtyp = t1;
                                          FStar_Syntax_Syntax.lbeff =
-                                           (uu___3480_25257.FStar_Syntax_Syntax.lbeff);
+                                           (uu___3480_25237.FStar_Syntax_Syntax.lbeff);
                                          FStar_Syntax_Syntax.lbdef = e;
                                          FStar_Syntax_Syntax.lbattrs =
-                                           (uu___3480_25257.FStar_Syntax_Syntax.lbattrs);
+                                           (uu___3480_25237.FStar_Syntax_Syntax.lbattrs);
                                          FStar_Syntax_Syntax.lbpos =
-                                           (uu___3480_25257.FStar_Syntax_Syntax.lbpos)
+                                           (uu___3480_25237.FStar_Syntax_Syntax.lbpos)
                                        } in
-                                     let uu____25258 =
+                                     let uu____25238 =
                                        FStar_TypeChecker_Env.push_let_binding
                                          env2 lb1.FStar_Syntax_Syntax.lbname
                                          (univ_vars, t1) in
-                                     (lb1, uu____25258) in
-                               (match uu____25218 with
+                                     (lb1, uu____25238) in
+                               (match uu____25198 with
                                 | (lb1, env3) -> ((lb1 :: lbs1), env3, g)))))
             ([], env, FStar_TypeChecker_Env.trivial_guard) lbs in
-        match uu____25071 with
+        match uu____25051 with
         | (lbs1, env1, g) -> ((FStar_List.rev lbs1), env1, g)
 and (check_let_recs :
   FStar_TypeChecker_Env.env_t ->
@@ -9698,36 +9698,36 @@ and (check_let_recs :
   =
   fun env ->
     fun lbs ->
-      let uu____25298 =
-        let uu____25307 =
+      let uu____25278 =
+        let uu____25287 =
           FStar_All.pipe_right lbs
             (FStar_List.map
                (fun lb ->
-                  let uu____25333 =
+                  let uu____25313 =
                     FStar_Syntax_Util.abs_formals
                       lb.FStar_Syntax_Syntax.lbdef in
-                  match uu____25333 with
+                  match uu____25313 with
                   | (bs, t, lcomp) ->
                       (match bs with
                        | [] ->
-                           let uu____25363 =
+                           let uu____25343 =
                              FStar_Syntax_Syntax.range_of_lbname
                                lb.FStar_Syntax_Syntax.lbname in
                            FStar_Errors.raise_error
                              (FStar_Errors.Fatal_RecursiveFunctionLiteral,
                                "Only function literals may be defined recursively")
-                             uu____25363
-                       | uu____25368 ->
+                             uu____25343
+                       | uu____25348 ->
                            let arity =
-                             let uu____25371 =
+                             let uu____25351 =
                                FStar_TypeChecker_Env.get_letrec_arity env
                                  lb.FStar_Syntax_Syntax.lbname in
-                             match uu____25371 with
+                             match uu____25351 with
                              | FStar_Pervasives_Native.Some n -> n
                              | FStar_Pervasives_Native.None ->
                                  FStar_List.length bs in
-                           let uu____25381 = FStar_List.splitAt arity bs in
-                           (match uu____25381 with
+                           let uu____25361 = FStar_List.splitAt arity bs in
+                           (match uu____25361 with
                             | (bs0, bs1) ->
                                 let def =
                                   if FStar_List.isEmpty bs1
@@ -9745,36 +9745,36 @@ and (check_let_recs :
                                             FStar_Pervasives_Native.None))
                                        inner1.FStar_Syntax_Syntax.pos) in
                                 let lb1 =
-                                  let uu___3512_25476 = lb in
+                                  let uu___3512_25456 = lb in
                                   {
                                     FStar_Syntax_Syntax.lbname =
-                                      (uu___3512_25476.FStar_Syntax_Syntax.lbname);
+                                      (uu___3512_25456.FStar_Syntax_Syntax.lbname);
                                     FStar_Syntax_Syntax.lbunivs =
-                                      (uu___3512_25476.FStar_Syntax_Syntax.lbunivs);
+                                      (uu___3512_25456.FStar_Syntax_Syntax.lbunivs);
                                     FStar_Syntax_Syntax.lbtyp =
-                                      (uu___3512_25476.FStar_Syntax_Syntax.lbtyp);
+                                      (uu___3512_25456.FStar_Syntax_Syntax.lbtyp);
                                     FStar_Syntax_Syntax.lbeff =
-                                      (uu___3512_25476.FStar_Syntax_Syntax.lbeff);
+                                      (uu___3512_25456.FStar_Syntax_Syntax.lbeff);
                                     FStar_Syntax_Syntax.lbdef = def;
                                     FStar_Syntax_Syntax.lbattrs =
-                                      (uu___3512_25476.FStar_Syntax_Syntax.lbattrs);
+                                      (uu___3512_25456.FStar_Syntax_Syntax.lbattrs);
                                     FStar_Syntax_Syntax.lbpos =
-                                      (uu___3512_25476.FStar_Syntax_Syntax.lbpos)
+                                      (uu___3512_25456.FStar_Syntax_Syntax.lbpos)
                                   } in
-                                let uu____25477 =
-                                  let uu____25484 =
+                                let uu____25457 =
+                                  let uu____25464 =
                                     FStar_TypeChecker_Env.set_expected_typ
                                       env lb1.FStar_Syntax_Syntax.lbtyp in
-                                  tc_tot_or_gtot_term uu____25484
+                                  tc_tot_or_gtot_term uu____25464
                                     lb1.FStar_Syntax_Syntax.lbdef in
-                                (match uu____25477 with
+                                (match uu____25457 with
                                  | (e, c, g) ->
-                                     ((let uu____25493 =
-                                         let uu____25494 =
+                                     ((let uu____25473 =
+                                         let uu____25474 =
                                            FStar_TypeChecker_Common.is_total_lcomp
                                              c in
-                                         Prims.op_Negation uu____25494 in
-                                       if uu____25493
+                                         Prims.op_Negation uu____25474 in
+                                       if uu____25473
                                        then
                                          FStar_Errors.raise_error
                                            (FStar_Errors.Fatal_UnexpectedGTotForLetRec,
@@ -9790,8 +9790,8 @@ and (check_let_recs :
                                            e lb1.FStar_Syntax_Syntax.lbattrs
                                            lb1.FStar_Syntax_Syntax.lbpos in
                                        (lb2, g)))))))) in
-        FStar_All.pipe_right uu____25307 FStar_List.unzip in
-      match uu____25298 with
+        FStar_All.pipe_right uu____25287 FStar_List.unzip in
+      match uu____25278 with
       | (lbs1, gs) ->
           let g_lbs =
             FStar_List.fold_right FStar_TypeChecker_Env.conj_guard gs
@@ -9808,12 +9808,12 @@ and (check_let_bound_def :
   fun top_level ->
     fun env ->
       fun lb ->
-        let uu____25543 = FStar_TypeChecker_Env.clear_expected_typ env in
-        match uu____25543 with
-        | (env1, uu____25561) ->
+        let uu____25523 = FStar_TypeChecker_Env.clear_expected_typ env in
+        match uu____25523 with
+        | (env1, uu____25541) ->
             let e1 = lb.FStar_Syntax_Syntax.lbdef in
-            let uu____25569 = check_lbtyp top_level env lb in
-            (match uu____25569 with
+            let uu____25549 = check_lbtyp top_level env lb in
+            (match uu____25549 with
              | (topt, wf_annot, univ_vars, univ_opening, env11) ->
                  (if (Prims.op_Negation top_level) && (univ_vars <> [])
                   then
@@ -9823,137 +9823,137 @@ and (check_let_bound_def :
                       e1.FStar_Syntax_Syntax.pos
                   else ();
                   (let e11 = FStar_Syntax_Subst.subst univ_opening e1 in
-                   let uu____25613 =
+                   let uu____25593 =
                      tc_maybe_toplevel_term
-                       (let uu___3543_25622 = env11 in
+                       (let uu___3543_25602 = env11 in
                         {
                           FStar_TypeChecker_Env.solver =
-                            (uu___3543_25622.FStar_TypeChecker_Env.solver);
+                            (uu___3543_25602.FStar_TypeChecker_Env.solver);
                           FStar_TypeChecker_Env.range =
-                            (uu___3543_25622.FStar_TypeChecker_Env.range);
+                            (uu___3543_25602.FStar_TypeChecker_Env.range);
                           FStar_TypeChecker_Env.curmodule =
-                            (uu___3543_25622.FStar_TypeChecker_Env.curmodule);
+                            (uu___3543_25602.FStar_TypeChecker_Env.curmodule);
                           FStar_TypeChecker_Env.gamma =
-                            (uu___3543_25622.FStar_TypeChecker_Env.gamma);
+                            (uu___3543_25602.FStar_TypeChecker_Env.gamma);
                           FStar_TypeChecker_Env.gamma_sig =
-                            (uu___3543_25622.FStar_TypeChecker_Env.gamma_sig);
+                            (uu___3543_25602.FStar_TypeChecker_Env.gamma_sig);
                           FStar_TypeChecker_Env.gamma_cache =
-                            (uu___3543_25622.FStar_TypeChecker_Env.gamma_cache);
+                            (uu___3543_25602.FStar_TypeChecker_Env.gamma_cache);
                           FStar_TypeChecker_Env.modules =
-                            (uu___3543_25622.FStar_TypeChecker_Env.modules);
+                            (uu___3543_25602.FStar_TypeChecker_Env.modules);
                           FStar_TypeChecker_Env.expected_typ =
-                            (uu___3543_25622.FStar_TypeChecker_Env.expected_typ);
+                            (uu___3543_25602.FStar_TypeChecker_Env.expected_typ);
                           FStar_TypeChecker_Env.sigtab =
-                            (uu___3543_25622.FStar_TypeChecker_Env.sigtab);
+                            (uu___3543_25602.FStar_TypeChecker_Env.sigtab);
                           FStar_TypeChecker_Env.attrtab =
-                            (uu___3543_25622.FStar_TypeChecker_Env.attrtab);
+                            (uu___3543_25602.FStar_TypeChecker_Env.attrtab);
                           FStar_TypeChecker_Env.instantiate_imp =
-                            (uu___3543_25622.FStar_TypeChecker_Env.instantiate_imp);
+                            (uu___3543_25602.FStar_TypeChecker_Env.instantiate_imp);
                           FStar_TypeChecker_Env.effects =
-                            (uu___3543_25622.FStar_TypeChecker_Env.effects);
+                            (uu___3543_25602.FStar_TypeChecker_Env.effects);
                           FStar_TypeChecker_Env.generalize =
-                            (uu___3543_25622.FStar_TypeChecker_Env.generalize);
+                            (uu___3543_25602.FStar_TypeChecker_Env.generalize);
                           FStar_TypeChecker_Env.letrecs =
-                            (uu___3543_25622.FStar_TypeChecker_Env.letrecs);
+                            (uu___3543_25602.FStar_TypeChecker_Env.letrecs);
                           FStar_TypeChecker_Env.top_level = top_level;
                           FStar_TypeChecker_Env.check_uvars =
-                            (uu___3543_25622.FStar_TypeChecker_Env.check_uvars);
+                            (uu___3543_25602.FStar_TypeChecker_Env.check_uvars);
                           FStar_TypeChecker_Env.use_eq =
-                            (uu___3543_25622.FStar_TypeChecker_Env.use_eq);
+                            (uu___3543_25602.FStar_TypeChecker_Env.use_eq);
                           FStar_TypeChecker_Env.use_eq_strict =
-                            (uu___3543_25622.FStar_TypeChecker_Env.use_eq_strict);
+                            (uu___3543_25602.FStar_TypeChecker_Env.use_eq_strict);
                           FStar_TypeChecker_Env.is_iface =
-                            (uu___3543_25622.FStar_TypeChecker_Env.is_iface);
+                            (uu___3543_25602.FStar_TypeChecker_Env.is_iface);
                           FStar_TypeChecker_Env.admit =
-                            (uu___3543_25622.FStar_TypeChecker_Env.admit);
+                            (uu___3543_25602.FStar_TypeChecker_Env.admit);
                           FStar_TypeChecker_Env.lax =
-                            (uu___3543_25622.FStar_TypeChecker_Env.lax);
+                            (uu___3543_25602.FStar_TypeChecker_Env.lax);
                           FStar_TypeChecker_Env.lax_universes =
-                            (uu___3543_25622.FStar_TypeChecker_Env.lax_universes);
+                            (uu___3543_25602.FStar_TypeChecker_Env.lax_universes);
                           FStar_TypeChecker_Env.phase1 =
-                            (uu___3543_25622.FStar_TypeChecker_Env.phase1);
+                            (uu___3543_25602.FStar_TypeChecker_Env.phase1);
                           FStar_TypeChecker_Env.failhard =
-                            (uu___3543_25622.FStar_TypeChecker_Env.failhard);
+                            (uu___3543_25602.FStar_TypeChecker_Env.failhard);
                           FStar_TypeChecker_Env.nosynth =
-                            (uu___3543_25622.FStar_TypeChecker_Env.nosynth);
+                            (uu___3543_25602.FStar_TypeChecker_Env.nosynth);
                           FStar_TypeChecker_Env.uvar_subtyping =
-                            (uu___3543_25622.FStar_TypeChecker_Env.uvar_subtyping);
+                            (uu___3543_25602.FStar_TypeChecker_Env.uvar_subtyping);
                           FStar_TypeChecker_Env.tc_term =
-                            (uu___3543_25622.FStar_TypeChecker_Env.tc_term);
+                            (uu___3543_25602.FStar_TypeChecker_Env.tc_term);
                           FStar_TypeChecker_Env.type_of =
-                            (uu___3543_25622.FStar_TypeChecker_Env.type_of);
+                            (uu___3543_25602.FStar_TypeChecker_Env.type_of);
                           FStar_TypeChecker_Env.universe_of =
-                            (uu___3543_25622.FStar_TypeChecker_Env.universe_of);
+                            (uu___3543_25602.FStar_TypeChecker_Env.universe_of);
                           FStar_TypeChecker_Env.check_type_of =
-                            (uu___3543_25622.FStar_TypeChecker_Env.check_type_of);
+                            (uu___3543_25602.FStar_TypeChecker_Env.check_type_of);
                           FStar_TypeChecker_Env.use_bv_sorts =
-                            (uu___3543_25622.FStar_TypeChecker_Env.use_bv_sorts);
+                            (uu___3543_25602.FStar_TypeChecker_Env.use_bv_sorts);
                           FStar_TypeChecker_Env.qtbl_name_and_index =
-                            (uu___3543_25622.FStar_TypeChecker_Env.qtbl_name_and_index);
+                            (uu___3543_25602.FStar_TypeChecker_Env.qtbl_name_and_index);
                           FStar_TypeChecker_Env.normalized_eff_names =
-                            (uu___3543_25622.FStar_TypeChecker_Env.normalized_eff_names);
+                            (uu___3543_25602.FStar_TypeChecker_Env.normalized_eff_names);
                           FStar_TypeChecker_Env.fv_delta_depths =
-                            (uu___3543_25622.FStar_TypeChecker_Env.fv_delta_depths);
+                            (uu___3543_25602.FStar_TypeChecker_Env.fv_delta_depths);
                           FStar_TypeChecker_Env.proof_ns =
-                            (uu___3543_25622.FStar_TypeChecker_Env.proof_ns);
+                            (uu___3543_25602.FStar_TypeChecker_Env.proof_ns);
                           FStar_TypeChecker_Env.synth_hook =
-                            (uu___3543_25622.FStar_TypeChecker_Env.synth_hook);
+                            (uu___3543_25602.FStar_TypeChecker_Env.synth_hook);
                           FStar_TypeChecker_Env.try_solve_implicits_hook =
-                            (uu___3543_25622.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                            (uu___3543_25602.FStar_TypeChecker_Env.try_solve_implicits_hook);
                           FStar_TypeChecker_Env.splice =
-                            (uu___3543_25622.FStar_TypeChecker_Env.splice);
+                            (uu___3543_25602.FStar_TypeChecker_Env.splice);
                           FStar_TypeChecker_Env.mpreprocess =
-                            (uu___3543_25622.FStar_TypeChecker_Env.mpreprocess);
+                            (uu___3543_25602.FStar_TypeChecker_Env.mpreprocess);
                           FStar_TypeChecker_Env.postprocess =
-                            (uu___3543_25622.FStar_TypeChecker_Env.postprocess);
+                            (uu___3543_25602.FStar_TypeChecker_Env.postprocess);
                           FStar_TypeChecker_Env.identifier_info =
-                            (uu___3543_25622.FStar_TypeChecker_Env.identifier_info);
+                            (uu___3543_25602.FStar_TypeChecker_Env.identifier_info);
                           FStar_TypeChecker_Env.tc_hooks =
-                            (uu___3543_25622.FStar_TypeChecker_Env.tc_hooks);
+                            (uu___3543_25602.FStar_TypeChecker_Env.tc_hooks);
                           FStar_TypeChecker_Env.dsenv =
-                            (uu___3543_25622.FStar_TypeChecker_Env.dsenv);
+                            (uu___3543_25602.FStar_TypeChecker_Env.dsenv);
                           FStar_TypeChecker_Env.nbe =
-                            (uu___3543_25622.FStar_TypeChecker_Env.nbe);
+                            (uu___3543_25602.FStar_TypeChecker_Env.nbe);
                           FStar_TypeChecker_Env.strict_args_tab =
-                            (uu___3543_25622.FStar_TypeChecker_Env.strict_args_tab);
+                            (uu___3543_25602.FStar_TypeChecker_Env.strict_args_tab);
                           FStar_TypeChecker_Env.erasable_types_tab =
-                            (uu___3543_25622.FStar_TypeChecker_Env.erasable_types_tab);
+                            (uu___3543_25602.FStar_TypeChecker_Env.erasable_types_tab);
                           FStar_TypeChecker_Env.enable_defer_to_tac =
-                            (uu___3543_25622.FStar_TypeChecker_Env.enable_defer_to_tac)
+                            (uu___3543_25602.FStar_TypeChecker_Env.enable_defer_to_tac)
                         }) e11 in
-                   match uu____25613 with
+                   match uu____25593 with
                    | (e12, c1, g1) ->
-                       let uu____25636 =
-                         let uu____25641 =
+                       let uu____25616 =
+                         let uu____25621 =
                            FStar_TypeChecker_Env.set_range env11
                              e12.FStar_Syntax_Syntax.pos in
                          FStar_TypeChecker_Util.strengthen_precondition
                            (FStar_Pervasives_Native.Some
-                              (fun uu____25646 ->
+                              (fun uu____25626 ->
                                  FStar_Util.return_all
                                    FStar_TypeChecker_Err.ill_kinded_type))
-                           uu____25641 e12 c1 wf_annot in
-                       (match uu____25636 with
+                           uu____25621 e12 c1 wf_annot in
+                       (match uu____25616 with
                         | (c11, guard_f) ->
                             let g11 =
                               FStar_TypeChecker_Env.conj_guard g1 guard_f in
-                            ((let uu____25661 =
+                            ((let uu____25641 =
                                 FStar_TypeChecker_Env.debug env
                                   FStar_Options.Extreme in
-                              if uu____25661
+                              if uu____25641
                               then
-                                let uu____25662 =
+                                let uu____25642 =
                                   FStar_Syntax_Print.lbname_to_string
                                     lb.FStar_Syntax_Syntax.lbname in
-                                let uu____25663 =
+                                let uu____25643 =
                                   FStar_TypeChecker_Common.lcomp_to_string
                                     c11 in
-                                let uu____25664 =
+                                let uu____25644 =
                                   FStar_TypeChecker_Rel.guard_to_string env
                                     g11 in
                                 FStar_Util.print3
                                   "checked let-bound def %s : %s guard is %s\n"
-                                  uu____25662 uu____25663 uu____25664
+                                  uu____25642 uu____25643 uu____25644
                               else ());
                              (e12, univ_vars, c11, g11,
                                (FStar_Option.isSome topt)))))))
@@ -9972,21 +9972,21 @@ and (check_lbtyp :
         let t = FStar_Syntax_Subst.compress lb.FStar_Syntax_Syntax.lbtyp in
         match t.FStar_Syntax_Syntax.n with
         | FStar_Syntax_Syntax.Tm_unknown ->
-            let uu____25698 =
+            let uu____25678 =
               FStar_Syntax_Subst.univ_var_opening
                 lb.FStar_Syntax_Syntax.lbunivs in
-            (match uu____25698 with
+            (match uu____25678 with
              | (univ_opening, univ_vars) ->
-                 let uu____25731 =
+                 let uu____25711 =
                    FStar_TypeChecker_Env.push_univ_vars env univ_vars in
                  (FStar_Pervasives_Native.None,
                    FStar_TypeChecker_Env.trivial_guard, univ_vars,
-                   univ_opening, uu____25731))
-        | uu____25736 ->
-            let uu____25737 =
+                   univ_opening, uu____25711))
+        | uu____25716 ->
+            let uu____25717 =
               FStar_Syntax_Subst.univ_var_opening
                 lb.FStar_Syntax_Syntax.lbunivs in
-            (match uu____25737 with
+            (match uu____25717 with
              | (univ_opening, univ_vars) ->
                  let t1 = FStar_Syntax_Subst.subst univ_opening t in
                  let env1 =
@@ -9995,41 +9995,41 @@ and (check_lbtyp :
                    top_level &&
                      (Prims.op_Negation env.FStar_TypeChecker_Env.generalize)
                  then
-                   let uu____25786 =
+                   let uu____25766 =
                      FStar_TypeChecker_Env.set_expected_typ env1 t1 in
                    ((FStar_Pervasives_Native.Some t1),
                      FStar_TypeChecker_Env.trivial_guard, univ_vars,
-                     univ_opening, uu____25786)
+                     univ_opening, uu____25766)
                  else
-                   (let uu____25792 = FStar_Syntax_Util.type_u () in
-                    match uu____25792 with
-                    | (k, uu____25812) ->
-                        let uu____25813 =
+                   (let uu____25772 = FStar_Syntax_Util.type_u () in
+                    match uu____25772 with
+                    | (k, uu____25792) ->
+                        let uu____25793 =
                           tc_check_tot_or_gtot_term env1 t1 k "" in
-                        (match uu____25813 with
-                         | (t2, uu____25835, g) ->
-                             ((let uu____25838 =
+                        (match uu____25793 with
+                         | (t2, uu____25815, g) ->
+                             ((let uu____25818 =
                                  FStar_TypeChecker_Env.debug env
                                    FStar_Options.Medium in
-                               if uu____25838
+                               if uu____25818
                                then
-                                 let uu____25839 =
-                                   let uu____25840 =
+                                 let uu____25819 =
+                                   let uu____25820 =
                                      FStar_Syntax_Util.range_of_lbname
                                        lb.FStar_Syntax_Syntax.lbname in
-                                   FStar_Range.string_of_range uu____25840 in
-                                 let uu____25841 =
+                                   FStar_Range.string_of_range uu____25820 in
+                                 let uu____25821 =
                                    FStar_Syntax_Print.term_to_string t2 in
                                  FStar_Util.print2
                                    "(%s) Checked type annotation %s\n"
-                                   uu____25839 uu____25841
+                                   uu____25819 uu____25821
                                else ());
                               (let t3 = norm env1 t2 in
-                               let uu____25844 =
+                               let uu____25824 =
                                  FStar_TypeChecker_Env.set_expected_typ env1
                                    t3 in
                                ((FStar_Pervasives_Native.Some t3), g,
-                                 univ_vars, univ_opening, uu____25844))))))
+                                 univ_vars, univ_opening, uu____25824))))))
 and (tc_binder :
   FStar_TypeChecker_Env.env ->
     (FStar_Syntax_Syntax.bv * FStar_Syntax_Syntax.arg_qualifier
@@ -10039,86 +10039,86 @@ and (tc_binder :
         FStar_TypeChecker_Env.guard_t * FStar_Syntax_Syntax.universe))
   =
   fun env ->
-    fun uu____25850 ->
-      match uu____25850 with
+    fun uu____25830 ->
+      match uu____25830 with
       | (x, imp) ->
-          let uu____25877 = FStar_Syntax_Util.type_u () in
-          (match uu____25877 with
+          let uu____25857 = FStar_Syntax_Util.type_u () in
+          (match uu____25857 with
            | (tu, u) ->
-               ((let uu____25899 =
+               ((let uu____25879 =
                    FStar_TypeChecker_Env.debug env FStar_Options.Extreme in
-                 if uu____25899
+                 if uu____25879
                  then
-                   let uu____25900 = FStar_Syntax_Print.bv_to_string x in
-                   let uu____25901 =
+                   let uu____25880 = FStar_Syntax_Print.bv_to_string x in
+                   let uu____25881 =
                      FStar_Syntax_Print.term_to_string
                        x.FStar_Syntax_Syntax.sort in
-                   let uu____25902 = FStar_Syntax_Print.term_to_string tu in
+                   let uu____25882 = FStar_Syntax_Print.term_to_string tu in
                    FStar_Util.print3 "Checking binder %s:%s at type %s\n"
-                     uu____25900 uu____25901 uu____25902
+                     uu____25880 uu____25881 uu____25882
                  else ());
-                (let uu____25904 =
+                (let uu____25884 =
                    tc_check_tot_or_gtot_term env x.FStar_Syntax_Syntax.sort
                      tu "" in
-                 match uu____25904 with
-                 | (t, uu____25926, g) ->
-                     let uu____25928 =
+                 match uu____25884 with
+                 | (t, uu____25906, g) ->
+                     let uu____25908 =
                        match imp with
                        | FStar_Pervasives_Native.Some
                            (FStar_Syntax_Syntax.Meta tau_or_attr) ->
                            (match tau_or_attr with
                             | FStar_Syntax_Syntax.Arg_qualifier_meta_tac tau
                                 ->
-                                let uu____25951 =
+                                let uu____25931 =
                                   tc_tactic FStar_Syntax_Syntax.t_unit
                                     FStar_Syntax_Syntax.t_unit env tau in
-                                (match uu____25951 with
-                                 | (tau1, uu____25965, g1) ->
+                                (match uu____25931 with
+                                 | (tau1, uu____25945, g1) ->
                                      ((FStar_Pervasives_Native.Some
                                          (FStar_Syntax_Syntax.Meta
                                             (FStar_Syntax_Syntax.Arg_qualifier_meta_tac
                                                tau1))), g1))
                             | FStar_Syntax_Syntax.Arg_qualifier_meta_attr
                                 attr ->
-                                let uu____25972 =
+                                let uu____25952 =
                                   tc_check_tot_or_gtot_term env attr
                                     FStar_Syntax_Syntax.t_unit "" in
-                                (match uu____25972 with
-                                 | (attr1, uu____25986, g1) ->
+                                (match uu____25952 with
+                                 | (attr1, uu____25966, g1) ->
                                      ((FStar_Pervasives_Native.Some
                                          (FStar_Syntax_Syntax.Meta
                                             (FStar_Syntax_Syntax.Arg_qualifier_meta_attr
                                                attr1))),
                                        FStar_TypeChecker_Env.trivial_guard)))
-                       | uu____25990 ->
+                       | uu____25970 ->
                            (imp, FStar_TypeChecker_Env.trivial_guard) in
-                     (match uu____25928 with
+                     (match uu____25908 with
                       | (imp1, g') ->
                           let x1 =
-                            ((let uu___3613_26025 = x in
+                            ((let uu___3613_26005 = x in
                               {
                                 FStar_Syntax_Syntax.ppname =
-                                  (uu___3613_26025.FStar_Syntax_Syntax.ppname);
+                                  (uu___3613_26005.FStar_Syntax_Syntax.ppname);
                                 FStar_Syntax_Syntax.index =
-                                  (uu___3613_26025.FStar_Syntax_Syntax.index);
+                                  (uu___3613_26005.FStar_Syntax_Syntax.index);
                                 FStar_Syntax_Syntax.sort = t
                               }), imp1) in
-                          ((let uu____26027 =
+                          ((let uu____26007 =
                               FStar_TypeChecker_Env.debug env
                                 FStar_Options.High in
-                            if uu____26027
+                            if uu____26007
                             then
-                              let uu____26028 =
+                              let uu____26008 =
                                 FStar_Syntax_Print.bv_to_string
                                   (FStar_Pervasives_Native.fst x1) in
-                              let uu____26031 =
+                              let uu____26011 =
                                 FStar_Syntax_Print.term_to_string t in
                               FStar_Util.print2
-                                "Pushing binder %s at type %s\n" uu____26028
-                                uu____26031
+                                "Pushing binder %s at type %s\n" uu____26008
+                                uu____26011
                             else ());
-                           (let uu____26033 = push_binding env x1 in
-                            (x1, uu____26033, g, u)))))))
+                           (let uu____26013 = push_binding env x1 in
+                            (x1, uu____26013, g, u)))))))
 and (tc_binders :
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.binders ->
@@ -10127,29 +10127,29 @@ and (tc_binders :
   =
   fun env ->
     fun bs ->
-      (let uu____26045 =
+      (let uu____26025 =
          FStar_TypeChecker_Env.debug env FStar_Options.Extreme in
-       if uu____26045
+       if uu____26025
        then
-         let uu____26046 = FStar_Syntax_Print.binders_to_string ", " bs in
-         FStar_Util.print1 "Checking binders %s\n" uu____26046
+         let uu____26026 = FStar_Syntax_Print.binders_to_string ", " bs in
+         FStar_Util.print1 "Checking binders %s\n" uu____26026
        else ());
       (let rec aux env1 bs1 =
          match bs1 with
          | [] -> ([], env1, FStar_TypeChecker_Env.trivial_guard, [])
          | b::bs2 ->
-             let uu____26155 = tc_binder env1 b in
-             (match uu____26155 with
+             let uu____26135 = tc_binder env1 b in
+             (match uu____26135 with
               | (b1, env', g, u) ->
-                  let uu____26204 = aux env' bs2 in
-                  (match uu____26204 with
+                  let uu____26184 = aux env' bs2 in
+                  (match uu____26184 with
                    | (bs3, env'1, g', us) ->
-                       let uu____26265 =
-                         let uu____26266 =
+                       let uu____26245 =
+                         let uu____26246 =
                            FStar_TypeChecker_Env.close_guard_univs [u] 
                              [b1] g' in
-                         FStar_TypeChecker_Env.conj_guard g uu____26266 in
-                       ((b1 :: bs3), env'1, uu____26265, (u :: us)))) in
+                         FStar_TypeChecker_Env.conj_guard g uu____26246 in
+                       ((b1 :: bs3), env'1, uu____26245, (u :: us)))) in
        aux env bs)
 and (tc_smt_pats :
   FStar_TypeChecker_Env.env ->
@@ -10164,28 +10164,28 @@ and (tc_smt_pats :
     fun pats ->
       let tc_args en1 args =
         FStar_List.fold_right
-          (fun uu____26374 ->
-             fun uu____26375 ->
-               match (uu____26374, uu____26375) with
+          (fun uu____26354 ->
+             fun uu____26355 ->
+               match (uu____26354, uu____26355) with
                | ((t, imp), (args1, g)) ->
                    (FStar_All.pipe_right t (check_no_smt_theory_symbols en1);
-                    (let uu____26467 = tc_term en1 t in
-                     match uu____26467 with
-                     | (t1, uu____26487, g') ->
-                         let uu____26489 =
+                    (let uu____26447 = tc_term en1 t in
+                     match uu____26447 with
+                     | (t1, uu____26467, g') ->
+                         let uu____26469 =
                            FStar_TypeChecker_Env.conj_guard g g' in
-                         (((t1, imp) :: args1), uu____26489)))) args
+                         (((t1, imp) :: args1), uu____26469)))) args
           ([], FStar_TypeChecker_Env.trivial_guard) in
       FStar_List.fold_right
         (fun p ->
-           fun uu____26543 ->
-             match uu____26543 with
+           fun uu____26523 ->
+             match uu____26523 with
              | (pats1, g) ->
-                 let uu____26570 = tc_args en p in
-                 (match uu____26570 with
+                 let uu____26550 = tc_args en p in
+                 (match uu____26550 with
                   | (args, g') ->
-                      let uu____26583 = FStar_TypeChecker_Env.conj_guard g g' in
-                      ((args :: pats1), uu____26583))) pats
+                      let uu____26563 = FStar_TypeChecker_Env.conj_guard g g' in
+                      ((args :: pats1), uu____26563))) pats
         ([], FStar_TypeChecker_Env.trivial_guard)
 and (tc_tot_or_gtot_term' :
   FStar_TypeChecker_Env.env ->
@@ -10197,62 +10197,62 @@ and (tc_tot_or_gtot_term' :
   fun env ->
     fun e ->
       fun msg ->
-        let uu____26597 = tc_maybe_toplevel_term env e in
-        match uu____26597 with
+        let uu____26577 = tc_maybe_toplevel_term env e in
+        match uu____26577 with
         | (e1, c, g) ->
-            let uu____26613 = FStar_TypeChecker_Common.is_tot_or_gtot_lcomp c in
-            if uu____26613
+            let uu____26593 = FStar_TypeChecker_Common.is_tot_or_gtot_lcomp c in
+            if uu____26593
             then (e1, c, g)
             else
               (let g1 =
                  FStar_TypeChecker_Rel.solve_deferred_constraints env g in
-               let uu____26622 = FStar_TypeChecker_Common.lcomp_comp c in
-               match uu____26622 with
+               let uu____26602 = FStar_TypeChecker_Common.lcomp_comp c in
+               match uu____26602 with
                | (c1, g_c) ->
                    let c2 = norm_c env c1 in
-                   let uu____26636 =
-                     let uu____26641 =
+                   let uu____26616 =
+                     let uu____26621 =
                        FStar_TypeChecker_Util.is_pure_effect env
                          (FStar_Syntax_Util.comp_effect_name c2) in
-                     if uu____26641
+                     if uu____26621
                      then
-                       let uu____26646 =
+                       let uu____26626 =
                          FStar_Syntax_Syntax.mk_Total
                            (FStar_Syntax_Util.comp_result c2) in
-                       (uu____26646, false)
+                       (uu____26626, false)
                      else
-                       (let uu____26648 =
+                       (let uu____26628 =
                           FStar_Syntax_Syntax.mk_GTotal
                             (FStar_Syntax_Util.comp_result c2) in
-                        (uu____26648, true)) in
-                   (match uu____26636 with
+                        (uu____26628, true)) in
+                   (match uu____26616 with
                     | (target_comp, allow_ghost) ->
-                        let uu____26657 =
+                        let uu____26637 =
                           FStar_TypeChecker_Rel.sub_comp env c2 target_comp in
-                        (match uu____26657 with
+                        (match uu____26637 with
                          | FStar_Pervasives_Native.Some g' ->
-                             let uu____26667 =
+                             let uu____26647 =
                                FStar_TypeChecker_Common.lcomp_of_comp
                                  target_comp in
-                             let uu____26668 =
-                               let uu____26669 =
+                             let uu____26648 =
+                               let uu____26649 =
                                  FStar_TypeChecker_Env.conj_guard g_c g' in
                                FStar_TypeChecker_Env.conj_guard g1
-                                 uu____26669 in
-                             (e1, uu____26667, uu____26668)
-                         | uu____26670 ->
+                                 uu____26649 in
+                             (e1, uu____26647, uu____26648)
+                         | uu____26650 ->
                              if allow_ghost
                              then
-                               let uu____26679 =
+                               let uu____26659 =
                                  FStar_TypeChecker_Err.expected_ghost_expression
                                    e1 c2 msg in
-                               FStar_Errors.raise_error uu____26679
+                               FStar_Errors.raise_error uu____26659
                                  e1.FStar_Syntax_Syntax.pos
                              else
-                               (let uu____26691 =
+                               (let uu____26671 =
                                   FStar_TypeChecker_Err.expected_pure_expression
                                     e1 c2 msg in
-                                FStar_Errors.raise_error uu____26691
+                                FStar_Errors.raise_error uu____26671
                                   e1.FStar_Syntax_Syntax.pos))))
 and (tc_tot_or_gtot_term :
   FStar_TypeChecker_Env.env ->
@@ -10281,8 +10281,8 @@ and (tc_trivial_guard :
   =
   fun env ->
     fun t ->
-      let uu____26717 = tc_tot_or_gtot_term env t in
-      match uu____26717 with
+      let uu____26697 = tc_tot_or_gtot_term env t in
+      match uu____26697 with
       | (t1, c, g) ->
           (FStar_TypeChecker_Rel.force_trivial_guard env g; (t1, c))
 let (tc_check_trivial_guard :
@@ -10293,9 +10293,9 @@ let (tc_check_trivial_guard :
   fun env ->
     fun t ->
       fun k ->
-        let uu____26747 = tc_check_tot_or_gtot_term env t k "" in
-        match uu____26747 with
-        | (t1, uu____26755, g) ->
+        let uu____26727 = tc_check_tot_or_gtot_term env t k "" in
+        match uu____26727 with
+        | (t1, uu____26735, g) ->
             (FStar_TypeChecker_Rel.force_trivial_guard env g; t1)
 let (type_of_tot_term :
   FStar_TypeChecker_Env.env ->
@@ -10305,150 +10305,150 @@ let (type_of_tot_term :
   =
   fun env ->
     fun e ->
-      (let uu____26775 =
+      (let uu____26755 =
          FStar_All.pipe_left (FStar_TypeChecker_Env.debug env)
            (FStar_Options.Other "RelCheck") in
-       if uu____26775
+       if uu____26755
        then
-         let uu____26776 = FStar_Syntax_Print.term_to_string e in
-         FStar_Util.print1 "Checking term %s\n" uu____26776
+         let uu____26756 = FStar_Syntax_Print.term_to_string e in
+         FStar_Util.print1 "Checking term %s\n" uu____26756
        else ());
       (let env1 =
-         let uu___3709_26779 = env in
+         let uu___3709_26759 = env in
          {
            FStar_TypeChecker_Env.solver =
-             (uu___3709_26779.FStar_TypeChecker_Env.solver);
+             (uu___3709_26759.FStar_TypeChecker_Env.solver);
            FStar_TypeChecker_Env.range =
-             (uu___3709_26779.FStar_TypeChecker_Env.range);
+             (uu___3709_26759.FStar_TypeChecker_Env.range);
            FStar_TypeChecker_Env.curmodule =
-             (uu___3709_26779.FStar_TypeChecker_Env.curmodule);
+             (uu___3709_26759.FStar_TypeChecker_Env.curmodule);
            FStar_TypeChecker_Env.gamma =
-             (uu___3709_26779.FStar_TypeChecker_Env.gamma);
+             (uu___3709_26759.FStar_TypeChecker_Env.gamma);
            FStar_TypeChecker_Env.gamma_sig =
-             (uu___3709_26779.FStar_TypeChecker_Env.gamma_sig);
+             (uu___3709_26759.FStar_TypeChecker_Env.gamma_sig);
            FStar_TypeChecker_Env.gamma_cache =
-             (uu___3709_26779.FStar_TypeChecker_Env.gamma_cache);
+             (uu___3709_26759.FStar_TypeChecker_Env.gamma_cache);
            FStar_TypeChecker_Env.modules =
-             (uu___3709_26779.FStar_TypeChecker_Env.modules);
+             (uu___3709_26759.FStar_TypeChecker_Env.modules);
            FStar_TypeChecker_Env.expected_typ =
-             (uu___3709_26779.FStar_TypeChecker_Env.expected_typ);
+             (uu___3709_26759.FStar_TypeChecker_Env.expected_typ);
            FStar_TypeChecker_Env.sigtab =
-             (uu___3709_26779.FStar_TypeChecker_Env.sigtab);
+             (uu___3709_26759.FStar_TypeChecker_Env.sigtab);
            FStar_TypeChecker_Env.attrtab =
-             (uu___3709_26779.FStar_TypeChecker_Env.attrtab);
+             (uu___3709_26759.FStar_TypeChecker_Env.attrtab);
            FStar_TypeChecker_Env.instantiate_imp =
-             (uu___3709_26779.FStar_TypeChecker_Env.instantiate_imp);
+             (uu___3709_26759.FStar_TypeChecker_Env.instantiate_imp);
            FStar_TypeChecker_Env.effects =
-             (uu___3709_26779.FStar_TypeChecker_Env.effects);
+             (uu___3709_26759.FStar_TypeChecker_Env.effects);
            FStar_TypeChecker_Env.generalize =
-             (uu___3709_26779.FStar_TypeChecker_Env.generalize);
+             (uu___3709_26759.FStar_TypeChecker_Env.generalize);
            FStar_TypeChecker_Env.letrecs = [];
            FStar_TypeChecker_Env.top_level = false;
            FStar_TypeChecker_Env.check_uvars =
-             (uu___3709_26779.FStar_TypeChecker_Env.check_uvars);
+             (uu___3709_26759.FStar_TypeChecker_Env.check_uvars);
            FStar_TypeChecker_Env.use_eq =
-             (uu___3709_26779.FStar_TypeChecker_Env.use_eq);
+             (uu___3709_26759.FStar_TypeChecker_Env.use_eq);
            FStar_TypeChecker_Env.use_eq_strict =
-             (uu___3709_26779.FStar_TypeChecker_Env.use_eq_strict);
+             (uu___3709_26759.FStar_TypeChecker_Env.use_eq_strict);
            FStar_TypeChecker_Env.is_iface =
-             (uu___3709_26779.FStar_TypeChecker_Env.is_iface);
+             (uu___3709_26759.FStar_TypeChecker_Env.is_iface);
            FStar_TypeChecker_Env.admit =
-             (uu___3709_26779.FStar_TypeChecker_Env.admit);
+             (uu___3709_26759.FStar_TypeChecker_Env.admit);
            FStar_TypeChecker_Env.lax =
-             (uu___3709_26779.FStar_TypeChecker_Env.lax);
+             (uu___3709_26759.FStar_TypeChecker_Env.lax);
            FStar_TypeChecker_Env.lax_universes =
-             (uu___3709_26779.FStar_TypeChecker_Env.lax_universes);
+             (uu___3709_26759.FStar_TypeChecker_Env.lax_universes);
            FStar_TypeChecker_Env.phase1 =
-             (uu___3709_26779.FStar_TypeChecker_Env.phase1);
+             (uu___3709_26759.FStar_TypeChecker_Env.phase1);
            FStar_TypeChecker_Env.failhard =
-             (uu___3709_26779.FStar_TypeChecker_Env.failhard);
+             (uu___3709_26759.FStar_TypeChecker_Env.failhard);
            FStar_TypeChecker_Env.nosynth =
-             (uu___3709_26779.FStar_TypeChecker_Env.nosynth);
+             (uu___3709_26759.FStar_TypeChecker_Env.nosynth);
            FStar_TypeChecker_Env.uvar_subtyping =
-             (uu___3709_26779.FStar_TypeChecker_Env.uvar_subtyping);
+             (uu___3709_26759.FStar_TypeChecker_Env.uvar_subtyping);
            FStar_TypeChecker_Env.tc_term =
-             (uu___3709_26779.FStar_TypeChecker_Env.tc_term);
+             (uu___3709_26759.FStar_TypeChecker_Env.tc_term);
            FStar_TypeChecker_Env.type_of =
-             (uu___3709_26779.FStar_TypeChecker_Env.type_of);
+             (uu___3709_26759.FStar_TypeChecker_Env.type_of);
            FStar_TypeChecker_Env.universe_of =
-             (uu___3709_26779.FStar_TypeChecker_Env.universe_of);
+             (uu___3709_26759.FStar_TypeChecker_Env.universe_of);
            FStar_TypeChecker_Env.check_type_of =
-             (uu___3709_26779.FStar_TypeChecker_Env.check_type_of);
+             (uu___3709_26759.FStar_TypeChecker_Env.check_type_of);
            FStar_TypeChecker_Env.use_bv_sorts =
-             (uu___3709_26779.FStar_TypeChecker_Env.use_bv_sorts);
+             (uu___3709_26759.FStar_TypeChecker_Env.use_bv_sorts);
            FStar_TypeChecker_Env.qtbl_name_and_index =
-             (uu___3709_26779.FStar_TypeChecker_Env.qtbl_name_and_index);
+             (uu___3709_26759.FStar_TypeChecker_Env.qtbl_name_and_index);
            FStar_TypeChecker_Env.normalized_eff_names =
-             (uu___3709_26779.FStar_TypeChecker_Env.normalized_eff_names);
+             (uu___3709_26759.FStar_TypeChecker_Env.normalized_eff_names);
            FStar_TypeChecker_Env.fv_delta_depths =
-             (uu___3709_26779.FStar_TypeChecker_Env.fv_delta_depths);
+             (uu___3709_26759.FStar_TypeChecker_Env.fv_delta_depths);
            FStar_TypeChecker_Env.proof_ns =
-             (uu___3709_26779.FStar_TypeChecker_Env.proof_ns);
+             (uu___3709_26759.FStar_TypeChecker_Env.proof_ns);
            FStar_TypeChecker_Env.synth_hook =
-             (uu___3709_26779.FStar_TypeChecker_Env.synth_hook);
+             (uu___3709_26759.FStar_TypeChecker_Env.synth_hook);
            FStar_TypeChecker_Env.try_solve_implicits_hook =
-             (uu___3709_26779.FStar_TypeChecker_Env.try_solve_implicits_hook);
+             (uu___3709_26759.FStar_TypeChecker_Env.try_solve_implicits_hook);
            FStar_TypeChecker_Env.splice =
-             (uu___3709_26779.FStar_TypeChecker_Env.splice);
+             (uu___3709_26759.FStar_TypeChecker_Env.splice);
            FStar_TypeChecker_Env.mpreprocess =
-             (uu___3709_26779.FStar_TypeChecker_Env.mpreprocess);
+             (uu___3709_26759.FStar_TypeChecker_Env.mpreprocess);
            FStar_TypeChecker_Env.postprocess =
-             (uu___3709_26779.FStar_TypeChecker_Env.postprocess);
+             (uu___3709_26759.FStar_TypeChecker_Env.postprocess);
            FStar_TypeChecker_Env.identifier_info =
-             (uu___3709_26779.FStar_TypeChecker_Env.identifier_info);
+             (uu___3709_26759.FStar_TypeChecker_Env.identifier_info);
            FStar_TypeChecker_Env.tc_hooks =
-             (uu___3709_26779.FStar_TypeChecker_Env.tc_hooks);
+             (uu___3709_26759.FStar_TypeChecker_Env.tc_hooks);
            FStar_TypeChecker_Env.dsenv =
-             (uu___3709_26779.FStar_TypeChecker_Env.dsenv);
+             (uu___3709_26759.FStar_TypeChecker_Env.dsenv);
            FStar_TypeChecker_Env.nbe =
-             (uu___3709_26779.FStar_TypeChecker_Env.nbe);
+             (uu___3709_26759.FStar_TypeChecker_Env.nbe);
            FStar_TypeChecker_Env.strict_args_tab =
-             (uu___3709_26779.FStar_TypeChecker_Env.strict_args_tab);
+             (uu___3709_26759.FStar_TypeChecker_Env.strict_args_tab);
            FStar_TypeChecker_Env.erasable_types_tab =
-             (uu___3709_26779.FStar_TypeChecker_Env.erasable_types_tab);
+             (uu___3709_26759.FStar_TypeChecker_Env.erasable_types_tab);
            FStar_TypeChecker_Env.enable_defer_to_tac =
-             (uu___3709_26779.FStar_TypeChecker_Env.enable_defer_to_tac)
+             (uu___3709_26759.FStar_TypeChecker_Env.enable_defer_to_tac)
          } in
-       let uu____26788 =
+       let uu____26768 =
          try
-           (fun uu___3713_26802 ->
+           (fun uu___3713_26782 ->
               match () with | () -> tc_tot_or_gtot_term env1 e) ()
          with
-         | FStar_Errors.Error (e1, msg, uu____26823) ->
-             let uu____26824 = FStar_TypeChecker_Env.get_range env1 in
-             FStar_Errors.raise_error (e1, msg) uu____26824 in
-       match uu____26788 with
+         | FStar_Errors.Error (e1, msg, uu____26803) ->
+             let uu____26804 = FStar_TypeChecker_Env.get_range env1 in
+             FStar_Errors.raise_error (e1, msg) uu____26804 in
+       match uu____26768 with
        | (t, c, g) ->
            let c1 = FStar_TypeChecker_Normalize.ghost_to_pure_lcomp env1 c in
-           let uu____26841 = FStar_TypeChecker_Common.is_total_lcomp c1 in
-           if uu____26841
+           let uu____26821 = FStar_TypeChecker_Common.is_total_lcomp c1 in
+           if uu____26821
            then (t, (c1.FStar_TypeChecker_Common.res_typ), g)
            else
-             (let uu____26849 =
-                let uu____26854 =
-                  let uu____26855 = FStar_Syntax_Print.term_to_string e in
+             (let uu____26829 =
+                let uu____26834 =
+                  let uu____26835 = FStar_Syntax_Print.term_to_string e in
                   FStar_Util.format1
                     "Implicit argument: Expected a total term; got a ghost term: %s"
-                    uu____26855 in
-                (FStar_Errors.Fatal_UnexpectedImplictArgument, uu____26854) in
-              let uu____26856 = FStar_TypeChecker_Env.get_range env1 in
-              FStar_Errors.raise_error uu____26849 uu____26856))
+                    uu____26835 in
+                (FStar_Errors.Fatal_UnexpectedImplictArgument, uu____26834) in
+              let uu____26836 = FStar_TypeChecker_Env.get_range env1 in
+              FStar_Errors.raise_error uu____26829 uu____26836))
 let level_of_type_fail :
-  'uuuuuu26871 .
+  'uuuuuu26851 .
     FStar_TypeChecker_Env.env ->
-      FStar_Syntax_Syntax.term -> Prims.string -> 'uuuuuu26871
+      FStar_Syntax_Syntax.term -> Prims.string -> 'uuuuuu26851
   =
   fun env ->
     fun e ->
       fun t ->
-        let uu____26887 =
-          let uu____26892 =
-            let uu____26893 = FStar_Syntax_Print.term_to_string e in
+        let uu____26867 =
+          let uu____26872 =
+            let uu____26873 = FStar_Syntax_Print.term_to_string e in
             FStar_Util.format2 "Expected a term of type 'Type'; got %s : %s"
-              uu____26893 t in
-          (FStar_Errors.Fatal_UnexpectedTermType, uu____26892) in
-        let uu____26894 = FStar_TypeChecker_Env.get_range env in
-        FStar_Errors.raise_error uu____26887 uu____26894
+              uu____26873 t in
+          (FStar_Errors.Fatal_UnexpectedTermType, uu____26872) in
+        let uu____26874 = FStar_TypeChecker_Env.get_range env in
+        FStar_Errors.raise_error uu____26867 uu____26874
 let (level_of_type :
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.term ->
@@ -10458,12 +10458,12 @@ let (level_of_type :
     fun e ->
       fun t ->
         let rec aux retry t1 =
-          let uu____26925 =
-            let uu____26926 = FStar_Syntax_Util.unrefine t1 in
-            uu____26926.FStar_Syntax_Syntax.n in
-          match uu____26925 with
+          let uu____26905 =
+            let uu____26906 = FStar_Syntax_Util.unrefine t1 in
+            uu____26906.FStar_Syntax_Syntax.n in
+          match uu____26905 with
           | FStar_Syntax_Syntax.Tm_type u -> u
-          | uu____26930 ->
+          | uu____26910 ->
               if retry
               then
                 let t2 =
@@ -10472,113 +10472,113 @@ let (level_of_type :
                        FStar_Syntax_Syntax.delta_constant] env t1 in
                 aux false t2
               else
-                (let uu____26933 = FStar_Syntax_Util.type_u () in
-                 match uu____26933 with
+                (let uu____26913 = FStar_Syntax_Util.type_u () in
+                 match uu____26913 with
                  | (t_u, u) ->
                      let env1 =
-                       let uu___3745_26941 = env in
+                       let uu___3745_26921 = env in
                        {
                          FStar_TypeChecker_Env.solver =
-                           (uu___3745_26941.FStar_TypeChecker_Env.solver);
+                           (uu___3745_26921.FStar_TypeChecker_Env.solver);
                          FStar_TypeChecker_Env.range =
-                           (uu___3745_26941.FStar_TypeChecker_Env.range);
+                           (uu___3745_26921.FStar_TypeChecker_Env.range);
                          FStar_TypeChecker_Env.curmodule =
-                           (uu___3745_26941.FStar_TypeChecker_Env.curmodule);
+                           (uu___3745_26921.FStar_TypeChecker_Env.curmodule);
                          FStar_TypeChecker_Env.gamma =
-                           (uu___3745_26941.FStar_TypeChecker_Env.gamma);
+                           (uu___3745_26921.FStar_TypeChecker_Env.gamma);
                          FStar_TypeChecker_Env.gamma_sig =
-                           (uu___3745_26941.FStar_TypeChecker_Env.gamma_sig);
+                           (uu___3745_26921.FStar_TypeChecker_Env.gamma_sig);
                          FStar_TypeChecker_Env.gamma_cache =
-                           (uu___3745_26941.FStar_TypeChecker_Env.gamma_cache);
+                           (uu___3745_26921.FStar_TypeChecker_Env.gamma_cache);
                          FStar_TypeChecker_Env.modules =
-                           (uu___3745_26941.FStar_TypeChecker_Env.modules);
+                           (uu___3745_26921.FStar_TypeChecker_Env.modules);
                          FStar_TypeChecker_Env.expected_typ =
-                           (uu___3745_26941.FStar_TypeChecker_Env.expected_typ);
+                           (uu___3745_26921.FStar_TypeChecker_Env.expected_typ);
                          FStar_TypeChecker_Env.sigtab =
-                           (uu___3745_26941.FStar_TypeChecker_Env.sigtab);
+                           (uu___3745_26921.FStar_TypeChecker_Env.sigtab);
                          FStar_TypeChecker_Env.attrtab =
-                           (uu___3745_26941.FStar_TypeChecker_Env.attrtab);
+                           (uu___3745_26921.FStar_TypeChecker_Env.attrtab);
                          FStar_TypeChecker_Env.instantiate_imp =
-                           (uu___3745_26941.FStar_TypeChecker_Env.instantiate_imp);
+                           (uu___3745_26921.FStar_TypeChecker_Env.instantiate_imp);
                          FStar_TypeChecker_Env.effects =
-                           (uu___3745_26941.FStar_TypeChecker_Env.effects);
+                           (uu___3745_26921.FStar_TypeChecker_Env.effects);
                          FStar_TypeChecker_Env.generalize =
-                           (uu___3745_26941.FStar_TypeChecker_Env.generalize);
+                           (uu___3745_26921.FStar_TypeChecker_Env.generalize);
                          FStar_TypeChecker_Env.letrecs =
-                           (uu___3745_26941.FStar_TypeChecker_Env.letrecs);
+                           (uu___3745_26921.FStar_TypeChecker_Env.letrecs);
                          FStar_TypeChecker_Env.top_level =
-                           (uu___3745_26941.FStar_TypeChecker_Env.top_level);
+                           (uu___3745_26921.FStar_TypeChecker_Env.top_level);
                          FStar_TypeChecker_Env.check_uvars =
-                           (uu___3745_26941.FStar_TypeChecker_Env.check_uvars);
+                           (uu___3745_26921.FStar_TypeChecker_Env.check_uvars);
                          FStar_TypeChecker_Env.use_eq =
-                           (uu___3745_26941.FStar_TypeChecker_Env.use_eq);
+                           (uu___3745_26921.FStar_TypeChecker_Env.use_eq);
                          FStar_TypeChecker_Env.use_eq_strict =
-                           (uu___3745_26941.FStar_TypeChecker_Env.use_eq_strict);
+                           (uu___3745_26921.FStar_TypeChecker_Env.use_eq_strict);
                          FStar_TypeChecker_Env.is_iface =
-                           (uu___3745_26941.FStar_TypeChecker_Env.is_iface);
+                           (uu___3745_26921.FStar_TypeChecker_Env.is_iface);
                          FStar_TypeChecker_Env.admit =
-                           (uu___3745_26941.FStar_TypeChecker_Env.admit);
+                           (uu___3745_26921.FStar_TypeChecker_Env.admit);
                          FStar_TypeChecker_Env.lax = true;
                          FStar_TypeChecker_Env.lax_universes =
-                           (uu___3745_26941.FStar_TypeChecker_Env.lax_universes);
+                           (uu___3745_26921.FStar_TypeChecker_Env.lax_universes);
                          FStar_TypeChecker_Env.phase1 =
-                           (uu___3745_26941.FStar_TypeChecker_Env.phase1);
+                           (uu___3745_26921.FStar_TypeChecker_Env.phase1);
                          FStar_TypeChecker_Env.failhard =
-                           (uu___3745_26941.FStar_TypeChecker_Env.failhard);
+                           (uu___3745_26921.FStar_TypeChecker_Env.failhard);
                          FStar_TypeChecker_Env.nosynth =
-                           (uu___3745_26941.FStar_TypeChecker_Env.nosynth);
+                           (uu___3745_26921.FStar_TypeChecker_Env.nosynth);
                          FStar_TypeChecker_Env.uvar_subtyping =
-                           (uu___3745_26941.FStar_TypeChecker_Env.uvar_subtyping);
+                           (uu___3745_26921.FStar_TypeChecker_Env.uvar_subtyping);
                          FStar_TypeChecker_Env.tc_term =
-                           (uu___3745_26941.FStar_TypeChecker_Env.tc_term);
+                           (uu___3745_26921.FStar_TypeChecker_Env.tc_term);
                          FStar_TypeChecker_Env.type_of =
-                           (uu___3745_26941.FStar_TypeChecker_Env.type_of);
+                           (uu___3745_26921.FStar_TypeChecker_Env.type_of);
                          FStar_TypeChecker_Env.universe_of =
-                           (uu___3745_26941.FStar_TypeChecker_Env.universe_of);
+                           (uu___3745_26921.FStar_TypeChecker_Env.universe_of);
                          FStar_TypeChecker_Env.check_type_of =
-                           (uu___3745_26941.FStar_TypeChecker_Env.check_type_of);
+                           (uu___3745_26921.FStar_TypeChecker_Env.check_type_of);
                          FStar_TypeChecker_Env.use_bv_sorts =
-                           (uu___3745_26941.FStar_TypeChecker_Env.use_bv_sorts);
+                           (uu___3745_26921.FStar_TypeChecker_Env.use_bv_sorts);
                          FStar_TypeChecker_Env.qtbl_name_and_index =
-                           (uu___3745_26941.FStar_TypeChecker_Env.qtbl_name_and_index);
+                           (uu___3745_26921.FStar_TypeChecker_Env.qtbl_name_and_index);
                          FStar_TypeChecker_Env.normalized_eff_names =
-                           (uu___3745_26941.FStar_TypeChecker_Env.normalized_eff_names);
+                           (uu___3745_26921.FStar_TypeChecker_Env.normalized_eff_names);
                          FStar_TypeChecker_Env.fv_delta_depths =
-                           (uu___3745_26941.FStar_TypeChecker_Env.fv_delta_depths);
+                           (uu___3745_26921.FStar_TypeChecker_Env.fv_delta_depths);
                          FStar_TypeChecker_Env.proof_ns =
-                           (uu___3745_26941.FStar_TypeChecker_Env.proof_ns);
+                           (uu___3745_26921.FStar_TypeChecker_Env.proof_ns);
                          FStar_TypeChecker_Env.synth_hook =
-                           (uu___3745_26941.FStar_TypeChecker_Env.synth_hook);
+                           (uu___3745_26921.FStar_TypeChecker_Env.synth_hook);
                          FStar_TypeChecker_Env.try_solve_implicits_hook =
-                           (uu___3745_26941.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                           (uu___3745_26921.FStar_TypeChecker_Env.try_solve_implicits_hook);
                          FStar_TypeChecker_Env.splice =
-                           (uu___3745_26941.FStar_TypeChecker_Env.splice);
+                           (uu___3745_26921.FStar_TypeChecker_Env.splice);
                          FStar_TypeChecker_Env.mpreprocess =
-                           (uu___3745_26941.FStar_TypeChecker_Env.mpreprocess);
+                           (uu___3745_26921.FStar_TypeChecker_Env.mpreprocess);
                          FStar_TypeChecker_Env.postprocess =
-                           (uu___3745_26941.FStar_TypeChecker_Env.postprocess);
+                           (uu___3745_26921.FStar_TypeChecker_Env.postprocess);
                          FStar_TypeChecker_Env.identifier_info =
-                           (uu___3745_26941.FStar_TypeChecker_Env.identifier_info);
+                           (uu___3745_26921.FStar_TypeChecker_Env.identifier_info);
                          FStar_TypeChecker_Env.tc_hooks =
-                           (uu___3745_26941.FStar_TypeChecker_Env.tc_hooks);
+                           (uu___3745_26921.FStar_TypeChecker_Env.tc_hooks);
                          FStar_TypeChecker_Env.dsenv =
-                           (uu___3745_26941.FStar_TypeChecker_Env.dsenv);
+                           (uu___3745_26921.FStar_TypeChecker_Env.dsenv);
                          FStar_TypeChecker_Env.nbe =
-                           (uu___3745_26941.FStar_TypeChecker_Env.nbe);
+                           (uu___3745_26921.FStar_TypeChecker_Env.nbe);
                          FStar_TypeChecker_Env.strict_args_tab =
-                           (uu___3745_26941.FStar_TypeChecker_Env.strict_args_tab);
+                           (uu___3745_26921.FStar_TypeChecker_Env.strict_args_tab);
                          FStar_TypeChecker_Env.erasable_types_tab =
-                           (uu___3745_26941.FStar_TypeChecker_Env.erasable_types_tab);
+                           (uu___3745_26921.FStar_TypeChecker_Env.erasable_types_tab);
                          FStar_TypeChecker_Env.enable_defer_to_tac =
-                           (uu___3745_26941.FStar_TypeChecker_Env.enable_defer_to_tac)
+                           (uu___3745_26921.FStar_TypeChecker_Env.enable_defer_to_tac)
                        } in
                      let g = FStar_TypeChecker_Rel.teq env1 t1 t_u in
                      ((match g.FStar_TypeChecker_Common.guard_f with
                        | FStar_TypeChecker_Common.NonTrivial f ->
-                           let uu____26945 =
+                           let uu____26925 =
                              FStar_Syntax_Print.term_to_string t1 in
-                           level_of_type_fail env1 e uu____26945
-                       | uu____26946 ->
+                           level_of_type_fail env1 e uu____26925
+                       | uu____26926 ->
                            FStar_TypeChecker_Rel.force_trivial_guard env1 g);
                       u)) in
         aux true t
@@ -10589,60 +10589,60 @@ let rec (universe_of_aux :
   =
   fun env ->
     fun e ->
-      let uu____26961 =
-        let uu____26962 = FStar_Syntax_Subst.compress e in
-        uu____26962.FStar_Syntax_Syntax.n in
-      match uu____26961 with
-      | FStar_Syntax_Syntax.Tm_bvar uu____26965 -> failwith "Impossible"
+      let uu____26941 =
+        let uu____26942 = FStar_Syntax_Subst.compress e in
+        uu____26942.FStar_Syntax_Syntax.n in
+      match uu____26941 with
+      | FStar_Syntax_Syntax.Tm_bvar uu____26945 -> failwith "Impossible"
       | FStar_Syntax_Syntax.Tm_unknown -> failwith "Impossible"
-      | FStar_Syntax_Syntax.Tm_delayed uu____26966 -> failwith "Impossible"
-      | FStar_Syntax_Syntax.Tm_let uu____26981 ->
+      | FStar_Syntax_Syntax.Tm_delayed uu____26946 -> failwith "Impossible"
+      | FStar_Syntax_Syntax.Tm_let uu____26961 ->
           let e1 = FStar_TypeChecker_Normalize.normalize [] env e in
           universe_of_aux env e1
-      | FStar_Syntax_Syntax.Tm_abs (bs, t, uu____26997) ->
+      | FStar_Syntax_Syntax.Tm_abs (bs, t, uu____26977) ->
           level_of_type_fail env e "arrow type"
       | FStar_Syntax_Syntax.Tm_uvar (u, s) ->
           FStar_Syntax_Subst.subst' s u.FStar_Syntax_Syntax.ctx_uvar_typ
-      | FStar_Syntax_Syntax.Tm_meta (t, uu____27041) -> universe_of_aux env t
+      | FStar_Syntax_Syntax.Tm_meta (t, uu____27021) -> universe_of_aux env t
       | FStar_Syntax_Syntax.Tm_name n -> n.FStar_Syntax_Syntax.sort
       | FStar_Syntax_Syntax.Tm_fvar fv ->
-          let uu____27048 =
+          let uu____27028 =
             FStar_TypeChecker_Env.lookup_lid env
               (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-          (match uu____27048 with | ((uu____27057, t), uu____27059) -> t)
+          (match uu____27028 with | ((uu____27037, t), uu____27039) -> t)
       | FStar_Syntax_Syntax.Tm_lazy i ->
-          let uu____27065 = FStar_Syntax_Util.unfold_lazy i in
-          universe_of_aux env uu____27065
+          let uu____27045 = FStar_Syntax_Util.unfold_lazy i in
+          universe_of_aux env uu____27045
       | FStar_Syntax_Syntax.Tm_ascribed
-          (uu____27068, (FStar_Util.Inl t, uu____27070), uu____27071) -> t
+          (uu____27048, (FStar_Util.Inl t, uu____27050), uu____27051) -> t
       | FStar_Syntax_Syntax.Tm_ascribed
-          (uu____27118, (FStar_Util.Inr c, uu____27120), uu____27121) ->
+          (uu____27098, (FStar_Util.Inr c, uu____27100), uu____27101) ->
           FStar_Syntax_Util.comp_result c
       | FStar_Syntax_Syntax.Tm_type u ->
           FStar_Syntax_Syntax.mk
             (FStar_Syntax_Syntax.Tm_type (FStar_Syntax_Syntax.U_succ u))
             e.FStar_Syntax_Syntax.pos
-      | FStar_Syntax_Syntax.Tm_quoted uu____27169 -> FStar_Syntax_Util.ktype0
+      | FStar_Syntax_Syntax.Tm_quoted uu____27149 -> FStar_Syntax_Util.ktype0
       | FStar_Syntax_Syntax.Tm_constant sc ->
           tc_constant env e.FStar_Syntax_Syntax.pos sc
       | FStar_Syntax_Syntax.Tm_uinst
           ({ FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar fv;
-             FStar_Syntax_Syntax.pos = uu____27178;
-             FStar_Syntax_Syntax.vars = uu____27179;_},
+             FStar_Syntax_Syntax.pos = uu____27158;
+             FStar_Syntax_Syntax.vars = uu____27159;_},
            us)
           ->
-          let uu____27185 =
+          let uu____27165 =
             FStar_TypeChecker_Env.lookup_lid env
               (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-          (match uu____27185 with
-           | ((us', t), uu____27196) ->
+          (match uu____27165 with
+           | ((us', t), uu____27176) ->
                (if (FStar_List.length us) <> (FStar_List.length us')
                 then
-                  (let uu____27202 = FStar_TypeChecker_Env.get_range env in
+                  (let uu____27182 = FStar_TypeChecker_Env.get_range env in
                    FStar_Errors.raise_error
                      (FStar_Errors.Fatal_UnexpectedNumberOfUniverse,
                        "Unexpected number of universe instantiations")
-                     uu____27202)
+                     uu____27182)
                 else
                   FStar_List.iter2
                     (fun u' ->
@@ -10650,29 +10650,29 @@ let rec (universe_of_aux :
                          match u' with
                          | FStar_Syntax_Syntax.U_unif u'' ->
                              FStar_Syntax_Unionfind.univ_change u'' u
-                         | uu____27220 -> failwith "Impossible") us' us;
+                         | uu____27200 -> failwith "Impossible") us' us;
                 t))
-      | FStar_Syntax_Syntax.Tm_uinst uu____27221 ->
+      | FStar_Syntax_Syntax.Tm_uinst uu____27201 ->
           failwith "Impossible: Tm_uinst's head must be an fvar"
-      | FStar_Syntax_Syntax.Tm_refine (x, uu____27229) ->
+      | FStar_Syntax_Syntax.Tm_refine (x, uu____27209) ->
           universe_of_aux env x.FStar_Syntax_Syntax.sort
       | FStar_Syntax_Syntax.Tm_arrow (bs, c) ->
-          let uu____27256 = FStar_Syntax_Subst.open_comp bs c in
-          (match uu____27256 with
+          let uu____27236 = FStar_Syntax_Subst.open_comp bs c in
+          (match uu____27236 with
            | (bs1, c1) ->
                let us =
                  FStar_List.map
-                   (fun uu____27276 ->
-                      match uu____27276 with
-                      | (b, uu____27284) ->
-                          let uu____27289 =
+                   (fun uu____27256 ->
+                      match uu____27256 with
+                      | (b, uu____27264) ->
+                          let uu____27269 =
                             universe_of_aux env b.FStar_Syntax_Syntax.sort in
                           level_of_type env b.FStar_Syntax_Syntax.sort
-                            uu____27289) bs1 in
+                            uu____27269) bs1 in
                let u_res =
                  let res = FStar_Syntax_Util.comp_result c1 in
-                 let uu____27294 = universe_of_aux env res in
-                 level_of_type env res uu____27294 in
+                 let uu____27274 = universe_of_aux env res in
+                 level_of_type env res uu____27274 in
                let u_c =
                  FStar_All.pipe_right c1
                    (FStar_TypeChecker_Util.universe_of_comp env u_res) in
@@ -10686,195 +10686,195 @@ let rec (universe_of_aux :
             let hd2 = FStar_Syntax_Subst.compress hd1 in
             match hd2.FStar_Syntax_Syntax.n with
             | FStar_Syntax_Syntax.Tm_unknown -> failwith "Impossible"
-            | FStar_Syntax_Syntax.Tm_bvar uu____27402 ->
+            | FStar_Syntax_Syntax.Tm_bvar uu____27382 ->
                 failwith "Impossible"
-            | FStar_Syntax_Syntax.Tm_delayed uu____27417 ->
+            | FStar_Syntax_Syntax.Tm_delayed uu____27397 ->
                 failwith "Impossible"
-            | FStar_Syntax_Syntax.Tm_fvar uu____27446 ->
-                let uu____27447 = universe_of_aux env hd2 in
-                (uu____27447, args1)
-            | FStar_Syntax_Syntax.Tm_name uu____27458 ->
-                let uu____27459 = universe_of_aux env hd2 in
-                (uu____27459, args1)
-            | FStar_Syntax_Syntax.Tm_uvar uu____27470 ->
-                let uu____27483 = universe_of_aux env hd2 in
-                (uu____27483, args1)
-            | FStar_Syntax_Syntax.Tm_uinst uu____27494 ->
-                let uu____27501 = universe_of_aux env hd2 in
-                (uu____27501, args1)
-            | FStar_Syntax_Syntax.Tm_ascribed uu____27512 ->
-                let uu____27539 = universe_of_aux env hd2 in
-                (uu____27539, args1)
-            | FStar_Syntax_Syntax.Tm_refine uu____27550 ->
-                let uu____27557 = universe_of_aux env hd2 in
-                (uu____27557, args1)
-            | FStar_Syntax_Syntax.Tm_constant uu____27568 ->
-                let uu____27569 = universe_of_aux env hd2 in
-                (uu____27569, args1)
-            | FStar_Syntax_Syntax.Tm_arrow uu____27580 ->
-                let uu____27595 = universe_of_aux env hd2 in
-                (uu____27595, args1)
-            | FStar_Syntax_Syntax.Tm_meta uu____27606 ->
-                let uu____27613 = universe_of_aux env hd2 in
-                (uu____27613, args1)
-            | FStar_Syntax_Syntax.Tm_type uu____27624 ->
-                let uu____27625 = universe_of_aux env hd2 in
-                (uu____27625, args1)
-            | FStar_Syntax_Syntax.Tm_match (uu____27636, hd3::uu____27638) ->
-                let uu____27703 = FStar_Syntax_Subst.open_branch hd3 in
-                (match uu____27703 with
-                 | (uu____27718, uu____27719, hd4) ->
-                     let uu____27737 = FStar_Syntax_Util.head_and_args hd4 in
-                     (match uu____27737 with
+            | FStar_Syntax_Syntax.Tm_fvar uu____27426 ->
+                let uu____27427 = universe_of_aux env hd2 in
+                (uu____27427, args1)
+            | FStar_Syntax_Syntax.Tm_name uu____27438 ->
+                let uu____27439 = universe_of_aux env hd2 in
+                (uu____27439, args1)
+            | FStar_Syntax_Syntax.Tm_uvar uu____27450 ->
+                let uu____27463 = universe_of_aux env hd2 in
+                (uu____27463, args1)
+            | FStar_Syntax_Syntax.Tm_uinst uu____27474 ->
+                let uu____27481 = universe_of_aux env hd2 in
+                (uu____27481, args1)
+            | FStar_Syntax_Syntax.Tm_ascribed uu____27492 ->
+                let uu____27519 = universe_of_aux env hd2 in
+                (uu____27519, args1)
+            | FStar_Syntax_Syntax.Tm_refine uu____27530 ->
+                let uu____27537 = universe_of_aux env hd2 in
+                (uu____27537, args1)
+            | FStar_Syntax_Syntax.Tm_constant uu____27548 ->
+                let uu____27549 = universe_of_aux env hd2 in
+                (uu____27549, args1)
+            | FStar_Syntax_Syntax.Tm_arrow uu____27560 ->
+                let uu____27575 = universe_of_aux env hd2 in
+                (uu____27575, args1)
+            | FStar_Syntax_Syntax.Tm_meta uu____27586 ->
+                let uu____27593 = universe_of_aux env hd2 in
+                (uu____27593, args1)
+            | FStar_Syntax_Syntax.Tm_type uu____27604 ->
+                let uu____27605 = universe_of_aux env hd2 in
+                (uu____27605, args1)
+            | FStar_Syntax_Syntax.Tm_match (uu____27616, hd3::uu____27618) ->
+                let uu____27683 = FStar_Syntax_Subst.open_branch hd3 in
+                (match uu____27683 with
+                 | (uu____27698, uu____27699, hd4) ->
+                     let uu____27717 = FStar_Syntax_Util.head_and_args hd4 in
+                     (match uu____27717 with
                       | (hd5, args') ->
                           type_of_head retry hd5
                             (FStar_List.append args' args1)))
-            | uu____27802 when retry ->
+            | uu____27782 when retry ->
                 let e1 =
                   FStar_TypeChecker_Normalize.normalize
                     [FStar_TypeChecker_Env.Beta;
                     FStar_TypeChecker_Env.DoNotUnfoldPureLets] env e in
-                let uu____27804 = FStar_Syntax_Util.head_and_args e1 in
-                (match uu____27804 with
+                let uu____27784 = FStar_Syntax_Util.head_and_args e1 in
+                (match uu____27784 with
                  | (hd3, args2) -> type_of_head false hd3 args2)
-            | uu____27861 ->
-                let uu____27862 =
+            | uu____27841 ->
+                let uu____27842 =
                   FStar_TypeChecker_Env.clear_expected_typ env in
-                (match uu____27862 with
-                 | (env1, uu____27884) ->
+                (match uu____27842 with
+                 | (env1, uu____27864) ->
                      let env2 =
-                       let uu___3906_27890 = env1 in
+                       let uu___3906_27870 = env1 in
                        {
                          FStar_TypeChecker_Env.solver =
-                           (uu___3906_27890.FStar_TypeChecker_Env.solver);
+                           (uu___3906_27870.FStar_TypeChecker_Env.solver);
                          FStar_TypeChecker_Env.range =
-                           (uu___3906_27890.FStar_TypeChecker_Env.range);
+                           (uu___3906_27870.FStar_TypeChecker_Env.range);
                          FStar_TypeChecker_Env.curmodule =
-                           (uu___3906_27890.FStar_TypeChecker_Env.curmodule);
+                           (uu___3906_27870.FStar_TypeChecker_Env.curmodule);
                          FStar_TypeChecker_Env.gamma =
-                           (uu___3906_27890.FStar_TypeChecker_Env.gamma);
+                           (uu___3906_27870.FStar_TypeChecker_Env.gamma);
                          FStar_TypeChecker_Env.gamma_sig =
-                           (uu___3906_27890.FStar_TypeChecker_Env.gamma_sig);
+                           (uu___3906_27870.FStar_TypeChecker_Env.gamma_sig);
                          FStar_TypeChecker_Env.gamma_cache =
-                           (uu___3906_27890.FStar_TypeChecker_Env.gamma_cache);
+                           (uu___3906_27870.FStar_TypeChecker_Env.gamma_cache);
                          FStar_TypeChecker_Env.modules =
-                           (uu___3906_27890.FStar_TypeChecker_Env.modules);
+                           (uu___3906_27870.FStar_TypeChecker_Env.modules);
                          FStar_TypeChecker_Env.expected_typ =
-                           (uu___3906_27890.FStar_TypeChecker_Env.expected_typ);
+                           (uu___3906_27870.FStar_TypeChecker_Env.expected_typ);
                          FStar_TypeChecker_Env.sigtab =
-                           (uu___3906_27890.FStar_TypeChecker_Env.sigtab);
+                           (uu___3906_27870.FStar_TypeChecker_Env.sigtab);
                          FStar_TypeChecker_Env.attrtab =
-                           (uu___3906_27890.FStar_TypeChecker_Env.attrtab);
+                           (uu___3906_27870.FStar_TypeChecker_Env.attrtab);
                          FStar_TypeChecker_Env.instantiate_imp =
-                           (uu___3906_27890.FStar_TypeChecker_Env.instantiate_imp);
+                           (uu___3906_27870.FStar_TypeChecker_Env.instantiate_imp);
                          FStar_TypeChecker_Env.effects =
-                           (uu___3906_27890.FStar_TypeChecker_Env.effects);
+                           (uu___3906_27870.FStar_TypeChecker_Env.effects);
                          FStar_TypeChecker_Env.generalize =
-                           (uu___3906_27890.FStar_TypeChecker_Env.generalize);
+                           (uu___3906_27870.FStar_TypeChecker_Env.generalize);
                          FStar_TypeChecker_Env.letrecs =
-                           (uu___3906_27890.FStar_TypeChecker_Env.letrecs);
+                           (uu___3906_27870.FStar_TypeChecker_Env.letrecs);
                          FStar_TypeChecker_Env.top_level = false;
                          FStar_TypeChecker_Env.check_uvars =
-                           (uu___3906_27890.FStar_TypeChecker_Env.check_uvars);
+                           (uu___3906_27870.FStar_TypeChecker_Env.check_uvars);
                          FStar_TypeChecker_Env.use_eq =
-                           (uu___3906_27890.FStar_TypeChecker_Env.use_eq);
+                           (uu___3906_27870.FStar_TypeChecker_Env.use_eq);
                          FStar_TypeChecker_Env.use_eq_strict =
-                           (uu___3906_27890.FStar_TypeChecker_Env.use_eq_strict);
+                           (uu___3906_27870.FStar_TypeChecker_Env.use_eq_strict);
                          FStar_TypeChecker_Env.is_iface =
-                           (uu___3906_27890.FStar_TypeChecker_Env.is_iface);
+                           (uu___3906_27870.FStar_TypeChecker_Env.is_iface);
                          FStar_TypeChecker_Env.admit =
-                           (uu___3906_27890.FStar_TypeChecker_Env.admit);
+                           (uu___3906_27870.FStar_TypeChecker_Env.admit);
                          FStar_TypeChecker_Env.lax = true;
                          FStar_TypeChecker_Env.lax_universes =
-                           (uu___3906_27890.FStar_TypeChecker_Env.lax_universes);
+                           (uu___3906_27870.FStar_TypeChecker_Env.lax_universes);
                          FStar_TypeChecker_Env.phase1 =
-                           (uu___3906_27890.FStar_TypeChecker_Env.phase1);
+                           (uu___3906_27870.FStar_TypeChecker_Env.phase1);
                          FStar_TypeChecker_Env.failhard =
-                           (uu___3906_27890.FStar_TypeChecker_Env.failhard);
+                           (uu___3906_27870.FStar_TypeChecker_Env.failhard);
                          FStar_TypeChecker_Env.nosynth =
-                           (uu___3906_27890.FStar_TypeChecker_Env.nosynth);
+                           (uu___3906_27870.FStar_TypeChecker_Env.nosynth);
                          FStar_TypeChecker_Env.uvar_subtyping =
-                           (uu___3906_27890.FStar_TypeChecker_Env.uvar_subtyping);
+                           (uu___3906_27870.FStar_TypeChecker_Env.uvar_subtyping);
                          FStar_TypeChecker_Env.tc_term =
-                           (uu___3906_27890.FStar_TypeChecker_Env.tc_term);
+                           (uu___3906_27870.FStar_TypeChecker_Env.tc_term);
                          FStar_TypeChecker_Env.type_of =
-                           (uu___3906_27890.FStar_TypeChecker_Env.type_of);
+                           (uu___3906_27870.FStar_TypeChecker_Env.type_of);
                          FStar_TypeChecker_Env.universe_of =
-                           (uu___3906_27890.FStar_TypeChecker_Env.universe_of);
+                           (uu___3906_27870.FStar_TypeChecker_Env.universe_of);
                          FStar_TypeChecker_Env.check_type_of =
-                           (uu___3906_27890.FStar_TypeChecker_Env.check_type_of);
+                           (uu___3906_27870.FStar_TypeChecker_Env.check_type_of);
                          FStar_TypeChecker_Env.use_bv_sorts = true;
                          FStar_TypeChecker_Env.qtbl_name_and_index =
-                           (uu___3906_27890.FStar_TypeChecker_Env.qtbl_name_and_index);
+                           (uu___3906_27870.FStar_TypeChecker_Env.qtbl_name_and_index);
                          FStar_TypeChecker_Env.normalized_eff_names =
-                           (uu___3906_27890.FStar_TypeChecker_Env.normalized_eff_names);
+                           (uu___3906_27870.FStar_TypeChecker_Env.normalized_eff_names);
                          FStar_TypeChecker_Env.fv_delta_depths =
-                           (uu___3906_27890.FStar_TypeChecker_Env.fv_delta_depths);
+                           (uu___3906_27870.FStar_TypeChecker_Env.fv_delta_depths);
                          FStar_TypeChecker_Env.proof_ns =
-                           (uu___3906_27890.FStar_TypeChecker_Env.proof_ns);
+                           (uu___3906_27870.FStar_TypeChecker_Env.proof_ns);
                          FStar_TypeChecker_Env.synth_hook =
-                           (uu___3906_27890.FStar_TypeChecker_Env.synth_hook);
+                           (uu___3906_27870.FStar_TypeChecker_Env.synth_hook);
                          FStar_TypeChecker_Env.try_solve_implicits_hook =
-                           (uu___3906_27890.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                           (uu___3906_27870.FStar_TypeChecker_Env.try_solve_implicits_hook);
                          FStar_TypeChecker_Env.splice =
-                           (uu___3906_27890.FStar_TypeChecker_Env.splice);
+                           (uu___3906_27870.FStar_TypeChecker_Env.splice);
                          FStar_TypeChecker_Env.mpreprocess =
-                           (uu___3906_27890.FStar_TypeChecker_Env.mpreprocess);
+                           (uu___3906_27870.FStar_TypeChecker_Env.mpreprocess);
                          FStar_TypeChecker_Env.postprocess =
-                           (uu___3906_27890.FStar_TypeChecker_Env.postprocess);
+                           (uu___3906_27870.FStar_TypeChecker_Env.postprocess);
                          FStar_TypeChecker_Env.identifier_info =
-                           (uu___3906_27890.FStar_TypeChecker_Env.identifier_info);
+                           (uu___3906_27870.FStar_TypeChecker_Env.identifier_info);
                          FStar_TypeChecker_Env.tc_hooks =
-                           (uu___3906_27890.FStar_TypeChecker_Env.tc_hooks);
+                           (uu___3906_27870.FStar_TypeChecker_Env.tc_hooks);
                          FStar_TypeChecker_Env.dsenv =
-                           (uu___3906_27890.FStar_TypeChecker_Env.dsenv);
+                           (uu___3906_27870.FStar_TypeChecker_Env.dsenv);
                          FStar_TypeChecker_Env.nbe =
-                           (uu___3906_27890.FStar_TypeChecker_Env.nbe);
+                           (uu___3906_27870.FStar_TypeChecker_Env.nbe);
                          FStar_TypeChecker_Env.strict_args_tab =
-                           (uu___3906_27890.FStar_TypeChecker_Env.strict_args_tab);
+                           (uu___3906_27870.FStar_TypeChecker_Env.strict_args_tab);
                          FStar_TypeChecker_Env.erasable_types_tab =
-                           (uu___3906_27890.FStar_TypeChecker_Env.erasable_types_tab);
+                           (uu___3906_27870.FStar_TypeChecker_Env.erasable_types_tab);
                          FStar_TypeChecker_Env.enable_defer_to_tac =
-                           (uu___3906_27890.FStar_TypeChecker_Env.enable_defer_to_tac)
+                           (uu___3906_27870.FStar_TypeChecker_Env.enable_defer_to_tac)
                        } in
-                     ((let uu____27892 =
+                     ((let uu____27872 =
                          FStar_All.pipe_left
                            (FStar_TypeChecker_Env.debug env2)
                            (FStar_Options.Other "UniverseOf") in
-                       if uu____27892
+                       if uu____27872
                        then
-                         let uu____27893 =
-                           let uu____27894 =
+                         let uu____27873 =
+                           let uu____27874 =
                              FStar_TypeChecker_Env.get_range env2 in
-                           FStar_Range.string_of_range uu____27894 in
-                         let uu____27895 =
+                           FStar_Range.string_of_range uu____27874 in
+                         let uu____27875 =
                            FStar_Syntax_Print.term_to_string hd2 in
                          FStar_Util.print2 "%s: About to type-check %s\n"
-                           uu____27893 uu____27895
+                           uu____27873 uu____27875
                        else ());
-                      (let uu____27897 = tc_term env2 hd2 in
-                       match uu____27897 with
-                       | (uu____27918,
-                          { FStar_TypeChecker_Common.eff_name = uu____27919;
+                      (let uu____27877 = tc_term env2 hd2 in
+                       match uu____27877 with
+                       | (uu____27898,
+                          { FStar_TypeChecker_Common.eff_name = uu____27899;
                             FStar_TypeChecker_Common.res_typ = t;
-                            FStar_TypeChecker_Common.cflags = uu____27921;
-                            FStar_TypeChecker_Common.comp_thunk = uu____27922;_},
+                            FStar_TypeChecker_Common.cflags = uu____27901;
+                            FStar_TypeChecker_Common.comp_thunk = uu____27902;_},
                           g) ->
-                           ((let uu____27940 =
+                           ((let uu____27920 =
                                FStar_TypeChecker_Rel.solve_deferred_constraints
                                  env2 g in
-                             FStar_All.pipe_right uu____27940
-                               (fun uu____27941 -> ()));
+                             FStar_All.pipe_right uu____27920
+                               (fun uu____27921 -> ()));
                             (t, args1))))) in
-          let uu____27952 = type_of_head true hd args in
-          (match uu____27952 with
+          let uu____27932 = type_of_head true hd args in
+          (match uu____27932 with
            | (t, args1) ->
                let t1 =
                  FStar_TypeChecker_Normalize.normalize
                    [FStar_TypeChecker_Env.UnfoldUntil
                       FStar_Syntax_Syntax.delta_constant] env t in
-               let uu____27990 = FStar_Syntax_Util.arrow_formals_comp t1 in
-               (match uu____27990 with
+               let uu____27970 = FStar_Syntax_Util.arrow_formals_comp t1 in
+               (match uu____27970 with
                 | (bs, res) ->
                     let res1 = FStar_Syntax_Util.comp_result res in
                     if (FStar_List.length bs) = (FStar_List.length args1)
@@ -10882,14 +10882,14 @@ let rec (universe_of_aux :
                       let subst = FStar_Syntax_Util.subst_of_list bs args1 in
                       FStar_Syntax_Subst.subst subst res1
                     else
-                      (let uu____28016 =
+                      (let uu____27996 =
                          FStar_Syntax_Print.term_to_string res1 in
-                       level_of_type_fail env e uu____28016)))
-      | FStar_Syntax_Syntax.Tm_match (uu____28017, hd::uu____28019) ->
-          let uu____28084 = FStar_Syntax_Subst.open_branch hd in
-          (match uu____28084 with
-           | (uu____28085, uu____28086, hd1) -> universe_of_aux env hd1)
-      | FStar_Syntax_Syntax.Tm_match (uu____28104, []) ->
+                       level_of_type_fail env e uu____27996)))
+      | FStar_Syntax_Syntax.Tm_match (uu____27997, hd::uu____27999) ->
+          let uu____28064 = FStar_Syntax_Subst.open_branch hd in
+          (match uu____28064 with
+           | (uu____28065, uu____28066, hd1) -> universe_of_aux env hd1)
+      | FStar_Syntax_Syntax.Tm_match (uu____28084, []) ->
           level_of_type_fail env e "empty match cases"
 let (universe_of :
   FStar_TypeChecker_Env.env ->
@@ -10897,19 +10897,19 @@ let (universe_of :
   =
   fun env ->
     fun e ->
-      (let uu____28150 = FStar_TypeChecker_Env.debug env FStar_Options.High in
-       if uu____28150
+      (let uu____28130 = FStar_TypeChecker_Env.debug env FStar_Options.High in
+       if uu____28130
        then
-         let uu____28151 = FStar_Syntax_Print.term_to_string e in
-         FStar_Util.print1 "Calling universe_of_aux with %s\n" uu____28151
+         let uu____28131 = FStar_Syntax_Print.term_to_string e in
+         FStar_Util.print1 "Calling universe_of_aux with %s\n" uu____28131
        else ());
       (let r = universe_of_aux env e in
-       (let uu____28155 = FStar_TypeChecker_Env.debug env FStar_Options.High in
-        if uu____28155
+       (let uu____28135 = FStar_TypeChecker_Env.debug env FStar_Options.High in
+        if uu____28135
         then
-          let uu____28156 = FStar_Syntax_Print.term_to_string r in
+          let uu____28136 = FStar_Syntax_Print.term_to_string r in
           FStar_Util.print1 "Got result from universe_of_aux = %s\n"
-            uu____28156
+            uu____28136
         else ());
        level_of_type env e r)
 let (tc_tparams :
@@ -10920,8 +10920,8 @@ let (tc_tparams :
   =
   fun env0 ->
     fun tps ->
-      let uu____28180 = tc_binders env0 tps in
-      match uu____28180 with
+      let uu____28160 = tc_binders env0 tps in
+      match uu____28160 with
       | (tps1, env, g, us) ->
           (FStar_TypeChecker_Rel.force_trivial_guard env0 g; (tps1, env, us))
 let rec (type_of_well_typed_term :
@@ -10936,130 +10936,130 @@ let rec (type_of_well_typed_term :
           t.FStar_Syntax_Syntax.pos in
       let t1 = FStar_Syntax_Subst.compress t in
       match t1.FStar_Syntax_Syntax.n with
-      | FStar_Syntax_Syntax.Tm_delayed uu____28237 -> failwith "Impossible"
-      | FStar_Syntax_Syntax.Tm_bvar uu____28254 -> failwith "Impossible"
+      | FStar_Syntax_Syntax.Tm_delayed uu____28217 -> failwith "Impossible"
+      | FStar_Syntax_Syntax.Tm_bvar uu____28234 -> failwith "Impossible"
       | FStar_Syntax_Syntax.Tm_name x ->
           FStar_Pervasives_Native.Some (x.FStar_Syntax_Syntax.sort)
       | FStar_Syntax_Syntax.Tm_lazy i ->
-          let uu____28259 = FStar_Syntax_Util.unfold_lazy i in
-          type_of_well_typed_term env uu____28259
+          let uu____28239 = FStar_Syntax_Util.unfold_lazy i in
+          type_of_well_typed_term env uu____28239
       | FStar_Syntax_Syntax.Tm_fvar fv ->
-          let uu____28261 =
+          let uu____28241 =
             FStar_TypeChecker_Env.try_lookup_and_inst_lid env []
               (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-          FStar_Util.bind_opt uu____28261
-            (fun uu____28275 ->
-               match uu____28275 with
-               | (t2, uu____28283) -> FStar_Pervasives_Native.Some t2)
+          FStar_Util.bind_opt uu____28241
+            (fun uu____28255 ->
+               match uu____28255 with
+               | (t2, uu____28263) -> FStar_Pervasives_Native.Some t2)
       | FStar_Syntax_Syntax.Tm_uinst
           ({ FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar fv;
-             FStar_Syntax_Syntax.pos = uu____28285;
-             FStar_Syntax_Syntax.vars = uu____28286;_},
+             FStar_Syntax_Syntax.pos = uu____28265;
+             FStar_Syntax_Syntax.vars = uu____28266;_},
            us)
           ->
-          let uu____28292 =
+          let uu____28272 =
             FStar_TypeChecker_Env.try_lookup_and_inst_lid env us
               (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-          FStar_Util.bind_opt uu____28292
-            (fun uu____28306 ->
-               match uu____28306 with
-               | (t2, uu____28314) -> FStar_Pervasives_Native.Some t2)
+          FStar_Util.bind_opt uu____28272
+            (fun uu____28286 ->
+               match uu____28286 with
+               | (t2, uu____28294) -> FStar_Pervasives_Native.Some t2)
       | FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_reify) ->
           FStar_Pervasives_Native.None
       | FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_reflect
-          uu____28315) -> FStar_Pervasives_Native.None
+          uu____28295) -> FStar_Pervasives_Native.None
       | FStar_Syntax_Syntax.Tm_constant sc ->
-          let uu____28317 = tc_constant env t1.FStar_Syntax_Syntax.pos sc in
-          FStar_Pervasives_Native.Some uu____28317
+          let uu____28297 = tc_constant env t1.FStar_Syntax_Syntax.pos sc in
+          FStar_Pervasives_Native.Some uu____28297
       | FStar_Syntax_Syntax.Tm_type u ->
-          let uu____28319 = mk_tm_type (FStar_Syntax_Syntax.U_succ u) in
-          FStar_Pervasives_Native.Some uu____28319
+          let uu____28299 = mk_tm_type (FStar_Syntax_Syntax.U_succ u) in
+          FStar_Pervasives_Native.Some uu____28299
       | FStar_Syntax_Syntax.Tm_abs
           (bs, body, FStar_Pervasives_Native.Some
            { FStar_Syntax_Syntax.residual_effect = eff;
              FStar_Syntax_Syntax.residual_typ = FStar_Pervasives_Native.Some
                tbody;
-             FStar_Syntax_Syntax.residual_flags = uu____28324;_})
+             FStar_Syntax_Syntax.residual_flags = uu____28304;_})
           ->
           let mk_comp =
-            let uu____28368 =
+            let uu____28348 =
               FStar_Ident.lid_equals eff FStar_Parser_Const.effect_Tot_lid in
-            if uu____28368
+            if uu____28348
             then FStar_Pervasives_Native.Some FStar_Syntax_Syntax.mk_Total'
             else
-              (let uu____28396 =
+              (let uu____28376 =
                  FStar_Ident.lid_equals eff
                    FStar_Parser_Const.effect_GTot_lid in
-               if uu____28396
+               if uu____28376
                then
                  FStar_Pervasives_Native.Some FStar_Syntax_Syntax.mk_GTotal'
                else FStar_Pervasives_Native.None) in
           FStar_Util.bind_opt mk_comp
             (fun f ->
-               let uu____28463 = universe_of_well_typed_term env tbody in
-               FStar_Util.bind_opt uu____28463
+               let uu____28443 = universe_of_well_typed_term env tbody in
+               FStar_Util.bind_opt uu____28443
                  (fun u ->
-                    let uu____28471 =
-                      let uu____28474 =
-                        let uu____28475 =
-                          let uu____28490 =
+                    let uu____28451 =
+                      let uu____28454 =
+                        let uu____28455 =
+                          let uu____28470 =
                             f tbody (FStar_Pervasives_Native.Some u) in
-                          (bs, uu____28490) in
-                        FStar_Syntax_Syntax.Tm_arrow uu____28475 in
-                      FStar_Syntax_Syntax.mk uu____28474
+                          (bs, uu____28470) in
+                        FStar_Syntax_Syntax.Tm_arrow uu____28455 in
+                      FStar_Syntax_Syntax.mk uu____28454
                         t1.FStar_Syntax_Syntax.pos in
-                    FStar_Pervasives_Native.Some uu____28471))
+                    FStar_Pervasives_Native.Some uu____28451))
       | FStar_Syntax_Syntax.Tm_arrow (bs, c) ->
-          let uu____28527 = FStar_Syntax_Subst.open_comp bs c in
-          (match uu____28527 with
+          let uu____28507 = FStar_Syntax_Subst.open_comp bs c in
+          (match uu____28507 with
            | (bs1, c1) ->
                let rec aux env1 us bs2 =
                  match bs2 with
                  | [] ->
-                     let uu____28586 =
+                     let uu____28566 =
                        universe_of_well_typed_term env1
                          (FStar_Syntax_Util.comp_result c1) in
-                     FStar_Util.bind_opt uu____28586
+                     FStar_Util.bind_opt uu____28566
                        (fun uc ->
-                          let uu____28594 =
+                          let uu____28574 =
                             mk_tm_type (FStar_Syntax_Syntax.U_max (uc :: us)) in
-                          FStar_Pervasives_Native.Some uu____28594)
+                          FStar_Pervasives_Native.Some uu____28574)
                  | (x, imp)::bs3 ->
-                     let uu____28620 =
+                     let uu____28600 =
                        universe_of_well_typed_term env1
                          x.FStar_Syntax_Syntax.sort in
-                     FStar_Util.bind_opt uu____28620
+                     FStar_Util.bind_opt uu____28600
                        (fun u_x ->
                           let env2 = FStar_TypeChecker_Env.push_bv env1 x in
                           aux env2 (u_x :: us) bs3) in
                aux env [] bs1)
-      | FStar_Syntax_Syntax.Tm_abs uu____28629 ->
+      | FStar_Syntax_Syntax.Tm_abs uu____28609 ->
           FStar_Pervasives_Native.None
-      | FStar_Syntax_Syntax.Tm_refine (x, uu____28649) ->
-          let uu____28654 =
+      | FStar_Syntax_Syntax.Tm_refine (x, uu____28629) ->
+          let uu____28634 =
             universe_of_well_typed_term env x.FStar_Syntax_Syntax.sort in
-          FStar_Util.bind_opt uu____28654
+          FStar_Util.bind_opt uu____28634
             (fun u_x ->
-               let uu____28662 = mk_tm_type u_x in
-               FStar_Pervasives_Native.Some uu____28662)
+               let uu____28642 = mk_tm_type u_x in
+               FStar_Pervasives_Native.Some uu____28642)
       | FStar_Syntax_Syntax.Tm_app
           ({
              FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
                (FStar_Const.Const_range_of);
-             FStar_Syntax_Syntax.pos = uu____28667;
-             FStar_Syntax_Syntax.vars = uu____28668;_},
+             FStar_Syntax_Syntax.pos = uu____28647;
+             FStar_Syntax_Syntax.vars = uu____28648;_},
            a::hd::rest)
           ->
           let rest1 = hd :: rest in
-          let uu____28747 = FStar_Syntax_Util.head_and_args t1 in
-          (match uu____28747 with
-           | (unary_op, uu____28767) ->
+          let uu____28727 = FStar_Syntax_Util.head_and_args t1 in
+          (match uu____28727 with
+           | (unary_op, uu____28747) ->
                let head =
-                 let uu____28795 =
+                 let uu____28775 =
                    FStar_Range.union_ranges unary_op.FStar_Syntax_Syntax.pos
                      (FStar_Pervasives_Native.fst a).FStar_Syntax_Syntax.pos in
                  FStar_Syntax_Syntax.mk
-                   (FStar_Syntax_Syntax.Tm_app (unary_op, [a])) uu____28795 in
+                   (FStar_Syntax_Syntax.Tm_app (unary_op, [a])) uu____28775 in
                let t2 =
                  FStar_Syntax_Syntax.mk
                    (FStar_Syntax_Syntax.Tm_app (head, rest1))
@@ -11069,21 +11069,21 @@ let rec (type_of_well_typed_term :
           ({
              FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
                (FStar_Const.Const_set_range_of);
-             FStar_Syntax_Syntax.pos = uu____28843;
-             FStar_Syntax_Syntax.vars = uu____28844;_},
+             FStar_Syntax_Syntax.pos = uu____28823;
+             FStar_Syntax_Syntax.vars = uu____28824;_},
            a1::a2::hd::rest)
           ->
           let rest1 = hd :: rest in
-          let uu____28940 = FStar_Syntax_Util.head_and_args t1 in
-          (match uu____28940 with
-           | (unary_op, uu____28960) ->
+          let uu____28920 = FStar_Syntax_Util.head_and_args t1 in
+          (match uu____28920 with
+           | (unary_op, uu____28940) ->
                let head =
-                 let uu____28988 =
+                 let uu____28968 =
                    FStar_Range.union_ranges unary_op.FStar_Syntax_Syntax.pos
                      (FStar_Pervasives_Native.fst a1).FStar_Syntax_Syntax.pos in
                  FStar_Syntax_Syntax.mk
                    (FStar_Syntax_Syntax.Tm_app (unary_op, [a1; a2]))
-                   uu____28988 in
+                   uu____28968 in
                let t2 =
                  FStar_Syntax_Syntax.mk
                    (FStar_Syntax_Syntax.Tm_app (head, rest1))
@@ -11093,63 +11093,63 @@ let rec (type_of_well_typed_term :
           ({
              FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
                (FStar_Const.Const_range_of);
-             FStar_Syntax_Syntax.pos = uu____29044;
-             FStar_Syntax_Syntax.vars = uu____29045;_},
-           uu____29046::[])
+             FStar_Syntax_Syntax.pos = uu____29024;
+             FStar_Syntax_Syntax.vars = uu____29025;_},
+           uu____29026::[])
           -> FStar_Pervasives_Native.Some FStar_Syntax_Syntax.t_range
       | FStar_Syntax_Syntax.Tm_app
           ({
              FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
                (FStar_Const.Const_set_range_of);
-             FStar_Syntax_Syntax.pos = uu____29085;
-             FStar_Syntax_Syntax.vars = uu____29086;_},
-           (t2, uu____29088)::uu____29089::[])
+             FStar_Syntax_Syntax.pos = uu____29065;
+             FStar_Syntax_Syntax.vars = uu____29066;_},
+           (t2, uu____29068)::uu____29069::[])
           -> type_of_well_typed_term env t2
       | FStar_Syntax_Syntax.Tm_app (hd, args) ->
           let t_hd = type_of_well_typed_term env hd in
           let rec aux t_hd1 =
-            let uu____29185 =
-              let uu____29186 =
+            let uu____29165 =
+              let uu____29166 =
                 FStar_TypeChecker_Normalize.unfold_whnf env t_hd1 in
-              uu____29186.FStar_Syntax_Syntax.n in
-            match uu____29185 with
+              uu____29166.FStar_Syntax_Syntax.n in
+            match uu____29165 with
             | FStar_Syntax_Syntax.Tm_arrow (bs, c) ->
                 let n_args = FStar_List.length args in
                 let n_bs = FStar_List.length bs in
                 let bs_t_opt =
                   if n_args < n_bs
                   then
-                    let uu____29258 = FStar_Util.first_N n_args bs in
-                    match uu____29258 with
+                    let uu____29238 = FStar_Util.first_N n_args bs in
+                    match uu____29238 with
                     | (bs1, rest) ->
                         let t2 =
                           FStar_Syntax_Syntax.mk
                             (FStar_Syntax_Syntax.Tm_arrow (rest, c))
                             t_hd1.FStar_Syntax_Syntax.pos in
-                        let uu____29346 =
-                          let uu____29351 = FStar_Syntax_Syntax.mk_Total t2 in
-                          FStar_Syntax_Subst.open_comp bs1 uu____29351 in
-                        (match uu____29346 with
+                        let uu____29326 =
+                          let uu____29331 = FStar_Syntax_Syntax.mk_Total t2 in
+                          FStar_Syntax_Subst.open_comp bs1 uu____29331 in
+                        (match uu____29326 with
                          | (bs2, c1) ->
                              FStar_Pervasives_Native.Some
                                (bs2, (FStar_Syntax_Util.comp_result c1)))
                   else
                     if n_args = n_bs
                     then
-                      (let uu____29403 = FStar_Syntax_Subst.open_comp bs c in
-                       match uu____29403 with
+                      (let uu____29383 = FStar_Syntax_Subst.open_comp bs c in
+                       match uu____29383 with
                        | (bs1, c1) ->
-                           let uu____29424 =
+                           let uu____29404 =
                              FStar_Syntax_Util.is_tot_or_gtot_comp c1 in
-                           if uu____29424
+                           if uu____29404
                            then
                              FStar_Pervasives_Native.Some
                                (bs1, (FStar_Syntax_Util.comp_result c1))
                            else FStar_Pervasives_Native.None)
                     else FStar_Pervasives_Native.None in
                 FStar_Util.bind_opt bs_t_opt
-                  (fun uu____29502 ->
-                     match uu____29502 with
+                  (fun uu____29482 ->
+                     match uu____29482 with
                      | (bs1, t2) ->
                          let subst =
                            FStar_List.map2
@@ -11159,34 +11159,34 @@ let rec (type_of_well_typed_term :
                                     ((FStar_Pervasives_Native.fst b),
                                       (FStar_Pervasives_Native.fst a))) bs1
                              args in
-                         let uu____29578 = FStar_Syntax_Subst.subst subst t2 in
-                         FStar_Pervasives_Native.Some uu____29578)
-            | FStar_Syntax_Syntax.Tm_refine (x, uu____29580) ->
+                         let uu____29558 = FStar_Syntax_Subst.subst subst t2 in
+                         FStar_Pervasives_Native.Some uu____29558)
+            | FStar_Syntax_Syntax.Tm_refine (x, uu____29560) ->
                 aux x.FStar_Syntax_Syntax.sort
-            | FStar_Syntax_Syntax.Tm_ascribed (t2, uu____29586, uu____29587)
+            | FStar_Syntax_Syntax.Tm_ascribed (t2, uu____29566, uu____29567)
                 -> aux t2
-            | uu____29628 -> FStar_Pervasives_Native.None in
+            | uu____29608 -> FStar_Pervasives_Native.None in
           FStar_Util.bind_opt t_hd aux
       | FStar_Syntax_Syntax.Tm_ascribed
-          (uu____29629, (FStar_Util.Inl t2, uu____29631), uu____29632) ->
+          (uu____29609, (FStar_Util.Inl t2, uu____29611), uu____29612) ->
           FStar_Pervasives_Native.Some t2
       | FStar_Syntax_Syntax.Tm_ascribed
-          (uu____29679, (FStar_Util.Inr c, uu____29681), uu____29682) ->
+          (uu____29659, (FStar_Util.Inr c, uu____29661), uu____29662) ->
           FStar_Pervasives_Native.Some (FStar_Syntax_Util.comp_result c)
       | FStar_Syntax_Syntax.Tm_uvar (u, s) ->
-          let uu____29747 =
+          let uu____29727 =
             FStar_Syntax_Subst.subst' s u.FStar_Syntax_Syntax.ctx_uvar_typ in
-          FStar_Pervasives_Native.Some uu____29747
+          FStar_Pervasives_Native.Some uu____29727
       | FStar_Syntax_Syntax.Tm_quoted (tm, qi) ->
           FStar_Pervasives_Native.Some FStar_Syntax_Syntax.t_term
-      | FStar_Syntax_Syntax.Tm_meta (t2, uu____29755) ->
+      | FStar_Syntax_Syntax.Tm_meta (t2, uu____29735) ->
           type_of_well_typed_term env t2
-      | FStar_Syntax_Syntax.Tm_match uu____29760 ->
+      | FStar_Syntax_Syntax.Tm_match uu____29740 ->
           FStar_Pervasives_Native.None
-      | FStar_Syntax_Syntax.Tm_let uu____29783 ->
+      | FStar_Syntax_Syntax.Tm_let uu____29763 ->
           FStar_Pervasives_Native.None
       | FStar_Syntax_Syntax.Tm_unknown -> FStar_Pervasives_Native.None
-      | FStar_Syntax_Syntax.Tm_uinst uu____29796 ->
+      | FStar_Syntax_Syntax.Tm_uinst uu____29776 ->
           FStar_Pervasives_Native.None
 and (universe_of_well_typed_term :
   FStar_TypeChecker_Env.env ->
@@ -11195,14 +11195,14 @@ and (universe_of_well_typed_term :
   =
   fun env ->
     fun t ->
-      let uu____29807 = type_of_well_typed_term env t in
-      match uu____29807 with
+      let uu____29787 = type_of_well_typed_term env t in
+      match uu____29787 with
       | FStar_Pervasives_Native.Some
           { FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_type u;
-            FStar_Syntax_Syntax.pos = uu____29813;
-            FStar_Syntax_Syntax.vars = uu____29814;_}
+            FStar_Syntax_Syntax.pos = uu____29793;
+            FStar_Syntax_Syntax.vars = uu____29794;_}
           -> FStar_Pervasives_Native.Some u
-      | uu____29817 -> FStar_Pervasives_Native.None
+      | uu____29797 -> FStar_Pervasives_Native.None
 let (check_type_of_well_typed_term' :
   Prims.bool ->
     FStar_TypeChecker_Env.env ->
@@ -11215,143 +11215,143 @@ let (check_type_of_well_typed_term' :
         fun k ->
           let env1 = FStar_TypeChecker_Env.set_expected_typ env k in
           let env2 =
-            let uu___4190_29842 = env1 in
+            let uu___4190_29822 = env1 in
             {
               FStar_TypeChecker_Env.solver =
-                (uu___4190_29842.FStar_TypeChecker_Env.solver);
+                (uu___4190_29822.FStar_TypeChecker_Env.solver);
               FStar_TypeChecker_Env.range =
-                (uu___4190_29842.FStar_TypeChecker_Env.range);
+                (uu___4190_29822.FStar_TypeChecker_Env.range);
               FStar_TypeChecker_Env.curmodule =
-                (uu___4190_29842.FStar_TypeChecker_Env.curmodule);
+                (uu___4190_29822.FStar_TypeChecker_Env.curmodule);
               FStar_TypeChecker_Env.gamma =
-                (uu___4190_29842.FStar_TypeChecker_Env.gamma);
+                (uu___4190_29822.FStar_TypeChecker_Env.gamma);
               FStar_TypeChecker_Env.gamma_sig =
-                (uu___4190_29842.FStar_TypeChecker_Env.gamma_sig);
+                (uu___4190_29822.FStar_TypeChecker_Env.gamma_sig);
               FStar_TypeChecker_Env.gamma_cache =
-                (uu___4190_29842.FStar_TypeChecker_Env.gamma_cache);
+                (uu___4190_29822.FStar_TypeChecker_Env.gamma_cache);
               FStar_TypeChecker_Env.modules =
-                (uu___4190_29842.FStar_TypeChecker_Env.modules);
+                (uu___4190_29822.FStar_TypeChecker_Env.modules);
               FStar_TypeChecker_Env.expected_typ =
-                (uu___4190_29842.FStar_TypeChecker_Env.expected_typ);
+                (uu___4190_29822.FStar_TypeChecker_Env.expected_typ);
               FStar_TypeChecker_Env.sigtab =
-                (uu___4190_29842.FStar_TypeChecker_Env.sigtab);
+                (uu___4190_29822.FStar_TypeChecker_Env.sigtab);
               FStar_TypeChecker_Env.attrtab =
-                (uu___4190_29842.FStar_TypeChecker_Env.attrtab);
+                (uu___4190_29822.FStar_TypeChecker_Env.attrtab);
               FStar_TypeChecker_Env.instantiate_imp =
-                (uu___4190_29842.FStar_TypeChecker_Env.instantiate_imp);
+                (uu___4190_29822.FStar_TypeChecker_Env.instantiate_imp);
               FStar_TypeChecker_Env.effects =
-                (uu___4190_29842.FStar_TypeChecker_Env.effects);
+                (uu___4190_29822.FStar_TypeChecker_Env.effects);
               FStar_TypeChecker_Env.generalize =
-                (uu___4190_29842.FStar_TypeChecker_Env.generalize);
+                (uu___4190_29822.FStar_TypeChecker_Env.generalize);
               FStar_TypeChecker_Env.letrecs =
-                (uu___4190_29842.FStar_TypeChecker_Env.letrecs);
+                (uu___4190_29822.FStar_TypeChecker_Env.letrecs);
               FStar_TypeChecker_Env.top_level =
-                (uu___4190_29842.FStar_TypeChecker_Env.top_level);
+                (uu___4190_29822.FStar_TypeChecker_Env.top_level);
               FStar_TypeChecker_Env.check_uvars =
-                (uu___4190_29842.FStar_TypeChecker_Env.check_uvars);
+                (uu___4190_29822.FStar_TypeChecker_Env.check_uvars);
               FStar_TypeChecker_Env.use_eq =
-                (uu___4190_29842.FStar_TypeChecker_Env.use_eq);
+                (uu___4190_29822.FStar_TypeChecker_Env.use_eq);
               FStar_TypeChecker_Env.use_eq_strict =
-                (uu___4190_29842.FStar_TypeChecker_Env.use_eq_strict);
+                (uu___4190_29822.FStar_TypeChecker_Env.use_eq_strict);
               FStar_TypeChecker_Env.is_iface =
-                (uu___4190_29842.FStar_TypeChecker_Env.is_iface);
+                (uu___4190_29822.FStar_TypeChecker_Env.is_iface);
               FStar_TypeChecker_Env.admit =
-                (uu___4190_29842.FStar_TypeChecker_Env.admit);
+                (uu___4190_29822.FStar_TypeChecker_Env.admit);
               FStar_TypeChecker_Env.lax =
-                (uu___4190_29842.FStar_TypeChecker_Env.lax);
+                (uu___4190_29822.FStar_TypeChecker_Env.lax);
               FStar_TypeChecker_Env.lax_universes =
-                (uu___4190_29842.FStar_TypeChecker_Env.lax_universes);
+                (uu___4190_29822.FStar_TypeChecker_Env.lax_universes);
               FStar_TypeChecker_Env.phase1 =
-                (uu___4190_29842.FStar_TypeChecker_Env.phase1);
+                (uu___4190_29822.FStar_TypeChecker_Env.phase1);
               FStar_TypeChecker_Env.failhard =
-                (uu___4190_29842.FStar_TypeChecker_Env.failhard);
+                (uu___4190_29822.FStar_TypeChecker_Env.failhard);
               FStar_TypeChecker_Env.nosynth =
-                (uu___4190_29842.FStar_TypeChecker_Env.nosynth);
+                (uu___4190_29822.FStar_TypeChecker_Env.nosynth);
               FStar_TypeChecker_Env.uvar_subtyping =
-                (uu___4190_29842.FStar_TypeChecker_Env.uvar_subtyping);
+                (uu___4190_29822.FStar_TypeChecker_Env.uvar_subtyping);
               FStar_TypeChecker_Env.tc_term =
-                (uu___4190_29842.FStar_TypeChecker_Env.tc_term);
+                (uu___4190_29822.FStar_TypeChecker_Env.tc_term);
               FStar_TypeChecker_Env.type_of =
-                (uu___4190_29842.FStar_TypeChecker_Env.type_of);
+                (uu___4190_29822.FStar_TypeChecker_Env.type_of);
               FStar_TypeChecker_Env.universe_of =
-                (uu___4190_29842.FStar_TypeChecker_Env.universe_of);
+                (uu___4190_29822.FStar_TypeChecker_Env.universe_of);
               FStar_TypeChecker_Env.check_type_of =
-                (uu___4190_29842.FStar_TypeChecker_Env.check_type_of);
+                (uu___4190_29822.FStar_TypeChecker_Env.check_type_of);
               FStar_TypeChecker_Env.use_bv_sorts = true;
               FStar_TypeChecker_Env.qtbl_name_and_index =
-                (uu___4190_29842.FStar_TypeChecker_Env.qtbl_name_and_index);
+                (uu___4190_29822.FStar_TypeChecker_Env.qtbl_name_and_index);
               FStar_TypeChecker_Env.normalized_eff_names =
-                (uu___4190_29842.FStar_TypeChecker_Env.normalized_eff_names);
+                (uu___4190_29822.FStar_TypeChecker_Env.normalized_eff_names);
               FStar_TypeChecker_Env.fv_delta_depths =
-                (uu___4190_29842.FStar_TypeChecker_Env.fv_delta_depths);
+                (uu___4190_29822.FStar_TypeChecker_Env.fv_delta_depths);
               FStar_TypeChecker_Env.proof_ns =
-                (uu___4190_29842.FStar_TypeChecker_Env.proof_ns);
+                (uu___4190_29822.FStar_TypeChecker_Env.proof_ns);
               FStar_TypeChecker_Env.synth_hook =
-                (uu___4190_29842.FStar_TypeChecker_Env.synth_hook);
+                (uu___4190_29822.FStar_TypeChecker_Env.synth_hook);
               FStar_TypeChecker_Env.try_solve_implicits_hook =
-                (uu___4190_29842.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                (uu___4190_29822.FStar_TypeChecker_Env.try_solve_implicits_hook);
               FStar_TypeChecker_Env.splice =
-                (uu___4190_29842.FStar_TypeChecker_Env.splice);
+                (uu___4190_29822.FStar_TypeChecker_Env.splice);
               FStar_TypeChecker_Env.mpreprocess =
-                (uu___4190_29842.FStar_TypeChecker_Env.mpreprocess);
+                (uu___4190_29822.FStar_TypeChecker_Env.mpreprocess);
               FStar_TypeChecker_Env.postprocess =
-                (uu___4190_29842.FStar_TypeChecker_Env.postprocess);
+                (uu___4190_29822.FStar_TypeChecker_Env.postprocess);
               FStar_TypeChecker_Env.identifier_info =
-                (uu___4190_29842.FStar_TypeChecker_Env.identifier_info);
+                (uu___4190_29822.FStar_TypeChecker_Env.identifier_info);
               FStar_TypeChecker_Env.tc_hooks =
-                (uu___4190_29842.FStar_TypeChecker_Env.tc_hooks);
+                (uu___4190_29822.FStar_TypeChecker_Env.tc_hooks);
               FStar_TypeChecker_Env.dsenv =
-                (uu___4190_29842.FStar_TypeChecker_Env.dsenv);
+                (uu___4190_29822.FStar_TypeChecker_Env.dsenv);
               FStar_TypeChecker_Env.nbe =
-                (uu___4190_29842.FStar_TypeChecker_Env.nbe);
+                (uu___4190_29822.FStar_TypeChecker_Env.nbe);
               FStar_TypeChecker_Env.strict_args_tab =
-                (uu___4190_29842.FStar_TypeChecker_Env.strict_args_tab);
+                (uu___4190_29822.FStar_TypeChecker_Env.strict_args_tab);
               FStar_TypeChecker_Env.erasable_types_tab =
-                (uu___4190_29842.FStar_TypeChecker_Env.erasable_types_tab);
+                (uu___4190_29822.FStar_TypeChecker_Env.erasable_types_tab);
               FStar_TypeChecker_Env.enable_defer_to_tac =
-                (uu___4190_29842.FStar_TypeChecker_Env.enable_defer_to_tac)
+                (uu___4190_29822.FStar_TypeChecker_Env.enable_defer_to_tac)
             } in
-          let slow_check uu____29848 =
+          let slow_check uu____29828 =
             if must_total
             then
-              let uu____29849 = env2.FStar_TypeChecker_Env.type_of env2 t in
-              match uu____29849 with | (uu____29856, uu____29857, g) -> g
+              let uu____29829 = env2.FStar_TypeChecker_Env.type_of env2 t in
+              match uu____29829 with | (uu____29836, uu____29837, g) -> g
             else
-              (let uu____29860 = env2.FStar_TypeChecker_Env.tc_term env2 t in
-               match uu____29860 with | (uu____29867, uu____29868, g) -> g) in
-          let uu____29870 = type_of_well_typed_term env2 t in
-          match uu____29870 with
+              (let uu____29840 = env2.FStar_TypeChecker_Env.tc_term env2 t in
+               match uu____29840 with | (uu____29847, uu____29848, g) -> g) in
+          let uu____29850 = type_of_well_typed_term env2 t in
+          match uu____29850 with
           | FStar_Pervasives_Native.None -> slow_check ()
           | FStar_Pervasives_Native.Some k' ->
-              ((let uu____29875 =
+              ((let uu____29855 =
                   FStar_All.pipe_left (FStar_TypeChecker_Env.debug env2)
                     (FStar_Options.Other "FastImplicits") in
-                if uu____29875
+                if uu____29855
                 then
-                  let uu____29876 =
+                  let uu____29856 =
                     FStar_Range.string_of_range t.FStar_Syntax_Syntax.pos in
-                  let uu____29877 = FStar_Syntax_Print.term_to_string t in
-                  let uu____29878 = FStar_Syntax_Print.term_to_string k' in
-                  let uu____29879 = FStar_Syntax_Print.term_to_string k in
+                  let uu____29857 = FStar_Syntax_Print.term_to_string t in
+                  let uu____29858 = FStar_Syntax_Print.term_to_string k' in
+                  let uu____29859 = FStar_Syntax_Print.term_to_string k in
                   FStar_Util.print4 "(%s) Fast check  %s : %s <:? %s\n"
-                    uu____29876 uu____29877 uu____29878 uu____29879
+                    uu____29856 uu____29857 uu____29858 uu____29859
                 else ());
                (let g = FStar_TypeChecker_Rel.subtype_nosmt env2 k' k in
-                (let uu____29885 =
+                (let uu____29865 =
                    FStar_All.pipe_left (FStar_TypeChecker_Env.debug env2)
                      (FStar_Options.Other "FastImplicits") in
-                 if uu____29885
+                 if uu____29865
                  then
-                   let uu____29886 =
+                   let uu____29866 =
                      FStar_Range.string_of_range t.FStar_Syntax_Syntax.pos in
-                   let uu____29887 = FStar_Syntax_Print.term_to_string t in
-                   let uu____29888 = FStar_Syntax_Print.term_to_string k' in
-                   let uu____29889 = FStar_Syntax_Print.term_to_string k in
+                   let uu____29867 = FStar_Syntax_Print.term_to_string t in
+                   let uu____29868 = FStar_Syntax_Print.term_to_string k' in
+                   let uu____29869 = FStar_Syntax_Print.term_to_string k in
                    FStar_Util.print5 "(%s) Fast check %s: %s : %s <: %s\n"
-                     uu____29886
+                     uu____29866
                      (if FStar_Option.isSome g
                       then "succeeded with guard"
-                      else "failed") uu____29887 uu____29888 uu____29889
+                      else "failed") uu____29867 uu____29868 uu____29869
                  else ());
                 (match g with
                  | FStar_Pervasives_Native.None -> slow_check ()
@@ -11368,113 +11368,113 @@ let (check_type_of_well_typed_term :
         fun k ->
           let env1 = FStar_TypeChecker_Env.set_expected_typ env k in
           let env2 =
-            let uu___4221_29915 = env1 in
+            let uu___4221_29895 = env1 in
             {
               FStar_TypeChecker_Env.solver =
-                (uu___4221_29915.FStar_TypeChecker_Env.solver);
+                (uu___4221_29895.FStar_TypeChecker_Env.solver);
               FStar_TypeChecker_Env.range =
-                (uu___4221_29915.FStar_TypeChecker_Env.range);
+                (uu___4221_29895.FStar_TypeChecker_Env.range);
               FStar_TypeChecker_Env.curmodule =
-                (uu___4221_29915.FStar_TypeChecker_Env.curmodule);
+                (uu___4221_29895.FStar_TypeChecker_Env.curmodule);
               FStar_TypeChecker_Env.gamma =
-                (uu___4221_29915.FStar_TypeChecker_Env.gamma);
+                (uu___4221_29895.FStar_TypeChecker_Env.gamma);
               FStar_TypeChecker_Env.gamma_sig =
-                (uu___4221_29915.FStar_TypeChecker_Env.gamma_sig);
+                (uu___4221_29895.FStar_TypeChecker_Env.gamma_sig);
               FStar_TypeChecker_Env.gamma_cache =
-                (uu___4221_29915.FStar_TypeChecker_Env.gamma_cache);
+                (uu___4221_29895.FStar_TypeChecker_Env.gamma_cache);
               FStar_TypeChecker_Env.modules =
-                (uu___4221_29915.FStar_TypeChecker_Env.modules);
+                (uu___4221_29895.FStar_TypeChecker_Env.modules);
               FStar_TypeChecker_Env.expected_typ =
-                (uu___4221_29915.FStar_TypeChecker_Env.expected_typ);
+                (uu___4221_29895.FStar_TypeChecker_Env.expected_typ);
               FStar_TypeChecker_Env.sigtab =
-                (uu___4221_29915.FStar_TypeChecker_Env.sigtab);
+                (uu___4221_29895.FStar_TypeChecker_Env.sigtab);
               FStar_TypeChecker_Env.attrtab =
-                (uu___4221_29915.FStar_TypeChecker_Env.attrtab);
+                (uu___4221_29895.FStar_TypeChecker_Env.attrtab);
               FStar_TypeChecker_Env.instantiate_imp =
-                (uu___4221_29915.FStar_TypeChecker_Env.instantiate_imp);
+                (uu___4221_29895.FStar_TypeChecker_Env.instantiate_imp);
               FStar_TypeChecker_Env.effects =
-                (uu___4221_29915.FStar_TypeChecker_Env.effects);
+                (uu___4221_29895.FStar_TypeChecker_Env.effects);
               FStar_TypeChecker_Env.generalize =
-                (uu___4221_29915.FStar_TypeChecker_Env.generalize);
+                (uu___4221_29895.FStar_TypeChecker_Env.generalize);
               FStar_TypeChecker_Env.letrecs =
-                (uu___4221_29915.FStar_TypeChecker_Env.letrecs);
+                (uu___4221_29895.FStar_TypeChecker_Env.letrecs);
               FStar_TypeChecker_Env.top_level =
-                (uu___4221_29915.FStar_TypeChecker_Env.top_level);
+                (uu___4221_29895.FStar_TypeChecker_Env.top_level);
               FStar_TypeChecker_Env.check_uvars =
-                (uu___4221_29915.FStar_TypeChecker_Env.check_uvars);
+                (uu___4221_29895.FStar_TypeChecker_Env.check_uvars);
               FStar_TypeChecker_Env.use_eq =
-                (uu___4221_29915.FStar_TypeChecker_Env.use_eq);
+                (uu___4221_29895.FStar_TypeChecker_Env.use_eq);
               FStar_TypeChecker_Env.use_eq_strict =
-                (uu___4221_29915.FStar_TypeChecker_Env.use_eq_strict);
+                (uu___4221_29895.FStar_TypeChecker_Env.use_eq_strict);
               FStar_TypeChecker_Env.is_iface =
-                (uu___4221_29915.FStar_TypeChecker_Env.is_iface);
+                (uu___4221_29895.FStar_TypeChecker_Env.is_iface);
               FStar_TypeChecker_Env.admit =
-                (uu___4221_29915.FStar_TypeChecker_Env.admit);
+                (uu___4221_29895.FStar_TypeChecker_Env.admit);
               FStar_TypeChecker_Env.lax =
-                (uu___4221_29915.FStar_TypeChecker_Env.lax);
+                (uu___4221_29895.FStar_TypeChecker_Env.lax);
               FStar_TypeChecker_Env.lax_universes =
-                (uu___4221_29915.FStar_TypeChecker_Env.lax_universes);
+                (uu___4221_29895.FStar_TypeChecker_Env.lax_universes);
               FStar_TypeChecker_Env.phase1 =
-                (uu___4221_29915.FStar_TypeChecker_Env.phase1);
+                (uu___4221_29895.FStar_TypeChecker_Env.phase1);
               FStar_TypeChecker_Env.failhard =
-                (uu___4221_29915.FStar_TypeChecker_Env.failhard);
+                (uu___4221_29895.FStar_TypeChecker_Env.failhard);
               FStar_TypeChecker_Env.nosynth =
-                (uu___4221_29915.FStar_TypeChecker_Env.nosynth);
+                (uu___4221_29895.FStar_TypeChecker_Env.nosynth);
               FStar_TypeChecker_Env.uvar_subtyping =
-                (uu___4221_29915.FStar_TypeChecker_Env.uvar_subtyping);
+                (uu___4221_29895.FStar_TypeChecker_Env.uvar_subtyping);
               FStar_TypeChecker_Env.tc_term =
-                (uu___4221_29915.FStar_TypeChecker_Env.tc_term);
+                (uu___4221_29895.FStar_TypeChecker_Env.tc_term);
               FStar_TypeChecker_Env.type_of =
-                (uu___4221_29915.FStar_TypeChecker_Env.type_of);
+                (uu___4221_29895.FStar_TypeChecker_Env.type_of);
               FStar_TypeChecker_Env.universe_of =
-                (uu___4221_29915.FStar_TypeChecker_Env.universe_of);
+                (uu___4221_29895.FStar_TypeChecker_Env.universe_of);
               FStar_TypeChecker_Env.check_type_of =
-                (uu___4221_29915.FStar_TypeChecker_Env.check_type_of);
+                (uu___4221_29895.FStar_TypeChecker_Env.check_type_of);
               FStar_TypeChecker_Env.use_bv_sorts = true;
               FStar_TypeChecker_Env.qtbl_name_and_index =
-                (uu___4221_29915.FStar_TypeChecker_Env.qtbl_name_and_index);
+                (uu___4221_29895.FStar_TypeChecker_Env.qtbl_name_and_index);
               FStar_TypeChecker_Env.normalized_eff_names =
-                (uu___4221_29915.FStar_TypeChecker_Env.normalized_eff_names);
+                (uu___4221_29895.FStar_TypeChecker_Env.normalized_eff_names);
               FStar_TypeChecker_Env.fv_delta_depths =
-                (uu___4221_29915.FStar_TypeChecker_Env.fv_delta_depths);
+                (uu___4221_29895.FStar_TypeChecker_Env.fv_delta_depths);
               FStar_TypeChecker_Env.proof_ns =
-                (uu___4221_29915.FStar_TypeChecker_Env.proof_ns);
+                (uu___4221_29895.FStar_TypeChecker_Env.proof_ns);
               FStar_TypeChecker_Env.synth_hook =
-                (uu___4221_29915.FStar_TypeChecker_Env.synth_hook);
+                (uu___4221_29895.FStar_TypeChecker_Env.synth_hook);
               FStar_TypeChecker_Env.try_solve_implicits_hook =
-                (uu___4221_29915.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                (uu___4221_29895.FStar_TypeChecker_Env.try_solve_implicits_hook);
               FStar_TypeChecker_Env.splice =
-                (uu___4221_29915.FStar_TypeChecker_Env.splice);
+                (uu___4221_29895.FStar_TypeChecker_Env.splice);
               FStar_TypeChecker_Env.mpreprocess =
-                (uu___4221_29915.FStar_TypeChecker_Env.mpreprocess);
+                (uu___4221_29895.FStar_TypeChecker_Env.mpreprocess);
               FStar_TypeChecker_Env.postprocess =
-                (uu___4221_29915.FStar_TypeChecker_Env.postprocess);
+                (uu___4221_29895.FStar_TypeChecker_Env.postprocess);
               FStar_TypeChecker_Env.identifier_info =
-                (uu___4221_29915.FStar_TypeChecker_Env.identifier_info);
+                (uu___4221_29895.FStar_TypeChecker_Env.identifier_info);
               FStar_TypeChecker_Env.tc_hooks =
-                (uu___4221_29915.FStar_TypeChecker_Env.tc_hooks);
+                (uu___4221_29895.FStar_TypeChecker_Env.tc_hooks);
               FStar_TypeChecker_Env.dsenv =
-                (uu___4221_29915.FStar_TypeChecker_Env.dsenv);
+                (uu___4221_29895.FStar_TypeChecker_Env.dsenv);
               FStar_TypeChecker_Env.nbe =
-                (uu___4221_29915.FStar_TypeChecker_Env.nbe);
+                (uu___4221_29895.FStar_TypeChecker_Env.nbe);
               FStar_TypeChecker_Env.strict_args_tab =
-                (uu___4221_29915.FStar_TypeChecker_Env.strict_args_tab);
+                (uu___4221_29895.FStar_TypeChecker_Env.strict_args_tab);
               FStar_TypeChecker_Env.erasable_types_tab =
-                (uu___4221_29915.FStar_TypeChecker_Env.erasable_types_tab);
+                (uu___4221_29895.FStar_TypeChecker_Env.erasable_types_tab);
               FStar_TypeChecker_Env.enable_defer_to_tac =
-                (uu___4221_29915.FStar_TypeChecker_Env.enable_defer_to_tac)
+                (uu___4221_29895.FStar_TypeChecker_Env.enable_defer_to_tac)
             } in
-          let slow_check uu____29921 =
+          let slow_check uu____29901 =
             if must_total
             then
-              let uu____29922 = env2.FStar_TypeChecker_Env.type_of env2 t in
-              match uu____29922 with | (uu____29929, uu____29930, g) -> g
+              let uu____29902 = env2.FStar_TypeChecker_Env.type_of env2 t in
+              match uu____29902 with | (uu____29909, uu____29910, g) -> g
             else
-              (let uu____29933 = env2.FStar_TypeChecker_Env.tc_term env2 t in
-               match uu____29933 with | (uu____29940, uu____29941, g) -> g) in
-          let uu____29943 =
-            let uu____29944 = FStar_Options.__temp_fast_implicits () in
-            FStar_All.pipe_left Prims.op_Negation uu____29944 in
-          if uu____29943
+              (let uu____29913 = env2.FStar_TypeChecker_Env.tc_term env2 t in
+               match uu____29913 with | (uu____29920, uu____29921, g) -> g) in
+          let uu____29923 =
+            let uu____29924 = FStar_Options.__temp_fast_implicits () in
+            FStar_All.pipe_left Prims.op_Negation uu____29924 in
+          if uu____29923
           then slow_check ()
           else check_type_of_well_typed_term' must_total env2 t k

--- a/src/parser/FStar.Parser.ToDocument.fs
+++ b/src/parser/FStar.Parser.ToDocument.fs
@@ -1187,7 +1187,7 @@ and p_tvar lid =
  * to prevent swallowing semicolons or not. For instance, in a record field, we
  * do. *)
 
-and paren_if b =
+and paren_if (b:bool) =
   if b then
     soft_parens_with_nesting
   else

--- a/src/tosyntax/FStar.ToSyntax.ToSyntax.fs
+++ b/src/tosyntax/FStar.ToSyntax.ToSyntax.fs
@@ -1439,6 +1439,7 @@ and desugar_term_maybe_top (top_level:bool) (env:env_t) (top:term) : S.term * an
       let x = Syntax.new_bv (Some t3.range) (tun_r t3.range) in
       let t_bool = mk (Tm_fvar(S.lid_as_fv C.bool_lid delta_constant None)) in
       let t1', aq1 = desugar_term_aq env t1 in
+      let t1' = U.ascribe t1' (Inl t_bool, None) in
       let t2', aq2 = desugar_term_aq env t2 in
       let t3', aq3 = desugar_term_aq env t3 in
       mk (Tm_match(t1',

--- a/src/tosyntax/FStar.ToSyntax.ToSyntax.fs
+++ b/src/tosyntax/FStar.ToSyntax.ToSyntax.fs
@@ -1258,7 +1258,8 @@ and desugar_term_maybe_top (top_level:bool) (env:env_t) (top:term) : S.term * an
           aux (arg::args) (aq::aqs) e
         | _ ->
           let head, aq = desugar_term_aq env e in
-          mk (Tm_app(head, args)), join_aqs (aq::aqs) in
+          S.extend_app_n head args top.range, join_aqs (aq::aqs)
+      in
       aux [] [] top
 
     | Bind(x, t1, t2) ->

--- a/tests/error-messages/IfCond.fst
+++ b/tests/error-messages/IfCond.fst
@@ -1,0 +1,4 @@
+module IfCond
+
+[@@expect_failure]
+let test () = if 2 then 1 else 3

--- a/tests/error-messages/IfCond.fst.expected
+++ b/tests/error-messages/IfCond.fst.expected
@@ -1,0 +1,5 @@
+>> Got issues: [
+IfCond.fst(4,17-4,18): (Error 189) Expected expression of type "Prims.bool"; got expression "2" of type "Prims.int"
+>>]
+Verified module: IfCond
+All verification conditions discharged successfully


### PR DESCRIPTION
In order to improve error messages. For
```fstar
let test () = if 2 then 1 else 3
```
We got:
```
A.fst(3,17-3,18): (Error 114) Type of pattern (Prims.bool) does not match type of scrutinee (Prims.int)
```
But now:
```
A.fst(3,17-3,18): (Error 189) Expected expression of type "Prims.bool"; got expression "2" of type "Prims.int"
```

This seemed like an omission since there was an unused `t_bool` in the desugaring. Mysteriously, it introduced a regression in the pretty printer, which I didn't try to debug (I tried a minimal example and couldn't repro).