### PR TITLE
Add constants zero and one to machine integer interface

### DIFF
--- a/ulib/FStar.Int128.fst
+++ b/ulib/FStar.Int128.fst
@@ -39,6 +39,10 @@ let vu_inv _ = ()
 
 let v_inj _ _ = ()
 
+let zero = int_to_t 0
+
+let one = int_to_t 1
+
 let add a b = Mk (add (v a) (v b))
 
 let sub a b = Mk (sub (v a) (v b))

--- a/ulib/FStar.Int128.fst
+++ b/ulib/FStar.Int128.fst
@@ -41,7 +41,9 @@ let v_inj _ _ = ()
 
 let zero = int_to_t 0
 
-let one = int_to_t 1
+let one =
+  FStar.Math.Lemmas.pow2_lt_compat (n - 1) 1;
+  int_to_t 1
 
 let add a b = Mk (add (v a) (v b))
 

--- a/ulib/FStar.Int128.fsti
+++ b/ulib/FStar.Int128.fsti
@@ -47,6 +47,10 @@ val v_inj (x1 x2: t): Lemma
   (requires (v x1 == v x2))
   (ensures (x1 == x2))
 
+val zero : x:t{v x = 0}
+
+val one : x:t{v x = 1}
+
 val add (a:t) (b:t) : Pure t
   (requires (size (v a + v b) n))
   (ensures (fun c -> v a + v b = v c))
@@ -137,7 +141,7 @@ let ct_abs (a:t{min_int n < v a}) : Tot (b:t{v b = abs (v a)}) =
   if 0 <= v a then
     begin
     sign_bit_positive (v a);
-    nth_lemma (v mask) (zero _);
+    nth_lemma (v mask) (FStar.Int.zero _);
     logxor_lemma_1 (v a)
     end
   else

--- a/ulib/FStar.Int16.fst
+++ b/ulib/FStar.Int16.fst
@@ -39,6 +39,10 @@ let vu_inv _ = ()
 
 let v_inj _ _ = ()
 
+let zero = int_to_t 0
+
+let one = int_to_t 1
+
 let add a b = Mk (add (v a) (v b))
 
 let sub a b = Mk (sub (v a) (v b))

--- a/ulib/FStar.Int16.fst
+++ b/ulib/FStar.Int16.fst
@@ -41,7 +41,9 @@ let v_inj _ _ = ()
 
 let zero = int_to_t 0
 
-let one = int_to_t 1
+let one =
+  FStar.Math.Lemmas.pow2_lt_compat (n - 1) 1;
+  int_to_t 1
 
 let add a b = Mk (add (v a) (v b))
 

--- a/ulib/FStar.Int16.fsti
+++ b/ulib/FStar.Int16.fsti
@@ -47,6 +47,10 @@ val v_inj (x1 x2: t): Lemma
   (requires (v x1 == v x2))
   (ensures (x1 == x2))
 
+val zero : x:t{v x = 0}
+
+val one : x:t{v x = 1}
+
 val add (a:t) (b:t) : Pure t
   (requires (size (v a + v b) n))
   (ensures (fun c -> v a + v b = v c))
@@ -137,7 +141,7 @@ let ct_abs (a:t{min_int n < v a}) : Tot (b:t{v b = abs (v a)}) =
   if 0 <= v a then
     begin
     sign_bit_positive (v a);
-    nth_lemma (v mask) (zero _);
+    nth_lemma (v mask) (FStar.Int.zero _);
     logxor_lemma_1 (v a)
     end
   else

--- a/ulib/FStar.Int32.fst
+++ b/ulib/FStar.Int32.fst
@@ -39,6 +39,10 @@ let vu_inv _ = ()
 
 let v_inj _ _ = ()
 
+let zero = int_to_t 0
+
+let one = int_to_t 1
+
 let add a b = Mk (add (v a) (v b))
 
 let sub a b = Mk (sub (v a) (v b))

--- a/ulib/FStar.Int32.fst
+++ b/ulib/FStar.Int32.fst
@@ -41,7 +41,9 @@ let v_inj _ _ = ()
 
 let zero = int_to_t 0
 
-let one = int_to_t 1
+let one =
+  FStar.Math.Lemmas.pow2_lt_compat (n - 1) 1;
+  int_to_t 1
 
 let add a b = Mk (add (v a) (v b))
 

--- a/ulib/FStar.Int32.fsti
+++ b/ulib/FStar.Int32.fsti
@@ -47,6 +47,10 @@ val v_inj (x1 x2: t): Lemma
   (requires (v x1 == v x2))
   (ensures (x1 == x2))
 
