### PR TITLE
Remove backslash from title of tutorial.mdk

### DIFF
--- a/doc/tutorial/tutorial.mdk
+++ b/doc/tutorial/tutorial.mdk
@@ -1,4 +1,4 @@
-Title         : Verified programming in F\*
+Title         : Verified programming in F*
 Sub title     : A tutorial
 Heading Base  : 2
 Author        : The F* Team


### PR DESCRIPTION
Currently, [the no-editor tutorial](https://www.fstar-lang.org/tutorial/tutorial.html) has the title 'Verified programming in F\\\*' instead of 'Verified programming in F\*'.
Although this seems rather a bug of Madoko, we can fix this just by removing the backslash from the Title field of tutorial.mdk.