### PR TITLE
tc: norm: adding a DescendIntoUvarTypes flag

### DIFF
--- a/src/parser/FStar.Parser.Const.fs
+++ b/src/parser/FStar.Parser.Const.fs
@@ -304,6 +304,7 @@ let steps_unfoldonly    = psconst "delta_only"
 let steps_unfoldfully   = psconst "delta_fully"
 let steps_unfoldattr    = psconst "delta_attr"
 let steps_nbe           = psconst "nbe"
+let steps_descend_into_uvar_types  = psconst "descend_into_uvar_types"
 
 (* attributes *)
 let deprecated_attr = pconst "deprecated"

--- a/src/syntax/FStar.Syntax.Embeddings.fs
+++ b/src/syntax/FStar.Syntax.Embeddings.fs
@@ -580,6 +580,7 @@ type norm_step =
     | UnfoldFully of list<string>
     | UnfoldAttr  of list<string>
     | NBE
+    | DescendIntoUvarTypes
 
 (* the steps as terms *)
 let steps_Simpl         = tconst PC.steps_simpl
@@ -595,6 +596,7 @@ let steps_UnfoldOnly    = tconst PC.steps_unfoldonly
 let steps_UnfoldFully   = tconst PC.steps_unfoldonly
 let steps_UnfoldAttr    = tconst PC.steps_unfoldattr
 let steps_NBE           = tconst PC.steps_nbe
+let steps_DescendIntoUvarTypes = tconst PC.steps_descend_into_uvar_types
 
 let e_norm_step =
     let t_norm_step = U.fvar_const (Ident.lid_of_str "FStar.Syntax.Embeddings.norm_step") in
@@ -619,6 +621,8 @@ let e_norm_step =
                     steps_Primops
                 | Delta ->
                     steps_Delta
+                | DescendIntoUvarTypes ->
+                    steps_DescendIntoUvarTypes
                 | Zeta ->
                     steps_Zeta
                 | ZetaFull ->
@@ -660,6 +664,8 @@ let e_norm_step =
                     Some Primops
                 | Tm_fvar fv, [] when S.fv_eq_lid fv PC.steps_delta ->
                     Some Delta
+                | Tm_fvar fv, [] when S.fv_eq_lid fv PC.steps_descend_into_uvar_types ->
+                    Some DescendIntoUvarTypes
                 | Tm_fvar fv, [] when S.fv_eq_lid fv PC.steps_zeta ->
                     Some Zeta
                 | Tm_fvar fv, [] when S.fv_eq_lid fv PC.steps_zeta_full ->

--- a/src/syntax/FStar.Syntax.Embeddings.fsi
+++ b/src/syntax/FStar.Syntax.Embeddings.fsi
@@ -26,6 +26,7 @@ type norm_step =
     | UnfoldFully of list<string>
     | UnfoldAttr  of list<string>
     | NBE
+    | DescendIntoUvarTypes
 
 val steps_Simpl         : term
 val steps_Weak          : term
@@ -40,6 +41,7 @@ val steps_UnfoldOnly    : term
 val steps_UnfoldFully   : term
 val steps_UnfoldAttr    : term
 val steps_NBE           : term