+val zero : x:t{v x = 0}
+
+val one : x:t{v x = 1}
+
 val add (a:t) (b:t) : Pure t
   (requires (size (v a + v b) n))
   (ensures (fun c -> v a + v b = v c))
@@ -137,7 +141,7 @@ let ct_abs (a:t{min_int n < v a}) : Tot (b:t{v b = abs (v a)}) =
   if 0 <= v a then
     begin
     sign_bit_positive (v a);
-    nth_lemma (v mask) (zero _);
+    nth_lemma (v mask) (FStar.Int.zero _);
     logxor_lemma_1 (v a)
     end
   else

--- a/ulib/FStar.Int64.fst
+++ b/ulib/FStar.Int64.fst
@@ -39,6 +39,10 @@ let vu_inv _ = ()
 
 let v_inj _ _ = ()
 
+let zero = int_to_t 0
+
+let one = int_to_t 1
+
 let add a b = Mk (add (v a) (v b))
 
 let sub a b = Mk (sub (v a) (v b))

--- a/ulib/FStar.Int64.fst
+++ b/ulib/FStar.Int64.fst
@@ -41,7 +41,9 @@ let v_inj _ _ = ()
 
 let zero = int_to_t 0
 
-let one = int_to_t 1
+let one =
+  FStar.Math.Lemmas.pow2_lt_compat (n - 1) 1;
+  int_to_t 1
 
 let add a b = Mk (add (v a) (v b))
 

--- a/ulib/FStar.Int64.fsti
+++ b/ulib/FStar.Int64.fsti
@@ -47,6 +47,10 @@ val v_inj (x1 x2: t): Lemma
   (requires (v x1 == v x2))
   (ensures (x1 == x2))
 
+val zero : x:t{v x = 0}
+
+val one : x:t{v x = 1}
+
 val add (a:t) (b:t) : Pure t
   (requires (size (v a + v b) n))
   (ensures (fun c -> v a + v b = v c))
@@ -137,7 +141,7 @@ let ct_abs (a:t{min_int n < v a}) : Tot (b:t{v b = abs (v a)}) =
   if 0 <= v a then
     begin
     sign_bit_positive (v a);
-    nth_lemma (v mask) (zero _);
+    nth_lemma (v mask) (FStar.Int.zero _);
     logxor_lemma_1 (v a)
     end
   else

--- a/ulib/FStar.Int8.fst
+++ b/ulib/FStar.Int8.fst
@@ -39,6 +39,10 @@ let vu_inv _ = ()
 
 let v_inj _ _ = ()
 
+let zero = int_to_t 0
+
+let one = int_to_t 1
+
 let add a b = Mk (add (v a) (v b))
 
 let sub a b = Mk (sub (v a) (v b))

--- a/ulib/FStar.Int8.fst
+++ b/ulib/FStar.Int8.fst
@@ -41,7 +41,9 @@ let v_inj _ _ = ()
 
 let zero = int_to_t 0
 
-let one = int_to_t 1
+let one =
+  FStar.Math.Lemmas.pow2_lt_compat (n - 1) 1;
+  int_to_t 1
 
 let add a b = Mk (add (v a) (v b))
 

--- a/ulib/FStar.Int8.fsti
+++ b/ulib/FStar.Int8.fsti
@@ -47,6 +47,10 @@ val v_inj (x1 x2: t): Lemma
   (requires (v x1 == v x2))
   (ensures (x1 == x2))
 
+val zero : x:t{v x = 0}
+
+val one : x:t{v x = 1}
+
 val add (a:t) (b:t) : Pure t
   (requires (size (v a + v b) n))
   (ensures (fun c -> v a + v b = v c))
@@ -137,7 +141,7 @@ let ct_abs (a:t{min_int n < v a}) : Tot (b:t{v b = abs (v a)}) =
   if 0 <= v a then
     begin
     sign_bit_positive (v a);
-    nth_lemma (v mask) (zero _);
+    nth_lemma (v mask) (FStar.Int.zero _);
     logxor_lemma_1 (v a)
     end
   else

--- a/ulib/FStar.IntN.fstip
+++ b/ulib/FStar.IntN.fstip
@@ -26,6 +26,10 @@ val v_inj (x1 x2: t): Lemma
   (requires (v x1 == v x2))
   (ensures (x1 == x2))
 
+val zero : x:t{v x = 0}
+
+val one : x:t{v x = 1}
+
 val add (a:t) (b:t) : Pure t
   (requires (size (v a + v b) n))
   (ensures (fun c -> v a + v b = v c))
@@ -116,7 +120,7 @@ let ct_abs (a:t{min_int n < v a}) : Tot (b:t{v b = abs (v a)}) =
   if 0 <= v a then
     begin
     sign_bit_positive (v a);
