### PR TITLE
A new syntax for layered effect definitions

### DIFF
--- a/src/parser/parse.fsy
+++ b/src/parser/parse.fsy
@@ -776,6 +776,9 @@ let ids =     ( xs ) in
 | LAYERED_EFFECT effectDefinition
     {let (_1, ne) = ((), $2) in
       ( LayeredEffect ne )}
+| EFFECT layeredEffectDefinition
+    {let (_1, ne) = ((), $2) in
+      ( LayeredEffect ne )}
 | SUB_EFFECT subEffect
     {let (_1, se) = ((), $2) in
       ( SubEffect se )}
@@ -875,6 +878,35 @@ effectDefinition:
   LBRACE uident binders COLON tmArrow_tmNoEq_ WITH separated_nonempty_list_SEMICOLON_effectDecl_ RBRACE
     {let (_1, lid, bs, _4, typ, _6, eds, _8) = ((), $2, $3, (), $5, (), $7, ()) in
     ( DefineEffect(lid, bs, typ, eds) )}
+
+layeredEffectDefinition:
+  LBRACE uident binders WITH tmNoEq RBRACE
+    {let (_1, lid, bs, _4, r, _6) = ((), $2, $3, (), $5, ()) in
+    (
+      let typ =  (* bs -> Effect *)
+        let first_b, last_b =
+          match bs with
+          | [] ->
+             raise_error (Fatal_SyntaxError,
+                          "Syntax error: unexpected empty binders list in the layered effect definition")
+                         (range_of_id lid)
+          | _ -> hd bs, last bs |> must in
+        let r = union_ranges first_b.brange last_b.brange in
+        mk_term (Product (bs, mk_term (Name (lid_of_str "Effect")) r Type_level)) r Type_level in
+      let rec decls (r:term) =
+        match r.tm with
+        | Paren r -> decls r
+        | Record (None, flds) ->
+           flds |> List.map (fun (lid, t) ->
+                              mk_decl (Tycon (false,
+                                              false,
+                                              [TyconAbbrev (ident_of_lid lid, [], None, t)]))
+                                      t.range [])
+        | _ ->
+           raise_error (Fatal_SyntaxError,
+                        "Syntax error: layered effect combinators should be declared as a record")
+                       r.range in
+      DefineEffect (lid, [], typ, decls r) )}
 
 effectDecl:
   lident binders EQUALS simpleTerm
@@ -2573,4 +2605,5 @@ in
    ( x :: xs )}
 
 %%
+
 

--- a/ulib/experimental/MST.fst
+++ b/ulib/experimental/MST.fst
@@ -100,19 +100,9 @@ let if_then_else
     (fun s0 x s1 -> (p ==> ens_then s0 x s1) /\ ((~ p) ==> ens_else s0 x s1))
 
 reifiable reflectable
