### PR TITLE
No return in VCs for reifiable layered effects

### DIFF
--- a/src/ocaml-output/FStar_TypeChecker_Util.ml
+++ b/src/ocaml-output/FStar_TypeChecker_Util.ml
@@ -969,7 +969,14 @@ let (should_return :
             FStar_All.pipe_right uu___1 FStar_Pervasives_Native.snd in
           FStar_All.pipe_right uu___
             (fun c ->
-               (let uu___1 = FStar_TypeChecker_Env.is_reifiable_comp env c in
+               (let uu___1 =
+                  (FStar_TypeChecker_Env.is_reifiable_comp env c) &&
+                    (let uu___2 =
+                       let uu___3 =
+                         FStar_TypeChecker_Env.norm_eff_name env
+                           lc.FStar_TypeChecker_Common.eff_name in
+                       FStar_TypeChecker_Env.is_layered_effect env uu___3 in
+                     Prims.op_Negation uu___2) in
                 Prims.op_Negation uu___1) &&
                  ((FStar_All.pipe_right (FStar_Syntax_Util.comp_result c)
                      FStar_Syntax_Util.is_unit)

--- a/src/typechecker/FStar.TypeChecker.Util.fs
+++ b/src/typechecker/FStar.TypeChecker.Util.fs
@@ -530,7 +530,8 @@ let should_return env eopt lc =
     //if lc.res_typ is not an arrow, arrow_formals_comp returns Tot lc.res_typ
     let lc_is_unit_or_effectful =
       lc.res_typ |> U.arrow_formals_comp |> snd |> (fun c ->
-        not (Env.is_reifiable_comp env c) &&
+        (not (Env.is_reifiable_comp env c &&
+              not (Env.is_layered_effect env (Env.norm_eff_name env lc.eff_name)))) &&
         (U.comp_result c |> U.is_unit || not (U.is_pure_or_ghost_comp c)))
     in
     match eopt with


### PR DESCRIPTION
A small patch to not insert returns in VCs for reifiable layered effects because:

1. They are pretty useless, since reifiable layered effects are not encoded to SMT
2. The additional returns lead to larger VCs that also end up confusing some of our Steel framing tactics.