### PR TITLE
Add constraint on ocaml-migrate-parsetree

### DIFF
--- a/fstar.opam
+++ b/fstar.opam
@@ -19,7 +19,7 @@ depends: [
   "ppx_deriving"
   "ppx_deriving_yojson"
   "process"
-  "ocaml-migrate-parsetree"
+  "ocaml-migrate-parsetree" {< "2.1.0"}
 ]
 depexts: ["coreutils"] {os = "macos" & os-distribution = "homebrew"}
 build: [


### PR DESCRIPTION
`ocaml-migrate-parsetree` 2.1.0 is missing `Migrate_parsetree.Versions` and it makes building fail (at least on macOS Catalina).
This PR just adds an upper bound to the package in the `opam` file.