### PR TITLE
Make effect coherence check less conservative

### DIFF
--- a/src/ocaml-output/FStar_TypeChecker_Env.ml
+++ b/src/ocaml-output/FStar_TypeChecker_Env.ml
@@ -4618,15 +4618,17 @@ let (update_effect_lattice :
                              | FStar_Pervasives_Native.None -> []
                              | FStar_Pervasives_Native.Some (k, e1, e2) ->
                                  let uu___1 =
-                                   (let uu___2 =
-                                      exists_polymonadic_bind env1 i j in
-                                    FStar_All.pipe_right uu___2
-                                      FStar_Util.is_some)
-                                     ||
-                                     (let uu___2 =
-                                        exists_polymonadic_bind env1 j i in
-                                      FStar_All.pipe_right uu___2
-                                        FStar_Util.is_some) in
+                                   (let uu___2 = FStar_Ident.lid_equals i j in
+                                    Prims.op_Negation uu___2) &&
+                                     ((let uu___2 =
+                                         exists_polymonadic_bind env1 i j in
+                                       FStar_All.pipe_right uu___2
+                                         FStar_Util.is_some)
+                                        ||
+                                        (let uu___2 =
+                                           exists_polymonadic_bind env1 j i in
+                                         FStar_All.pipe_right uu___2
+                                           FStar_Util.is_some)) in
                                  if uu___1
                                  then
                                    let uu___2 =

--- a/src/typechecker/FStar.TypeChecker.Env.fs
+++ b/src/typechecker/FStar.TypeChecker.Env.fs
@@ -1524,9 +1524,14 @@ let update_effect_lattice env src tgt st_mlift =
        *     if there exists polymonadic binds i, j or j, i
        *     then there are multiple ways to bind i, j or j, i computations now
        *     so error out
+       *
+       *     02/23: But if i = j, the loop above returns the identity edge
+       *     Since that edge is not user added, if there is a (i, j)
+       *       polymonadic bind, we don't count that as a conflict
        *)
-      if exists_polymonadic_bind env i j |> is_some ||
-         exists_polymonadic_bind env j i |> is_some
+      if (not (lid_equals i j)) &&
+         (exists_polymonadic_bind env i j |> is_some ||
+          exists_polymonadic_bind env j i |> is_some)
       then raise_error (Errors.Fatal_Effects_Ordering_Coherence,
              BU.format5 "Updating effect lattice with a lift between %s and %s \
                induces a least upper bound %s of %s and %s, and this \


### PR DESCRIPTION
A fix from @aseemr that was only present in the steel branch, and which is explained in detail in the comments in the file.