### PR TITLE
extraction: disable name burning for letbindings when going to Kremlin

### DIFF
--- a/src/extraction/FStar.Extraction.ML.Term.fs
+++ b/src/extraction/FStar.Extraction.ML.Term.fs
@@ -1656,12 +1656,18 @@ and term_as_mlexpr' (g:uenv) (top:term) : (mlexpr * e_tag * mlty) =
 
           (* env_burn only matters for non-recursive lets and simply burns
            * the let bound variable in its own definition to generate
-           * code that is more understandable. *)
+           * code that is more understandable. We only do it for OCaml,
+           * to not affect Kremlin naming. *)
           let env_body, lbs, env_burn = List.fold_right (fun lb (env, lbs, env_burn) ->
               let (lbname, _, (t, (_, polytype)), add_unit, _) = lb in
               let env, nm, _ = UEnv.extend_lb env lbname t polytype add_unit in
-              let env_burn = UEnv.burn_name env_burn nm in
-              env, (nm,lb)::lbs, env_burn) lbs (g, [], g) in
+              let env_burn =
+                if Options.codegen () <> Some Options.Kremlin
+                then UEnv.burn_name env_burn nm
+                else env_burn
+              in
+              env, (nm,lb)::lbs, env_burn) lbs (g, [], g)
+          in
 
           let env_def = if is_rec then env_body else env_burn in
 

--- a/src/ocaml-output/FStar_Extraction_ML_Term.ml
+++ b/src/ocaml-output/FStar_Extraction_ML_Term.ml
@@ -3436,8 +3436,17 @@ and (term_as_mlexpr' :
                                   (match uu___8 with
                                    | (env1, nm, uu___9) ->
                                        let env_burn1 =
-                                         FStar_Extraction_ML_UEnv.burn_name
-                                           env_burn nm in
+                                         let uu___10 =
+                                           let uu___11 =
+                                             FStar_Options.codegen () in
+                                           uu___11 <>
+                                             (FStar_Pervasives_Native.Some
+                                                FStar_Options.Kremlin) in
+                                         if uu___10
+                                         then
+                                           FStar_Extraction_ML_UEnv.burn_name
+                                             env_burn nm
+                                         else env_burn in
                                        (env1, ((nm, lb) :: lbs4), env_burn1))))
                     lbs3 (g, [], g) in
                 (match uu___2 with


### PR DESCRIPTION
(Proposal)

To address name changes observed in HACL*. I haven't debugged the root cause of why they appear... but we could take this patch for the time being to avoid it. 