### PR TITLE
Port ghost references to SteelSelGhost

### DIFF
--- a/ulib/experimental/Steel.HigherReference.fst
+++ b/ulib/experimental/Steel.HigherReference.fst
@@ -353,6 +353,15 @@ let ghost_ref a = erased (ref a)
 [@@__reduce__]
 let ghost_pts_to #a (r:ghost_ref a) (p:perm) (x:erased a) = pts_to (reveal r) p x
 
+let ghost_pts_to_witinv (#a:Type) (r:ghost_ref a) (p:perm) : Lemma (is_witness_invariant (ghost_pts_to r p)) =
+  let aux (x y : erased a) (m:mem)
+    : Lemma (requires (interp (ghost_pts_to r p x) m /\ interp (ghost_pts_to r p y) m))
+            (ensures  (x == y))
+    =
+    Mem.pts_to_join (Ghost.reveal r) (Some (Ghost.reveal x, p)) (Some (Ghost.reveal y, p)) m
+  in
+  Classical.forall_intro_3 (fun x y -> Classical.move_requires (aux x y))
+
 let ghost_alloc_aux (#a:Type) (#u:_) (x:a)
   : SteelGhostT (ref a) u
                  emp

--- a/ulib/experimental/Steel.HigherReference.fsti
+++ b/ulib/experimental/Steel.HigherReference.fsti
@@ -109,6 +109,8 @@ val ghost_ref (a:Type u#1) : Type u#0
 
 val ghost_pts_to (#a:_) (r:ghost_ref a) (p:perm) (x:erased a) : slprop u#1
 
+val ghost_pts_to_witinv (#a:Type) (r:ghost_ref a) (p:perm) : Lemma (is_witness_invariant (ghost_pts_to r p))
+
 val ghost_alloc (#a:Type) (#u:_) (x:erased a)
   : SteelGhostT (ghost_ref a) u
                  emp

--- a/ulib/experimental/Steel.Reference.fst
+++ b/ulib/experimental/Steel.Reference.fst
@@ -201,6 +201,15 @@ let raise_erased (#a:Type0) (x:erased a)
 [@__reduce__]
 let ghost_pts_to #a r p x = H.ghost_pts_to #(U.raise_t a) r p (raise_erased x)
 
+let ghost_pts_to_witinv (#a:Type) (r:ghost_ref a) (p:perm) : Lemma (is_witness_invariant (ghost_pts_to r p)) =
+  let aux (x y : erased a) (m:mem)
+    : Lemma (requires (interp (ghost_pts_to r p x) m /\ interp (ghost_pts_to r p y) m))
+            (ensures  (x == y))
+    = H.ghost_pts_to_witinv r p;
+      raise_val_inj (reveal x) (reveal y)
+  in
+  Classical.forall_intro_3 (fun x y -> Classical.move_requires (aux x y))
+
 let ghost_alloc (#a:Type) (#u:_) (x:erased a)
   : SteelGhostT (ghost_ref a) u
     emp

--- a/ulib/experimental/Steel.Reference.fsti
+++ b/ulib/experimental/Steel.Reference.fsti
@@ -108,6 +108,8 @@ val ghost_ref (a:Type u#0) : Type u#0
 
 val ghost_pts_to (#a:_) (r:ghost_ref a) ([@@@ smt_fallback] p:perm) ([@@@ smt_fallback] x:erased a) : slprop u#1
 
+val ghost_pts_to_witinv (#a:Type) (r:ghost_ref a) (p:perm) : Lemma (is_witness_invariant (ghost_pts_to r p))
+
 val ghost_alloc (#a:Type) (#u:_) (x:erased a)
   : SteelGhostT (ghost_ref a) u
     emp

--- a/ulib/experimental/Steel.SelEffect.Atomic.fst
+++ b/ulib/experimental/Steel.SelEffect.Atomic.fst
@@ -636,3 +636,109 @@ let elim_vrewrite
     v
     (fun y x -> y == f x)
     (fun m -> vrewrite_sel_eq v f m)
+
+
+(*** Ghost pointers *)
+open Steel.FractionalPermission
+
+val ghost_ptr_sel' (#a:Type0) (r: ghost_ref a) : selector' a (ghost_ptr r)
+let ghost_ptr_sel' #a r = fun h ->
+  let x = id_elim_exists #(erased a) (R.ghost_pts_to r full_perm) h in
+  reveal (reveal x)
+
+let ghost_ptr_sel_depends_only_on (#a:Type0) (r:ghost_ref a)
+  (m0:Mem.hmem (ghost_ptr r)) (m1:mem{disjoint m0 m1})
+  : Lemma (ghost_ptr_sel' r m0 == ghost_ptr_sel' r (Mem.join m0 m1))
+  = let x = reveal (id_elim_exists #(erased a) (R.ghost_pts_to r full_perm) m0) in
+    let y = reveal (id_elim_exists #(erased a) (R.ghost_pts_to r full_perm) (Mem.join m0 m1)) in
+    R.ghost_pts_to_witinv r full_perm;
+    elim_wi (R.ghost_pts_to r full_perm) x y (Mem.join m0 m1)
+
+let ghost_ptr_sel_depends_only_on_core (#a:Type0) (r:ghost_ref a)
+  (m0:Mem.hmem (ghost_ptr r))
+  : Lemma (ghost_ptr_sel' r m0 == ghost_ptr_sel' r (core_mem m0))
+  = let x = reveal (id_elim_exists #(erased a) (R.ghost_pts_to r full_perm) m0) in
+    let y = reveal (id_elim_exists #(erased a) (R.ghost_pts_to r full_perm) (core_mem m0)) in
+    R.ghost_pts_to_witinv r full_perm;
+    elim_wi (R.ghost_pts_to r full_perm) x y (core_mem m0)
+
+let ghost_ptr_sel r =
+  Classical.forall_intro_2 (ghost_ptr_sel_depends_only_on r);
+  Classical.forall_intro (ghost_ptr_sel_depends_only_on_core r);
+  ghost_ptr_sel' r
+
+let ghost_ptr_sel_interp #a r m = R.ghost_pts_to_witinv r full_perm
+
+friend Steel.Effect.Atomic
+module Eff = Steel.Effect.Atomic
+
+let as_steelselghost0 (#a:Type) (#opened: _)
+  (#pre:pre_t) (#post:post_t a)
+  (#req:prop) (#ens:a -> prop)
+  ($f:Eff.repr a false opened Eff.Unobservable (hp_of pre) (fun x -> hp_of (post x)) (fun h -> req) (fun _ x _ -> ens x))
+: repr a false opened Unobservable pre post (fun _ -> req) (fun _ x _ -> ens x)
+  = fun frame -> f frame
+
+let as_steelselghost1 (#a:Type) (#opened: _)
+  (#pre:vprop) (#post:a -> vprop)
+  (#req:prop) (#ens:a -> prop)
+  ($f:Eff.repr a false opened Eff.Unobservable (hp_of pre) (fun x -> hp_of (post x)) (fun h -> req) (fun _ x _ -> ens x))
+: SteelSelGhost a opened pre post (fun _ -> req) (fun _ x _ -> ens x)
+  = SteelSelGhost?.reflect (as_steelselghost0 f)
+
+let as_steelselghost (#a:Type) (#opened: _)
+  (#pre:pre_t) (#post:post_t a)
+  (#req:prop) (#ens:a -> prop)
+  ($f:unit -> Eff.SteelGhost a opened (hp_of pre) (fun x -> hp_of (post x)) (fun h -> req) (fun _ x _ -> ens x))
+: SteelSelGhost a opened pre post (fun _ -> req) (fun _ x _ -> ens x)
+  = as_steelselghost1 (Steel.Effect.Atomic.reify_steel_ghost_comp f)
+
+let _:squash (hp_of vemp == emp /\ t_of vemp == unit) = reveal_vemp ()
+
+unfold
+let ghost_vptr_tmp' (#a:Type) (r:ghost_ref a) (p:perm) (v:erased a) : vprop' =
+  { hp = R.ghost_pts_to r p v;
+    t = unit;
+    sel = fun _ -> ()}
+unfold
+let ghost_vptr_tmp r p v : vprop = VUnit (ghost_vptr_tmp' r p v)
+
+val ghost_alloc0 (#a:Type0) (#opened: _) (x:a) : SteelSelGhost (ghost_ref a) opened
+  vemp (fun r -> ghost_vptr_tmp r full_perm x)
+  (requires fun _ -> True)
+  (ensures fun _ r h1 -> True)
+
+let ghost_alloc0 #a x = as_steelselghost (fun _ -> R.ghost_alloc x)
+
+let intro_ghost_vptr (#a:Type) (r:ghost_ref a) (v:erased a) (m:mem) : Lemma
+  (requires interp (hp_of (ghost_vptr_tmp r full_perm v)) m)
+  (ensures interp (hp_of (ghost_vptr r)) m /\ sel_of (ghost_vptr r) m == reveal v)
+  = Mem.intro_h_exists v (R.ghost_pts_to r full_perm) m;
+    R.ghost_pts_to_witinv r full_perm
+
+let elim_ghost_vptr (#a:Type) (r:ghost_ref a) (v:erased a) (m:mem) : Lemma
+  (requires interp (hp_of (ghost_vptr r)) m /\ sel_of (ghost_vptr r) m == reveal v)
+  (ensures interp (hp_of (ghost_vptr_tmp r full_perm v)) m)
+  = Mem.elim_h_exists (R.ghost_pts_to r full_perm) m;
+    R.ghost_pts_to_witinv r full_perm
+
+let ghost_alloc x =
+  let r = ghost_alloc0 (Ghost.reveal x) in
+  change_slprop (ghost_vptr_tmp r full_perm (Ghost.reveal x)) (ghost_vptr r) () x (intro_ghost_vptr r x);
+  r
+
+let ghost_free r = change_slprop_rel (ghost_vptr r) vemp (fun _ _ -> True) intro_emp
+
+val ghost_write0 (#a:Type0) (#opened: _) (v:erased a) (r:ghost_ref a) (x:a)
+  : SteelSelGhost unit opened
+    (ghost_vptr_tmp r full_perm v) (fun _ -> ghost_vptr_tmp r full_perm x)
+    (fun _ -> True) (fun _ _ _ -> True)
+
+let ghost_write0 #a #opened v r x = as_steelselghost (fun _ -> R.ghost_write #a #opened #v r x)
+
+let ghost_write r x
+  = 
+    let v = gget (ghost_vptr r) in
+    change_slprop (ghost_vptr r) (ghost_vptr_tmp r full_perm v) v () (elim_ghost_vptr r v);
+    ghost_write0 v r (Ghost.reveal x);
+    change_slprop (ghost_vptr_tmp r full_perm (Ghost.reveal x)) (ghost_vptr r) () x (intro_ghost_vptr r x)

--- a/ulib/experimental/Steel.SelEffect.Atomic.fst
+++ b/ulib/experimental/Steel.SelEffect.Atomic.fst
@@ -638,8 +638,19 @@ let elim_vrewrite
     (fun m -> vrewrite_sel_eq v f m)
 
 
-(*** Ghost pointers *)
+(*** Lemmas on references *)
+
 open Steel.FractionalPermission
+
+let vptr_not_null
+  #opened #a r
+= change_slprop_rel
+    (vptr r)
+    (vptr r)
+    (fun x y -> x == y /\ R.is_null r == false)
+    (fun m -> R.pts_to_not_null r full_perm (ptr_sel r m) m)
+
+(*** Ghost pointers *)
 
 val ghost_ptr_sel' (#a:Type0) (r: ghost_ref a) : selector' a (ghost_ptr r)
 let ghost_ptr_sel' #a r = fun h ->

--- a/ulib/experimental/Steel.SelEffect.Atomic.fsti
+++ b/ulib/experimental/Steel.SelEffect.Atomic.fsti
@@ -496,3 +496,53 @@ val elim_vrewrite (#opened:inames)
 : SteelSelGhost unit opened (vrewrite v f) (fun _ -> v)
     (fun _ -> True)
     (fun h _ h' -> h (vrewrite v f) == f (h' v))
+
+(*** Ghost references ***)
+
+module R = Steel.Reference
+
+[@@ erasable]
+let ghost_ref (a:Type u#0) : Type u#0 = R.ghost_ref a
+let ghost_ptr (#a: Type0) (r: ghost_ref a) : Tot (slprop u#1) = h_exists (R.ghost_pts_to r Steel.FractionalPermission.full_perm)
+
+val ghost_ptr_sel (#a:Type0) (r:ghost_ref a) : selector a (ghost_ptr r)
+
+val ghost_ptr_sel_interp (#a:Type0) (r:ghost_ref a) (m:mem) : Lemma
+  (requires interp (ghost_ptr r) m)
+  (ensures interp (R.ghost_pts_to r Steel.FractionalPermission.full_perm (ghost_ptr_sel r m)) m)
+
+[@@ __steel_reduce__]
+let ghost_vptr' #a r : vprop' =
+  {hp = ghost_ptr r;
+   t = a;
+   sel = ghost_ptr_sel r}
+
+[@@ __steel_reduce__]
+unfold
+let ghost_vptr r = VUnit (ghost_vptr' r)
+
+val ghost_alloc (#a:Type0) (#opened:inames) (x:Ghost.erased a) : SteelSelGhost (ghost_ref a) opened
+  vemp (fun r -> ghost_vptr r)
+  (requires fun _ -> True)
+  (ensures fun _ r h1 -> h1 (ghost_vptr r) == Ghost.reveal x)
+
+val ghost_free (#a:Type0) (#opened:inames) (r:ghost_ref a) : SteelSelGhost unit opened
+  (ghost_vptr r) (fun _ -> vemp)
+  (requires fun _ -> True)
+  (ensures fun _ _ _ -> True)
+
+let ghost_read (#a:Type0) (#opened:inames) (r:ghost_ref a) : SteelSelGhost (Ghost.erased a) opened
+  (ghost_vptr r) (fun _ -> ghost_vptr r)
+  (requires fun _ -> True)
+  (ensures fun h0 x h1 -> h0 (ghost_vptr r) == h1 (ghost_vptr r) /\ Ghost.reveal x == h1 (ghost_vptr r))
+= gget (ghost_vptr r)
+
+val ghost_write (#a:Type0) (#opened:inames) (r:ghost_ref a) (x:Ghost.erased a) : SteelSelGhost unit opened
+  (ghost_vptr r) (fun _ -> ghost_vptr r)
+  (requires fun _ -> True)
+  (ensures fun _ _ h1 -> Ghost.reveal x == h1 (ghost_vptr r))
+
+[@@ __steel_reduce__]
+let ghost_sel (#a:Type) (#p:vprop) (r:ghost_ref a)
+  (h:rmem p{FStar.Tactics.with_tactic selector_tactic (can_be_split p (ghost_vptr r) /\ True)})
+  = h (ghost_vptr r)

--- a/ulib/experimental/Steel.SelEffect.Atomic.fsti
+++ b/ulib/experimental/Steel.SelEffect.Atomic.fsti
@@ -497,9 +497,23 @@ val elim_vrewrite (#opened:inames)
     (fun _ -> True)
     (fun h _ h' -> h (vrewrite v f) == f (h' v))
 
-(*** Ghost references ***)
+(*** Lemmas on references *)
 
 module R = Steel.Reference
+
+val vptr_not_null (#opened: _)
+  (#a: Type)
+  (r: R.ref a)
+: SteelSelGhost unit opened
+    (Steel.SelEffect.vptr r)
+    (fun _ -> Steel.SelEffect.vptr r)
+    (fun _ -> True)
+    (fun h0 _ h1 ->
+      h1 (Steel.SelEffect.vptr r) == h0 (Steel.SelEffect.vptr r) /\
+      R.is_null r == false
+    )
+
+(*** Ghost references ***)
 
 [@@ erasable]
 let ghost_ref (a:Type u#0) : Type u#0 = R.ghost_ref a

--- a/ulib/experimental/Steel.SelEffect.fst
+++ b/ulib/experimental/Steel.SelEffect.fst
@@ -725,11 +725,3 @@ let write (#a:Type0) (r:ref a) (x:a) : SteelSel unit
     change_slprop (vptr r) (vptr_tmp r full_perm v) v () (elim_vptr r v);
     write0 v r x;
     change_slprop (vptr_tmp r full_perm x) (vptr r) () x (intro_vptr r x)
-
-let vptr_not_null
-  #a r
-= change_slprop_rel
-    (vptr r)
-    (vptr r)
-    (fun x y -> x == y /\ R.is_null r == false)
-    (fun m -> R.pts_to_not_null r full_perm (ptr_sel r m) m)

--- a/ulib/experimental/Steel.SelEffect.fsti
+++ b/ulib/experimental/Steel.SelEffect.fsti
@@ -275,15 +275,3 @@ val write (#a:Type0) (r:ref a) (x:a) : SteelSel unit
 let sel (#a:Type) (#p:vprop) (r:ref a)
   (h:rmem p{FStar.Tactics.with_tactic selector_tactic (can_be_split p (vptr r) /\ True)})
   = h (vptr r)
-
-val vptr_not_null
-  (#a: Type)
-  (r: ref a)
-: SteelSel unit
-    (vptr r)
-    (fun _ -> vptr r)
-    (fun _ -> True)
-    (fun h0 _ h1 ->
-      h1 (vptr r) == h0 (vptr r) /\
-      R.is_null r == false
-    )


### PR DESCRIPTION
Many thanks @R1kM for having ported SteelGhost to SteelSel. Based on that, here is a basic port of ghost references from SteelGhost to SteelSelGhost (ignoring permissions so far.)

(Besides, I also moved vptr_not_null to SteelSelGhost instead of SteelSel.)
