### PR TITLE
Give prims types special treatment in OCaml extraction

### DIFF
--- a/src/extraction/ml/FStar_Extraction_ML_PrintML.ml
+++ b/src/extraction/ml/FStar_Extraction_ML_PrintML.ml
@@ -162,6 +162,11 @@ and build_constructor_pat ((path, sym), p) =
         | "Cons" -> ([], "::")
         | "Nil" -> ([], "[]")
         | x -> (path, x))
+     | ["FStar"; "Pervasives"; "Native"] ->
+       (match sym with
+        | "None" -> ([], "None")
+        | "Some" -> ([], "Some")
+        | x -> (path, x))
      | _ -> (path, sym)) in
   match p with
   | [] ->
@@ -194,6 +199,17 @@ let rec build_core_type ?(annots = []) (ty: mlty): core_type =
          * the condition below might need to be more specific. *)
         if BatString.starts_with sym "tuple" then
           Typ.mk (Ptyp_tuple (map build_core_type tys))
+        else
+        if BatString.equal sym "option" then
+          Typ.mk (Ptyp_constr (mk_lident "option", c_tys))
+        else
+          ty
+      | ["Prims"] ->
+        if BatString.equal sym "bool" then
+          Typ.mk (Ptyp_constr (mk_lident "bool", []))
+        else
+        if BatString.equal sym "list" then
+          Typ.mk (Ptyp_constr (mk_lident "list", c_tys))
         else
           ty
       | _ -> ty)
@@ -334,6 +350,8 @@ and build_constructor_expr ((path, sym), exp): expression =
     (match path, sym with
     | ["Prims"], "Cons" -> ([], "::")
     | ["Prims"], "Nil" -> ([], "[]")
+    | ["FStar"; "Pervasives"; "Native"], "None" -> ([], "None")
+    | ["FStar"; "Pervasives"; "Native"], "Some" -> ([], "Some")
     | path, x -> (path, x)) in
   match exp with
   | [] -> Exp.construct (path_to_ident(path', name)) None


### PR DESCRIPTION
This PR closes #2304, by adding special cases in the OCaml extraction to extract the `Prims` and `FStar.Pervasives.Native` types (`bool`, `list`, `option`) directly to their OCaml counterparts.