-layered_effect {
-  MSTATE :
-    a:Type ->
-    state:Type u#2 ->
-    rel:P.preorder state ->
-    req:pre_t state ->
-    ens:post_t state a -> Effect
-  with
-  repr = repr;
-  return = return;
-  bind = bind;
-  subcomp = subcomp;
-  if_then_else = if_then_else
+effect {
+  MSTATE (a:Type) (state:Type u#2) (rel:P.preorder state) (req:pre_t state) (ens:post_t state a)
+  with { repr; return; bind; subcomp; if_then_else }
 }
 
 let get (#state:Type u#2) (#rel:P.preorder state) ()

--- a/ulib/experimental/MSTTotal.fst
+++ b/ulib/experimental/MSTTotal.fst
@@ -101,19 +101,9 @@ let if_then_else
 
 total
 reifiable reflectable
-layered_effect {
-  MSTATETOT :
-    a:Type ->
-    state:Type u#2 ->
-    rel:P.preorder state ->
-    req:pre_t state ->
-    ens:post_t state a -> Effect
-  with
-  repr = repr;
-  return = return;
-  bind = bind;
-  subcomp = subcomp;
-  if_then_else = if_then_else
+effect {
+  MSTATETOT (a:Type) (state:Type u#2) (rel:P.preorder state) (req:pre_t state) (ens:post_t state a)
+  with { repr; return; bind; subcomp; if_then_else }
 }
 
 let get (#state:Type u#2) (#rel:P.preorder state) ()

--- a/ulib/experimental/NMST.fst
+++ b/ulib/experimental/NMST.fst
@@ -92,19 +92,9 @@ let if_then_else
     (fun s0 x s1 -> (p ==> ens_then s0 x s1) /\ ((~ p) ==> ens_else s0 x s1))
 
 reifiable reflectable
-layered_effect {
-  NMSTATE :
-    a:Type ->
-    state:Type u#2 ->
-    rel:P.preorder state ->
-    req:M.pre_t state ->
-    ens:M.post_t state a -> Effect
-  with
-    repr = repr;
-    return = return;
-    bind = bind;
-    subcomp = subcomp;
-    if_then_else = if_then_else
+effect {
+  NMSTATE (a:Type) (state:Type u#2) (rel:P.preorder state) (req:M.pre_t state) (ens:M.post_t state a)
+  with { repr; return; bind; subcomp; if_then_else }
 }
 
 let get (#state:Type u#2) (#rel:P.preorder state) ()

--- a/ulib/experimental/NMSTTotal.fst
+++ b/ulib/experimental/NMSTTotal.fst
@@ -93,19 +93,9 @@ let if_then_else
 
 total
 reifiable reflectable
-layered_effect {
-  NMSTATETOT :
-    a:Type ->
-    state:Type u#2 ->
-    rel:P.preorder state ->
-    req:M.pre_t state ->
-    ens:M.post_t state a -> Effect
-  with
-    repr = repr;
-    return = return;
-    bind = bind;
-    subcomp = subcomp;
-    if_then_else = if_then_else
+effect {
+  NMSTATETOT (a:Type) (state:Type u#2) (rel:P.preorder state) (req:M.pre_t state) (ens:M.post_t state a)
+  with { repr; return; bind; subcomp; if_then_else }
 }
 
 let get (#state:Type u#2) (#rel:P.preorder state) ()

--- a/ulib/experimental/Steel.Effect.Atomic.fst
+++ b/ulib/experimental/Steel.Effect.Atomic.fst
@@ -26,7 +26,7 @@ let has_eq_observability () = ()
 let observable = true
 let unobservable = false
 
-let atomic_repr a opened_invariants f pre post =
+let repr a opened_invariants f pre post =
     action_except a opened_invariants pre post
 
 let return a x o p = fun _ -> x

--- a/ulib/experimental/Steel.Effect.fst
+++ b/ulib/experimental/Steel.Effect.fst
@@ -106,7 +106,7 @@ let repr a pre post req ens =
     (req_to_act_req req)
     (ens_to_act_ens ens)
 
-let returnc (a:Type u#a) (x:a) (p:a -> slprop) = fun _ -> x
+let return (a:Type u#a) (x:a) (p:a -> slprop) = fun _ -> x
 
 let bind a b pre_f post_f req_f ens_f post_g req_g ens_g f g
   = fun frame ->
@@ -262,7 +262,7 @@ let add_action f = Steel?.reflect (action_as_repr f)
 (***** Bind and Subcomp relation with Steel.Atomic *****)
 
 friend Steel.Effect.Atomic
-open Steel.Effect.Atomic
+//open Steel.Effect.Atomic
 
 #push-options "--z3rlimit 40"
 let bind_atomic_steel _ _ _ _ _ _ _ _ f g

--- a/ulib/experimental/Steel.Effect.fsti
+++ b/ulib/experimental/Steel.Effect.fsti
@@ -66,7 +66,7 @@ let return_req (p:slprop) : fp_mprop p = fun _ -> True
 unfold
 let return_ens (#a:Type) (x:a) (p:a -> slprop) : fp_binary_mprop (p x) p = fun _ r _ -> r == x
 
-val returnc (a:Type u#a) (x:a) (p:a -> slprop)
+val return (a:Type u#a) (x:a) (p:a -> slprop)
   : repr a (p x) p (return_req (p x)) (return_ens x p)
 
 unfold
@@ -157,19 +157,13 @@ let if_then_else (a:Type)
 
 [@@ allow_informative_binders]
 reifiable reflectable
-layered_effect {
-  Steel : a:Type
-        -> pre:slprop u#1
-        -> post:(a -> slprop u#1)
-        -> req:fp_mprop pre
-        -> ens:fp_binary_mprop pre post
-        -> Effect
-  with
-  repr = repr;
-  return = returnc;
-  bind = bind;
-  subcomp = subcomp;
-  if_then_else = if_then_else
+effect {
+  Steel (a:Type)
+        (pre:slprop u#1)
+        (post:a -> slprop u#1)
+        (req:fp_mprop pre)
+        (ens:fp_binary_mprop pre post)
+  with { repr; return; bind; subcomp; if_then_else }
 }
 
 effect SteelT (a:Type) (pre:slprop) (post:a -> slprop) =

--- a/ulib/experimental/Steel.Effect.fsti
+++ b/ulib/experimental/Steel.Effect.fsti
@@ -375,7 +375,7 @@ val add_action (#a:Type)
 
 (***** Bind and Subcomp relation with Steel.Atomic *****)
 
-open Steel.Effect.Atomic
+module Atomic = Steel.Effect.Atomic
 
 unfold
 let bind_req_atomic_steel (#a:Type) (#pre_f:slprop) (#post_f:a -> slprop) (req_g:(x:a -> fp_mprop (post_f x)))
@@ -389,14 +389,14 @@ let bind_ens_atomic_steel (#a:Type) (#b:Type)
 = fun _ y h2 -> exists x h1. (ens_g x) h1 y h2
 
 val bind_atomic_steel (a:Type) (b:Type)
-  (pre_f:slprop) (post_f:a -> slprop) (obs:observability)
+  (pre_f:slprop) (post_f:a -> slprop) (obs:Atomic.observability)
   (post_g:b -> slprop) (req_g:(x:a -> fp_mprop (post_f x))) (ens_g:(x:a -> fp_binary_mprop (post_f x) post_g))
-  (f:atomic_repr a Set.empty obs pre_f post_f) (g:(x:a -> repr b (post_f x) post_g (req_g x) (ens_g x)))
+  (f:Atomic.repr a Set.empty obs pre_f post_f) (g:(x:a -> repr b (post_f x) post_g (req_g x) (ens_g x)))
 : repr b pre_f post_g
     (bind_req_atomic_steel req_g)
     (bind_ens_atomic_steel ens_g)
 
-polymonadic_bind (SteelAtomic, Steel) |> Steel = bind_atomic_steel
+polymonadic_bind (Atomic.SteelAtomic, Steel) |> Steel = bind_atomic_steel
 
 unfold
 let subcomp_req_atomic_steel (a:Type) (pre_f:slprop) : fp_mprop pre_f = fun _ -> True
@@ -407,8 +407,8 @@ let subcomp_ens_atomic_steel (#a:Type) (pre_f:slprop) (post_f:a -> slprop)
 = fun _ _ _ -> True
 
 val subcomp_atomic_steel (a:Type)
-  (pre_f:slprop) (post_f:a -> slprop) (obs:observability)
-  (f:atomic_repr a Set.empty obs pre_f post_f)
+  (pre_f:slprop) (post_f:a -> slprop) (obs:Atomic.observability)
+  (f:Atomic.repr a Set.empty obs pre_f post_f)
 : repr a pre_f post_f (subcomp_req_atomic_steel a pre_f) (subcomp_ens_atomic_steel pre_f post_f)
 
-polymonadic_subcomp SteelAtomic <: Steel = subcomp_atomic_steel
+polymonadic_subcomp Atomic.SteelAtomic <: Steel = subcomp_atomic_steel

--- a/ulib/experimental/Steel.FramingEffect.fst
+++ b/ulib/experimental/Steel.FramingEffect.fst
@@ -240,13 +240,9 @@ let if_then_else (a:Type)
     (if_then_else_ens ens_then ens_else p)
 
 reifiable reflectable
-layered_effect {
-  SteelF: a:Type -> pre:pre_t -> post:post_t a -> req_t pre -> ens_t pre a post -> Effect
-  with repr = repr;
-       return = return;
-       bind = bind;
-       subcomp = subcomp;
-       if_then_else = if_then_else
+effect {
+  SteelF (a:Type) (pre:pre_t) (post:post_t a) (req:req_t pre) (ens:ens_t pre a post)
+  with { repr; return; bind; subcomp; if_then_else }
 }
 
 new_effect Steel = SteelF


### PR DESCRIPTION
See https://github.com/FStarLang/FStar/commit/b375b896f423d55edf7a363d520e4244c7e72770 for examples.

The layered effect combinators can now be declared using a record literal syntax, which means one can use the `{f; g}` syntax for a record literal that has field names `f` and `g` (in addition to the usual `{ f = e1; g = e2 }` syntax).

Also instead of saying `layered_effect { M : bs -> Effect with ... }` we can now write `effect { M bs with ... }`.

The older syntax is still valid for backward compatibility.