### PR TITLE
--ide_id_info_off to turn of id tables in ide mode

### DIFF
--- a/src/basic/FStar.Options.fs
+++ b/src/basic/FStar.Options.fs
@@ -191,6 +191,7 @@ let defaults =
       ("hint_file"                    , Unset);
       ("in"                           , Bool false);
       ("ide"                          , Bool false);
+      ("ide_id_info_off"              , Bool false);
       ("lsp"                          , Bool false);
       ("include"                      , List []);
       ("print"                        , Bool false);
@@ -373,6 +374,7 @@ let get_hint_dir                ()      = lookup_opt "hint_dir"                 
 let get_hint_file               ()      = lookup_opt "hint_file"                (as_option as_string)
 let get_in                      ()      = lookup_opt "in"                       as_bool
 let get_ide                     ()      = lookup_opt "ide"                      as_bool
+let get_ide_id_info_off         ()      = lookup_opt "ide_id_info_off"          as_bool
 let get_lsp                     ()      = lookup_opt "lsp"                      as_bool
 let get_include                 ()      = lookup_opt "include"                  (as_list as_string)
 let get_print                   ()      = lookup_opt "print"                    as_bool
@@ -830,6 +832,11 @@ let rec specs_with_types warn_unsafe : list<(char * string * opt_type * string)>
         "ide",
         Const (Bool true),
         "JSON-based interactive mode for IDEs");
+
+       ( noshort,
+        "ide_id_info_off",
+        Const (Bool true),
+        "Disable identifier tables in IDE mode (temporary workaround useful in Steel)");
 
        ( noshort,
         "lsp",
@@ -1381,6 +1388,7 @@ let settable = function
     | "ifuel"
     | "initial_fuel"
     | "initial_ifuel"
+    | "ide_id_info_off"
     | "lax"
     | "load"
     | "load_cmxs"
@@ -1702,6 +1710,7 @@ let hint_file_for_src src_filename =
         in
         Util.format1 "%s.hints" file_name
 let ide                          () = get_ide                         ()
+let ide_id_info_off              () = get_ide_id_info_off             ()
 let print                        () = get_print                       ()
 let print_in_place               () = get_print_in_place              ()
 let initial_fuel                 () = min (get_initial_fuel ()) (get_max_fuel ())

--- a/src/basic/FStar.Options.fsi
+++ b/src/basic/FStar.Options.fsi
@@ -138,6 +138,7 @@ val hide_uvar_nums              : unit    -> bool
 val hint_info                   : unit    -> bool
 val hint_file_for_src           : string  -> string
 val ide                         : unit    -> bool
+val ide_id_info_off             : unit    -> bool
 val include_path                : unit    -> list<string>
 val print                       : unit    -> bool
 val print_in_place              : unit    -> bool

--- a/src/fstar/FStar.Interactive.Ide.fs
+++ b/src/fstar/FStar.Interactive.Ide.fs
@@ -696,7 +696,11 @@ let run_push_without_deps st query =
 
   let frag = { frag_fname = "<input>"; frag_text = text; frag_line = line; frag_col = column } in
 
-  TcEnv.toggle_id_info st.repl_env true;
+  let _ =
+    if FStar.Options.ide_id_info_off()
+    then TcEnv.toggle_id_info st.repl_env false
+    else TcEnv.toggle_id_info st.repl_env true
+  in
   let st = set_nosynth_flag st peek_only in
   let success, st = run_repl_transaction st push_kind peek_only (PushFragment frag) in
   let st = set_nosynth_flag st false in

--- a/src/ocaml-output/FStar_Interactive_Ide.ml
+++ b/src/ocaml-output/FStar_Interactive_Ide.ml
@@ -1589,8 +1589,14 @@ let run_push_without_deps :
               FStar_Parser_ParseIt.frag_line = line;
               FStar_Parser_ParseIt.frag_col = column
             } in
