### PR TITLE
Decompose and delay solving unification problems involving umax

### DIFF
--- a/tests/bug-reports/Bug2211.fst
+++ b/tests/bug-reports/Bug2211.fst
@@ -1,0 +1,5 @@
+module Bug2211
+assume val comba (ret:Type u#a) : Type u#(max a 1)
+assume val f: #ret:Type u#a -> list u#(max a 1) (comba u#a ret) -> list u#a ret
+assume val x: list u#1 (comba u#0 int)
+let t = f x

--- a/tests/bug-reports/Makefile
+++ b/tests/bug-reports/Makefile
@@ -41,7 +41,8 @@ SHOULD_VERIFY_CLOSED=Bug022.fst Bug024.fst Bug025.fst Bug026.fst Bug026b.fst Bug
   Bug1903.fst Bug1121a.fst Bug1121b.fst Bug1956.fst Bug1228.fst Bug829.fst Bug451.fst Bug1966a.fst Bug1966b.fst Bug1976.fst \
   Bug1986.fst Bug1995.fst Bug1507.fst Bug2001.fst Bug2004.fst Bug855a.fst Bug855b.fst Bug1097.fst Bug1918.fst Bug1390.fst Bug2031.fst \
   Bug379.fst Bug1182a.fst Bug1182b.fst Bug1901.fst Bug1902.fst Bug258.fst Bug2055.fst Bug2081.fst Bug2099.fst Bug2106.fst Bug2132.fst \
-  Bug2138.fst Bug2146.fst Bug2074.fst Bug2125a.fst Bug2125b.fst Bug2167.fst Bug2169.fst Bug2169b.fst Bug2066.fst Bug2189.fst Bug2184.fst
+  Bug2138.fst Bug2146.fst Bug2074.fst Bug2125a.fst Bug2125b.fst Bug2167.fst Bug2169.fst Bug2169b.fst Bug2066.fst Bug2189.fst Bug2184.fst \
+  Bug2211.fst
 
 SHOULD_VERIFY_INTERFACE_CLOSED=Bug771.fsti Bug771b.fsti
 SHOULD_VERIFY_AND_WARN_CLOSED=Bug016.fst


### PR DESCRIPTION
cf #2211

When solving a unification problem of the form

```
1. t u#?x s =?= t u#(max _ _) s'
```

The existing code would consider the head symbols of the two terms to be an exact match and proceed to attempt to unify 

```
2. t u#?x =?= t u#(max _ _)
```

If deferring is enabled, problem 2 is identified as ineligible for immediate solving, but then the entire original problem 1 is deferred, rather than, e.g., trying to solve `s == s'`. Since the entire problem is deferred, later, when no other problems are left to solve, we consider solving problem 1 again, this time without enabling deferral, and now 2 is eligible for solving. However, solving the universe equation `u#?x = u#(max _ _)` is heuristic and can lead to incorrect solutions. 

The fix is to notice that in case unification problems involving umax are involved, problems like 1. should always be decomposed immediately into 

```
2. t u#?x =?= t u#(max _ _)`
3. s =?= s'
```

Now, 2 can be deferred, while 3 could be solved, making progress and eventually rendering 2 also solvable without heuristics.

This patch enables the failing type inference problem in issue #2211 to be soled.