### PR TITLE
Fix testcase for #2257

### DIFF
--- a/tests/bug-reports/Bug2257.fst
+++ b/tests/bug-reports/Bug2257.fst
@@ -5,7 +5,7 @@ open FStar.Tactics
 let match_sigelt (n: name) =
   let se = lookup_typ (top_env ()) n in
   match se with | Some _ -> ()
-                | None -> ()
+                | None -> fail ""
 
 val foo: int
-let _ = run_tactic (fun _ -> match_sigelt ["SigeltVal";"foo"])
+let _ = run_tactic (fun _ -> match_sigelt ["Bug2257";"foo"])


### PR DESCRIPTION
@aseemr, I think the test for issue #2257 is wrong, it's explicitly looking for the module `SigeltVal`, not `Bug2257`.
So I changed that, and added a fail if the `sigelt` is not found :)