### PR TITLE
Tactics: some fixes to `ctrl_rewrite`

### DIFF
--- a/src/basic/FStar.Errors.fs
+++ b/src/basic/FStar.Errors.fs
@@ -366,6 +366,7 @@ type raw_error =
   | Error_BadSplice
   | Error_UnexpectedUnresolvedUvar
   | Warning_UnfoldPlugin
+  | Error_LayeredMissingAnnot
 
 type flag = error_flag
 type error_setting = raw_error * error_flag * int
@@ -711,6 +712,7 @@ let default_settings : list<error_setting> =
     Error_BadSplice                                   , CError, 338;
     Error_UnexpectedUnresolvedUvar                    , CAlwaysError, 339;
     Warning_UnfoldPlugin                              , CWarning, 340;
+    Error_LayeredMissingAnnot                         , CAlwaysError, 341;
     ]
 module BU = FStar.Util
 

--- a/src/basic/FStar.Options.fs
+++ b/src/basic/FStar.Options.fs
@@ -1372,6 +1372,7 @@ let settable = function
     | "detail_errors"
     | "detail_hint_replay"
     | "eager_subtyping"
+    | "error_contexts"
     | "hide_uvar_nums"
     | "hint_dir"
     | "hint_file"

--- a/src/ocaml-output/FStar_Errors.ml
+++ b/src/ocaml-output/FStar_Errors.ml
@@ -367,6 +367,7 @@ type raw_error =
   | Error_BadSplice 
   | Error_UnexpectedUnresolvedUvar 
   | Warning_UnfoldPlugin 