+val steps_DescendIntoUvarTypes : term
 
 (*
  * Unmbedding functions return an option because they might fail

--- a/src/typechecker/FStar.TypeChecker.Cfg.fs
+++ b/src/typechecker/FStar.TypeChecker.Cfg.fs
@@ -49,7 +49,8 @@ type fsteps = {
      in_full_norm_request: bool;
      weakly_reduce_scrutinee:bool;
      nbe_step:bool;
-     for_extraction:bool
+     for_extraction:bool;
+     descend_into_uvar_types:bool;
 }
 
 let steps_to_string f =
@@ -87,6 +88,7 @@ let steps_to_string f =
     in_full_norm_request = %s;\n\
     weakly_reduce_scrutinee = %s;\n\
     for_extraction = %s;\n\
+    descend_into_uvar_types = %s;\n\
   }"
   [ f.beta |> b;
     f.iota |> b;
@@ -114,6 +116,7 @@ let steps_to_string f =
     f.in_full_norm_request |> b;
     f.weakly_reduce_scrutinee |> b;
     f.for_extraction |> b;
+    f.descend_into_uvar_types |> b;
    ]
 
 let default_steps : fsteps = {
@@ -143,7 +146,8 @@ let default_steps : fsteps = {
     in_full_norm_request = false;
     weakly_reduce_scrutinee = true;
     nbe_step = false;
-    for_extraction = false
+    for_extraction = false;
+    descend_into_uvar_types = false;
 }
 
 let fstep_add_one s fs =
@@ -179,6 +183,7 @@ let fstep_add_one s fs =
     | Unascribe ->  { fs with unascribe = true }
     | NBE -> {fs with nbe_step = true }
     | ForExtraction -> {fs with for_extraction = true }
+    | DescendIntoUvarTypes -> {fs with descend_into_uvar_types = true }
 
 let to_fsteps (s : list<step>) : fsteps =
     List.fold_right fstep_add_one s default_steps

--- a/src/typechecker/FStar.TypeChecker.Cfg.fsi
+++ b/src/typechecker/FStar.TypeChecker.Cfg.fsi
@@ -54,6 +54,7 @@ type fsteps = {
      weakly_reduce_scrutinee:bool;
      nbe_step:bool;
      for_extraction:bool;
+     descend_into_uvar_types:bool;
 }
 
 val default_steps : fsteps

--- a/src/typechecker/FStar.TypeChecker.Env.fs
+++ b/src/typechecker/FStar.TypeChecker.Env.fs
@@ -68,6 +68,7 @@ type step =
   | Unascribe
   | NBE
   | ForExtraction //marking an invocation of the normalizer for extraction
+  | DescendIntoUvarTypes // normalize the types of occurrences of uvars
 and steps = list<step>
 
 let rec eq_step s1 s2 =

--- a/src/typechecker/FStar.TypeChecker.Env.fsi
+++ b/src/typechecker/FStar.TypeChecker.Env.fsi
@@ -55,6 +55,7 @@ type step =
   | Unascribe
   | NBE
   | ForExtraction   //marking an invocation of the normalizer for extraction
+  | DescendIntoUvarTypes // normalize the types of occurrences of uvars
 and steps = list<step>
 
 val eq_step : step -> step -> bool

--- a/ulib/FStar.Pervasives.fst
+++ b/ulib/FStar.Pervasives.fst
@@ -96,6 +96,7 @@ type norm_step =
   // idem
   | UnfoldFully : list string -> norm_step
   | UnfoldAttr : list string -> norm_step // Unfold definitions marked with the given attributes
+  | DescendIntoUvarTypes
 
 let simplify = Simpl
 
@@ -106,6 +107,8 @@ let hnf = HNF
 let primops = Primops
 
 let delta = Delta
+
+let descend_into_uvar_types = DescendIntoUvarTypes
 
 let zeta = Zeta
 

--- a/ulib/FStar.Pervasives.fsti
+++ b/ulib/FStar.Pervasives.fsti
@@ -749,6 +749,9 @@ val primops : norm_step
 (** Unfold all non-recursive definitions *)
 val delta : norm_step
 
+(** Normalize the types of occurrences of uvars *)
+val descend_into_uvar_types : norm_step
+
 (** Unroll recursive calls
 
     Note: Since F*'s termination check is semantic rather than

--- a/ulib/tactics_ml/FStar_Tactics_Builtins.ml
+++ b/ulib/tactics_ml/FStar_Tactics_Builtins.ml
@@ -35,6 +35,8 @@ let tr1 = function
           | UnfoldOnly  ss -> EMB.UnfoldOnly ss
           | UnfoldFully ss -> EMB.UnfoldFully ss
           | UnfoldAttr  ss -> EMB.UnfoldAttr  ss
+          | DescendIntoUvarTypes -> EMB.DescendIntoUvarTypes
+
 let rt1 = function
           | EMB.Simpl          -> Simpl
           | EMB.Weak           -> Weak
@@ -49,6 +51,7 @@ let rt1 = function
           | EMB.UnfoldOnly  ss -> UnfoldOnly ss
           | EMB.UnfoldFully ss -> UnfoldFully ss
           | EMB.UnfoldAttr  ss -> UnfoldAttr  ss
+          | EMB.DescendIntoUvarTypes -> DescendIntoUvarTypes
 
 (* the one plugins actually use *)
 let e_norm_step' : norm_step EMB.embedding =


### PR DESCRIPTION
This PR adds a `DescendIntoUvarTypes` normalizer flag that make the normalizer descend on the types of each uvar *occurrence*. This may be useful in the context of Steel (though I think we're not yet sure). A second set of eyes on the change would be good. I'm calling `norm` non-tail-recursively in the patch, I could add a stack node for this if preferred.

cc @R1kM 

Here is a rudimentary test: the two uvar dumps should differ in their types.
```fstar
open FStar.Tactics

let trans (x y z : 'a) ( _ : squash (x == y)) ( _ : squash (y == z)) : squash (x == z) = ()

type ty = list nat

let test (x : ty) =
  assert (x == x) by begin
    dump "1";
    apply_lemma (`trans);
    dump_uvars_of (_cur_goal ()) "uvars1";
    norm [descend_into_uvar_types; delta];
    dump_uvars_of (_cur_goal ()) "uvars2";
    ()
  end
```