-    nth_lemma (v mask) (zero _);
+    nth_lemma (v mask) (FStar.Int.zero _);
     logxor_lemma_1 (v a)
     end
   else

--- a/ulib/FStar.IntN.fstp
+++ b/ulib/FStar.IntN.fstp
@@ -22,7 +22,9 @@ let v_inj _ _ = ()
 
 let zero = int_to_t 0
 
-let one = int_to_t 1
+let one =
+  FStar.Math.Lemmas.pow2_lt_compat (n - 1) 1;
+  int_to_t 1
 
 let add a b = Mk (add (v a) (v b))
 

--- a/ulib/FStar.IntN.fstp
+++ b/ulib/FStar.IntN.fstp
@@ -20,6 +20,10 @@ let vu_inv _ = ()
 
 let v_inj _ _ = ()
 
+let zero = int_to_t 0
+
+let one = int_to_t 1
+
 let add a b = Mk (add (v a) (v b))
 
 let sub a b = Mk (sub (v a) (v b))

--- a/ulib/FStar.UInt16.fst
+++ b/ulib/FStar.UInt16.fst
@@ -35,6 +35,10 @@ let vu_inv _ = ()
 
 let v_inj _ _ = ()
 
+let zero = uint_to_t 0
+
+let one = uint_to_t 1
+
 let add a b = Mk (add (v a) (v b))
 
 let add_underspec a b = Mk (add_underspec (v a) (v b))

--- a/ulib/FStar.UInt16.fsti
+++ b/ulib/FStar.UInt16.fsti
@@ -25,7 +25,7 @@ unfold let n = 16
 ///
 /// Except, as compared to [FStar.IntN.fstp], here:
 ///  - every occurrence of [int_t] has been replaced with [uint_t]
-///  - every occurrence of [@@%] has been replaced with [%].
+///  - every occurrence of [@%] has been replaced with [%].
 ///  - some functions (e.g., add_underspec, etc.) are only defined here, not on signed integers
 
 /// This module provides an abstract type for machine integers of a
@@ -73,6 +73,11 @@ val vu_inv (x : uint_t n) : Lemma
 val v_inj (x1 x2: t): Lemma
   (requires (v x1 == v x2))
   (ensures (x1 == x2))
+
+(** Constants 0 and 1 *)
+val zero : x:t{v x = 0}
+
+val one : x:t{v x = 1}
 
 (**** Addition primitives *)
 
@@ -271,7 +276,7 @@ let eq_mask (a:t) (b:t)
       lemma_msb_pow2 #n (v (lognot x));
       lemma_msb_pow2 #n (v minus_x);
       lemma_minus_zero #n (v x);
-      assert (v c = zero n)
+      assert (v c = FStar.UInt.zero n)
     end;
     c
 

--- a/ulib/FStar.UInt32.fst
+++ b/ulib/FStar.UInt32.fst
@@ -35,6 +35,10 @@ let vu_inv _ = ()
 
 let v_inj _ _ = ()
 
+let zero = uint_to_t 0
+
+let one = uint_to_t 1
+
 let add a b = Mk (add (v a) (v b))
 
 let add_underspec a b = Mk (add_underspec (v a) (v b))

--- a/ulib/FStar.UInt32.fsti
+++ b/ulib/FStar.UInt32.fsti
@@ -25,7 +25,7 @@ unfold let n = 32
 ///
 /// Except, as compared to [FStar.IntN.fstp], here:
 ///  - every occurrence of [int_t] has been replaced with [uint_t]
-///  - every occurrence of [@@%] has been replaced with [%].
+///  - every occurrence of [@%] has been replaced with [%].
 ///  - some functions (e.g., add_underspec, etc.) are only defined here, not on signed integers
 
 /// This module provides an abstract type for machine integers of a
@@ -73,6 +73,11 @@ val vu_inv (x : uint_t n) : Lemma
 val v_inj (x1 x2: t): Lemma
   (requires (v x1 == v x2))
   (ensures (x1 == x2))
+
+(** Constants 0 and 1 *)
+val zero : x:t{v x = 0}
+
+val one : x:t{v x = 1}
 
 (**** Addition primitives *)
 
@@ -271,7 +276,7 @@ let eq_mask (a:t) (b:t)
       lemma_msb_pow2 #n (v (lognot x));
       lemma_msb_pow2 #n (v minus_x);
       lemma_minus_zero #n (v x);
-      assert (v c = zero n)
+      assert (v c = FStar.UInt.zero n)
     end;
     c
 

--- a/ulib/FStar.UInt64.fst
+++ b/ulib/FStar.UInt64.fst
@@ -35,6 +35,10 @@ let vu_inv _ = ()
 
 let v_inj _ _ = ()
 
