### PR TITLE
Extracting FStar.Real constants

### DIFF
--- a/src/extraction/FStar.Extraction.ML.Util.fs
+++ b/src/extraction/FStar.Extraction.ML.Util.fs
@@ -48,6 +48,7 @@ let pruneNones (l : list<option<'a>>) : list<'a> =
 
 let mk_range_mle = with_ty MLTY_Top <| MLE_Name (["Prims"], "mk_range")
 let dummy_range_mle = with_ty MLTY_Top <| MLE_Name (["FStar"; "Range"], "dummyRange")
+let fstar_real_of_string = with_ty MLTY_Top <| MLE_Name (["FStar";"Real"], "of_string")
 
 (* private *)
 let mlconst_of_const' (sctt : sconst) =
@@ -101,6 +102,10 @@ let mlexpr_of_const (p:Range.range) (c:sconst) : mlexpr' =
     match c with
     | Const_range r ->
         mlexpr_of_range r
+
+    | Const_real s ->
+        let str = mlconst_of_const p (Const_string(s, p)) in
+        MLE_App(fstar_real_of_string, [with_ty ml_string_ty <| MLE_Const str])
 
     | _ ->
         MLE_Const (mlconst_of_const p c)

--- a/src/ocaml-output/FStar_Extraction_ML_Util.ml
+++ b/src/ocaml-output/FStar_Extraction_ML_Util.ml
@@ -20,6 +20,10 @@ let (dummy_range_mle : FStar_Extraction_ML_Syntax.mlexpr) =
   FStar_All.pipe_left
     (FStar_Extraction_ML_Syntax.with_ty FStar_Extraction_ML_Syntax.MLTY_Top)
     (FStar_Extraction_ML_Syntax.MLE_Name (["FStar"; "Range"], "dummyRange"))
+let (fstar_real_of_string : FStar_Extraction_ML_Syntax.mlexpr) =
+  FStar_All.pipe_left
+    (FStar_Extraction_ML_Syntax.with_ty FStar_Extraction_ML_Syntax.MLTY_Top)
+    (FStar_Extraction_ML_Syntax.MLE_Name (["FStar"; "Real"], "of_string"))
 let (mlconst_of_const' :
   FStar_Const.sconst -> FStar_Extraction_ML_Syntax.mlconstant) =
   fun sctt ->
@@ -127,6 +131,18 @@ let (mlexpr_of_const :
     fun c ->
       match c with
       | FStar_Const.Const_range r -> mlexpr_of_range r
+      | FStar_Const.Const_real s ->
+          let str = mlconst_of_const p (FStar_Const.Const_string (s, p)) in
+          let uu___ =
+            let uu___1 =
+              let uu___2 =
+                FStar_All.pipe_left
+                  (FStar_Extraction_ML_Syntax.with_ty
+                     FStar_Extraction_ML_Syntax.ml_string_ty)
+                  (FStar_Extraction_ML_Syntax.MLE_Const str) in
+              [uu___2] in
+            (fstar_real_of_string, uu___1) in
+          FStar_Extraction_ML_Syntax.MLE_App uu___
       | uu___ ->
           let uu___1 = mlconst_of_const p c in
           FStar_Extraction_ML_Syntax.MLE_Const uu___1

--- a/ulib/FStar.Real.fsti
+++ b/ulib/FStar.Real.fsti
@@ -28,6 +28,13 @@ val real : eqtype
 
 val of_int : int -> Tot real
 
+(**
+  Used to extract real constants; this function is
+  uninterpreted logically. i.e., 1.1R is extracted to
+  [of_string "1.1"]
+  *)
+val of_string: string -> Tot real
+
 val ( +. ) : real -> real -> Tot real
 val ( -. ) : real -> real -> Tot real
 val ( *. ) : real -> real -> Tot real


### PR DESCRIPTION
Thanks to @mateuszbujalski  for noticing.

Real constants are now extracted as `FStar.Real.of_string "..."`