### PR TITLE
Migrate from OMP to ppxlib

### DIFF
--- a/.docker/base/Dockerfile
+++ b/.docker/base/Dockerfile
@@ -16,7 +16,7 @@ USER build
 WORKDIR /home/build
 
 # Prepare and build OPAM and OCaml
-RUN opam init -y --disable-sandboxing --compiler=4.07.0
+RUN opam init -y --disable-sandboxing
 RUN opam update
 RUN opam install -y ocamlbuild ocamlfind batteries stdint zarith yojson fileutils pprint menhir sedlex ppx_deriving ppx_deriving_yojson process pprint visitors fix wasm ppxlib=0.22.0
 

--- a/.docker/base/Dockerfile
+++ b/.docker/base/Dockerfile
@@ -18,7 +18,7 @@ WORKDIR /home/build
 # Prepare and build OPAM and OCaml
 RUN opam init -y --disable-sandboxing --compiler=4.07.0
 RUN opam update
-RUN opam install -y ocamlbuild ocamlfind batteries stdint zarith yojson fileutils pprint menhir sedlex ppx_deriving ppx_deriving_yojson process pprint visitors fix wasm
+RUN opam install -y ocamlbuild ocamlfind batteries stdint zarith yojson fileutils pprint menhir sedlex ppx_deriving ppx_deriving_yojson process pprint visitors fix wasm ppxlib=0.22.0
 
 # Prepare and build Z3
 ENV z3=z3-4.8.5-x64-debian-8.11

--- a/.merlin
+++ b/.merlin
@@ -7,7 +7,7 @@ PKG zarith
 PKG menhirLib
 PKG sedlex
 PKG sedlex.ppx
