### PR TITLE
Record opening (RFC)

### DIFF
--- a/src/basic/FStar.Errors.fs
+++ b/src/basic/FStar.Errors.fs
@@ -371,6 +371,7 @@ type raw_error =
   | Error_ErasedCtor
   | Error_RemoveUnusedTypeParameter
   | Warning_NoMagicInFSharp
+  | Error_BadLetOpenRecord
 
 type flag = error_flag
 type error_setting = raw_error * error_flag * int
@@ -720,7 +721,8 @@ let default_settings : list<error_setting> =
     Error_CallToErased                                , CError, 342;
     Error_ErasedCtor                                  , CError, 343;
     Error_RemoveUnusedTypeParameter                   , CWarning, 344;
-    Warning_NoMagicInFSharp                           , CWarning, 345
+    Warning_NoMagicInFSharp                           , CWarning, 345;
+    Error_BadLetOpenRecord                            , CAlwaysError, 346;
     ]
 module BU = FStar.Util
 

--- a/src/ocaml-output/FStar_Errors.ml
+++ b/src/ocaml-output/FStar_Errors.ml
@@ -372,6 +372,7 @@ type raw_error =
   | Error_ErasedCtor 
   | Error_RemoveUnusedTypeParameter 
   | Warning_NoMagicInFSharp 
