### PR TITLE
Extract LowStar.UninitializedBuffer (witness|recall_initialized) to EUnit for Kremlin

### DIFF
--- a/src/extraction/FStar.Extraction.Kremlin.fs
+++ b/src/extraction/FStar.Extraction.Kremlin.fs
@@ -868,6 +868,11 @@ and translate_expr env e: expr =
           string_of_mlpath p = "LowStar.ImmutableBuffer.recall_contents") ->
       EUnit
 
+  | MLE_App ({ expr = MLE_TApp({ expr = MLE_Name p }, _) }, [ _ebuf; _eidx ])
+    when (string_of_mlpath p = "LowStar.UninitializedBuffer.witness_initialized" ||
+          string_of_mlpath p = "LowStar.UninitializedBuffer.recall_initialized") ->
+      EUnit
+
  | MLE_App ({ expr = MLE_TApp({ expr = MLE_Name p }, _) }, [ e1 ])
    when string_of_mlpath p = "LowStar.ConstBuffer.of_buffer"
      || string_of_mlpath p = "LowStar.ConstBuffer.of_ibuffer"


### PR DESCRIPTION
This avoids emitting no-op witness/recall calls in the generated code.