### PR TITLE
Canonize arrow on extraction

### DIFF
--- a/src/extraction/FStar.Extraction.ML.Term.fs
+++ b/src/extraction/FStar.Extraction.ML.Term.fs
@@ -1046,7 +1046,7 @@ let extract_lb_sig (g:uenv) (lbs:letbindings) =
               //   end
               // end;
               let f_e = effect_as_etag g lbeff in
-              let lbtyp = SS.compress lbtyp in
+              let lbtyp = SS.compress (U.canon_arrow lbtyp) in
               let no_gen () =
                   let expected_t = term_as_mlty g lbtyp in
                   (lbname_, f_e, (lbtyp, ([], ([],expected_t))), false, lbdef)


### PR DESCRIPTION
This PR closes #2290 by applying `canon_arrow` while packing an arrow type. 
This way, the arrow representation generated by `pack` is the same as the one used for parsing. 