### PR TITLE
A new option to load cmxs and fail hard if cmxs is not found, instead of compiling the ml file

### DIFF
--- a/src/basic/FStar.Options.fs
+++ b/src/basic/FStar.Options.fs
@@ -202,6 +202,7 @@ let defaults =
       ("keep_query_captions"          , Bool true);
       ("lax"                          , Bool false);
       ("load"                         , List []);
+      ("load_cmxs"                    , List []);
       ("log_queries"                  , Bool false);
       ("log_types"                    , Bool false);
       ("max_fuel"                     , Int 8);
@@ -382,6 +383,7 @@ let get_initial_ifuel           ()      = lookup_opt "initial_ifuel"            
 let get_keep_query_captions     ()      = lookup_opt "keep_query_captions"      as_bool
 let get_lax                     ()      = lookup_opt "lax"                      as_bool
 let get_load                    ()      = lookup_opt "load"                     (as_list as_string)
+let get_load_cmxs               ()      = lookup_opt "load_cmxs"                (as_list as_string) 
 let get_log_queries             ()      = lookup_opt "log_queries"              as_bool
 let get_log_types               ()      = lookup_opt "log_types"                as_bool
 let get_max_fuel                ()      = lookup_opt "max_fuel"                 as_int
@@ -915,7 +917,12 @@ let rec specs_with_types warn_unsafe : list<(char * string * opt_type * string)>
       ( noshort,
        "load",
         ReverseAccumulated (PathStr "module"),
-        "Load compiled module");
+        "Load OCaml module, compiling it if necessary");
+
+      ( noshort,
+       "load_cmxs",
+        ReverseAccumulated (PathStr "module"),
+        "Load compiled module, fails hard if the module is not already compiled");
 
        ( noshort,
         "log_types",
@@ -1383,6 +1390,7 @@ let settable = function
     | "initial_ifuel"
     | "lax"
     | "load"
+    | "load_cmxs"
     | "log_queries"
     | "log_types"
     | "max_fuel"
@@ -1709,6 +1717,7 @@ let initial_ifuel                () = min (get_initial_ifuel ()) (get_max_ifuel 
 let interactive                  () = get_in () || get_ide ()
 let lax                          () = get_lax                         ()
 let load                         () = get_load                        ()
+let load_cmxs                    () = get_load_cmxs                   ()
 let legacy_interactive           () = get_in                          ()
 let lsp_server                   () = get_lsp                         ()
 let log_queries                  () = get_log_queries                 ()

--- a/src/basic/FStar.Options.fsi
+++ b/src/basic/FStar.Options.fsi
@@ -147,6 +147,7 @@ val interactive                 : unit    -> bool
 val keep_query_captions         : unit    -> bool
 val lax                         : unit    -> bool
 val load                        : unit    -> list<string>
+val load_cmxs                   : unit    -> list<string>
 val legacy_interactive          : unit    -> bool
 val lsp_server                  : unit    -> bool
 val log_queries                 : unit    -> bool

--- a/src/fstar/FStar.Main.fs
+++ b/src/fstar/FStar.Main.fs
@@ -62,6 +62,7 @@ let report_errors fmods =
 
 let load_native_tactics () =
     let modules_to_load = Options.load() |> List.map Ident.lid_of_str in
+    let cmxs_to_load = Options.load_cmxs () |> List.map Ident.lid_of_str in
     let ml_module_name m = FStar.Extraction.ML.Util.ml_module_name_of_lid m in
     let ml_file m = ml_module_name m ^ ".ml" in
     let cmxs_file m =
@@ -69,21 +70,25 @@ let load_native_tactics () =
         match FStar.Options.find_file cmxs with
         | Some f -> f
         | None ->
-        match FStar.Options.find_file (ml_file m) with
-        | None ->
-            E.raise_err (E.Fatal_FailToCompileNativeTactic,
-                         Util.format1 "Failed to compile native tactic; extracted module %s not found" (ml_file m))
-        | Some ml ->
-            let dir = Util.dirname ml in
-            FStar.Tactics.Load.compile_modules dir [ml_module_name m];
-            begin match FStar.Options.find_file cmxs with
+          if List.contains m cmxs_to_load  //if this module comes from the cmxs list, fail hard
+          then E.raise_err (E.Fatal_FailToCompileNativeTactic,
+                            Util.format1 "Could not find %s to load" cmxs)
+          else  //else try to find and compile the ml file
+            match FStar.Options.find_file (ml_file m) with
             | None ->
-                E.raise_err (E.Fatal_FailToCompileNativeTactic,
-                         Util.format1 "Failed to compile native tactic; compiled object %s not found" cmxs)
-            | Some f -> f
-            end
+              E.raise_err (E.Fatal_FailToCompileNativeTactic,
+                           Util.format1 "Failed to compile native tactic; extracted module %s not found" (ml_file m))
+            | Some ml ->
+              let dir = Util.dirname ml in
+              FStar.Tactics.Load.compile_modules dir [ml_module_name m];
+              begin match FStar.Options.find_file cmxs with
+                | None ->
+                  E.raise_err (E.Fatal_FailToCompileNativeTactic,
+                               Util.format1 "Failed to compile native tactic; compiled object %s not found" cmxs)
+                | Some f -> f
+              end
     in
-    let cmxs_files = modules_to_load |> List.map cmxs_file in
+    let cmxs_files = (modules_to_load@cmxs_to_load) |> List.map cmxs_file in
     if Options.debug_any () then
       Util.print1 "Will try to load cmxs files: %s\n" (String.concat ", " cmxs_files);
     if not (Options.no_load_fstartaclib ()) && not (FStar.Platform.system = FStar.Platform.Windows) then

--- a/src/ocaml-output/FStar_Main.ml
+++ b/src/ocaml-output/FStar_Main.ml
@@ -60,6 +60,9 @@ let (load_native_tactics : unit -> unit) =
     let modules_to_load =
       let uu___1 = FStar_Options.load () in
       FStar_All.pipe_right uu___1 (FStar_List.map FStar_Ident.lid_of_str) in
+    let cmxs_to_load =
+      let uu___1 = FStar_Options.load_cmxs () in
+      FStar_All.pipe_right uu___1 (FStar_List.map FStar_Ident.lid_of_str) in
     let ml_module_name m = FStar_Extraction_ML_Util.ml_module_name_of_lid m in
     let ml_file m =
       let uu___1 = ml_module_name m in Prims.op_Hat uu___1 ".ml" in
@@ -69,35 +72,45 @@ let (load_native_tactics : unit -> unit) =
       match uu___1 with
       | FStar_Pervasives_Native.Some f -> f
       | FStar_Pervasives_Native.None ->
-          let uu___2 =
-            let uu___3 = ml_file m in FStar_Options.find_file uu___3 in
-          (match uu___2 with
-           | FStar_Pervasives_Native.None ->
-               let uu___3 =
+          if FStar_List.contains m cmxs_to_load
+          then
+            let uu___2 =
+              let uu___3 =
+                FStar_Util.format1 "Could not find %s to load" cmxs in
+              (FStar_Errors.Fatal_FailToCompileNativeTactic, uu___3) in
+            FStar_Errors.raise_err uu___2
+          else
+            (let uu___3 =
+               let uu___4 = ml_file m in FStar_Options.find_file uu___4 in
+             match uu___3 with
+             | FStar_Pervasives_Native.None ->
                  let uu___4 =
-                   let uu___5 = ml_file m in
-                   FStar_Util.format1
-                     "Failed to compile native tactic; extracted module %s not found"
-                     uu___5 in
-                 (FStar_Errors.Fatal_FailToCompileNativeTactic, uu___4) in
-               FStar_Errors.raise_err uu___3
-           | FStar_Pervasives_Native.Some ml ->
-               let dir = FStar_Util.dirname ml in
-               ((let uu___4 = let uu___5 = ml_module_name m in [uu___5] in
-                 FStar_Tactics_Load.compile_modules dir uu___4);
-                (let uu___4 = FStar_Options.find_file cmxs in
-                 match uu___4 with
-                 | FStar_Pervasives_Native.None ->
-                     let uu___5 =
+                   let uu___5 =
+                     let uu___6 = ml_file m in
+                     FStar_Util.format1
+                       "Failed to compile native tactic; extracted module %s not found"
+                       uu___6 in
+                   (FStar_Errors.Fatal_FailToCompileNativeTactic, uu___5) in
+                 FStar_Errors.raise_err uu___4
+             | FStar_Pervasives_Native.Some ml ->
+                 let dir = FStar_Util.dirname ml in
+                 ((let uu___5 = let uu___6 = ml_module_name m in [uu___6] in
+                   FStar_Tactics_Load.compile_modules dir uu___5);
+                  (let uu___5 = FStar_Options.find_file cmxs in
+                   match uu___5 with
+                   | FStar_Pervasives_Native.None ->
                        let uu___6 =
-                         FStar_Util.format1
-                           "Failed to compile native tactic; compiled object %s not found"
-                           cmxs in
-                       (FStar_Errors.Fatal_FailToCompileNativeTactic, uu___6) in
-                     FStar_Errors.raise_err uu___5
-                 | FStar_Pervasives_Native.Some f -> f))) in
+                         let uu___7 =
+                           FStar_Util.format1
+                             "Failed to compile native tactic; compiled object %s not found"
+                             cmxs in
+                         (FStar_Errors.Fatal_FailToCompileNativeTactic,
+                           uu___7) in
+                       FStar_Errors.raise_err uu___6
+                   | FStar_Pervasives_Native.Some f -> f))) in
     let cmxs_files =
-      FStar_All.pipe_right modules_to_load (FStar_List.map cmxs_file) in
+      FStar_All.pipe_right (FStar_List.append modules_to_load cmxs_to_load)
+        (FStar_List.map cmxs_file) in
     (let uu___2 = FStar_Options.debug_any () in
      if uu___2
      then

--- a/src/ocaml-output/FStar_Options.ml
+++ b/src/ocaml-output/FStar_Options.ml
@@ -239,6 +239,7 @@ let (defaults : (Prims.string * option_val) Prims.list) =
   ("keep_query_captions", (Bool true));
   ("lax", (Bool false));
   ("load", (List []));
+  ("load_cmxs", (List []));
   ("log_queries", (Bool false));
   ("log_types", (Bool false));
   ("max_fuel", (Int (Prims.of_int (8))));
@@ -453,6 +454,8 @@ let (get_keep_query_captions : unit -> Prims.bool) =
 let (get_lax : unit -> Prims.bool) = fun uu___ -> lookup_opt "lax" as_bool
 let (get_load : unit -> Prims.string Prims.list) =
   fun uu___ -> lookup_opt "load" (as_list as_string)
+let (get_load_cmxs : unit -> Prims.string Prims.list) =
+  fun uu___ -> lookup_opt "load_cmxs" (as_list as_string)
 let (get_log_queries : unit -> Prims.bool) =
   fun uu___ -> lookup_opt "log_queries" as_bool
 let (get_log_types : unit -> Prims.bool) =
@@ -923,7 +926,7 @@ let (interp_quake_arg : Prims.string -> (Prims.int * Prims.int * Prims.bool))
           let uu___ = ios f1 in let uu___1 = ios f2 in (uu___, uu___1, true)
         else failwith "unexpected value for --quake"
     | uu___ -> failwith "unexpected value for --quake"
-let (uu___404 : (((Prims.string -> unit) -> unit) * (Prims.string -> unit)))
+let (uu___405 : (((Prims.string -> unit) -> unit) * (Prims.string -> unit)))
   =
   let cb = FStar_Util.mk_ref FStar_Pervasives_Native.None in
   let set1 f = FStar_ST.op_Colon_Equals cb (FStar_Pervasives_Native.Some f) in
@@ -934,11 +937,11 @@ let (uu___404 : (((Prims.string -> unit) -> unit) * (Prims.string -> unit)))
     | FStar_Pervasives_Native.Some f -> f msg in
   (set1, call)
 let (set_option_warning_callback_aux : (Prims.string -> unit) -> unit) =
-  match uu___404 with
+  match uu___405 with
   | (set_option_warning_callback_aux1, option_warning_callback) ->
       set_option_warning_callback_aux1
 let (option_warning_callback : Prims.string -> unit) =
-  match uu___404 with
+  match uu___405 with
   | (set_option_warning_callback_aux1, option_warning_callback1) ->
       option_warning_callback1
 let (set_option_warning_callback : (Prims.string -> unit) -> unit) =
@@ -1104,7 +1107,10 @@ let rec (specs_with_types :
            (Const (Bool true)))),
       "Run the lax-type checker only (admit all verification conditions)");
     (FStar_Getopt.noshort, "load", (ReverseAccumulated (PathStr "module")),
-      "Load compiled module");
+      "Load OCaml module, compiling it if necessary");
+    (FStar_Getopt.noshort, "load_cmxs",
+      (ReverseAccumulated (PathStr "module")),
+      "Load compiled module, fails hard if the module is not already compiled");
     (FStar_Getopt.noshort, "log_types", (Const (Bool true)),
       "Print types computed for data/val/let-bindings");
     (FStar_Getopt.noshort, "log_queries", (Const (Bool true)),
@@ -1343,6 +1349,7 @@ let (settable : Prims.string -> Prims.bool) =
     | "initial_ifuel" -> true
     | "lax" -> true
     | "load" -> true
+    | "load_cmxs" -> true
     | "log_queries" -> true
     | "log_types" -> true
     | "max_fuel" -> true
@@ -1415,7 +1422,7 @@ let (settable_specs :
     (FStar_List.filter
        (fun uu___ ->
           match uu___ with | (uu___1, x, uu___2, uu___3) -> settable x))
-let (uu___584 :
+let (uu___586 :
   (((unit -> FStar_Getopt.parse_cmdline_res) -> unit) *
     (unit -> FStar_Getopt.parse_cmdline_res)))
   =
@@ -1431,11 +1438,11 @@ let (uu___584 :
   (set1, call)
 let (set_error_flags_callback_aux :
   (unit -> FStar_Getopt.parse_cmdline_res) -> unit) =
-  match uu___584 with
+  match uu___586 with
   | (set_error_flags_callback_aux1, set_error_flags) ->
       set_error_flags_callback_aux1
 let (set_error_flags : unit -> FStar_Getopt.parse_cmdline_res) =
-  match uu___584 with
+  match uu___586 with
   | (set_error_flags_callback_aux1, set_error_flags1) -> set_error_flags1
 let (set_error_flags_callback :
   (unit -> FStar_Getopt.parse_cmdline_res) -> unit) =
@@ -1815,6 +1822,8 @@ let (interactive : unit -> Prims.bool) =
   fun uu___ -> (get_in ()) || (get_ide ())
 let (lax : unit -> Prims.bool) = fun uu___ -> get_lax ()
 let (load : unit -> Prims.string Prims.list) = fun uu___ -> get_load ()
+let (load_cmxs : unit -> Prims.string Prims.list) =
+  fun uu___ -> get_load_cmxs ()
 let (legacy_interactive : unit -> Prims.bool) = fun uu___ -> get_in ()
 let (lsp_server : unit -> Prims.bool) = fun uu___ -> get_lsp ()
 let (log_queries : unit -> Prims.bool) = fun uu___ -> get_log_queries ()


### PR DESCRIPTION
We use this option in EverParse 3d to prevent potential race condition in compiling and writing the .cmxs file.