### PR TITLE
Pretty printer: fix nested refinement and implicit-only abstractions printing

### DIFF
--- a/src/parser/FStar.Parser.ToDocument.fs
+++ b/src/parser/FStar.Parser.ToDocument.fs
@@ -1078,7 +1078,7 @@ and p_binder' (is_atomic: bool) (b: binder): document * option<document> * catf 
           else
             p_tmFormula t
           in
-          optional p_aqual b.aqual ^^ p_lident lid, t'
+          optional p_aqual b.aqual ^^ p_lident lid, lparen ^^ t' ^^ rparen
         in
         let catf =
           if is_atomic || (is_meta_qualifier b.aqual) then

--- a/src/syntax/FStar.Syntax.Resugar.fs
+++ b/src/syntax/FStar.Syntax.Resugar.fs
@@ -373,7 +373,11 @@ let rec resugar_term' (env: DsEnv.env) (t : S.term) : A.term =
       //before inspecting any syntactic form that has binding structure
       //you must call SS.open_* to replace de Bruijn indexes with names
       let xs, body = SS.open_term xs body in
-      let xs = if Options.print_implicits () then xs else filter_imp xs in
+      let xs = if Options.print_implicits () then xs else (
+          match filter_imp xs with
+          | [] -> xs // if the abstraction has only implicit arguments, print them anyway
+          | xs -> xs
+        ) in
       let body_bv = FStar.Syntax.Free.names body in
       let patterns = xs |> List.choose (fun (x, qual) ->
         //x.sort contains a type annotation for the bound variable


### PR DESCRIPTION
Hi,

This PR fixes one of the issues addressed two issues with pretty-printing terms:
 - as mentioned in #1865, nested refinements miss some parenthesis, for instance `(forall (x: (y: int{y>0})). True)` is pretty printed as `forall (x: y: Prims.int{y > 0}). Prims.l_True`;
 - without `--print_implicits`, abstractions without any explicit binders are pretty printed as empty lambdas, for instance `fun #_ -> 0` becomes `fun  -> 0`.