### PR TITLE
Fix deferred to tac goals for lifted computations during a layered subcomp

### DIFF
--- a/src/ocaml-output/FStar_TypeChecker_Rel.ml
+++ b/src/ocaml-output/FStar_TypeChecker_Rel.ml
@@ -10178,9 +10178,13 @@ and (solve_c :
                                                             uu___12) uu___11 in
                                                    solve_prob orig uu___10 []
                                                      wl6 in
-                                                 let uu___10 =
+                                                 let wl8 =
                                                    attempt sub_probs wl7 in
-                                                 solve env uu___10))))))) in
+                                                 let wl9 =
+                                                   extend_wl wl8
+                                                     g_lift.FStar_TypeChecker_Common.deferred_to_tac
+                                                     [] in
+                                                 solve env wl9))))))) in
         let solve_sub c11 edge c21 =
           if
             problem.FStar_TypeChecker_Common.relation <>

--- a/src/ocaml-output/FStar_TypeChecker_Rel.ml
+++ b/src/ocaml-output/FStar_TypeChecker_Rel.ml
@@ -348,27 +348,32 @@ let (__proj__Failed__item___0 :
 let (extend_wl :
   worklist ->
     FStar_TypeChecker_Common.deferred ->
-      FStar_TypeChecker_Common.implicits -> worklist)
+      FStar_TypeChecker_Common.deferred ->
+        FStar_TypeChecker_Common.implicits -> worklist)
   =
   fun wl ->
-    fun defer_to_tac ->
-      fun imps ->
-        let uu___ = wl in
-        let uu___1 =
-          let uu___2 = as_wl_deferred wl defer_to_tac in
-          FStar_List.append wl.wl_deferred_to_tac uu___2 in
-        {
-          attempting = (uu___.attempting);
-          wl_deferred = (uu___.wl_deferred);
-          wl_deferred_to_tac = uu___1;
-          ctr = (uu___.ctr);
-          defer_ok = (uu___.defer_ok);
-          smt_ok = (uu___.smt_ok);
-          umax_heuristic_ok = (uu___.umax_heuristic_ok);
-          tcenv = (uu___.tcenv);
-          wl_implicits = (FStar_List.append wl.wl_implicits imps);
-          repr_subcomp_allowed = (uu___.repr_subcomp_allowed)
-        }
+    fun defers ->
+      fun defer_to_tac ->
+        fun imps ->
+          let uu___ = wl in
+          let uu___1 =
+            let uu___2 = as_wl_deferred wl defers in
+            FStar_List.append wl.wl_deferred uu___2 in
+          let uu___2 =
+            let uu___3 = as_wl_deferred wl defer_to_tac in
+            FStar_List.append wl.wl_deferred_to_tac uu___3 in
+          {
+            attempting = (uu___.attempting);
+            wl_deferred = uu___1;
+            wl_deferred_to_tac = uu___2;
+            ctr = (uu___.ctr);
+            defer_ok = (uu___.defer_ok);
+            smt_ok = (uu___.smt_ok);
+            umax_heuristic_ok = (uu___.umax_heuristic_ok);
+            tcenv = (uu___.tcenv);
+            wl_implicits = (FStar_List.append wl.wl_implicits imps);
+            repr_subcomp_allowed = (uu___.repr_subcomp_allowed)
+          }
 type variance =
   | COVARIANT 
   | CONTRAVARIANT 
