### PR TITLE
minor adjustment to `new_z3proc_with_id` 

### DIFF
--- a/src/smtencoding/FStar.SMTEncoding.Z3.fs
+++ b/src/smtencoding/FStar.SMTEncoding.Z3.fs
@@ -216,7 +216,9 @@ let new_z3proc_with_id =
     (fun cmd_and_args ->
       let p = new_z3proc (BU.format1 "bg-%s" (incr ctr; !ctr |> string_of_int)) cmd_and_args in
       let reply = BU.ask_process p "(echo \"Test\")\n(echo \"Done!\")\n" (fun _ -> "Killed") in
-      if reply = "Test\n"
+      let expectedPrefix = "Test\n" in
+      let expectedLength = FStar.String.length expectedPrefix in
+      if (FStar.String.substring reply 0 expectedLength) = expectedPrefix
       then p
       else failwith (BU.format1 "Failed to start and test Z3 process, expected output \"Test\" got \"%s\"" reply))
 


### PR DESCRIPTION
This function was failing in my environment and it seems to fix it.

This is checking just the prefix of the output rather than the whole of it.

Context: I was running **Verify current file in the command line** in emacs

before:

> "C:/dev/src/github.com/FStar/FStar/bin/fstar.exe" "c:/dev/src/github.com/mateuszbujalski/jsonstar/jsonstar/JsonStar.Json.fst" "--smt" "C:/dev/bin/z3-4.8.5-x64-win/bin/z3.exe"
Unexpected error; please file a bug report, ideally with a minimized version of the source program that triggered the error.
Failed to start and test Z3 process, expected output "Test" got "Test
Done!
"

after:

> "C:/dev/src/github.com/FStar/FStar/bin/fstar.exe" "c:/dev/src/github.com/mateuszbujalski/jsonstar/jsonstar/JsonStar.Json.fst" "--smt" "C:/dev/bin/z3-4.8.5-x64-win/bin/z3.exe"
C:\dev\src\github.com\FStar\FStar\ulib\prims.fst(0,0-0,0): (Warning 241) Unable to load C:\dev\src\github.com\FStar\FStar\ulib\prims.fst.checked since checked file C:\dev\src\github.com\FStar\FStar\ulib\prims.fst.checked does not exist; will recheck C:\dev\src\github.com\FStar\FStar\ulib\prims.fst (suppressing this warning for further modules)
Verified module: JsonStar.Json
All verification conditions discharged successfully

Please let me know any of the adjustments you'd like, or if there is an approach you'd like me to take to add a test.