### PR TITLE
Correct typo in `lex_t` ordering.

### DIFF
--- a/doc/tutorial/tutorial.mdk
+++ b/doc/tutorial/tutorial.mdk
@@ -1602,7 +1602,7 @@ This is a list of heterogenously typed elements.
 * `LexCons v1 v2 << LexCons v1' v2'`, if and only if, either
   `v1 << v1'`; or `v1===v1'` and `v2 << v2'`.
 
-* If `v:lex_t` and `v <> LexTop`, then `v << LexTop`.
+* If `v:lex_t` and `v <> LexTop`, then `LexTop << v`.
 
 ~MK
 We could explain what that means, that longer `lex_t` are smaller?


### PR DESCRIPTION
I was working through the tutorial and this part seemed off:

> If v:lex_t and v <> LexTop, then v << LexTop.

given that it would contradict the ordering rules on inductive types.