### PR TITLE
Tweak to the OCaml realization of references

### DIFF
--- a/ulib/ml/FStar_CommonST.ml
+++ b/ulib/ml/FStar_CommonST.ml
@@ -1,20 +1,14 @@
 open FStar_Monotonic_Heap
 
-let read x = x.contents
+let read x = !x
 
 let op_Bang x = read x
 
-let write x y = x.contents <- y
+let write x y = x := y
 
 let op_Colon_Equals x y = write x y
 
-let uid = ref 0
-
-let alloc contents =
-  let id = incr uid; !uid in
-  let r = { id; contents } in
-  Obj.(set_tag (repr r) object_tag);
-  r
+let alloc contents = ref contents
 
 let recall = (fun r -> ())
 let get () = ()

--- a/ulib/ml/FStar_Monotonic_Heap.ml
+++ b/ulib/ml/FStar_Monotonic_Heap.ml
@@ -1,10 +1,6 @@
 type heap = unit
 
-(* https://www.lexifi.com/blog/references-physical-equality *)
-type 'a ref = {
-  mutable contents: 'a;
-  id: int
-}
+type nonrec 'a ref = 'a ref
 
 type ('a, 'b) mref = 'a ref
             


### PR DESCRIPTION
This PR tweaks the definition of the type of mutable references in the native realization of `FStar.ST`.

Circa 2016, the `ref` type in F* allowed for decidable equality. As a result, the programmer could write:

```
if r1 = r2 then e1 else e2
```

and extract this code to OCaml as:

```
if r1 = r2 then e1_ml else e2_ml
```

But this resulted in a semantic mismatch. The equality on refs in F* was physical whereas in OCaml it is structural (i.e. two refs are equals if their contents are).

To remove this mismatch, following the recipe in this blogpost: https://www.lexifi.com/blog/ocaml/references-physical-equality/#, we provided a native implementation of the `ref` type (to be linked with code extracted from F*) as follows:

```
type 'a ref = {
  mutable contents: 'a;
  id: int
}
```

with some object tag tricks to guide the equality implementation in OCaml (see the blogpost for more details). Crucially, the `id` field is a unique identifier per reference, the implementation uses a counter to generate this id.

With upcoming Steel extraction, this is a problem, since using the counter for generating a fresh id is not thread-safe. The blogpost mentions other workarounds to make it thread-safe.

On the other hand, the memory models in F* underwent a big overhaul in 2017, as part of which we also removed the decidable equality on references. Therefore, writing `if r1 = r2 ...` does not verify anymore in F*.

This PR simplifies the `ref` implementation to remove the `id` trick, and instead use the OCaml refs as is. The main advantage is that we don't need to rely on the unspecified behaviors of OCaml which may change in future. The disadvantage is that there may be lax code in F* that uses decidable equality of refs (F* will allow it in the lax mode), such code will see a change in the behavior.

cc @nikswamy , @protz , @tahina-pro for comments. Thanks!