-          (FStar_TypeChecker_Env.toggle_id_info
-             st.FStar_Interactive_JsonHelper.repl_env true;
+          ((let uu___2 = FStar_Options.ide_id_info_off () in
+            if uu___2
+            then
+              FStar_TypeChecker_Env.toggle_id_info
+                st.FStar_Interactive_JsonHelper.repl_env false
+            else
+              FStar_TypeChecker_Env.toggle_id_info
+                st.FStar_Interactive_JsonHelper.repl_env true);
            (let st1 = set_nosynth_flag st peek_only in
             let uu___2 =
               run_repl_transaction st1 push_kind peek_only

--- a/src/ocaml-output/FStar_Options.ml
+++ b/src/ocaml-output/FStar_Options.ml
@@ -227,6 +227,7 @@ let (defaults : (Prims.string * option_val) Prims.list) =
   ("hint_file", Unset);
   ("in", (Bool false));
   ("ide", (Bool false));
+  ("ide_id_info_off", (Bool false));
   ("lsp", (Bool false));
   ("include", (List []));
   ("print", (Bool false));
@@ -436,6 +437,8 @@ let (get_hint_file : unit -> Prims.string FStar_Pervasives_Native.option) =
   fun uu___ -> lookup_opt "hint_file" (as_option as_string)
 let (get_in : unit -> Prims.bool) = fun uu___ -> lookup_opt "in" as_bool
 let (get_ide : unit -> Prims.bool) = fun uu___ -> lookup_opt "ide" as_bool
+let (get_ide_id_info_off : unit -> Prims.bool) =
+  fun uu___ -> lookup_opt "ide_id_info_off" as_bool
 let (get_lsp : unit -> Prims.bool) = fun uu___ -> lookup_opt "lsp" as_bool
 let (get_include : unit -> Prims.string Prims.list) =
   fun uu___ -> lookup_opt "include" (as_list as_string)
@@ -922,7 +925,7 @@ let (interp_quake_arg : Prims.string -> (Prims.int * Prims.int * Prims.bool))
           let uu___ = ios f1 in let uu___1 = ios f2 in (uu___, uu___1, true)
         else failwith "unexpected value for --quake"
     | uu___ -> failwith "unexpected value for --quake"
-let (uu___404 : (((Prims.string -> unit) -> unit) * (Prims.string -> unit)))
+let (uu___405 : (((Prims.string -> unit) -> unit) * (Prims.string -> unit)))
   =
   let cb = FStar_Util.mk_ref FStar_Pervasives_Native.None in
   let set1 f = FStar_ST.op_Colon_Equals cb (FStar_Pervasives_Native.Some f) in
@@ -933,11 +936,11 @@ let (uu___404 : (((Prims.string -> unit) -> unit) * (Prims.string -> unit)))
     | FStar_Pervasives_Native.Some f -> f msg in
   (set1, call)
 let (set_option_warning_callback_aux : (Prims.string -> unit) -> unit) =
-  match uu___404 with
+  match uu___405 with
   | (set_option_warning_callback_aux1, option_warning_callback) ->
       set_option_warning_callback_aux1
 let (option_warning_callback : Prims.string -> unit) =
-  match uu___404 with
+  match uu___405 with
   | (set_option_warning_callback_aux1, option_warning_callback1) ->
       option_warning_callback1
 let (set_option_warning_callback : (Prims.string -> unit) -> unit) =
@@ -1038,6 +1041,8 @@ let rec (specs_with_types :
       "Legacy interactive mode; reads input from stdin");
     (FStar_Getopt.noshort, "ide", (Const (Bool true)),
       "JSON-based interactive mode for IDEs");
+    (FStar_Getopt.noshort, "ide_id_info_off", (Const (Bool true)),
+      "Disable identifier tables in IDE mode (temporary workaround useful in Steel)");
     (FStar_Getopt.noshort, "lsp", (Const (Bool true)),
       "Language Server Protocol-based interactive mode for IDEs");
     (FStar_Getopt.noshort, "include", (ReverseAccumulated (PathStr "path")),
@@ -1341,6 +1346,7 @@ let (settable : Prims.string -> Prims.bool) =
     | "ifuel" -> true
     | "initial_fuel" -> true
     | "initial_ifuel" -> true
+    | "ide_id_info_off" -> true
     | "lax" -> true
     | "load" -> true
     | "load_cmxs" -> true
@@ -1415,7 +1421,7 @@ let (settable_specs :
     (FStar_List.filter
        (fun uu___ ->
           match uu___ with | (uu___1, x, uu___2, uu___3) -> settable x))
-let (uu___584 :
+let (uu___586 :
   (((unit -> FStar_Getopt.parse_cmdline_res) -> unit) *
     (unit -> FStar_Getopt.parse_cmdline_res)))
   =
@@ -1431,11 +1437,11 @@ let (uu___584 :
   (set1, call)
 let (set_error_flags_callback_aux :
   (unit -> FStar_Getopt.parse_cmdline_res) -> unit) =
-  match uu___584 with
+  match uu___586 with
   | (set_error_flags_callback_aux1, set_error_flags) ->
       set_error_flags_callback_aux1
 let (set_error_flags : unit -> FStar_Getopt.parse_cmdline_res) =
-  match uu___584 with
+  match uu___586 with
   | (set_error_flags_callback_aux1, set_error_flags1) -> set_error_flags1
 let (set_error_flags_callback :
   (unit -> FStar_Getopt.parse_cmdline_res) -> unit) =
@@ -1800,6 +1806,8 @@ let (hint_file_for_src : Prims.string -> Prims.string) =
           | uu___2 -> src_filename in
         FStar_Util.format1 "%s.hints" file_name
 let (ide : unit -> Prims.bool) = fun uu___ -> get_ide ()
+let (ide_id_info_off : unit -> Prims.bool) =
+  fun uu___ -> get_ide_id_info_off ()
 let (print : unit -> Prims.bool) = fun uu___ -> get_print ()
 let (print_in_place : unit -> Prims.bool) =
   fun uu___ -> get_print_in_place ()

--- a/src/ocaml-output/FStar_TypeChecker_Common.ml
+++ b/src/ocaml-output/FStar_TypeChecker_Common.ml
@@ -309,6 +309,15 @@ let (__proj__Mkid_info_table__item__id_info_buffer :
 let (id_info_table_empty : id_info_table) =
   let uu___ = FStar_Util.psmap_empty () in
   { id_info_enabled = false; id_info_db = uu___; id_info_buffer = [] }
+let (print_identifier_info : identifier_info -> Prims.string) =
+  fun info ->
+    let uu___ = FStar_Range.string_of_range info.identifier_range in
+    let uu___1 =
+      match info.identifier with
+      | FStar_Pervasives.Inl x -> FStar_Syntax_Print.bv_to_string x
+      | FStar_Pervasives.Inr fv -> FStar_Syntax_Print.fv_to_string fv in
+    let uu___2 = FStar_Syntax_Print.term_to_string info.identifier_ty in
+    FStar_Util.format3 "id info { %s, %s : %s}" uu___ uu___1 uu___2
 let (id_info__insert :
   (FStar_Syntax_Syntax.typ -> FStar_Syntax_Syntax.typ) ->
     (Prims.int * identifier_info) Prims.list FStar_Util.pimap
@@ -324,12 +333,15 @@ let (id_info__insert :
         let use_range =
           let uu___ = FStar_Range.use_range range in
           FStar_Range.set_def_range range uu___ in
+        let id_ty =
+          match info.identifier with
+          | FStar_Pervasives.Inr uu___ -> info.identifier_ty
+          | FStar_Pervasives.Inl x -> ty_map info.identifier_ty in
         let info1 =
           let uu___ = info in
-          let uu___1 = ty_map info.identifier_ty in
           {
             identifier = (uu___.identifier);
-            identifier_ty = uu___1;
+            identifier_ty = id_ty;
             identifier_range = use_range
           } in
         let fn = FStar_Range.file_of_range use_range in

--- a/src/ocaml-output/FStar_TypeChecker_Tc.ml
+++ b/src/ocaml-output/FStar_TypeChecker_Tc.ml
@@ -3752,45 +3752,55 @@ let (tc_decls :
                     ">>>>>>>>>>>>>>Checking top-level %s decl %s\n" uu___5
                     uu___6
                 else ());
-               (let uu___4 =
-                  let uu___5 =
-                    let uu___6 = FStar_Syntax_Print.sigelt_to_string_short se in
+               (let uu___5 = FStar_Options.ide_id_info_off () in
+                if uu___5
+                then FStar_TypeChecker_Env.toggle_id_info env1 false
+                else ());
+               (let uu___6 =
+                  FStar_TypeChecker_Env.debug env1
+                    (FStar_Options.Other "IdInfoOn") in
+                if uu___6
+                then FStar_TypeChecker_Env.toggle_id_info env1 true
+                else ());
+               (let uu___6 =
+                  let uu___7 =
+                    let uu___8 = FStar_Syntax_Print.sigelt_to_string_short se in
                     FStar_Util.format1
                       "While typechecking the top-level declaration `%s`"
-                      uu___6 in
-                  FStar_Errors.with_ctx uu___5
-                    (fun uu___6 -> tc_decl env1 se) in
-                match uu___4 with
+                      uu___8 in
+                  FStar_Errors.with_ctx uu___7
+                    (fun uu___8 -> tc_decl env1 se) in
+                match uu___6 with
                 | (ses', ses_elaborated, env2) ->
                     let ses'1 =
                       FStar_All.pipe_right ses'
                         (FStar_List.map
                            (fun se1 ->
-                              (let uu___6 =
+                              (let uu___8 =
                                  FStar_TypeChecker_Env.debug env2
                                    (FStar_Options.Other "UF") in
-                               if uu___6
+                               if uu___8
                                then
-                                 let uu___7 =
+                                 let uu___9 =
                                    FStar_Syntax_Print.sigelt_to_string se1 in
                                  FStar_Util.print1
-                                   "About to elim vars from %s\n" uu___7
+                                   "About to elim vars from %s\n" uu___9
                                else ());
                               FStar_TypeChecker_Normalize.elim_uvars env2 se1)) in
                     let ses_elaborated1 =
                       FStar_All.pipe_right ses_elaborated
                         (FStar_List.map
                            (fun se1 ->
-                              (let uu___6 =
+                              (let uu___8 =
                                  FStar_TypeChecker_Env.debug env2
                                    (FStar_Options.Other "UF") in
-                               if uu___6
+                               if uu___8
                                then
-                                 let uu___7 =
+                                 let uu___9 =
                                    FStar_Syntax_Print.sigelt_to_string se1 in
                                  FStar_Util.print1
                                    "About to elim vars from (elaborated) %s\n"
-                                   uu___7
+                                   uu___9
                                else ());
                               FStar_TypeChecker_Normalize.elim_uvars env2 se1)) in
                     (FStar_TypeChecker_Env.promote_id_info env2
@@ -3813,23 +3823,23 @@ let (tc_decls :
                                 fun se1 -> add_sigelt_to_env env4 se1 false)
                              env2) in
                       FStar_Syntax_Unionfind.reset ();
-                      (let uu___8 =
+                      (let uu___10 =
                          (FStar_Options.log_types ()) ||
                            (FStar_All.pipe_left
                               (FStar_TypeChecker_Env.debug env3)
                               (FStar_Options.Other "LogTypes")) in
-                       if uu___8
+                       if uu___10
                        then
-                         let uu___9 =
+                         let uu___11 =
                            FStar_List.fold_left
                              (fun s ->
                                 fun se1 ->
-                                  let uu___10 =
-                                    let uu___11 =
+                                  let uu___12 =
+                                    let uu___13 =
                                       FStar_Syntax_Print.sigelt_to_string se1 in
-                                    Prims.op_Hat uu___11 "\n" in
-                                  Prims.op_Hat s uu___10) "" ses'1 in
-                         FStar_Util.print1 "Checked: %s\n" uu___9
+                                    Prims.op_Hat uu___13 "\n" in
+                                  Prims.op_Hat s uu___12) "" ses'1 in
+                         FStar_Util.print1 "Checked: %s\n" uu___11
                        else ());
                       FStar_List.iter
                         (fun se1 ->
@@ -3867,7 +3877,7 @@ let (tc_decls :
              FStar_Util.fold_flatten process_one_decl_timed ([], env) ses) in
       match uu___ with
       | (ses1, env1) -> ((FStar_List.rev_append ses1 []), env1)
-let (uu___921 : unit) =
+let (uu___925 : unit) =
   FStar_ST.op_Colon_Equals tc_decls_knot
     (FStar_Pervasives_Native.Some tc_decls)
 let (snapshot_context :

--- a/src/typechecker/FStar.TypeChecker.Common.fs
+++ b/src/typechecker/FStar.TypeChecker.Common.fs
@@ -169,11 +169,27 @@ let id_info_table_empty =
 
 open FStar.Range
 
+let print_identifier_info info =
+  BU.format3 "id info { %s, %s : %s}"
+    (Range.string_of_range info.identifier_range)
+    (match info.identifier with
+     | Inl x -> Print.bv_to_string x
+     | Inr fv -> Print.fv_to_string fv)
+    (Print.term_to_string info.identifier_ty)
+
 let id_info__insert ty_map db info =
     let range = info.identifier_range in
     let use_range = Range.set_def_range range (Range.use_range range) in
+    let id_ty =
+      match info.identifier with
+      | Inr _ -> info.identifier_ty
+      | Inl x ->
+        // BU.print1 "id_info__insert: %s\n"
+        //           (print_identifier_info info);
+        ty_map info.identifier_ty
+    in
     let info = { info with identifier_range = use_range;
-                           identifier_ty = ty_map info.identifier_ty } in
+                           identifier_ty = id_ty } in
 
     let fn = file_of_range use_range in
     let start = start_of_range use_range in

--- a/src/typechecker/FStar.TypeChecker.Tc.fs
+++ b/src/typechecker/FStar.TypeChecker.Tc.fs
@@ -882,6 +882,9 @@ let tc_decls env ses =
                         (Print.tag_of_sigelt se)
                         (Print.sigelt_to_string se);
 
+    if Options.ide_id_info_off() then Env.toggle_id_info env false;
+    if Env.debug env (Options.Other "IdInfoOn") then Env.toggle_id_info env true;
+
     let ses', ses_elaborated, env =
             Errors.with_ctx (BU.format1 "While typechecking the top-level declaration `%s`" (Print.sigelt_to_string_short se))
                     (fun () -> tc_decl env se)


### PR DESCRIPTION
This PR is related to issue #2213.

Some unresolved uvars used in the IDE occasionally crash F* inside emacs when browsing Steel files.
While the root cause is still misunderstood, @nikswamy implemented a workaround as an option, --ide_id_info_off to disable the IDE feature causing crashes.

This PR aims at unifying src/ between the steel and master branch before merging steel into master.