### PR TITLE
Modeling the null pointer in Steel

### DIFF
--- a/examples/steel/Duplex.PCM.fst
+++ b/examples/steel/Duplex.PCM.fst
@@ -13,7 +13,7 @@ module R = FStar.ReflexiveTransitiveClosure
 // Simplifying protocols for now
 let rec no_loop (p:dprot') = match p with
   | Return _ -> False
-  | Msg _ a k -> (forall x. (WF.axiom1 k x; no_loop (k x)))
+  | Msg _ a k -> (forall x. no_loop (k x))
   | DoWhile _ _ -> False
 
 let dprot = p:dprot'{no_loop p}

--- a/ulib/experimental/Steel.Heap.fst
+++ b/ulib/experimental/Steel.Heap.fst
@@ -550,6 +550,8 @@ let pts_to_join' (#a:Type u#a) (#pcm:_) (r:ref a pcm) (v1 v2:a) (m:heap)
 let pts_to_compatible_equiv (#a:Type) (#pcm:_) (x:ref a pcm) (v0:a) (v1:a{composable pcm v0 v1})
   = FStar.Classical.forall_intro (pts_to_compatible x v0 v1)
 
+let pts_to_not_null (#a:Type) (#pcm:_) (x:ref a pcm) (v:a) (m:heap) = ()
+
 
 ////////////////////////////////////////////////////////////////////////////////
 // star

--- a/ulib/experimental/Steel.Heap.fst
+++ b/ulib/experimental/Steel.Heap.fst
@@ -87,6 +87,10 @@ type ref (a:Type u#a) (pcm:pcm a): Type u#0 =
   | Null
   | Addr of addr
 
+let null (#a:Type u#a) (#pcm:pcm a) : ref a pcm = Null
+
+let is_null (#a:Type u#a) (#pcm:pcm a) (r:ref a pcm) : (b:bool{b <==> r == null}) = Null? r
+
 let disjoint (m0 m1:heap u#h)
   : prop
   = forall a. disjoint_addr m0 m1 a

--- a/ulib/experimental/Steel.Heap.fst
+++ b/ulib/experimental/Steel.Heap.fst
@@ -83,7 +83,9 @@ let disjoint_addr (m0 m1:heap u#h) (a:addr)
     | None, None ->
       True
 
-let ref (a:Type u#a) (pcm:pcm a): Type u#0 = addr
+type ref (a:Type u#a) (pcm:pcm a): Type u#0 =
+  | Null
+  | Addr of addr
 
 let disjoint (m0 m1:heap u#h)
   : prop
@@ -290,21 +292,25 @@ let pts_to_cell_join (#a:Type u#a) (pcm:pcm a) (v1 v2:a) (c:cell u#a)
 
 let pts_to (#a:Type u#a) (#pcm:_) (r:ref a pcm) (v:a) : slprop u#a =
   let hprop  (h: heap) : Tot prop =
-    h `contains_addr` r /\
-    pts_to_cell pcm v (select_addr h r)
+    Addr? r /\
+    h `contains_addr` (Addr?._0 r) /\
+    pts_to_cell pcm v (select_addr h (Addr?._0 r))
   in
-  affine_hprop_intro hprop (fun h0 h1 -> match h0 r, h1 r, (join h0 h1) r with
-  | Some (Ref a0 pcm0 _ v0), Some (Ref a1 pcm1 _ v1), Some (Ref a01 pcm01 _ v01) ->
-     compatible_elim pcm01 v v0 (compatible pcm01 v v01) (fun frame ->
-       pcm01.comm frame v;
-       pcm01.assoc_r v frame v1;
-       pcm01.comm frame v1;
-       let new_frame = (op pcm01 v1 frame) in
-       pcm01.comm v new_frame
-     )
-  | None, Some _, _
-  | Some _, None, _ -> ()
-  | None, None, _ -> ()
+  affine_hprop_intro hprop (fun h0 h1 ->
+  match r with | Null -> () | Addr r -> (
+    match h0 r, h1 r, (join h0 h1) r with
+    | Some (Ref a0 pcm0 _ v0), Some (Ref a1 pcm1 _ v1), Some (Ref a01 pcm01 _ v01) ->
+       compatible_elim pcm01 v v0 (compatible pcm01 v v01) (fun frame ->
+         pcm01.comm frame v;
+         pcm01.assoc_r v frame v1;
+         pcm01.comm frame v1;
+         let new_frame = (op pcm01 v1 frame) in
+         pcm01.comm v new_frame
+       )
+    | None, Some _, _
+    | Some _, None, _ -> ()
+    | None, None, _ -> ()
+    )
   );
   hprop
 
@@ -386,8 +392,9 @@ let interp_depends_only_on (hp:slprop u#a) = emp_unit hp
 let intro_pts_to (#a:_) (#pcm:pcm a) (x:ref a pcm) (v:a) (m:heap)
   : Lemma
     (requires
-       m `contains_addr` x /\
-       (let Ref a' pcm' _ v' = select_addr m x in
+       Addr? x /\
+       m `contains_addr` (Addr?._0 x) /\
+       (let Ref a' pcm' _ v' = select_addr m (Addr?._0 x) in
         a == a' /\
         pcm == pcm' /\
         compatible pcm v v'))
@@ -407,8 +414,9 @@ let pts_to_compatible_fwd (#a:Type u#a)
     (ensures
       composable pcm v0 v1 /\
       interp (pts_to x (op pcm v0 v1)) m)
-  = let c = select_addr m x in
-    let Ref _ _ _ v = select_addr m x in
+  = let Addr addr = x in
+    let c = select_addr m addr in
+    let Ref _ _ _ v = select_addr m addr in
     let aux (c0 c1: cell u#a)
       : Lemma
         (requires
@@ -472,8 +480,9 @@ let pts_to_compatible_bk (#a:Type u#a)
       interp (pts_to x (op pcm v0 v1)) m)
     (ensures
       interp (pts_to x v0 `star` pts_to x v1) m)
-  = let c = select_addr m x in
-    let Ref _ _ _ v = select_addr m x in
+  = let Addr addr = x in
+    let c = select_addr m addr in
+    let Ref _ _ _ v = select_addr m addr in
     let v01 = (op pcm v0 v1) in
     assert (pts_to_cell pcm v01 c);
     let Ref _ _ frac v = c in
@@ -508,8 +517,8 @@ let pts_to_compatible_bk (#a:Type u#a)
         };
         assert (disjoint_cells c0 c1);
         assert (c == join_cells c0 c1);
-        let m0 = update_addr empty_heap x c0 in
-        let m1 = update_addr m x c1 in
+        let m0 = update_addr empty_heap addr c0 in
+        let m1 = update_addr m addr c1 in
         assert (disjoint m0 m1) //fire the existential
     in
     ()
@@ -531,7 +540,7 @@ let pts_to_join' (#a:Type u#a) (#pcm:_) (r:ref a pcm) (v1 v2:a) (m:heap)
   : Lemma (requires (interp (pts_to r v1) m /\ interp (pts_to r v2) m))
           (ensures (exists z. compatible pcm v1 z /\ compatible pcm v2 z /\
                          interp (pts_to r z) m))
-  = let Ref a' pcm' _ v' = (select_addr m r) in
+  = let Ref a' pcm' _ v' = (select_addr m (Addr?._0 r)) in
     compatible_refl pcm v'
 
 let pts_to_compatible_equiv (#a:Type) (#pcm:_) (x:ref a pcm) (v0:a) (v1:a{composable pcm v0 v1})
@@ -669,14 +678,14 @@ let weaken_free_above (h:heap) (a b:nat)
 ////////////////////////////////////////////////////////////////////////////////
 let sel #a #pcm (r:ref a pcm) (m:full_hheap (ptr r))
   : a
-  = let Ref _ _ _ v = select_addr m r in
+  = let Ref _ _ _ v = select_addr m (Addr?._0 r) in
     v
 
 let sel_v #a #pcm r v m = sel r m
 
 let sel_lemma (#a:_) (#pcm:_) (r:ref a pcm) (m:full_hheap (ptr r))
   : Lemma (interp (pts_to r (sel r m)) m)
-  = let Ref _ _ _ v = select_addr m r in
+  = let Ref _ _ _ v = select_addr m (Addr?._0 r) in
     assert (sel r m == v);
     compatible_refl pcm v
 
@@ -690,12 +699,13 @@ let witnessed_ref_stability #a #pcm (r:ref a pcm) (fact:a -> prop)
         (ensures
           fact_h h1)
         [SMTPat ()]
-      = assert (interp (ptr r) h0);
+      = let Addr addr = r in
+        assert (interp (ptr r) h0);
         assert (fact (sel r h0));
-        assert (contains_addr h1 r);
-        compatible_refl pcm (select_addr h1 r).v;
-        assert (compatible pcm (select_addr h1 r).v (select_addr h1 r).v);
-        assert (interp (pts_to r (select_addr h1 r).v) h1);
+        assert (contains_addr h1 addr);
+        compatible_refl pcm (select_addr h1 addr).v;
+        assert (compatible pcm (select_addr h1 addr).v (select_addr h1 addr).v);
+        assert (interp (pts_to r (select_addr h1 addr).v) h1);
         assert (interp (ptr r) h1);
         assert (fact (sel r h1))
     in
@@ -757,10 +767,10 @@ let select_join #a #p (r:ref a p) (x:erased a) (h:full_heap) (hl hr:heap)
       h == join hl hr /\
       interp (pts_to r x) h /\
       interp (pts_to r x) hl /\
-      contains_addr hr r)
+      contains_addr hr (Addr?._0 r))
     (ensures (
-      let Ref _ _ _ vl = select_addr hl r in
-      let Ref _ _ _ vr = select_addr hr r in
+      let Ref _ _ _ vl = select_addr hl (Addr?._0 r) in
+      let Ref _ _ _ vr = select_addr hr (Addr?._0 r) in
       sel_v r x h == op p vl vr))
   = ()
 
@@ -794,10 +804,11 @@ let select_refine_pre (#a:_) (#p:_)
                              interp (pts_to r (f v)) hl' /\
                              interp frame hr)
                  [SMTPat()]
-             = if contains_addr hr r
+             = let Addr ad = r in
+               if contains_addr hr ad
                then begin
-                    let Ref _ _ frac_l v_l = select_addr hl r in
-                    let Ref _ _ _ v_r = select_addr hr r in
+                    let Ref _ _ frac_l v_l = select_addr hl ad in
+                    let Ref _ _ _ v_r = select_addr hr ad in
                     assert (composable p v_l v_r);
                     select_join r x h0 hl hr;
                     assert (op p v_l v_r == v); //NS: this one seems to be fragile, without the lemma call above
@@ -825,17 +836,17 @@ let select_refine_pre (#a:_) (#p:_)
                         p.assoc (f v) frame_l v_r;
                         p.comm (f v) frame_l;
                         assert (op p (op p frame_l (f v)) v_r == v);
-                        let hl' = update_addr hl r (Ref a p frac_l (op p frame_l (f v))) in
+                        let hl' = update_addr hl ad (Ref a p frac_l (op p frame_l (f v))) in
                         assert (disjoint hl' hr);
                         assert (h0 == join hl hr);
-                        assert (forall a. a <> r ==> hl a == hl' a);
+                        assert (forall a. a <> ad ==> hl a == hl' a);
                         assert (frac_l =!= Frac.full_perm);
-                        assert (hl' r == Some (Ref a p frac_l (op p frame_l (f v))));
+                        assert (hl' ad == Some (Ref a p frac_l (op p frame_l (f v))));
                         let aux (a:addr)
                           : Lemma (h0 a == (join hl' hr) a)
                             [SMTPat (h0 a)]
                           = if (contains_addr hr a && contains_addr hl a)
-                            then if a <> r
+                            then if a <> ad
                                  then ()
                                  else ()
                             else ()
@@ -876,9 +887,9 @@ let upd' (#a:_) (#pcm:_) (r:ref a pcm) (v0:FStar.Ghost.erased a) (v1:a {frame_pr
   : pre_action (pts_to r v0) unit (fun _ -> pts_to r v1)
   = fun h ->
     let cell = Ref a pcm Frac.full_perm v1  in
-    let h' = update_addr h r cell in
-    assert (forall x. contains_addr h' x ==> x==r \/ contains_addr h x);
-    assert (h' `contains_addr` r);
+    let h' = update_addr h (Addr?._0 r) cell in
+    assert (forall x. contains_addr h' x ==> x==(Addr?._0 r) \/ contains_addr h x);
+    assert (h' `contains_addr` Addr?._0 r);
     assert (pts_to_cell pcm v1 cell);
     assert (interp (pts_to r v1) h');
     (| (), h' |)
@@ -932,7 +943,7 @@ let heap_evolves_by_frame_preserving_update #a #pcm (r:ref a pcm)
                                             (v0:Ghost.erased a)
                                             (v1:a {frame_preserving pcm v0 v1 /\ pcm.refine v1})
                                             (h0:full_hheap (pts_to r v0))
-   : Lemma (let h1 = update_addr_full_heap h0 r (Ref a pcm Frac.full_perm v1) in
+   : Lemma (let h1 = update_addr_full_heap h0 (Addr?._0 r) (Ref a pcm Frac.full_perm v1) in
             heap_evolves h0 h1)
   = let v = sel r h0 in
     PP.frame_preserving_is_preorder_respecting pcm v0 v1;
@@ -953,8 +964,8 @@ let upd_lemma'_1 (#a:_) #pcm (r:ref a pcm)
       interp frame hf)
     (ensures (
       let (| _, h' |) = upd' r v0 v1 h in
-      let cell0 = select_addr h0 r in
-      let h0' = update_addr h0 r (Ref a pcm cell0.frac v1) in
+      let cell0 = select_addr h0 (Addr?._0 r) in
+      let h0' = update_addr h0 (Addr?._0 r) (Ref a pcm cell0.frac v1) in
       disjoint h0' hf /\
       interp (pts_to r v1) h0' /\
       interp frame hf /\
@@ -962,15 +973,15 @@ let upd_lemma'_1 (#a:_) #pcm (r:ref a pcm)
       heap_evolves h h' /\
       (forall (hp:hprop frame). hp h == hp h')))
   = let (| _, h'|) = upd' r v0 v1 h in
-    let cell0 = select_addr h0 r in
+    let cell0 = select_addr h0 (Addr?._0 r) in
     let cell1 = (Ref a pcm cell0.frac v1) in
-    let h0' = update_addr h0 r cell1 in
+    let h0' = update_addr h0 (Addr?._0 r) cell1 in
     assert (interp (pts_to r v1) h0');
     assert (interp frame hf);
     let aux (a:addr)
       : Lemma (disjoint_addr h0' hf a )
               [SMTPat (disjoint_addr h0' hf a)]
-      = if a <> r then ()
+      = if a <> (Addr?._0 r) then ()
         else match h0 a, h0' a, hf a with
              | Some (Ref a0 p0 f0 v0_val),
                Some (Ref a0' p0' f0' v0'),
@@ -1024,7 +1035,7 @@ let upd_lemma'_1 (#a:_) #pcm (r:ref a pcm)
     let aux (a:addr)
          : Lemma (h' a == (join h0' hf) a)
                  [SMTPat ()]
-         = if a <> r
+         = if a <> (Addr?._0 r)
            then ()
            else begin
              assert (h0' a == Some cell1);
@@ -1078,8 +1089,8 @@ let upd_lemma' (#a:_) #pcm (r:ref a pcm)
          interp frame hf)
        (ensures (
          let (| _, h' |) = upd' r v0 v1 h in
-         let cell0 = select_addr h0 r in
-         let h0' = update_addr h0 r (Ref a pcm cell0.frac v1) in
+         let cell0 = select_addr h0 (Addr?._0 r) in
+         let h0' = update_addr h0 (Addr?._0 r) (Ref a pcm cell0.frac v1) in
          disjoint h0' hf /\
          interp (pts_to r v1) h0' /\
          interp frame hf /\
@@ -1115,10 +1126,10 @@ let upd_gen #a (#p:pcm a)
                        unit
                        (fun _ -> pts_to r v)
   = fun h ->
-     let Ref _ _ frac old_v = select_addr h r in
+     let Ref _ _ frac old_v = select_addr h (Addr?._0 r) in
      let new_v = f old_v in
      let cell = Ref a p frac new_v in
-     let h' = update_addr h r cell in
+     let h' = update_addr h (Addr?._0 r) cell in
      (| (), h' |)
 
 let upd_gen_updates_only_r #a (#p:pcm a) (r:ref a p)
@@ -1126,7 +1137,7 @@ let upd_gen_updates_only_r #a (#p:pcm a) (r:ref a p)
                            (f: frame_preserving_upd p x v)
                            (h0:hheap (pts_to r x))
   : Lemma (let (| _, h1 |) = upd_gen r x v f h0 in
-           forall s. s <> r ==> h0 s == h1 s)
+           forall s. s <> (Addr?._0 r) ==> h0 s == h1 s)
   = ()
 
 let frame_preserving_is_preorder_respecting_pcm_t #a (p:pcm a) (x y:a)
@@ -1151,8 +1162,8 @@ let upd_gen_full_evolution #a (#p:pcm a)
     frame_preserving_is_preorder_respecting_pcm_t p old_v new_v;
     assert (PP.preorder_of_pcm p old_v new_v);
     let (| _, h1 |) = upd_gen r x y f h in
-    assert (forall a. a<>r ==> h1 a == h a);
-    assert (forall (x:addr). contains_addr h1 x ==> x==r \/ contains_addr h x);
+    assert (forall a. a<>(Addr?._0 r) ==> h1 a == h a);
+    assert (forall (x:addr). contains_addr h1 x ==> x==(Addr?._0 r) \/ contains_addr h x);
     assert (full_heap_pred h1);
     assert (heap_evolves h h1)
 
@@ -1170,11 +1181,11 @@ let upd_gen_frame_preserving #a (#p:pcm a)
      (let (| b, h1 |) = upd_gen r x y f h in
       interp ((pts_to r y) `star` frame) h1 /\
       (forall (hp:hprop frame). hp h == hp h1)))
- = let Ref _ _ frac old_v = select_addr h r in
+ = let Ref _ _ frac old_v = select_addr h (Addr?._0 r) in
    let old_v : a = old_v in
    let (| _, h1 |) = upd_gen r x y f h in
    let new_v = f old_v in
-   assert (forall a. a<>r ==> h1 a == h a);
+   assert (forall a. a<>(Addr?._0 r) ==> h1 a == h a);
    let aux (hl hr:heap)
        : Lemma
          (requires
@@ -1188,16 +1199,16 @@ let upd_gen_frame_preserving #a (#p:pcm a)
            h1 == join hl' hr
            ))
          [SMTPat (disjoint hl hr)]
-       = assert (contains_addr hl r);
-         let Ref _ _ _ old_v_l = select_addr hl r in
+       = assert (contains_addr hl (Addr?._0 r));
+         let Ref _ _ _ old_v_l = select_addr hl (Addr?._0 r) in
          let old_v_l : a = old_v_l in
          let (| _, hl' |) = upd_gen r x y f hl in
          upd_gen_updates_only_r r x y f hl;
-         assert (forall s. s<>r ==> hl s == hl' s);
-         let Ref _ _ _ new_v_l = select_addr hl' r in
+         assert (forall s. s<>(Addr?._0 r) ==> hl s == hl' s);
+         let Ref _ _ _ new_v_l = select_addr hl' (Addr?._0 r) in
          let new_v_l : a = new_v_l in
-         if contains_addr hr r
-         then let Ref _ _ _ old_v_r = select_addr hr r in
+         if contains_addr hr (Addr?._0 r)
+         then let Ref _ _ _ old_v_r = select_addr hr (Addr?._0 r) in
               let old_v_r : a = old_v_r in
               assert (composable p old_v_l old_v_r);
               assert (op p old_v_l old_v_r == old_v); //old_v_l * old_v_r = old_v
@@ -1211,7 +1222,7 @@ let upd_gen_frame_preserving #a (#p:pcm a)
            assert (new_v == new_v_l);
            assert (disjoint hl hr);
            assert (disjoint hl' hr);
-           assert (h1 r == hl' r);
+           assert (h1 (Addr?._0 r) == hl' (Addr?._0 r));
            mem_equiv_eq h1 (join hl' hr);
            assert (h1 == join hl' hr);
            ()
@@ -1275,10 +1286,10 @@ let gather_action #a #pcm r v0 v1
 ////////////////////////////////////////////////////////////////////////////////
 #push-options "--z3rlimit 20"
 let extend #a #pcm x addr h =
-    let r : ref a pcm = addr in
-    let h' = update_addr_full_heap h r (Ref a pcm Frac.full_perm x) in
+    let r : ref a pcm = Addr addr in
+    let h' = update_addr_full_heap h addr (Ref a pcm Frac.full_perm x) in
     assert (h' `free_above_addr` (addr + 1));
-    assert (h' `contains_addr` r);
+    assert (h' `contains_addr` addr);
     assert (interp (pts_to r x) h');
     let extend_aux (frame:slprop) (h0 hf:heap)
       : Lemma
@@ -1288,7 +1299,7 @@ let extend #a #pcm x addr h =
           interp emp h0 /\
           interp frame hf)
        (ensures (
-          let h0' = update_addr h0 r (Ref a pcm Frac.full_perm x) in
+          let h0' = update_addr h0 addr (Ref a pcm Frac.full_perm x) in
           disjoint h0' hf /\
           interp (pts_to r x) h0' /\
           h' == join h0' hf /\
@@ -1298,7 +1309,7 @@ let extend #a #pcm x addr h =
          ))
        [SMTPat (interp emp h0);
         SMTPat (interp frame hf)]
-      = let h0' = update_addr h0 r (Ref a pcm Frac.full_perm x) in
+      = let h0' = update_addr h0 addr (Ref a pcm Frac.full_perm x) in
         // assert (disjoint h0' hf);
         // assert (interp (pts_to r x) h0');
         assert (mem_equiv h' (join h0' hf));
@@ -1431,5 +1442,5 @@ let elim_pure (p:prop)
 let pts_to_evolve (#a:Type u#a) (#pcm:_) (r:ref a pcm) (x y : a) (h:heap)
   : Lemma (requires (interp (pts_to r x) h /\ compatible pcm y x))
           (ensures  (interp (pts_to r y) h))
-  = let Ref a' pcm' _ v' = (select_addr h r) in
+  = let Ref a' pcm' _ v' = (select_addr h (Addr?._0 r)) in
     compatible_trans pcm y x v'

--- a/ulib/experimental/Steel.Heap.fsti
+++ b/ulib/experimental/Steel.Heap.fsti
@@ -260,6 +260,14 @@ val pts_to_compatible_equiv (#a:Type)
   : Lemma (equiv (pts_to x v0 `star` pts_to x v1)
                  (pts_to x (op pcm v0 v1)))
 
+val pts_to_not_null (#a:Type)
+                    (#pcm:_)
+                    (x:ref a pcm)
+                    (v:a)
+                    (m:heap)
+  : Lemma (requires interp (pts_to x v) m)
+          (ensures x =!= null)
+
 (***** Properties of separating conjunction *)
 
 (** The separating conjunction [star] arises from the disjointness of partial heaps *)

--- a/ulib/experimental/Steel.Heap.fsti
+++ b/ulib/experimental/Steel.Heap.fsti
@@ -42,6 +42,14 @@ val heap  : Type u#(a + 1)
 (** A [ref a pcm] is a key into the [heap], containing a value of type [a] governed by the [pcm] *)
 val ref (a:Type u#a) (pcm:pcm a) : Type u#0
 
+(** [null] is a specific reference, that is not associated to any value
+*)
+val null (#a:Type u#a) (#pcm:pcm a) : ref a pcm
+
+(** Checking whether [r] is the null pointer is decidable through [is_null]
+*)
+val is_null (#a:Type u#a) (#pcm:pcm a) (r:ref a pcm) : (b:bool{b <==> r == null})
+
 (** The predicate describing non-overlapping heaps *)
 val disjoint (h0 h1:heap u#h) : prop
 
@@ -373,7 +381,7 @@ let pre_action (fp:slprop u#a) (a:Type u#b) (fp':a -> slprop u#a) =
   - evolving the heap according to the heap preorder;
   - not allocating any new references;
   - preserving the validity of any heap proposition affecting any frame
-*)  
+*)
 unfold
 let action_related_heaps (frame:slprop) (h0 h1:full_heap) =
   heap_evolves h0 h1 /\

--- a/ulib/experimental/Steel.HigherReference.fst
+++ b/ulib/experimental/Steel.HigherReference.fst
@@ -106,6 +106,16 @@ let pts_to_ref_injective
                               (Some (Ghost.reveal v1, p1))
                               m
 
+let pts_to_not_null (#a:Type u#1)
+                    (r:ref a)
+                    (p:perm)
+                    (v: erased a)
+                    (m:mem)
+  : Lemma (requires interp (pts_to r p v) m)
+          (ensures r =!= null)
+  = Mem.affine_star (pts_to_raw r p v) (pure (perm_ok p)) m;
+    Mem.pts_to_not_null r (Some (Ghost.reveal v, p)) m
+
 let pts_to_witinv (#a:Type) (r:ref a) (p:perm) : Lemma (is_witness_invariant (pts_to r p)) =
   let aux (x y : erased a) (m:mem)
     : Lemma (requires (interp (pts_to r p x) m /\ interp (pts_to r p y) m))

--- a/ulib/experimental/Steel.HigherReference.fst
+++ b/ulib/experimental/Steel.HigherReference.fst
@@ -56,6 +56,8 @@ let pcm_frac #a : pcm (fractional a) = {
 module Mem = Steel.Memory
 
 let ref a = Mem.ref (fractional a) pcm_frac
+let null #a = Mem.null #(fractional a) #pcm_frac
+let is_null #a r = Mem.is_null #(fractional a) #pcm_frac r
 let perm_ok p : prop = (p.v <=. 1.0R == true) /\ True
 let pts_to_raw (#a:Type) (r:ref a) (p:perm) (v:erased a) = Mem.pts_to r (Some (Ghost.reveal v, p))
 let pts_to #a r p v = pts_to_raw r p v `star` pure (perm_ok p)

--- a/ulib/experimental/Steel.HigherReference.fsti
+++ b/ulib/experimental/Steel.HigherReference.fsti
@@ -23,6 +23,9 @@ open FStar.Ghost
 
 val ref (a:Type u#1) : Type u#0
 
+val null (#a:Type u#1) : ref a
+val is_null (#a:Type u#1) (r:ref a) : (b:bool{b <==> r == null})
+
 val pts_to (#a:Type u#1) (r:ref a) (p:perm) (v:erased a) : slprop u#1
 
 val pts_to_ref_injective

--- a/ulib/experimental/Steel.HigherReference.fsti
+++ b/ulib/experimental/Steel.HigherReference.fsti
@@ -39,6 +39,14 @@ val pts_to_ref_injective
         interp (pts_to r p0 v0 `star` pts_to r p1 v1) m)
       (ensures v0 == v1)
 
+val pts_to_not_null (#a:Type u#1)
+                    (x:ref a)
+                    (p:perm)
+                    (v: erased a)
+                    (m:mem)
+  : Lemma (requires interp (pts_to x p v) m)
+          (ensures x =!= null)
+
 val pts_to_witinv (#a:Type) (r:ref a) (p:perm) : Lemma (is_witness_invariant (pts_to r p))
 
 val alloc (#a:Type) (x:a)

--- a/ulib/experimental/Steel.Memory.fst
+++ b/ulib/experimental/Steel.Memory.fst
@@ -162,7 +162,8 @@ let pure_star_interp p q m = H.pure_star_interp p q (heap_of_mem m)
 ////////////////////////////////////////////////////////////////////////////////
 
 let pts_to_compatible x v0 v1 m = H.pts_to_compatible x v0 v1 (heap_of_mem m)
-let pts_to_compatible_equiv #a #pcm v0 v1 = H.pts_to_compatible_equiv v0 v1
+let pts_to_compatible_equiv #a #pcm x v0 v1 = H.pts_to_compatible_equiv x v0 v1
+let pts_to_not_null #a #pcm x v m = H.pts_to_not_null x v (heap_of_mem m)
 
 ////////////////////////////////////////////////////////////////////////////////
 // star

--- a/ulib/experimental/Steel.Memory.fst
+++ b/ulib/experimental/Steel.Memory.fst
@@ -82,6 +82,10 @@ let reveal_equiv p1 p2 = ()
 
 let ref = H.ref
 
+let null = H.null
+
+let is_null = H.is_null
+
 let emp : slprop u#a = H.emp
 let pure = H.pure
 let pts_to = H.pts_to

--- a/ulib/experimental/Steel.Memory.fsti
+++ b/ulib/experimental/Steel.Memory.fsti
@@ -99,6 +99,14 @@ let slimp (p1 p2 : slprop) : prop =
 (** A memory maps a [ref]erence to its associated value *)
 val ref (a:Type u#a) (pcm:pcm a) : Type u#0
 
+(** [null] is a specific reference, that is not associated to any value
+*)
+val null (#a:Type u#a) (#pcm:pcm a) : ref a pcm
+
+(** Checking whether [r] is the null pointer is decidable through [is_null]
+*)
+val is_null (#a:Type u#a) (#pcm:pcm a) (r:ref a pcm) : (b:bool{b <==> r == null})
+
 (** All the standard connectives of separation logic, based on [Steel.Heap] *)
 val emp : slprop u#a
 val pure (p:prop) : slprop u#a

--- a/ulib/experimental/Steel.Memory.fsti
+++ b/ulib/experimental/Steel.Memory.fsti
@@ -170,6 +170,14 @@ val pts_to_compatible_equiv (#a:Type)
   : Lemma (equiv (pts_to x v0 `star` pts_to x v1)
                  (pts_to x (op pcm v0 v1)))
 
+val pts_to_not_null (#a:Type u#a)
+                    (#pcm:_)
+                    (x:ref a pcm)
+                    (v:a)
+                    (m:mem u#a)
+  : Lemma (requires interp (pts_to x v) m)
+          (ensures x =!= null)
+
 (***** Properties of the separating conjunction *)
 
 /// See [Steel.Memory.Heap] for more explanations

--- a/ulib/experimental/Steel.Reference.fst
+++ b/ulib/experimental/Steel.Reference.fst
@@ -26,6 +26,9 @@ module A = Steel.Effect.Atomic
 
 let ref a = H.ref (U.raise_t a)
 
+let null #a = H.null #(U.raise_t a)
+let is_null #a r = H.is_null #(U.raise_t a) r
+
 let pts_to r p v = H.pts_to r p (hide (U.raise_val (reveal v)))
 
 val raise_val_inj (#a:Type) (x y:a) : Lemma

--- a/ulib/experimental/Steel.Reference.fst
+++ b/ulib/experimental/Steel.Reference.fst
@@ -39,6 +39,31 @@ let raise_val_inj x y =
   U.downgrade_val_raise_val x;
   U.downgrade_val_raise_val y
 
+let pts_to_ref_injective
+      (#a: Type u#0)
+      (r: ref a)
+      (p0 p1:perm)
+      (v0 v1: erased a)
+      (m:mem)
+    : Lemma
+      (requires
+        interp (pts_to r p0 v0 `star` pts_to r p1 v1) m)
+      (ensures v0 == v1)
+    = let v0' = hide (U.raise_val (reveal v0)) in
+      let v1' = hide (U.raise_val (reveal v1)) in
+      H.pts_to_ref_injective r p0 p1 v0' v1' m;
+      raise_val_inj (reveal v0) (reveal v1)
+
+let pts_to_not_null (#a:Type u#0)
+                    (x:ref a)
+                    (p:perm)
+                    (v: erased a)
+                    (m:mem)
+  : Lemma (requires interp (pts_to x p v) m)
+          (ensures x =!= null)
+  = let v = hide (U.raise_val (reveal v)) in
+    H.pts_to_not_null x p v m
+
 let pts_to_witinv (#a:Type) (r:ref a) (p:perm) : Lemma (is_witness_invariant (pts_to r p)) =
   let aux (x y : erased a) (m:mem)
     : Lemma (requires (interp (pts_to r p x) m /\ interp (pts_to r p y) m))

--- a/ulib/experimental/Steel.Reference.fsti
+++ b/ulib/experimental/Steel.Reference.fsti
@@ -28,6 +28,25 @@ val is_null (#a:Type u#0) (r:ref a) : (b:bool{b <==> r == null})
 
 val pts_to (#a:Type u#0) (r:ref a) (p:perm) (v:erased a) : slprop u#1
 
+val pts_to_ref_injective
+      (#a: Type u#0)
+      (r: ref a)
+      (p0 p1:perm)
+      (v0 v1: erased a)
+      (m:mem)
+    : Lemma
+      (requires
+        interp (pts_to r p0 v0 `star` pts_to r p1 v1) m)
+      (ensures v0 == v1)
+
+val pts_to_not_null (#a:Type u#0)
+                    (x:ref a)
+                    (p:perm)
+                    (v: erased a)
+                    (m:mem)
+  : Lemma (requires interp (pts_to x p v) m)
+          (ensures x =!= null)
+
 val pts_to_witinv (#a:Type) (r:ref a) (p:perm) : Lemma (is_witness_invariant (pts_to r p))
 
 val alloc (#a:Type) (x:a)

--- a/ulib/experimental/Steel.Reference.fsti
+++ b/ulib/experimental/Steel.Reference.fsti
@@ -23,6 +23,9 @@ open FStar.Ghost
 
 val ref (a:Type u#0) : Type u#0
 
+val null (#a:Type u#0) : ref a
+val is_null (#a:Type u#0) (r:ref a) : (b:bool{b <==> r == null})
+
 val pts_to (#a:Type u#0) (r:ref a) (p:perm) (v:erased a) : slprop u#1
 
 val pts_to_witinv (#a:Type) (r:ref a) (p:perm) : Lemma (is_witness_invariant (pts_to r p))


### PR DESCRIPTION
This PR proposes a simple model of the null pointer in Steel.

To preserve as much of the existing code and proofs as possible, references (defined in Steel.Heap) 
are extended to be an inductive type: either Null or an address in the heap.
Null is then propagated to Steel.Memory, Steel.HigherReference and Steel.Reference.

We've been discussing in the past about how null should be handled by separation logic assertions. This PR proposes the following: the validity of a pts_to predicate implies that the corresponding reference is not null.

For simplicity of the review, very little is currently exposed about the null pointer, only that there exists such a pointer that is a reference for any given type, and that checking whether a pointer is null is decidable (and exposed as a total function).

The current model would allow to remove several assumptions about null in examples on (doubly-)linked lists.

Ultimately, we will likely need a lemma specifying that the validity of pts_to implies that the pointer is not null.
We will also likely want a c_ptr separation logic assertion expressing that a pointer is either a `pts_to` or `null`, which would then be used in C APIs (to avoid implicitly assuming that a pointer is not null). This PR does not contain those, as they do not directly relate to the modeling of NULL.