### PR TITLE
find_taclib: what if ocamlfind not found?

### DIFF
--- a/src/tactics/ml/FStar_Tactics_Load.ml
+++ b/src/tactics/ml/FStar_Tactics_Load.ml
@@ -8,12 +8,16 @@ let perr  s   = if O.debug_any () then U.print_error s
 let perr1 s x = if O.debug_any () then U.print1_error s x
 
 let find_taclib () =
-  let r = Process.run "ocamlfind" [| "query"; "fstar-tactics-lib" |] in
-  match r with
-  | { Process.Output.exit_status = Process.Exit.Exit 0; stdout; _ } ->
-      String.trim (List.hd stdout)
-  | _ ->
-      FStar_Options.fstar_bin_directory ^ "/fstar-tactics-lib"
+  let default = FStar_Options.fstar_bin_directory ^ "/fstar-tactics-lib" in
+  try
+    begin
+      let r = Process.run "ocamlfind" [| "query"; "fstar-tactics-lib" |] in
+      match r with
+      | { Process.Output.exit_status = Process.Exit.Exit 0; stdout; _ } ->
+         String.trim (List.hd stdout)
+      | _ -> default
+    end
+  with _ -> default
 
 let dynlink fname =
   try


### PR DESCRIPTION
Trying to load native tactics on a system where OCaml is not installed currently yields the following error message:
```
Unexpected error; please file a bug report, ideally with a minimized version of the source program that triggered the error.
Unix.Unix_error(20, "create_process", "ocamlfind")
```
This pull request properly handles that case (there was already a default case for ocamlfind not finding fstar-tactics-lib, but it didn't support ocamlfind itself not being found)