+  | Error_LayeredMissingAnnot 
 let (uu___is_Error_DependencyAnalysisFailed : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with
@@ -1842,6 +1843,9 @@ let (uu___is_Error_UnexpectedUnresolvedUvar : raw_error -> Prims.bool) =
 let (uu___is_Warning_UnfoldPlugin : raw_error -> Prims.bool) =
   fun projectee ->
     match projectee with | Warning_UnfoldPlugin -> true | uu___ -> false
+let (uu___is_Error_LayeredMissingAnnot : raw_error -> Prims.bool) =
+  fun projectee ->
+    match projectee with | Error_LayeredMissingAnnot -> true | uu___ -> false
 type flag = error_flag
 type error_setting = (raw_error * error_flag * Prims.int)
 let (default_settings : error_setting Prims.list) =
@@ -2190,7 +2194,8 @@ let (default_settings : error_setting Prims.list) =
   (Warning_DeprecatedGeneric, CWarning, (Prims.of_int (337)));
   (Error_BadSplice, CError, (Prims.of_int (338)));
   (Error_UnexpectedUnresolvedUvar, CAlwaysError, (Prims.of_int (339)));
-  (Warning_UnfoldPlugin, CWarning, (Prims.of_int (340)))]
+  (Warning_UnfoldPlugin, CWarning, (Prims.of_int (340)));
+  (Error_LayeredMissingAnnot, CAlwaysError, (Prims.of_int (341)))]
 let lookup_error :
   'uuuuu 'uuuuu1 'uuuuu2 .
     ('uuuuu * 'uuuuu1 * 'uuuuu2) Prims.list ->

--- a/src/ocaml-output/FStar_Options.ml
+++ b/src/ocaml-output/FStar_Options.ml
@@ -1332,6 +1332,7 @@ let (settable : Prims.string -> Prims.bool) =
     | "detail_errors" -> true
     | "detail_hint_replay" -> true
     | "eager_subtyping" -> true
+    | "error_contexts" -> true
     | "hide_uvar_nums" -> true
     | "hint_dir" -> true
     | "hint_file" -> true
@@ -1414,7 +1415,7 @@ let (settable_specs :
     (FStar_List.filter
        (fun uu___ ->
           match uu___ with | (uu___1, x, uu___2, uu___3) -> settable x))
-let (uu___583 :
+let (uu___584 :
   (((unit -> FStar_Getopt.parse_cmdline_res) -> unit) *
     (unit -> FStar_Getopt.parse_cmdline_res)))
   =
@@ -1430,11 +1431,11 @@ let (uu___583 :
   (set1, call)
 let (set_error_flags_callback_aux :
   (unit -> FStar_Getopt.parse_cmdline_res) -> unit) =
-  match uu___583 with
+  match uu___584 with
   | (set_error_flags_callback_aux1, set_error_flags) ->
       set_error_flags_callback_aux1
 let (set_error_flags : unit -> FStar_Getopt.parse_cmdline_res) =
-  match uu___583 with
+  match uu___584 with
   | (set_error_flags_callback_aux1, set_error_flags1) -> set_error_flags1
 let (set_error_flags_callback :
   (unit -> FStar_Getopt.parse_cmdline_res) -> unit) =

--- a/src/ocaml-output/FStar_Parser_AST.ml
+++ b/src/ocaml-output/FStar_Parser_AST.ml
@@ -1425,6 +1425,9 @@ let rec (term_to_string : term -> Prims.string) =
   fun x ->
     match x.tm with
     | Wild -> "_"
+    | Decreases (t, uu___) ->
+        let uu___1 = term_to_string t in
+        FStar_Util.format1 "(decreases %s)" uu___1
     | Requires (t, uu___) ->
         let uu___1 = term_to_string t in
         FStar_Util.format1 "(requires %s)" uu___1

--- a/src/ocaml-output/FStar_Tactics_CtrlRewrite.ml
+++ b/src/ocaml-output/FStar_Tactics_CtrlRewrite.ml
@@ -14,164 +14,204 @@ let (__do_rewrite :
     fun rewriter ->
       fun env ->
         fun tm ->
-          let uu___ =
-            env.FStar_TypeChecker_Env.tc_term
-              (let uu___1 = env in
-               {
-                 FStar_TypeChecker_Env.solver =
-                   (uu___1.FStar_TypeChecker_Env.solver);
-                 FStar_TypeChecker_Env.range =
-                   (uu___1.FStar_TypeChecker_Env.range);
-                 FStar_TypeChecker_Env.curmodule =
-                   (uu___1.FStar_TypeChecker_Env.curmodule);
-                 FStar_TypeChecker_Env.gamma =
-                   (uu___1.FStar_TypeChecker_Env.gamma);
-                 FStar_TypeChecker_Env.gamma_sig =
-                   (uu___1.FStar_TypeChecker_Env.gamma_sig);
-                 FStar_TypeChecker_Env.gamma_cache =
-                   (uu___1.FStar_TypeChecker_Env.gamma_cache);
-                 FStar_TypeChecker_Env.modules =
-                   (uu___1.FStar_TypeChecker_Env.modules);
-                 FStar_TypeChecker_Env.expected_typ =
-                   (uu___1.FStar_TypeChecker_Env.expected_typ);
-                 FStar_TypeChecker_Env.sigtab =
-                   (uu___1.FStar_TypeChecker_Env.sigtab);
-                 FStar_TypeChecker_Env.attrtab =
-                   (uu___1.FStar_TypeChecker_Env.attrtab);
-                 FStar_TypeChecker_Env.instantiate_imp =
-                   (uu___1.FStar_TypeChecker_Env.instantiate_imp);
-                 FStar_TypeChecker_Env.effects =
-                   (uu___1.FStar_TypeChecker_Env.effects);
-                 FStar_TypeChecker_Env.generalize =
-                   (uu___1.FStar_TypeChecker_Env.generalize);
-                 FStar_TypeChecker_Env.letrecs =
-                   (uu___1.FStar_TypeChecker_Env.letrecs);
-                 FStar_TypeChecker_Env.top_level =
-                   (uu___1.FStar_TypeChecker_Env.top_level);
-                 FStar_TypeChecker_Env.check_uvars =
-                   (uu___1.FStar_TypeChecker_Env.check_uvars);
-                 FStar_TypeChecker_Env.use_eq =
-                   (uu___1.FStar_TypeChecker_Env.use_eq);
-                 FStar_TypeChecker_Env.use_eq_strict =
-                   (uu___1.FStar_TypeChecker_Env.use_eq_strict);
-                 FStar_TypeChecker_Env.is_iface =
-                   (uu___1.FStar_TypeChecker_Env.is_iface);
-                 FStar_TypeChecker_Env.admit =
-                   (uu___1.FStar_TypeChecker_Env.admit);
-                 FStar_TypeChecker_Env.lax = true;
-                 FStar_TypeChecker_Env.lax_universes =
-                   (uu___1.FStar_TypeChecker_Env.lax_universes);
-                 FStar_TypeChecker_Env.phase1 =
-                   (uu___1.FStar_TypeChecker_Env.phase1);
-                 FStar_TypeChecker_Env.failhard =
-                   (uu___1.FStar_TypeChecker_Env.failhard);
-                 FStar_TypeChecker_Env.nosynth =
-                   (uu___1.FStar_TypeChecker_Env.nosynth);
-                 FStar_TypeChecker_Env.uvar_subtyping =
-                   (uu___1.FStar_TypeChecker_Env.uvar_subtyping);
-                 FStar_TypeChecker_Env.tc_term =
-                   (uu___1.FStar_TypeChecker_Env.tc_term);
-                 FStar_TypeChecker_Env.type_of =
-                   (uu___1.FStar_TypeChecker_Env.type_of);
-                 FStar_TypeChecker_Env.universe_of =
-                   (uu___1.FStar_TypeChecker_Env.universe_of);
-                 FStar_TypeChecker_Env.check_type_of =
-                   (uu___1.FStar_TypeChecker_Env.check_type_of);
-                 FStar_TypeChecker_Env.use_bv_sorts =
-                   (uu___1.FStar_TypeChecker_Env.use_bv_sorts);
-                 FStar_TypeChecker_Env.qtbl_name_and_index =
-                   (uu___1.FStar_TypeChecker_Env.qtbl_name_and_index);
-                 FStar_TypeChecker_Env.normalized_eff_names =
-                   (uu___1.FStar_TypeChecker_Env.normalized_eff_names);
-                 FStar_TypeChecker_Env.fv_delta_depths =
-                   (uu___1.FStar_TypeChecker_Env.fv_delta_depths);
-                 FStar_TypeChecker_Env.proof_ns =
-                   (uu___1.FStar_TypeChecker_Env.proof_ns);
-                 FStar_TypeChecker_Env.synth_hook =
-                   (uu___1.FStar_TypeChecker_Env.synth_hook);
-                 FStar_TypeChecker_Env.try_solve_implicits_hook =
-                   (uu___1.FStar_TypeChecker_Env.try_solve_implicits_hook);
-                 FStar_TypeChecker_Env.splice =
-                   (uu___1.FStar_TypeChecker_Env.splice);
-                 FStar_TypeChecker_Env.mpreprocess =
-                   (uu___1.FStar_TypeChecker_Env.mpreprocess);
-                 FStar_TypeChecker_Env.postprocess =
-                   (uu___1.FStar_TypeChecker_Env.postprocess);
-                 FStar_TypeChecker_Env.identifier_info =
-                   (uu___1.FStar_TypeChecker_Env.identifier_info);
-                 FStar_TypeChecker_Env.tc_hooks =
-                   (uu___1.FStar_TypeChecker_Env.tc_hooks);
-                 FStar_TypeChecker_Env.dsenv =
-                   (uu___1.FStar_TypeChecker_Env.dsenv);
-                 FStar_TypeChecker_Env.nbe =
-                   (uu___1.FStar_TypeChecker_Env.nbe);
-                 FStar_TypeChecker_Env.strict_args_tab =
-                   (uu___1.FStar_TypeChecker_Env.strict_args_tab);
-                 FStar_TypeChecker_Env.erasable_types_tab =
-                   (uu___1.FStar_TypeChecker_Env.erasable_types_tab);
-                 FStar_TypeChecker_Env.enable_defer_to_tac =
-                   (uu___1.FStar_TypeChecker_Env.enable_defer_to_tac);
-                 FStar_TypeChecker_Env.unif_allow_ref_guards =
-                   (uu___1.FStar_TypeChecker_Env.unif_allow_ref_guards)
-               }) tm in
-          match uu___ with
-          | (uu___1, lcomp, g) ->
-              let uu___2 =
-                (let uu___3 =
-                   FStar_TypeChecker_Common.is_pure_or_ghost_lcomp lcomp in
-                 Prims.op_Negation uu___3) ||
-                  (let uu___3 = FStar_TypeChecker_Env.is_trivial g in
-                   Prims.op_Negation uu___3) in
-              if uu___2
-              then FStar_Tactics_Monad.ret tm
-              else
-                (let typ = lcomp.FStar_TypeChecker_Common.res_typ in
-                 let uu___4 =
-                   FStar_Tactics_Monad.new_uvar "do_rewrite.rhs" env typ in
-                 FStar_Tactics_Monad.bind uu___4
-                   (fun uu___5 ->
-                      match uu___5 with
-                      | (ut, uvar_ut) ->
-                          FStar_Tactics_Monad.mlog
-                            (fun uu___6 ->
-                               let uu___7 =
-                                 FStar_Syntax_Print.term_to_string tm in
-                               let uu___8 =
-                                 FStar_Syntax_Print.term_to_string ut in
-                               FStar_Util.print2
-                                 "do_rewrite: making equality\n\t%s ==\n\t%s\n"
-                                 uu___7 uu___8)
-                            (fun uu___6 ->
-                               let uu___7 =
-                                 let uu___8 =
-                                   let uu___9 =
-                                     env.FStar_TypeChecker_Env.universe_of
-                                       env typ in
-                                   FStar_Syntax_Util.mk_eq2 uu___9 typ tm ut in
-                                 FStar_Tactics_Monad.add_irrelevant_goal g0
-                                   "do_rewrite.eq" env uu___8 in
-                               FStar_Tactics_Monad.bind uu___7
-                                 (fun uu___8 ->
-                                    let uu___9 =
-                                      FStar_Tactics_Basic.focus rewriter in
-                                    FStar_Tactics_Monad.bind uu___9
-                                      (fun uu___10 ->
-                                         let ut1 =
-                                           FStar_TypeChecker_Normalize.reduce_uvar_solutions
-                                             env ut in
-                                         FStar_Tactics_Monad.mlog
-                                           (fun uu___11 ->
-                                              let uu___12 =
-                                                FStar_Syntax_Print.term_to_string
-                                                  tm in
-                                              let uu___13 =
-                                                FStar_Syntax_Print.term_to_string
-                                                  ut1 in
-                                              FStar_Util.print2
-                                                "rewrite_rec: succeeded rewriting\n\t%s to\n\t%s\n"
-                                                uu___12 uu___13)
-                                           (fun uu___11 ->
-                                              FStar_Tactics_Monad.ret ut1))))))
+          let should_skip =
+            let uu___ =
+              let uu___1 = FStar_Syntax_Subst.compress tm in
+              uu___1.FStar_Syntax_Syntax.n in
+            match uu___ with
+            | FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_reify) ->
+                true
+            | FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_reflect
+                uu___1) -> true
+            | FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_range_of) ->
+                true
+            | FStar_Syntax_Syntax.Tm_constant
+                (FStar_Const.Const_set_range_of) -> true
+            | uu___1 -> false in
+          if should_skip
+          then FStar_Tactics_Monad.ret tm
+          else
+            (let res =
+               try
+                 (fun uu___1 ->
+                    match () with
+                    | () ->
+                        FStar_Errors.with_ctx
+                          "While typechecking a subterm for ctrl_rewrite"
+                          (fun uu___2 ->
+                             let uu___3 =
+                               env.FStar_TypeChecker_Env.tc_term
+                                 (let uu___4 = env in
+                                  {
+                                    FStar_TypeChecker_Env.solver =
+                                      (uu___4.FStar_TypeChecker_Env.solver);
+                                    FStar_TypeChecker_Env.range =
+                                      (uu___4.FStar_TypeChecker_Env.range);
+                                    FStar_TypeChecker_Env.curmodule =
+                                      (uu___4.FStar_TypeChecker_Env.curmodule);
+                                    FStar_TypeChecker_Env.gamma =
+                                      (uu___4.FStar_TypeChecker_Env.gamma);
+                                    FStar_TypeChecker_Env.gamma_sig =
+                                      (uu___4.FStar_TypeChecker_Env.gamma_sig);
+                                    FStar_TypeChecker_Env.gamma_cache =
+                                      (uu___4.FStar_TypeChecker_Env.gamma_cache);
+                                    FStar_TypeChecker_Env.modules =
+                                      (uu___4.FStar_TypeChecker_Env.modules);
+                                    FStar_TypeChecker_Env.expected_typ =
+                                      (uu___4.FStar_TypeChecker_Env.expected_typ);
+                                    FStar_TypeChecker_Env.sigtab =
+                                      (uu___4.FStar_TypeChecker_Env.sigtab);
+                                    FStar_TypeChecker_Env.attrtab =
+                                      (uu___4.FStar_TypeChecker_Env.attrtab);
+                                    FStar_TypeChecker_Env.instantiate_imp =
+                                      (uu___4.FStar_TypeChecker_Env.instantiate_imp);
+                                    FStar_TypeChecker_Env.effects =
+                                      (uu___4.FStar_TypeChecker_Env.effects);
+                                    FStar_TypeChecker_Env.generalize =
+                                      (uu___4.FStar_TypeChecker_Env.generalize);
+                                    FStar_TypeChecker_Env.letrecs =
+                                      (uu___4.FStar_TypeChecker_Env.letrecs);
+                                    FStar_TypeChecker_Env.top_level =
+                                      (uu___4.FStar_TypeChecker_Env.top_level);
+                                    FStar_TypeChecker_Env.check_uvars =
+                                      (uu___4.FStar_TypeChecker_Env.check_uvars);
+                                    FStar_TypeChecker_Env.use_eq =
+                                      (uu___4.FStar_TypeChecker_Env.use_eq);
+                                    FStar_TypeChecker_Env.use_eq_strict =
+                                      (uu___4.FStar_TypeChecker_Env.use_eq_strict);
+                                    FStar_TypeChecker_Env.is_iface =
+                                      (uu___4.FStar_TypeChecker_Env.is_iface);
+                                    FStar_TypeChecker_Env.admit =
+                                      (uu___4.FStar_TypeChecker_Env.admit);
+                                    FStar_TypeChecker_Env.lax = true;
+                                    FStar_TypeChecker_Env.lax_universes =
+                                      (uu___4.FStar_TypeChecker_Env.lax_universes);
+                                    FStar_TypeChecker_Env.phase1 =
+                                      (uu___4.FStar_TypeChecker_Env.phase1);
+                                    FStar_TypeChecker_Env.failhard =
+                                      (uu___4.FStar_TypeChecker_Env.failhard);
+                                    FStar_TypeChecker_Env.nosynth =
+                                      (uu___4.FStar_TypeChecker_Env.nosynth);
+                                    FStar_TypeChecker_Env.uvar_subtyping =
+                                      (uu___4.FStar_TypeChecker_Env.uvar_subtyping);
+                                    FStar_TypeChecker_Env.tc_term =
+                                      (uu___4.FStar_TypeChecker_Env.tc_term);
+                                    FStar_TypeChecker_Env.type_of =
+                                      (uu___4.FStar_TypeChecker_Env.type_of);
+                                    FStar_TypeChecker_Env.universe_of =
+                                      (uu___4.FStar_TypeChecker_Env.universe_of);
+                                    FStar_TypeChecker_Env.check_type_of =
+                                      (uu___4.FStar_TypeChecker_Env.check_type_of);
+                                    FStar_TypeChecker_Env.use_bv_sorts =
+                                      (uu___4.FStar_TypeChecker_Env.use_bv_sorts);
+                                    FStar_TypeChecker_Env.qtbl_name_and_index
+                                      =
+                                      (uu___4.FStar_TypeChecker_Env.qtbl_name_and_index);
+                                    FStar_TypeChecker_Env.normalized_eff_names
+                                      =
+                                      (uu___4.FStar_TypeChecker_Env.normalized_eff_names);
+                                    FStar_TypeChecker_Env.fv_delta_depths =
+                                      (uu___4.FStar_TypeChecker_Env.fv_delta_depths);
+                                    FStar_TypeChecker_Env.proof_ns =
+                                      (uu___4.FStar_TypeChecker_Env.proof_ns);
+                                    FStar_TypeChecker_Env.synth_hook =
+                                      (uu___4.FStar_TypeChecker_Env.synth_hook);
+                                    FStar_TypeChecker_Env.try_solve_implicits_hook
+                                      =
+                                      (uu___4.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                                    FStar_TypeChecker_Env.splice =
+                                      (uu___4.FStar_TypeChecker_Env.splice);
+                                    FStar_TypeChecker_Env.mpreprocess =
+                                      (uu___4.FStar_TypeChecker_Env.mpreprocess);
+                                    FStar_TypeChecker_Env.postprocess =
+                                      (uu___4.FStar_TypeChecker_Env.postprocess);
+                                    FStar_TypeChecker_Env.identifier_info =
+                                      (uu___4.FStar_TypeChecker_Env.identifier_info);
+                                    FStar_TypeChecker_Env.tc_hooks =
+                                      (uu___4.FStar_TypeChecker_Env.tc_hooks);
+                                    FStar_TypeChecker_Env.dsenv =
+                                      (uu___4.FStar_TypeChecker_Env.dsenv);
+                                    FStar_TypeChecker_Env.nbe =
+                                      (uu___4.FStar_TypeChecker_Env.nbe);
+                                    FStar_TypeChecker_Env.strict_args_tab =
+                                      (uu___4.FStar_TypeChecker_Env.strict_args_tab);
+                                    FStar_TypeChecker_Env.erasable_types_tab
+                                      =
+                                      (uu___4.FStar_TypeChecker_Env.erasable_types_tab);
+                                    FStar_TypeChecker_Env.enable_defer_to_tac
+                                      =
+                                      (uu___4.FStar_TypeChecker_Env.enable_defer_to_tac);
+                                    FStar_TypeChecker_Env.unif_allow_ref_guards
+                                      =
+                                      (uu___4.FStar_TypeChecker_Env.unif_allow_ref_guards)
+                                  }) tm in
+                             FStar_Pervasives_Native.Some uu___3)) ()
+               with
+               | FStar_Errors.Error
+                   (FStar_Errors.Error_LayeredMissingAnnot, uu___2, uu___3,
+                    uu___4)
+                   -> FStar_Pervasives_Native.None
+               | e -> FStar_Exn.raise e in
+             match res with
+             | FStar_Pervasives_Native.None -> FStar_Tactics_Monad.ret tm
+             | FStar_Pervasives_Native.Some (uu___1, lcomp, g) ->
+                 let uu___2 =
+                   (let uu___3 =
+                      FStar_TypeChecker_Common.is_pure_or_ghost_lcomp lcomp in
+                    Prims.op_Negation uu___3) ||
+                     (let uu___3 = FStar_TypeChecker_Env.is_trivial g in
+                      Prims.op_Negation uu___3) in
+                 if uu___2
+                 then FStar_Tactics_Monad.ret tm
+                 else
+                   (let typ = lcomp.FStar_TypeChecker_Common.res_typ in
+                    let uu___4 =
+                      FStar_Tactics_Monad.new_uvar "do_rewrite.rhs" env typ in
+                    FStar_Tactics_Monad.bind uu___4
+                      (fun uu___5 ->
+                         match uu___5 with
+                         | (ut, uvar_ut) ->
+                             FStar_Tactics_Monad.mlog
+                               (fun uu___6 ->
+                                  let uu___7 =
+                                    FStar_Syntax_Print.term_to_string tm in
+                                  let uu___8 =
+                                    FStar_Syntax_Print.term_to_string ut in
+                                  FStar_Util.print2
+                                    "do_rewrite: making equality\n\t%s ==\n\t%s\n"
+                                    uu___7 uu___8)
+                               (fun uu___6 ->
+                                  let uu___7 =
+                                    let uu___8 =
+                                      let uu___9 =
+                                        env.FStar_TypeChecker_Env.universe_of
+                                          env typ in
+                                      FStar_Syntax_Util.mk_eq2 uu___9 typ tm
+                                        ut in
+                                    FStar_Tactics_Monad.add_irrelevant_goal
+                                      g0 "do_rewrite.eq" env uu___8 in
+                                  FStar_Tactics_Monad.bind uu___7
+                                    (fun uu___8 ->
+                                       let uu___9 =
+                                         FStar_Tactics_Basic.focus rewriter in
+                                       FStar_Tactics_Monad.bind uu___9
+                                         (fun uu___10 ->
+                                            let ut1 =
+                                              FStar_TypeChecker_Normalize.reduce_uvar_solutions
+                                                env ut in
+                                            FStar_Tactics_Monad.mlog
+                                              (fun uu___11 ->
+                                                 let uu___12 =
+                                                   FStar_Syntax_Print.term_to_string
+                                                     tm in
+                                                 let uu___13 =
+                                                   FStar_Syntax_Print.term_to_string
+                                                     ut1 in
+                                                 FStar_Util.print2
+                                                   "rewrite_rec: succeeded rewriting\n\t%s to\n\t%s\n"
+                                                   uu___12 uu___13)
+                                              (fun uu___11 ->
+                                                 FStar_Tactics_Monad.ret ut1)))))))
 let (do_rewrite :
   FStar_Tactics_Types.goal ->
     rewriter_ty ->
@@ -265,8 +305,6 @@ let rec map_ctac : 'a . 'a ctac -> 'a Prims.list ctac =
                match uu___1 with
                | ((x1, xs2), flag) ->
                    FStar_Tactics_Monad.ret ((x1 :: xs2), flag))
-let bind_ctac : 'a 'b . 'a ctac -> ('a -> 'b ctac) -> 'b ctac =
-  fun t -> fun f -> fun b1 -> failwith ""
 let ctac_id :
   'a . 'a -> ('a * FStar_Tactics_Types.ctrl_flag) FStar_Tactics_Monad.tac =
   fun x -> FStar_Tactics_Monad.ret (x, FStar_Tactics_Types.Continue)

--- a/src/ocaml-output/FStar_ToSyntax_ToSyntax.ml
+++ b/src/ocaml-output/FStar_ToSyntax_ToSyntax.ml
@@ -453,7 +453,7 @@ and (free_type_vars :
                          | FStar_Util.Inl binder ->
                              free_type_vars_b env1 binder
                          | FStar_Util.Inr t1 ->
-                             let uu___4 = free_type_vars env1 body in
+                             let uu___4 = free_type_vars env1 t1 in
                              (env1, uu___4) in
                        (match uu___3 with
                         | (env2, f) -> (env2, (FStar_List.append f free))))

--- a/src/ocaml-output/FStar_TypeChecker_Normalize.ml
+++ b/src/ocaml-output/FStar_TypeChecker_Normalize.ml
@@ -4388,8 +4388,7 @@ let rec (norm :
                                 t1.FStar_Syntax_Syntax.pos in
                             rebuild cfg env1 stack1 t2)))
            | FStar_Syntax_Syntax.Tm_delayed uu___2 ->
-               let t2 = FStar_Syntax_Subst.compress t1 in
-               norm cfg env1 stack1 t2
+               failwith "impossible: Tm_delayed on norm"
            | FStar_Syntax_Syntax.Tm_uvar uu___2 ->
                if
                  (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.check_no_uvars

--- a/src/ocaml-output/FStar_TypeChecker_Normalize.ml
+++ b/src/ocaml-output/FStar_TypeChecker_Normalize.ml
@@ -4391,25 +4391,20 @@ let rec (norm :
                let t2 = FStar_Syntax_Subst.compress t1 in
                norm cfg env1 stack1 t2
            | FStar_Syntax_Syntax.Tm_uvar uu___2 ->
-               let t2 = FStar_Syntax_Subst.compress t1 in
-               (match t2.FStar_Syntax_Syntax.n with
-                | FStar_Syntax_Syntax.Tm_uvar uu___3 ->
-                    if
-                      (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.check_no_uvars
-                    then
-                      let uu___4 =
-                        let uu___5 =
-                          FStar_Range.string_of_range
-                            t2.FStar_Syntax_Syntax.pos in
-                        let uu___6 = FStar_Syntax_Print.term_to_string t2 in
-                        FStar_Util.format2
-                          "(%s) CheckNoUvars: Unexpected unification variable remains: %s"
-                          uu___5 uu___6 in
-                      failwith uu___4
-                    else
-                      (let uu___5 = inline_closure_env cfg env1 [] t2 in
-                       rebuild cfg env1 stack1 uu___5)
-                | uu___3 -> norm cfg env1 stack1 t2))
+               if
+                 (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.check_no_uvars
+               then
+                 let uu___3 =
+                   let uu___4 =
+                     FStar_Range.string_of_range t1.FStar_Syntax_Syntax.pos in
+                   let uu___5 = FStar_Syntax_Print.term_to_string t1 in
+                   FStar_Util.format2
+                     "(%s) CheckNoUvars: Unexpected unification variable remains: %s"
+                     uu___4 uu___5 in
+                 failwith uu___3
+               else
+                 (let uu___4 = inline_closure_env cfg env1 [] t1 in
+                  rebuild cfg env1 stack1 uu___4))
 and (do_unfold_fv :
   FStar_TypeChecker_Cfg.cfg ->
     env ->

--- a/src/ocaml-output/FStar_TypeChecker_TcTerm.ml
+++ b/src/ocaml-output/FStar_TypeChecker_TcTerm.ml
@@ -562,7 +562,8 @@ let (check_expected_effect :
                                  FStar_Util.format2
                                    "Missing annotation for a layered effect (%s) computation at %s"
                                    uu___11 uu___12 in
-                               (FStar_Errors.Fatal_IllTyped, uu___10) in
+                               (FStar_Errors.Error_LayeredMissingAnnot,
+                                 uu___10) in
                              FStar_Errors.raise_error uu___9
                                e.FStar_Syntax_Syntax.pos
                            else

--- a/src/parser/FStar.Parser.AST.fs
+++ b/src/parser/FStar.Parser.AST.fs
@@ -525,6 +525,7 @@ let imp_to_string = function
     | _ -> ""
 let rec term_to_string (x:term) = match x.tm with
   | Wild -> "_"
+  | Decreases (t, _) -> Util.format1 "(decreases %s)" (term_to_string t)
   | Requires (t, _) -> Util.format1 "(requires %s)" (term_to_string t)
   | Ensures (t, _) -> Util.format1 "(ensures %s)" (term_to_string t)
   | Labeled (t, l, _) -> Util.format2 "(labeled %s %s)" l (term_to_string t)

--- a/src/tactics/FStar.Tactics.CtrlRewrite.fs
+++ b/src/tactics/FStar.Tactics.CtrlRewrite.fs
@@ -23,6 +23,8 @@ module Z      = FStar.BigInt
 module Env    = FStar.TypeChecker.Env
 module TcComm = FStar.TypeChecker.Common
 module N      = FStar.TypeChecker.Normalize
+module Const  = FStar.Const
+module Errors = FStar.Errors
 
 (* WHY DO I NEED TO COPY THESE? *)
 type controller_ty = term -> tac<(bool * ctrl_flag)>
@@ -35,18 +37,53 @@ let __do_rewrite
     (tm : term)
   : tac<term>
 =
+  (*
+   * We skip certain terms. In particular if the term is a constant
+   * which must have an argument (reify, reflect, range_of,
+   * set_range_of), since typechecking will then fail, and the tactic
+   * will also not be able to do anything useful. Morally, `reify` is
+   * not a term, so it's fine to skip it.
+   *
+   * This is not perfect since if we have any other node wrapping the
+   * `reify` (metadata?) this will still fail. But I don't think that
+   * ever happens currently.
+   *)
+  let should_skip =
+    match (SS.compress tm).n with
+    | S.Tm_constant Const.Const_reify
+    | S.Tm_constant (Const.Const_reflect _)
+    | S.Tm_constant Const.Const_range_of
+    | S.Tm_constant Const.Const_set_range_of ->
+      true
+    | _ -> false
+  in
+  if should_skip then ret tm else begin
+
     (* It's important to keep the original term if we want to do
      * nothing, (hence the underscore below) since after the call to
      * the typechecker, t can be elaborated and have more structure. In
      * particular, it can be abscribed and hence CONTAIN t AS A SUBTERM!
      * Which would cause an infinite loop between this function and
-     * ctrl_fold_env. *)
-    let _, lcomp, g = env.tc_term ({ env with Env.lax = true }) tm in
-    (* TODO: re-typechecking the goal is expensive *)
-    (* use type_of_well_typed_term...? *)
+     * ctrl_fold_env.
+     *
+     * If we got an error about a layered effect missing an annotation,
+     * we just skip the term, for reasons similar to unapplied constants
+     * above. Other exceptions are re-raised.
+     *)
+    let res =
+      try
+        Errors.with_ctx "While typechecking a subterm for ctrl_rewrite" (fun () ->
+          Some (env.tc_term ({ env with Env.lax = true }) tm))
+      with
+      | Errors.Error (Errors.Error_LayeredMissingAnnot, _, _, _) -> None
+      | e -> raise e
+    in
+    match res with
+    | None -> ret tm
+    | Some (_, lcomp, g) ->
 
     if not (TcComm.is_pure_or_ghost_lcomp lcomp) || not (Env.is_trivial g) then
-      ret tm (* SHOULD THIS CHECK BE IN MAYBE_REWRITE INSTEAD? *)
+      ret tm (* SHOULD THIS CHECK BE IN maybe_rewrite INSTEAD? *)
     else
     let typ = lcomp.res_typ in
     bind (new_uvar "do_rewrite.rhs" env typ) (fun (ut, uvar_ut) ->
@@ -66,6 +103,7 @@ let __do_rewrite
                    (Print.term_to_string tm)
                    (Print.term_to_string ut)) (fun () ->
     ret ut)))))
+  end
 
 (* If __do_rewrite fails with "SKIP" we do nothing *)
 let do_rewrite
@@ -122,11 +160,11 @@ let rec map_ctac (c : ctac<'a>)
         bind (par_ctac c (map_ctac c) (x, xs)) (fun ((x, xs), flag) ->
         ret (x::xs, flag))
 
-let bind_ctac
-    (t : ctac<'a>)
-    (f : 'a -> ctac<'b>)
-  : ctac<'b>
-  = fun b -> failwith ""
+(* let bind_ctac *)
+(*     (t : ctac<'a>) *)
+(*     (f : 'a -> ctac<'b>) *)
+(*   : ctac<'b> *)
+(*   = fun b -> failwith "" *)
 
 let ctac_id (* : ctac<'a> *) =
   fun (x:'a) -> ret (x, Continue)

--- a/src/tosyntax/FStar.ToSyntax.ToSyntax.fs
+++ b/src/tosyntax/FStar.ToSyntax.ToSyntax.fs
@@ -261,7 +261,7 @@ and free_type_vars env t = match (unparen t).tm with
       let env, f =
         match bt with
         | Inl binder -> free_type_vars_b env binder
-        | Inr t -> env, free_type_vars env body
+        | Inr t -> env, free_type_vars env t
       in
       env, f@free) (env, []) binders in
     free@free_type_vars env body

--- a/src/typechecker/FStar.TypeChecker.Normalize.fs
+++ b/src/typechecker/FStar.TypeChecker.Normalize.fs
@@ -1520,8 +1520,7 @@ let rec norm : cfg -> env -> stack -> term -> term =
         end //Tm_meta
 
         | Tm_delayed _ ->
-          let t = SS.compress t in
-          norm cfg env stack t
+          failwith "impossible: Tm_delayed on norm"
 
         | Tm_uvar _ ->
           if cfg.steps.check_no_uvars

--- a/src/typechecker/FStar.TypeChecker.Normalize.fs
+++ b/src/typechecker/FStar.TypeChecker.Normalize.fs
@@ -1524,17 +1524,11 @@ let rec norm : cfg -> env -> stack -> term -> term =
           norm cfg env stack t
 
         | Tm_uvar _ ->
-          let t = SS.compress t in
-          match t.n with
-          | Tm_uvar _ ->
-            if cfg.steps.check_no_uvars
-            then failwith (BU.format2 "(%s) CheckNoUvars: Unexpected unification variable remains: %s"
-                                    (Range.string_of_range t.pos)
-                                    (Print.term_to_string t))
-            else rebuild cfg env stack (inline_closure_env cfg env [] t)
-
-          | _ ->
-            norm cfg env stack t
+          if cfg.steps.check_no_uvars
+          then failwith (BU.format2 "(%s) CheckNoUvars: Unexpected unification variable remains: %s"
+                                  (Range.string_of_range t.pos)
+                                  (Print.term_to_string t))
+          else rebuild cfg env stack (inline_closure_env cfg env [] t)
 
 and do_unfold_fv cfg env stack (t0:term) (qninfo : qninfo) (f:fv) : term =
     match Env.lookup_definition_qninfo cfg.delta_level f.fv_name.v qninfo with

--- a/src/typechecker/FStar.TypeChecker.TcTerm.fs
+++ b/src/typechecker/FStar.TypeChecker.TcTerm.fs
@@ -213,7 +213,7 @@ let check_expected_effect env (copt:option<comp>) (ec : term * comp) : term * co
         else if U.is_pure_or_ghost_comp c
         then Some (tot_or_gtot c), c, None
         else if U.comp_effect_name c |> Env.norm_eff_name env |> Env.is_layered_effect env
-        then raise_error (Errors.Fatal_IllTyped,  //hard error if layered effects are used without annotations
+        then raise_error (Errors.Error_LayeredMissingAnnot,  //hard error if layered effects are used without annotations
                BU.format2 "Missing annotation for a layered effect (%s) computation at %s"
                  (c |> U.comp_effect_name |> Ident.string_of_lid) (Range.string_of_range e.pos)) e.pos
         else if Options.trivial_pre_for_unannotated_effectful_fns ()

--- a/tests/bug-reports/Bug2169.fst
+++ b/tests/bug-reports/Bug2169.fst
@@ -1,0 +1,260 @@
+module Bug2169
+
+(* An effect for (demonic) nondeterminism via lists. *)
+
+open FStar.List.Tot
+open FStar.Tactics
+
+open FStar.FunctionalExtensionality
+module T = FStar.Tactics
+
+let elim_pure #a #wp ($f : unit -> PURE a wp) p
+ : Pure a (requires (wp p)) (ensures (fun r -> p r))
+ //: PURE a (fun p' -> wp p /\ (forall r. p r ==> p' r))
+ // ^ basically this, requires monotonicity
+ = FStar.Monotonic.Pure.wp_monotonic_pure ();
+   f ()
+
+// m is a monad. In this particular example, lists
+val m (a : Type u#a) : Type u#a
+let m a = list a
+
+val m_return (#a : Type) : a -> m a
+let m_return x = [x]
+
+val m_bind (#a #b : Type) : m a -> (a -> m b) -> m b
+let m_bind l f = concatMap f l
+
+// w is an ordered (w_ord) monad with conjunction (w_conj) and actions from prop (w_act_prop)
+// In this example, good ol' continuations into prop
+val w0 (a : Type u#a) : Type u#(max 1 a)
+let w0 a = (a -> Type0) -> Type0
+
+let monotonic (w:w0 'a) =
+  forall p1 p2. (forall x. p1 x ==> p2 x) ==> w p1 ==> w p2
+
+val w (a : Type u#a) : Type u#(max 1 a)
+let w a = w:(w0 a)//{monotonic w}
+
+val w_ord (#a : Type) : w a -> w a -> Type0
+let w_ord wp1 wp2 = forall p. wp1 p ==> wp2 p
+
+unfold
+val w_return (#a : Type) : a -> w a
+unfold
+let w_return x = fun p -> p x
+
+unfold
+val w_bind (#a #b : Type) : w a -> (a -> w b) -> w b
+unfold
+let w_bind wp1 k =
+  fun p -> wp1 (fun x -> k x p)
+
+val interp (#a : Type) : m a -> w a
+let interp #a (l:list a) = fun p -> forall x. memP x l ==> p x
+
+val concatlemma (#a:Type) (l1 l2 :list a) (x:a) : Lemma (memP x (l1@l2) <==> memP x l1 \/ memP x l2)
+let rec concatlemma #a l1 l2 x =
+  match l1 with
+  | [] -> ()
+  | h::t -> concatlemma t l2 x
+
+val concatmaplemma : (#a:Type) -> (#b:Type) -> l:list a -> (f:(a -> list b)) -> x:b ->
+                               Lemma (memP x (concatMap f l) <==> (exists a. memP a l /\ memP x (f a)))
+                                     [SMTPat (memP x (concatMap f l))]
+
+let rec concatmaplemma #a #b l f x =
+  match l with
+  | [] -> ()
+  | h::t ->
+    concatlemma (f h) (concatMap f t) x;
+    concatmaplemma t f x
+
+let dm (a : Type) (wp : w a) : Type = 
+  p:(a -> Type0) -> squash (wp p) -> l:(m a){forall x. memP x l ==> p x}
+  
+let irepr (a : Type) (wp: w a) = dm a wp
+
+let ireturn (a : Type) (x : a) : irepr a (w_return x) = fun _ _ -> [x]
+
+let rec pmap #a #b #pre (#post:b->Type0)
+  (f : (x:a -> Pure b (requires (pre x)) (ensures post)))
+  (l : list a)
+  : Pure (list (v:b{post v}))
+         (requires (forall x. memP x l ==> pre x))
+         (ensures (fun _ -> True))
+  = match l with
+    | [] -> []
+    | x::xs -> f x :: pmap #_ #_ #pre #post f xs
+
+let rec unref #a #p (l : list (v:a{p v})) : l:(list a){forall x. memP x l ==> p x} =
+  match l with
+  | [] -> []
+  | x :: xs -> x :: unref xs
+
+let mem_memP
+  (#a: eqtype)
+  (x: a)
+  (l: list a)
+: Lemma (ensures (mem x l <==> memP x l))
+        [SMTPat (memP x l); SMTPat (mem x l)]
+= FStar.List.Tot.Properties.mem_memP x l
+
+val append_memP: #t:Type ->  l1:list t
+              -> l2:list t
+              -> a:t
+              -> Lemma (requires True)
+                       (ensures (memP a (l1@l2) <==> (memP a l1 \/ memP a l2)))
+let rec append_memP #t l1 l2 a = match l1 with
+  | [] -> ()
+  | hd::tl -> append_memP tl l2 a
+
+let rec flatten_mem_lem #a (l : list (list a)) (x:a)
+  : Lemma (memP x (flatten l) <==> (exists l0. memP l0 l /\ memP x l0))
+          [SMTPat (memP x (flatten l))]
+  = match l with
+    | [] -> ()
+    | l1::ls -> (append_memP l1 (flatten ls) x; flatten_mem_lem ls x)
+
+let ibind (a : Type) (b : Type) (wp_v : w a) (wp_f: a -> w b) (v : irepr a wp_v) (f : (x:a -> irepr b (wp_f x))) : irepr b (w_bind wp_v wp_f) =
+  fun p _ -> let l1 = v (fun x -> wp_f x p) () in
+          let l2 = pmap #_ #(list b) #(fun x -> wp_f x p) #(fun l -> forall x. memP x l ==> p x) (fun x -> f x p ()) l1 in
+          let l2 = unref l2 in
+          let l2f = List.Tot.flatten l2 in
+          l2f
+ 
+let isubcomp (a:Type) (wp1 wp2: w a) (f : irepr a wp1) : Pure (irepr a wp2) (requires w_ord wp2 wp1) (ensures fun _ -> True) = f
+
+let wp_if_then_else (#a:Type) (wp1 wp2:w a) (b:bool) : w a=
+  fun p -> (b ==> wp1 p) /\ ((~b) ==> wp2 p)
+
+let i_if_then_else (a : Type) (wp1 wp2 : w a) (f : irepr a wp1) (g : irepr a wp2) (b : bool) : Type =
+  irepr a (wp_if_then_else wp1 wp2 b)
+
+total
+reifiable
+reflectable
+layered_effect {
+  ND : a:Type -> wp : w a -> Effect
+  with repr         = irepr;
+       return       = ireturn;
+       bind         = ibind;
+       subcomp      = isubcomp; 
+       if_then_else = i_if_then_else
+}
+
+let lift_pure_nd (a:Type) (wp:pure_wp a) (f:(eqtype_as_type unit -> PURE a wp)) :
+  Pure (irepr a wp) (requires True)
+                    (ensures (fun _ -> True))
+  = fun p _ -> let r = elim_pure f p in [r]
+
+sub_effect PURE ~> ND = lift_pure_nd
+
+val test_f : unit -> ND int (fun p -> p 5 /\ p 3)
+let test_f () =
+  ND?.reflect (fun _ _ -> [3; 5])
+
+//let l () : (l:(list int){forall p. p 5 /\ p 3 ==> interp l p}) = reify (test_f ())
+// ^ This one doesn't work... datatype subtyping to blame?
+
+let l () : (l:(list int)) = reify (test_f ()) (fun _ -> True) ()
+
+effect Nd (a:Type) (pre:pure_pre) (post:pure_post' a pre) =
+        ND a (fun (p:pure_post a) -> pre /\ (forall (pure_result:a). post pure_result ==> p pure_result))
+
+val choose : #a:Type0 -> x:a -> y:a -> ND a (fun p -> p x /\ p y)
+let choose #a x y =
+    ND?.reflect (fun _ _ -> [x;y])
+
+val fail : #a:Type0 -> unit -> ND a (fun p -> True)
+let fail #a () =
+    ND?.reflect (fun _ _ -> [])
+
+let flip () : ND bool (fun p -> p true /\ p false) =
+    choose true false
+
+let test () : ND int (fun p -> forall (x:int). 0 <= x /\ x < 10 ==> p x)  by (compute ()) =
+    let x = choose 0 1 in
+    let y = choose 2 3 in
+    let z = choose 4 5 in
+    x + y + z
+
+[@expect_failure]
+let test_bad () : ND int (fun p -> forall (x:int). 0 <= x /\ x < 5 ==> p x) by (compute ()) =
+    let x = choose 0 1 in
+    let y = choose 2 3 in
+    let z = choose 4 5 in
+    x + y + z
+
+let guard (b:bool) : ND unit (fun p -> b ==> p ()) by (compute ()) =
+  if b
+  then ()
+  else fail ()
+  
+let rec pick_from #a (l : list a) : ND a (fun p -> forall x. memP x l ==> p x) by (compute ()) =
+    match l with
+    | [] -> fail ()
+    | x::xs ->
+      if flip ()
+      then x
+      else pick_from xs
+
+let ( * ) = op_Multiply
+
+let pyths () : ND (int & int & int) (fun p -> forall x y z. x*x + y*y == z*z ==> p (x,y,z)) by (compute ()) =
+  let l = [1;2;3;4;5;6;7;8;9;10] in
+  let x = pick_from l in
+  let y = pick_from l in
+  let z = pick_from l in
+  guard (x*x + y*y = z*z);
+  (x,y,z)
+
+(* Extracted code for pyths:
+
+let (pyths_norm : unit -> (Prims.int * Prims.int * Prims.int) Prims.list) =
+  fun uu____1038  ->
+    [((Prims.parse_int "3"), (Prims.parse_int "4"), (Prims.parse_int "5"));
+    ((Prims.parse_int "4"), (Prims.parse_int "3"), (Prims.parse_int "5"));
+    ((Prims.parse_int "6"), (Prims.parse_int "8"), (Prims.parse_int "10"));
+    ((Prims.parse_int "8"), (Prims.parse_int "6"), (Prims.parse_int "10"))]
+*)
+let pyths_norm () = normalize_term (reify (pyths ()))
+
+(* ^ Try it in emacs: C-c C-s C-e pyths_norm ():
+Reducing ‘pyths_norm ()’…
+pyths_norm () ↓βδιζr [3, 4, 5; 4, 3, 5; 6, 8, 10; 8, 6, 10] <: list ((int * int) * int)
+*)
+
+opaque
+let g (x:int) : option int = Some x
+
+let wrap (f:int -> ND unit (fun p -> True)) (x':int) : ND unit (fun p -> True) =
+  match g x' with
+  | Some x -> f x
+  | None -> f 4
+
+// The test below use to fail while running the tactic, now it leaves a
+// goal that cannot be solved. That's what we check for with the 19.
+
+[@@expect_failure [19]]
+let rewrite_inside_reify
+  (f : int -> ND unit (fun p -> True))
+  (g : int -> Tot (option int))
+  (x' : int) : Tot unit = 
+
+  let f' = wrap f in 
+  let l = reify (f' x') (fun _ -> True) in
+
+  match g x' with
+  | Some x -> 
+     let ll = reify (f x) (fun _ -> True) in
+     assert (l == ll) by (
+       unfold_def (`wrap);
+       // This puts in rwr: g x' == Some b
+       let rwr = (match (List.Tot.nth (cur_binders ()) 11) with
+       | Some y -> y | None -> T.fail "no goal found") in
+       l_to_r [`rwr];
+       dump "H")
+     // The assert ^ fails with the error:
+     // "(Error) user tactic failed: Ill-typed reify: this constant must be fully applied"
+  | None -> ()

--- a/tests/bug-reports/Makefile
+++ b/tests/bug-reports/Makefile
@@ -41,7 +41,7 @@ SHOULD_VERIFY_CLOSED=Bug022.fst Bug024.fst Bug025.fst Bug026.fst Bug026b.fst Bug
   Bug1903.fst Bug1121a.fst Bug1121b.fst Bug1956.fst Bug1228.fst Bug829.fst Bug451.fst Bug1966a.fst Bug1966b.fst Bug1976.fst \
   Bug1986.fst Bug1995.fst Bug1507.fst Bug2001.fst Bug2004.fst Bug855a.fst Bug855b.fst Bug1097.fst Bug1918.fst Bug1390.fst Bug2031.fst \
   Bug379.fst Bug1182a.fst Bug1182b.fst Bug1901.fst Bug1902.fst Bug258.fst Bug2055.fst Bug2081.fst Bug2099.fst Bug2106.fst Bug2132.fst \
-  Bug2138.fst Bug2146.fst Bug2074.fst Bug2125a.fst Bug2125b.fst Bug2167.fst
+  Bug2138.fst Bug2146.fst Bug2074.fst Bug2125a.fst Bug2125b.fst Bug2167.fst Bug2169.fst
 
 SHOULD_VERIFY_INTERFACE_CLOSED=Bug771.fsti Bug771b.fsti
 SHOULD_VERIFY_AND_WARN_CLOSED=Bug016.fst


### PR DESCRIPTION
This fixes the issues in #2169. The assertion later fails... but the tactic engine accepts the rewrites now. The problems were:

1- `ctrl_rewrite` was descending into the unapplied `reify`, which fails to typecheck and so it crashed. I made it ignore constants which need an argument (reify, reflect, range_of, set_range_of) and are unapplied. Morally I think this is fine since I don't consider them real subterms.

2- I also made it skip the subterm if it is an unannotated layered effect computation, since that also fails to typecheck. I think this is similar to the previous case: without an annotation, these terms cannot stand on their own. @aseemr could you confirm this makes sense? (I also changed the error code.)

I suppose we could always skip on an error... the primary reason for the typecheck on `ctrl_rewrite` is to obtain a type to make the equality goal. Maybe `type_of_well_typed` term would also do.

This does not make the file work, the assertion still fails and the rewrite doesn't really do anything since `g x` does not appear in the goal. @andricicezar can you confirm this is expected, and whether this unblocks you?