+let zero = uint_to_t 0
+
+let one = uint_to_t 1
+
 let add a b = Mk (add (v a) (v b))
 
 let add_underspec a b = Mk (add_underspec (v a) (v b))

--- a/ulib/FStar.UInt64.fsti
+++ b/ulib/FStar.UInt64.fsti
@@ -25,7 +25,7 @@ unfold let n = 64
 ///
 /// Except, as compared to [FStar.IntN.fstp], here:
 ///  - every occurrence of [int_t] has been replaced with [uint_t]
-///  - every occurrence of [@@%] has been replaced with [%].
+///  - every occurrence of [@%] has been replaced with [%].
 ///  - some functions (e.g., add_underspec, etc.) are only defined here, not on signed integers
 
 /// This module provides an abstract type for machine integers of a
@@ -73,6 +73,11 @@ val vu_inv (x : uint_t n) : Lemma
 val v_inj (x1 x2: t): Lemma
   (requires (v x1 == v x2))
   (ensures (x1 == x2))
+
+(** Constants 0 and 1 *)
+val zero : x:t{v x = 0}
+
+val one : x:t{v x = 1}
 
 (**** Addition primitives *)
 
@@ -271,7 +276,7 @@ let eq_mask (a:t) (b:t)
       lemma_msb_pow2 #n (v (lognot x));
       lemma_msb_pow2 #n (v minus_x);
       lemma_minus_zero #n (v x);
-      assert (v c = zero n)
+      assert (v c = FStar.UInt.zero n)
     end;
     c
 

--- a/ulib/FStar.UInt8.fst
+++ b/ulib/FStar.UInt8.fst
@@ -35,6 +35,10 @@ let vu_inv _ = ()
 
 let v_inj _ _ = ()
 
+let zero = uint_to_t 0
+
+let one = uint_to_t 1
+
 let add a b = Mk (add (v a) (v b))
 
 let add_underspec a b = Mk (add_underspec (v a) (v b))

--- a/ulib/FStar.UInt8.fsti
+++ b/ulib/FStar.UInt8.fsti
@@ -25,7 +25,7 @@ unfold let n = 8
 ///
 /// Except, as compared to [FStar.IntN.fstp], here:
 ///  - every occurrence of [int_t] has been replaced with [uint_t]
-///  - every occurrence of [@@%] has been replaced with [%].
+///  - every occurrence of [@%] has been replaced with [%].
 ///  - some functions (e.g., add_underspec, etc.) are only defined here, not on signed integers
 
 /// This module provides an abstract type for machine integers of a
@@ -73,6 +73,11 @@ val vu_inv (x : uint_t n) : Lemma
 val v_inj (x1 x2: t): Lemma
   (requires (v x1 == v x2))
   (ensures (x1 == x2))
+
+(** Constants 0 and 1 *)
+val zero : x:t{v x = 0}
+
+val one : x:t{v x = 1}
 
 (**** Addition primitives *)
 
@@ -271,7 +276,7 @@ let eq_mask (a:t) (b:t)
       lemma_msb_pow2 #n (v (lognot x));
       lemma_msb_pow2 #n (v minus_x);
       lemma_minus_zero #n (v x);
-      assert (v c = zero n)
+      assert (v c = FStar.UInt.zero n)
     end;
     c
 

--- a/ulib/FStar.UIntN.fstip
+++ b/ulib/FStar.UIntN.fstip
@@ -53,6 +53,11 @@ val v_inj (x1 x2: t): Lemma
   (requires (v x1 == v x2))
   (ensures (x1 == x2))
 
+(** Constants 0 and 1 *)
+val zero : x:t{v x = 0}
+
+val one : x:t{v x = 1}
+
 (**** Addition primitives *)
 
 (** Bounds-respecting addition
@@ -250,7 +255,7 @@ let eq_mask (a:t) (b:t)
       lemma_msb_pow2 #n (v (lognot x));
       lemma_msb_pow2 #n (v minus_x);
       lemma_minus_zero #n (v x);
-      assert (v c = zero n)
+      assert (v c = FStar.UInt.zero n)
     end;
     c
 

--- a/ulib/FStar.UIntN.fstp
+++ b/ulib/FStar.UIntN.fstp
@@ -16,6 +16,10 @@ let vu_inv _ = ()
 
 let v_inj _ _ = ()
 
+let zero = uint_to_t 0
+
+let one = uint_to_t 1
+
 let add a b = Mk (add (v a) (v b))
 
 let add_underspec a b = Mk (add_underspec (v a) (v b))


### PR DESCRIPTION
This PR closes #2301. 

As explained on the issue, we expose the `zero` and `one` constants in the machine integer modules' interfaces.
We don't have to change the OCaml or F# realizations, as they already define these constants.