### PR TITLE
Minor: Add missing dump_uvars_of to Tactics_Builtins_ml

### DIFF
--- a/ulib/tactics_ml/FStar_Tactics_Builtins.ml
+++ b/ulib/tactics_ml/FStar_Tactics_Builtins.ml
@@ -118,6 +118,7 @@ let print                   = from_tac_1 B.print
 let debugging               = from_tac_1 B.debugging
 let dump                    = from_tac_1 B.dump
 let dump_all                = from_tac_2 B.dump_all
+let dump_uvars_of           = from_tac_2 B.dump_uvars_of
 let t_trefl                 = from_tac_1 B.t_trefl
 let dup                     = from_tac_1 B.dup
 let prune                   = from_tac_1 B.prune


### PR DESCRIPTION
The ML file corresponding to FStar.Tactics.Builtins does not expose dump_uvars_of, which leads to OCaml compilation issues when trying to use this tactic.
This patch fixes that.