### PR TITLE
Removing FStar.WellFounded.axiom1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -89,6 +89,8 @@ Guidelines for the changelog:
      in your programs. Instead, we have enhanced F*'s SMT encoding of
      inductive types to include additional, more targeted
      well-foundedness axioms.
+     tests/micro-benchmarks/TestWellFoundedRecursion.fst provides
+     several small representative examples.
 
    * Two core axioms were discovered by Aseem Rastogi to be formulated
      in an unsound manner.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -77,6 +77,19 @@ Guidelines for the changelog:
 
 ## Libraries
 
+   * Guido Martinez found that `FStar.WellFounded.axiom1_dep` (and its
+     specialization axiom1) is unsound when instantiated across
+     different universe levels. The issue and fix is discussed in
+     detail here: https://github.com/FStarLang/FStar/issues/2069
+
+     In summary, `FStar.WellFounded.axiom1_dep`,
+     `FStar.WellFounded.axiom1`, and `FStar.WellFounded.apply` have
+     all been removed. The user-facing universe polymorphic axiom is
+     no longer needed---you should just be able to remove calls to it
+     in your programs. Instead, we have enhanced F*'s SMT encoding of
+     inductive types to include additional, more targeted
+     well-foundedness axioms.
+
    * Two core axioms were discovered by Aseem Rastogi to be formulated
      in an unsound manner.
 

--- a/examples/csl/Lang.fst
+++ b/examples/csl/Lang.fst
@@ -68,7 +68,6 @@ let rec wpsep_command (#a:Type0) (c:command a) :st_wp a
        * again into h1' and h1'', where c2 runs on h1' resulting in h2.
        * The final heap is then join of h2 and h1''.
        *)
