### PR TITLE
Make DeferredImplicits more precise

### DIFF
--- a/src/ocaml-output/FStar_TypeChecker_DeferredImplicits.ml
+++ b/src/ocaml-output/FStar_TypeChecker_DeferredImplicits.ml
@@ -538,7 +538,8 @@ let (solve_deferred_to_tactic_goals :
                                 FStar_TypeChecker_Env.new_implicit_var_aux
                                   reason
                                   (tp.FStar_TypeChecker_Common.lhs).FStar_Syntax_Syntax.pos
-                                  env2 goal_ty FStar_Syntax_Syntax.Strict
+                                  env2 goal_ty
+                                  FStar_Syntax_Syntax.Allow_untyped
                                   FStar_Pervasives_Native.None in
                               (match uu___7 with
                                | (goal, ctx_uvar, uu___8) ->
@@ -562,9 +563,24 @@ let (solve_deferred_to_tactic_goals :
                                      if uu___9
                                      then
                                        let uu___10 =
-                                         flex_uvar_head
-                                           tp.FStar_TypeChecker_Common.lhs in
-                                       find_user_tac_for_uvar env2 uu___10
+                                         let uu___11 =
+                                           flex_uvar_head
+                                             tp.FStar_TypeChecker_Common.lhs in
+                                         find_user_tac_for_uvar env2 uu___11 in
+                                       match uu___10 with
+                                       | FStar_Pervasives_Native.None ->
+                                           let uu___11 =
+                                             is_flex
+                                               tp.FStar_TypeChecker_Common.rhs in
+                                           (if uu___11
+                                            then
+                                              let uu___12 =
+                                                flex_uvar_head
+                                                  tp.FStar_TypeChecker_Common.rhs in
+                                              find_user_tac_for_uvar env2
+                                                uu___12
+                                            else FStar_Pervasives_Native.None)
+                                       | v -> v
                                      else
                                        (let uu___11 =
                                           is_flex

--- a/src/typechecker/FStar.TypeChecker.DeferredImplicits.fs
+++ b/src/typechecker/FStar.TypeChecker.DeferredImplicits.fs
@@ -138,7 +138,7 @@ let solve_deferred_to_tactic_goals env g =
         in
         let goal_ty = U.mk_eq2 (env.universe_of env_lax t_eq) t_eq tp.lhs tp.rhs in
         let goal, ctx_uvar, _ =
-            Env.new_implicit_var_aux reason tp.lhs.pos env goal_ty Strict None
+            Env.new_implicit_var_aux reason tp.lhs.pos env goal_ty Allow_untyped None
         in
         let imp =
             { imp_reason = "";
@@ -149,7 +149,9 @@ let solve_deferred_to_tactic_goals env g =
         in
         let sigelt =
             if is_flex tp.lhs
-            then find_user_tac_for_uvar env (flex_uvar_head tp.lhs)
+            then (match find_user_tac_for_uvar env (flex_uvar_head tp.lhs) with
+              | None -> if is_flex tp.rhs then find_user_tac_for_uvar env (flex_uvar_head tp.rhs) else None
+              | v -> v)
             else if is_flex tp.rhs
             then find_user_tac_for_uvar env (flex_uvar_head tp.rhs)
             else None


### PR DESCRIPTION
Deferring implicits to tactics sometimes fails when deferring a flex-flex constraint.

Consider ?u1 == ?u2 when ?u2 only is marked with a deferring annotation. 
Since ?u1 is a flex variable, the existing code looks for a tactic associated to it, and fails.
This happens quite often in Steel, when the layered effects combinators implicits are annotated,
but an slprop function implicit might not be.
This PR modifies the code to instead check both uvars when the constraint is a flex-flex.
This will remove the need to annotate all slprop implicits in Steel, limiting the annotations to the layered effects combinators.

It also propagates the Allow_untyped attribute which is currently used on the Steel branch