### PR TITLE
Add requires/ensures to atomic effect

### DIFF
--- a/examples/steel/NewCanon.fst
+++ b/examples/steel/NewCanon.fst
@@ -108,39 +108,39 @@ let swap2 (#a:Type) (r0 r1:reference a) (v0 v1:erased a)
 
 open Steel.Effect.Atomic
 
-assume val alloc2 (x:int)  : SteelAtomic ref Set.empty observable emp (fun y -> ptr y)
-assume val free2 (r:ref) : SteelAtomic unit Set.empty observable (ptr r) (fun _ -> emp)
-assume val ghost_read (r:ref) : SteelAtomic int Set.empty unobservable (ptr r) (fun _ -> ptr r)
+assume val alloc2 (x:int)  : SteelAtomicT ref Set.empty observable emp (fun y -> ptr y)
+assume val free2 (r:ref) : SteelAtomicT unit Set.empty observable (ptr r) (fun _ -> emp)
+assume val ghost_read (r:ref) : SteelAtomicT int Set.empty unobservable (ptr r) (fun _ -> ptr r)
 
-let test21 (x:int) : SteelAtomic ref Set.empty observable emp ptr =
+let test21 (x:int) : SteelAtomicT ref Set.empty observable emp ptr =
   let y = alloc2 x in y
 
 [@expect_failure]
 // Cannot have two observable atomic computations
-let test22 (x:int) : SteelAtomic unit Set.empty observable emp (fun _ -> emp) =
+let test22 (x:int) : SteelAtomicT unit Set.empty observable emp (fun _ -> emp) =
   let y = alloc2 x in
   free2 y
 
-let test23 (r:ref) : SteelAtomic int Set.empty unobservable (ptr r) (fun _ -> ptr r)
+let test23 (r:ref) : SteelAtomicT int Set.empty unobservable (ptr r) (fun _ -> ptr r)
   = let x = ghost_read r in
     let y = ghost_read r in
     x
 
-let test24 (r:ref) : SteelAtomic ref Set.empty observable (ptr r) (fun y -> ptr r `star` ptr y)
+let test24 (r:ref) : SteelAtomicT ref Set.empty observable (ptr r) (fun y -> ptr r `star` ptr y)
   = let y = alloc2 0 in
     y
 
-let test25 (r1 r2:ref) : SteelAtomic ref Set.empty observable
+let test25 (r1 r2:ref) : SteelAtomicT ref Set.empty observable
     (ptr r1 `star` ptr r2) (fun y -> ptr r1 `star` ptr r2 `star` ptr y)
   = let y = alloc2 0 in
     y
 
 // Exercising subcomp on observability
-let test26 (r1 r2:ref) : SteelAtomic unit Set.empty observable (ptr r1 `star` ptr r2) (fun _ -> ptr r2 `star` ptr r1)
+let test26 (r1 r2:ref) : SteelAtomicT unit Set.empty observable (ptr r1 `star` ptr r2) (fun _ -> ptr r2 `star` ptr r1)
   = let _ = ghost_read r1 in
     ()
 
-let test27 (a:unit) : SteelAtomic ref Set.empty observable emp (fun y -> ptr y) =
+let test27 (a:unit) : SteelAtomicT ref Set.empty observable emp (fun y -> ptr y) =
   let x = alloc2 0 in
   let v = ghost_read x in
   x

--- a/ulib/experimental/Steel.Array.fsti
+++ b/ulib/experimental/Steel.Array.fsti
@@ -74,12 +74,12 @@ val join (#t:Type) (#p:perm) (#rl #rr:contents t) (al ar:array t)
           (fun _ _ _ -> True)
 
 val share (#t:Type) (#uses:_) (#p:perm) (#r:contents t) (a:array t) (i:U32.t { U32.v i < length r })
-  : SteelAtomic unit uses unobservable
+  : SteelAtomicT unit uses unobservable
            (is_array a p r)
            (fun _ -> is_array a (half_perm p) r `star` is_array a (half_perm p) r)
 
 val gather (#t:Type) (#uses:_) (#p #p':perm) (#r #r':contents t) (a:array t) (i:U32.t { U32.v i < length r })
-  : SteelAtomic unit uses unobservable
+  : SteelAtomicT unit uses unobservable
            (is_array a p r `star` is_array a p' r')
            (fun _ -> is_array a (sum_perm p p') r)
 

--- a/ulib/experimental/Steel.Effect.Atomic.fst
+++ b/ulib/experimental/Steel.Effect.Atomic.fst
@@ -35,7 +35,7 @@ let return (a:Type u#a)
    (x:a)
    (opened_invariants:inames)
    (#[@@ framing_implicit] p:a -> slprop u#1)
-  : atomic_repr a opened_invariants unobservable (p x) p
+  : atomic_repr a opened_invariants unobservable (p x) p (return_req (p x)) (return_ens a x p)
   = fun _ -> x
 
 #push-options "--fuel 0 --ifuel 0"
@@ -59,21 +59,10 @@ let interp_trans_left
           p2 `star` (frame `star` locks_invariant o m);
     }
 
-let bind (a:Type u#a) (b:Type u#b)
-   (opened:inames)
-   (o1:observability)
-   (o2:observability)
-   (#[@@ framing_implicit] pre_f:pre_t) (#[@@ framing_implicit] post_f:post_t a)
-   (#[@@ framing_implicit] pre_g:a -> pre_t) (#[@@ framing_implicit] post_g:a -> post_t b)
-   (#[@@ framing_implicit] post:post_t b)
-   (#[@@ framing_implicit] p1:squash (can_be_split_forall post_f pre_g))
-   (#[@@ framing_implicit] p2:squash (can_be_split_post post_g post))
-   (f:atomic_repr a opened o1 pre_f post_f)
-   (g:(x:a -> atomic_repr b opened o2 (pre_g x) (post_g x)))
-  : Pure (atomic_repr b opened (join_obs o1 o2) pre_f post)
-         (requires obs_at_most_one o1 o2)
-         (ensures fun _ -> True)
-  = fun frame ->
+let bind (a:Type u#a) (b:Type u#b) opened o1 o2
+   #pre_f #post_f #req_f #ens_f #pre_g #post_g #req_g #ens_g #post #p1 #p2
+   f g
+ = fun frame ->
     let m0:full_mem = NMSTTotal.get() in
     let x = f frame in
     let m1:full_mem = NMSTTotal.get() in
@@ -83,18 +72,8 @@ let bind (a:Type u#a) (b:Type u#b)
     interp_trans_left opened (post_g x y) (post y) frame m2;
     y
 
-let subcomp (a:Type)
-  (opened:inames)
-  (o1:observability)
-  (o2:observability)
-  (#[@@ framing_implicit] pre_f:pre_t) (#[@@ framing_implicit] post_f:post_t a)
-  (#[@@ framing_implicit] pre_g:pre_t) (#[@@ framing_implicit] post_g:post_t a)
-  (#[@@ framing_implicit] p1:squash (can_be_split pre_g pre_f))
-  (#[@@ framing_implicit] p2:squash (can_be_split_forall post_f post_g))
-  (f:atomic_repr a opened o1 pre_f post_f)
-: Pure (atomic_repr a opened o2 pre_g post_g)
-       (requires o1 == observable ==> o2 == observable)
-       (ensures fun _ -> True)
+let subcomp (a:Type) opened o1 o2
+  #pre_f #post_f #req_f #ens_f #pre_g #post_g #req_g #ens_g #p1 #p2 f
  = fun frame ->
      let m0:full_mem = NMSTTotal.get() in
      interp_trans_left opened pre_g pre_f frame m0;
@@ -108,25 +87,10 @@ let equiv_middle_left_assoc (a b c d:slprop)
   = star_associative a b c;
     star_congruence ((a `star` b) `star` c) d (a `star` (b `star` c)) d
 
-let bind_steela_steela (a:Type) (b:Type)
-  (opened:inames)
-  (o1:observability)
-  (o2:observability)
-  (#[@@ framing_implicit] pre_f:pre_t) (#[@@ framing_implicit] post_f:post_t a)
-  (#[@@ framing_implicit] pre_g:a -> pre_t) (#[@@ framing_implicit] post_g:a -> post_t b)
-  (#[@@ framing_implicit] frame_f:slprop) (#[@@ framing_implicit] frame_g:a -> slprop)
-  (#[@@ framing_implicit] post:post_t b)
-  (#[@@ framing_implicit] p:squash (can_be_split_forall
-    (fun x -> post_f x `star` frame_f) (fun x -> pre_g x `star` frame_g x)))
-  (#[@@ framing_implicit] p2:squash (can_be_split_post (fun x y -> post_g x y `star` frame_g x) post))
-  (f:atomic_repr a opened o1 pre_f post_f)
-  (g:(x:a -> atomic_repr b opened o2 (pre_g x) (post_g x)))
-: Pure (atomic_repr b opened (join_obs o1 o2)
-    (pre_f `star` frame_f)
-    post)
-    (requires obs_at_most_one o1 o2)
-    (ensures fun _ -> True)
-
+#push-options "--z3rlimit_factor 2"
+let bind_steela_steela a b opened o1 o2
+  #pre_f #post_f #req_f #ens_f #pre_g #post_g #req_g #ens_g #frame_f #frame_g #post #p #p2
+  f g
   = fun frame ->
     let m0:full_mem = NMSTTotal.get() in
     // Initially:
@@ -152,7 +116,6 @@ let bind_steela_steela (a:Type) (b:Type)
 
     let y = g x (frame_g x `star` frame) in
     let m2:full_mem = NMSTTotal.get() in
-
     // Post-condition of executing g
     assert (interp (post_g x y `star` (frame_g x `star` frame) `star` locks_invariant opened m2) m2);
     // By AC-rewriting
@@ -162,25 +125,10 @@ let bind_steela_steela (a:Type) (b:Type)
     interp_trans_left opened (post_g x y `star` frame_g x) (post y) frame m2;
 
     y
+#pop-options
 
-let bind_steela_steelaf (a:Type) (b:Type)
-  (opened:inames)
-  (o1:observability)
-  (o2:observability)
-  (#[@@ framing_implicit] pre_f:pre_t) (#[@@ framing_implicit] post_f:post_t a)
-  (#[@@ framing_implicit] pre_g:a -> pre_t) (#[@@ framing_implicit] post_g:a -> post_t b)
-  (#[@@ framing_implicit] frame_f:slprop)
-  (#[@@ framing_implicit] post:post_t b)
-  (#[@@ framing_implicit] p:squash (can_be_split_forall (fun x -> post_f x `star` frame_f) pre_g))
-  (#[@@ framing_implicit] p2:squash (can_be_split_post post_g post))
-  (f:atomic_repr a opened o1 pre_f post_f)
-  (g:(x:a -> atomic_repr b opened o2 (pre_g x) (post_g x)))
-: Pure (atomic_repr b opened (join_obs o1 o2)
-         (pre_f `star` frame_f)
-         post)
-       (requires obs_at_most_one o1 o2)
-       (ensures fun _ -> True)
-
+let bind_steela_steelaf a b opened o1 o2
+  #pre_f #post_f #req_f #ens_f #pre_g #post_g #req_g #ens_g #frame_f #post #p #p2 f g
   = fun frame ->
     let m0:full_mem = NMSTTotal.get() in
     // Initially
@@ -204,24 +152,8 @@ let bind_steela_steelaf (a:Type) (b:Type)
 
     y
 
-let bind_steelaf_steela (a:Type) (b:Type)
-  (opened:inames)
-  (o1:observability)
-  (o2:observability)
-  (#[@@ framing_implicit] pre_f:pre_t) (#[@@ framing_implicit] post_f:post_t a)
-  (#[@@ framing_implicit] pre_g:a -> pre_t) (#[@@ framing_implicit] post_g:a -> post_t b)
-  (#[@@ framing_implicit] frame_g:a -> slprop)
-  (#[@@ framing_implicit] post:post_t b)
-  (#[@@ framing_implicit] p:squash (can_be_split_forall post_f (fun x -> pre_g x `star` frame_g x)))
-  (#[@@ framing_implicit] p2:squash (can_be_split_post (fun x y -> post_g x y `star` frame_g x) post))
-  (f:atomic_repr a opened o1 pre_f post_f)
-  (g:(x:a -> atomic_repr b opened o2 (pre_g x) (post_g x)))
-: Pure (atomic_repr b opened (join_obs o1 o2)
-        pre_f
-        post)
-    (requires obs_at_most_one o1 o2)
-    (ensures fun _ -> True)
-
+let bind_steelaf_steela (a:Type) (b:Type) opened o1 o2
+  #pre_f #post_f #req_f #ens_f #pre_g #post_g #req_g #ens_g #frame_g #post #p #p2 f g
   = fun frame ->
     let m0:full_mem = NMSTTotal.get() in
     let x = f frame in
@@ -247,38 +179,16 @@ let bind_steelaf_steela (a:Type) (b:Type)
 
     y
 
-let bind_pure_steela_ (a:Type) (b:Type)
-  (opened_invariants:inames)
-  (o:observability)
-  (wp:pure_wp a)
-  (#[@@ framing_implicit] pre:pre_t) (#[@@ framing_implicit] post:post_t b)
-  (f:eqtype_as_type unit -> PURE a wp) (g:(x:a -> atomic_repr b opened_invariants o pre post))
-: Pure (atomic_repr b opened_invariants o
-    pre
-    post)
-  (requires wp (fun _ -> True))
-  (ensures fun _ -> True)
-  = fun frame ->
+let bind_pure_steela_ (a:Type) (b:Type) opened o wp #pre #post #req #ens f g
+= fun frame ->
     let x = f () in
     g x frame
 
 module Sems = Steel.Semantics.Hoare.MST
 module Ins = Steel.Semantics.Instantiate
 
-let bind_steelatomicf_steelf (a:Type) (b:Type)
-  (is_ghost:observability)
-  (#[@@ framing_implicit] pre_f:pre_t) (#[@@ framing_implicit] post_f:post_t a)
-  (#[@@ framing_implicit] pre_g:a -> pre_t) (#[@@ framing_implicit] post_g:a -> post_t b)
-  (#[@@ framing_implicit] req_g:(x:a -> req_t (pre_g x)))
-  (#[@@ framing_implicit] ens_g:(x:a -> ens_t (pre_g x) b (post_g x)))
-  (#[@@ framing_implicit] post:post_t b)
-  (#[@@ framing_implicit] p1:squash (can_be_split_forall post_f pre_g))
-  (#[@@ framing_implicit] p2:squash (can_be_split_post post_g post))
-  (f:atomic_repr a Set.empty is_ghost pre_f post_f)
-  (g:(x:a -> Steel.Effect.repr b (pre_g x) (post_g x) (req_g x) (ens_g x)))
-: Steel.Effect.repr b pre_f post
-    (bind_req_atomicf_steelf req_g)
-    (bind_ens_atomicf_steelf ens_g post p2)
+let bind_steelatomicf_steelf (a:Type) (b:Type) is_ghost
+  #pre_f #post_f #req_f #ens_f #pre_g #post_g #req_g #ens_g #post #p1 #p2 f g
 = fun frame ->
     let m0:full_mem = NMSTTotal.get() in
     let x = f frame in
@@ -289,23 +199,8 @@ let bind_steelatomicf_steelf (a:Type) (b:Type)
     interp_trans_left Set.empty (post_g x y) (post y) frame m2;
     y
 
-let bind_steelatomic_steelf (a:Type) (b:Type)
-  (o:observability)
-  (#[@@ framing_implicit] pre_f:pre_t) (#[@@ framing_implicit] post_f:post_t a)
-  (#[@@ framing_implicit] pre_g:a -> pre_t) (#[@@ framing_implicit] post_g:a -> post_t b)
-  (#[@@ framing_implicit] req_g:(x:a -> req_t (pre_g x)))
-  (#[@@ framing_implicit] ens_g:(x:a -> ens_t (pre_g x) b (post_g x)))
-  (#[@@ framing_implicit] frame_f:slprop)
-  (#[@@ framing_implicit] post:post_t b)
-  (#[@@ framing_implicit] p:squash (can_be_split_forall (fun x -> post_f x `star` frame_f) pre_g))
-  (#[@@ framing_implicit] p2: squash (can_be_split_post post_g post))
-  (f:atomic_repr a Set.empty o pre_f post_f)
-  (g:(x:a -> Steel.Effect.repr b (pre_g x) (post_g x) (req_g x) (ens_g x)))
-: Steel.Effect.repr b
-    (pre_f `star` frame_f)
-    post
-    (bind_steelatomic_steelf_req req_g frame_f p)
-    (bind_steelatomic_steelf_ens ens_g frame_f post p p2)
+let bind_steelatomic_steelf (a:Type) (b:Type) o
+  #pre_f #post_f #req_f #ens_f #pre_g #post_g #req_g #ens_g #frame_f #post #p #p2 f g
 = fun frame ->
     let m0:full_mem = NMST.get() in
 
@@ -331,24 +226,8 @@ let bind_steelatomic_steelf (a:Type) (b:Type)
 
 #push-options "--z3rlimit 50"
 
-let bind_steelatomic_steel (a:Type) (b:Type)
-  (o:observability)
-  (#[@@ framing_implicit] pre_f:pre_t) (#[@@ framing_implicit] post_f:post_t a)
-  (#[@@ framing_implicit] pre_g:a -> pre_t) (#[@@ framing_implicit] post_g:a -> post_t b)
-  (#[@@ framing_implicit] req_g:(x:a -> req_t (pre_g x)))
-  (#[@@ framing_implicit] ens_g:(x:a -> ens_t (pre_g x) b (post_g x)))
-  (#[@@ framing_implicit] frame_f:slprop) (#[@@ framing_implicit] frame_g:a -> slprop)
-  (#[@@ framing_implicit] post:post_t b)
-  (#[@@ framing_implicit] p:squash (can_be_split_forall
-    (fun x -> post_f x `star` frame_f) (fun x -> pre_g x `star` frame_g x)))
-  (#[@@ framing_implicit] p2:squash (can_be_split_post (fun x y -> post_g x y `star` frame_g x) post))
-  (f:atomic_repr a Set.empty o pre_f post_f)
-  (g:(x:a -> Steel.Effect.repr b (pre_g x) (post_g x) (req_g x) (ens_g x)))
-: Steel.Effect.repr b
-    (pre_f `star` frame_f)
-    post
-    (bind_steelatomic_steel_req req_g frame_f frame_g p)
-    (bind_steelatomic_steel_ens ens_g frame_f frame_g post p p2)
+let bind_steelatomic_steel (a:Type) (b:Type) o
+  #pre_f #post_f #req_f #ens_f #pre_g #post_g #req_g #ens_g #frame_f #frame_g #post #p #p2 f g
 = fun frame ->
     let m0:full_mem = NMST.get() in
 
@@ -385,18 +264,23 @@ let bind_steelatomic_steel (a:Type) (b:Type)
 
 #pop-options
 
-let subcomp_atomic_steel (a:Type)
-  (#[@@framing_implicit] pre_f:pre_t) (#[@@ framing_implicit] post_f:post_t a) (is_ghost:observability)
-  (f:atomic_repr a Set.empty is_ghost pre_f post_f)
-: Steel.Effect.repr a pre_f post_f (subcomp_req_atomic_steel a pre_f) (subcomp_ens_atomic_steel pre_f post_f)
-= fun frame -> f frame
+let subcomp_atomic_steel (a:Type) is_ghost
+  #pre_f #post_f #req_f #ens_f #pre_g #post_g #req_g #ens_g #p1 #p2 f
+  = fun frame ->
+     let m0:full_mem = NMSTTotal.get() in
+     interp_trans_left Set.empty pre_g pre_f frame m0;
+     let x = f frame in
+     let m1:full_mem = NMSTTotal.get () in
+     interp_trans_left Set.empty (post_f x) (post_g x) frame m1;
+     x
 
-let lift_atomic_to_steelT f = f()
 let as_atomic_action f = SteelAtomic?.reflect f
 let new_invariant i p = SteelAtomic?.reflect (Steel.Memory.new_invariant i p)
-let with_invariant i f = SteelAtomic?.reflect (Steel.Memory.with_invariant i (reify (f())))
+let with_invariant #a #fp #fp' #opened i f =
+  SteelAtomic?.reflect (Steel.Memory.with_invariant #a #fp #fp' #opened i (reify (f())))
 let frame frame f = SteelAtomic?.reflect (Steel.Memory.frame frame (reify (f ())))
-let change_slprop p q proof = SteelAtomic?.reflect (Steel.Memory.change_slprop p q proof)
+let change_slprop #opened p q proof =
+  SteelAtomic?.reflect (Steel.Memory.change_slprop #opened p q proof)
 
 let h_assert_atomic p = change_slprop p p (fun m -> ())
 let h_intro_emp_l p = change_slprop p (emp `star` p) (fun m -> emp_unit p; star_commutative p emp)
@@ -412,7 +296,7 @@ let h_affine p q = change_slprop (p `star` q) p (fun m -> affine_star p q m)
 // open NMSTTotal
 // open MSTTotal
 
-let witness_h_exists #a #u #p s = SteelAtomic?.reflect (Steel.Memory.witness_h_exists p)
+let witness_h_exists #a #u #p s = SteelAtomic?.reflect (Steel.Memory.witness_h_exists #u p)
 let lift_h_exists_atomic #a #u p = SteelAtomic?.reflect (Steel.Memory.lift_h_exists #u p)
 let h_exists_cong_atomic p q = change_slprop (h_exists p) (h_exists q) (fun m -> h_exists_cong p q)
 let elim_pure #uses p = SteelAtomic?.reflect (Steel.Memory.elim_pure #uses p)

--- a/ulib/experimental/Steel.Effect.Atomic.fsti
+++ b/ulib/experimental/Steel.Effect.Atomic.fsti
@@ -41,40 +41,95 @@ val atomic_repr (a:Type u#a)
    (g:observability)
    (pre:slprop u#1)
    (post:a -> slprop u#1)
+   (req:req_t pre)
+   (ens:ens_t pre a post)
   : Type u#(max a 2)
+
+unfold
+let return_req (p:slprop u#1) : req_t p = fun _ -> True
+
+unfold
+let return_ens (a:Type) (x:a) (p:a -> slprop u#1) : ens_t (p x) a p = fun _ r _ -> r == x
 
 val return (a:Type u#a)
    (x:a)
    (opened_invariants:inames)
    (#[@@ framing_implicit] p:a -> slprop u#1)
-  : atomic_repr a opened_invariants unobservable (return_pre (p x)) (return_post p)
+  : atomic_repr a opened_invariants unobservable
+                (return_pre (p x)) (return_post p)
+                (return_req (p x)) (return_ens a x p)
+
+unfold
+let bind_req (#a:Type)
+  (#pre_f:pre_t) (#post_f:post_t a)
+  (req_f:req_t pre_f) (ens_f:ens_t pre_f a post_f)
+  (#pre_g:a -> pre_t)
+  (req_g:(x:a -> req_t (pre_g x)))
+  (_:squash (can_be_split_forall post_f pre_g))
+: req_t pre_f
+= fun m0 ->
+  req_f m0 /\
+  (forall (x:a) (m1:hmem (post_f x)). ens_f m0 x m1 ==> (req_g x) m1)
+
+unfold
+let bind_ens (#a:Type) (#b:Type)
+  (#pre_f:pre_t) (#post_f:post_t a)
+  (req_f:req_t pre_f) (ens_f:ens_t pre_f a post_f)
+  (#pre_g:a -> pre_t) (#post_g:a -> post_t b)
+  (ens_g:(x:a -> ens_t (pre_g x) b (post_g x)))
+  (post:post_t b)
+  (_:squash (can_be_split_forall post_f pre_g))
+  (_:squash (can_be_split_post post_g post))
+: ens_t pre_f b post
+= fun m0 y m2 ->
+  req_f m0 /\
+  (exists (x:a) (m1:hmem (post_f x)). ens_f m0 x m1 /\ (ens_g x) m1 y m2)
 
 val bind (a:Type u#a) (b:Type u#b)
    (opened_invariants:inames)
    (o1:observability)
    (o2:observability)
    (#[@@ framing_implicit] pre_f:pre_t) (#[@@ framing_implicit] post_f:post_t a)
+   (#[@@ framing_implicit] req_f:req_t pre_f) (#[@@ framing_implicit] ens_f:ens_t pre_f a post_f)
    (#[@@ framing_implicit] pre_g:a -> pre_t) (#[@@ framing_implicit] post_g:a -> post_t b)
+   (#[@@ framing_implicit] req_g:(x:a -> req_t (pre_g x))) (#[@@ framing_implicit] ens_g:(x:a -> ens_t (pre_g x) b (post_g x)))
    (#[@@ framing_implicit] post:post_t b)
    (#[@@ framing_implicit] p1:squash (can_be_split_forall post_f pre_g))
    (#[@@ framing_implicit] p2:squash (can_be_split_post post_g post))
-   (f:atomic_repr a opened_invariants o1 pre_f post_f)
-   (g:(x:a -> atomic_repr b opened_invariants o2 (pre_g x) (post_g x)))
-  : Pure (atomic_repr b opened_invariants (join_obs o1 o2) pre_f post)
+   (f:atomic_repr a opened_invariants o1 pre_f post_f req_f ens_f)
+   (g:(x:a -> atomic_repr b opened_invariants o2 (pre_g x) (post_g x) (req_g x) (ens_g x)))
+  : Pure (atomic_repr b opened_invariants (join_obs o1 o2)
+                      pre_f post
+                      (bind_req req_f ens_f req_g p1)
+                      (bind_ens req_f ens_f ens_g post p1 p2)
+                      )
          (requires obs_at_most_one o1 o2)
          (ensures fun _ -> True)
+
+unfold
+let subcomp_pre (#a:Type)
+  (#pre_f:pre_t) (#post_f:post_t a) (req_f:req_t pre_f) (ens_f:ens_t pre_f a post_f)
+  (#pre_g:pre_t) (#post_g:post_t a) (req_g:req_t pre_g) (ens_g:ens_t pre_g a post_g)
+  (_:squash (can_be_split pre_g pre_f))
+  (_:squash (can_be_split_forall post_f post_g))
+: pure_pre
+= (forall (m0:hmem pre_g). req_g m0 ==> req_f m0) /\
+  (forall (m0:hmem pre_g) (x:a) (m1:hmem (post_f x)). ens_f m0 x m1 ==> ens_g m0 x m1)
 
 val subcomp (a:Type)
   (opened_invariants:inames)
   (o1:observability)
   (o2:observability)
   (#[@@ framing_implicit] pre_f:pre_t) (#[@@ framing_implicit] post_f:post_t a)
+  (#[@@ framing_implicit] req_f:req_t pre_f) (#[@@ framing_implicit] ens_f:ens_t pre_f a post_f)
   (#[@@ framing_implicit] pre_g:pre_t) (#[@@ framing_implicit] post_g:post_t a)
+  (#[@@ framing_implicit] req_g:req_t pre_g) (#[@@ framing_implicit] ens_g:ens_t pre_g a post_g)
   (#[@@ framing_implicit] p1:squash (can_be_split pre_g pre_f))
   (#[@@ framing_implicit] p2:squash (can_be_split_forall post_f post_g))
-  (f:atomic_repr a opened_invariants o1 pre_f post_f)
-: Pure (atomic_repr a opened_invariants o2 pre_g post_g)
-       (requires o1 == observable ==> o2 == observable)
+  (f:atomic_repr a opened_invariants o1 pre_f post_f req_f ens_f)
+: Pure (atomic_repr a opened_invariants o2 pre_g post_g req_g ens_g)
+       (requires (o1 == observable ==> o2 == observable) /\
+         subcomp_pre req_f ens_f req_g ens_g p1 p2)
        (ensures fun _ -> True)
 
 // let if_then_else (a:Type)
@@ -96,6 +151,8 @@ layered_effect {
               -> o:observability
               -> pre:slprop u#1
               -> post:(a -> slprop u#1)
+              -> req:req_t pre
+              -> ens:ens_t pre a post
               -> Effect
   with
   repr = atomic_repr;
@@ -110,76 +167,195 @@ total
 reifiable reflectable
 new_effect SteelAtomic = SteelAtomicF
 
+unfold
+let bind_steela_steela_req (#a:Type)
+  (#pre_f:pre_t) (#post_f:post_t a)
+  (req_f:req_t pre_f) (ens_f:ens_t pre_f a post_f)
+  (#pre_g:a -> pre_t)
+  (req_g:(x:a -> req_t (pre_g x)))
+  (frame_f:slprop) (frame_g:a -> slprop)
+  (_:squash (can_be_split_forall (fun x -> post_f x `star` frame_f) (fun x -> pre_g x `star` frame_g x)))
+: req_t (pre_f `star` frame_f)
+= fun m0 ->
+  req_f m0 /\
+  (forall (x:a) (m1:hmem (post_f x `star` frame_f)). ens_f m0 x m1 ==> (req_g x) m1)
+
+unfold
+let bind_steela_steela_ens (#a:Type) (#b:Type)
+  (#pre_f:pre_t) (#post_f:post_t a)
+  (req_f:req_t pre_f) (ens_f:ens_t pre_f a post_f)
+  (#pre_g:a -> pre_t) (#post_g:a -> post_t b)
+  (ens_g:(x:a -> ens_t (pre_g x) b (post_g x)))
+  (frame_f:slprop) (frame_g:a -> slprop)
+  (post:post_t b)
+  (_:squash (can_be_split_forall (fun x -> post_f x `star` frame_f) (fun x -> pre_g x `star` frame_g x)))
+  (_:squash (can_be_split_post (fun x y -> post_g x y `star` frame_g x) post))
+: ens_t (pre_f `star` frame_f) b post
+= fun m0 y m2 ->
+  req_f m0 /\
+  (exists (x:a) (m1:hmem (post_f x `star` frame_f)). ens_f m0 x m1 /\ (ens_g x) m1 y m2)
+
 val bind_steela_steela (a:Type) (b:Type)
   (opened_invariants:inames)
   (o1:observability)
   (o2:observability)
   (#[@@ framing_implicit] pre_f:pre_t) (#[@@ framing_implicit] post_f:post_t a)
+  (#[@@ framing_implicit] req_f:req_t pre_f) (#[@@ framing_implicit] ens_f:ens_t pre_f a post_f)
   (#[@@ framing_implicit] pre_g:a -> pre_t) (#[@@ framing_implicit] post_g:a -> post_t b)
+  (#[@@ framing_implicit] req_g:(x:a -> req_t (pre_g x))) (#[@@ framing_implicit] ens_g:(x:a -> ens_t (pre_g x) b (post_g x)))
   (#[@@ framing_implicit] frame_f:slprop) (#[@@ framing_implicit] frame_g:a -> slprop)
   (#[@@ framing_implicit] post:post_t b)
   (#[@@ framing_implicit] p:squash (can_be_split_forall
     (fun x -> post_f x `star` frame_f) (fun x -> pre_g x `star` frame_g x)))
   (#[@@ framing_implicit] p2:squash (can_be_split_post (fun x y -> post_g x y `star` frame_g x) post))
-  (f:atomic_repr a opened_invariants o1 pre_f post_f)
-  (g:(x:a -> atomic_repr b opened_invariants o2 (pre_g x) (post_g x)))
+  (f:atomic_repr a opened_invariants o1 pre_f post_f req_f ens_f)
+  (g:(x:a -> atomic_repr b opened_invariants o2 (pre_g x) (post_g x) (req_g x) (ens_g x)))
 : Pure (atomic_repr b opened_invariants (join_obs o1 o2)
-    (pre_f `star` frame_f)
-    post)
+      (pre_f `star` frame_f)
+      post
+      (bind_steela_steela_req req_f ens_f req_g frame_f frame_g p)
+      (bind_steela_steela_ens req_f ens_f ens_g frame_f frame_g post p p2)
+    )
     (requires obs_at_most_one o1 o2)
     (ensures fun _ -> True)
 
 polymonadic_bind (SteelAtomic, SteelAtomic) |> SteelAtomicF = bind_steela_steela
+
+unfold
+let bind_steela_steelaf_req (#a:Type)
+  (#pre_f:pre_t) (#post_f:post_t a)
+  (req_f:req_t pre_f) (ens_f:ens_t pre_f a post_f)
+  (#pre_g:a -> pre_t)
+  (req_g:(x:a -> req_t (pre_g x)))
+  (frame_f:slprop)
+  (_:squash (can_be_split_forall (fun x -> post_f x `star` frame_f) pre_g))
+: req_t (pre_f `star` frame_f)
+= fun m0 ->
+  req_f m0 /\
+  (forall (x:a) (m1:hmem (post_f x `star` frame_f)). ens_f m0 x m1 ==> (req_g x) m1)
+
+unfold
+let bind_steela_steelaf_ens (#a:Type) (#b:Type)
+  (#pre_f:pre_t) (#post_f:post_t a)
+  (req_f:req_t pre_f) (ens_f:ens_t pre_f a post_f)
+  (#pre_g:a -> pre_t) (#post_g:a -> post_t b)
+  (ens_g:(x:a -> ens_t (pre_g x) b (post_g x)))
+  (frame_f:slprop)
+  (post:post_t b)
+  (_:squash (can_be_split_forall (fun x -> post_f x `star` frame_f) pre_g))
+  (_: squash (can_be_split_post post_g post))
+: ens_t (pre_f `star` frame_f) b post
+= fun m0 y m2 ->
+  req_f m0 /\
+  (exists (x:a) (m1:hmem (post_f x `star` frame_f)). ens_f m0 x m1 /\ (ens_g x) m1 y m2)
+
 
 val bind_steela_steelaf (a:Type) (b:Type)
   (opened_invariants:inames)
   (o1:observability)
   (o2:observability)
   (#[@@ framing_implicit] pre_f:pre_t) (#[@@ framing_implicit] post_f:post_t a)
+  (#[@@ framing_implicit] req_f:req_t pre_f) (#[@@ framing_implicit] ens_f:ens_t pre_f a post_f)
   (#[@@ framing_implicit] pre_g:a -> pre_t) (#[@@ framing_implicit] post_g:a -> post_t b)
+  (#[@@ framing_implicit] req_g:(x:a -> req_t (pre_g x))) (#[@@ framing_implicit] ens_g:(x:a -> ens_t (pre_g x) b (post_g x)))
   (#[@@ framing_implicit] frame_f:slprop)
   (#[@@ framing_implicit] post:post_t b)
   (#[@@ framing_implicit] p:squash (can_be_split_forall (fun x -> post_f x `star` frame_f) pre_g))
   (#[@@ framing_implicit] p2:squash (can_be_split_post post_g post))
-  (f:atomic_repr a opened_invariants o1 pre_f post_f)
-  (g:(x:a -> atomic_repr b opened_invariants o2 (pre_g x) (post_g x)))
+  (f:atomic_repr a opened_invariants o1 pre_f post_f req_f ens_f)
+  (g:(x:a -> atomic_repr b opened_invariants o2 (pre_g x) (post_g x) (req_g x) (ens_g x)))
 : Pure (atomic_repr b opened_invariants (join_obs o1 o2)
          (pre_f `star` frame_f)
-         post)
+         post
+        (bind_steela_steelaf_req req_f ens_f req_g frame_f p)
+        (bind_steela_steelaf_ens req_f ens_f ens_g frame_f post p p2)
+       )
        (requires obs_at_most_one o1 o2)
        (ensures fun _ -> True)
 
 polymonadic_bind (SteelAtomic, SteelAtomicF) |> SteelAtomicF = bind_steela_steelaf
+
+unfold
+let bind_steelaf_steela_req (#a:Type)
+  (#pre_f:pre_t) (#post_f:post_t a)
+  (req_f:req_t pre_f) (ens_f:ens_t pre_f a post_f)
+  (#pre_g:a -> pre_t)
+  (req_g:(x:a -> req_t (pre_g x)))
+  (frame_g:a -> slprop)
+  (_:squash (can_be_split_forall post_f (fun x -> pre_g x `star` frame_g x)))
+: req_t pre_f
+= fun m0 ->
+  req_f m0 /\
+  (forall (x:a) (m1:hmem (post_f x)). ens_f m0 x m1 ==> (req_g x) m1)
+
+unfold
+let bind_steelaf_steela_ens (#a:Type) (#b:Type)
+  (#pre_f:pre_t) (#post_f:post_t a)
+  (req_f:req_t pre_f) (ens_f:ens_t pre_f a post_f)
+  (#pre_g:a -> pre_t) (#post_g:a -> post_t b)
+  (ens_g:(x:a -> ens_t (pre_g x) b (post_g x)))
+  (frame_g:a -> slprop)
+  (post:post_t b)
+  (_:squash (can_be_split_forall post_f (fun x -> pre_g x `star` frame_g x)))
+  (_:squash (can_be_split_post (fun x y -> post_g x y `star` frame_g x) post))
+: ens_t pre_f b post
+= fun m0 y m2 ->
+  req_f m0 /\
+  (exists (x:a) (m1:hmem (post_f x)). ens_f m0 x m1 /\ (ens_g x) m1 y m2)
 
 val bind_steelaf_steela (a:Type) (b:Type)
   (opened_invariants:inames)
   (o1:observability)
   (o2:observability)
   (#[@@ framing_implicit] pre_f:pre_t) (#[@@ framing_implicit] post_f:post_t a)
+  (#[@@ framing_implicit] req_f:req_t pre_f) (#[@@ framing_implicit] ens_f:ens_t pre_f a post_f)
   (#[@@ framing_implicit] pre_g:a -> pre_t) (#[@@ framing_implicit] post_g:a -> post_t b)
+  (#[@@ framing_implicit] req_g:(x:a -> req_t (pre_g x))) (#[@@ framing_implicit] ens_g:(x:a -> ens_t (pre_g x) b (post_g x)))
   (#[@@ framing_implicit] frame_g:a -> slprop)
   (#[@@ framing_implicit] post:post_t b)
   (#[@@ framing_implicit] p:squash (can_be_split_forall post_f (fun x -> pre_g x `star` frame_g x)))
   (#[@@ framing_implicit] p2:squash (can_be_split_post (fun x y -> post_g x y `star` frame_g x) post))
-  (f:atomic_repr a opened_invariants o1 pre_f post_f)
-  (g:(x:a -> atomic_repr b opened_invariants o2 (pre_g x) (post_g x)))
+  (f:atomic_repr a opened_invariants o1 pre_f post_f req_f ens_f)
+  (g:(x:a -> atomic_repr b opened_invariants o2 (pre_g x) (post_g x) (req_g x) (ens_g x)))
 : Pure (atomic_repr b opened_invariants (join_obs o1 o2)
-        pre_f
-        post)
+          pre_f
+          post
+         (bind_steelaf_steela_req req_f ens_f req_g frame_g p)
+         (bind_steelaf_steela_ens req_f ens_f ens_g frame_g post p p2)
+        )
     (requires obs_at_most_one o1 o2)
     (ensures fun _ -> True)
 
 polymonadic_bind (SteelAtomicF, SteelAtomic) |> SteelAtomicF = bind_steelaf_steela
+
+unfold
+let bind_pure_steela__req (#a:Type) (wp:pure_wp a)
+  (#pre:pre_t) (req:a -> req_t pre)
+: req_t pre
+= fun m -> wp (fun x -> (req x) m) /\ as_requires wp
+
+unfold
+let bind_pure_steela__ens (#a:Type) (#b:Type)
+  (wp:pure_wp a)
+  (#pre:pre_t) (#post:post_t b) (ens:a -> ens_t pre b post)
+: ens_t pre b post
+= fun m0 r m1 -> as_requires wp /\ (exists (x:a). as_ensures wp x /\ (ens x) m0 r m1)
+
 
 val bind_pure_steela_ (a:Type) (b:Type)
   (opened_invariants:inames)
   (o:observability)
   (wp:pure_wp a)
   (#[@@ framing_implicit] pre:pre_t) (#[@@ framing_implicit] post:post_t b)
-  (f:eqtype_as_type unit -> PURE a wp) (g:(x:a -> atomic_repr b opened_invariants o pre post))
+  (#[@@ framing_implicit] req:a -> req_t pre) (#[@@ framing_implicit] ens:a -> ens_t pre b post)
+  (f:eqtype_as_type unit -> PURE a wp)
+  (g:(x:a -> atomic_repr b opened_invariants o pre post (req x) (ens x)))
 : Pure (atomic_repr b opened_invariants o
     pre
-    post)
+    post
+    (bind_pure_steela__req wp req)
+    (bind_pure_steela__ens wp ens)
+  )
   (requires wp (fun _ -> True))
   (ensures fun _ -> True)
 
@@ -189,69 +365,33 @@ polymonadic_bind (PURE, SteelAtomic) |> SteelAtomic = bind_pure_steela_
 
 polymonadic_subcomp SteelAtomicF <: SteelAtomic = subcomp
 
+effect SteelAtomicT (a:Type) (opened:inames) (o:observability) (pre:pre_t) (post:post_t a) =
+  SteelAtomic a opened o pre post (fun _ -> True) (fun _ _ _ -> True)
+
 (***** Bind and Subcomp relation with Steel.Atomic *****)
-
-unfold
-let bind_req_atomicf_steelf (#a:Type) (#pre_f:pre_t) (#post_f:post_t a) (req_g:(x:a -> req_t (post_f x)))
-: req_t pre_f
-= fun _ -> forall (x:a) h1. req_g x h1
-
-unfold
-let bind_ens_atomicf_steelf (#a:Type) (#b:Type)
-  (#pre_f:pre_t)
-  (#pre_g:a -> pre_t)
-  (#post_g:a -> post_t b)
-  (ens_g:(x:a -> ens_t (pre_g x) b (post_g x)))
-  (post:post_t b)
-  (_:squash (can_be_split_post post_g post))
-: ens_t pre_f b post
-= fun _ y h2 -> exists x h1. (ens_g x) h1 y h2
 
 val bind_steelatomicf_steelf (a:Type) (b:Type)
   (is_ghost:observability)
   (#[@@ framing_implicit] pre_f:pre_t) (#[@@ framing_implicit] post_f:post_t a)
+  (#[@@ framing_implicit] req_f:req_t pre_f) (#[@@ framing_implicit] ens_f:ens_t pre_f a post_f)
   (#[@@ framing_implicit] pre_g:a -> pre_t) (#[@@ framing_implicit] post_g:a -> post_t b)
   (#[@@ framing_implicit] req_g:(x:a -> req_t (pre_g x)))
   (#[@@ framing_implicit] ens_g:(x:a -> ens_t (pre_g x) b (post_g x)))
   (#[@@ framing_implicit] post:post_t b)
   (#[@@ framing_implicit] p1:squash (can_be_split_forall post_f pre_g))
   (#[@@ framing_implicit] p2:squash (can_be_split_post post_g post))
-  (f:atomic_repr a Set.empty is_ghost pre_f post_f)
+  (f:atomic_repr a Set.empty is_ghost pre_f post_f req_f ens_f)
   (g:(x:a -> Steel.Effect.repr b (pre_g x) (post_g x) (req_g x) (ens_g x)))
 : Steel.Effect.repr b pre_f post
-    (bind_req_atomicf_steelf req_g)
-    (bind_ens_atomicf_steelf ens_g post p2)
+    (bind_req req_f ens_f req_g p1)
+    (bind_ens req_f ens_f ens_g post p1 p2)
 
 polymonadic_bind (SteelAtomicF, Steel.Effect.SteelF) |> Steel.Effect.SteelF = bind_steelatomicf_steelf
-
-
-unfold
-let bind_steelatomic_steelf_req (#a:Type)
-  (#pre_f:pre_t) (#post_f:post_t a)
-  (#pre_g:a -> pre_t)
-  (req_g:(x:a -> req_t (pre_g x)))
-  (frame_f:slprop)
-  (_:squash (can_be_split_forall (fun x -> post_f x `star` frame_f) pre_g))
-: req_t (pre_f `star` frame_f)
-= fun m0 ->
-  (forall (x:a) (m1:hmem (post_f x `star` frame_f)). (req_g x) m1)
-
-unfold
-let bind_steelatomic_steelf_ens (#a:Type) (#b:Type)
-  (#pre_f:pre_t) (#post_f:post_t a)
-  (#pre_g:a -> pre_t) (#post_g:a -> post_t b)
-  (ens_g:(x:a -> ens_t (pre_g x) b (post_g x)))
-  (frame_f:slprop)
-  (post:post_t b)
-  (_:squash (can_be_split_forall (fun x -> post_f x `star` frame_f) pre_g))
-  (_: squash (can_be_split_post post_g post))
-: ens_t (pre_f `star` frame_f) b post
-= fun m0 y m2 ->
-  (exists (x:a) (m1:hmem (post_f x `star` frame_f)). (ens_g x) m1 y m2)
 
 val bind_steelatomic_steelf (a:Type) (b:Type)
   (o:observability)
   (#[@@ framing_implicit] pre_f:pre_t) (#[@@ framing_implicit] post_f:post_t a)
+  (#[@@ framing_implicit] req_f:req_t pre_f) (#[@@ framing_implicit] ens_f:ens_t pre_f a post_f)
   (#[@@ framing_implicit] pre_g:a -> pre_t) (#[@@ framing_implicit] post_g:a -> post_t b)
   (#[@@ framing_implicit] req_g:(x:a -> req_t (pre_g x)))
   (#[@@ framing_implicit] ens_g:(x:a -> ens_t (pre_g x) b (post_g x)))
@@ -259,45 +399,21 @@ val bind_steelatomic_steelf (a:Type) (b:Type)
   (#[@@ framing_implicit] post:post_t b)
   (#[@@ framing_implicit] p:squash (can_be_split_forall (fun x -> post_f x `star` frame_f) pre_g))
   (#[@@ framing_implicit] p2: squash (can_be_split_post post_g post))
-  (f:atomic_repr a Set.empty o pre_f post_f)
+  (f:atomic_repr a Set.empty o pre_f post_f req_f ens_f)
   (g:(x:a -> Steel.Effect.repr b (pre_g x) (post_g x) (req_g x) (ens_g x)))
 : Steel.Effect.repr b
     (pre_f `star` frame_f)
     post
-    (bind_steelatomic_steelf_req req_g frame_f p)
-    (bind_steelatomic_steelf_ens ens_g frame_f post p p2)
+    (bind_steela_steelaf_req req_f ens_f req_g frame_f p)
+    (bind_steela_steelaf_ens req_f ens_f ens_g frame_f post p p2)
 
 
 polymonadic_bind (SteelAtomic, Steel.Effect.SteelF) |> Steel.Effect.SteelF = bind_steelatomic_steelf
 
-
-unfold
-let bind_steelatomic_steel_req (#a:Type)
-  (#pre_f:pre_t) (#post_f:post_t a)
-  (#pre_g:a -> pre_t)
-  (req_g:(x:a -> req_t (pre_g x)))
-  (frame_f:slprop) (frame_g:a -> slprop)
-  (_:squash (can_be_split_forall (fun x -> post_f x `star` frame_f) (fun x -> pre_g x `star` frame_g x)))
-: req_t (pre_f `star` frame_f)
-= fun m0 ->
-  (forall (x:a) (m1:hmem (post_f x `star` frame_f)). (req_g x) m1)
-
-unfold
-let bind_steelatomic_steel_ens (#a:Type) (#b:Type)
-  (#pre_f:pre_t) (#post_f:post_t a)
-  (#pre_g:a -> pre_t) (#post_g:a -> post_t b)
-  (ens_g:(x:a -> ens_t (pre_g x) b (post_g x)))
-  (frame_f:slprop) (frame_g:a -> slprop)
-  (post:post_t b)
-  (_:squash (can_be_split_forall (fun x -> post_f x `star` frame_f) (fun x -> pre_g x `star` frame_g x)))
-  (_:squash (can_be_split_post (fun x y -> post_g x y `star` frame_g x) post))
-: ens_t (pre_f `star` frame_f) b post
-= fun m0 y m2 ->
-  (exists (x:a) (m1:hmem (post_f x `star` frame_f)).  (ens_g x) m1 y m2)
-
 val bind_steelatomic_steel (a:Type) (b:Type)
   (o:observability)
   (#[@@ framing_implicit] pre_f:pre_t) (#[@@ framing_implicit] post_f:post_t a)
+  (#[@@ framing_implicit] req_f:req_t pre_f) (#[@@ framing_implicit] ens_f:ens_t pre_f a post_f)
   (#[@@ framing_implicit] pre_g:a -> pre_t) (#[@@ framing_implicit] post_g:a -> post_t b)
   (#[@@ framing_implicit] req_g:(x:a -> req_t (pre_g x)))
   (#[@@ framing_implicit] ens_g:(x:a -> ens_t (pre_g x) b (post_g x)))
@@ -306,42 +422,31 @@ val bind_steelatomic_steel (a:Type) (b:Type)
   (#[@@ framing_implicit] p:squash (can_be_split_forall
     (fun x -> post_f x `star` frame_f) (fun x -> pre_g x `star` frame_g x)))
   (#[@@ framing_implicit] p2:squash (can_be_split_post (fun x y -> post_g x y `star` frame_g x) post))
-  (f:atomic_repr a Set.empty o pre_f post_f)
+  (f:atomic_repr a Set.empty o pre_f post_f req_f ens_f)
   (g:(x:a -> Steel.Effect.repr b (pre_g x) (post_g x) (req_g x) (ens_g x)))
 : Steel.Effect.repr b
     (pre_f `star` frame_f)
     post
-    (bind_steelatomic_steel_req req_g frame_f frame_g p)
-    (bind_steelatomic_steel_ens ens_g frame_f frame_g post p p2)
+    (bind_steela_steela_req req_f ens_f req_g frame_f frame_g p)
+    (bind_steela_steela_ens req_f ens_f ens_g frame_f frame_g post p p2)
 
 polymonadic_bind (SteelAtomic, Steel.Effect.Steel) |> Steel.Effect.SteelF =
   bind_steelatomic_steel
 
-
-unfold
-let subcomp_req_atomic_steel (a:Type) (pre_f:pre_t) : req_t pre_f = fun _ -> True
-
-unfold
-let subcomp_ens_atomic_steel (#a:Type) (pre_f:pre_t) (post_f:post_t a)
-: ens_t pre_f a post_f
-= fun _ _ _ -> True
-
-
-val subcomp_atomic_steel (a:Type)
-  (#[@@framing_implicit] pre_f:pre_t) (#[@@ framing_implicit] post_f:post_t a) (is_ghost:observability)
-  (f:atomic_repr a Set.empty is_ghost pre_f post_f)
-: Steel.Effect.repr a pre_f post_f (subcomp_req_atomic_steel a pre_f) (subcomp_ens_atomic_steel pre_f post_f)
+val subcomp_atomic_steel (a:Type) (is_ghost:observability)
+  (#[@@ framing_implicit] pre_f:pre_t) (#[@@ framing_implicit] post_f:post_t a)
+  (#[@@ framing_implicit] req_f:req_t pre_f) (#[@@ framing_implicit] ens_f:ens_t pre_f a post_f)
+  (#[@@ framing_implicit] pre_g:pre_t) (#[@@ framing_implicit] post_g:post_t a)
+  (#[@@ framing_implicit] req_g:req_t pre_g) (#[@@ framing_implicit] ens_g:ens_t pre_g a post_g)
+  (#[@@ framing_implicit] p1:squash (can_be_split pre_g pre_f))
+  (#[@@ framing_implicit] p2:squash (can_be_split_forall post_f post_g))
+  (f:atomic_repr a Set.empty is_ghost pre_f post_f req_f ens_f)
+: Pure (Steel.Effect.repr a pre_g post_g req_g ens_g)
+       (requires subcomp_pre req_f ens_f req_g ens_g p1 p2)
+       (ensures fun _ -> True)
 
 polymonadic_subcomp SteelAtomic <: Steel.Effect.Steel = subcomp_atomic_steel
 polymonadic_subcomp SteelAtomicF <: Steel.Effect.Steel = subcomp_atomic_steel
-
-
-val lift_atomic_to_steelT (#a:Type)
-                          (#o:observability)
-                          (#fp:slprop)
-                          (#fp':a -> slprop)
-                          ($f:unit -> SteelAtomic a Set.empty o fp fp')
-  : Steel.Effect.SteelT a fp fp'
 
 [@@warn_on_use "as_atomic_action is a trusted primitive"]
 val as_atomic_action (#a:Type u#a)
@@ -350,10 +455,10 @@ val as_atomic_action (#a:Type u#a)
                      (#fp:slprop)
                      (#fp': a -> slprop)
                      (f:action_except a opened_invariants fp fp')
-  : SteelAtomic a opened_invariants o fp fp'
+  : SteelAtomicT a opened_invariants o fp fp'
 
 val new_invariant (opened_invariants:inames) (p:slprop)
-  : SteelAtomic (inv p) opened_invariants unobservable p (fun _ -> emp)
+  : SteelAtomicT (inv p) opened_invariants unobservable p (fun _ -> emp)
 
 let set_add i o : inames = Set.union (Set.singleton i) o
 val with_invariant (#a:Type)
@@ -363,10 +468,10 @@ val with_invariant (#a:Type)
                    (#o:observability)
                    (#p:slprop)
                    (i:inv p{not (i `Set.mem` opened_invariants)})
-                   ($f:unit -> SteelAtomic a (set_add i opened_invariants) o
+                   ($f:unit -> SteelAtomicT a (set_add i opened_invariants) o
                                          (p `star` fp)
                                          (fun x -> p `star` fp' x))
-  : SteelAtomic a opened_invariants o fp fp'
+  : SteelAtomicT a opened_invariants o fp fp'
 
 val frame (#a:Type)
           (#opened_invariants:inames)
@@ -374,71 +479,71 @@ val frame (#a:Type)
           (#pre:slprop)
           (#post:a -> slprop)
           (frame:slprop)
-          ($f:unit -> SteelAtomic a opened_invariants o pre post)
-  : SteelAtomic a opened_invariants o
+          ($f:unit -> SteelAtomicT a opened_invariants o pre post)
+  : SteelAtomicT a opened_invariants o
                 (pre `star` frame)
                 (fun x -> post x `star` frame)
 
 val change_slprop (#opened_invariants:inames)
                   (p q:slprop)
                   (proof: (m:mem) -> Lemma (requires interp p m) (ensures interp q m))
-  : SteelAtomic unit opened_invariants unobservable p (fun _ -> q)
+  : SteelAtomicT unit opened_invariants unobservable p (fun _ -> q)
 
 // Some utilities
 let return_atomic #a #opened_invariants #p (x:a)
-  : SteelAtomic a opened_invariants unobservable (p x) p
+  : SteelAtomic a opened_invariants unobservable (p x) p (return_req (p x)) (return_ens a x p)
   = SteelAtomic?.reflect (return a x opened_invariants #p)
 
 val h_assert_atomic (#opened_invariants:_) (p:slprop)
-  : SteelAtomic unit opened_invariants unobservable p (fun _ -> p)
+  : SteelAtomicT unit opened_invariants unobservable p (fun _ -> p)
 
 val h_intro_emp_l (#opened_invariants:_) (p:slprop)
-  : SteelAtomic unit opened_invariants unobservable p (fun _ -> emp `star` p)
+  : SteelAtomicT unit opened_invariants unobservable p (fun _ -> emp `star` p)
 
 val h_elim_emp_l (#opened_invariants:_) (p:slprop)
-  : SteelAtomic unit opened_invariants unobservable (emp `star` p) (fun _ -> p)
+  : SteelAtomicT unit opened_invariants unobservable (emp `star` p) (fun _ -> p)
 
 val intro_pure (#opened_invariants:_) (#p:slprop) (q:prop { q })
-  : SteelAtomic unit opened_invariants unobservable p (fun _ -> p `star` pure q)
+  : SteelAtomicT unit opened_invariants unobservable p (fun _ -> p `star` pure q)
 
 val h_commute (#opened_invariants:_) (p q:slprop)
-  : SteelAtomic unit opened_invariants unobservable (p `star` q) (fun _ -> q `star` p)
+  : SteelAtomicT unit opened_invariants unobservable (p `star` q) (fun _ -> q `star` p)
 
 val h_assoc_left (#opened_invariants:_) (p q r:slprop)
-  : SteelAtomic unit opened_invariants unobservable ((p `star` q) `star` r) (fun _ -> p `star` (q `star` r))
+  : SteelAtomicT unit opened_invariants unobservable ((p `star` q) `star` r) (fun _ -> p `star` (q `star` r))
 
 val h_assoc_right (#opened_invariants:_) (p q r:slprop)
-  : SteelAtomic unit opened_invariants unobservable (p `star` (q `star` r)) (fun _ -> (p `star` q) `star` r)
+  : SteelAtomicT unit opened_invariants unobservable (p `star` (q `star` r)) (fun _ -> (p `star` q) `star` r)
 
 val intro_h_exists (#a:Type) (#opened_invariants:_) (x:a) (p:a -> slprop)
-  : SteelAtomic unit opened_invariants unobservable (p x) (fun _ -> h_exists p)
+  : SteelAtomicT unit opened_invariants unobservable (p x) (fun _ -> h_exists p)
 
 val intro_h_exists_erased (#a:Type) (#opened_invariants:_) (x:Ghost.erased a) (p:a -> slprop)
-  : SteelAtomic unit opened_invariants unobservable (p x) (fun _ -> h_exists p)
+  : SteelAtomicT unit opened_invariants unobservable (p x) (fun _ -> h_exists p)
 
 val h_affine (#opened_invariants:_) (p q:slprop)
-  : SteelAtomic unit opened_invariants unobservable (p `star` q) (fun _ -> p)
+  : SteelAtomicT unit opened_invariants unobservable (p `star` q) (fun _ -> p)
 
 (* Witnessing an existential can only be done for frame-monotonic properties.
  * Most PCMs we use have a witness-invariant pts_to, which means this
  * condition is usually trivial and can be hidden from programs. *)
 val witness_h_exists (#a:Type) (#opened_invariants:_) (#p:a -> slprop) (_:squash (is_frame_monotonic p))
-  : SteelAtomic (Ghost.erased a) opened_invariants unobservable
+  : SteelAtomicT (Ghost.erased a) opened_invariants unobservable
                 (h_exists p) (fun x -> p x)
 
 module U = FStar.Universe
 
 val lift_h_exists_atomic (#a:_) (#u:_) (p:a -> slprop)
-  : SteelAtomic unit u unobservable
+  : SteelAtomicT unit u unobservable
                 (h_exists p)
                 (fun _a -> h_exists #(U.raise_t a) (U.lift_dom p))
 
 val h_exists_cong_atomic (#a:_) (#u:_) (p:a -> slprop) (q:a -> slprop {forall x. equiv (p x) (q x) })
-  : SteelAtomic unit u unobservable
+  : SteelAtomicT unit u unobservable
                 (h_exists p)
                 (fun _ -> h_exists q)
 
 val elim_pure (#uses:_) (p:prop)
-  : SteelAtomic (_:unit{p}) uses unobservable
+  : SteelAtomicT (_:unit{p}) uses unobservable
                 (pure p)
                 (fun _ -> emp)

--- a/ulib/experimental/Steel.Effect.fsti
+++ b/ulib/experimental/Steel.Effect.fsti
@@ -418,10 +418,11 @@ effect SteelT (a:Type) (pre:pre_t) (post:post_t a) =
 
 
 
+module AtomicX = Steel.EffectX.Atomic
 module EffectX = Steel.EffectX
 
-let triv_pre (fp:pre_t) : EffectX.fp_mprop fp = fun _ -> True
-let triv_post (fp:pre_t) (#a:Type) (fp':post_t a) : EffectX.fp_binary_mprop fp fp'
+let triv_pre (fp:pre_t) : AtomicX.fp_mprop fp = fun _ -> True
+let triv_post (fp:pre_t) (#a:Type) (fp':post_t a) : AtomicX.fp_binary_mprop fp fp'
   = fun _ _ _ -> True
 
 let triv_pre' (fp:pre_t) : req_t fp = fun _ -> True

--- a/ulib/experimental/Steel.EffectX.Atomic.fst
+++ b/ulib/experimental/Steel.EffectX.Atomic.fst
@@ -26,15 +26,40 @@ let has_eq_observability () = ()
 let observable = true
 let unobservable = false
 
-let atomic_repr a opened_invariants f pre post =
-    action_except a opened_invariants pre post
+let join_preserves_interp hp m0 m1
+  = intro_emp m1;
+    intro_star hp emp m0 m1;
+    affine_star hp emp (join m0 m1)
+
+let respects_fp #fp p =
+  forall (m0:hmem fp) (m1:mem{disjoint m0 m1}). p m0 <==> p (join m0 m1)
+let reveal_respects_fp p = ()
+
+let respects_binary_fp #a #pre #post q
+  = (forall x (h_pre:hmem pre) h_post (h:mem{disjoint h_pre h}).
+      q h_pre x h_post <==> q (join h_pre h) x h_post) /\
+    (forall x h_pre (h_post:hmem (post x)) (h:mem{disjoint h_post h}).
+      q h_pre x h_post <==> q h_pre x (join h_post h))
+let reveal_respects_binary_fp q = ()
+
+let req_to_act_req (#pre:slprop) (req:fp_mprop pre) : mprop pre =
+  fun m -> interp pre m /\ req m
+
+let ens_to_act_ens (#pre:slprop) (#a:Type) (#post:a -> slprop) (ens:fp_binary_mprop pre post)
+: mprop2 pre post
+= fun m0 x m1 -> interp pre m0 /\ interp (post x) m1 /\ ens m0 x m1
+
+let atomic_repr a opened_invariants f pre post req ens =
+    action_except_full a opened_invariants pre post (req_to_act_req req) (ens_to_act_ens ens)
 
 let return a x o p = fun _ -> x
 
-let bind a b o o1 o2 pre_f post_f post_g f g =
+let bind a b o o1 o2 pre_f post_f req_f ens_f post_g req_g ens_g f g =
   fun frame ->
     let x = f frame in
     g x frame
+
+let subcomp a opened o pre post req_f ens_f req_g ens_g f = f
 
 inline_for_extraction
 let lift_pure_steel_atomic a op p wp f
@@ -43,13 +68,13 @@ let lift_pure_steel_atomic a op p wp f
 
 let as_atomic_action f = SteelAtomicX?.reflect f
 let new_invariant i p = SteelAtomicX?.reflect (Steel.Memory.new_invariant i p)
-let with_invariant i f = SteelAtomicX?.reflect (Steel.Memory.with_invariant i (reify (f())))
+let with_invariant #a #fp #fp' #opened i f = SteelAtomicX?.reflect (Steel.Memory.with_invariant #_ #fp #fp' #opened i (reify (f())))
 let frame frame f = SteelAtomicX?.reflect (Steel.Memory.frame frame (reify (f ())))
-let change_slprop p q proof = SteelAtomicX?.reflect (Steel.Memory.change_slprop p q proof)
+let change_slprop #opened p q proof = SteelAtomicX?.reflect (Steel.Memory.change_slprop #opened p q proof)
 
 open NMSTTotal
 open MSTTotal
 
-let witness_h_exists #a #u #p () = SteelAtomicX?.reflect (Steel.Memory.witness_h_exists p)
+let witness_h_exists #a #u #p () = SteelAtomicX?.reflect (Steel.Memory.witness_h_exists #u p)
 let lift_h_exists_atomic #a #u p = SteelAtomicX?.reflect (Steel.Memory.lift_h_exists #u p)
 let elim_pure #uses p = SteelAtomicX?.reflect (Steel.Memory.elim_pure #uses p)

--- a/ulib/experimental/Steel.EffectX.Atomic.fsti
+++ b/ulib/experimental/Steel.EffectX.Atomic.fsti
@@ -19,6 +19,8 @@ module Steel.EffectX.Atomic
 open FStar.PCM
 open Steel.Memory
 
+#set-options "--warn_error -330"  //turn off the experimental feature warning
+
 val observability : Type0
 val has_eq_observability (_:unit) : Lemma (hasEq observability)
 val observable : observability
@@ -37,18 +39,73 @@ let join_obs (o1:observability) (o2:observability) =
   then observable
   else unobservable
 
+val join_preserves_interp (hp:slprop) (m0 m1:mem)
+  : Lemma
+    (requires (interp hp m0 /\ disjoint m0 m1))
+    (ensures (interp hp (join m0 m1)))
+    [SMTPat (interp hp (join m0 m1))]
+
+val respects_fp (#fp:slprop) (p: hmem fp -> prop) : prop
+#push-options "--query_stats"
+val reveal_respects_fp (#fp:_) (p:hmem fp -> prop)
+  : Lemma (respects_fp p <==>
+           (forall (m0:hmem fp) (m1:mem{disjoint m0 m1}). p m0 <==> p (join m0 m1)))
+          [SMTPat (respects_fp #fp p)]
+#pop-options
+let fp_mprop (fp:slprop) = p:(hmem fp -> prop) { respects_fp p }
+
+val respects_binary_fp (#a:Type) (#pre:slprop) (#post:a -> slprop)
+                       (q:(hmem pre -> x:a -> hmem (post x) -> prop)) : prop
+
+val reveal_respects_binary_fp (#a:Type) (#pre:slprop) (#post:a -> slprop)
+                              (q:(hmem pre -> x:a -> hmem (post x) -> prop))
+  : Lemma (respects_binary_fp q <==>
+            //at this point we need to know interp pre (join h_pre h) -- use join_preserves_interp for that
+            (forall x (h_pre:hmem pre) h_post (h:mem{disjoint h_pre h}).
+              q h_pre x h_post <==> q (join h_pre h) x h_post) /\
+            //can join any disjoint heap to the post-heap and q is still valid
+            (forall x h_pre (h_post:hmem (post x)) (h:mem{disjoint h_post h}).
+              q h_pre x h_post <==> q h_pre x (join h_post h)))
+           [SMTPat (respects_binary_fp #a #pre #post q)]
+
+let fp_binary_mprop #a (pre:slprop) (post: a -> slprop) =
+  p:(hmem pre -> x:a -> hmem (post x) -> prop){ respects_binary_fp p }
+
+
 val atomic_repr (a:Type u#a)
                 (opened_invariants:inames)
                 (g:observability)
                 (pre:slprop u#1)
                 (post:a -> slprop u#1)
+                (req:fp_mprop pre)
+                (ens:fp_binary_mprop pre post)
   : Type u#(max a 2)
+
+unfold
+let return_req (p:slprop) : fp_mprop p = fun _ -> True
+
+unfold
+let return_ens (#a:Type) (x:a) (p:a -> slprop) : fp_binary_mprop (p x) p = fun _ r _ -> r == x
 
 val return (a:Type u#a)
            (x:a)
            (opened_invariants:inames)
            (p:a -> slprop u#1)
-  : atomic_repr a opened_invariants unobservable (p x) p
+  : atomic_repr a opened_invariants unobservable (p x) p (return_req (p x)) (return_ens x p)
+
+unfold
+let bind_req (#a:Type) (#pre_f:slprop) (#post_f:a -> slprop)
+             (req_f:fp_mprop pre_f) (ens_f:fp_binary_mprop pre_f post_f)
+             (req_g:(x:a -> fp_mprop (post_f x)))
+  : fp_mprop pre_f
+  = fun h -> req_f h /\ (forall (x:a) h1. ens_f h x h1 ==> req_g x h1)
+
+unfold
+let bind_ens (#a:Type) (#b:Type) (#pre_f:slprop) (#post_f:a -> slprop)
+             (req_f:fp_mprop pre_f) (ens_f:fp_binary_mprop pre_f post_f)
+             (#post_g:b -> slprop) (ens_g:(x:a -> fp_binary_mprop (post_f x) post_g))
+  : fp_binary_mprop pre_f post_g
+  = fun h0 y h2 -> req_f h0 /\ (exists x h1. ens_f h0 x h1 /\ (ens_g x) h1 y h2)
 
 val bind (a:Type u#a)
          (b:Type u#b)
@@ -57,12 +114,47 @@ val bind (a:Type u#a)
          (o2:observability)
          (pre_f:slprop)
          (post_f:a -> slprop)
+         (req_f:fp_mprop pre_f)
+         (ens_f:fp_binary_mprop pre_f post_f)
          (post_g:b -> slprop)
-         (f:atomic_repr a opened_invariants o1 pre_f post_f)
-         (g:(x:a -> atomic_repr b opened_invariants o2 (post_f x) post_g))
-  : Pure (atomic_repr b opened_invariants (join_obs o1 o2) pre_f post_g)
+         (req_g:(x:a -> fp_mprop (post_f x)))
+         (ens_g:(x:a -> fp_binary_mprop (post_f x) post_g))
+         (f:atomic_repr a opened_invariants o1 pre_f post_f req_f ens_f)
+         (g:(x:a -> atomic_repr b opened_invariants o2 (post_f x) post_g (req_g x) (ens_g x)))
+  : Pure (atomic_repr b opened_invariants (join_obs o1 o2)
+                      pre_f
+                      post_g
+                      (bind_req req_f ens_f req_g)
+                      (bind_ens req_f ens_f ens_g)
+          )
       (requires obs_at_most_one o1 o2)
       (ensures fun _ -> True)
+
+unfold
+let subcomp_pre (#a:Type)
+                (#pre:slprop)
+                (#post:a -> slprop)
+                (req_f:fp_mprop pre)
+                (ens_f:fp_binary_mprop pre post)
+                (req_g:fp_mprop pre)
+                (ens_g:fp_binary_mprop pre post)
+   : pure_pre
+   = (forall h. req_g h ==> req_f h) /\
+     (forall h0 x h1. (req_g h0 /\ ens_f h0 x h1) ==> ens_g h0 x h1)
+
+val subcomp (a:Type)
+            (opened_invariants:inames)
+            (o:observability)
+            (pre:slprop)
+            (post:a -> slprop)
+            (req_f:fp_mprop pre)
+            (ens_f:fp_binary_mprop pre post)
+            (req_g:fp_mprop pre)
+            (ens_g:fp_binary_mprop pre post)
+            (f:atomic_repr a opened_invariants o pre post req_f ens_f)
+  : Pure (atomic_repr a opened_invariants o pre post req_g ens_g)
+         (requires subcomp_pre req_f ens_f req_g ens_g)
+         (ensures fun _ -> True)
 
 [@@allow_informative_binders]
 total
@@ -73,12 +165,23 @@ layered_effect {
               -> o:observability
               -> pre:slprop u#1
               -> post:(a -> slprop u#1)
+              -> req:fp_mprop pre
+              -> ens:fp_binary_mprop pre post
               -> Effect
   with
   repr = atomic_repr;
   return = return;
-  bind = bind
+  bind = bind;
+  subcomp = subcomp
 }
+
+unfold
+let trivial_req (p:slprop) : fp_mprop p = fun _ -> True
+
+unfold
+let trivial_ens (#a:Type) (pre:slprop) (post:a -> slprop) : fp_binary_mprop pre post
+  = fun _ _ _ -> True
+
 
 inline_for_extraction
 val lift_pure_steel_atomic (a:Type)
@@ -86,11 +189,17 @@ val lift_pure_steel_atomic (a:Type)
                            (p:slprop)
                            (wp:pure_wp a)
                            (f:eqtype_as_type unit -> PURE a wp)
-  : Pure (atomic_repr a opened_invariants unobservable p (fun _ -> p))
+  : Pure (atomic_repr a opened_invariants unobservable
+           p (fun _ -> p)
+           (trivial_req p) (trivial_ens p (fun _ -> p))
+         )
          (requires wp (fun _ -> True))
          (ensures fun _ -> True)
 
 sub_effect PURE ~> SteelAtomicX = lift_pure_steel_atomic
+
+effect SteelAtomicXT (a:Type) (opened:inames) (o:observability) (pre:slprop) (post:a -> slprop) =
+  SteelAtomicX a opened o pre post (fun _ -> True) (fun _ _ _ -> True)
 
 [@@warn_on_use "as_atomic_action is a trusted primitive"]
 val as_atomic_action (#a:Type u#a)
@@ -99,10 +208,10 @@ val as_atomic_action (#a:Type u#a)
                      (#fp:slprop)
                      (#fp': a -> slprop)
                      (f:action_except a opened_invariants fp fp')
-  : SteelAtomicX a opened_invariants o fp fp'
+  : SteelAtomicXT a opened_invariants o fp fp'
 
 val new_invariant (opened_invariants:inames) (p:slprop)
-  : SteelAtomicX (inv p) opened_invariants unobservable p (fun _ -> emp)
+  : SteelAtomicXT (inv p) opened_invariants unobservable p (fun _ -> emp)
 
 let set_add i o : inames = Set.union (Set.singleton i) o
 val with_invariant (#a:Type)
@@ -112,96 +221,98 @@ val with_invariant (#a:Type)
                    (#o:observability)
                    (#p:slprop)
                    (i:inv p{not (i `Set.mem` opened_invariants)})
-                   (f:unit -> SteelAtomicX a (set_add i opened_invariants) o
+                   (f:unit -> SteelAtomicXT a (set_add i opened_invariants) o
                                          (p `star` fp)
                                          (fun x -> p `star` fp' x))
-  : SteelAtomicX a opened_invariants o fp fp'
+  : SteelAtomicXT a opened_invariants o fp fp'
 
 val frame (#a:Type)
           (#opened_invariants:inames)
           (#o:observability)
           (#pre:slprop)
           (#post:a -> slprop)
+          (#req:fp_mprop pre)
+          (#ens:fp_binary_mprop pre post)
           (frame:slprop)
-          ($f:unit -> SteelAtomicX a opened_invariants o pre post)
+          ($f:unit -> SteelAtomicX a opened_invariants o pre post req ens)
   : SteelAtomicX a opened_invariants o
                 (pre `star` frame)
                 (fun x -> post x `star` frame)
+                req
+                ens
 
 val change_slprop (#opened_invariants:inames)
                   (p q:slprop)
                   (proof: (m:mem) -> Lemma (requires interp p m) (ensures interp q m))
-  : SteelAtomicX unit opened_invariants unobservable p (fun _ -> q)
+  : SteelAtomicXT unit opened_invariants unobservable p (fun _ -> q)
 
 // Some utilities
 let return_atomic #a #opened_invariants #p (x:a)
-  : SteelAtomicX a opened_invariants unobservable (p x) p
+  : SteelAtomicX a opened_invariants unobservable (p x) p (return_req (p x)) (return_ens x p)
   = SteelAtomicX?.reflect (return a x opened_invariants p)
 
-#push-options "--query_stats" //working around some flakiness
 let h_assert_atomic (#opened_invariants:_) (p:slprop)
-  : SteelAtomicX unit opened_invariants unobservable p (fun _ -> p)
+  : SteelAtomicXT unit opened_invariants unobservable p (fun _ -> p)
   = change_slprop p p (fun m -> ())
-#pop-options
 
 let h_intro_emp_l (#opened_invariants:_) (p:slprop)
-  : SteelAtomicX unit opened_invariants unobservable p (fun _ -> emp `star` p)
+  : SteelAtomicXT unit opened_invariants unobservable p (fun _ -> emp `star` p)
   = change_slprop p (emp `star` p) (fun m -> emp_unit p; star_commutative p emp)
 
 let h_elim_emp_l (#opened_invariants:_) (p:slprop)
-  : SteelAtomicX unit opened_invariants unobservable (emp `star` p) (fun _ -> p)
+  : SteelAtomicXT unit opened_invariants unobservable (emp `star` p) (fun _ -> p)
   = change_slprop (emp `star` p) p (fun m -> emp_unit p; star_commutative p emp)
 
 let intro_pure #opened_invariants (#p:slprop) (q:prop { q })
-  : SteelAtomicX unit opened_invariants unobservable p (fun _ -> p `star` pure q)
+  : SteelAtomicXT unit opened_invariants unobservable p (fun _ -> p `star` pure q)
   = change_slprop p (p `star` pure q) (fun m -> emp_unit p; pure_star_interp p q m)
 
 let h_commute (#opened_invariants:_) (p q:slprop)
-  : SteelAtomicX unit opened_invariants unobservable (p `star` q) (fun _ -> q `star` p)
+  : SteelAtomicXT unit opened_invariants unobservable (p `star` q) (fun _ -> q `star` p)
   = change_slprop (p `star` q) (q `star` p) (fun m -> star_commutative p q)
 
 let h_assoc_left (#opened_invariants:_) (p q r:slprop)
-  : SteelAtomicX unit opened_invariants unobservable ((p `star` q) `star` r) (fun _ -> p `star` (q `star` r))
+  : SteelAtomicXT unit opened_invariants unobservable ((p `star` q) `star` r) (fun _ -> p `star` (q `star` r))
   = change_slprop ((p `star` q) `star` r) (p `star` (q `star` r)) (fun m -> star_associative p q r)
 
 let h_assoc_right (#opened_invariants:_) (p q r:slprop)
-  : SteelAtomicX unit opened_invariants unobservable (p `star` (q `star` r)) (fun _ -> (p `star` q) `star` r)
+  : SteelAtomicXT unit opened_invariants unobservable (p `star` (q `star` r)) (fun _ -> (p `star` q) `star` r)
   = change_slprop (p `star` (q `star` r)) ((p `star` q) `star` r) (fun m -> star_associative p q r)
 
 let intro_h_exists (#a:Type) (#opened_invariants:_) (x:a) (p:a -> slprop)
-  : SteelAtomicX unit opened_invariants unobservable (p x) (fun _ -> h_exists p)
+  : SteelAtomicXT unit opened_invariants unobservable (p x) (fun _ -> h_exists p)
   = change_slprop (p x) (h_exists p) (fun m -> intro_h_exists x p m)
 
 let intro_h_exists_erased (#a:Type) (#opened_invariants:_) (x:Ghost.erased a) (p:a -> slprop)
-  : SteelAtomicX unit opened_invariants unobservable (p x) (fun _ -> h_exists p)
+  : SteelAtomicXT unit opened_invariants unobservable (p x) (fun _ -> h_exists p)
   = change_slprop (p x) (h_exists p) (fun m -> Steel.Memory.intro_h_exists (Ghost.reveal x) p m)
 
 let h_affine (#opened_invariants:_) (p q:slprop)
-  : SteelAtomicX unit opened_invariants unobservable (p `star` q) (fun _ -> p)
+  : SteelAtomicXT unit opened_invariants unobservable (p `star` q) (fun _ -> p)
   = change_slprop (p `star` q) p (fun m -> affine_star p q m)
 
 (* Witnessing an existential can only be done for frame-monotonic properties.
  * Most PCMs we use have a witness-invariant pts_to, which means this
  * condition is usually trivial and can be hidden from programs. *)
 val witness_h_exists (#a:Type) (#opened_invariants:_) (#p:(a -> slprop){is_frame_monotonic p}) (_:unit)
-  : SteelAtomicX (Ghost.erased a) opened_invariants unobservable
+  : SteelAtomicXT (Ghost.erased a) opened_invariants unobservable
                 (h_exists p) (fun x -> p x)
 
 module U = FStar.Universe
 
 val lift_h_exists_atomic (#a:_) (#u:_) (p:a -> slprop)
-  : SteelAtomicX unit u unobservable
+  : SteelAtomicXT unit u unobservable
                 (h_exists p)
                 (fun _a -> h_exists #(U.raise_t a) (U.lift_dom p))
 
 let h_exists_cong_atomic (#a:_) #u (p:a -> slprop) (q:a -> slprop {forall x. equiv (p x) (q x) })
-  : SteelAtomicX unit u unobservable
+  : SteelAtomicXT unit u unobservable
                 (h_exists p)
                 (fun _ -> h_exists q)
   = change_slprop _ _ (fun m -> h_exists_cong p q)
 
 
 val elim_pure (#uses:_) (p:prop)
-  : SteelAtomicX (_:unit{p}) uses unobservable
+  : SteelAtomicXT (_:unit{p}) uses unobservable
                 (pure p)
                 (fun _ -> emp)

--- a/ulib/experimental/Steel.EffectX.fst
+++ b/ulib/experimental/Steel.EffectX.fst
@@ -26,7 +26,11 @@ open Steel.Memory
 
 #set-options "--warn_error -330"  //turn off the experimental feature warning
 
-let join_preserves_interp hp m0 m1
+let join_preserves_interp (hp:slprop) (m0 m1:mem)
+  : Lemma
+    (requires (interp hp m0 /\ disjoint m0 m1))
+    (ensures (interp hp (join m0 m1)))
+    [SMTPat (interp hp (join m0 m1))]
   = intro_emp m1;
     intro_star hp emp m0 m1;
     affine_star hp emp (join m0 m1)
@@ -267,12 +271,12 @@ friend Steel.EffectX.Atomic
 open Steel.EffectX.Atomic
 
 #push-options "--z3rlimit 40"
-let bind_atomic_steel _ _ _ _ _ _ _ _ f g
+let bind_atomic_steel _ _ _ _ _ _ _ _ _ _ f g
 = fun frame ->
   let x = f frame in
   g x frame
 #pop-options
 
 #push-options "--z3rlimit 40"
-let subcomp_atomic_steel _ _ _ _ f = fun m0 -> f m0
+let subcomp_atomic_steel _ _ _ _ _ _ _ _ f = fun m0 -> f m0
 #pop-options

--- a/ulib/experimental/Steel.HigherReference.fst
+++ b/ulib/experimental/Steel.HigherReference.fst
@@ -338,6 +338,8 @@ let cas_action (#t:Type) (eq: (x:t -> y:t -> b:bool{b <==> (x == y)}))
         (pts_to r full_perm v)
         (cas_provides r v v_new)
         fr
+        (fun _ -> True)
+        (fun _ _ _ -> True)
    = let m0 : full_mem = NMSTTotal.get () in
      let fv = Ghost.hide (Some (Ghost.reveal v, full_perm)) in
      let fv' = Some (v_new, full_perm) in

--- a/ulib/experimental/Steel.HigherReference.fst
+++ b/ulib/experimental/Steel.HigherReference.fst
@@ -134,33 +134,33 @@ let drop (p:slprop)
 
 let comm (#opened_invariants:inames)
          (#p #q:slprop) (_:unit)
-  : SteelAtomic unit opened_invariants unobservable
+  : SteelAtomicT unit opened_invariants unobservable
                 (p `star` q)
                 (fun x -> q `star` p)
   = Atomic.change_slprop (p `star` q) (q `star` p) (fun m -> Mem.star_commutative p q)
 
 let intro_perm_ok #uses (p:perm{perm_ok p}) (q:slprop)
-  : SteelAtomic unit uses unobservable
+  : SteelAtomicT unit uses unobservable
                 q
                 (fun _ -> q `star` pure (perm_ok p))
   = Atomic.change_slprop q (q `star` pure (perm_ok p))
     (fun m -> emp_unit q; pure_star_interp q (perm_ok p) m)
 
 let elim_perm_ok #uses (p:perm)
-  : SteelAtomic (q:perm{perm_ok q /\ q == p}) uses unobservable
+  : SteelAtomicT (q:perm{perm_ok q /\ q == p}) uses unobservable
                 (pure (perm_ok p))
                 (fun _ -> emp)
   = let _ = Atomic.elim_pure (perm_ok p) in
     p
 
 let intro_pts_to (p:perm{perm_ok p}) #a #uses (#v:erased a) (r:ref a) (_:unit)
-  : SteelAtomic unit uses unobservable
+  : SteelAtomicT unit uses unobservable
                 (pts_to_raw r p v)
                 (fun _ -> pts_to r p v)
   = intro_perm_ok p _
 
 let drop_l_atomic #uses (p q:slprop)  ()
-  : SteelAtomic unit uses unobservable (p `star` q) (fun _ -> q)
+  : SteelAtomicT unit uses unobservable (p `star` q) (fun _ -> q)
   = Atomic.change_slprop (p `star` q) q (affine_star p q)
 
 let alloc #a x =
@@ -232,13 +232,13 @@ let mem_share_atomic_raw (#a:Type) (#uses:_) (#p:perm{perm_ok p}) (r:ref a)
 #pop-options
 
 let share_atomic_raw #a #uses (#p:perm) (r:ref a{perm_ok p}) (v0:erased a)
-  : SteelAtomic unit uses unobservable
+  : SteelAtomicT unit uses unobservable
                 (pts_to_raw r p v0)
                 (fun _ -> pts_to_raw r (half_perm p) v0 `star` pts_to_raw r (half_perm p) v0)
   = as_atomic_action (mem_share_atomic_raw r v0)
 
 let share_atomic (#a:Type) #uses (#p:perm) (#v:erased a) (r:ref a)
-  : SteelAtomic unit uses unobservable
+  : SteelAtomicT unit uses unobservable
                (pts_to r p v)
                (fun _ -> pts_to r (half_perm p) v `star` pts_to r (half_perm p) v)
   = let v_old : erased (fractional a) = Ghost.hide (Some (Ghost.reveal v, p)) in
@@ -262,7 +262,7 @@ let mem_gather_atomic_raw (#a:Type) (#uses:_) (#p0 #p1:perm) (r:ref a) (v0:erase
     Mem.gather_action uses r v0 v1
 
 let gather_atomic_raw (#a:Type) (#uses:_) (#p0 #p1:perm) (r:ref a) (v0:erased a) (v1:erased a)
-  : SteelAtomic  (_:unit{v0==v1 /\ perm_ok (sum_perm p0 p1)}) uses unobservable
+  : SteelAtomicT  (_:unit{v0==v1 /\ perm_ok (sum_perm p0 p1)}) uses unobservable
                  (pts_to_raw r p0 v0 `star` pts_to_raw r p1 v1)
                  (fun _ -> pts_to_raw r (sum_perm p0 p1) v0)
   = as_atomic_action (mem_gather_atomic_raw r v0 v1)

--- a/ulib/experimental/Steel.HigherReference.fsti
+++ b/ulib/experimental/Steel.HigherReference.fsti
@@ -68,7 +68,7 @@ val free (#a:Type) (#v:erased a) (r:ref a)
   : SteelT unit (pts_to r full_perm v) (fun _ -> emp)
 
 val share_atomic (#a:Type) (#uses:_) (#p:perm) (#v:erased a) (r:ref a)
-  : SteelAtomic unit uses unobservable
+  : SteelAtomicT unit uses unobservable
     (pts_to r p v)
     (fun _ -> pts_to r (half_perm p) v `star` pts_to r (half_perm p) v)
 
@@ -78,7 +78,7 @@ val share (#a:Type) (#p:perm) (#v:erased a) (r:ref a)
     (fun _ -> pts_to r (half_perm p) v `star` pts_to r (half_perm p) v)
 
 val gather_atomic (#a:Type) (#uses:_) (#p0:perm) (#p1:perm) (#v0 #v1:erased a) (r:ref a)
-  : SteelAtomic (_:unit{v0==v1}) uses unobservable
+  : SteelAtomicT (_:unit{v0==v1}) uses unobservable
     (pts_to r p0 v0 `star` pts_to r p1 v1)
     (fun _ -> pts_to r (sum_perm p0 p1) v0)
 

--- a/ulib/experimental/Steel.Memory.fst
+++ b/ulib/experimental/Steel.Memory.fst
@@ -544,7 +544,7 @@ let lift_tot_action_nf #a #e #fp #fp' ($f:tot_action_nf_except e fp a fp')
 let lift_tot_action #a #e #fp #fp'
   ($f:tot_action_nf_except e fp a fp')
   (frame:slprop)
-  : MstTot a e fp fp' frame
+  : MstTot a e fp fp' frame (fun _ -> True) (fun _ _ _ -> True)
   = let m0 = NMSTTotal.get #(full_mem) #_ () in
     ac_reasoning_for_m_frame_preserving fp frame (locks_invariant e m0) m0;
     assert (interp (fp `star` frame `star` locks_invariant e m0) m0);
@@ -609,7 +609,7 @@ let lift_heap_action_with_frame
 let lift_tot_action_with_frame #a #e #fp #fp'
   ($f:tot_action_with_frame_except e fp a fp')
   (frame:slprop)
-  : MstTot a e fp fp' frame
+  : MstTot a e fp fp' frame (fun _ -> True) (fun _ _ _ -> True)
   = let m0 = NMSTTotal.get () in
     assert (inames_ok e m0);
     ac_reasoning_for_m_frame_preserving fp frame (locks_invariant e m0) m0;
@@ -877,6 +877,8 @@ let witness (#a:Type) (#pcm:pcm a)
   : MstTot unit e
            (pts_to r v)
            (fun _ -> pts_to r v `star` pure (witnessed r fact)) frame
+           (fun _ -> True)
+           (fun _ _ _ -> True)
   = let m0 = NMSTTotal.get () in
     let v' = H.sel_v r v (heap_of_mem m0) in
     assert (interp (H.ptr r) m0 /\ H.sel r (heap_of_mem m0) == v');
@@ -1051,7 +1053,7 @@ let new_invariant_tot_action (e:inames) (p:slprop) (m0:hmem_with_inv_except e p{
     ( i, m1 )
 
 let new_invariant (e:inames) (p:slprop) (frame:slprop)
-  : MstTot (inv p) e p (fun _ -> emp) frame
+  : MstTot (inv p) e p (fun _ -> emp) frame (fun _ -> True) (fun _ _ _ -> True)
   = let m0 = NMSTTotal.get () in
     ac_reasoning_for_m_frame_preserving p frame (locks_invariant e m0) m0;
     assert (interp (p `star` locks_invariant e m0) m0);
@@ -1207,7 +1209,7 @@ let with_invariant (#a:Type)
                    (i:inv p{not (i `Set.mem` opened_invariants)})
                    (f:action_except a (set_add i opened_invariants) (p `star` fp) (fun x -> p `star` fp' x))
                    (frame:slprop)
-  : MstTot a opened_invariants fp fp' frame
+  : MstTot a opened_invariants fp fp' frame (fun _ -> True) (fun _ _ _ -> True)
   = let m0 = NMSTTotal.get () in
     NMSTTotal.recall _ mem_evolves (iname_for_p_mem i p);
     assert (iname_for_p i p m0.locks);
@@ -1275,6 +1277,7 @@ let frame (#a:Type)
           ($f:action_except a opened_invariants pre post)
           (frame0:slprop)
   : MstTot a opened_invariants (pre `star` frame) (fun x -> post x `star` frame) frame0
+           (fun _ -> True) (fun _ _ _ -> True)
   = let m0 : full_mem = NMSTTotal.get () in
     equiv_pqrs_p_qr_s pre frame frame0 (linv opened_invariants m0);
     assert (interp (pre `star` frame `star` frame0 `star` linv opened_invariants m0) m0);

--- a/ulib/experimental/Steel.Memory.fst
+++ b/ulib/experimental/Steel.Memory.fst
@@ -1273,11 +1273,13 @@ let frame (#a:Type)
           (#opened_invariants:inames)
           (#pre:slprop)
           (#post:a -> slprop)
+          (#req:mprop pre)
+          (#ens:mprop2 pre post)
           (frame:slprop)
-          ($f:action_except a opened_invariants pre post)
+          ($f:action_except_full a opened_invariants pre post req ens)
           (frame0:slprop)
   : MstTot a opened_invariants (pre `star` frame) (fun x -> post x `star` frame) frame0
-           (fun _ -> True) (fun _ _ _ -> True)
+           req ens
   = let m0 : full_mem = NMSTTotal.get () in
     equiv_pqrs_p_qr_s pre frame frame0 (linv opened_invariants m0);
     assert (interp (pre `star` frame `star` frame0 `star` linv opened_invariants m0) m0);

--- a/ulib/experimental/Steel.Memory.fsti
+++ b/ulib/experimental/Steel.Memory.fsti
@@ -291,6 +291,15 @@ let mprop (fp:slprop u#a) =
     forall (m0:mem{interp fp m0}) (m1:mem{disjoint m0 m1}).
       q m0 <==> q (join m0 m1)}
 
+let mprop2 (#a:Type u#b) (fp_pre:slprop u#a) (fp_post:a -> slprop u#a) =
+  q:(mem u#a -> a -> mem u#a -> prop){
+    // can join any disjoint mem to the pre-mem and q is still valid
+    (forall (x:a) (m0:mem{interp fp_pre m0}) (m_post:mem{interp (fp_post x) m_post}) (m1:mem{disjoint m0 m1}).
+      q m0 x m_post <==> q (join m0 m1) x m_post) /\
+    // can join any mem to the post-mem and q is still valid
+    (forall (x:a) (m_pre:mem{interp fp_pre m_pre}) (m0:mem{interp (fp_post x) m0}) (m1:mem{disjoint m0 m1}).
+      q m_pre x m0 <==> q m_pre x (join m0 m1))}
+
 (**
   The preorder along wich the memory evolves with every update. See [Steel.Heap.heap_evolves]
 *)
@@ -308,19 +317,23 @@ effect MstTot
   (expects:slprop u#1)
   (provides: a -> slprop u#1)
   (frame:slprop u#1)
+  (pre:mprop expects)
+  (post:mprop2 expects provides)
   = NMSTTotal.NMSTATETOT a (full_mem u#1) mem_evolves
     (requires fun m0 ->
         inames_ok except m0 /\
-        interp (expects `star` frame `star` locks_invariant except m0) m0)
+        interp (expects `star` frame `star` locks_invariant except m0) m0 /\
+        pre (core_mem m0))
     (ensures fun m0 x m1 ->
         inames_ok except m1 /\
         interp (expects `star` frame `star` locks_invariant except m0) m0 /\  //TODO: fix the effect so as not to repeat this
         interp (provides x `star` frame `star` locks_invariant except m1) m1 /\
+        post (core_mem m0) x (core_mem m1) /\
         (forall (f_frame:mprop frame). f_frame (core_mem m0) == f_frame (core_mem m1)))
 
 (** An action is just a thunked computation in [MstTot] that takes a frame as argument *)
 let action_except (a:Type u#a) (except:inames) (expects:slprop) (provides: a -> slprop) =
-  frame:slprop -> MstTot a except expects provides frame
+  frame:slprop -> MstTot a except expects provides frame (fun _ -> True) (fun _ _ _ -> True)
 
 val sel_action (#a:Type u#1) (#pcm:_) (e:inames) (r:ref a pcm) (v0:erased a)
   : action_except (v:a{compatible pcm v0 v}) e (pts_to r v0) (fun _ -> pts_to r v0)

--- a/ulib/experimental/Steel.Memory.fsti
+++ b/ulib/experimental/Steel.Memory.fsti
@@ -335,6 +335,14 @@ effect MstTot
 let action_except (a:Type u#a) (except:inames) (expects:slprop) (provides: a -> slprop) =
   frame:slprop -> MstTot a except expects provides frame (fun _ -> True) (fun _ _ _ -> True)
 
+let action_except_full (a:Type u#a)
+  (except:inames)
+  (expects:slprop)
+  (provides: a -> slprop)
+  (req:mprop expects)
+  (ens:mprop2 expects provides)
+= frame:slprop -> MstTot a except expects provides frame req ens
+
 val sel_action (#a:Type u#1) (#pcm:_) (e:inames) (r:ref a pcm) (v0:erased a)
   : action_except (v:a{compatible pcm v0 v}) e (pts_to r v0) (fun _ -> pts_to r v0)
 
@@ -448,9 +456,11 @@ val frame (#a:Type)
           (#opened_invariants:inames)
           (#pre:slprop)
           (#post:a -> slprop)
+          (#req:mprop pre)
+          (#ens:mprop2 pre post)
           (frame:slprop)
-          ($f:action_except a opened_invariants pre post)
-  : action_except a opened_invariants (pre `star` frame) (fun x -> post x `star` frame)
+          ($f:action_except_full a opened_invariants pre post req ens)
+  : action_except_full a opened_invariants (pre `star` frame) (fun x -> post x `star` frame) req ens
 
 val change_slprop (#opened_invariants:inames)
                   (p q:slprop)

--- a/ulib/experimental/Steel.MonotonicHigherReference.fst
+++ b/ulib/experimental/Steel.MonotonicHigherReference.fst
@@ -272,7 +272,7 @@ let extract_pure #a #uses #p #f
                  (r:ref a p)
                  (v:Ghost.erased a)
                  (h:Ghost.erased (history a p))
-  : SteelAtomic (_:unit{history_val h v f})
+  : SteelAtomicT (_:unit{history_val h v f})
            uses
            unobservable
            (pts_to_body r f v h)
@@ -289,7 +289,7 @@ let elim_pure #a #uses #p #f
                  (r:ref a p)
                  (v:Ghost.erased a)
                  (h:Ghost.erased (history a p))
-  : SteelAtomic (_:unit{history_val h v f})
+  : SteelAtomicT (_:unit{history_val h v f})
            uses
            unobservable
            (pts_to_body r f v h)

--- a/ulib/experimental/Steel.Reference.fst
+++ b/ulib/experimental/Steel.Reference.fst
@@ -165,6 +165,8 @@ let cas_action (#t:eqtype)
             (pts_to r full_perm v)
             (fun b -> if b then pts_to r full_perm v_new else pts_to r full_perm v)
             frame
+            (fun _ -> True)
+            (fun _ _ _ -> True)
    = let hv =     (Ghost.hide (U.raise_val (Ghost.reveal v))) in
      let b = H.cas_action #(U.raise_t t)
                   (lift_eq #t)

--- a/ulib/experimental/Steel.Reference.fsti
+++ b/ulib/experimental/Steel.Reference.fsti
@@ -69,12 +69,12 @@ val free (#a:Type0) (#v:erased a) (r:ref a)
 
 
 val share_atomic (#a:Type0) (#uses:_) (#p:perm) (#v:erased a) (r:ref a)
-  : SteelAtomic unit uses unobservable
+  : SteelAtomicT unit uses unobservable
     (pts_to r p v)
     (fun _ -> pts_to r (half_perm p) v `star` pts_to r (half_perm p) v)
 
 val gather_atomic (#a:Type0) (#uses:_) (#p0:perm) (#p1:perm) (#v0 #v1:erased a) (r:ref a)
-  : SteelAtomic (_:unit{v0 == v1}) uses unobservable
+  : SteelAtomicT (_:unit{v0 == v1}) uses unobservable
     (pts_to r p0 v0 `star` pts_to r p1 v1)
     (fun _ -> pts_to r (sum_perm p0 p1) v0)
 
@@ -84,7 +84,7 @@ val cas (#t:eqtype)
         (v:Ghost.erased t)
         (v_old:t)
         (v_new:t)
-  : SteelAtomic
+  : SteelAtomicT
         (b:bool{b <==> (Ghost.reveal v == v_old)})
         uses
         observable


### PR DESCRIPTION
This PR adds support to use requires/ensures self-framing clauses with the SteelAtomic effect. In particular,
- it enhances MstTot in Steel.Memory to take an additional pre and postcondition
- it propagates this modification to Steel.EffectX.Atomic and Steel.Effect.Atomic
- it defines a new action_except_full, which is similar to action_except, but also takes a requires/ensures. The signature of action_except remains the same, and matches to an MstTot with trivial requires/ensures to ensure compatibility with existing code.
- it changes relations between Steel and SteelAtomic effect to account for requires/ensures when using polymonadic binds and subcomps
- it defines a new effect SteelAtomicT corresponding to SteelAtomic with trivial requires/ensures (similar to SteelT)
- For backwards compatibility, it modifies existing atomic code to use SteelAtomicT instead of SteelAtomic