-PKG ocaml-migrate-parsetree
+PKG ppxlib
 
 S src/basic/ml
 S src/extraction/ml

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -120,7 +120,7 @@ running the following commands. (Note: On Windows this requires Cygwin and `make
    your OS; then use the following command to install the packages
    required to compile OCaml programs extracted from F\* code:
 
-        $ opam install ocamlfind batteries stdint zarith yojson ppx_deriving ppx_deriving_yojson process ocaml-migrate-parsetree.1.8.0
+        $ opam install ocamlfind batteries stdint zarith yojson ppx_deriving ppx_deriving_yojson ppxlib=0.22.0 process
 
 5. (Optional) You can also verify all the examples, keep in mind that this will
    take a long time, use a lot of resources, and there are also some quirks
@@ -243,7 +243,7 @@ Then follow step 4 in [Instructions for all OSes](#instructions-for-all-oses) be
 4. F\* depends on a bunch of external OCaml packages which you should install using OPAM:
 
   ```sh
-  $ opam install ocamlbuild ocamlfind batteries stdint zarith yojson fileutils pprint menhir sedlex ppx_deriving ppx_deriving_yojson process ocaml-migrate-parsetree.1.8.0
+  $ opam install ocamlbuild ocamlfind batteries stdint zarith yojson fileutils pprint menhir sedlex ppx_deriving ppx_deriving_yojson process ppxlib=0.22.0
   ```
 
   **Note:** This list of opam packages is longer than the list in the

--- a/_tags
+++ b/_tags
@@ -26,7 +26,7 @@ true: \
   package(sedlex), \
   package(stdint), \
   package(yojson), \
-  package(ocaml-migrate-parsetree), \
+  package(ppxlib), \
   package(process)
 
 # This ensures that main.native bundles its dependencies, which dynlinked tactics might need.

--- a/fstar.opam
+++ b/fstar.opam
@@ -5,7 +5,7 @@ authors: "Nik Swamy <nswamy@microsoft.com>,Jonathan Protzenko <protz@microsoft.c
 homepage: "http://fstar-lang.org"
 license: "Apache-2.0"
 depends: [
-  "ocaml" {>= "4.04.0" & < "4.10.0" }
+  "ocaml" {>= "4.04.1" & < "4.13.0" }
   "ocamlfind"
   "batteries"
   "zarith"
@@ -16,10 +16,10 @@ depends: [
   "menhir" {>= "20161115" build}
   "pprint" {build}
   "sedlex" {build}
+  "ppxlib" {= "0.22.0"}
   "ppx_deriving"
   "ppx_deriving_yojson"
   "process"
-  "ocaml-migrate-parsetree" {< "2.1.0"}
 ]
 depexts: ["coreutils"] {os = "macos" & os-distribution = "homebrew"}
 build: [

--- a/src/extraction/ml/.merlin
+++ b/src/extraction/ml/.merlin
@@ -1,7 +1,7 @@
 PKG batteries
 PKG compiler-libs
 PKG zarith
-PKG ocaml-migrate-parsetree
+PKG ppxlib
 
 B ../../ocaml-output/_build/src/ocaml-output
 B ../../ocaml-output/_build/src/basic/ml

--- a/src/parser/parse.fsy
+++ b/src/parser/parse.fsy
@@ -914,10 +914,7 @@ subEffect:
 | quident SQUIGGLY_RARROW quident LBRACE IDENT EQUALS simpleTerm RBRACE
     {let (src_eff, _2, tgt_eff, _4, x, _2_inlined1, y, _7) = ($1, (), $3, (), $5, (), $7, ()) in
 let lift2_opt =     ( None ) in
-let lift1 =
-  let _2 = _2_inlined1 in
-      ( (x, y) )
-in
+let lift1 =     ( (x, y) ) in
      (
        match lift2_opt with
        | None ->
@@ -941,17 +938,14 @@ in
 | quident SQUIGGLY_RARROW quident LBRACE IDENT EQUALS simpleTerm SEMICOLON IDENT EQUALS simpleTerm RBRACE
     {let (src_eff, _2, tgt_eff, _4, x, _2_inlined1, y, _1, id, _2_inlined2, y_inlined1, _7) = ($1, (), $3, (), $5, (), $7, (), $9, (), $11, ()) in
 let lift2_opt =
-  let (y, _2) = (y_inlined1, _2_inlined2) in
+  let y = y_inlined1 in
   let x =
     let x =                                                           (id) in
         ( (x, y) )
   in
       ( Some x )
 in
-let lift1 =
-  let _2 = _2_inlined1 in
-      ( (x, y) )
-in
+let lift1 =     ( (x, y) ) in
      (
        match lift2_opt with
        | None ->
@@ -1399,10 +1393,7 @@ noSeqTerm:
       ( mk_term (Ascribed(e,{t with level=Expr},tactic_opt)) (rhs2 parseState 1 4) Expr )}
 | atomicTermNotQUident DOT_LPAREN term RPAREN LARROW noSeqTerm
     {let (e1, _1, e, _3_inlined1, _3, e3) = ($1, (), $3, (), (), $6) in
-let op_expr =
-  let _3 = _3_inlined1 in
-                               ( mk_ident (".()", rhs parseState 1), e, rhs2 parseState 1 3 )
-in
+let op_expr =                              ( mk_ident (".()", rhs parseState 1), e, rhs2 parseState 1 3 ) in
       (
         let (op, e2, _) = op_expr in
         let opid = mk_ident (string_of_id op ^ "<-", range_of_id op) in
@@ -1410,10 +1401,7 @@ in
       )}
 | atomicTermNotQUident DOT_LBRACK term RBRACK LARROW noSeqTerm
     {let (e1, _1, e, _3_inlined1, _3, e3) = ($1, (), $3, (), (), $6) in
-let op_expr =
-  let _3 = _3_inlined1 in
-                               ( mk_ident (".[]", rhs parseState 1), e, rhs2 parseState 1 3 )
-in
+let op_expr =                              ( mk_ident (".[]", rhs parseState 1), e, rhs2 parseState 1 3 ) in
       (
         let (op, e2, _) = op_expr in
         let opid = mk_ident (string_of_id op ^ "<-", range_of_id op) in
@@ -1421,10 +1409,7 @@ in
       )}
 | atomicTermNotQUident DOT_LBRACK_BAR term BAR_RBRACK LARROW noSeqTerm
     {let (e1, _1, e, _3_inlined1, _3, e3) = ($1, (), $3, (), (), $6) in
-let op_expr =
-  let _3 = _3_inlined1 in
-                                       ( mk_ident (".[||]", rhs parseState 1), e, rhs2 parseState 1 3 )
-in
+let op_expr =                                      ( mk_ident (".[||]", rhs parseState 1), e, rhs2 parseState 1 3 ) in
       (
         let (op, e2, _) = op_expr in
         let opid = mk_ident (string_of_id op ^ "<-", range_of_id op) in
@@ -1432,10 +1417,7 @@ in
       )}
 | atomicTermNotQUident DOT_LENS_PAREN_LEFT term LENS_PAREN_RIGHT LARROW noSeqTerm
     {let (e1, _1, e, _3_inlined1, _3, e3) = ($1, (), $3, (), (), $6) in
-let op_expr =
-  let _3 = _3_inlined1 in
-                                                  ( mk_ident (".(||)", rhs parseState 1), e, rhs2 parseState 1 3 )
-in
+let op_expr =                                                 ( mk_ident (".(||)", rhs parseState 1), e, rhs2 parseState 1 3 ) in
       (
         let (op, e2, _) = op_expr in
         let opid = mk_ident (string_of_id op ^ "<-", range_of_id op) in

--- a/tests/interactive/backtracking.refinements.out.expected
+++ b/tests/interactive/backtracking.refinements.out.expected
@@ -1,7 +1,7 @@
 {"kind": "protocol-info", "rest": "[...]"}
 {"kind": "response", "query-id": "1", "response": [], "status": "success"}
 {"kind": "response", "query-id": "2", "response": [], "status": "success"}
-{"kind": "response", "query-id": "3", "response": [{"level": "error", "message": "Syntax error: Stdlib.Parsing.Parse_error", "number": 168, "ranges": [{"beg": [3, 6], "end": [3, 6], "fname": "<input>"}]}], "status": "success"}
+{"kind": "response", "query-id": "3", "response": [{"level": "error", "message": "Syntax error: Parsing.Parse_error", "number": 168, "ranges": [{"beg": [3, 6], "end": [3, 6], "fname": "<input>"}]}], "status": "success"}
 {"kind": "response", "query-id": "4", "response": [], "status": "success"}
 {"kind": "response", "query-id": "5", "response": [], "status": "success"}
 {"kind": "response", "query-id": "6", "response": [], "status": "success"}
@@ -10,11 +10,11 @@
 {"kind": "response", "query-id": "9", "response": [], "status": "success"}
 {"kind": "response", "query-id": "10", "response": [], "status": "success"}
 {"kind": "response", "query-id": "11", "response": null, "status": "success"}
-{"kind": "response", "query-id": "12", "response": [{"level": "error", "message": "Syntax error: Stdlib.Parsing.Parse_error", "number": 168, "ranges": [{"beg": [3, 12], "end": [3, 12], "fname": "<input>"}]}], "status": "success"}
-{"kind": "response", "query-id": "13", "response": [{"level": "error", "message": "Syntax error: Stdlib.Parsing.Parse_error", "number": 168, "ranges": [{"beg": [3, 12], "end": [3, 12], "fname": "<input>"}]}], "status": "success"}
-{"kind": "response", "query-id": "14", "response": [{"level": "error", "message": "Syntax error: Stdlib.Parsing.Parse_error", "number": 168, "ranges": [{"beg": [3, 12], "end": [3, 12], "fname": "<input>"}]}], "status": "success"}
-{"kind": "response", "query-id": "15", "response": [{"level": "error", "message": "Syntax error: Stdlib.Parsing.Parse_error", "number": 168, "ranges": [{"beg": [3, 12], "end": [3, 12], "fname": "<input>"}]}], "status": "success"}
-{"kind": "response", "query-id": "16", "response": [{"level": "error", "message": "Syntax error: Stdlib.Parsing.Parse_error", "number": 168, "ranges": [{"beg": [3, 12], "end": [3, 12], "fname": "<input>"}]}], "status": "success"}
+{"kind": "response", "query-id": "12", "response": [{"level": "error", "message": "Syntax error: Parsing.Parse_error", "number": 168, "ranges": [{"beg": [3, 12], "end": [3, 12], "fname": "<input>"}]}], "status": "success"}
+{"kind": "response", "query-id": "13", "response": [{"level": "error", "message": "Syntax error: Parsing.Parse_error", "number": 168, "ranges": [{"beg": [3, 12], "end": [3, 12], "fname": "<input>"}]}], "status": "success"}
+{"kind": "response", "query-id": "14", "response": [{"level": "error", "message": "Syntax error: Parsing.Parse_error", "number": 168, "ranges": [{"beg": [3, 12], "end": [3, 12], "fname": "<input>"}]}], "status": "success"}
+{"kind": "response", "query-id": "15", "response": [{"level": "error", "message": "Syntax error: Parsing.Parse_error", "number": 168, "ranges": [{"beg": [3, 12], "end": [3, 12], "fname": "<input>"}]}], "status": "success"}
+{"kind": "response", "query-id": "16", "response": [{"level": "error", "message": "Syntax error: Parsing.Parse_error", "number": 168, "ranges": [{"beg": [3, 12], "end": [3, 12], "fname": "<input>"}]}], "status": "success"}
 {"kind": "response", "query-id": "17", "response": [], "status": "success"}
 {"kind": "response", "query-id": "18", "response": [{"level": "error", "message": "Subtyping check failed; expected type a: nat{a > 2}; got type int; The SMT solver could not prove the query, try to spell your proof in more detail or increase fuel/ifuel", "number": 19, "ranges": [{"beg": [3, 23], "end": [3, 24], "fname": "<input>"}, {"beg": [3, 14], "end": [3, 19], "fname": "<input>"}]}], "status": "failure"}
 {"kind": "response", "query-id": "19", "response": [], "status": "success"}
@@ -29,17 +29,17 @@
 {"kind": "response", "query-id": "28", "response": [], "status": "success"}
 {"kind": "response", "query-id": "29", "response": [], "status": "success"}
 {"kind": "response", "query-id": "30", "response": [], "status": "success"}
-{"kind": "response", "query-id": "31", "response": [{"level": "error", "message": "Syntax error: Stdlib.Parsing.Parse_error", "number": 168, "ranges": [{"beg": [5, 5], "end": [5, 5], "fname": "<input>"}]}], "status": "success"}
-{"kind": "response", "query-id": "32", "response": [{"level": "error", "message": "Syntax error: Stdlib.Parsing.Parse_error", "number": 168, "ranges": [{"beg": [5, 8], "end": [5, 8], "fname": "<input>"}]}], "status": "success"}
+{"kind": "response", "query-id": "31", "response": [{"level": "error", "message": "Syntax error: Parsing.Parse_error", "number": 168, "ranges": [{"beg": [5, 5], "end": [5, 5], "fname": "<input>"}]}], "status": "success"}
+{"kind": "response", "query-id": "32", "response": [{"level": "error", "message": "Syntax error: Parsing.Parse_error", "number": 168, "ranges": [{"beg": [5, 8], "end": [5, 8], "fname": "<input>"}]}], "status": "success"}
 {"kind": "response", "query-id": "33", "response": [], "status": "success"}
 {"kind": "response", "query-id": "34", "response": [], "status": "success"}
 {"kind": "response", "query-id": "35", "response": [{"level": "error", "message": "Identifier not found: [b]", "number": 72, "ranges": [{"beg": [5, 7], "end": [5, 8], "fname": "<input>"}]}], "status": "success"}
 {"kind": "response", "query-id": "36", "response": [{"level": "error", "message": "Identifier not found: [b]", "number": 72, "ranges": [{"beg": [5, 7], "end": [5, 8], "fname": "<input>"}]}], "status": "success"}
 {"kind": "response", "query-id": "37", "response": [[3, "Prims", "nat"]], "status": "success"}
 {"kind": "response", "query-id": "38", "response": [], "status": "success"}
-{"kind": "response", "query-id": "39", "response": [{"level": "error", "message": "Syntax error: Stdlib.Parsing.Parse_error", "number": 168, "ranges": [{"beg": [5, 15], "end": [5, 15], "fname": "<input>"}]}], "status": "success"}
-{"kind": "response", "query-id": "40", "response": [{"level": "error", "message": "Syntax error: Stdlib.Parsing.Parse_error", "number": 168, "ranges": [{"beg": [5, 19], "end": [5, 19], "fname": "<input>"}]}], "status": "success"}
-{"kind": "response", "query-id": "41", "response": [{"level": "error", "message": "Syntax error: Stdlib.Parsing.Parse_error", "number": 168, "ranges": [{"beg": [5, 26], "end": [5, 26], "fname": "<input>"}]}], "status": "success"}
+{"kind": "response", "query-id": "39", "response": [{"level": "error", "message": "Syntax error: Parsing.Parse_error", "number": 168, "ranges": [{"beg": [5, 15], "end": [5, 15], "fname": "<input>"}]}], "status": "success"}
+{"kind": "response", "query-id": "40", "response": [{"level": "error", "message": "Syntax error: Parsing.Parse_error", "number": 168, "ranges": [{"beg": [5, 19], "end": [5, 19], "fname": "<input>"}]}], "status": "success"}
+{"kind": "response", "query-id": "41", "response": [{"level": "error", "message": "Syntax error: Parsing.Parse_error", "number": 168, "ranges": [{"beg": [5, 26], "end": [5, 26], "fname": "<input>"}]}], "status": "success"}
 {"kind": "response", "query-id": "42", "response": [], "status": "success"}
 {"kind": "response", "query-id": "43", "response": [], "status": "success"}
 {"kind": "response", "query-id": "44", "response": [], "status": "success"}

--- a/tests/interactive/integration.push-pop.out.expected
+++ b/tests/interactive/integration.push-pop.out.expected
@@ -76,7 +76,7 @@
 {"kind": "response", "query-id": "75", "response": [], "status": "success"}
 {"kind": "response", "query-id": "79", "response": [], "status": "success"}
 {"kind": "response", "query-id": "80", "response": [], "status": "success"}
-{"kind": "response", "query-id": "91", "response": [{"level": "error", "message": "Syntax error: Stdlib.Parsing.Parse_error", "number": 168, "ranges": [{"beg": [12, 0], "end": [12, 0], "fname": "<input>"}]}], "status": "success"}
+{"kind": "response", "query-id": "91", "response": [{"level": "error", "message": "Syntax error: Parsing.Parse_error", "number": 168, "ranges": [{"beg": [12, 0], "end": [12, 0], "fname": "<input>"}]}], "status": "success"}
 {"kind": "response", "query-id": "98", "response": [], "status": "success"}
 {"kind": "response", "query-id": "101", "response": [{"level": "error", "message": "Subtyping check failed; expected type nat; got type int; The SMT solver could not prove the query, try to spell your proof in more detail or increase fuel/ifuel", "number": 19, "ranges": [{"beg": [11, 15], "end": [11, 17], "fname": "<input>"}, {"beg": [626, 18], "end": [626, 24], "fname": "prims.fst"}]}], "status": "failure"}
 {"kind": "response", "query-id": "107", "response": [], "status": "success"}
@@ -92,7 +92,7 @@
 {"kind": "response", "query-id": "128", "response": [], "status": "success"}
 {"kind": "response", "query-id": "130", "response": [], "status": "success"}
 {"kind": "response", "query-id": "133", "response": [], "status": "success"}
-{"kind": "response", "query-id": "137", "response": [{"level": "error", "message": "Syntax error: Stdlib.Parsing.Parse_error", "number": 168, "ranges": [{"beg": [13, 4], "end": [13, 4], "fname": "<input>"}]}], "status": "success"}
+{"kind": "response", "query-id": "137", "response": [{"level": "error", "message": "Syntax error: Parsing.Parse_error", "number": 168, "ranges": [{"beg": [13, 4], "end": [13, 4], "fname": "<input>"}]}], "status": "success"}
 {"kind": "response", "query-id": "159", "response": [{"level": "error", "message": "Expected expression of type \"Type0\"; got expression \"Integration.xx\" of type \"nat\"", "number": 189, "ranges": [{"beg": [13, 15], "end": [13, 20], "fname": "<input>"}]}], "status": "success"}
 {"kind": "response", "query-id": "163", "response": [], "status": "success"}
 {"kind": "response", "query-id": "164", "response": [], "status": "success"}

--- a/ulib/ml/fstar-compiler-lib-META
+++ b/ulib/ml/fstar-compiler-lib-META
@@ -1,4 +1,4 @@
 name="fstar-compiler-lib"
 version="__FSTAR_VERSION__"
 description="FStar compiler"
-requires="batteries,compiler-libs,compiler-libs.common,dynlink,pprint,stdint,yojson,zarith,ocaml-migrate-parsetree"
+requires="batteries,compiler-libs,compiler-libs.common,dynlink,pprint,stdint,yojson,zarith,ppxlib"


### PR DESCRIPTION
See #2246 for more context

In ocaml-migrate-parsetree 2.0, there is only functionality to migrate ASTs, but not constructing ASTs. This commit removes the OMP library and uses ppxlib instead, ppxlib is supposed to be replacement for such functionality