### PR TITLE
Fix detection of associated tactic in DeferredImplicits

### DIFF
--- a/src/ocaml-output/FStar_Syntax_Embeddings.ml
+++ b/src/ocaml-output/FStar_Syntax_Embeddings.ml
@@ -557,7 +557,7 @@ let e_option :
       let t = FStar_Syntax_Util.unmeta_safe t0 in
       lazy_unembed printer1 emb_t_option_a t t_option_a
         (fun t1 ->
-           let uu___ = FStar_Syntax_Util.head_and_args' t1 in
+           let uu___ = FStar_Syntax_Util.head_and_args_full t1 in
            match uu___ with
            | (hd, args) ->
                let uu___1 =
@@ -690,7 +690,7 @@ let e_tuple2 : 'a 'b . 'a embedding -> 'b embedding -> ('a * 'b) embedding =
         let t = FStar_Syntax_Util.unmeta_safe t0 in
         lazy_unembed printer1 emb_t_pair_a_b t t_pair_a_b
           (fun t1 ->
-             let uu___ = FStar_Syntax_Util.head_and_args' t1 in
+             let uu___ = FStar_Syntax_Util.head_and_args_full t1 in
              match uu___ with
              | (hd, args) ->
                  let uu___1 =
@@ -880,7 +880,7 @@ let e_either :
         let t = FStar_Syntax_Util.unmeta_safe t0 in
         lazy_unembed printer1 emb_t_sum_a_b t t_sum_a_b
           (fun t1 ->
-             let uu___ = FStar_Syntax_Util.head_and_args' t1 in
+             let uu___ = FStar_Syntax_Util.head_and_args_full t1 in
              match uu___ with
              | (hd, args) ->
                  let uu___1 =
@@ -1010,7 +1010,7 @@ let e_list : 'a . 'a embedding -> 'a Prims.list embedding =
       let t = FStar_Syntax_Util.unmeta_safe t0 in
       lazy_unembed printer1 emb_t_list_a t t_list_a
         (fun t1 ->
-           let uu___ = FStar_Syntax_Util.head_and_args' t1 in
+           let uu___ = FStar_Syntax_Util.head_and_args_full t1 in
            match uu___ with
            | (hd, args) ->
                let uu___1 =

--- a/src/ocaml-output/FStar_Syntax_Util.ml
+++ b/src/ocaml-output/FStar_Syntax_Util.ml
@@ -593,7 +593,7 @@ let (head_and_args :
     match t1.FStar_Syntax_Syntax.n with
     | FStar_Syntax_Syntax.Tm_app (head, args) -> (head, args)
     | uu___ -> (t1, [])
-let rec (head_and_args' :
+let rec (head_and_args_full :
   FStar_Syntax_Syntax.term ->
     (FStar_Syntax_Syntax.term * (FStar_Syntax_Syntax.term'
       FStar_Syntax_Syntax.syntax * FStar_Syntax_Syntax.arg_qualifier
@@ -603,7 +603,7 @@ let rec (head_and_args' :
     let t1 = FStar_Syntax_Subst.compress t in
     match t1.FStar_Syntax_Syntax.n with
     | FStar_Syntax_Syntax.Tm_app (head, args) ->
-        let uu___ = head_and_args' head in
+        let uu___ = head_and_args_full head in
         (match uu___ with
          | (head1, args') -> (head1, (FStar_List.append args' args)))
     | uu___ -> (t1, [])
@@ -829,7 +829,7 @@ let (canon_app :
     FStar_Syntax_Syntax.term)
   =
   fun t ->
-    let uu___ = let uu___1 = unascribe t in head_and_args' uu___1 in
+    let uu___ = let uu___1 = unascribe t in head_and_args_full uu___1 in
     match uu___ with
     | (hd, args) ->
         FStar_Syntax_Syntax.mk_Tm_app hd args t.FStar_Syntax_Syntax.pos
@@ -2860,7 +2860,7 @@ let (destruct_typ_as_formula :
       let uu___ = un_squash t in
       FStar_Util.bind_opt uu___
         (fun t1 ->
-           let uu___1 = head_and_args' t1 in
+           let uu___1 = head_and_args_full t1 in
            match uu___1 with
            | (hd, args) ->
                let uu___2 =
@@ -3016,7 +3016,7 @@ let (destruct_typ_as_formula :
       let uu___ = un_squash t in
       FStar_Util.bind_opt uu___
         (fun t1 ->
-           let uu___1 = head_and_args' t1 in
+           let uu___1 = head_and_args_full t1 in
            match uu___1 with
            | (hd, args) ->
                let uu___2 =

--- a/src/ocaml-output/FStar_Tactics_Basic.ml
+++ b/src/ocaml-output/FStar_Tactics_Basic.ml
@@ -4313,7 +4313,7 @@ let (t_destruct :
                              s_ty in
                          let uu___5 =
                            let uu___6 = FStar_Syntax_Util.unrefine s_ty1 in
-                           FStar_Syntax_Util.head_and_args' uu___6 in
+                           FStar_Syntax_Util.head_and_args_full uu___6 in
                          match uu___5 with
                          | (h, args) ->
                              let uu___6 =

--- a/src/ocaml-output/FStar_TypeChecker_Cfg.ml
+++ b/src/ocaml-output/FStar_TypeChecker_Cfg.ml
@@ -1720,7 +1720,7 @@ let (built_in_primitive_steps : primitive_step FStar_Util.psmap) =
   let arg_as_bounded_int uu___ =
     match uu___ with
     | (a, uu___1) ->
-        let uu___2 = FStar_Syntax_Util.head_and_args' a in
+        let uu___2 = FStar_Syntax_Util.head_and_args_full a in
         (match uu___2 with
          | (hd, args) ->
              let a1 = FStar_Syntax_Util.unlazy_emb a in

--- a/src/ocaml-output/FStar_TypeChecker_Common.ml
+++ b/src/ocaml-output/FStar_TypeChecker_Common.ml
@@ -827,7 +827,7 @@ let (simplify :
            let uu___2 = FStar_Syntax_Print.tag_of_term t in
            FStar_Util.print2 "WPE> is_applied %s -- %s\n" uu___1 uu___2)
         else ();
-        (let uu___1 = FStar_Syntax_Util.head_and_args' t in
+        (let uu___1 = FStar_Syntax_Util.head_and_args_full t in
          match uu___1 with
          | (hd, args) ->
              let uu___2 =

--- a/src/ocaml-output/FStar_TypeChecker_DeferredImplicits.ml
+++ b/src/ocaml-output/FStar_TypeChecker_DeferredImplicits.ml
@@ -1,7 +1,7 @@
 open Prims
 let (is_flex : FStar_Syntax_Syntax.term -> Prims.bool) =
   fun t ->
-    let uu___ = FStar_Syntax_Util.head_and_args t in
+    let uu___ = FStar_Syntax_Util.head_and_args_full t in
     match uu___ with
     | (head, _args) ->
         let uu___1 =
@@ -13,7 +13,7 @@ let (is_flex : FStar_Syntax_Syntax.term -> Prims.bool) =
 let (flex_uvar_head :
   FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.ctx_uvar) =
   fun t ->
-    let uu___ = FStar_Syntax_Util.head_and_args t in
+    let uu___ = FStar_Syntax_Util.head_and_args_full t in
     match uu___ with
     | (head, _args) ->
         let uu___1 =

--- a/src/ocaml-output/FStar_TypeChecker_Normalize.ml
+++ b/src/ocaml-output/FStar_TypeChecker_Normalize.ml
@@ -130,7 +130,7 @@ let (__proj__Debug__item___0 :
 type stack = stack_elt Prims.list
 let (head_of : FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term) =
   fun t ->
-    let uu___ = FStar_Syntax_Util.head_and_args' t in
+    let uu___ = FStar_Syntax_Util.head_and_args_full t in
     match uu___ with | (hd, uu___1) -> hd
 let set_memo :
   'a . FStar_TypeChecker_Cfg.cfg -> 'a FStar_Syntax_Syntax.memo -> 'a -> unit
@@ -5679,7 +5679,7 @@ and (maybe_simplify_aux :
                   FStar_Util.print2 "WPE> is_applied %s -- %s\n" uu___3
                     uu___4)
                else ();
-               (let uu___3 = FStar_Syntax_Util.head_and_args' t in
+               (let uu___3 = FStar_Syntax_Util.head_and_args_full t in
                 match uu___3 with
                 | (hd, args) ->
                     let uu___4 =

--- a/src/ocaml-output/FStar_TypeChecker_TcInductive.ml
+++ b/src/ocaml-output/FStar_TypeChecker_TcInductive.ml
@@ -381,7 +381,7 @@ let (tc_data :
                                       (match uu___6 with
                                        | (result1, res_lcomp) ->
                                            let uu___7 =
-                                             FStar_Syntax_Util.head_and_args'
+                                             FStar_Syntax_Util.head_and_args_full
                                                result1 in
                                            (match uu___7 with
                                             | (head, args) ->

--- a/src/ocaml-output/FStar_TypeChecker_Util.ml
+++ b/src/ocaml-output/FStar_TypeChecker_Util.ml
@@ -989,7 +989,7 @@ let (should_return :
             (((FStar_TypeChecker_Common.is_pure_or_ghost_lcomp lc) &&
                 (Prims.op_Negation lc_is_unit_or_effectful))
                &&
-               (let uu___ = FStar_Syntax_Util.head_and_args' e in
+               (let uu___ = FStar_Syntax_Util.head_and_args_full e in
                 match uu___ with
                 | (head, uu___1) ->
                     let uu___2 =

--- a/src/syntax/FStar.Syntax.Embeddings.fs
+++ b/src/syntax/FStar.Syntax.Embeddings.fs
@@ -323,7 +323,7 @@ let e_option (ea : embedding<'a>) =
             t
             t_option_a
             (fun t ->
-                let hd, args = U.head_and_args' t in
+                let hd, args = U.head_and_args_full t in
                 match (U.un_uinst hd).n, args with
                 | Tm_fvar fv, _ when S.fv_eq_lid fv PC.none_lid -> Some None
                 | Tm_fvar fv, [_; (a, _)] when S.fv_eq_lid fv PC.some_lid ->
@@ -386,7 +386,7 @@ let e_tuple2 (ea:embedding<'a>) (eb:embedding<'b>) =
             t
             t_pair_a_b
             (fun t ->
-                let hd, args = U.head_and_args' t in
+                let hd, args = U.head_and_args_full t in
                 match (U.un_uinst hd).n, args with
                 | Tm_fvar fv, [_; _; (a, _); (b, _)] when S.fv_eq_lid fv PC.lid_Mktuple2 ->
                     BU.bind_opt (unembed ea a w norm) (fun a ->
@@ -467,7 +467,7 @@ let e_either (ea:embedding<'a>) (eb:embedding<'b>) =
             t
             t_sum_a_b
             (fun t ->
-                let hd, args = U.head_and_args' t in
+                let hd, args = U.head_and_args_full t in
                 match (U.un_uinst hd).n, args with
                 | Tm_fvar fv, [_; _; (a, _)] when S.fv_eq_lid fv PC.inl_lid ->
                     BU.bind_opt (unembed ea a w norm) (fun a ->
@@ -541,7 +541,7 @@ let e_list (ea:embedding<'a>) =
             t
             t_list_a
             (fun t ->
-                let hd, args = U.head_and_args' t in
+                let hd, args = U.head_and_args_full t in
                 match (U.un_uinst hd).n, args with
                 | Tm_fvar fv, _
                     when S.fv_eq_lid fv PC.nil_lid -> Some []

--- a/src/syntax/FStar.Syntax.Util.fs
+++ b/src/syntax/FStar.Syntax.Util.fs
@@ -354,11 +354,11 @@ let head_and_args t =
         | Tm_app(head, args) -> head, args
         | _ -> t, []
 
-let rec head_and_args' t =
+let rec head_and_args_full t =
     let t = compress t in
     match t.n with
         | Tm_app(head, args) ->
-            let (head, args') = head_and_args' head
+            let (head, args') = head_and_args_full head
             in (head, args'@args)
         | _ -> t, []
 
@@ -478,7 +478,7 @@ let mk_lazy (t : 'a) (typ : typ) (k : lazy_kind) (r : option<range>) : term =
     mk (Tm_lazy i) rng
 
 let canon_app t =
-    let hd, args = head_and_args' (unascribe t) in
+    let hd, args = head_and_args_full (unascribe t) in
     mk_Tm_app hd args t.pos
 
 (* ---------------------------------------------------------------------- *)
@@ -1445,7 +1445,7 @@ let destruct_typ_as_formula f : option<connective> =
     in
     let destruct_sq_base_conn t =
         bind_opt (un_squash t) (fun t ->
-        let hd, args = head_and_args' t in
+        let hd, args = head_and_args_full t in
         match (un_uinst hd).n with
         | Tm_fvar fv -> lookup_arity_lid destruct_sq_base_table fv.fv_name.v args
         | _ -> None
@@ -1507,7 +1507,7 @@ let destruct_typ_as_formula f : option<connective> =
         | _ -> None)
     and destruct_sq_exists t =
         bind_opt (un_squash t) (fun t ->
-        let hd, args = head_and_args' t in
+        let hd, args = head_and_args_full t in
         match (un_uinst hd).n, args with
         | Tm_fvar fv, [(a1, _); (a2, _)]
             when fv_eq_lid fv PC.dtuple2_lid ->

--- a/src/tactics/FStar.Tactics.Basic.fs
+++ b/src/tactics/FStar.Tactics.Basic.fs
@@ -1347,7 +1347,7 @@ let t_destruct (s_tm : term) : tac<list<(fv * Z.t)>> = wrap_err "destruct" <|
     bind (proc_guard "destruct" (goal_env g) guard) (fun () ->
     let s_ty = N.normalize [Env.UnfoldTac; Env.Weak; Env.HNF; Env.UnfoldUntil delta_constant]
                            (goal_env g) s_ty in
-    let h, args = U.head_and_args' (U.unrefine s_ty) in
+    let h, args = U.head_and_args_full (U.unrefine s_ty) in
     bind (match (SS.compress h).n with
           | Tm_fvar fv -> ret (fv, [])
           | Tm_uinst ({ n = Tm_fvar fv }, us) -> ret (fv, us)

--- a/src/typechecker/FStar.TypeChecker.Cfg.fs
+++ b/src/typechecker/FStar.TypeChecker.Cfg.fs
@@ -307,7 +307,7 @@ let built_in_primitive_steps : prim_step_set =
     let arg_as_string (a:arg) = fst a |> try_unembed_simple EMB.e_string in
     let arg_as_list   (e:EMB.embedding<'a>) a = fst a |> try_unembed_simple (EMB.e_list e) in
     let arg_as_bounded_int (a, _) : option<(fv * Z.t)> =
-        let hd, args = U.head_and_args' a in
+        let hd, args = U.head_and_args_full a in
         let a = U.unlazy_emb a in
         match (SS.compress hd).n, args with
         | Tm_fvar fv1, [(arg, _)]

--- a/src/typechecker/FStar.TypeChecker.Common.fs
+++ b/src/typechecker/FStar.TypeChecker.Common.fs
@@ -419,7 +419,7 @@ let simplify (debug:bool) (tm:term) : term =
     let is_applied (bs:binders) (t : term) : option<bv> =
         if debug then
             BU.print2 "WPE> is_applied %s -- %s\n"  (Print.term_to_string t) (Print.tag_of_term t);
-        let hd, args = U.head_and_args' t in
+        let hd, args = U.head_and_args_full t in
         match (SS.compress hd).n with
         | Tm_name bv when args_are_binders args bs ->
             if debug then

--- a/src/typechecker/FStar.TypeChecker.DeferredImplicits.fs
+++ b/src/typechecker/FStar.TypeChecker.DeferredImplicits.fs
@@ -39,13 +39,13 @@ module U = FStar.Syntax.Util
 module SS = FStar.Syntax.Subst
 
 let is_flex t =
-  let head, _args = U.head_and_args t in
+  let head, _args = U.head_and_args_full t in
   match (SS.compress head).n with
   | Tm_uvar _ -> true
   | _ -> false
 
 let flex_uvar_head t =
-    let head, _args = U.head_and_args t in
+    let head, _args = U.head_and_args_full t in
     match (SS.compress head).n with
     | Tm_uvar (u, _) -> u
     | _ -> failwith "Not a flex-uvar"

--- a/src/typechecker/FStar.TypeChecker.Normalize.fs
+++ b/src/typechecker/FStar.TypeChecker.Normalize.fs
@@ -84,7 +84,7 @@ type stack_elt =
  | Debug    of term * BU.time
 type stack = list<stack_elt>
 
-let head_of t = let hd, _ = U.head_and_args' t in hd
+let head_of t = let hd, _ = U.head_and_args_full t in hd
 
 let set_memo cfg (r:memo<'a>) (t:'a) =
   if cfg.memoize_lazy then
@@ -2058,7 +2058,7 @@ and maybe_simplify_aux (cfg:cfg) (env:env) (stack:stack) (tm:term) : term =
     let is_applied (bs:binders) (t : term) : option<bv> =
         if cfg.debug.wpe then
             BU.print2 "WPE> is_applied %s -- %s\n"  (Print.term_to_string t) (Print.tag_of_term t);
-        let hd, args = U.head_and_args' t in
+        let hd, args = U.head_and_args_full t in
         match (SS.compress hd).n with
         | Tm_name bv when args_are_binders args bs ->
             if cfg.debug.wpe then

--- a/src/typechecker/FStar.TypeChecker.TcInductive.fs
+++ b/src/typechecker/FStar.TypeChecker.TcInductive.fs
@@ -159,7 +159,7 @@ let tc_data (env:env_t) (tcs : list<(sigelt * universe)>)
          let type_u_tc = S.mk (Tm_type u_tc) result.pos in
          let env' = Env.set_expected_typ env' type_u_tc in
          let result, res_lcomp = tc_trivial_guard env' result in
-         let head, args = U.head_and_args' result in (* collect nested applications too *)
+         let head, args = U.head_and_args_full result in (* collect nested applications too *)
 
          (* Make sure the parameters are respected, cf #1534 *)
          (* The first few arguments, as many as List.length tps, must exactly match the

--- a/src/typechecker/FStar.TypeChecker.Util.fs
+++ b/src/typechecker/FStar.TypeChecker.Util.fs
@@ -539,7 +539,7 @@ let should_return env eopt lc =
     | Some e ->
       TcComm.is_pure_or_ghost_lcomp lc                &&  //condition (a), (see above)
       not lc_is_unit_or_effectful                &&  //condition (b)
-      (let head, _ = U.head_and_args' e in
+      (let head, _ = U.head_and_args_full e in
        match (U.un_uinst head).n with
        | Tm_fvar fv ->  not (Env.is_irreducible env (lid_of_fv fv)) //condition (c)
        | _ -> true)                              &&


### PR DESCRIPTION
This PR improves the detection of a tactic associated to a deferred implicit. It also renames the helper head_and_args' (returning the true head of the application and its list of arguments) into the more descriptive head_and_args_full.

The issue was with a problem of the shape `?u x y == term`, where `?u` is an implicit deferred to some tactic. The previous version was checking whether the head of the lhs is a uvar with an associated tactic using head_and_args (which returned `?u x, and lead to a failure in DeferredImplicits since no associated tactic could be found).
The new version calls head_and_args_full, and hence looks instead at the attribute of the uvar ?u