### PR TITLE
Fixing universes in decreases clauses

### DIFF
--- a/src/ocaml-output/FStar_Syntax_Free.ml
+++ b/src/ocaml-output/FStar_Syntax_Free.ml
@@ -317,16 +317,32 @@ and (free_names_and_uvars_comp :
                 let uu___3 = free_names_and_uvars t use_cache in
                 union uu___2 uu___3
             | FStar_Syntax_Syntax.Comp ct ->
+                let decreases_vars =
+                  let uu___2 =
+                    FStar_List.tryFind
+                      (fun uu___3 ->
+                         match uu___3 with
+                         | FStar_Syntax_Syntax.DECREASES uu___4 -> true
+                         | uu___4 -> false) ct.FStar_Syntax_Syntax.flags in
+                  match uu___2 with
+                  | FStar_Pervasives_Native.None -> no_free_vars
+                  | FStar_Pervasives_Native.Some
+                      (FStar_Syntax_Syntax.DECREASES d) ->
+                      free_names_and_uvars d use_cache
+                  | FStar_Pervasives_Native.Some uu___3 ->
+                      failwith "impossible" in
                 let us =
                   let uu___2 =
                     free_names_and_uvars ct.FStar_Syntax_Syntax.result_typ
                       use_cache in
+                  union uu___2 decreases_vars in
+                let us1 =
                   free_names_and_uvars_args
-                    ct.FStar_Syntax_Syntax.effect_args uu___2 use_cache in
+                    ct.FStar_Syntax_Syntax.effect_args us use_cache in
                 FStar_List.fold_left
-                  (fun us1 ->
-                     fun u -> let uu___2 = free_univs u in union us1 uu___2)
-                  us ct.FStar_Syntax_Syntax.comp_univs in
+                  (fun us2 ->
+                     fun u -> let uu___2 = free_univs u in union us2 uu___2)
+                  us1 ct.FStar_Syntax_Syntax.comp_univs in
           (FStar_ST.op_Colon_Equals c.FStar_Syntax_Syntax.vars
              (FStar_Pervasives_Native.Some (FStar_Pervasives_Native.fst n));
            n)

--- a/src/ocaml-output/FStar_Syntax_Util.ml
+++ b/src/ocaml-output/FStar_Syntax_Util.ml
@@ -2323,15 +2323,9 @@ let (mk_with_type :
 let (lex_t : FStar_Syntax_Syntax.term) =
   fvar_const FStar_Parser_Const.lex_t_lid
 let (lex_top : FStar_Syntax_Syntax.term) =
-  let uu___ =
-    let uu___1 =
-      let uu___2 =
-        FStar_Syntax_Syntax.fvar FStar_Parser_Const.lextop_lid
-          FStar_Syntax_Syntax.delta_constant
-          (FStar_Pervasives_Native.Some FStar_Syntax_Syntax.Data_ctor) in
-      (uu___2, [FStar_Syntax_Syntax.U_zero]) in
-    FStar_Syntax_Syntax.Tm_uinst uu___1 in
-  FStar_Syntax_Syntax.mk uu___ FStar_Range.dummyRange
+  FStar_Syntax_Syntax.fvar FStar_Parser_Const.lextop_lid
+    FStar_Syntax_Syntax.delta_constant
+    (FStar_Pervasives_Native.Some FStar_Syntax_Syntax.Data_ctor)
 let (lex_pair : FStar_Syntax_Syntax.term) =
   FStar_Syntax_Syntax.fvar FStar_Parser_Const.lexcons_lid
     FStar_Syntax_Syntax.delta_constant

--- a/src/ocaml-output/FStar_TypeChecker_Tc.ml
+++ b/src/ocaml-output/FStar_TypeChecker_Tc.ml
@@ -341,9 +341,6 @@ let tc_lex_t :
                    FStar_Syntax_Syntax.sigattrs = [];
                    FStar_Syntax_Syntax.sigopts = FStar_Pervasives_Native.None
                  } in
-               let utop =
-                 FStar_Syntax_Syntax.new_univ_name
-                   (FStar_Pervasives_Native.Some r1) in
                let lex_top_t =
                  let uu___20 =
                    let uu___21 =
@@ -354,16 +351,14 @@ let tc_lex_t :
                        FStar_Syntax_Syntax.fvar uu___23
                          FStar_Syntax_Syntax.delta_constant
                          FStar_Pervasives_Native.None in
-                     (uu___22, [FStar_Syntax_Syntax.U_name utop]) in
+                     (uu___22, [FStar_Syntax_Syntax.U_zero]) in
                    FStar_Syntax_Syntax.Tm_uinst uu___21 in
                  FStar_Syntax_Syntax.mk uu___20 r1 in
-               let lex_top_t1 =
-                 FStar_Syntax_Subst.close_univ_vars [utop] lex_top_t in
                let dc_lextop =
                  {
                    FStar_Syntax_Syntax.sigel =
                      (FStar_Syntax_Syntax.Sig_datacon
-                        (lex_top, [utop], lex_top_t1,
+                        (lex_top, [], lex_top_t,
                           FStar_Parser_Const.lex_t_lid, Prims.int_zero, []));
                    FStar_Syntax_Syntax.sigrng = r1;
                    FStar_Syntax_Syntax.sigquals = [];
@@ -4148,7 +4143,7 @@ let (tc_decls :
              FStar_Util.fold_flatten process_one_decl_timed ([], env) ses) in
       match uu___ with
       | (ses1, env1) -> ((FStar_List.rev_append ses1 []), env1)
-let (uu___1000 : unit) =
+let (uu___998 : unit) =
   FStar_ST.op_Colon_Equals tc_decls_knot
     (FStar_Pervasives_Native.Some tc_decls)
 let (snapshot_context :

--- a/src/ocaml-output/FStar_TypeChecker_TcTerm.ml
+++ b/src/ocaml-output/FStar_TypeChecker_TcTerm.ml
@@ -1050,12 +1050,15 @@ let (guard_letrecs :
                  let uu___1 = FStar_Syntax_Util.head_and_args dec in
                  match uu___1 with
                  | (head, uu___2) ->
-                     (match head.FStar_Syntax_Syntax.n with
+                     let uu___3 =
+                       let uu___4 = FStar_Syntax_Util.un_uinst head in
+                       uu___4.FStar_Syntax_Syntax.n in
+                     (match uu___3 with
                       | FStar_Syntax_Syntax.Tm_fvar fv when
                           FStar_Syntax_Syntax.fv_eq_lid fv
                             FStar_Parser_Const.lexcons_lid
                           -> dec
-                      | uu___3 -> mk_lex_list [dec]) in
+                      | uu___4 -> mk_lex_list [dec]) in
                let cflags = FStar_Syntax_Util.comp_flags c in
                let uu___1 =
                  FStar_All.pipe_right cflags

--- a/src/syntax/FStar.Syntax.Util.fs
+++ b/src/syntax/FStar.Syntax.Util.fs
@@ -1228,7 +1228,7 @@ let mk_with_type u t e =
     mk (Tm_app(t_with_type, [iarg t; as_arg e])) dummyRange
 
 let lex_t    = fvar_const PC.lex_t_lid
-let lex_top :term = mk (Tm_uinst (fvar PC.lextop_lid delta_constant (Some Data_ctor), [U_zero])) dummyRange //NS delta: ok
+let lex_top :term = fvar PC.lextop_lid delta_constant (Some Data_ctor) //NS delta: ok
 let lex_pair = fvar PC.lexcons_lid delta_constant (Some Data_ctor) //NS delta: ok
 let tforall  = fvar PC.forall_lid (Delta_constant_at_level 1) None //NS delta: wrong level 2
 let t_haseq   = fvar PC.haseq_lid delta_constant None //NS delta: wrong Delta_abstract (Delta_constant_at_level 0)?

--- a/src/typechecker/FStar.TypeChecker.Tc.fs
+++ b/src/typechecker/FStar.TypeChecker.Tc.fs
@@ -115,10 +115,8 @@ let tc_lex_t env ses quals lids =
                    sigattrs = [];
                    sigopts = None; } in
 
-        let utop = S.new_univ_name (Some r1) in
-        let lex_top_t = mk (Tm_uinst(S.fvar (Ident.set_lid_range PC.lex_t_lid r1) delta_constant None, [U_name utop])) r1 in
-        let lex_top_t = Subst.close_univ_vars [utop] lex_top_t in
-        let dc_lextop = { sigel = Sig_datacon(lex_top, [utop], lex_top_t, PC.lex_t_lid, 0, []);
+        let lex_top_t = mk (Tm_uinst(S.fvar (Ident.set_lid_range PC.lex_t_lid r1) delta_constant None, [U_zero])) r1 in
+        let dc_lextop = { sigel = Sig_datacon(lex_top, [], lex_top_t, PC.lex_t_lid, 0, []);
                           sigquals = [];
                           sigrng = r1;
                           sigmeta = default_sigmeta;

--- a/src/typechecker/FStar.TypeChecker.TcTerm.fs
+++ b/src/typechecker/FStar.TypeChecker.TcTerm.fs
@@ -387,7 +387,7 @@ let guard_letrecs env actuals expected_c : list<(lbname*typ*univ_names)> =
                         | _ -> [S.bv_to_name b]) in
           let as_lex_list dec =
                 let head, _ = U.head_and_args dec in
-                match head.n with (* The decreases clause is always an expression of type lex_t; promote if it isn't *)
+                match (U.un_uinst head).n with (* The decreases clause is always an expression of type lex_t; promote if it isn't *)
                     | Tm_fvar fv when S.fv_eq_lid fv Const.lexcons_lid -> dec
                     | _ -> mk_lex_list [dec] in
           let cflags = U.comp_flags c in

--- a/tests/bug-reports/Bug2193.fst
+++ b/tests/bug-reports/Bug2193.fst
@@ -1,0 +1,8 @@
+module Bug2193
+
+#set-options "--lax"
+
+type foo: Type u#m = | FOO
+
+let i (n: nat): Tot unit (decreases FOO)
+  = admit () 

--- a/tests/bug-reports/BugLexTop.fst
+++ b/tests/bug-reports/BugLexTop.fst
@@ -4,7 +4,7 @@ module BugLexTop
    Also, with contributions from Jay Bosamiya for the proof of False.
    It was fixed in 92e50f9b5ba34afe97b2cc09ba66dfa090438825
 *)
-val n_lexcons : nat -> lex_t
+val n_lexcons : nat -> lex_t u#0
 let rec n_lexcons n =
   if n = 0 then LexTop else LexCons LexTop (n_lexcons (n-1))
 

--- a/tests/bug-reports/Makefile
+++ b/tests/bug-reports/Makefile
@@ -41,7 +41,8 @@ SHOULD_VERIFY_CLOSED=Bug022.fst Bug024.fst Bug025.fst Bug026.fst Bug026b.fst Bug
   Bug1903.fst Bug1121a.fst Bug1121b.fst Bug1956.fst Bug1228.fst Bug829.fst Bug451.fst Bug1966a.fst Bug1966b.fst Bug1976.fst \
   Bug1986.fst Bug1995.fst Bug1507.fst Bug2001.fst Bug2004.fst Bug855a.fst Bug855b.fst Bug1097.fst Bug1918.fst Bug1390.fst Bug2031.fst \
   Bug379.fst Bug1182a.fst Bug1182b.fst Bug1901.fst Bug1902.fst Bug258.fst Bug2055.fst Bug2081.fst Bug2099.fst Bug2106.fst Bug2132.fst \
-  Bug2138.fst Bug2146.fst Bug2074.fst Bug2125a.fst Bug2125b.fst Bug2167.fst Bug2169.fst Bug2169b.fst Bug2066.fst Bug2189.fst Bug2184.fst
+  Bug2138.fst Bug2146.fst Bug2074.fst Bug2125a.fst Bug2125b.fst Bug2167.fst Bug2169.fst Bug2169b.fst Bug2066.fst Bug2189.fst Bug2184.fst \
+  Bug2193.fst
 
 SHOULD_VERIFY_INTERFACE_CLOSED=Bug771.fsti Bug771b.fsti
 SHOULD_VERIFY_AND_WARN_CLOSED=Bug016.fst


### PR DESCRIPTION
This fixes an omission in Syntax.Free where the free variables of decreases clauses were not accounted for. Fixing that alone lead to several regressions due to unresolved universe variables, caused by the fact that both `LexCons` and `LexTop` are universe polymorphic, and not restricted at all. To fix that, I made `LexTop` a `lex_t u#0` instead. Along the way I noticed some ill-formed tuples such as `LexCons (LexCons _ _) LexTop`, generated by the typechecker due to a missing `un_uinst`.

Heads up @aseemr, since this may conflict with your work on lex tuples.

Fixes #2193 