+  | Error_BadLetOpenRecord 
 let (uu___is_Error_DependencyAnalysisFailed : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
@@ -1864,6 +1865,9 @@ let (uu___is_Error_RemoveUnusedTypeParameter : raw_error -> Prims.bool) =
 let (uu___is_Warning_NoMagicInFSharp : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with | Warning_NoMagicInFSharp -> true | uu___ -> false
+let (uu___is_Error_BadLetOpenRecord : raw_error -> Prims.bool) =
+  fun projectee ->
+    match projectee with | Error_BadLetOpenRecord -> true | uu___ -> false
 type flag = error_flag
 type error_setting = (raw_error * error_flag * Prims.int)
 let (default_settings : error_setting Prims.list) =
@@ -2217,7 +2221,8 @@ let (default_settings : error_setting Prims.list) =
   (Error_CallToErased, CError, (Prims.of_int (342)));
   (Error_ErasedCtor, CError, (Prims.of_int (343)));
   (Error_RemoveUnusedTypeParameter, CWarning, (Prims.of_int (344)));
-  (Warning_NoMagicInFSharp, CWarning, (Prims.of_int (345)))]
+  (Warning_NoMagicInFSharp, CWarning, (Prims.of_int (345)));
+  (Error_BadLetOpenRecord, CAlwaysError, (Prims.of_int (346)))]
 let lookup_error :
   'uuuuu 'uuuuu1 'uuuuu2 .
     ('uuuuu * 'uuuuu1 * 'uuuuu2) Prims.list ->

--- a/src/ocaml-output/FStar_Parser_AST.ml
+++ b/src/ocaml-output/FStar_Parser_AST.ml
@@ -45,6 +45,7 @@ type term' =
   | Let of (let_qualifier * (term Prims.list FStar_Pervasives_Native.option *
   (pattern * term)) Prims.list * term) 
   | LetOpen of (FStar_Ident.lid * term) 
+  | LetOpenRecord of (term * term * term) 
   | Seq of (term * term) 
   | Bind of (FStar_Ident.ident * term * term) 
   | If of (term * term * term) 
@@ -182,6 +183,11 @@ let (uu___is_LetOpen : term' -> Prims.bool) =
   fun projectee -> match projectee with | LetOpen _0 -> true | uu___ -> false
 let (__proj__LetOpen__item___0 : term' -> (FStar_Ident.lid * term)) =
   fun projectee -> match projectee with | LetOpen _0 -> _0
+let (uu___is_LetOpenRecord : term' -> Prims.bool) =
+  fun projectee ->
+    match projectee with | LetOpenRecord _0 -> true | uu___ -> false
+let (__proj__LetOpenRecord__item___0 : term' -> (term * term * term)) =
+  fun projectee -> match projectee with | LetOpenRecord _0 -> _0
 let (uu___is_Seq : term' -> Prims.bool) =
   fun projectee -> match projectee with | Seq _0 -> true | uu___ -> false
 let (__proj__Seq__item___0 : term' -> (term * term)) =

--- a/src/ocaml-output/FStar_Parser_Dep.ml
+++ b/src/ocaml-output/FStar_Parser_Dep.ml
@@ -1326,6 +1326,8 @@ let (collect_one :
                   collect_term t)
              | FStar_Parser_AST.LetOpen (lid, t) ->
                  (add_to_parsing_data (P_open (true, lid)); collect_term t)
+             | FStar_Parser_AST.LetOpenRecord (r, rty, e) ->
+                 (collect_term r; collect_term rty; collect_term e)
              | FStar_Parser_AST.Bind (uu___3, t1, t2) ->
                  (collect_term t1; collect_term t2)
              | FStar_Parser_AST.Seq (t1, t2) ->

--- a/src/ocaml-output/FStar_Parser_ToDocument.ml
+++ b/src/ocaml-output/FStar_Parser_ToDocument.ml
@@ -2439,6 +2439,25 @@ and (p_noSeqTerm' :
                 FStar_Pprint.op_Hat_Slash_Hat uu___2 uu___3 in
               FStar_Pprint.group uu___1 in
             let uu___1 = paren_if ps in uu___1 uu___
+        | FStar_Parser_AST.LetOpenRecord (r, rty, e1) ->
+            let uu___ =
+              let uu___1 =
+                let uu___2 =
+                  let uu___3 = str "let open" in
+                  let uu___4 = p_term false pb r in
+                  let uu___5 = str "as" in
+                  FStar_Pprint.surround (Prims.of_int (2)) Prims.int_one
+                    uu___3 uu___4 uu___5 in
+                let uu___3 =
+                  let uu___4 = p_term false pb rty in
+                  let uu___5 =
+                    let uu___6 = str "in" in
+                    let uu___7 = p_term false pb e1 in
+                    FStar_Pprint.op_Hat_Slash_Hat uu___6 uu___7 in
+                  FStar_Pprint.op_Hat_Slash_Hat uu___4 uu___5 in
+                FStar_Pprint.op_Hat_Slash_Hat uu___2 uu___3 in
+              FStar_Pprint.group uu___1 in
+            let uu___1 = paren_if ps in uu___1 uu___
         | FStar_Parser_AST.Let (q, lbs, e1) ->
             let p_lb q1 uu___ is_last =
               match uu___ with
@@ -3862,6 +3881,8 @@ and (p_projectionLHS : FStar_Parser_AST.term -> FStar_Pprint.document) =
     | FStar_Parser_AST.Let uu___ ->
         let uu___1 = p_term false false e in soft_parens_with_nesting uu___1
     | FStar_Parser_AST.LetOpen uu___ ->
+        let uu___1 = p_term false false e in soft_parens_with_nesting uu___1
+    | FStar_Parser_AST.LetOpenRecord uu___ ->
         let uu___1 = p_term false false e in soft_parens_with_nesting uu___1
     | FStar_Parser_AST.Seq uu___ ->
         let uu___1 = p_term false false e in soft_parens_with_nesting uu___1

--- a/src/ocaml-output/FStar_Syntax_DsEnv.ml
+++ b/src/ocaml-output/FStar_Syntax_DsEnv.ml
@@ -710,6 +710,11 @@ let (string_of_exported_id_kind : exported_id_kind -> Prims.string) =
     match uu___ with
     | Exported_id_field -> "field"
     | Exported_id_term_type -> "term/type"
+let (is_exported_id_termtype : exported_id_kind -> Prims.bool) =
+  fun uu___ ->
+    match uu___ with | Exported_id_term_type -> true | uu___1 -> false
+let (is_exported_id_field : exported_id_kind -> Prims.bool) =
+  fun uu___ -> match uu___ with | Exported_id_field -> true | uu___1 -> false
 let find_in_module_with_includes :
   'a .
     exported_id_kind ->
@@ -754,8 +759,6 @@ let find_in_module_with_includes :
                      | Cont_ignore -> aux (FStar_List.append mincludes q)
                      | uu___1 -> look_into) in
               aux [ns]
-let (is_exported_id_field : exported_id_kind -> Prims.bool) =
-  fun uu___ -> match uu___ with | Exported_id_field -> true | uu___1 -> false
 let try_lookup_id'' :
   'a .
     env ->
@@ -820,6 +823,11 @@ let try_lookup_id'' :
                              let uu___2 = FStar_Ident.ns_of_lid lid in
                              find_in_record uu___2 id1 r k_record)
                           Cont_ignore env1 uu___1 id
+                    | Record_or_dc r when is_exported_id_termtype eikind ->
+                        let uu___1 =
+                          let uu___2 = FStar_Ident.ident_of_lid r.typename in
+                          FStar_Ident.ident_equals uu___2 id in
+                        if uu___1 then k_record r else Cont_ignore
                     | uu___1 -> Cont_ignore in
                   let rec aux uu___ =
                     match uu___ with
@@ -2082,6 +2090,31 @@ let (try_lookup_record_by_field_name :
       | FStar_Pervasives_Native.Some r when r.is_record ->
           FStar_Pervasives_Native.Some r
       | uu___1 -> FStar_Pervasives_Native.None
+let (try_lookup_record_type :
+  env -> FStar_Ident.lident -> record_or_dc FStar_Pervasives_Native.option) =
+  fun env1 ->
+    fun typename ->
+      let find_in_cache name =
+        let uu___ =
+          let uu___1 = FStar_Ident.ns_of_lid name in
+          let uu___2 = FStar_Ident.ident_of_lid name in (uu___1, uu___2) in
+        match uu___ with
+        | (ns, id) ->
+            let uu___1 = peek_record_cache () in
+            FStar_Util.find_map uu___1
+              (fun record ->
+                 let uu___2 =
+                   let uu___3 = FStar_Ident.ident_of_lid record.typename in
+                   FStar_Ident.ident_equals uu___3 id in
+                 if uu___2
+                 then FStar_Pervasives_Native.Some record
+                 else FStar_Pervasives_Native.None) in
+      resolve_in_open_namespaces'' env1 typename Exported_id_term_type
+        (fun uu___ -> Cont_ignore) (fun uu___ -> Cont_ignore)
+        (fun r -> Cont_ok r)
+        (fun l ->
+           let uu___ = find_in_cache l in cont_of_option Cont_ignore uu___)
+        (fun k -> fun uu___ -> k)
 let (belongs_to_record :
   env -> FStar_Ident.lident -> record_or_dc -> Prims.bool) =
   fun env1 ->

--- a/src/ocaml-output/FStar_ToSyntax_ToSyntax.ml
+++ b/src/ocaml-output/FStar_ToSyntax_ToSyntax.ml
@@ -2908,6 +2908,73 @@ and (desugar_term_maybe_top :
               let uu___2 = FStar_Syntax_DsEnv.expect_typ env1 in
               if uu___2 then desugar_typ_aq else desugar_term_aq in
             uu___1 env1 e
+        | FStar_Parser_AST.LetOpenRecord (r, rty, e) ->
+            let rec head_of t =
+              match t.FStar_Parser_AST.tm with
+              | FStar_Parser_AST.App (t1, uu___1, uu___2) -> head_of t1
+              | uu___1 -> t in
+            let tycon = head_of rty in
+            let tycon_name =
+              match tycon.FStar_Parser_AST.tm with
+              | FStar_Parser_AST.Var l -> l
+              | uu___1 ->
+                  let uu___2 =
+                    let uu___3 =
+                      let uu___4 = FStar_Parser_AST.term_to_string rty in
+                      FStar_Util.format1
+                        "This type must be a (possibly applied) record name"
+                        uu___4 in
+                    (FStar_Errors.Error_BadLetOpenRecord, uu___3) in
+                  FStar_Errors.raise_error uu___2 rty.FStar_Parser_AST.range in
+            let record =
+              let uu___1 =
+                FStar_Syntax_DsEnv.try_lookup_record_type env tycon_name in
+              match uu___1 with
+              | FStar_Pervasives_Native.Some r1 -> r1
+              | FStar_Pervasives_Native.None ->
+                  let uu___2 =
+                    let uu___3 =
+                      let uu___4 = FStar_Parser_AST.term_to_string rty in
+                      FStar_Util.format1 "Not a record type: `%s`" uu___4 in
+                    (FStar_Errors.Error_BadLetOpenRecord, uu___3) in
+                  FStar_Errors.raise_error uu___2 rty.FStar_Parser_AST.range in
+            let constrname =
+              let uu___1 =
+                FStar_Ident.ns_of_lid record.FStar_Syntax_DsEnv.typename in
+              FStar_Ident.lid_of_ns_and_id uu___1
+                record.FStar_Syntax_DsEnv.constrname in
+            let mk_pattern p =
+              FStar_Parser_AST.mk_pattern p r.FStar_Parser_AST.range in
+            let elab =
+              let pat =
+                let uu___1 =
+                  let uu___2 =
+                    let uu___3 =
+                      FStar_List.map
+                        (fun uu___4 ->
+                           match uu___4 with
+                           | (field, uu___5) ->
+                               mk_pattern
+                                 (FStar_Parser_AST.PatVar
+                                    (field, FStar_Pervasives_Native.None)))
+                        record.FStar_Syntax_DsEnv.fields in
+                    ((mk_pattern (FStar_Parser_AST.PatName constrname)),
+                      uu___3) in
+                  FStar_Parser_AST.PatApp uu___2 in
+                mk_pattern uu___1 in
+              let branch = (pat, FStar_Pervasives_Native.None, e) in
+              let r1 =
+                FStar_Parser_AST.mk_term
+                  (FStar_Parser_AST.Ascribed
+                     (r, rty, FStar_Pervasives_Native.None))
+                  r.FStar_Parser_AST.range FStar_Parser_AST.Expr in
+              let uu___1 = top in
+              {
+                FStar_Parser_AST.tm = (FStar_Parser_AST.Match (r1, [branch]));
+                FStar_Parser_AST.range = (uu___1.FStar_Parser_AST.range);
+                FStar_Parser_AST.level = (uu___1.FStar_Parser_AST.level)
+              } in
+            desugar_term_maybe_top top_level env elab
         | FStar_Parser_AST.Let (qual, lbs, body) ->
             let is_rec = qual = FStar_Parser_AST.Rec in
             let ds_let_rec_or_app uu___1 =

--- a/src/parser/FStar.Parser.AST.fs
+++ b/src/parser/FStar.Parser.AST.fs
@@ -57,6 +57,7 @@ type term' =
   | App       of term * term * imp                    (* aqual marks an explicitly provided implicit parameter *)
   | Let       of let_qualifier * list<(option<attributes_> * (pattern * term))> * term
   | LetOpen   of lid * term
+  | LetOpenRecord of term * term * term
   | Seq       of term * term
   | Bind      of ident * term * term
   | If        of term * term * term

--- a/src/parser/FStar.Parser.Dep.fs
+++ b/src/parser/FStar.Parser.Dep.fs
@@ -859,6 +859,10 @@ let collect_one
         | LetOpen (lid, t) ->
             add_to_parsing_data (P_open (true, lid));
             collect_term t
+        | LetOpenRecord (r, rty, e) ->
+            collect_term r;
+            collect_term rty;
+            collect_term e
         | Bind(_, t1, t2)
         | Seq (t1, t2) ->
             collect_term t1;

--- a/src/parser/FStar.Parser.ToDocument.fs
+++ b/src/parser/FStar.Parser.ToDocument.fs
@@ -1285,6 +1285,11 @@ and p_noSeqTerm' ps pb e = match e.tm with
       paren_if ps (
         group (surround 2 1 (str "let open") (p_quident uid) (str "in") ^/^ p_term false pb e)
       )
+  | LetOpenRecord (r, rty, e) ->
+      paren_if ps (
+        group (surround 2 1 (str "let open") (p_term false pb r) (str "as") ^/^ (p_term false pb rty)
+               ^/^ str "in" ^/^ p_term false pb e)
+      )
   | Let(q, lbs, e) ->
     (* We wish to print let-bindings as follows.
      *
@@ -1885,6 +1890,7 @@ and p_projectionLHS e = match e.tm with
   | App _       (* p_appTerm *)
   | Let _       (* p_noSeqTerm *)
   | LetOpen _   (* p_noSeqTerm *)
+  | LetOpenRecord _ (* p_noSeqTerm *)
   | Seq _       (* p_term *)
   | Bind _      (* p_term *)
   | If _        (* p_noSeqTerm *)

--- a/src/parser/ml/FStar_Parser_LexFStar.ml
+++ b/src/parser/ml/FStar_Parser_LexFStar.ml
@@ -45,6 +45,7 @@ let () =
   Hashtbl.add keywords "noeq"          NOEQUALITY  ;
   Hashtbl.add keywords "unopteq"       UNOPTEQUALITY  ;
   Hashtbl.add keywords "and"           AND         ;
+  Hashtbl.add keywords "as"            AS          ;
   Hashtbl.add keywords "assert"        ASSERT      ;
   Hashtbl.add keywords "assume"        ASSUME      ;
   Hashtbl.add keywords "begin"         BEGIN       ;

--- a/src/parser/parse.fsy
+++ b/src/parser/parse.fsy
@@ -37,6 +37,7 @@ let old_attribute_syntax_warning =
 %start warn_error_list
 %token AMP
 %token AND
+%token AS
 %token ASSERT
 %token ASSUME
 %token ATTRIBUTES
@@ -1616,6 +1617,9 @@ in
 | LET OPEN quident IN term
     {let (_1, _2, uid, _4, e) = ($1, (), $3, (), $5) in
       ( mk_term (LetOpen(uid, e)) (rhs2 parseState 1 5) Expr )}
+| LET OPEN term AS typ IN term
+    {let (_1, _2, r, _4, rty, _6, e) = ($1, (), $3, (), $5, (), $7) in
+      ( mk_term (LetOpenRecord(r, rty, e)) (rhs2 parseState 1 7) Expr )}
 | LET letqualifier letbinding list_attr_letbinding_ IN term
     {let (_2, q, lb, lbs, _6, e) = ($1, $2, $3, $4, (), $6) in
 let attrs =

--- a/src/parser/parse.mly
+++ b/src/parser/parse.mly
@@ -57,6 +57,7 @@ let old_attribute_syntax_warning =
 %token <char> CHAR
 %token <bool> LET
 
+%token AS
 %token FORALL EXISTS ASSUME NEW LOGIC ATTRIBUTES
 %token IRREDUCIBLE UNFOLDABLE INLINE OPAQUE UNFOLD INLINE_FOR_EXTRACTION
 %token NOEXTRACT
@@ -668,8 +669,13 @@ noSeqTerm:
         let branches = focusBranches pbs (rhs2 parseState 1 4) in
         mk_term (Match(e, branches)) (rhs2 parseState 1 4) Expr
       }
+
   | LET OPEN uid=quident IN e=term
       { mk_term (LetOpen(uid, e)) (rhs2 parseState 1 5) Expr }
+
+  | LET OPEN r=term AS rty=typ IN e=term
+      { mk_term (LetOpenRecord(r, rty, e)) (rhs2 parseState 1 7) Expr }
+
   | attrs=ioption(attribute)
     LET q=letqualifier lb=letbinding lbs=list(attr_letbinding) IN e=term
       {

--- a/src/syntax/FStar.Syntax.DsEnv.fs
+++ b/src/syntax/FStar.Syntax.DsEnv.fs
@@ -235,6 +235,15 @@ let string_of_exported_id_kind = function
     | Exported_id_field -> "field"
     | Exported_id_term_type -> "term/type"
 
+let is_exported_id_termtype = function
+  | Exported_id_term_type -> true
+  | _ -> false
+
+let is_exported_id_field = function
+  | Exported_id_field -> true
+  | _ -> false
+
+
 let find_in_module_with_includes
     (eikind: exported_id_kind)
     (find_in_module: lident -> cont_t<'a>)
@@ -271,10 +280,6 @@ let find_in_module_with_includes
       look_into
     end
   in aux [ ns ]
-
-let is_exported_id_field = function
-  | Exported_id_field -> true
-  | _ -> false
 
 let try_lookup_id''
   env
@@ -325,6 +330,12 @@ let try_lookup_id''
             let id = ident_of_lid lid in
             find_in_record (ns_of_lid lid) id r k_record
         ) Cont_ignore env (lid_of_ids curmod_ns) id
+
+      | Record_or_dc r
+        when (is_exported_id_termtype eikind) ->
+        if ident_equals (ident_of_lid r.typename) id
+        then k_record r
+        else Cont_ignore
 
       | _ ->
         Cont_ignore
@@ -723,7 +734,6 @@ let find_all_datacons env (lid:lident) =
       | _ -> None in
   resolve_in_open_namespaces' env lid (fun _ -> None) (fun _ -> None) k_global_def
 
-//no top-level pattern in F*, so need to do this ugliness
 let record_cache_aux_with_filter =
     // push, pop, etc. already signal-atomic: no need for BU.atomically
     let record_cache : ref<list<list<record_or_dc>>> = BU.mk_ref [[]] in
@@ -833,6 +843,23 @@ let try_lookup_record_by_field_name env (fieldname:lident) =
     match try_lookup_record_or_dc_by_field_name env fieldname with
         | Some r when r.is_record -> Some r
         | _ -> None
+
+let try_lookup_record_type env (typename:lident) : option<record_or_dc> =
+  let find_in_cache (name:lident) : option<record_or_dc> =
+    let ns, id = ns_of_lid name, ident_of_lid name in
+    BU.find_map (peek_record_cache()) (fun record ->
+      if ident_equals (ident_of_lid record.typename) id
+      then Some record
+      else None
+    )
+  in
+  resolve_in_open_namespaces'' env typename
+      Exported_id_term_type
+      (fun _ -> Cont_ignore)
+      (fun _ -> Cont_ignore)
+      (fun r -> Cont_ok r)
+      (fun l -> cont_of_option Cont_ignore (find_in_cache l))
+      (fun k _ -> k)
 
 let belongs_to_record env lid record =
     (* first determine whether lid is a valid record field name, and

--- a/src/syntax/FStar.Syntax.DsEnv.fsi
+++ b/src/syntax/FStar.Syntax.DsEnv.fsi
@@ -101,6 +101,7 @@ arguments are instantiated. *)
 val try_lookup_root_effect_name: env -> lident -> option<lident>
 val try_lookup_datacon: env -> lident -> option<fv>
 val try_lookup_record_by_field_name: env -> lident -> option<record_or_dc>
+val try_lookup_record_type: env -> lident -> option<record_or_dc>
 val belongs_to_record: env -> lident -> record_or_dc -> bool
 val try_lookup_dc_by_field_name: env -> lident -> option<(lident * bool)>
 val try_lookup_definition: env -> lident -> option<term>

--- a/src/tosyntax/FStar.ToSyntax.ToSyntax.fs
+++ b/src/tosyntax/FStar.ToSyntax.ToSyntax.fs
@@ -1312,6 +1312,7 @@ and desugar_term_maybe_top (top_level:bool) (env:env_t) (top:term) : S.term * an
       let mk_pattern p = mk_pattern p r.range in
       let elab =
         let pat =
+          (* All of the fields are explicit arguments of the constructor, hence the None below *)
           mk_pattern (PatApp (mk_pattern (PatName constrname),
                               List.map (fun (field, _) -> mk_pattern (PatVar (field, None))) record.fields))
         in

--- a/src/tosyntax/FStar.ToSyntax.ToSyntax.fs
+++ b/src/tosyntax/FStar.ToSyntax.ToSyntax.fs
@@ -1285,6 +1285,42 @@ and desugar_term_maybe_top (top_level:bool) (env:env_t) (top:term) : S.term * an
       let env = Env.push_namespace env lid in
       (if Env.expect_typ env then desugar_typ_aq else desugar_term_aq) env e
 
+    | LetOpenRecord (r, rty, e) ->
+      let rec head_of (t:term) : term =
+        match t.tm with
+        | App (t, _, _) -> head_of t
+        | _ -> t
+      in
+      let tycon = head_of rty in
+      let tycon_name =
+        match tycon.tm with
+        | Var l -> l
+        | _ ->
+          raise_error (Errors.Error_BadLetOpenRecord,
+                       BU.format1 "This type must be a (possibly applied) record name" (term_to_string rty))
+                      rty.range
+      in
+      let record =
+        match Env.try_lookup_record_type env tycon_name with
+        | Some r -> r
+        | None ->
+          raise_error (Errors.Error_BadLetOpenRecord,
+                       BU.format1 "Not a record type: `%s`" (term_to_string rty))
+                      rty.range
+      in
+      let constrname = lid_of_ns_and_id (ns_of_lid record.typename) record.constrname in
+      let mk_pattern p = mk_pattern p r.range in
+      let elab =
+        let pat =
+          mk_pattern (PatApp (mk_pattern (PatName constrname),
+                              List.map (fun (field, _) -> mk_pattern (PatVar (field, None))) record.fields))
+        in
+        let branch = (pat, None, e) in
+        let r = mk_term (Ascribed (r, rty, None)) r.range Expr in
+        { top with tm = Match (r, [branch]) }
+      in
+      desugar_term_maybe_top top_level env elab
+
     | Let(qual, lbs, body) ->
       let is_rec = qual = Rec in
       let ds_let_rec_or_app () =

--- a/tests/micro-benchmarks/RecordOpen.fst
+++ b/tests/micro-benchmarks/RecordOpen.fst
@@ -1,0 +1,58 @@
+module RecordOpen
+
+open FStar.VConfig
+open FStar.Mul
+
+type ty = {x:int; y:bool}
+
+let f (r:ty) : int =
+  let open r as ty in
+  if y then x else -x
+
+let _ = assert (f ({x=3; y=true}) == 3)
+let _ = assert (f ({x=3; y=false}) == -3)
+
+type ty2 (t:Type) = {x:t; y:bool}
+
+(* Arguments on the type are OK *)
+let f2 (r:ty2 int) : int =
+  let open r as ty2 int in
+  if y then x else -x
+
+(* Shadowing as expected *)
+let f3 (r:ty2 int) : unit =
+  assume (r.x == 10);
+  let x = 42 in
+  let open r as ty2 int in
+  assert (x == 10)
+
+[@@expect_failure [189]]
+let f4 (r:ty2 int) : int =
+  let open r as ty in
+  if y then x else -x
+
+let t = 42
+
+[@@expect_failure [341]]
+let not_a_record (r:ty2 int) : int =
+  let open r as int in
+  if y then x else -x
+
+type indty =
+  | Mkindty : x:int -> indty
+
+let f6 (r:indty) : int =
+  let open r as indty in
+  x
+
+let bump_rlimit (v:vconfig) : vconfig =
+  let open v as vconfig in
+  { v with z3rlimit = 2 * z3rlimit }
+
+let bump_rlimit2 (v:vconfig) : vconfig =
+  let open v as FStar.VConfig.vconfig in
+  { v with z3rlimit = 2 * z3rlimit }
+
+let bump_rlimit3 (v:vconfig) : vconfig =
+  let open v as VConfig.vconfig in
+  { v with z3rlimit = 2 * z3rlimit }

--- a/ulib/FStar.InteractiveHelpers.Output.fst
+++ b/ulib/FStar.InteractiveHelpers.Output.fst
@@ -36,7 +36,7 @@ let rec _split_subst_at_bv (#a : Type) (b : bv) (subst : list (bv & a)) :
       (src, tgt) :: s1, s2
 
 val subst_shadowed_with_abs_in_assertions : bool -> genv -> option bv -> assertions -> Tac (genv & assertions)
-let subst_shadowed_with_abs_in_assertions dbg ge shadowed_bv as =
+let subst_shadowed_with_abs_in_assertions dbg ge shadowed_bv asn =
   (* When generating the substitution, we need to pay attention to the fact that
    * the returned value potentially bound by a let may shadow another variable.
    * We need to take this into account for the post-assertions (but not the
@@ -68,8 +68,8 @@ let subst_shadowed_with_abs_in_assertions dbg ge shadowed_bv as =
     end;
   (* Apply *)
   let apply = (fun s -> map (fun t -> apply_subst ge1.env t s)) in
-  let pres = apply pre_subst as.pres in
-  let posts = apply post_subst as.posts in
+  let pres = apply pre_subst asn.pres in
+  let posts = apply post_subst asn.posts in
   ge1, mk_assertions pres posts
 
 (*** Convert propositions to string *)

--- a/ulib/FStar.List.Tot.Base.fst
+++ b/ulib/FStar.List.Tot.Base.fst
@@ -469,10 +469,10 @@ let unsnoc #a l =
     element itself. *)
 val split3: #a:Type -> l:list a -> i:nat{i < length l} -> Tot (list a * a * list a)
 let split3 #a l i =
-  let a, as = splitAt i l in
+  let x, xs = splitAt i l in
   lemma_splitAt_snd_length i l;
-  let b :: c = as in
-  a, b, c
+  let y :: z = xs in
+  x, y, z
 
 (** Sorting (implemented as quicksort) **)
 

--- a/ulib/FStar.List.Tot.Properties.fst
+++ b/ulib/FStar.List.Tot.Properties.fst
@@ -343,9 +343,9 @@ let rec lemma_unsnoc_append (#a:Type) (l1 l2:list a) :
   Lemma
     (requires (length l2 > 0)) // the [length l2 = 0] is trivial
     (ensures (
-        let as, a = unsnoc (l1 @ l2) in
-        let bs, b = unsnoc l2 in
-        as == l1 @ bs /\ a == b)) =
+        let aa, a = unsnoc (l1 @ l2) in
+        let bb, b = unsnoc l2 in
+        aa == l1 @ bb /\ a == b)) =
   match l1 with
   | [] -> ()
   | _ :: l1' -> lemma_unsnoc_append l1' l2
@@ -381,11 +381,11 @@ let rec split_using (#t:Type) (l:list t) (x:t{x `memP` l}) :
   GTot (list t * list t) =
   match l with
   | [_] -> [], l
-  | a :: as ->
+  | a :: aa ->
     if FStar.StrongExcludedMiddle.strong_excluded_middle (a == x) then (
       [], l
     ) else (
-      let l1', l2' = split_using as x in
+      let l1', l2' = split_using aa x in
       a :: l1', l2'
     )
 
@@ -399,7 +399,7 @@ let rec lemma_split_using (#t:Type) (l:list t) (x:t{x `memP` l}) :
         append l1 l2 == l)) =
   match l with
   | [_] -> ()
-  | a :: as ->
+  | a :: aa ->
     let goal =
       let l1, l2 = split_using l x in
         length l2 > 0 /\
@@ -411,7 +411,7 @@ let rec lemma_split_using (#t:Type) (l:list t) (x:t{x `memP` l}) :
       #_ #_
       #(fun () -> goal)
       (fun (_:squash (a == x)) -> ())
-      (fun (_:squash (x `memP` as)) -> lemma_split_using as x)
+      (fun (_:squash (x `memP` aa)) -> lemma_split_using aa x)
 
 (** Definition of [index_of] *)
 
@@ -422,11 +422,11 @@ let rec index_of (#t:Type) (l:list t) (x:t{x `memP` l}) :
   GTot (i:nat{i < length l /\ index l i == x}) =
   match l with
   | [_] -> 0
-  | a :: as ->
+  | a :: aa ->
     if FStar.StrongExcludedMiddle.strong_excluded_middle (a == x) then (
       0
     ) else (
-      1 + index_of as x
+      1 + index_of aa x
     )
 
 (** Properties about partition **)

--- a/ulib/LowStar.BufferView.Down.fst
+++ b/ulib/LowStar.BufferView.Down.fst
@@ -78,12 +78,12 @@ let indexing' (#a #b: _) (v:view a b) (len_as:nat) (i:nat{i < len_as * View?.n v
 let indexing #b vb i = indexing' (get_view vb) (B.length (as_buffer vb)) i
 
 let sel' (#a #b: _) (v:view a b)
-         (as:Seq.seq a)
-         (i:nat{i / View?.n v < Seq.length as})
+         (xs:Seq.seq a)
+         (i:nat{i / View?.n v < Seq.length xs})
    : GTot b
    = let n = View?.n v in
      let a_i = i / n in
-     let bs = View?.get v (Seq.index as a_i) in
+     let bs = View?.get v (Seq.index xs a_i) in
      Seq.index bs (i % n)
 
 let sel (#b: _)
@@ -92,9 +92,9 @@ let sel (#b: _)
         (i:nat{i < length vb})
    : GTot b
    = indexing vb i;
-     let as = B.as_seq h (as_buffer vb) in
+     let xs = B.as_seq h (as_buffer vb) in
      let v = get_view vb in
-     sel' v as i
+     sel' v xs i
 
 let lemma_g_upd_with_same_seq (#a:Type0) (#rrel #rel:srel a) (b:mbuffer a rrel rel) (h:HS.mem{B.live h b}) (s:_)
   : Lemma (Seq.equal s (B.as_seq h b) ==>
@@ -129,17 +129,17 @@ val upd' (#b: _)
 #push-options "--z3rlimit_factor 8"
 let upd' #b h vb i x =
     indexing vb i;
-    let as = B.as_seq h (as_buffer vb) in
+    let xs = B.as_seq h (as_buffer vb) in
     let v = get_view vb in
     let n = View?.n v in
     let a_i = i / n in
-    let bs = View?.get v (Seq.index as a_i) in
+    let bs = View?.get v (Seq.index xs a_i) in
     let bs' = Seq.upd bs (i % n) x in
     assert (x == sel h vb i ==> Seq.equal bs bs');
     let a' = View?.put v bs' in
     let mem = B.g_upd (as_buffer vb) a_i a' h in
-    B.g_upd_seq_as_seq (as_buffer vb) (Seq.upd as a_i a') h;
-    lemma_g_upd_with_same_seq (as_buffer vb) h (Seq.upd as a_i a');
+    B.g_upd_seq_as_seq (as_buffer vb) (Seq.upd xs a_i a') h;
+    lemma_g_upd_with_same_seq (as_buffer vb) h (Seq.upd xs a_i a');
     mem
 #pop-options
 
@@ -157,14 +157,14 @@ let rec seq_fold_right_gtot #a #b (s:Seq.seq a) (f:a -> b -> GTot b) (acc:b)
 let cons_view #a #b (v:view a b) (x:a) (tl:Seq.seq b) : GTot (Seq.seq b) =
   Seq.append (View?.get v x) tl
 
-let as_seq' (#a #b:_) (as:Seq.seq a) (v:view a b) : GTot (Seq.seq b) =
-  seq_fold_right_gtot #a #(Seq.seq b) as (cons_view #a #b v) Seq.empty
+let as_seq' (#a #b:_) (xs:Seq.seq a) (v:view a b) : GTot (Seq.seq b) =
+  seq_fold_right_gtot #a #(Seq.seq b) xs (cons_view #a #b v) Seq.empty
 
-let rec as_seq'_len (#a #b:_) (as:Seq.seq a) (v:view a b)
-  : Lemma (ensures (Seq.length (as_seq' as v) == View?.n v * Seq.length as))
-          (decreases (Seq.length as))
-  = if Seq.length as = 0 then ()
-    else as_seq'_len (Seq.tail as) v
+let rec as_seq'_len (#a #b:_) (xs:Seq.seq a) (v:view a b)
+  : Lemma (ensures (Seq.length (as_seq' xs v) == View?.n v * Seq.length xs))
+          (decreases (Seq.length xs))
+  = if Seq.length xs = 0 then ()
+    else as_seq'_len (Seq.tail xs) v
 
 let rec as_seq'_injective #a #b (v:view a b) (as1 as2:Seq.seq a)
   : Lemma
@@ -189,36 +189,36 @@ let rec as_seq'_injective #a #b (v:view a b) (as1 as2:Seq.seq a)
 
 let as_seq #b h vb =
   let (| a, _, _, BufferView buf v |) = vb in
-  let as = B.as_seq h buf in
-  let bs = as_seq' #a #b as v in
-  as_seq'_len as v;
+  let xs = B.as_seq h buf in
+  let bs = as_seq' #a #b xs v in
+  as_seq'_len xs v;
   bs
 
 #push-options "--max_ifuel 0"
-val sel'_tail (#a #b:_) (v:view a b) (as:Seq.seq a{Seq.length as > 0})
-              (i:nat{View?.n v <= i /\ i < Seq.length as * View?.n v})
+val sel'_tail (#a #b:_) (v:view a b) (xs:Seq.seq a{Seq.length xs > 0})
+              (i:nat{View?.n v <= i /\ i < Seq.length xs * View?.n v})
   : Lemma (let j = i - View?.n v in
-           sel' v as i == sel' v (Seq.tail as) j)
-let sel'_tail #a #b v as i =
-  let len_as = Seq.length as in
+           sel' v xs i == sel' v (Seq.tail xs) j)
+let sel'_tail #a #b v xs i =
+  let len_as = Seq.length xs in
   indexing' v len_as i;
   let n = View?.n v in
   let j = i - n in
   let a_i = i / n in
-  assert (sel' v as i == Seq.index (View?.get v (Seq.index as a_i)) (i % n));
+  assert (sel' v xs i == Seq.index (View?.get v (Seq.index xs a_i)) (i % n));
   FStar.Math.Lemmas.lemma_mod_sub i n 1;
   FStar.Math.Lemmas.add_div_mod_1 j n;
   assert (j / n == (i / n) - 1)
 
 val as_seq'_sel' (#a #b: _)
                  (v:view a b)
-                 (as:Seq.seq a)
-                 (i:nat{i < Seq.length as * View?.n v})
+                 (xs:Seq.seq a)
+                 (i:nat{i < Seq.length xs * View?.n v})
   : Lemma
      (ensures (
-       as_seq'_len as v;
-       sel' v as i == Seq.index (as_seq' as v) i))
-     (decreases (Seq.length as))
+       as_seq'_len xs v;
+       sel' v xs i == Seq.index (as_seq' xs v) i))
+     (decreases (Seq.length xs))
 
 //flaky
 #reset-options
@@ -227,74 +227,74 @@ val as_seq'_sel' (#a #b: _)
 #set-options "--smtencoding.nl_arith_repr wrapped"
 #set-options "--z3rlimit_factor 10" //just being conservative
 #set-options "--initial_fuel 1 --max_fuel 1 --max_ifuel 0"
-let rec as_seq'_sel' #a #b v as i =
-  as_seq'_len as v;
+let rec as_seq'_sel' #a #b v xs i =
+  as_seq'_len xs v;
   let n : pos = View?.n v in
-  assert (i / n < Seq.length as);
-  if Seq.length as = 0 then ()
-  else let bs = as_seq' as v in
-       assert (Seq.length bs = n + Seq.length (as_seq' (Seq.tail as) v));
+  assert (i / n < Seq.length xs);
+  if Seq.length xs = 0 then ()
+  else let bs = as_seq' xs v in
+       assert (Seq.length bs = n + Seq.length (as_seq' (Seq.tail xs) v));
        if (i < n) then
          begin
-           assert (Seq.index bs i == Seq.index (View?.get v (Seq.head as)) i)
+           assert (Seq.index bs i == Seq.index (View?.get v (Seq.head xs)) i)
          end
        else
          begin
-           let as' = Seq.tail as in
+           let as' = Seq.tail xs in
            as_seq'_len as' v;
            let j = i - n in
            assert (j / n < Seq.length as');
            assert (j < Seq.length (as_seq' as' v));
            as_seq'_sel' v as' j;
            assert (sel' v as' j == Seq.index (as_seq' as' v) j);
-           assert (Seq.index (as_seq' as v) i ==
+           assert (Seq.index (as_seq' xs v) i ==
                    Seq.index (as_seq' as' v) j);
-           sel'_tail v as i
+           sel'_tail v xs i
          end
 #reset-options
 
 let as_seq_sel #b h vb i =
   indexing vb i;
   let (| a, _, _, BufferView buf v |) = vb in
-  let as = B.as_seq h buf in
-  as_seq'_len as v;
-  as_seq'_sel' v as i
+  let xs = B.as_seq h buf in
+  as_seq'_len xs v;
+  as_seq'_sel' v xs i
 
 let get_sel #b h vb i = as_seq_sel h vb i
 
 val as_seq'_slice (#a #b: _)
                   (v:view a b)
-                  (as:Seq.seq a)
-                  (i:nat{i < Seq.length as * View?.n v})
+                  (xs:Seq.seq a)
+                  (i:nat{i < Seq.length xs * View?.n v})
   : Lemma
     (ensures (
-      as_seq'_len as v;
-      indexing' v (Seq.length as) i;
+      as_seq'_len xs v;
+      indexing' v (Seq.length xs) i;
       let n = View?.n v in
-      View?.get v (Seq.index as (i / n)) ==
-      Seq.slice (as_seq' as v) (n * (i /n)) (n * (i / n) + n)))
-    (decreases (Seq.length as))
+      View?.get v (Seq.index xs (i / n)) ==
+      Seq.slice (as_seq' xs v) (n * (i /n)) (n * (i / n) + n)))
+    (decreases (Seq.length xs))
 
 #push-options "--z3rlimit 100"
-let rec as_seq'_slice #a #b v as i =
+let rec as_seq'_slice #a #b v xs i =
   let n = View?.n v in
-  if Seq.length as = 0 then ()
-  else let bs = as_seq' as v in
+  if Seq.length xs = 0 then ()
+  else let bs = as_seq' xs v in
        if i < n then
          begin
-         assert (View?.get v (Seq.index as (i / n)) `Seq.equal`
-                 Seq.slice (as_seq' as v) (n * (i /n)) (n * (i / n) + n))
+         assert (View?.get v (Seq.index xs (i / n)) `Seq.equal`
+                 Seq.slice (as_seq' xs v) (n * (i /n)) (n * (i / n) + n))
          end
-       else let as' = Seq.tail as in
+       else let as' = Seq.tail xs in
             let j  = i - n in
-            as_seq'_slice v (Seq.tail as) (i - n);
+            as_seq'_slice v (Seq.tail xs) (i - n);
             as_seq'_len as' v;
             indexing' v (Seq.length as') j;
             FStar.Math.Lemmas.add_div_mod_1 j n;
             assert (View?.get v (Seq.index as' (j / n)) `Seq.equal`
                     Seq.slice (as_seq' as' v) (n * (j / n)) (n * (j / n) + n));
             assert (Seq.slice (as_seq' as' v) (n * (j / n)) (n * (j / n) + n) `Seq.equal`
-                    Seq.slice (as_seq' as v) (n * (j / n) + n) (n * (j / n) + n + n));
+                    Seq.slice (as_seq' xs v) (n * (j / n) + n) (n * (j / n) + n + n));
             FStar.Math.Lemmas.add_div_mod_1 j n;
             assert (j / n == i / n - 1)
 #pop-options
@@ -303,11 +303,11 @@ let put_sel #b h vb i =
     indexing vb i;
     let v = get_view vb in
     let n = View?.n v in
-    let as = (B.as_seq h (as_buffer vb)) in
-    as_seq'_slice v as i;
-    as_seq'_len as v;
-    assert (View?.put v (View?.get v (Seq.index as (i / n))) ==
-            View?.put v (Seq.slice (as_seq' as v) (n * (i /n)) (n * (i / n) + n)))
+    let xs = (B.as_seq h (as_buffer vb)) in
+    as_seq'_slice v xs i;
+    as_seq'_len xs v;
+    assert (View?.put v (View?.get v (Seq.index xs (i / n))) ==
+            View?.put v (Seq.slice (as_seq' xs v) (n * (i /n)) (n * (i / n) + n)))
 
 let rec upd_seq' (#a #b: _) (v:view a b) (s:Seq.seq b{Seq.length s % View?.n v = 0}) (acc:Seq.seq a)
   : GTot (Seq.lseq a (Seq.length acc + Seq.length s / View?.n v))
@@ -316,14 +316,14 @@ let rec upd_seq' (#a #b: _) (v:view a b) (s:Seq.seq b{Seq.length s % View?.n v =
   if Seq.length s = 0 then acc
   else let pfx, suffix = Seq.split s n in
        Math.lemma_mod_sub (Seq.length s) n 1;
-       let as = upd_seq' v suffix acc in
-       Seq.cons (View?.put v pfx) as
+       let xs = upd_seq' v suffix acc in
+       Seq.cons (View?.put v pfx) xs
 
 let upd_seq #b h vb s =
   let (| a, _, _, BufferView b v |) = vb in
   Math.cancel_mul_mod (B.length b) (View?.n v);
-  let as : Seq.seq a = upd_seq' v s Seq.empty in
-  B.g_upd_seq b as h
+  let xs : Seq.seq a = upd_seq' v s Seq.empty in
+  B.g_upd_seq b xs h
 
 let as_seq'_cons (#a #b:_) (v:view a b) (hd:a) (tl:Seq.seq a)
   : Lemma (as_seq' (Seq.cons hd tl) v == View?.get v hd `Seq.append` as_seq' tl v)
@@ -334,8 +334,8 @@ let as_seq'_cons (#a #b:_) (v:view a b) (hd:a) (tl:Seq.seq a)
 let rec upd_seq'_spec (#a #b: _) (v:view a b) (s:Seq.seq b{Seq.length s % View?.n v = 0}) (acc:Seq.seq a)
   : Lemma
       (ensures (
-        let as = upd_seq' v s acc in
-        as_seq' as v `Seq.equal` Seq.append s (as_seq' acc v)))
+        let xs = upd_seq' v s acc in
+        as_seq' xs v `Seq.equal` Seq.append s (as_seq' acc v)))
       (decreases (Seq.length s))
   = if Seq.length s = 0 then ()
     else let n = View?.n v in
@@ -345,24 +345,24 @@ let rec upd_seq'_spec (#a #b: _) (v:view a b) (s:Seq.seq b{Seq.length s % View?.
          as_seq'_slice v (upd_seq' v s acc) 0;
          let as' = upd_seq' v suffix acc in
          assert (as_seq' as' v `Seq.equal` Seq.append suffix (as_seq' acc v));
-         let as = upd_seq' v s acc in
-         assert (as `Seq.equal` Seq.cons (View?.put v pfx) as');
+         let xs = upd_seq' v s acc in
+         assert (xs `Seq.equal` Seq.cons (View?.put v pfx) as');
          as_seq'_cons v (View?.put v pfx) as'
 
 #set-options "--z3rlimit 20"
 let upd_seq_spec (#b: _) (h:HS.mem) (vb:buffer b{live h vb}) (s:Seq.seq b{Seq.length s = length vb})
   = let h' = upd_seq h vb s in
     Math.cancel_mul_mod (B.length (as_buffer vb)) (View?.n (get_view vb));
-    let as = upd_seq' (get_view vb) s Seq.empty in
-    B.g_upd_seq_as_seq (as_buffer vb) as h;
-    lemma_g_upd_with_same_seq (as_buffer vb) h as;
+    let xs = upd_seq' (get_view vb) s Seq.empty in
+    B.g_upd_seq_as_seq (as_buffer vb) xs h;
+    lemma_g_upd_with_same_seq (as_buffer vb) h xs;
     assert (FStar.HyperStack.ST.equal_domains h h');
     assert (modifies vb h h');
     upd_seq'_spec (get_view vb) s Seq.empty;
     assert (as_seq h' vb `Seq.equal` s);
     assert (as_seq h vb == as_seq' (B.as_seq h (as_buffer vb)) (get_view vb));
     assert (as_seq h' vb == s);
-    assert (as == B.as_seq h' (as_buffer vb));
+    assert (xs == B.as_seq h' (as_buffer vb));
     let v= get_view vb in
     FStar.Classical.forall_intro_2 (fun as1 as2 ->
       Classical.move_requires (as_seq'_injective v as1) as2

--- a/ulib/LowStar.BufferView.Up.fst
+++ b/ulib/LowStar.BufferView.Up.fst
@@ -51,9 +51,9 @@ let split_at_i (#b: _) (vb:buffer b) (i:nat{i < length vb}) (h:HS.mem)
                 Seq.seq src_t *
                 Seq.lseq src_t (View?.n (get_view vb)) *
                 Seq.seq src_t){
-               let prefix, as, suffix = frags in
+               let prefix, xs, suffix = frags in
                Down.as_seq h (as_down_buffer vb) ==
-               (prefix `Seq.append` (as `Seq.append` suffix))
+               (prefix `Seq.append` (xs `Seq.append` suffix))
             })
     = let open FStar.Mul in
       let s0 = Down.as_seq h (as_down_buffer vb) in
@@ -64,15 +64,15 @@ let split_at_i (#b: _) (vb:buffer b) (i:nat{i < length vb}) (h:HS.mem)
       length_eq vb;
       let prefix, suffix = Seq.split s0 start in
       Seq.lemma_split s0 start;
-      let as, tail = Seq.split suffix n in
+      let xs, tail = Seq.split suffix n in
       Seq.lemma_split suffix n;
-      prefix, as, tail
+      prefix, xs, tail
 
 let sel (#b: _) (h:HS.mem) (vb:buffer b) (i:nat{i < length vb})
    : GTot b
    = let v = get_view vb in
-     let _, as, _ = split_at_i vb i h in
-     View?.get v as
+     let _, xs, _ = split_at_i vb i h in
+     View?.get v xs
 
 let upd' (#b: _)
          (h:HS.mem)
@@ -155,9 +155,9 @@ let sel_upd #b vb i j x h =
 
 let lemma_upd_with_sel #b vb i h =
   let v = get_view vb in
-  let prefix, as, suffix = split_at_i vb i h in
+  let prefix, xs, suffix = split_at_i vb i h in
   let s0 = Down.as_seq h (as_down_buffer vb) in
-  let s1 = prefix `Seq.append` (View?.put v (View?.get v as) `Seq.append` suffix) in
+  let s1 = prefix `Seq.append` (View?.put v (View?.get v xs) `Seq.append` suffix) in
   assert (Seq.equal s0 s1);
   Down.upd_seq_spec h (as_down_buffer vb) s0
 

--- a/ulib/LowStar.BufferView.fst
+++ b/ulib/LowStar.BufferView.fst
@@ -53,9 +53,9 @@ let split_at_i (#b: _) (vb:buffer b) (i:nat{i < length vb}) (h:HS.mem)
                 Seq.seq src_t *
                 Seq.lseq src_t (View?.n (get_view vb)) *
                 Seq.seq src_t){
-               let prefix, as, suffix = frags in
+               let prefix, xs, suffix = frags in
                B.as_seq h (as_buffer vb) ==
-               (prefix `Seq.append` (as `Seq.append` suffix))
+               (prefix `Seq.append` (xs `Seq.append` suffix))
             })
     = let open FStar.Mul in
       let s0 = B.as_seq h (as_buffer vb) in
@@ -66,15 +66,15 @@ let split_at_i (#b: _) (vb:buffer b) (i:nat{i < length vb}) (h:HS.mem)
       length_eq vb;
       let prefix, suffix = Seq.split s0 start in
       Seq.lemma_split s0 start;
-      let as, tail = Seq.split suffix n in
+      let xs, tail = Seq.split suffix n in
       Seq.lemma_split suffix n;
-      prefix, as, tail
+      prefix, xs, tail
 
 let sel (#b: _) (h:HS.mem) (vb:buffer b) (i:nat{i < length vb})
    : GTot b
    = let v = get_view vb in
-     let _, as, _ = split_at_i vb i h in
-     View?.get v as
+     let _, xs, _ = split_at_i vb i h in
+     View?.get v xs
 
 let upd #b h vb i x
   : GTot HS.mem
@@ -90,7 +90,7 @@ let sel_upd1 (#b:_) (vb:buffer b) (i:nat{i < length vb}) (x:b) (h:HS.mem{live h 
     let v = get_view vb in
     view_indexing vb i;
     let h' = upd h vb i x in
-    let prefix, as, suffix = split_at_i vb i h in
+    let prefix, xs, suffix = split_at_i vb i h in
     let as' = View?.put v x in
     let s' = B.as_seq h' (as_buffer vb) in
     B.g_upd_seq_as_seq (as_buffer vb) (prefix `Seq.append` (as' `Seq.append` suffix)) h;
@@ -157,9 +157,9 @@ let sel_upd #b vb i j x h =
 
 let lemma_upd_with_sel #b vb i h =
   let v = get_view vb in
-  let prefix, as, suffix = split_at_i vb i h in
+  let prefix, xs, suffix = split_at_i vb i h in
   let s0 = B.as_seq h (as_buffer vb) in
-  let s1 = prefix `Seq.append` (View?.put v (View?.get v as) `Seq.append` suffix) in
+  let s1 = prefix `Seq.append` (View?.put v (View?.get v xs) `Seq.append` suffix) in
   assert (Seq.equal s0 s1);
   B.lemma_g_upd_with_same_seq (as_buffer vb) h
 

--- a/ulib/Makefile.extract
+++ b/ulib/Makefile.extract
@@ -27,8 +27,9 @@ $(OUTPUT_DIRECTORY)/%.ml:
 	$(MY_FSTAR) $(subst .checked.lax,,$(notdir $<)) --codegen $(CODEGEN) --extract_module $(basename $(notdir $(subst .checked.lax,,$<)))
 
 .depend.extract:
-	mkdir -p .cache.lax
-	$(MY_FSTAR) --dep full $(EXTRACT_MODULES) $(addprefix --include , $(INCLUDE_PATHS)) $(FSTAR_FILES) > .depend.extract
+	$(Q)mkdir -p .cache.lax
+	$(Q)$(MY_FSTAR) --dep full $(EXTRACT_MODULES) $(addprefix --include , $(INCLUDE_PATHS)) $(FSTAR_FILES) > .depend.extract
+	@echo "[DEPEND]"
 
 depend.extract: .depend.extract
 

--- a/ulib/legacy/FStar.Pointer.Base.fst
+++ b/ulib/legacy/FStar.Pointer.Base.fst
@@ -3226,13 +3226,13 @@ let disjoint_sym''
   (ensures (disjoint p1 p2 <==> disjoint p2 p1))
 = disjoint_sym' p1 p2
 
-let disjoint_includes_l #a #as #a' (x: pointer a) (subx:pointer as) (y:pointer a') : Lemma
+let disjoint_includes_l #a #xs #a' (x: pointer a) (subx:pointer xs) (y:pointer a') : Lemma
   (requires (includes x subx /\ disjoint x y))
   (ensures  (disjoint subx y))
   [SMTPat (disjoint subx y); SMTPat (includes x subx)]
   = disjoint_includes x y subx y
 
-let disjoint_includes_l_swap #a #as #a' (x:pointer a) (subx:pointer as) (y:pointer a') : Lemma
+let disjoint_includes_l_swap #a #xs #a' (x:pointer a) (subx:pointer xs) (y:pointer a') : Lemma
   (requires (includes x subx /\ disjoint x y))
   (ensures  (disjoint y subx))
   [SMTPat (disjoint y subx); SMTPat (includes x subx)]


### PR DESCRIPTION
This introduces syntax to open all the fields of a record and bring them into scope, implemented by desugaring into a match of the record. The implementation has a huge hack and hence provides bad errors in some cases, but I wanted to start a discussion on whether this feature is desirable. Opinions very welcome!

The concrete syntax is:
```fstar
let open e as typ in e'
```
where it's expected that `e` has type `typ _ _ _ _` (arguments are allowed and need not be given) and `typ` is a record type. It is then desugared to:
```fstar
match e with
| Mktyp f1 f2 f3 ... fn -> e'
```
with the expected shadowings taking place.

The opening needs the type for the record, since at desugaring time we cannot infer it. Agda has similar syntax.

cc @mateuszbujalski
I suspect @Kachoc may also be interested since I remember some issues with records.
See also #2109