-      FStar.Classical.forall_intro (FStar.WellFounded.axiom1 #a #(command b) c2);
       fun p h3 -> exists (h2':heap) (h2'':heap). h3 == join_tot h2' h2'' /\
      (wpsep_command c1) (fun x h1 -> exists (h1':heap) (h1'':heap). (join_tot h1 h2'') == (join_tot h1' h1'') /\
      (wpsep_command (c2 x)) (fun y h2 -> p y (join_tot h2 h1'')) h1') h2'

--- a/examples/layeredeffects/Alg.fst
+++ b/examples/layeredeffects/Alg.fst
@@ -6,7 +6,7 @@ open Common
 open FStar.Tactics
 open FStar.List.Tot
 open FStar.Universe
-module WF = FStar.WellFounded
+//module WF = FStar.WellFounded
 module L = Lattice
 
 type state = int
@@ -49,7 +49,7 @@ let sublist (l1 l2 : ops) = forall x. memP x l1 ==> memP x l2
 (* Limiting the operations allowed in a tree *)
 let rec abides #a (labs:ops) (f : tree0 a) : prop =
   begin match f with
-  | Op a i k -> a `memP` labs /\ (forall o. (WF.axiom1 k o; abides labs (k o)))
+  | Op a i k -> a `memP` labs /\ (forall o. abides labs (k o))
   | Return _ -> True
   end
 
@@ -88,7 +88,6 @@ let rec abides_sublist_nopat #a (l1 l2 : ops) (c : tree0 a)
     | Return _ -> ()
     | Op a i k ->
       let sub o : Lemma (abides l2 (k o)) =
-        FStar.WellFounded.axiom1 k o;
         abides_sublist_nopat l1 l2 (k o)
       in
       Classical.forall_intro sub
@@ -129,7 +128,6 @@ let rec fold_with #a #b #labs f v h =
   | Return x -> v x
   | Op act i k ->
     let k' (o : op_out act) : b =
-       WF.axiom1 k o;
        fold_with #_ #_ #labs (k o) v h
     in
     h act i k'
@@ -262,7 +260,6 @@ let rec __catch0 #a #labs (t1 : tree a (Raise::labs)) (t2 : tree a labs)
     | Op Raise e _ -> t2
     | Op act i k ->
       let k' o : tree a labs =
-        WF.axiom1 k o;
         __catch0 (k o) t2
       in
       Op act i k'
@@ -368,12 +365,11 @@ let test_try_with3 (f : unit -> Alg int [Raise; Write]) : Alg int [Write] =
 let rec __catchST0 #a #labs (t1 : tree a (Read::Write::labs)) (s0:state) : tree (a & int) labs =
   match t1 with
   | Return v -> Return (v, s0)
-  | Op Write s k -> WF.axiom1 k (); __catchST0 (k ()) s
-  | Op Read  _ k -> WF.axiom1 k s0; __catchST0 (k s0) s0
+  | Op Write s k -> __catchST0 (k ()) s
+  | Op Read  _ k -> __catchST0 (k s0) s0
   | Op act i k ->
      (* default case *)
      let k' o : tree (a & int) labs =
-       WF.axiom1 k o;
        __catchST0 #a #labs (k o) s0
      in
      Op act i k'
@@ -591,7 +587,6 @@ let rec interp_rd_tree #a (t : tree a [Read]) (s:state) : Tot a =
   match t with
   | Return x -> x
   | Op Read _ k ->
-    FStar.WellFounded.axiom1 k s;
     interp_rd_tree (k s) s
 
 let interp_rd #a (f : unit -> Alg a [Read]) (s:state) : Tot a = interp_rd_tree (reify (f ())) s
@@ -600,10 +595,8 @@ let rec interp_rdwr_tree #a (t : tree a [Read; Write]) (s:state) : Tot (a & stat
   match t with
   | Return x -> (x, s)
   | Op Read _ k ->
-    FStar.WellFounded.axiom1 k s;
     interp_rdwr_tree (k s) s
   | Op Write s k ->
-    FStar.WellFounded.axiom1 k ();
     interp_rdwr_tree (k ()) s
 
 let interp_rdwr #a (f : unit -> Alg a [Read; Write]) (s:state) : Tot (a & state) = interp_rdwr_tree (reify (f ())) s
@@ -612,7 +605,6 @@ let rec interp_read_raise_tree #a (t : tree a [Read; Raise]) (s:state) : either 
   match t with
   | Return x -> Inr x
   | Op Read _ k ->
-    FStar.WellFounded.axiom1 k s;
     interp_read_raise_tree (k s) s
   | Op Raise e k ->
     Inl e
@@ -624,10 +616,8 @@ let rec interp_all_tree #a (t : tree a [Read; Write; Raise]) (s:state) : Tot (op
   match t with
   | Return x -> (Some x, s)
   | Op Read _ k ->
-    FStar.WellFounded.axiom1 k s;
     interp_all_tree (k s) s
   | Op Write s k ->
-    FStar.WellFounded.axiom1 k ();
     interp_all_tree (k ()) s
   | Op Raise e k ->
     (None, s)
@@ -672,10 +662,9 @@ let rec handle #a #b #labs l f h v =
   | Return x -> v x
   | Op act i k ->
     if act = l
-    then h i (fun o -> WF.axiom1 k o; handle l (k o) h v)
+    then h i (fun o -> handle l (k o) h v)
     else begin
       let k' o : tree b labs =
-         WF.axiom1 k o;
          handle l (k o) h v
       in
       Op act i k'
@@ -694,12 +683,11 @@ let rec handle2 #a #b #labs l1 l2 f h1 h2 v =
   | Return x -> v x
   | Op act i k ->
     if act = l1
-    then h1 i (fun o -> WF.axiom1 k o; handle2 l1 l2 (k o) h1 h2 v)
+    then h1 i (fun o -> handle2 l1 l2 (k o) h1 h2 v)
     else if act = l2
-    then h2 i (fun o -> WF.axiom1 k o; handle2 l1 l2 (k o) h1 h2 v)
+    then h2 i (fun o -> handle2 l1 l2 (k o) h1 h2 v)
     else begin
       let k' o : tree b labs =
-         WF.axiom1 k o;
          handle2 l1 l2 (k o) h1 h2 v
       in
       Op act i k'
@@ -772,16 +760,13 @@ let rec interp_into_lattice_tree #a (#labs:list baseop)
     | Return x -> L.return _ x
     | Op Read i k ->
       L.bind _ _ _ _ (reify (L.get i))
-       (fun x -> WF.axiom1 k x;
-              interp_into_lattice_tree #a #labs (k x))
+       (fun x -> interp_into_lattice_tree #a #labs (k x))
     | Op Write i k ->
       L.bind _ _ _ _ (reify (L.put i))
-       (fun x -> WF.axiom1 k x;
-              interp_into_lattice_tree #a #labs (k x))
+       (fun x -> interp_into_lattice_tree #a #labs (k x))
     | Op Raise i k ->
       L.bind _ _ _ _ (reify (L.raise ()))
-       (fun x -> WF.axiom1 k x;
-              interp_into_lattice_tree #a #labs (k x))
+       (fun x -> interp_into_lattice_tree #a #labs (k x))
 
 let interp_into_lattice #a (#labs:list baseop)
   (f : unit -> Alg a (fixup labs))
@@ -811,13 +796,9 @@ let rec interp_sem #a (#labs:list baseop) (t : tree a (fixup labs)) : sem a labs
   match t with
   | Return x -> fun s0 -> (Inr x, s0)
   | Op Read _ k ->
-    (* Needs this trick for termination. Trying to call axiom1 within
-     * `r` messes up the refinement about Read. *)
-    let k : (s:state -> (r:(tree a (fixup labs)){r << k})) = fun s -> WF.axiom1 k s; k s in
     let r : sem a labs = fun s0 -> interp_sem #a #labs (k s0) s0 in
     r
   | Op Write s k ->
-    WF.axiom1 k ();
     fun s0 -> interp_sem #a #labs (k ()) s
   | Op Raise e k -> fun s0 -> (Inl e, s0)
 

--- a/examples/layeredeffects/DijkstraStateMonad.fst
+++ b/examples/layeredeffects/DijkstraStateMonad.fst
@@ -17,7 +17,6 @@
 module DijkstraStateMonad
 open FStar.FunctionalExtensionality
 module F = FStar.FunctionalExtensionality
-module W = FStar.WellFounded
 module T = FStar.Tactics
 
 /// This example illustrates how to derive a WP-indexed state monad
@@ -34,7 +33,7 @@ type m (s:Type0) (a:Type) =
 let rec bind_m #s #a #b (x:m s a) (y: (a -> m s b)) : m s b =
   match x with
   | Ret x -> y x
-  | Get k -> Get (fun s -> W.axiom1 k s; bind_m (k s) y)
+  | Get k -> Get (fun s -> bind_m (k s) y)
   | Put s k -> Put s (bind_m k y)
 
 /// Now, we want to build an indexed version of m, where the index is
@@ -82,7 +81,7 @@ let rec wp_of #a #s (x:m s a)
   : wp_t s a
   = match x with
     | Ret v -> wp_return v
-    | Get k -> F.on _ (fun s0 -> W.axiom1 k s0; (wp_of (k s0)) s0)
+    | Get k -> F.on _ (fun s0 -> (wp_of (k s0)) s0)
     | Put s k -> wp_put (wp_of k) s
 
 /// We prove the soundness of the wp semantics by giving it a model in
@@ -96,7 +95,6 @@ let rec run (#a:_) (#s:_) (m:m s a) (s0:s) (post: post_t s a)
   = match m with
     | Ret x -> (x, s0)
     | Get k ->
-      W.axiom1 k s0;
       run (k s0) s0 post
     | Put s k ->
       run k s post
@@ -184,8 +182,7 @@ let rec bind_wp_lem' (#a:Type u#aa) (#b:Type u#bb) (#s:_) (f:m s a) (g: (a -> m 
           (ensures (wp_of (bind_m (k x) g) `F.feq`
                     bind_wp (wp_of (k x)) (wp_of *. g)))
           [SMTPat (k x)]
-        = W.axiom1 k x;
-          bind_wp_lem' (k x) g
+        = bind_wp_lem' (k x) g
       in
       assert_norm (wp_of (bind_m (Get k) g) ==
                    wp_of (Get (fun x -> bind_m (k x) g)));

--- a/examples/layeredeffects/RunST.fst
+++ b/examples/layeredeffects/RunST.fst
@@ -8,10 +8,6 @@ open FStar.List.Tot
 open FStar.Universe
 open FStar.Ghost
 
-module WF = FStar.WellFounded
-
-let axiom1 = WF.axiom1
-
 #set-options "--print_universes --print_implicits --print_effect_args"
 
 // GM: Force a type equality by SMT
@@ -50,7 +46,7 @@ let abides_act #i #o (ann:annot) (a : action i o 'st0 'st1) : prop =
 let rec abides #a (ann:annot) (f : repr0 a 'st0 'st1) : prop =
   begin match f with
   | Op a i k ->
-    abides_act ann a /\ (forall o. (axiom1 k o; abides ann (k o)))
+    abides_act ann a /\ (forall o. abides ann (k o))
   | Return _ -> True
   end
 
@@ -107,7 +103,6 @@ let rec abides_sublist #a (l1 l2 : list eff_label) (c : repr0 a 'st0 'st1)
     | Return _ -> ()
     | Op a i k ->
       let sub o : Lemma (abides (interp l2) (k o)) =
-        axiom1 k o;
         abides_sublist l1 l2 (k o)
       in
       Classical.forall_intro sub
@@ -122,7 +117,6 @@ let rec abides_app #a (l1 l2 : list eff_label) (c : repr0 a 'st0 'st1)
     | Return _ -> ()
     | Op a i k ->
       let sub o : Lemma (abides (interp (l1@l2)) (k o)) =
-        axiom1 k o;
         abides_app l1 l2 (k o)
       in
       Classical.forall_intro sub
@@ -152,7 +146,6 @@ let rec bind (a b : Type)
     | Return x -> f x
     | Op a i k ->
       let k' o : repr b _ _ (labs1@labs2) =
-        axiom1 k o;
         bind _ _ _ _ _ _ _ (k o) f
       in
       Op a i k'
@@ -270,8 +263,8 @@ let _runST (#a:Type0) #labs #si #sf ($c : repr a si sf labs) (s0:si) : Tot (opti
   let rec aux #st0 (s:st0) (c : repr a st0 sf labs) : Tot (option (a & sf)) (decreases c) =
     match c with
     | Return x -> Some (x, s)
-    | Op Read  _ k -> axiom1 k s; aux s (k s)
-    | Op Write s k -> axiom1 k (); aux s (k ())
+    | Op Read  _ k -> aux s (k s)
+    | Op Write s k -> aux s (k ())
     | Op Raise e k -> None
   in
   aux s0 c
@@ -298,8 +291,8 @@ let rec _catchST (#a:Type0) #labs #si #sf
 : repr (a & sf) stt stt labs
 = match c with
   | Return x -> Return (x, s0)
-  | Op Read _i k -> axiom1 k s0; _catchST #a #labs stt (k s0) s0
-  | Op Write s k -> axiom1 k (); _catchST #a #labs stt (k ()) s
+  | Op Read _i k -> _catchST #a #labs stt (k s0) s0
+  | Op Write s k -> _catchST #a #labs stt (k ()) s
   | Op Raise e k ->
     let k' (o : c_False) : repr (a & sf) stt stt labs =
       unreachable ()
@@ -309,7 +302,6 @@ let rec _catchST (#a:Type0) #labs #si #sf
 // if exceptions did not change the state type, we could in theory
 // handle its continuation as well, though it would never be called.
 //  let k' o : repr (a & sf) _ _ labs =
-//    axiom1 k o;
 //    _catchST #a #labs stt (k o) s0
 
 (* I would hope to write a general case like this:
@@ -323,7 +315,6 @@ val act_keeps_state (a:action 'in 'out 'st0 'st1) : Lemma ('st0 == 'st1)
     assert (st1 == unit);
     assert (st2__ == unit);
     let k' o : repr (a & sf) st1 st2__ labs =
-      axiom1 k o;
       _catchST #a #labs stt (k o) s0
     in
     Op act e k'
@@ -351,7 +342,6 @@ let rec _catchE (#a:Type0) #labs #si #sf
   | Op Raise e k -> h si
   | Op act i k ->
     let k' o : repr a _ _ labs =
-      axiom1 k o;
       _catchE (k o) h
     in
     Op act i k'
@@ -411,7 +401,6 @@ let rec interp_rd_tree #a #st0 #st1 (t : repr a st0 st1 [RD]) (s:st0) : Tot a =
   match t with
   | Return x -> x
   | Op Read _ k ->
-    axiom1 k s;
     interp_rd_tree (k s) s
 
 let interp_rd #a #st0 #st1 (f : unit -> EFF a st0 st1 [RD]) (s:st0) : Tot a
@@ -421,10 +410,8 @@ let rec interp_rdwr_tree #a #st0 #st1 (t : repr a st0 st1 [RD;WR]) (s:st0) : Tot
   match t with
   | Return x -> (x, s)
   | Op Read _ k ->
-    axiom1 k s;
     interp_rdwr_tree (k s) s
   | Op Write s k ->
-    axiom1 k ();
     interp_rdwr_tree (k ()) s
 
 let interp_rdwr #a #st0 #st1

--- a/examples/rel/Memo.fst
+++ b/examples/rel/Memo.fst
@@ -406,7 +406,7 @@ let rec complete_memo_rec_extr
   | Done y -> y
   | Need x' cont ->
     let y = memo_extr_p (p x px) (memo_rec_extr_temp f x px) x' in
-    complete_memo_rec_extr f x (cont <| y)
+    complete_memo_rec_extr f x (cont y)
 
 and memo_rec_extr_temp (f: (x:dom -> partial_result x)) (x0:dom) (px0:partial_result x0) (x:dom{p x0 px0 x})
   : Memo codom (decreases %[x0 ; 0 ; px0])
@@ -444,7 +444,7 @@ let rec complete_memo_rec_extr_computes :
     let y, h1 = reify (memo_extr_p (p x px) (memo_rec_extr_temp f x px) x') h0 in
     assert (y == fixp f x') ;
     assert (valid_memo h1 (fixp f)) ;
-    complete_memo_rec_extr_computes f x (cont <| y) h1
+    complete_memo_rec_extr_computes f x (cont y) h1
 and memo_rec_extr_computes :
   (f:(x:dom -> partial_result x)) ->
   (x:dom) ->
@@ -494,7 +494,7 @@ let rec complete_fixp_eq_proof
   match px with
   | Done y -> y == g x
   | Need x1 cont ->
-    fixp f x1 == g x1 ==> complete_fixp_eq_proof f g x (cont <| (fixp f x1))
+    fixp f x1 == g x1 ==> complete_fixp_eq_proof f g x (cont (fixp f x1))
 
 unfold
 let fixp_eq_proof f g = forall x. complete_fixp_eq_proof f g x (f x)
@@ -514,7 +514,7 @@ let rec complete_fixp_eq
   match px with
   | Done y -> ()
   | Need x1 cont ->
-    fixp_eq' f g x1 ; complete_fixp_eq f g x (cont <| (fixp f x1))
+    fixp_eq' f g x1 ; complete_fixp_eq f g x (cont  (fixp f x1))
 
 and fixp_eq'
   (f: (x:dom -> Tot (partial_result x)))

--- a/examples/rel/Memo.fst
+++ b/examples/rel/Memo.fst
@@ -17,7 +17,7 @@ module Memo
 
 open FStar.Classical
 open FStar.Squash
-open FStar.WellFounded
+
 
 (* These should be indices of our effect *)
 type dom : eqtype = int
@@ -270,11 +270,6 @@ noeq type partial_result (x0:dom) : Type =
 (* Or a computation asking for the result of the recursive call on [x] and a continuation [cont] *)
 | Need : x:dom{x << x0} -> cont:(codom -> Tot (partial_result x0)) -> partial_result x0
 
-(* The rule [f x << f] is currently not primitive but take as an axiom in FStar.WellFounded *)
-(* We define a convenience operator doing the application and ensuring the corresponding decreasing clause *)
-unfold
-let ( <| ) #x = apply #codom #(fun _ -> partial_result x)
-
 
 (* We can define the actual total function represented *)
 (* by [f : x:dom -> Tot (partial_result x)] with *)
@@ -286,7 +281,7 @@ let rec  complete_fixp (f: (x:dom) -> partial_result x) (x:dom) (px:partial_resu
   match px with
   | Done y -> y
   | Need x' cont ->
-    complete_fixp f x (cont <| (fixp f x'))
+    complete_fixp f x (cont (fixp f x'))
 
 and fixp (f: (x:dom -> Tot (partial_result x))) (x0:dom)
   : Tot codom (decreases %[x0 ; 1 ; ()])
@@ -313,7 +308,7 @@ let rec fpartial_result x (f: (x:dom -> partial_result x)) (px:partial_result x)
   match px with
   | Done y -> y == fixp f x
   | Need x1 cont ->
-    fpartial_result x f (cont <| (fixp f x1))
+    fpartial_result x f (cont (fixp f x1))
 
 
 let rec fpartial_result_lemma f x px (w:reachable f x px) : Lemma (requires True) (ensures (fpartial_result x f px)) (decreases px)
@@ -321,7 +316,7 @@ let rec fpartial_result_lemma f x px (w:reachable f x px) : Lemma (requires True
   | Done y -> reachable_lemma f x px w (* ; assert (y == fixp f x) ;     assert (fpartial_result x f px) *)
 
   | Need x' cont ->
-    let px' = cont <| (fixp f x') in
+    let px' = cont (fixp f x') in
     fpartial_result_lemma f x px' (Later x' cont w)
 
 let fpartial_result_init_lemma f x
@@ -368,7 +363,7 @@ let rec complete_memo_rec (f: (x:dom -> Tot (partial_result x))) (x:dom) (px:par
         y
     in
     assert (y == fixp f x') ;
-    let px1 = cont <| y in
+    let px1 = cont y in
     assert (fpartial_result x f px1) ;
     complete_memo_rec f x px1
 

--- a/examples/seplogic/Lang.fst
+++ b/examples/seplogic/Lang.fst
@@ -68,7 +68,6 @@ let rec wpsep_command (#a:Type0) (c:command a) :st_wp a
        * again into h1' and h1'', where c2 runs on h1' resulting in h2.
        * The final heap is then join of h2 and h1''.
        *)
-      FStar.Classical.forall_intro (FStar.WellFounded.axiom1 #a #(command b) c2);
       fun p h3 -> exists (h2':heap) (h2'':heap). h3 == join_tot h2' h2'' /\
      (wpsep_command c1) (fun x h1 -> exists (h1':heap) (h1'':heap). (join_tot h1 h2'') == (join_tot h1' h1'') /\
      (wpsep_command (c2 x)) (fun y h2 -> p y (join_tot h2 h1'')) h1') h2'

--- a/examples/tactics/Postprocess.fst
+++ b/examples/tactics/Postprocess.fst
@@ -47,7 +47,7 @@ let rec lift : t1 -> t2 =
     function
     | A1 -> A2
     | B1 i -> B2 i
-    | C1 f -> C2 (fun x -> lift (FStar.WellFounded.axiom1 f x; f x))
+    | C1 f -> C2 (fun x -> lift (f x))
 
 let lemA () : Lemma (lift A1 == A2) = ()
 let lemB x : Lemma (lift (B1 x) == (B2 x)) = ()

--- a/src/fstar/FStar.CheckedFiles.fs
+++ b/src/fstar/FStar.CheckedFiles.fs
@@ -42,7 +42,7 @@ module Dep     = FStar.Parser.Dep
  * detect when loading the cache that the version number is same
  * It needs to be kept in sync with prims.fst
  *)
-let cache_version_number = 30
+let cache_version_number = 31
 
 type tc_result = {
   checked_module: Syntax.modul; //persisted

--- a/src/ocaml-output/FStar_CheckedFiles.ml
+++ b/src/ocaml-output/FStar_CheckedFiles.ml
@@ -1,5 +1,5 @@
 open Prims
-let (cache_version_number : Prims.int) = (Prims.of_int (30))
+let (cache_version_number : Prims.int) = (Prims.of_int (31))
 type tc_result =
   {
   checked_module: FStar_Syntax_Syntax.modul ;

--- a/src/ocaml-output/FStar_SMTEncoding_Encode.ml
+++ b/src/ocaml-output/FStar_SMTEncoding_Encode.ml
@@ -5635,18 +5635,18 @@ and (encode_sigelt' :
                                                                     ddconstrsym)) in
                                                                     FStar_SMTEncoding_Util.mkAssume
                                                                     uu___21 in
-                                                                   let codomain_ordering
+                                                                   let uu___21
                                                                     =
                                                                     let tot_or_gtot_inductive_codomain
                                                                     c =
                                                                     let is_inductive
                                                                     l =
-                                                                    let uu___21
+                                                                    let uu___22
                                                                     =
                                                                     FStar_TypeChecker_Env.lookup_sigelt
                                                                     env1.FStar_SMTEncoding_Env.tcenv
                                                                     l in
-                                                                    match uu___21
+                                                                    match uu___22
                                                                     with
                                                                     | 
                                                                     FStar_Pervasives_Native.Some
@@ -5654,45 +5654,45 @@ and (encode_sigelt' :
                                                                     FStar_Syntax_Syntax.sigel
                                                                     =
                                                                     FStar_Syntax_Syntax.Sig_inductive_typ
-                                                                    uu___22;
+                                                                    uu___23;
                                                                     FStar_Syntax_Syntax.sigrng
-                                                                    = uu___23;
-                                                                    FStar_Syntax_Syntax.sigquals
                                                                     = uu___24;
-                                                                    FStar_Syntax_Syntax.sigmeta
+                                                                    FStar_Syntax_Syntax.sigquals
                                                                     = uu___25;
-                                                                    FStar_Syntax_Syntax.sigattrs
+                                                                    FStar_Syntax_Syntax.sigmeta
                                                                     = uu___26;
+                                                                    FStar_Syntax_Syntax.sigattrs
+                                                                    = uu___27;
                                                                     FStar_Syntax_Syntax.sigopts
-                                                                    = uu___27;_}
+                                                                    = uu___28;_}
                                                                     -> true
                                                                     | 
-                                                                    uu___22
+                                                                    uu___23
                                                                     -> false in
                                                                     let res =
-                                                                    let uu___21
-                                                                    =
                                                                     let uu___22
+                                                                    =
+                                                                    let uu___23
                                                                     =
                                                                     FStar_Syntax_Util.is_tot_or_gtot_comp
                                                                     c in
                                                                     Prims.op_Negation
-                                                                    uu___22 in
+                                                                    uu___23 in
                                                                     if
-                                                                    uu___21
+                                                                    uu___22
                                                                     then
                                                                     false
                                                                     else
-                                                                    (let uu___23
+                                                                    (let uu___24
                                                                     =
                                                                     FStar_Syntax_Util.head_and_args
                                                                     (FStar_Syntax_Util.comp_result
                                                                     c) in
-                                                                    match uu___23
+                                                                    match uu___24
                                                                     with
                                                                     | 
                                                                     (head1,
-                                                                    uu___24)
+                                                                    uu___25)
                                                                     ->
                                                                     FStar_Util.for_some
                                                                     (fun
@@ -5705,27 +5705,27 @@ and (encode_sigelt' :
                                                                     head1))
                                                                     mutuals) in
                                                                     res in
-                                                                    let codomain_prec_l
+                                                                    let uu___22
                                                                     =
-                                                                    let uu___21
-                                                                    =
-                                                                    FStar_List.zip
-                                                                    formals
-                                                                    vars in
-                                                                    FStar_List.collect
+                                                                    FStar_List.fold_left2
                                                                     (fun
-                                                                    uu___22
+                                                                    uu___23
                                                                     ->
-                                                                    match uu___22
+                                                                    fun
+                                                                    formal ->
+                                                                    fun var
+                                                                    ->
+                                                                    match uu___23
                                                                     with
                                                                     | 
-                                                                    (formal,
-                                                                    var) ->
-                                                                    let uu___23
+                                                                    (codomain_prec_l,
+                                                                    cod_decls)
+                                                                    ->
+                                                                    let uu___24
                                                                     =
                                                                     FStar_Syntax_Util.arrow_formals_comp
                                                                     (formal.FStar_Syntax_Syntax.binder_bv).FStar_Syntax_Syntax.sort in
-                                                                    (match uu___23
+                                                                    (match uu___24
                                                                     with
                                                                     | 
                                                                     (bs, c)
@@ -5733,72 +5733,61 @@ and (encode_sigelt' :
                                                                     (match bs
                                                                     with
                                                                     | 
-                                                                    [] -> []
+                                                                    [] ->
+                                                                    (codomain_prec_l,
+                                                                    cod_decls)
                                                                     | 
-                                                                    uu___24
+                                                                    uu___25
                                                                     when
-                                                                    let uu___25
+                                                                    let uu___26
                                                                     =
                                                                     tot_or_gtot_inductive_codomain
                                                                     c in
                                                                     Prims.op_Negation
-                                                                    uu___25
-                                                                    -> []
-                                                                    | 
-                                                                    uu___24
+                                                                    uu___26
                                                                     ->
-                                                                    let uu___25
+                                                                    (codomain_prec_l,
+                                                                    cod_decls)
+                                                                    | 
+                                                                    uu___25
+                                                                    ->
+                                                                    let uu___26
                                                                     =
                                                                     FStar_SMTEncoding_EncodeTerm.encode_binders
                                                                     FStar_Pervasives_Native.None
                                                                     bs env'' in
-                                                                    (match uu___25
+                                                                    (match uu___26
                                                                     with
                                                                     | 
                                                                     (bs',
                                                                     guards'1,
-                                                                    env'1,
+                                                                    _env',
                                                                     bs_decls,
-                                                                    uu___26)
+                                                                    uu___27)
                                                                     ->
                                                                     let fun_app
                                                                     =
-                                                                    let uu___27
+                                                                    let uu___28
                                                                     =
                                                                     FStar_SMTEncoding_Util.mkFreeV
                                                                     var in
                                                                     FStar_SMTEncoding_EncodeTerm.mk_Apply
-                                                                    uu___27
+                                                                    uu___28
                                                                     bs' in
-                                                                    let uu___27
-                                                                    =
                                                                     let uu___28
                                                                     =
-                                                                    FStar_Ident.range_of_lid
-                                                                    d in
                                                                     let uu___29
                                                                     =
                                                                     let uu___30
                                                                     =
-                                                                    let uu___31
-                                                                    =
-                                                                    let uu___32
-                                                                    =
-                                                                    FStar_SMTEncoding_Util.mk_Precedes
-                                                                    lex_t
-                                                                    lex_t
-                                                                    fun_app
-                                                                    dapp1 in
-                                                                    [uu___32] in
-                                                                    [uu___31] in
+                                                                    FStar_Ident.range_of_lid
+                                                                    d in
                                                                     let uu___31
                                                                     =
                                                                     let uu___32
                                                                     =
                                                                     let uu___33
                                                                     =
-                                                                    FStar_SMTEncoding_Util.mk_and_l
-                                                                    guards'1 in
                                                                     let uu___34
                                                                     =
                                                                     FStar_SMTEncoding_Util.mk_Precedes
@@ -5806,82 +5795,127 @@ and (encode_sigelt' :
                                                                     lex_t
                                                                     fun_app
                                                                     dapp1 in
-                                                                    (uu___33,
-                                                                    uu___34) in
+                                                                    [uu___34] in
+                                                                    [uu___33] in
+                                                                    let uu___33
+                                                                    =
+                                                                    let uu___34
+                                                                    =
+                                                                    let uu___35
+                                                                    =
+                                                                    FStar_SMTEncoding_Util.mk_and_l
+                                                                    guards'1 in
+                                                                    let uu___36
+                                                                    =
+                                                                    FStar_SMTEncoding_Util.mk_Precedes
+                                                                    lex_t
+                                                                    lex_t
+                                                                    fun_app
+                                                                    dapp1 in
+                                                                    (uu___35,
+                                                                    uu___36) in
                                                                     FStar_SMTEncoding_Util.mkImp
-                                                                    uu___32 in
-                                                                    (uu___30,
+                                                                    uu___34 in
+                                                                    (uu___32,
                                                                     bs',
-                                                                    uu___31) in
+                                                                    uu___33) in
                                                                     FStar_SMTEncoding_Term.mkForall
-                                                                    uu___28
-                                                                    uu___29 in
-                                                                    [uu___27]))))
-                                                                    uu___21 in
-                                                                    match codomain_prec_l
+                                                                    uu___30
+                                                                    uu___31 in
+                                                                    uu___29
+                                                                    ::
+                                                                    codomain_prec_l in
+                                                                    (uu___28,
+                                                                    (FStar_List.append
+                                                                    bs_decls
+                                                                    cod_decls))))))
+                                                                    ([], [])
+                                                                    formals
+                                                                    vars in
+                                                                    match uu___22
                                                                     with
                                                                     | 
-                                                                    [] -> []
-                                                                    | 
-                                                                    uu___21
+                                                                    (codomain_prec_l,
+                                                                    cod_decls)
                                                                     ->
-                                                                    let uu___22
-                                                                    =
-                                                                    let uu___23
-                                                                    =
+                                                                    (match codomain_prec_l
+                                                                    with
+                                                                    | 
+                                                                    [] ->
+                                                                    ([],
+                                                                    cod_decls)
+                                                                    | 
+                                                                    uu___23
+                                                                    ->
                                                                     let uu___24
                                                                     =
                                                                     let uu___25
                                                                     =
-                                                                    FStar_Ident.range_of_lid
-                                                                    d in
                                                                     let uu___26
                                                                     =
                                                                     let uu___27
                                                                     =
                                                                     let uu___28
                                                                     =
-                                                                    FStar_SMTEncoding_Term.mk_fv
-                                                                    (fuel_var,
-                                                                    FStar_SMTEncoding_Term.Fuel_sort) in
-                                                                    FStar_SMTEncoding_Env.add_fuel
-                                                                    uu___28
-                                                                    (FStar_List.append
-                                                                    vars
-                                                                    arg_binders) in
-                                                                    let uu___28
-                                                                    =
+                                                                    FStar_Ident.range_of_lid
+                                                                    d in
                                                                     let uu___29
                                                                     =
                                                                     let uu___30
                                                                     =
+                                                                    let uu___31
+                                                                    =
+                                                                    FStar_SMTEncoding_Term.mk_fv
+                                                                    (fuel_var,
+                                                                    FStar_SMTEncoding_Term.Fuel_sort) in
+                                                                    FStar_SMTEncoding_Env.add_fuel
+                                                                    uu___31
+                                                                    (FStar_List.append
+                                                                    vars
+                                                                    arg_binders) in
+                                                                    let uu___31
+                                                                    =
+                                                                    let uu___32
+                                                                    =
+                                                                    let uu___33
+                                                                    =
                                                                     FStar_SMTEncoding_Util.mk_and_l
                                                                     codomain_prec_l in
                                                                     (ty_pred,
-                                                                    uu___30) in
+                                                                    uu___33) in
                                                                     FStar_SMTEncoding_Util.mkImp
-                                                                    uu___29 in
+                                                                    uu___32 in
                                                                     ([
                                                                     [ty_pred]],
-                                                                    uu___27,
-                                                                    uu___28) in
+                                                                    uu___30,
+                                                                    uu___31) in
                                                                     FStar_SMTEncoding_Term.mkForall
-                                                                    uu___25
-                                                                    uu___26 in
-                                                                    (uu___24,
+                                                                    uu___28
+                                                                    uu___29 in
+                                                                    (uu___27,
                                                                     (FStar_Pervasives_Native.Some
                                                                     "well-founded ordering on codomain"),
                                                                     (Prims.op_Hat
                                                                     "well_founded_ordering_on_comdain_"
                                                                     ddconstrsym)) in
                                                                     FStar_SMTEncoding_Util.mkAssume
-                                                                    uu___23 in
-                                                                    [uu___22] in
-                                                                   (arg_decls,
+                                                                    uu___26 in
+                                                                    [uu___25] in
+                                                                    (uu___24,
+                                                                    cod_decls)) in
+                                                                   (match uu___21
+                                                                    with
+                                                                    | 
+                                                                    (codomain_ordering,
+                                                                    codomain_decls)
+                                                                    ->
+                                                                    ((FStar_List.append
+                                                                    arg_decls
+                                                                    codomain_decls),
                                                                     (FStar_List.append
                                                                     [typing_inversion;
                                                                     subterm_ordering]
-                                                                    codomain_ordering))))
+                                                                    codomain_ordering)))))
                                                      | FStar_Syntax_Syntax.Tm_fvar
                                                          fv ->
                                                          let encoded_head_fvb
@@ -6205,18 +6239,18 @@ and (encode_sigelt' :
                                                                     ddconstrsym)) in
                                                                     FStar_SMTEncoding_Util.mkAssume
                                                                     uu___18 in
-                                                                   let codomain_ordering
+                                                                   let uu___18
                                                                     =
                                                                     let tot_or_gtot_inductive_codomain
                                                                     c =
                                                                     let is_inductive
                                                                     l =
-                                                                    let uu___18
+                                                                    let uu___19
                                                                     =
                                                                     FStar_TypeChecker_Env.lookup_sigelt
                                                                     env1.FStar_SMTEncoding_Env.tcenv
                                                                     l in
-                                                                    match uu___18
+                                                                    match uu___19
                                                                     with
                                                                     | 
                                                                     FStar_Pervasives_Native.Some
@@ -6224,45 +6258,45 @@ and (encode_sigelt' :
                                                                     FStar_Syntax_Syntax.sigel
                                                                     =
                                                                     FStar_Syntax_Syntax.Sig_inductive_typ
-                                                                    uu___19;
+                                                                    uu___20;
                                                                     FStar_Syntax_Syntax.sigrng
-                                                                    = uu___20;
-                                                                    FStar_Syntax_Syntax.sigquals
                                                                     = uu___21;
-                                                                    FStar_Syntax_Syntax.sigmeta
+                                                                    FStar_Syntax_Syntax.sigquals
                                                                     = uu___22;
-                                                                    FStar_Syntax_Syntax.sigattrs
+                                                                    FStar_Syntax_Syntax.sigmeta
                                                                     = uu___23;
+                                                                    FStar_Syntax_Syntax.sigattrs
+                                                                    = uu___24;
                                                                     FStar_Syntax_Syntax.sigopts
-                                                                    = uu___24;_}
+                                                                    = uu___25;_}
                                                                     -> true
                                                                     | 
-                                                                    uu___19
+                                                                    uu___20
                                                                     -> false in
                                                                     let res =
-                                                                    let uu___18
-                                                                    =
                                                                     let uu___19
+                                                                    =
+                                                                    let uu___20
                                                                     =
                                                                     FStar_Syntax_Util.is_tot_or_gtot_comp
                                                                     c in
                                                                     Prims.op_Negation
-                                                                    uu___19 in
+                                                                    uu___20 in
                                                                     if
-                                                                    uu___18
+                                                                    uu___19
                                                                     then
                                                                     false
                                                                     else
-                                                                    (let uu___20
+                                                                    (let uu___21
                                                                     =
                                                                     FStar_Syntax_Util.head_and_args
                                                                     (FStar_Syntax_Util.comp_result
                                                                     c) in
-                                                                    match uu___20
+                                                                    match uu___21
                                                                     with
                                                                     | 
                                                                     (head1,
-                                                                    uu___21)
+                                                                    uu___22)
                                                                     ->
                                                                     FStar_Util.for_some
                                                                     (fun
@@ -6275,27 +6309,27 @@ and (encode_sigelt' :
                                                                     head1))
                                                                     mutuals) in
                                                                     res in
-                                                                    let codomain_prec_l
+                                                                    let uu___19
                                                                     =
-                                                                    let uu___18
-                                                                    =
-                                                                    FStar_List.zip
-                                                                    formals
-                                                                    vars in
-                                                                    FStar_List.collect
+                                                                    FStar_List.fold_left2
                                                                     (fun
-                                                                    uu___19
+                                                                    uu___20
                                                                     ->
-                                                                    match uu___19
+                                                                    fun
+                                                                    formal ->
+                                                                    fun var
+                                                                    ->
+                                                                    match uu___20
                                                                     with
                                                                     | 
-                                                                    (formal,
-                                                                    var) ->
-                                                                    let uu___20
+                                                                    (codomain_prec_l,
+                                                                    cod_decls)
+                                                                    ->
+                                                                    let uu___21
                                                                     =
                                                                     FStar_Syntax_Util.arrow_formals_comp
                                                                     (formal.FStar_Syntax_Syntax.binder_bv).FStar_Syntax_Syntax.sort in
-                                                                    (match uu___20
+                                                                    (match uu___21
                                                                     with
                                                                     | 
                                                                     (bs, c)
@@ -6303,72 +6337,61 @@ and (encode_sigelt' :
                                                                     (match bs
                                                                     with
                                                                     | 
-                                                                    [] -> []
+                                                                    [] ->
+                                                                    (codomain_prec_l,
+                                                                    cod_decls)
                                                                     | 
-                                                                    uu___21
+                                                                    uu___22
                                                                     when
-                                                                    let uu___22
+                                                                    let uu___23
                                                                     =
                                                                     tot_or_gtot_inductive_codomain
                                                                     c in
                                                                     Prims.op_Negation
-                                                                    uu___22
-                                                                    -> []
-                                                                    | 
-                                                                    uu___21
+                                                                    uu___23
                                                                     ->
-                                                                    let uu___22
+                                                                    (codomain_prec_l,
+                                                                    cod_decls)
+                                                                    | 
+                                                                    uu___22
+                                                                    ->
+                                                                    let uu___23
                                                                     =
                                                                     FStar_SMTEncoding_EncodeTerm.encode_binders
                                                                     FStar_Pervasives_Native.None
                                                                     bs env'' in
-                                                                    (match uu___22
+                                                                    (match uu___23
                                                                     with
                                                                     | 
                                                                     (bs',
                                                                     guards'1,
-                                                                    env'1,
+                                                                    _env',
                                                                     bs_decls,
-                                                                    uu___23)
+                                                                    uu___24)
                                                                     ->
                                                                     let fun_app
                                                                     =
-                                                                    let uu___24
+                                                                    let uu___25
                                                                     =
                                                                     FStar_SMTEncoding_Util.mkFreeV
                                                                     var in
                                                                     FStar_SMTEncoding_EncodeTerm.mk_Apply
-                                                                    uu___24
+                                                                    uu___25
                                                                     bs' in
-                                                                    let uu___24
-                                                                    =
                                                                     let uu___25
                                                                     =
-                                                                    FStar_Ident.range_of_lid
-                                                                    d in
                                                                     let uu___26
                                                                     =
                                                                     let uu___27
                                                                     =
-                                                                    let uu___28
-                                                                    =
-                                                                    let uu___29
-                                                                    =
-                                                                    FStar_SMTEncoding_Util.mk_Precedes
-                                                                    lex_t
-                                                                    lex_t
-                                                                    fun_app
-                                                                    dapp1 in
-                                                                    [uu___29] in
-                                                                    [uu___28] in
+                                                                    FStar_Ident.range_of_lid
+                                                                    d in
                                                                     let uu___28
                                                                     =
                                                                     let uu___29
                                                                     =
                                                                     let uu___30
                                                                     =
-                                                                    FStar_SMTEncoding_Util.mk_and_l
-                                                                    guards'1 in
                                                                     let uu___31
                                                                     =
                                                                     FStar_SMTEncoding_Util.mk_Precedes
@@ -6376,82 +6399,127 @@ and (encode_sigelt' :
                                                                     lex_t
                                                                     fun_app
                                                                     dapp1 in
-                                                                    (uu___30,
-                                                                    uu___31) in
+                                                                    [uu___31] in
+                                                                    [uu___30] in
+                                                                    let uu___30
+                                                                    =
+                                                                    let uu___31
+                                                                    =
+                                                                    let uu___32
+                                                                    =
+                                                                    FStar_SMTEncoding_Util.mk_and_l
+                                                                    guards'1 in
+                                                                    let uu___33
+                                                                    =
+                                                                    FStar_SMTEncoding_Util.mk_Precedes
+                                                                    lex_t
+                                                                    lex_t
+                                                                    fun_app
+                                                                    dapp1 in
+                                                                    (uu___32,
+                                                                    uu___33) in
                                                                     FStar_SMTEncoding_Util.mkImp
-                                                                    uu___29 in
-                                                                    (uu___27,
+                                                                    uu___31 in
+                                                                    (uu___29,
                                                                     bs',
-                                                                    uu___28) in
+                                                                    uu___30) in
                                                                     FStar_SMTEncoding_Term.mkForall
-                                                                    uu___25
-                                                                    uu___26 in
-                                                                    [uu___24]))))
-                                                                    uu___18 in
-                                                                    match codomain_prec_l
+                                                                    uu___27
+                                                                    uu___28 in
+                                                                    uu___26
+                                                                    ::
+                                                                    codomain_prec_l in
+                                                                    (uu___25,
+                                                                    (FStar_List.append
+                                                                    bs_decls
+                                                                    cod_decls))))))
+                                                                    ([], [])
+                                                                    formals
+                                                                    vars in
+                                                                    match uu___19
                                                                     with
                                                                     | 
-                                                                    [] -> []
-                                                                    | 
-                                                                    uu___18
+                                                                    (codomain_prec_l,
+                                                                    cod_decls)
                                                                     ->
-                                                                    let uu___19
-                                                                    =
-                                                                    let uu___20
-                                                                    =
+                                                                    (match codomain_prec_l
+                                                                    with
+                                                                    | 
+                                                                    [] ->
+                                                                    ([],
+                                                                    cod_decls)
+                                                                    | 
+                                                                    uu___20
+                                                                    ->
                                                                     let uu___21
                                                                     =
                                                                     let uu___22
                                                                     =
-                                                                    FStar_Ident.range_of_lid
-                                                                    d in
                                                                     let uu___23
                                                                     =
                                                                     let uu___24
                                                                     =
                                                                     let uu___25
                                                                     =
-                                                                    FStar_SMTEncoding_Term.mk_fv
-                                                                    (fuel_var,
-                                                                    FStar_SMTEncoding_Term.Fuel_sort) in
-                                                                    FStar_SMTEncoding_Env.add_fuel
-                                                                    uu___25
-                                                                    (FStar_List.append
-                                                                    vars
-                                                                    arg_binders) in
-                                                                    let uu___25
-                                                                    =
+                                                                    FStar_Ident.range_of_lid
+                                                                    d in
                                                                     let uu___26
                                                                     =
                                                                     let uu___27
                                                                     =
+                                                                    let uu___28
+                                                                    =
+                                                                    FStar_SMTEncoding_Term.mk_fv
+                                                                    (fuel_var,
+                                                                    FStar_SMTEncoding_Term.Fuel_sort) in
+                                                                    FStar_SMTEncoding_Env.add_fuel
+                                                                    uu___28
+                                                                    (FStar_List.append
+                                                                    vars
+                                                                    arg_binders) in
+                                                                    let uu___28
+                                                                    =
+                                                                    let uu___29
+                                                                    =
+                                                                    let uu___30
+                                                                    =
                                                                     FStar_SMTEncoding_Util.mk_and_l
                                                                     codomain_prec_l in
                                                                     (ty_pred,
-                                                                    uu___27) in
+                                                                    uu___30) in
                                                                     FStar_SMTEncoding_Util.mkImp
-                                                                    uu___26 in
+                                                                    uu___29 in
                                                                     ([
                                                                     [ty_pred]],
-                                                                    uu___24,
-                                                                    uu___25) in
+                                                                    uu___27,
+                                                                    uu___28) in
                                                                     FStar_SMTEncoding_Term.mkForall
-                                                                    uu___22
-                                                                    uu___23 in
-                                                                    (uu___21,
+                                                                    uu___25
+                                                                    uu___26 in
+                                                                    (uu___24,
                                                                     (FStar_Pervasives_Native.Some
                                                                     "well-founded ordering on codomain"),
                                                                     (Prims.op_Hat
                                                                     "well_founded_ordering_on_comdain_"
                                                                     ddconstrsym)) in
                                                                     FStar_SMTEncoding_Util.mkAssume
-                                                                    uu___20 in
-                                                                    [uu___19] in
-                                                                   (arg_decls,
+                                                                    uu___23 in
+                                                                    [uu___22] in
+                                                                    (uu___21,
+                                                                    cod_decls)) in
+                                                                   (match uu___18
+                                                                    with
+                                                                    | 
+                                                                    (codomain_ordering,
+                                                                    codomain_decls)
+                                                                    ->
+                                                                    ((FStar_List.append
+                                                                    arg_decls
+                                                                    codomain_decls),
                                                                     (FStar_List.append
                                                                     [typing_inversion;
                                                                     subterm_ordering]
-                                                                    codomain_ordering))))
+                                                                    codomain_ordering)))))
                                                      | uu___14 ->
                                                          ((let uu___16 =
                                                              let uu___17 =

--- a/src/ocaml-output/FStar_SMTEncoding_Encode.ml
+++ b/src/ocaml-output/FStar_SMTEncoding_Encode.ml
@@ -5153,32 +5153,32 @@ and (encode_sigelt' :
            FStar_Ident.lid_equals d FStar_Parser_Const.lexcons_lid ->
            ([], env)
        | FStar_Syntax_Syntax.Sig_datacon
-           (d, uu___1, t, uu___2, n_tps, uu___3) ->
+           (d, uu___1, t, uu___2, n_tps, mutuals) ->
            let quals = se.FStar_Syntax_Syntax.sigquals in
            let t1 = norm_before_encoding env t in
-           let uu___4 = FStar_Syntax_Util.arrow_formals t1 in
-           (match uu___4 with
+           let uu___3 = FStar_Syntax_Util.arrow_formals t1 in
+           (match uu___3 with
             | (formals, t_res) ->
                 let arity = FStar_List.length formals in
-                let uu___5 =
+                let uu___4 =
                   FStar_SMTEncoding_Env.new_term_constant_and_tok_from_lid
                     env d arity in
-                (match uu___5 with
+                (match uu___4 with
                  | (ddconstrsym, ddtok, env1) ->
                      let ddtok_tm = FStar_SMTEncoding_Util.mkApp (ddtok, []) in
-                     let uu___6 =
+                     let uu___5 =
                        FStar_SMTEncoding_Env.fresh_fvar
                          env1.FStar_SMTEncoding_Env.current_module_name "f"
                          FStar_SMTEncoding_Term.Fuel_sort in
-                     (match uu___6 with
+                     (match uu___5 with
                       | (fuel_var, fuel_tm) ->
                           let s_fuel_tm =
                             FStar_SMTEncoding_Util.mkApp ("SFuel", [fuel_tm]) in
-                          let uu___7 =
+                          let uu___6 =
                             FStar_SMTEncoding_EncodeTerm.encode_binders
                               (FStar_Pervasives_Native.Some fuel_tm) formals
                               env1 in
-                          (match uu___7 with
+                          (match uu___6 with
                            | (vars, guards, env', binder_decls, names) ->
                                let fields =
                                  FStar_All.pipe_right names
@@ -5186,25 +5186,25 @@ and (encode_sigelt' :
                                       (fun n ->
                                          fun x ->
                                            let projectible = true in
-                                           let uu___8 =
+                                           let uu___7 =
                                              FStar_SMTEncoding_Env.mk_term_projector_name
                                                d x in
-                                           (uu___8,
+                                           (uu___7,
                                              FStar_SMTEncoding_Term.Term_sort,
                                              projectible))) in
                                let datacons =
-                                 let uu___8 =
-                                   let uu___9 =
+                                 let uu___7 =
+                                   let uu___8 =
                                      FStar_SMTEncoding_Env.varops.FStar_SMTEncoding_Env.next_id
                                        () in
                                    (ddconstrsym, fields,
                                      FStar_SMTEncoding_Term.Term_sort,
-                                     uu___9, true) in
-                                 let uu___9 =
-                                   let uu___10 = FStar_Ident.range_of_lid d in
+                                     uu___8, true) in
+                                 let uu___8 =
+                                   let uu___9 = FStar_Ident.range_of_lid d in
                                    FStar_SMTEncoding_Term.constructor_to_decl
-                                     uu___10 in
-                                 FStar_All.pipe_right uu___8 uu___9 in
+                                     uu___9 in
+                                 FStar_All.pipe_right uu___7 uu___8 in
                                let app =
                                  FStar_SMTEncoding_EncodeTerm.mk_Apply
                                    ddtok_tm vars in
@@ -5216,15 +5216,15 @@ and (encode_sigelt' :
                                let dapp =
                                  FStar_SMTEncoding_Util.mkApp
                                    (ddconstrsym, xvars) in
-                               let uu___8 =
+                               let uu___7 =
                                  FStar_SMTEncoding_EncodeTerm.encode_term_pred
                                    FStar_Pervasives_Native.None t1 env1
                                    ddtok_tm in
-                               (match uu___8 with
+                               (match uu___7 with
                                 | (tok_typing, decls3) ->
                                     let tok_typing1 =
                                       match fields with
-                                      | uu___9::uu___10 ->
+                                      | uu___8::uu___9 ->
                                           let ff =
                                             FStar_SMTEncoding_Term.mk_fv
                                               ("ty",
@@ -5235,33 +5235,33 @@ and (encode_sigelt' :
                                             FStar_SMTEncoding_EncodeTerm.mk_Apply
                                               ddtok_tm [ff] in
                                           let vtok_app_r =
-                                            let uu___11 =
-                                              let uu___12 =
+                                            let uu___10 =
+                                              let uu___11 =
                                                 FStar_SMTEncoding_Term.mk_fv
                                                   (ddtok,
                                                     FStar_SMTEncoding_Term.Term_sort) in
-                                              [uu___12] in
+                                              [uu___11] in
                                             FStar_SMTEncoding_EncodeTerm.mk_Apply
-                                              f uu___11 in
-                                          let uu___11 =
+                                              f uu___10 in
+                                          let uu___10 =
                                             FStar_Ident.range_of_lid d in
-                                          let uu___12 =
-                                            let uu___13 =
+                                          let uu___11 =
+                                            let uu___12 =
                                               FStar_SMTEncoding_Term.mk_NoHoist
                                                 f tok_typing in
                                             ([[vtok_app_l]; [vtok_app_r]],
-                                              [ff], uu___13) in
+                                              [ff], uu___12) in
                                           FStar_SMTEncoding_Term.mkForall
-                                            uu___11 uu___12
-                                      | uu___9 -> tok_typing in
-                                    let uu___9 =
+                                            uu___10 uu___11
+                                      | uu___8 -> tok_typing in
+                                    let uu___8 =
                                       FStar_SMTEncoding_EncodeTerm.encode_binders
                                         (FStar_Pervasives_Native.Some fuel_tm)
                                         formals env1 in
-                                    (match uu___9 with
+                                    (match uu___8 with
                                      | (vars', guards', env'', decls_formals,
-                                        uu___10) ->
-                                         let uu___11 =
+                                        uu___9) ->
+                                         let uu___10 =
                                            let xvars1 =
                                              FStar_List.map
                                                FStar_SMTEncoding_Util.mkFreeV
@@ -5272,7 +5272,7 @@ and (encode_sigelt' :
                                            FStar_SMTEncoding_EncodeTerm.encode_term_pred
                                              (FStar_Pervasives_Native.Some
                                                 fuel_tm) t_res env'' dapp1 in
-                                         (match uu___11 with
+                                         (match uu___10 with
                                           | (ty_pred', decls_pred) ->
                                               let guard' =
                                                 FStar_SMTEncoding_Util.mk_and_l
@@ -5280,28 +5280,28 @@ and (encode_sigelt' :
                                               let proxy_fresh =
                                                 match formals with
                                                 | [] -> []
-                                                | uu___12 ->
-                                                    let uu___13 =
-                                                      let uu___14 =
+                                                | uu___11 ->
+                                                    let uu___12 =
+                                                      let uu___13 =
                                                         FStar_SMTEncoding_Env.varops.FStar_SMTEncoding_Env.next_id
                                                           () in
                                                       FStar_SMTEncoding_Term.fresh_token
                                                         (ddtok,
                                                           FStar_SMTEncoding_Term.Term_sort)
-                                                        uu___14 in
-                                                    [uu___13] in
-                                              let encode_elim uu___12 =
-                                                let uu___13 =
+                                                        uu___13 in
+                                                    [uu___12] in
+                                              let encode_elim uu___11 =
+                                                let uu___12 =
                                                   FStar_Syntax_Util.head_and_args
                                                     t_res in
-                                                match uu___13 with
+                                                match uu___12 with
                                                 | (head, args) ->
-                                                    let uu___14 =
-                                                      let uu___15 =
+                                                    let uu___13 =
+                                                      let uu___14 =
                                                         FStar_Syntax_Subst.compress
                                                           head in
-                                                      uu___15.FStar_Syntax_Syntax.n in
-                                                    (match uu___14 with
+                                                      uu___14.FStar_Syntax_Syntax.n in
+                                                    (match uu___13 with
                                                      | FStar_Syntax_Syntax.Tm_uinst
                                                          ({
                                                             FStar_Syntax_Syntax.n
@@ -5309,20 +5309,20 @@ and (encode_sigelt' :
                                                               FStar_Syntax_Syntax.Tm_fvar
                                                               fv;
                                                             FStar_Syntax_Syntax.pos
-                                                              = uu___15;
+                                                              = uu___14;
                                                             FStar_Syntax_Syntax.vars
-                                                              = uu___16;_},
-                                                          uu___17)
+                                                              = uu___15;_},
+                                                          uu___16)
                                                          ->
                                                          let encoded_head_fvb
                                                            =
                                                            FStar_SMTEncoding_Env.lookup_free_var_name
                                                              env'
                                                              fv.FStar_Syntax_Syntax.fv_name in
-                                                         let uu___18 =
+                                                         let uu___17 =
                                                            FStar_SMTEncoding_EncodeTerm.encode_args
                                                              args env' in
-                                                         (match uu___18 with
+                                                         (match uu___17 with
                                                           | (encoded_args,
                                                              arg_decls) ->
                                                               let guards_for_parameter
@@ -5335,23 +5335,23 @@ and (encode_sigelt' :
                                                                   | FStar_SMTEncoding_Term.FreeV
                                                                     fv2 ->
                                                                     fv2
-                                                                  | uu___19
+                                                                  | uu___18
                                                                     ->
+                                                                    let uu___19
+                                                                    =
                                                                     let uu___20
                                                                     =
                                                                     let uu___21
-                                                                    =
-                                                                    let uu___22
                                                                     =
                                                                     FStar_Syntax_Print.term_to_string
                                                                     orig_arg in
                                                                     FStar_Util.format1
                                                                     "Inductive type parameter %s must be a variable ; You may want to change it to an index."
-                                                                    uu___22 in
+                                                                    uu___21 in
                                                                     (FStar_Errors.Fatal_NonVariableInductiveTypeParameter,
-                                                                    uu___21) in
+                                                                    uu___20) in
                                                                     FStar_Errors.raise_error
-                                                                    uu___20
+                                                                    uu___19
                                                                     orig_arg.FStar_Syntax_Syntax.pos in
                                                                 let guards1 =
                                                                   FStar_All.pipe_right
@@ -5359,41 +5359,41 @@ and (encode_sigelt' :
                                                                     (
                                                                     FStar_List.collect
                                                                     (fun g ->
-                                                                    let uu___19
+                                                                    let uu___18
                                                                     =
-                                                                    let uu___20
+                                                                    let uu___19
                                                                     =
                                                                     FStar_SMTEncoding_Term.free_variables
                                                                     g in
                                                                     FStar_List.contains
                                                                     fv1
-                                                                    uu___20 in
+                                                                    uu___19 in
                                                                     if
-                                                                    uu___19
+                                                                    uu___18
                                                                     then
-                                                                    let uu___20
+                                                                    let uu___19
                                                                     =
                                                                     FStar_SMTEncoding_Term.subst
                                                                     g fv1 xv in
-                                                                    [uu___20]
+                                                                    [uu___19]
                                                                     else [])) in
                                                                 FStar_SMTEncoding_Util.mk_and_l
                                                                   guards1 in
-                                                              let uu___19 =
-                                                                let uu___20 =
+                                                              let uu___18 =
+                                                                let uu___19 =
                                                                   FStar_List.zip
                                                                     args
                                                                     encoded_args in
                                                                 FStar_List.fold_left
                                                                   (fun
-                                                                    uu___21
+                                                                    uu___20
                                                                     ->
                                                                     fun
-                                                                    uu___22
+                                                                    uu___21
                                                                     ->
                                                                     match 
-                                                                    (uu___21,
-                                                                    uu___22)
+                                                                    (uu___20,
+                                                                    uu___21)
                                                                     with
                                                                     | 
                                                                     ((env2,
@@ -5402,20 +5402,20 @@ and (encode_sigelt' :
                                                                     i),
                                                                     (orig_arg,
                                                                     arg)) ->
-                                                                    let uu___23
+                                                                    let uu___22
                                                                     =
-                                                                    let uu___24
+                                                                    let uu___23
                                                                     =
                                                                     FStar_Syntax_Syntax.new_bv
                                                                     FStar_Pervasives_Native.None
                                                                     FStar_Syntax_Syntax.tun in
                                                                     FStar_SMTEncoding_Env.gen_term_var
                                                                     env2
-                                                                    uu___24 in
-                                                                    (match uu___23
+                                                                    uu___23 in
+                                                                    (match uu___22
                                                                     with
                                                                     | 
-                                                                    (uu___24,
+                                                                    (uu___23,
                                                                     xv, env3)
                                                                     ->
                                                                     let eqns
@@ -5423,21 +5423,21 @@ and (encode_sigelt' :
                                                                     if
                                                                     i < n_tps
                                                                     then
-                                                                    let uu___25
+                                                                    let uu___24
                                                                     =
                                                                     guards_for_parameter
                                                                     (FStar_Pervasives_Native.fst
                                                                     orig_arg)
                                                                     arg xv in
-                                                                    uu___25
+                                                                    uu___24
                                                                     ::
                                                                     eqns_or_guards
                                                                     else
-                                                                    (let uu___26
+                                                                    (let uu___25
                                                                     =
                                                                     FStar_SMTEncoding_Util.mkEq
                                                                     (arg, xv) in
-                                                                    uu___26
+                                                                    uu___25
                                                                     ::
                                                                     eqns_or_guards) in
                                                                     (env3,
@@ -5449,13 +5449,13 @@ and (encode_sigelt' :
                                                                   (env', [],
                                                                     [],
                                                                     Prims.int_zero)
-                                                                  uu___20 in
-                                                              (match uu___19
+                                                                  uu___19 in
+                                                              (match uu___18
                                                                with
-                                                               | (uu___20,
+                                                               | (uu___19,
                                                                   arg_vars,
                                                                   elim_eqns_or_guards,
-                                                                  uu___21) ->
+                                                                  uu___20) ->
                                                                    let arg_vars1
                                                                     =
                                                                     FStar_List.rev
@@ -5488,79 +5488,79 @@ and (encode_sigelt' :
                                                                     arg_vars1 in
                                                                    let typing_inversion
                                                                     =
+                                                                    let uu___21
+                                                                    =
                                                                     let uu___22
                                                                     =
                                                                     let uu___23
                                                                     =
-                                                                    let uu___24
-                                                                    =
                                                                     FStar_Ident.range_of_lid
                                                                     d in
+                                                                    let uu___24
+                                                                    =
                                                                     let uu___25
                                                                     =
                                                                     let uu___26
-                                                                    =
-                                                                    let uu___27
                                                                     =
                                                                     FStar_SMTEncoding_Term.mk_fv
                                                                     (fuel_var,
                                                                     FStar_SMTEncoding_Term.Fuel_sort) in
                                                                     FStar_SMTEncoding_Env.add_fuel
-                                                                    uu___27
+                                                                    uu___26
                                                                     (FStar_List.append
                                                                     vars
                                                                     arg_binders) in
+                                                                    let uu___26
+                                                                    =
                                                                     let uu___27
                                                                     =
                                                                     let uu___28
-                                                                    =
-                                                                    let uu___29
                                                                     =
                                                                     FStar_SMTEncoding_Util.mk_and_l
                                                                     (FStar_List.append
                                                                     elim_eqns_or_guards
                                                                     guards) in
                                                                     (ty_pred,
-                                                                    uu___29) in
+                                                                    uu___28) in
                                                                     FStar_SMTEncoding_Util.mkImp
-                                                                    uu___28 in
+                                                                    uu___27 in
                                                                     ([
                                                                     [ty_pred]],
-                                                                    uu___26,
-                                                                    uu___27) in
+                                                                    uu___25,
+                                                                    uu___26) in
                                                                     FStar_SMTEncoding_Term.mkForall
-                                                                    uu___24
-                                                                    uu___25 in
-                                                                    (uu___23,
+                                                                    uu___23
+                                                                    uu___24 in
+                                                                    (uu___22,
                                                                     (FStar_Pervasives_Native.Some
                                                                     "data constructor typing elim"),
                                                                     (Prims.op_Hat
                                                                     "data_elim_"
                                                                     ddconstrsym)) in
                                                                     FStar_SMTEncoding_Util.mkAssume
-                                                                    uu___22 in
-                                                                   let subterm_ordering
+                                                                    uu___21 in
+                                                                   let lex_t
                                                                     =
-                                                                    let lex_t
+                                                                    let uu___21
                                                                     =
                                                                     let uu___22
                                                                     =
                                                                     let uu___23
                                                                     =
-                                                                    let uu___24
-                                                                    =
                                                                     FStar_Ident.string_of_lid
                                                                     FStar_Parser_Const.lex_t_lid in
-                                                                    (uu___24,
+                                                                    (uu___23,
                                                                     FStar_SMTEncoding_Term.Term_sort) in
                                                                     FStar_SMTEncoding_Term.mk_fv
-                                                                    uu___23 in
+                                                                    uu___22 in
                                                                     FStar_All.pipe_left
                                                                     FStar_SMTEncoding_Util.mkFreeV
-                                                                    uu___22 in
+                                                                    uu___21 in
+                                                                   let subterm_ordering
+                                                                    =
                                                                     let prec
                                                                     =
-                                                                    let uu___22
+                                                                    let uu___21
                                                                     =
                                                                     FStar_All.pipe_right
                                                                     vars
@@ -5571,73 +5571,317 @@ and (encode_sigelt' :
                                                                     i < n_tps
                                                                     then []
                                                                     else
-                                                                    (let uu___24
+                                                                    (let uu___23
                                                                     =
-                                                                    let uu___25
+                                                                    let uu___24
                                                                     =
                                                                     FStar_SMTEncoding_Util.mkFreeV
                                                                     v in
                                                                     FStar_SMTEncoding_Util.mk_Precedes
                                                                     lex_t
                                                                     lex_t
-                                                                    uu___25
+                                                                    uu___24
                                                                     dapp1 in
-                                                                    [uu___24]))) in
+                                                                    [uu___23]))) in
                                                                     FStar_All.pipe_right
-                                                                    uu___22
+                                                                    uu___21
                                                                     FStar_List.flatten in
+                                                                    let uu___21
+                                                                    =
                                                                     let uu___22
                                                                     =
                                                                     let uu___23
                                                                     =
-                                                                    let uu___24
-                                                                    =
                                                                     FStar_Ident.range_of_lid
                                                                     d in
+                                                                    let uu___24
+                                                                    =
                                                                     let uu___25
                                                                     =
                                                                     let uu___26
-                                                                    =
-                                                                    let uu___27
                                                                     =
                                                                     FStar_SMTEncoding_Term.mk_fv
                                                                     (fuel_var,
                                                                     FStar_SMTEncoding_Term.Fuel_sort) in
                                                                     FStar_SMTEncoding_Env.add_fuel
-                                                                    uu___27
+                                                                    uu___26
                                                                     (FStar_List.append
                                                                     vars
                                                                     arg_binders) in
+                                                                    let uu___26
+                                                                    =
                                                                     let uu___27
                                                                     =
                                                                     let uu___28
                                                                     =
-                                                                    let uu___29
-                                                                    =
                                                                     FStar_SMTEncoding_Util.mk_and_l
                                                                     prec in
                                                                     (ty_pred,
-                                                                    uu___29) in
+                                                                    uu___28) in
                                                                     FStar_SMTEncoding_Util.mkImp
-                                                                    uu___28 in
+                                                                    uu___27 in
                                                                     ([
                                                                     [ty_pred]],
-                                                                    uu___26,
-                                                                    uu___27) in
+                                                                    uu___25,
+                                                                    uu___26) in
                                                                     FStar_SMTEncoding_Term.mkForall
-                                                                    uu___24
-                                                                    uu___25 in
-                                                                    (uu___23,
+                                                                    uu___23
+                                                                    uu___24 in
+                                                                    (uu___22,
                                                                     (FStar_Pervasives_Native.Some
                                                                     "subterm ordering"),
                                                                     (Prims.op_Hat
                                                                     "subterm_ordering_"
                                                                     ddconstrsym)) in
                                                                     FStar_SMTEncoding_Util.mkAssume
+                                                                    uu___21 in
+                                                                   let codomain_ordering
+                                                                    =
+                                                                    let tot_or_gtot_inductive_codomain
+                                                                    c =
+                                                                    let is_inductive
+                                                                    l =
+                                                                    let uu___21
+                                                                    =
+                                                                    FStar_TypeChecker_Env.lookup_sigelt
+                                                                    env1.FStar_SMTEncoding_Env.tcenv
+                                                                    l in
+                                                                    match uu___21
+                                                                    with
+                                                                    | 
+                                                                    FStar_Pervasives_Native.Some
+                                                                    {
+                                                                    FStar_Syntax_Syntax.sigel
+                                                                    =
+                                                                    FStar_Syntax_Syntax.Sig_inductive_typ
+                                                                    uu___22;
+                                                                    FStar_Syntax_Syntax.sigrng
+                                                                    = uu___23;
+                                                                    FStar_Syntax_Syntax.sigquals
+                                                                    = uu___24;
+                                                                    FStar_Syntax_Syntax.sigmeta
+                                                                    = uu___25;
+                                                                    FStar_Syntax_Syntax.sigattrs
+                                                                    = uu___26;
+                                                                    FStar_Syntax_Syntax.sigopts
+                                                                    = uu___27;_}
+                                                                    -> true
+                                                                    | 
+                                                                    uu___22
+                                                                    -> false in
+                                                                    let res =
+                                                                    let uu___21
+                                                                    =
+                                                                    let uu___22
+                                                                    =
+                                                                    FStar_Syntax_Util.is_tot_or_gtot_comp
+                                                                    c in
+                                                                    Prims.op_Negation
                                                                     uu___22 in
+                                                                    if
+                                                                    uu___21
+                                                                    then
+                                                                    false
+                                                                    else
+                                                                    (let uu___23
+                                                                    =
+                                                                    FStar_Syntax_Util.head_and_args
+                                                                    (FStar_Syntax_Util.comp_result
+                                                                    c) in
+                                                                    match uu___23
+                                                                    with
+                                                                    | 
+                                                                    (head1,
+                                                                    uu___24)
+                                                                    ->
+                                                                    FStar_Util.for_some
+                                                                    (fun
+                                                                    mutual ->
+                                                                    (is_inductive
+                                                                    mutual)
+                                                                    &&
+                                                                    (FStar_Syntax_Util.is_fvar
+                                                                    mutual
+                                                                    head1))
+                                                                    mutuals) in
+                                                                    res in
+                                                                    let codomain_prec_l
+                                                                    =
+                                                                    let uu___21
+                                                                    =
+                                                                    FStar_List.zip
+                                                                    formals
+                                                                    vars in
+                                                                    FStar_List.collect
+                                                                    (fun
+                                                                    uu___22
+                                                                    ->
+                                                                    match uu___22
+                                                                    with
+                                                                    | 
+                                                                    (formal,
+                                                                    var) ->
+                                                                    let uu___23
+                                                                    =
+                                                                    FStar_Syntax_Util.arrow_formals_comp
+                                                                    (formal.FStar_Syntax_Syntax.binder_bv).FStar_Syntax_Syntax.sort in
+                                                                    (match uu___23
+                                                                    with
+                                                                    | 
+                                                                    (bs, c)
+                                                                    ->
+                                                                    (match bs
+                                                                    with
+                                                                    | 
+                                                                    [] -> []
+                                                                    | 
+                                                                    uu___24
+                                                                    when
+                                                                    let uu___25
+                                                                    =
+                                                                    tot_or_gtot_inductive_codomain
+                                                                    c in
+                                                                    Prims.op_Negation
+                                                                    uu___25
+                                                                    -> []
+                                                                    | 
+                                                                    uu___24
+                                                                    ->
+                                                                    let uu___25
+                                                                    =
+                                                                    FStar_SMTEncoding_EncodeTerm.encode_binders
+                                                                    FStar_Pervasives_Native.None
+                                                                    bs env'' in
+                                                                    (match uu___25
+                                                                    with
+                                                                    | 
+                                                                    (bs',
+                                                                    guards'1,
+                                                                    env'1,
+                                                                    bs_decls,
+                                                                    uu___26)
+                                                                    ->
+                                                                    let fun_app
+                                                                    =
+                                                                    let uu___27
+                                                                    =
+                                                                    FStar_SMTEncoding_Util.mkFreeV
+                                                                    var in
+                                                                    FStar_SMTEncoding_EncodeTerm.mk_Apply
+                                                                    uu___27
+                                                                    bs' in
+                                                                    let uu___27
+                                                                    =
+                                                                    let uu___28
+                                                                    =
+                                                                    FStar_Ident.range_of_lid
+                                                                    d in
+                                                                    let uu___29
+                                                                    =
+                                                                    let uu___30
+                                                                    =
+                                                                    let uu___31
+                                                                    =
+                                                                    let uu___32
+                                                                    =
+                                                                    FStar_SMTEncoding_Util.mk_Precedes
+                                                                    lex_t
+                                                                    lex_t
+                                                                    fun_app
+                                                                    dapp1 in
+                                                                    [uu___32] in
+                                                                    [uu___31] in
+                                                                    let uu___31
+                                                                    =
+                                                                    let uu___32
+                                                                    =
+                                                                    let uu___33
+                                                                    =
+                                                                    FStar_SMTEncoding_Util.mk_and_l
+                                                                    guards'1 in
+                                                                    let uu___34
+                                                                    =
+                                                                    FStar_SMTEncoding_Util.mk_Precedes
+                                                                    lex_t
+                                                                    lex_t
+                                                                    fun_app
+                                                                    dapp1 in
+                                                                    (uu___33,
+                                                                    uu___34) in
+                                                                    FStar_SMTEncoding_Util.mkImp
+                                                                    uu___32 in
+                                                                    (uu___30,
+                                                                    bs',
+                                                                    uu___31) in
+                                                                    FStar_SMTEncoding_Term.mkForall
+                                                                    uu___28
+                                                                    uu___29 in
+                                                                    [uu___27]))))
+                                                                    uu___21 in
+                                                                    match codomain_prec_l
+                                                                    with
+                                                                    | 
+                                                                    [] -> []
+                                                                    | 
+                                                                    uu___21
+                                                                    ->
+                                                                    let uu___22
+                                                                    =
+                                                                    let uu___23
+                                                                    =
+                                                                    let uu___24
+                                                                    =
+                                                                    let uu___25
+                                                                    =
+                                                                    FStar_Ident.range_of_lid
+                                                                    d in
+                                                                    let uu___26
+                                                                    =
+                                                                    let uu___27
+                                                                    =
+                                                                    let uu___28
+                                                                    =
+                                                                    FStar_SMTEncoding_Term.mk_fv
+                                                                    (fuel_var,
+                                                                    FStar_SMTEncoding_Term.Fuel_sort) in
+                                                                    FStar_SMTEncoding_Env.add_fuel
+                                                                    uu___28
+                                                                    (FStar_List.append
+                                                                    vars
+                                                                    arg_binders) in
+                                                                    let uu___28
+                                                                    =
+                                                                    let uu___29
+                                                                    =
+                                                                    let uu___30
+                                                                    =
+                                                                    FStar_SMTEncoding_Util.mk_and_l
+                                                                    codomain_prec_l in
+                                                                    (ty_pred,
+                                                                    uu___30) in
+                                                                    FStar_SMTEncoding_Util.mkImp
+                                                                    uu___29 in
+                                                                    ([
+                                                                    [ty_pred]],
+                                                                    uu___27,
+                                                                    uu___28) in
+                                                                    FStar_SMTEncoding_Term.mkForall
+                                                                    uu___25
+                                                                    uu___26 in
+                                                                    (uu___24,
+                                                                    (FStar_Pervasives_Native.Some
+                                                                    "well-founded ordering on codomain"),
+                                                                    (Prims.op_Hat
+                                                                    "well_founded_ordering_on_comdain_"
+                                                                    ddconstrsym)) in
+                                                                    FStar_SMTEncoding_Util.mkAssume
+                                                                    uu___23 in
+                                                                    [uu___22] in
                                                                    (arg_decls,
+                                                                    (FStar_List.append
                                                                     [typing_inversion;
-                                                                    subterm_ordering])))
+                                                                    subterm_ordering]
+                                                                    codomain_ordering))))
                                                      | FStar_Syntax_Syntax.Tm_fvar
                                                          fv ->
                                                          let encoded_head_fvb
@@ -5645,10 +5889,10 @@ and (encode_sigelt' :
                                                            FStar_SMTEncoding_Env.lookup_free_var_name
                                                              env'
                                                              fv.FStar_Syntax_Syntax.fv_name in
-                                                         let uu___15 =
+                                                         let uu___14 =
                                                            FStar_SMTEncoding_EncodeTerm.encode_args
                                                              args env' in
-                                                         (match uu___15 with
+                                                         (match uu___14 with
                                                           | (encoded_args,
                                                              arg_decls) ->
                                                               let guards_for_parameter
@@ -5661,23 +5905,23 @@ and (encode_sigelt' :
                                                                   | FStar_SMTEncoding_Term.FreeV
                                                                     fv2 ->
                                                                     fv2
-                                                                  | uu___16
+                                                                  | uu___15
                                                                     ->
+                                                                    let uu___16
+                                                                    =
                                                                     let uu___17
                                                                     =
                                                                     let uu___18
-                                                                    =
-                                                                    let uu___19
                                                                     =
                                                                     FStar_Syntax_Print.term_to_string
                                                                     orig_arg in
                                                                     FStar_Util.format1
                                                                     "Inductive type parameter %s must be a variable ; You may want to change it to an index."
-                                                                    uu___19 in
+                                                                    uu___18 in
                                                                     (FStar_Errors.Fatal_NonVariableInductiveTypeParameter,
-                                                                    uu___18) in
+                                                                    uu___17) in
                                                                     FStar_Errors.raise_error
-                                                                    uu___17
+                                                                    uu___16
                                                                     orig_arg.FStar_Syntax_Syntax.pos in
                                                                 let guards1 =
                                                                   FStar_All.pipe_right
@@ -5685,41 +5929,41 @@ and (encode_sigelt' :
                                                                     (
                                                                     FStar_List.collect
                                                                     (fun g ->
-                                                                    let uu___16
+                                                                    let uu___15
                                                                     =
-                                                                    let uu___17
+                                                                    let uu___16
                                                                     =
                                                                     FStar_SMTEncoding_Term.free_variables
                                                                     g in
                                                                     FStar_List.contains
                                                                     fv1
-                                                                    uu___17 in
+                                                                    uu___16 in
                                                                     if
-                                                                    uu___16
+                                                                    uu___15
                                                                     then
-                                                                    let uu___17
+                                                                    let uu___16
                                                                     =
                                                                     FStar_SMTEncoding_Term.subst
                                                                     g fv1 xv in
-                                                                    [uu___17]
+                                                                    [uu___16]
                                                                     else [])) in
                                                                 FStar_SMTEncoding_Util.mk_and_l
                                                                   guards1 in
-                                                              let uu___16 =
-                                                                let uu___17 =
+                                                              let uu___15 =
+                                                                let uu___16 =
                                                                   FStar_List.zip
                                                                     args
                                                                     encoded_args in
                                                                 FStar_List.fold_left
                                                                   (fun
-                                                                    uu___18
+                                                                    uu___17
                                                                     ->
                                                                     fun
-                                                                    uu___19
+                                                                    uu___18
                                                                     ->
                                                                     match 
-                                                                    (uu___18,
-                                                                    uu___19)
+                                                                    (uu___17,
+                                                                    uu___18)
                                                                     with
                                                                     | 
                                                                     ((env2,
@@ -5728,20 +5972,20 @@ and (encode_sigelt' :
                                                                     i),
                                                                     (orig_arg,
                                                                     arg)) ->
-                                                                    let uu___20
+                                                                    let uu___19
                                                                     =
-                                                                    let uu___21
+                                                                    let uu___20
                                                                     =
                                                                     FStar_Syntax_Syntax.new_bv
                                                                     FStar_Pervasives_Native.None
                                                                     FStar_Syntax_Syntax.tun in
                                                                     FStar_SMTEncoding_Env.gen_term_var
                                                                     env2
-                                                                    uu___21 in
-                                                                    (match uu___20
+                                                                    uu___20 in
+                                                                    (match uu___19
                                                                     with
                                                                     | 
-                                                                    (uu___21,
+                                                                    (uu___20,
                                                                     xv, env3)
                                                                     ->
                                                                     let eqns
@@ -5749,21 +5993,21 @@ and (encode_sigelt' :
                                                                     if
                                                                     i < n_tps
                                                                     then
-                                                                    let uu___22
+                                                                    let uu___21
                                                                     =
                                                                     guards_for_parameter
                                                                     (FStar_Pervasives_Native.fst
                                                                     orig_arg)
                                                                     arg xv in
-                                                                    uu___22
+                                                                    uu___21
                                                                     ::
                                                                     eqns_or_guards
                                                                     else
-                                                                    (let uu___23
+                                                                    (let uu___22
                                                                     =
                                                                     FStar_SMTEncoding_Util.mkEq
                                                                     (arg, xv) in
-                                                                    uu___23
+                                                                    uu___22
                                                                     ::
                                                                     eqns_or_guards) in
                                                                     (env3,
@@ -5775,13 +6019,13 @@ and (encode_sigelt' :
                                                                   (env', [],
                                                                     [],
                                                                     Prims.int_zero)
-                                                                  uu___17 in
-                                                              (match uu___16
+                                                                  uu___16 in
+                                                              (match uu___15
                                                                with
-                                                               | (uu___17,
+                                                               | (uu___16,
                                                                   arg_vars,
                                                                   elim_eqns_or_guards,
-                                                                  uu___18) ->
+                                                                  uu___17) ->
                                                                    let arg_vars1
                                                                     =
                                                                     FStar_List.rev
@@ -5814,79 +6058,79 @@ and (encode_sigelt' :
                                                                     arg_vars1 in
                                                                    let typing_inversion
                                                                     =
+                                                                    let uu___18
+                                                                    =
                                                                     let uu___19
                                                                     =
                                                                     let uu___20
                                                                     =
-                                                                    let uu___21
-                                                                    =
                                                                     FStar_Ident.range_of_lid
                                                                     d in
+                                                                    let uu___21
+                                                                    =
                                                                     let uu___22
                                                                     =
                                                                     let uu___23
-                                                                    =
-                                                                    let uu___24
                                                                     =
                                                                     FStar_SMTEncoding_Term.mk_fv
                                                                     (fuel_var,
                                                                     FStar_SMTEncoding_Term.Fuel_sort) in
                                                                     FStar_SMTEncoding_Env.add_fuel
-                                                                    uu___24
+                                                                    uu___23
                                                                     (FStar_List.append
                                                                     vars
                                                                     arg_binders) in
+                                                                    let uu___23
+                                                                    =
                                                                     let uu___24
                                                                     =
                                                                     let uu___25
-                                                                    =
-                                                                    let uu___26
                                                                     =
                                                                     FStar_SMTEncoding_Util.mk_and_l
                                                                     (FStar_List.append
                                                                     elim_eqns_or_guards
                                                                     guards) in
                                                                     (ty_pred,
-                                                                    uu___26) in
+                                                                    uu___25) in
                                                                     FStar_SMTEncoding_Util.mkImp
-                                                                    uu___25 in
+                                                                    uu___24 in
                                                                     ([
                                                                     [ty_pred]],
-                                                                    uu___23,
-                                                                    uu___24) in
+                                                                    uu___22,
+                                                                    uu___23) in
                                                                     FStar_SMTEncoding_Term.mkForall
-                                                                    uu___21
-                                                                    uu___22 in
-                                                                    (uu___20,
+                                                                    uu___20
+                                                                    uu___21 in
+                                                                    (uu___19,
                                                                     (FStar_Pervasives_Native.Some
                                                                     "data constructor typing elim"),
                                                                     (Prims.op_Hat
                                                                     "data_elim_"
                                                                     ddconstrsym)) in
                                                                     FStar_SMTEncoding_Util.mkAssume
-                                                                    uu___19 in
-                                                                   let subterm_ordering
+                                                                    uu___18 in
+                                                                   let lex_t
                                                                     =
-                                                                    let lex_t
+                                                                    let uu___18
                                                                     =
                                                                     let uu___19
                                                                     =
                                                                     let uu___20
                                                                     =
-                                                                    let uu___21
-                                                                    =
                                                                     FStar_Ident.string_of_lid
                                                                     FStar_Parser_Const.lex_t_lid in
-                                                                    (uu___21,
+                                                                    (uu___20,
                                                                     FStar_SMTEncoding_Term.Term_sort) in
                                                                     FStar_SMTEncoding_Term.mk_fv
-                                                                    uu___20 in
+                                                                    uu___19 in
                                                                     FStar_All.pipe_left
                                                                     FStar_SMTEncoding_Util.mkFreeV
-                                                                    uu___19 in
+                                                                    uu___18 in
+                                                                   let subterm_ordering
+                                                                    =
                                                                     let prec
                                                                     =
-                                                                    let uu___19
+                                                                    let uu___18
                                                                     =
                                                                     FStar_All.pipe_right
                                                                     vars
@@ -5897,99 +6141,376 @@ and (encode_sigelt' :
                                                                     i < n_tps
                                                                     then []
                                                                     else
-                                                                    (let uu___21
+                                                                    (let uu___20
                                                                     =
-                                                                    let uu___22
+                                                                    let uu___21
                                                                     =
                                                                     FStar_SMTEncoding_Util.mkFreeV
                                                                     v in
                                                                     FStar_SMTEncoding_Util.mk_Precedes
                                                                     lex_t
                                                                     lex_t
-                                                                    uu___22
+                                                                    uu___21
                                                                     dapp1 in
-                                                                    [uu___21]))) in
+                                                                    [uu___20]))) in
                                                                     FStar_All.pipe_right
-                                                                    uu___19
+                                                                    uu___18
                                                                     FStar_List.flatten in
+                                                                    let uu___18
+                                                                    =
                                                                     let uu___19
                                                                     =
                                                                     let uu___20
                                                                     =
-                                                                    let uu___21
-                                                                    =
                                                                     FStar_Ident.range_of_lid
                                                                     d in
+                                                                    let uu___21
+                                                                    =
                                                                     let uu___22
                                                                     =
                                                                     let uu___23
-                                                                    =
-                                                                    let uu___24
                                                                     =
                                                                     FStar_SMTEncoding_Term.mk_fv
                                                                     (fuel_var,
                                                                     FStar_SMTEncoding_Term.Fuel_sort) in
                                                                     FStar_SMTEncoding_Env.add_fuel
-                                                                    uu___24
+                                                                    uu___23
                                                                     (FStar_List.append
                                                                     vars
                                                                     arg_binders) in
+                                                                    let uu___23
+                                                                    =
                                                                     let uu___24
                                                                     =
                                                                     let uu___25
                                                                     =
-                                                                    let uu___26
-                                                                    =
                                                                     FStar_SMTEncoding_Util.mk_and_l
                                                                     prec in
                                                                     (ty_pred,
-                                                                    uu___26) in
+                                                                    uu___25) in
                                                                     FStar_SMTEncoding_Util.mkImp
-                                                                    uu___25 in
+                                                                    uu___24 in
                                                                     ([
                                                                     [ty_pred]],
-                                                                    uu___23,
-                                                                    uu___24) in
+                                                                    uu___22,
+                                                                    uu___23) in
                                                                     FStar_SMTEncoding_Term.mkForall
-                                                                    uu___21
-                                                                    uu___22 in
-                                                                    (uu___20,
+                                                                    uu___20
+                                                                    uu___21 in
+                                                                    (uu___19,
                                                                     (FStar_Pervasives_Native.Some
                                                                     "subterm ordering"),
                                                                     (Prims.op_Hat
                                                                     "subterm_ordering_"
                                                                     ddconstrsym)) in
                                                                     FStar_SMTEncoding_Util.mkAssume
+                                                                    uu___18 in
+                                                                   let codomain_ordering
+                                                                    =
+                                                                    let tot_or_gtot_inductive_codomain
+                                                                    c =
+                                                                    let is_inductive
+                                                                    l =
+                                                                    let uu___18
+                                                                    =
+                                                                    FStar_TypeChecker_Env.lookup_sigelt
+                                                                    env1.FStar_SMTEncoding_Env.tcenv
+                                                                    l in
+                                                                    match uu___18
+                                                                    with
+                                                                    | 
+                                                                    FStar_Pervasives_Native.Some
+                                                                    {
+                                                                    FStar_Syntax_Syntax.sigel
+                                                                    =
+                                                                    FStar_Syntax_Syntax.Sig_inductive_typ
+                                                                    uu___19;
+                                                                    FStar_Syntax_Syntax.sigrng
+                                                                    = uu___20;
+                                                                    FStar_Syntax_Syntax.sigquals
+                                                                    = uu___21;
+                                                                    FStar_Syntax_Syntax.sigmeta
+                                                                    = uu___22;
+                                                                    FStar_Syntax_Syntax.sigattrs
+                                                                    = uu___23;
+                                                                    FStar_Syntax_Syntax.sigopts
+                                                                    = uu___24;_}
+                                                                    -> true
+                                                                    | 
+                                                                    uu___19
+                                                                    -> false in
+                                                                    let res =
+                                                                    let uu___18
+                                                                    =
+                                                                    let uu___19
+                                                                    =
+                                                                    FStar_Syntax_Util.is_tot_or_gtot_comp
+                                                                    c in
+                                                                    Prims.op_Negation
                                                                     uu___19 in
+                                                                    if
+                                                                    uu___18
+                                                                    then
+                                                                    false
+                                                                    else
+                                                                    (let uu___20
+                                                                    =
+                                                                    FStar_Syntax_Util.head_and_args
+                                                                    (FStar_Syntax_Util.comp_result
+                                                                    c) in
+                                                                    match uu___20
+                                                                    with
+                                                                    | 
+                                                                    (head1,
+                                                                    uu___21)
+                                                                    ->
+                                                                    FStar_Util.for_some
+                                                                    (fun
+                                                                    mutual ->
+                                                                    (is_inductive
+                                                                    mutual)
+                                                                    &&
+                                                                    (FStar_Syntax_Util.is_fvar
+                                                                    mutual
+                                                                    head1))
+                                                                    mutuals) in
+                                                                    res in
+                                                                    let codomain_prec_l
+                                                                    =
+                                                                    let uu___18
+                                                                    =
+                                                                    FStar_List.zip
+                                                                    formals
+                                                                    vars in
+                                                                    FStar_List.collect
+                                                                    (fun
+                                                                    uu___19
+                                                                    ->
+                                                                    match uu___19
+                                                                    with
+                                                                    | 
+                                                                    (formal,
+                                                                    var) ->
+                                                                    let uu___20
+                                                                    =
+                                                                    FStar_Syntax_Util.arrow_formals_comp
+                                                                    (formal.FStar_Syntax_Syntax.binder_bv).FStar_Syntax_Syntax.sort in
+                                                                    (match uu___20
+                                                                    with
+                                                                    | 
+                                                                    (bs, c)
+                                                                    ->
+                                                                    (match bs
+                                                                    with
+                                                                    | 
+                                                                    [] -> []
+                                                                    | 
+                                                                    uu___21
+                                                                    when
+                                                                    let uu___22
+                                                                    =
+                                                                    tot_or_gtot_inductive_codomain
+                                                                    c in
+                                                                    Prims.op_Negation
+                                                                    uu___22
+                                                                    -> []
+                                                                    | 
+                                                                    uu___21
+                                                                    ->
+                                                                    let uu___22
+                                                                    =
+                                                                    FStar_SMTEncoding_EncodeTerm.encode_binders
+                                                                    FStar_Pervasives_Native.None
+                                                                    bs env'' in
+                                                                    (match uu___22
+                                                                    with
+                                                                    | 
+                                                                    (bs',
+                                                                    guards'1,
+                                                                    env'1,
+                                                                    bs_decls,
+                                                                    uu___23)
+                                                                    ->
+                                                                    let fun_app
+                                                                    =
+                                                                    let uu___24
+                                                                    =
+                                                                    FStar_SMTEncoding_Util.mkFreeV
+                                                                    var in
+                                                                    FStar_SMTEncoding_EncodeTerm.mk_Apply
+                                                                    uu___24
+                                                                    bs' in
+                                                                    let uu___24
+                                                                    =
+                                                                    let uu___25
+                                                                    =
+                                                                    FStar_Ident.range_of_lid
+                                                                    d in
+                                                                    let uu___26
+                                                                    =
+                                                                    let uu___27
+                                                                    =
+                                                                    let uu___28
+                                                                    =
+                                                                    let uu___29
+                                                                    =
+                                                                    FStar_SMTEncoding_Util.mk_Precedes
+                                                                    lex_t
+                                                                    lex_t
+                                                                    fun_app
+                                                                    dapp1 in
+                                                                    [uu___29] in
+                                                                    [uu___28] in
+                                                                    let uu___28
+                                                                    =
+                                                                    let uu___29
+                                                                    =
+                                                                    let uu___30
+                                                                    =
+                                                                    FStar_SMTEncoding_Util.mk_and_l
+                                                                    guards'1 in
+                                                                    let uu___31
+                                                                    =
+                                                                    FStar_SMTEncoding_Util.mk_Precedes
+                                                                    lex_t
+                                                                    lex_t
+                                                                    fun_app
+                                                                    dapp1 in
+                                                                    (uu___30,
+                                                                    uu___31) in
+                                                                    FStar_SMTEncoding_Util.mkImp
+                                                                    uu___29 in
+                                                                    (uu___27,
+                                                                    bs',
+                                                                    uu___28) in
+                                                                    FStar_SMTEncoding_Term.mkForall
+                                                                    uu___25
+                                                                    uu___26 in
+                                                                    [uu___24]))))
+                                                                    uu___18 in
+                                                                    match codomain_prec_l
+                                                                    with
+                                                                    | 
+                                                                    [] -> []
+                                                                    | 
+                                                                    uu___18
+                                                                    ->
+                                                                    let uu___19
+                                                                    =
+                                                                    let uu___20
+                                                                    =
+                                                                    let uu___21
+                                                                    =
+                                                                    let uu___22
+                                                                    =
+                                                                    FStar_Ident.range_of_lid
+                                                                    d in
+                                                                    let uu___23
+                                                                    =
+                                                                    let uu___24
+                                                                    =
+                                                                    let uu___25
+                                                                    =
+                                                                    FStar_SMTEncoding_Term.mk_fv
+                                                                    (fuel_var,
+                                                                    FStar_SMTEncoding_Term.Fuel_sort) in
+                                                                    FStar_SMTEncoding_Env.add_fuel
+                                                                    uu___25
+                                                                    (FStar_List.append
+                                                                    vars
+                                                                    arg_binders) in
+                                                                    let uu___25
+                                                                    =
+                                                                    let uu___26
+                                                                    =
+                                                                    let uu___27
+                                                                    =
+                                                                    FStar_SMTEncoding_Util.mk_and_l
+                                                                    codomain_prec_l in
+                                                                    (ty_pred,
+                                                                    uu___27) in
+                                                                    FStar_SMTEncoding_Util.mkImp
+                                                                    uu___26 in
+                                                                    ([
+                                                                    [ty_pred]],
+                                                                    uu___24,
+                                                                    uu___25) in
+                                                                    FStar_SMTEncoding_Term.mkForall
+                                                                    uu___22
+                                                                    uu___23 in
+                                                                    (uu___21,
+                                                                    (FStar_Pervasives_Native.Some
+                                                                    "well-founded ordering on codomain"),
+                                                                    (Prims.op_Hat
+                                                                    "well_founded_ordering_on_comdain_"
+                                                                    ddconstrsym)) in
+                                                                    FStar_SMTEncoding_Util.mkAssume
+                                                                    uu___20 in
+                                                                    [uu___19] in
                                                                    (arg_decls,
+                                                                    (FStar_List.append
                                                                     [typing_inversion;
-                                                                    subterm_ordering])))
-                                                     | uu___15 ->
-                                                         ((let uu___17 =
-                                                             let uu___18 =
-                                                               let uu___19 =
+                                                                    subterm_ordering]
+                                                                    codomain_ordering))))
+                                                     | uu___14 ->
+                                                         ((let uu___16 =
+                                                             let uu___17 =
+                                                               let uu___18 =
                                                                  FStar_Syntax_Print.lid_to_string
                                                                    d in
-                                                               let uu___20 =
+                                                               let uu___19 =
                                                                  FStar_Syntax_Print.term_to_string
                                                                    head in
                                                                FStar_Util.format2
                                                                  "Constructor %s builds an unexpected type %s\n"
-                                                                 uu___19
-                                                                 uu___20 in
+                                                                 uu___18
+                                                                 uu___19 in
                                                              (FStar_Errors.Warning_ConstructorBuildsUnexpectedType,
-                                                               uu___18) in
+                                                               uu___17) in
                                                            FStar_Errors.log_issue
                                                              se.FStar_Syntax_Syntax.sigrng
-                                                             uu___17);
+                                                             uu___16);
                                                           ([], []))) in
-                                              let uu___12 = encode_elim () in
-                                              (match uu___12 with
+                                              let uu___11 = encode_elim () in
+                                              (match uu___11 with
                                                | (decls2, elim) ->
                                                    let g =
-                                                     let uu___13 =
-                                                       let uu___14 =
-                                                         let uu___15 =
+                                                     let uu___12 =
+                                                       let uu___13 =
+                                                         let uu___14 =
+                                                           let uu___15 =
+                                                             let uu___16 =
+                                                               let uu___17 =
+                                                                 let uu___18
+                                                                   =
+                                                                   let uu___19
+                                                                    =
+                                                                    let uu___20
+                                                                    =
+                                                                    let uu___21
+                                                                    =
+                                                                    let uu___22
+                                                                    =
+                                                                    FStar_Syntax_Print.lid_to_string
+                                                                    d in
+                                                                    FStar_Util.format1
+                                                                    "data constructor proxy: %s"
+                                                                    uu___22 in
+                                                                    FStar_Pervasives_Native.Some
+                                                                    uu___21 in
+                                                                    (ddtok,
+                                                                    [],
+                                                                    FStar_SMTEncoding_Term.Term_sort,
+                                                                    uu___20) in
+                                                                   FStar_SMTEncoding_Term.DeclFun
+                                                                    uu___19 in
+                                                                 [uu___18] in
+                                                               FStar_List.append
+                                                                 uu___17
+                                                                 proxy_fresh in
+                                                             FStar_All.pipe_right
+                                                               uu___16
+                                                               FStar_SMTEncoding_Term.mk_decls_trivial in
                                                            let uu___16 =
                                                              let uu___17 =
                                                                let uu___18 =
@@ -5999,39 +6520,6 @@ and (encode_sigelt' :
                                                                     =
                                                                     let uu___21
                                                                     =
-                                                                    let uu___22
-                                                                    =
-                                                                    let uu___23
-                                                                    =
-                                                                    FStar_Syntax_Print.lid_to_string
-                                                                    d in
-                                                                    FStar_Util.format1
-                                                                    "data constructor proxy: %s"
-                                                                    uu___23 in
-                                                                    FStar_Pervasives_Native.Some
-                                                                    uu___22 in
-                                                                    (ddtok,
-                                                                    [],
-                                                                    FStar_SMTEncoding_Term.Term_sort,
-                                                                    uu___21) in
-                                                                   FStar_SMTEncoding_Term.DeclFun
-                                                                    uu___20 in
-                                                                 [uu___19] in
-                                                               FStar_List.append
-                                                                 uu___18
-                                                                 proxy_fresh in
-                                                             FStar_All.pipe_right
-                                                               uu___17
-                                                               FStar_SMTEncoding_Term.mk_decls_trivial in
-                                                           let uu___17 =
-                                                             let uu___18 =
-                                                               let uu___19 =
-                                                                 let uu___20
-                                                                   =
-                                                                   let uu___21
-                                                                    =
-                                                                    let uu___22
-                                                                    =
                                                                     FStar_SMTEncoding_Util.mkAssume
                                                                     (tok_typing1,
                                                                     (FStar_Pervasives_Native.Some
@@ -6039,6 +6527,8 @@ and (encode_sigelt' :
                                                                     (Prims.op_Hat
                                                                     "typing_tok_"
                                                                     ddtok)) in
+                                                                    let uu___22
+                                                                    =
                                                                     let uu___23
                                                                     =
                                                                     let uu___24
@@ -6047,31 +6537,31 @@ and (encode_sigelt' :
                                                                     =
                                                                     let uu___26
                                                                     =
-                                                                    let uu___27
-                                                                    =
                                                                     FStar_Ident.range_of_lid
                                                                     d in
-                                                                    let uu___28
+                                                                    let uu___27
                                                                     =
-                                                                    let uu___29
+                                                                    let uu___28
                                                                     =
                                                                     FStar_SMTEncoding_Util.mkEq
                                                                     (app,
                                                                     dapp) in
                                                                     ([[app]],
                                                                     vars,
-                                                                    uu___29) in
+                                                                    uu___28) in
                                                                     FStar_SMTEncoding_Term.mkForall
-                                                                    uu___27
-                                                                    uu___28 in
-                                                                    (uu___26,
+                                                                    uu___26
+                                                                    uu___27 in
+                                                                    (uu___25,
                                                                     (FStar_Pervasives_Native.Some
                                                                     "equality for proxy"),
                                                                     (Prims.op_Hat
                                                                     "equality_tok_"
                                                                     ddtok)) in
                                                                     FStar_SMTEncoding_Util.mkAssume
-                                                                    uu___25 in
+                                                                    uu___24 in
+                                                                    let uu___24
+                                                                    =
                                                                     let uu___25
                                                                     =
                                                                     let uu___26
@@ -6080,77 +6570,75 @@ and (encode_sigelt' :
                                                                     =
                                                                     let uu___28
                                                                     =
-                                                                    let uu___29
-                                                                    =
                                                                     FStar_Ident.range_of_lid
                                                                     d in
+                                                                    let uu___29
+                                                                    =
                                                                     let uu___30
                                                                     =
                                                                     let uu___31
-                                                                    =
-                                                                    let uu___32
                                                                     =
                                                                     FStar_SMTEncoding_Term.mk_fv
                                                                     (fuel_var,
                                                                     FStar_SMTEncoding_Term.Fuel_sort) in
                                                                     FStar_SMTEncoding_Env.add_fuel
-                                                                    uu___32
+                                                                    uu___31
                                                                     vars' in
-                                                                    let uu___32
+                                                                    let uu___31
                                                                     =
                                                                     FStar_SMTEncoding_Util.mkImp
                                                                     (guard',
                                                                     ty_pred') in
                                                                     ([
                                                                     [ty_pred']],
-                                                                    uu___31,
-                                                                    uu___32) in
+                                                                    uu___30,
+                                                                    uu___31) in
                                                                     FStar_SMTEncoding_Term.mkForall
-                                                                    uu___29
-                                                                    uu___30 in
-                                                                    (uu___28,
+                                                                    uu___28
+                                                                    uu___29 in
+                                                                    (uu___27,
                                                                     (FStar_Pervasives_Native.Some
                                                                     "data constructor typing intro"),
                                                                     (Prims.op_Hat
                                                                     "data_typing_intro_"
                                                                     ddtok)) in
                                                                     FStar_SMTEncoding_Util.mkAssume
-                                                                    uu___27 in
-                                                                    [uu___26] in
-                                                                    uu___24
+                                                                    uu___26 in
+                                                                    [uu___25] in
+                                                                    uu___23
                                                                     ::
-                                                                    uu___25 in
-                                                                    uu___22
-                                                                    ::
-                                                                    uu___23 in
-                                                                   FStar_List.append
+                                                                    uu___24 in
                                                                     uu___21
+                                                                    ::
+                                                                    uu___22 in
+                                                                   FStar_List.append
+                                                                    uu___20
                                                                     elim in
                                                                  FStar_All.pipe_right
-                                                                   uu___20
+                                                                   uu___19
                                                                    FStar_SMTEncoding_Term.mk_decls_trivial in
                                                                FStar_List.append
                                                                  decls_pred
-                                                                 uu___19 in
+                                                                 uu___18 in
                                                              FStar_List.append
                                                                decls_formals
-                                                               uu___18 in
+                                                               uu___17 in
                                                            FStar_List.append
-                                                             uu___16 uu___17 in
+                                                             uu___15 uu___16 in
                                                          FStar_List.append
-                                                           decls3 uu___15 in
+                                                           decls3 uu___14 in
                                                        FStar_List.append
-                                                         decls2 uu___14 in
+                                                         decls2 uu___13 in
                                                      FStar_List.append
-                                                       binder_decls uu___13 in
-                                                   let uu___13 =
-                                                     let uu___14 =
+                                                       binder_decls uu___12 in
+                                                   let uu___12 =
+                                                     let uu___13 =
                                                        FStar_All.pipe_right
                                                          datacons
                                                          FStar_SMTEncoding_Term.mk_decls_trivial in
                                                      FStar_List.append
-                                                       uu___14 g in
-                                                   (uu___13, env1))))))))))
+                                                       uu___13 g in
+                                                   (uu___12, env1))))))))))
 and (encode_sigelts :
   FStar_SMTEncoding_Env.env_t ->
     FStar_Syntax_Syntax.sigelt Prims.list ->

--- a/src/ocaml-output/FStar_TypeChecker_TcInductive.ml
+++ b/src/ocaml-output/FStar_TypeChecker_TcInductive.ml
@@ -216,7 +216,7 @@ let (tc_data :
       fun se ->
         match se.FStar_Syntax_Syntax.sigel with
         | FStar_Syntax_Syntax.Sig_datacon
-            (c, _uvs, t, tc_lid, ntps, _mutual_tcs) ->
+            (c, _uvs, t, tc_lid, ntps, mutual_tcs) ->
             let uu___ = FStar_Syntax_Subst.univ_var_opening _uvs in
             (match uu___ with
              | (usubst, _uvs1) ->
@@ -636,7 +636,7 @@ let (tc_data :
                                                           (FStar_Syntax_Syntax.Sig_datacon
                                                              (c, _uvs1, t3,
                                                                tc_lid, ntps,
-                                                               []));
+                                                               mutual_tcs));
                                                         FStar_Syntax_Syntax.sigrng
                                                           =
                                                           (uu___11.FStar_Syntax_Syntax.sigrng);

--- a/src/smtencoding/FStar.SMTEncoding.Encode.fs
+++ b/src/smtencoding/FStar.SMTEncoding.Encode.fs
@@ -1392,7 +1392,7 @@ and encode_sigelt' (env:env_t) (se:sigelt) : (decls_t * env_t) =
 
     | Sig_datacon(d, _, _, _, _, _) when (lid_equals d Const.lexcons_lid) -> [], env
 
-    | Sig_datacon(d, _, t, _, n_tps, _) ->
+    | Sig_datacon(d, _, t, _, n_tps, mutuals) ->
         let quals = se.sigquals in
         let t = norm_before_encoding env t in
         let formals, t_res = U.arrow_formals t in
@@ -1449,12 +1449,12 @@ and encode_sigelt' (env:env_t) (se:sigelt) : (decls_t * env_t) =
         let encode_elim () =
             let head, args = U.head_and_args t_res in
             match (SS.compress head).n with
-                | Tm_uinst({n=Tm_fvar fv}, _)
-                | Tm_fvar fv ->
-                  let encoded_head_fvb = lookup_free_var_name env' fv.fv_name in
-                  let encoded_args, arg_decls = encode_args args env' in
-                  let guards_for_parameter (orig_arg:S.term)(arg:term) xv =
-                    let fv =
+            | Tm_uinst({n=Tm_fvar fv}, _)
+            | Tm_fvar fv ->
+              let encoded_head_fvb = lookup_free_var_name env' fv.fv_name in
+              let encoded_args, arg_decls = encode_args args env' in
+              let guards_for_parameter (orig_arg:S.term)(arg:term) xv =
+                  let fv =
                       match arg.tm with
                       | FreeV fv -> fv
                       | _ ->
@@ -1462,16 +1462,17 @@ and encode_sigelt' (env:env_t) (se:sigelt) : (decls_t * env_t) =
                            BU.format1 "Inductive type parameter %s must be a variable ; \
                                        You may want to change it to an index."
                                       (FStar.Syntax.Print.term_to_string orig_arg)) orig_arg.pos
-                    in
-                    let guards = guards |> List.collect (fun g ->
+                  in
+                  let guards = guards |> List.collect (fun g ->
                         if List.contains fv (Term.free_variables g)
                         then [Term.subst g fv xv]
                         else [])
-                    in
-                    mk_and_l guards
                   in
-                  let _, arg_vars, elim_eqns_or_guards, _ =
-                    List.fold_left (fun (env, arg_vars, eqns_or_guards, i) (orig_arg, arg) ->
+                  mk_and_l guards
+              in
+              let _, arg_vars, elim_eqns_or_guards, _ =
+                  List.fold_left
+                    (fun (env, arg_vars, eqns_or_guards, i) (orig_arg, arg) ->
                       let _, xv, env = gen_term_var env (S.new_bv None tun) in
                       (* we only get equations induced on the type indices, not parameters; *)
                       (* Also see https://github.com/FStarLang/FStar/issues/349 *)
@@ -1481,24 +1482,25 @@ and encode_sigelt' (env:env_t) (se:sigelt) : (decls_t * env_t) =
                         else mkEq(arg, xv)::eqns_or_guards
                       in
                       (env, xv::arg_vars, eqns, i + 1))
-                      (env', [], [], 0) (FStar.List.zip args encoded_args)
-                  in
-                  let arg_vars = List.rev arg_vars in
-                  let ty = maybe_curry_fvb fv.fv_name.p encoded_head_fvb arg_vars in
-                  let xvars = List.map mkFreeV vars in
-                  let dapp =  mkApp(ddconstrsym, xvars) in //arity ok; |xvars| = |formals| = arity
-                  let ty_pred = mk_HasTypeWithFuel (Some s_fuel_tm) dapp ty in
-                  let arg_binders = List.map fv_of_term arg_vars in
-                  let typing_inversion =
+                    (env', [], [], 0)
+                    (FStar.List.zip args encoded_args)
+              in
+              let arg_vars = List.rev arg_vars in
+              let ty = maybe_curry_fvb fv.fv_name.p encoded_head_fvb arg_vars in
+              let xvars = List.map mkFreeV vars in
+              let dapp =  mkApp(ddconstrsym, xvars) in //arity ok; |xvars| = |formals| = arity
+              let ty_pred = mk_HasTypeWithFuel (Some s_fuel_tm) dapp ty in
+              let arg_binders = List.map fv_of_term arg_vars in
+              let typing_inversion =
                     Util.mkAssume(mkForall (Ident.range_of_lid d) ([[ty_pred]],
                                         add_fuel (mk_fv (fuel_var, Fuel_sort)) (vars@arg_binders),
                                         mkImp(ty_pred, mk_and_l (elim_eqns_or_guards@guards))),
                                Some "data constructor typing elim",
                                ("data_elim_" ^ ddconstrsym)) in
-                  let subterm_ordering =
-                    let lex_t = mkFreeV <| mk_fv (string_of_lid Const.lex_t_lid, Term_sort) in
-                    (* subterm ordering *)
-                    let prec =
+              let lex_t = mkFreeV <| mk_fv (string_of_lid Const.lex_t_lid, Term_sort) in
+              let subterm_ordering =
+                  (* subterm ordering *)
+                  let prec =
                         vars
                           |> List.mapi (fun i v ->
                                 (* it's a parameter, so it's inaccessible and no need for a sub-term ordering on it *)
@@ -1506,20 +1508,69 @@ and encode_sigelt' (env:env_t) (se:sigelt) : (decls_t * env_t) =
                                 then []
                                 else [mk_Precedes lex_t lex_t (mkFreeV v) dapp])
                           |> List.flatten
-                     in
-                     Util.mkAssume(mkForall (Ident.range_of_lid d)
-                                             ([[ty_pred]],
-                                              add_fuel (mk_fv (fuel_var, Fuel_sort)) (vars@arg_binders),
-                                              mkImp(ty_pred, mk_and_l prec)),
-                                    Some "subterm ordering",
-                                    ("subterm_ordering_"^ddconstrsym))
                   in
-                  arg_decls, [typing_inversion; subterm_ordering]
-
+                  Util.mkAssume(mkForall (Ident.range_of_lid d)
+                                         ([[ty_pred]],
+                                          add_fuel (mk_fv (fuel_var, Fuel_sort)) (vars@arg_binders),
+                                          mkImp(ty_pred, mk_and_l prec)),
+                                Some "subterm ordering",
+                                ("subterm_ordering_"^ddconstrsym))
+              in
+              let codomain_ordering =
+                let tot_or_gtot_inductive_codomain c =
+                  let is_inductive l =
+                      match FStar.TypeChecker.Env.lookup_sigelt env.tcenv l with
+                      | Some ({sigel=Sig_inductive_typ _}) -> true
+                      | _ -> false
+                  in
+                  let res =
+                   if not (U.is_tot_or_gtot_comp c)
+                   then false
+                   else let head, _ = U.head_and_args (U.comp_result c) in
+                        BU.for_some
+                          (fun mutual -> is_inductive mutual && U.is_fvar mutual head)
+                          mutuals
+                  in
+                  res
+                in
+                let codomain_prec_l =
+                  List.collect
+                    (fun (formal, var) ->
+                        let bs, c = U.arrow_formals_comp formal.binder_bv.sort in
+                        match bs with
+                        | [] -> []
+                        | _ when not (tot_or_gtot_inductive_codomain c) -> []
+                        | _ ->
+                         //var bs << D ... var ...
+                         let bs', guards', env', bs_decls, _ = encode_binders None bs env'' in
+                         let fun_app = mk_Apply (mkFreeV var) bs' in
+                         [mkForall (Ident.range_of_lid d)
+                                   ([[mk_Precedes lex_t lex_t fun_app dapp]],
+                                    bs',
+                                    mkImp (mk_and_l guards',
+                                           mk_Precedes lex_t lex_t fun_app dapp))])
+                    (List.zip formals vars)
+                in
+                match codomain_prec_l with
+                | [] -> []
                 | _ ->
-                  Errors.log_issue se.sigrng (Errors.Warning_ConstructorBuildsUnexpectedType, (BU.format2 "Constructor %s builds an unexpected type %s\n"
-                        (Print.lid_to_string d) (Print.term_to_string head)));
-                  [], [] in
+                  [Util.mkAssume(mkForall (Ident.range_of_lid d)
+                                         ([[ty_pred]],
+                                          add_fuel (mk_fv (fuel_var, Fuel_sort)) (vars@arg_binders),
+                                          mkImp(ty_pred, mk_and_l codomain_prec_l)),
+                                Some "well-founded ordering on codomain",
+                                ("well_founded_ordering_on_comdain_"^ddconstrsym))]
+              in
+              arg_decls,
+              [typing_inversion; subterm_ordering] @ codomain_ordering
+
+            | _ ->
+              Errors.log_issue se.sigrng
+                  (Errors.Warning_ConstructorBuildsUnexpectedType,
+                   BU.format2 "Constructor %s builds an unexpected type %s\n"
+                              (Print.lid_to_string d) (Print.term_to_string head));
+              [], []
+        in
         let decls2, elim = encode_elim () in
         let g = binder_decls
                 @decls2

--- a/src/typechecker/FStar.TypeChecker.TcInductive.fs
+++ b/src/typechecker/FStar.TypeChecker.TcInductive.fs
@@ -107,7 +107,7 @@ let tc_tycon (env:env_t)     (* environment that contains all mutually defined t
 let tc_data (env:env_t) (tcs : list<(sigelt * universe)>)
   : sigelt -> sigelt * guard_t =
     fun se -> match se.sigel with
-    | Sig_datacon(c, _uvs, t, tc_lid, ntps, _mutual_tcs) ->
+    | Sig_datacon(c, _uvs, t, tc_lid, ntps, mutual_tcs) ->
          //assert (_uvs = []);
          let usubst, _uvs = SS.univ_var_opening _uvs in
          let env, t = Env.push_univ_vars env _uvs, SS.subst usubst t in
@@ -214,7 +214,7 @@ let tc_data (env:env_t) (tcs : list<(sigelt * universe)>)
 (*close*)let t = U.arrow ((tps |> List.map (fun b -> {b with binder_qual=Some (Implicit true)}))@arguments) (S.mk_Total result) in
                         //NB: the tps are tagged as Implicit inaccessbile arguments of the data constructor
          let t = SS.close_univ_vars _uvs t in
-         { se with sigel = Sig_datacon(c, _uvs, t, tc_lid, ntps, []) },
+         { se with sigel = Sig_datacon(c, _uvs, t, tc_lid, ntps, mutual_tcs) },
          g
 
    | _ -> failwith "impossible"

--- a/tests/micro-benchmarks/TestWellFoundedRecursion.fst
+++ b/tests/micro-benchmarks/TestWellFoundedRecursion.fst
@@ -61,11 +61,11 @@ let rec fmap_stream' (#a #b:Type) (f:a -> b) (x:stream' a) : stream' b =
 noeq 
 type stream (a:Type) =
   | SNil: stream a
-  | SCons: _:unit -> f:(unit -> stream a) -> stream a
+  | SCons: _:a -> f:(unit -> stream a) -> stream a
 
 let rec fmap_stream (#a #b:Type) (f:a -> b) (x:stream a) : stream b =
   match x with
   | SNil -> SNil
   | SCons h t ->
     let ft () = fmap_stream f (t ()) in
-    SCons () ft
+    SCons (f h) ft

--- a/tests/micro-benchmarks/TestWellFoundedRecursion.fst
+++ b/tests/micro-benchmarks/TestWellFoundedRecursion.fst
@@ -1,0 +1,71 @@
+module TestWellFoundedRecursion
+
+noeq
+type ord =
+  | Z : ord
+  | Succ : ord -> ord
+  | Lim : (nat -> ord) -> ord
+
+let rec sum (x:ord) (y:ord) =
+  match x with
+  | Z -> y
+  | Succ x -> Succ (sum x y)
+  | Lim f -> Lim (fun n -> sum (f n) y)
+
+noeq
+type t =
+  | T0 : bool -> t
+  | T : (nat -> s) -> t
+and s =
+  | S0 : bool -> s
+  | S : (nat -> t) -> s
+
+let rec neg_t (x:t) =
+  match x with
+  | T0 b -> T0 (not b)
+  | T f -> T (fun y -> neg_s (f y))
+
+and neg_s (x:s) =
+  match x with
+  | S0 b -> S0 (not b)
+  | S f -> S (fun y -> neg_t (f y))
+
+
+noeq
+type tree a =
+  | Leaf : data:a -> tree a
+  | Node : children:(nat -> tree a) -> tree a
+
+let rec map #a #b (f:a -> b) (x:tree a)
+  : Tot (tree b)
+  = match x with
+    | Leaf data -> Leaf (f data)
+    | Node ch -> Node (fun n -> map f (ch n))
+
+noeq 
+type stream' (a:Type) =
+  | SNil': stream' a
+  | SCons': a & (unit -> stream' a) -> stream' a
+
+//we do not generate well-foundedness axioms for function within
+//other inductives, i.e., we don't destruct the pair above
+[@@expect_failure [19]]
+let rec fmap_stream' (#a #b:Type) (f:a -> b) (x:stream' a) : stream' b =
+  match x with
+  | SNil' -> SNil'
+  | SCons' (h, t) ->
+    let ft () = fmap_stream' f (t ()) in
+    SCons' (f h, ft)
+
+//You have to write it this way
+noeq 
+type stream (a:Type) =
+  | SNil: stream a
+  | SCons: _:unit -> f:(unit -> stream a) -> stream a
+
+let rec fmap_stream (#a #b:Type) (f:a -> b) (x:stream a) : stream b =
+  match x with
+  | SNil -> SNil
+  | SCons h t ->
+    let ft () = fmap_stream f (t ()) in
+    SCons () ft

--- a/ulib/FStar.WellFounded.fst
+++ b/ulib/FStar.WellFounded.fst
@@ -20,16 +20,6 @@
 
 module FStar.WellFounded
 
-[@@deprecated "this is no longer needed"]
-let axiom1_dep (#a:Type) (#b:(a->Type)) (f:(y:a -> Tot (b y))) (x:a)
-  : Lemma True
-  = ()
-
-[@@deprecated "this is no longer needed"]
-let axiom1 (#a:Type) (#b:Type) (f:(a -> Tot b)) (x:a)
-  : Lemma True
-  = ()
-
 noeq
 type acc (a:Type) (r:(a -> a -> Type)) (x:a) : Type =
   | AccIntro : (y:a -> r y x -> Tot (acc a r y)) -> acc a r x

--- a/ulib/FStar.WellFounded.fst
+++ b/ulib/FStar.WellFounded.fst
@@ -20,36 +20,34 @@
 
 module FStar.WellFounded
 
-noeq type acc (a:Type) (r:(a -> a -> Type)) (x:a) : Type =
+[@@deprecated "this is no longer needed"]
+let axiom1_dep (#a:Type) (#b:(a->Type)) (f:(y:a -> Tot (b y))) (x:a)
+  : Lemma True
+  = ()
+
+[@@deprecated "this is no longer needed"]
+let axiom1 (#a:Type) (#b:Type) (f:(a -> Tot b)) (x:a)
+  : Lemma True
+  = ()
+
+noeq
+type acc (a:Type) (r:(a -> a -> Type)) (x:a) : Type =
   | AccIntro : (y:a -> r y x -> Tot (acc a r y)) -> acc a r x
 
-type well_founded (a:Type) (r:(a -> a -> Type)) = x:a -> Tot (acc a r x)
+let well_founded (a:Type) (r:(a -> a -> Type)) = x:a -> Tot (acc a r x)
 
-val acc_inv : #aa:Type -> #r:(aa -> aa -> Type) -> x:aa -> a:(acc aa r x) ->
-              Tot (e:(y:aa -> r y x -> Tot (acc aa r y)){e << a})
-let acc_inv #aa #r x a = match a with | AccIntro h1 -> h1
+let acc_inv (#aa:Type) (#r:(aa -> aa -> Type)) (x:aa) (a:acc aa r x)
+  : Tot (e:(y:aa -> r y x -> Tot (acc aa r y)){e << a})
+  = match a with | AccIntro h1 -> h1
 
-assume val axiom1_dep : #a:Type -> #b:(a->Type) -> f:(y:a -> Tot (b y)) -> x:a ->
-                        Lemma (f x << f)
+let rec fix_F (#aa:Type) (#r:(aa -> aa -> Type)) (#p:(aa -> Type))
+              (f: (x:aa -> (y:aa -> r y x -> Tot (p y)) -> Tot (p x)))
+              (x:aa) (a:acc aa r x)
+  : Tot (p x) (decreases a)
+  = f x (fun y h -> fix_F f y (acc_inv x a y h))
 
-val axiom1 : #a:Type -> #b:Type -> f:(a -> Tot b) -> x:a ->
-             Lemma (precedes (f x) f)
-let axiom1 #a #b f x = axiom1_dep f x
-
-let apply (#a:Type) (#b:a -> Type) (f: (x:a -> Tot (b x))) (x:a)
-  : Pure (b x) (requires True) (ensures (fun r -> r == f x /\ f x << f))
-=
-  axiom1_dep #a #b f x ; f x
-
-val fix_F : #aa:Type -> #r:(aa -> aa -> Type) -> #p:(aa -> Type) ->
-            (x:aa -> (y:aa -> r y x -> Tot (p y)) -> Tot (p x)) ->
-            x:aa -> a:(acc aa r x) -> Tot (p x) (decreases a)
-let rec fix_F #aa #r #p f x a =
-  f x (fun y h ->
-         axiom1_dep (acc_inv x a) y;
-         axiom1 (acc_inv x a y) h;
-         fix_F f y (acc_inv x a y h))
-
-val fix : #aa:Type -> #r:(aa -> aa -> Type) -> well_founded aa r -> p:(aa -> Type) ->
-          (x:aa -> (y:aa -> r y x -> Tot (p y)) -> Tot (p x)) -> x:aa -> Tot (p x)
-let fix #aa #r rwf p f x = fix_F f x (rwf x)
+let fix (#aa:Type) (#r:(aa -> aa -> Type)) (rwf:well_founded aa r)
+        (p:aa -> Type) (f:(x:aa -> (y:aa -> r y x -> Tot (p y)) -> Tot (p x)))
+        (x:aa)
+  : Tot (p x)
+  = fix_F f x (rwf x)

--- a/ulib/experimental/Steel.Heap.fst
+++ b/ulib/experimental/Steel.Heap.fst
@@ -750,7 +750,7 @@ let refined_pre_action_as_action (#fp0:slprop) (#a:Type) (#fp1:a -> slprop)
     in
     g
 
-#push-options "--z3rlimit_factor 8 --max_fuel 0 --initial_ifuel 2 --max_ifuel 2"
+#push-options "--z3rlimit_factor 20 --max_fuel 0 --initial_ifuel 2 --max_ifuel 2"
 let select_refine_pre (#a:_) (#p:_)
                       (r:ref a p)
                       (x:erased a)
@@ -785,7 +785,7 @@ let select_refine_pre (#a:_) (#p:_)
                     let Ref _ _ frac_l v_l = select_addr hl r in
                     let Ref _ _ _ v_r = select_addr hr r in
                     assert (composable p v_l v_r);
-                    assert (op p v_l v_r == v);
+                    assert (op p v_l v_r == v); //NS: this one seems to be fragile
                     assert (compatible p x v_l);
                     let aux (frame_l:a)
                       : Lemma

--- a/ulib/experimental/Steel.Heap.fst
+++ b/ulib/experimental/Steel.Heap.fst
@@ -750,7 +750,21 @@ let refined_pre_action_as_action (#fp0:slprop) (#a:Type) (#fp1:a -> slprop)
     in
     g
 
-#push-options "--z3rlimit_factor 20 --max_fuel 0 --initial_ifuel 2 --max_ifuel 2"
+let select_join #a #p (r:ref a p) (x:erased a) (h:full_heap) (hl hr:heap)
+  : Lemma
+    (requires
+      disjoint hl hr /\
+      h == join hl hr /\
+      interp (pts_to r x) h /\
+      interp (pts_to r x) hl /\
+      contains_addr hr r)
+    (ensures (
+      let Ref _ _ _ vl = select_addr hl r in
+      let Ref _ _ _ vr = select_addr hr r in
+      sel_v r x h == op p vl vr))
+  = ()
+
+#push-options "--z3rlimit_factor 8 --max_fuel 0 --initial_ifuel 2 --max_ifuel 2"
 let select_refine_pre (#a:_) (#p:_)
                       (r:ref a p)
                       (x:erased a)
@@ -785,7 +799,8 @@ let select_refine_pre (#a:_) (#p:_)
                     let Ref _ _ frac_l v_l = select_addr hl r in
                     let Ref _ _ _ v_r = select_addr hr r in
                     assert (composable p v_l v_r);
-                    assert (op p v_l v_r == v); //NS: this one seems to be fragile
+                    select_join r x h0 hl hr;
+                    assert (op p v_l v_r == v); //NS: this one seems to be fragile, without the lemma call above
                     assert (compatible p x v_l);
                     let aux (frame_l:a)
                       : Lemma

--- a/ulib/prims.fst
+++ b/ulib/prims.fst
@@ -696,4 +696,4 @@ let labeled (r: range) (msg: string) (b: Type) : Type = b
 (** THIS IS MEANT TO BE KEPT IN SYNC WITH FStar.CheckedFiles.fs
     Incrementing this forces all .checked files to be invalidated *)
 irreducible
-let __cache_version_number__ = 30
+let __cache_version_number__ = 31


### PR DESCRIPTION
See issue #2069 

This fix enhances the SMT encoding of inductives to include an additional property on `f x << D f` for data constructors `D` of an inductive `t` whose argument include a ghost or total function returning a `t`. 

All prior uses of the axiom have been removed in the F* tree. 

See tests/micro-benchmarks/TestWellFoundedRecursion.fst for several small examples.

 