### PR TITLE
normalizer: do not reuse memos across normalization calls

### DIFF
--- a/src/ocaml-output/FStar_Syntax_Free.ml
+++ b/src/ocaml-output/FStar_Syntax_Free.ml
@@ -317,16 +317,32 @@ and (free_names_and_uvars_comp :
                 let uu___3 = free_names_and_uvars t use_cache in
                 union uu___2 uu___3
             | FStar_Syntax_Syntax.Comp ct ->
+                let decreases_vars =
+                  let uu___2 =
+                    FStar_List.tryFind
+                      (fun uu___3 ->
+                         match uu___3 with
+                         | FStar_Syntax_Syntax.DECREASES uu___4 -> true
+                         | uu___4 -> false) ct.FStar_Syntax_Syntax.flags in
+                  match uu___2 with
+                  | FStar_Pervasives_Native.None -> no_free_vars
+                  | FStar_Pervasives_Native.Some
+                      (FStar_Syntax_Syntax.DECREASES d) ->
+                      free_names_and_uvars d use_cache
+                  | FStar_Pervasives_Native.Some uu___3 ->
+                      failwith "impossible" in
                 let us =
                   let uu___2 =
                     free_names_and_uvars ct.FStar_Syntax_Syntax.result_typ
                       use_cache in
+                  union uu___2 decreases_vars in
+                let us1 =
                   free_names_and_uvars_args
-                    ct.FStar_Syntax_Syntax.effect_args uu___2 use_cache in
+                    ct.FStar_Syntax_Syntax.effect_args us use_cache in
                 FStar_List.fold_left
-                  (fun us1 ->
-                     fun u -> let uu___2 = free_univs u in union us1 uu___2)
-                  us ct.FStar_Syntax_Syntax.comp_univs in
+                  (fun us2 ->
+                     fun u -> let uu___2 = free_univs u in union us2 uu___2)
+                  us1 ct.FStar_Syntax_Syntax.comp_univs in
           (FStar_ST.op_Colon_Equals c.FStar_Syntax_Syntax.vars
              (FStar_Pervasives_Native.Some (FStar_Pervasives_Native.fst n));
            n)

--- a/src/ocaml-output/FStar_TypeChecker_TcTerm.ml
+++ b/src/ocaml-output/FStar_TypeChecker_TcTerm.ml
@@ -1057,20 +1057,29 @@ let (guard_letrecs :
                           -> dec
                       | uu___3 -> mk_lex_list [dec]) in
                let cflags = FStar_Syntax_Util.comp_flags c in
-               let uu___1 =
-                 FStar_All.pipe_right cflags
-                   (FStar_List.tryFind
-                      (fun uu___2 ->
-                         match uu___2 with
-                         | FStar_Syntax_Syntax.DECREASES uu___3 -> true
-                         | uu___3 -> false)) in
-               match uu___1 with
-               | FStar_Pervasives_Native.Some (FStar_Syntax_Syntax.DECREASES
-                   dec) -> as_lex_list dec
-               | uu___2 ->
-                   let xs =
-                     FStar_All.pipe_right bs filter_types_and_functions in
-                   mk_lex_list xs) in
+               let res =
+                 let uu___1 =
+                   FStar_All.pipe_right cflags
+                     (FStar_List.tryFind
+                        (fun uu___2 ->
+                           match uu___2 with
+                           | FStar_Syntax_Syntax.DECREASES uu___3 -> true
+                           | uu___3 -> false)) in
+                 match uu___1 with
+                 | FStar_Pervasives_Native.Some
+                     (FStar_Syntax_Syntax.DECREASES dec) -> as_lex_list dec
+                 | uu___2 ->
+                     let xs =
+                       FStar_All.pipe_right bs filter_types_and_functions in
+                     mk_lex_list xs in
+               (let uu___2 =
+                  FStar_TypeChecker_Env.debug env1 FStar_Options.Low in
+                if uu___2
+                then
+                  let uu___3 = FStar_Syntax_Print.term_to_string res in
+                  FStar_Util.print1 "Building a decreases = %s\n" uu___3
+                else ());
+               res) in
             let previous_dec = decreases_clause actuals expected_c in
             let guard_one_letrec uu___ =
               match uu___ with
@@ -3329,6 +3338,13 @@ and (tc_value :
                               FStar_TypeChecker_Common.lcomp_of_comp uu___6 in
                           FStar_Util.Inr uu___5) in
                      value_check_expected_typ env1 e2 tc implicits)))