@@ -4133,7 +4138,7 @@ and (solve_rigid_flex_or_flex_rigid_subtyping :
                                                      (FStar_Syntax_Unionfind.commit
                                                         tx;
                                                       (let uu___11 =
-                                                         extend_wl wl4
+                                                         extend_wl wl4 []
                                                            defer_to_tac imps in
                                                        FStar_Pervasives_Native.Some
                                                          uu___11))
@@ -4586,7 +4591,7 @@ and (solve_rigid_flex_or_flex_rigid_subtyping :
                                                           (uu___14.repr_subcomp_allowed)
                                                       } in
                                                     let wl3 =
-                                                      extend_wl wl2
+                                                      extend_wl wl2 []
                                                         defer_to_tac imps in
                                                     let g =
                                                       FStar_List.fold_left
@@ -5189,7 +5194,7 @@ and (try_solve_without_smt_or_else :
           match uu___ with
           | Success (uu___1, defer_to_tac, imps) ->
               (FStar_Syntax_Unionfind.commit tx;
-               (let wl1 = extend_wl wl defer_to_tac imps in solve env wl1))
+               (let wl1 = extend_wl wl [] defer_to_tac imps in solve env wl1))
           | Failed (p, s) ->
               (FStar_Syntax_Unionfind.rollback tx; else_solve env wl (p, s))
 and (solve_t : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
@@ -6477,7 +6482,7 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                                           (uu___10, defer_to_tac', imps') ->
                                           (FStar_Syntax_Unionfind.commit tx;
                                            (let uu___12 =
-                                              extend_wl wl4
+                                              extend_wl wl4 []
                                                 (FStar_List.append
                                                    defer_to_tac defer_to_tac')
                                                 (FStar_List.append imps imps') in
@@ -8010,7 +8015,7 @@ and (solve_t' : FStar_TypeChecker_Env.env -> tprob -> worklist -> solution) =
                                                            (uu___16.repr_subcomp_allowed)
                                                        } in
                                                      let wl5 =
-                                                       extend_wl wl4
+                                                       extend_wl wl4 []
                                                          defer_to_tac imps in
                                                      let uu___16 =
                                                        attempt [base_prob]
@@ -9801,22 +9806,9 @@ and (solve_c :
                    (let stronger_t =
                       FStar_All.pipe_right stronger_t_opt FStar_Util.must in
                     let wl1 =
-                      let uu___4 = wl in
-                      {
-                        attempting = (uu___4.attempting);
-                        wl_deferred = (uu___4.wl_deferred);
-                        wl_deferred_to_tac = (uu___4.wl_deferred_to_tac);
-                        ctr = (uu___4.ctr);
-                        defer_ok = (uu___4.defer_ok);
-                        smt_ok = (uu___4.smt_ok);
-                        umax_heuristic_ok = (uu___4.umax_heuristic_ok);
-                        tcenv = (uu___4.tcenv);
-                        wl_implicits =
-                          (FStar_List.append
-                             g_lift.FStar_TypeChecker_Common.implicits
-                             wl.wl_implicits);
-                        repr_subcomp_allowed = (uu___4.repr_subcomp_allowed)
-                      } in
+                      extend_wl wl g_lift.FStar_TypeChecker_Common.deferred
+                        g_lift.FStar_TypeChecker_Common.deferred_to_tac
+                        g_lift.FStar_TypeChecker_Common.implicits in
                     let uu___4 =
                       if is_polymonadic
                       then ([], wl1)
@@ -10128,30 +10120,13 @@ and (solve_c :
                                                          stronger_ct.FStar_Syntax_Syntax.result_typ
                                                          wp
                                                          FStar_Range.dummyRange in
-                                                 let sub_probs =
-                                                   let uu___10 =
-                                                     let uu___11 =
-                                                       let uu___12 =
-                                                         let uu___13 =
-                                                           FStar_All.pipe_right
-                                                             g_lift.FStar_TypeChecker_Common.deferred
-                                                             (FStar_List.map
-                                                                (fun uu___14
-                                                                   ->
-                                                                   match uu___14
-                                                                   with
-                                                                   | 
-                                                                   (uu___15,
-                                                                    uu___16,
-                                                                    p) -> p)) in
-                                                         FStar_List.append
-                                                           g_sub_probs
-                                                           uu___13 in
-                                                       FStar_List.append
-                                                         f_sub_probs uu___12 in
-                                                     FStar_List.append
-                                                       is_sub_probs uu___11 in
-                                                   ret_sub_prob :: uu___10 in
+                                                 let sub_probs = ret_sub_prob
+                                                   ::
+                                                   (FStar_List.append
+                                                      is_sub_probs
+                                                      (FStar_List.append
+                                                         f_sub_probs
+                                                         g_sub_probs)) in
                                                  let guard =
                                                    let guard1 =
                                                      let uu___10 =
@@ -10178,13 +10153,9 @@ and (solve_c :
                                                             uu___12) uu___11 in
                                                    solve_prob orig uu___10 []
                                                      wl6 in
-                                                 let wl8 =
+                                                 let uu___10 =
                                                    attempt sub_probs wl7 in
-                                                 let wl9 =
-                                                   extend_wl wl8
-                                                     g_lift.FStar_TypeChecker_Common.deferred_to_tac
-                                                     [] in
-                                                 solve env wl9))))))) in
+                                                 solve env uu___10))))))) in
         let solve_sub c11 edge c21 =
           if
             problem.FStar_TypeChecker_Common.relation <>

--- a/src/typechecker/FStar.TypeChecker.Rel.fs
+++ b/src/typechecker/FStar.TypeChecker.Rel.fs
@@ -3503,7 +3503,10 @@ and solve_c (env:Env.env) (problem:problem<comp>) (wl:worklist) : solution =
             | Trivial -> guard
             | NonTrivial f -> U.mk_conj guard f in
           let wl = solve_prob orig (Some <| U.mk_conj guard fml) [] wl in
-          solve env (attempt sub_probs wl) in
+
+          let wl = attempt sub_probs wl in
+          let wl = extend_wl wl g_lift.deferred_to_tac [] in
+          solve env wl in
 
     let solve_sub c1 edge c2 =
         if problem.relation <> SUB then
@@ -4448,4 +4451,3 @@ let layered_effect_teq env (t1:term) (t2:term) (reason:option<string>) : guard_t
 let universe_inequality (u1:universe) (u2:universe) : guard_t =
     //Printf.printf "Universe inequality %s <= %s\n" (Print.univ_to_string u1) (Print.univ_to_string u2);
     {trivial_guard with univ_ineqs=([], [u1,u2])}
-


### PR DESCRIPTION
Goals deferred to tactics inside the guard for a lifted computation created in solve_layered_sub in Rel were previously not propagated, which led to unresolved implicits in Steel for instance.

This PR ensures that these goals are stored in the worklist when solving generated subproblems