### PR TITLE
ulib: some changes to Squash and IndefiniteDescription

### DIFF
--- a/ulib/FStar.Squash.fst
+++ b/ulib/FStar.Squash.fst
@@ -32,7 +32,9 @@ let give_proof (#p:Type) _ = ()
 let proof_irrelevance (p:Type) x y = ()
 
 let squash_double_arrow #a #p f =
-    bind_squash f push_squash
+  bind_squash f (fun (f : (x:a -> GTot (squash (p x)))) ->
+  bind_squash (push_squash f) (fun (f':(x:a -> Tot (p x))) ->
+  return_squash (fun x -> f' x <: GTot (p x))))
 
 let push_sum (#a:Type) (#b:(a -> Type)) ($p : dtuple2 a (fun (x:a) -> squash (b x))) =
     match p with

--- a/ulib/FStar.Squash.fsti
+++ b/ulib/FStar.Squash.fsti
@@ -51,9 +51,9 @@ val bind_squash (#a #b: Type) (x: squash a) (f: (a -> GTot (squash b))) : Tot (s
     proof-irrelevant proof of [forall (x:a). b x].
 
     Note: since [f] is not itself squashed, [push_squash f] is not
-    equal to [f].  *)
+    equal to [f]. *)
 val push_squash (#a: Type) (#b: (a -> Type)) (f: (x: a -> Tot (squash (b x))))
-    : Tot (squash (x: a -> GTot (b x)))
+    : Tot (squash (x: a -> Tot (b x)))
 
 /// The pre- and postconditions of of [Pure] are equivalent to
 /// squashed arguments and results.

--- a/ulib/experimental/Steel.Heap.fst
+++ b/ulib/experimental/Steel.Heap.fst
@@ -750,7 +750,7 @@ let refined_pre_action_as_action (#fp0:slprop) (#a:Type) (#fp1:a -> slprop)
     in
     g
 
-#push-options "--z3rlimit_factor 8 --max_fuel 0 --initial_ifuel 2 --max_ifuel 2"
+#push-options "--z3rlimit 80 --max_fuel 0 --initial_ifuel 2 --max_ifuel 2"
 let select_refine_pre (#a:_) (#p:_)
                       (r:ref a p)
                       (x:erased a)


### PR DESCRIPTION
As discussed on Slack, I tweaked `push_squash` to allow to prove the `ghost_choice` theorem. While at it, I reformulated the indefinite description axiom to be of shape `squash a -> GTot a`, which is equivalent, but simpler. I could leave this out or make a separate PR if that's better.

I considered making `squash_double_arrow` also return a `squash (x:a -> Tot (p x))` (instead of a `GTot`), but that cascades and needs several fixed. I think this mostly stems from the fact that `l_imp` and `l_forall` are defined to be squashed *ghost* arrows, but they could also be made total I think?

Commit message below

------------

Motivated by a discussion on Slack where we noticed we could not define
a function from [a -> GTot b] into [GTot (a -> b)], which is the axiom
of choice for GTot functions.

This commit tweaks the type of [push_squash] to return a squashed total
function (instead of a ghost function. The [push_squash] axiom is very
similar to what we need here, so we can repurpose it via indefinite
description to obtain the [GTot] choice.

Further, this commit simplifies the indefinite description axiom into
simply a function of type [squash a -> GTot a]. This is already provable
with the current formulation (by introducing a dummy existential and
obtaining its witness), but it seems more natural to state it like this.
The old versions are all proven with this axiom, some of them in simpler
ways.