+      | FStar_Syntax_Syntax.Tm_fvar fv when
+          (FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.lex_t_lid) ||
+            (FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.lextop_lid)
+          ->
+          let uu___ =
+            FStar_Syntax_Syntax.mk_Tm_uinst top [FStar_Syntax_Syntax.U_zero] in
+          tc_value env1 uu___
       | FStar_Syntax_Syntax.Tm_uinst
           ({ FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar fv;
              FStar_Syntax_Syntax.pos = uu___;

--- a/src/typechecker/FStar.TypeChecker.TcTerm.fs
+++ b/src/typechecker/FStar.TypeChecker.TcTerm.fs
@@ -1139,6 +1139,11 @@ and tc_value env (e:term) : term
     let tc = if Env.should_verify env then Inl t else Inr (TcComm.lcomp_of_comp <| mk_Total t) in
     value_check_expected_typ env e tc implicits
 
+  (* Unannotated lex_t and LexTop should default to universe 0 *)
+  | Tm_fvar fv when S.fv_eq_lid fv Const.lex_t_lid ||
+                    S.fv_eq_lid fv Const.lextop_lid ->
+    tc_value env (S.mk_Tm_uinst top [U_zero])
+
   | Tm_uinst({n=Tm_fvar fv}, _)
   | Tm_fvar fv when S.fv_eq_lid fv Const.synth_lid && not env.phase1 ->
     raise_error (Errors.Fatal_BadlyInstantiatedSynthByTactic, "Badly instantiated synth_by_tactic") (Env.get_range env)

--- a/src/typechecker/FStar.TypeChecker.TcTerm.fs
+++ b/src/typechecker/FStar.TypeChecker.TcTerm.fs
@@ -391,11 +391,17 @@ let guard_letrecs env actuals expected_c : list<(lbname*typ*univ_names)> =
                     | Tm_fvar fv when S.fv_eq_lid fv Const.lexcons_lid -> dec
                     | _ -> mk_lex_list [dec] in
           let cflags = U.comp_flags c in
+          let res =
           match cflags |> List.tryFind (function DECREASES _ -> true | _ -> false) with
                 | Some (DECREASES dec) -> as_lex_list dec
                 | _ ->
                     let xs = bs |> filter_types_and_functions in
                     mk_lex_list xs
+          in
+          if debug env Options.Low
+          then BU.print1 "Building a decreases = %s\n"
+                (Print.term_to_string res);
+          res
       in
 
       let previous_dec = decreases_clause actuals expected_c in

--- a/tests/bug-reports/Bug2193.fst
+++ b/tests/bug-reports/Bug2193.fst
@@ -1,0 +1,8 @@
+module Bug2193
+
+#set-options "--lax"
+
+type foo: Type u#m = | FOO
+
+let i (n: nat): Tot unit (decreases FOO)
+  = admit () 

--- a/tests/bug-reports/Makefile
+++ b/tests/bug-reports/Makefile
@@ -41,7 +41,8 @@ SHOULD_VERIFY_CLOSED=Bug022.fst Bug024.fst Bug025.fst Bug026.fst Bug026b.fst Bug
   Bug1903.fst Bug1121a.fst Bug1121b.fst Bug1956.fst Bug1228.fst Bug829.fst Bug451.fst Bug1966a.fst Bug1966b.fst Bug1976.fst \
   Bug1986.fst Bug1995.fst Bug1507.fst Bug2001.fst Bug2004.fst Bug855a.fst Bug855b.fst Bug1097.fst Bug1918.fst Bug1390.fst Bug2031.fst \
   Bug379.fst Bug1182a.fst Bug1182b.fst Bug1901.fst Bug1902.fst Bug258.fst Bug2055.fst Bug2081.fst Bug2099.fst Bug2106.fst Bug2132.fst \
-  Bug2138.fst Bug2146.fst Bug2074.fst Bug2125a.fst Bug2125b.fst Bug2167.fst Bug2169.fst Bug2169b.fst Bug2066.fst Bug2189.fst Bug2184.fst
+  Bug2138.fst Bug2146.fst Bug2074.fst Bug2125a.fst Bug2125b.fst Bug2167.fst Bug2169.fst Bug2169b.fst Bug2066.fst Bug2189.fst Bug2184.fst \
+  Bug2193.fst
 
 SHOULD_VERIFY_INTERFACE_CLOSED=Bug771.fsti Bug771b.fsti
 SHOULD_VERIFY_AND_WARN_CLOSED=Bug016.fst


### PR DESCRIPTION
Making the PR to not forget about this. This is an alternative fix to #2155, since the first one proved too aggresive and we reverted it.

    normalizer: do not reuse memos across normalization calls
    
    This is a revamp of 4504873d3609253f9a22656dd5c55ae1f7f3b9d6
    ("normalizer: make memoization valid only for a given cfg") which is not
    so aggresive.

