### PR TITLE
Modifications to frame preserving PCM updates

### DIFF
--- a/examples/steel/Duplex.PCM.fst
+++ b/examples/steel/Duplex.PCM.fst
@@ -642,7 +642,7 @@ let upd_gen_action #p r x y f =
   change_slprop (pts_to r (reveal (hide y))) (pts_to r y) (fun _ -> ())
 
 
-#push-options "--z3rlimit 100 --warn_error -271"
+#push-options "--z3rlimit_factor 8 --ifuel 2 --fuel 1"
 #restart-solver
 let write_a_f_aux
   (#p:dprot)
@@ -687,7 +687,6 @@ let write_a_f_aux
       : Lemma (requires composable (A_W next tr) frame)
               (ensures composable post frame /\ (compose (A_W next tr) frame == v ==>
                                                 compose post frame == res))
-              [SMTPat()]
       = match frame with
         | Nil -> ()
         | B_R q' s' ->
@@ -699,8 +698,12 @@ let write_a_f_aux
           extend_increase_length tr x;
           assert (trace_length (extend tr x) > trace_length tr)
     in
+    Classical.forall_intro (Classical.move_requires aux_composable);
     res
+#pop-options
 
+#push-options "--z3rlimit_factor 8 --ifuel 2 --fuel 1"
+#restart-solver
 let write_b_f_aux
 (#p:dprot)
 (#next:dprot{more next /\ tag_of next = Recv})

--- a/examples/steel/Duplex.PCM.fst
+++ b/examples/steel/Duplex.PCM.fst
@@ -642,63 +642,77 @@ let upd_gen_action #p r x y f =
   change_slprop (pts_to r (reveal (hide y))) (pts_to r y) (fun _ -> ())
 
 
-#push-options "--z3rlimit 20"
+#push-options "--z3rlimit 100 --warn_error -271"
 #restart-solver
 let write_a_f_aux
   (#p:dprot)
   (#next:dprot{more next /\ tag_of next = Send})
   (tr:trace p next)
   (x:msg_t next)
-  : FStar.PCM.frame_preserving_upd_0 (pcm p) (A_W next tr)
+  : FStar.PCM.frame_preserving_upd (pcm p) (A_W next tr)
     (if is_send (step next x)
-    then A_W (step next x) (extend tr x)
-    else if is_recv (step next x)
-    then A_R (step next x) (extend tr x)
-    else A_Fin (step next x) (extend tr x))
-  = fun (v:t p{compatible (pcm p) (A_W next tr) v}) ->
+     then A_W (step next x) (extend tr x)
+     else if is_recv (step next x)
+     then A_R (step next x) (extend tr x)
+     else A_Fin (step next x) (extend tr x))
+  = fun v ->
     let post =
-      if is_send (step next x)
+    if is_send (step next x)
     then A_W (step next x) (extend tr x)
     else if is_recv (step next x)
     then A_R (step next x) (extend tr x)
     else A_Fin (step next x) (extend tr x)
   in
   match v with
-  | A_W n tr' ->
-      assert (n == next /\ tr' == tr);
-      compatible_refl (pcm p) post;
-      post
   | V tr' ->
-      assert (tr'.to == next /\ tr'.tr == tr);
-      let res = V ({to = (step next x); tr = extend tr x}) in
-      let aux () : Lemma (compatible (pcm p) post res)
-        = if is_send (step next x) then (
-            assert (composable post (B_R next tr));
-            assert (compose (B_R next tr) post == res)
-          ) else if is_recv (step next x) then (
-            assert (composable post (B_W (step next x) (extend tr x)));
-            assert (compose (B_W (step next x) (extend tr x)) post == res)
-          ) else (
-            assert (is_fin (step next x));
-            assert (post == A_Fin (step next x) (extend tr x));
-            assert (composable post (B_R next tr));
-            assert (compose (B_R next tr) post == res)
-          )
-      in aux ();
-      res
+    assert (tr'.to == next /\ tr'.tr == tr);
+    let res = V ({to = (step next x); tr = extend tr x}) in
+
+    let aux () : Lemma (compatible (pcm p) post res)
+      = if is_send (step next x) then (
+          assert (composable post (B_R next tr));
+          assert (compose (B_R next tr) post == res)
+        ) else if is_recv (step next x) then (
+          assert (composable post (B_W (step next x) (extend tr x)));
+          assert (compose (B_W (step next x) (extend tr x)) post == res)
+        ) else (
+          assert (is_fin (step next x));
+          assert (post == A_Fin (step next x) (extend tr x));
+          assert (composable post (B_R next tr));
+          assert (compose (B_R next tr) post == res)
+        )
+    in
+    aux ();
+    let aux_composable frame
+      : Lemma (requires composable (A_W next tr) frame)
+              (ensures composable post frame /\ (compose (A_W next tr) frame == v ==>
+                                                compose post frame == res))
+              [SMTPat()]
+      = match frame with
+        | Nil -> ()
+        | B_R q' s' ->
+          assert (ahead A next q' tr s');
+          lemma_ahead_is_longer A next tr q' s';
+          assert (trace_length tr >= trace_length s');
+          assert (ahead A (step next x) next (extend tr x) tr);
+          assert (ahead A (step next x) q' (extend tr x) s');
+          extend_increase_length tr x;
+          assert (trace_length (extend tr x) > trace_length tr)
+    in
+    res
 
 let write_b_f_aux
 (#p:dprot)
 (#next:dprot{more next /\ tag_of next = Recv})
 (tr:trace p next)
 (x:msg_t next)
-: FStar.PCM.frame_preserving_upd_0 (pcm p) (B_W next tr)
+: FStar.PCM.frame_preserving_upd (pcm p) (B_W next tr)
   (if is_send (step next x)
    then B_R (step next x) (extend tr x)
    else if is_recv (step next x)
    then B_W (step next x) (extend tr x)
    else B_Fin (step next x) (extend tr x))
-= fun (v:t p{compatible (pcm p) (B_W next tr) v}) ->
+= fun v ->
   let post =
     if is_send (step next x)
     then B_R (step next x) (extend tr x)
@@ -707,10 +721,6 @@ let write_b_f_aux
     else B_Fin (step next x) (extend tr x)
   in
   match v with
-  | B_W n tr' ->
-      assert (n == next /\ tr' == tr);
-      compatible_refl (pcm p) post;
-      post
   | V tr' ->
       assert (tr'.to == next /\ tr'.tr == tr);
       let res = V ({to = (step next x); tr = extend tr x}) in
@@ -727,7 +737,24 @@ let write_b_f_aux
             assert (composable post (A_R next tr));
             assert (compose (A_R next tr) post == res)
           )
-      in aux ();
+      in
+      aux ();
+      let aux_composable frame
+      : Lemma (requires composable (B_W next tr) frame)
+              (ensures composable post frame /\ (compose (B_W next tr) frame == v ==>
+                                                compose post frame == res))
+      = match frame with
+        | Nil -> ()
+        | A_R q' s' ->
+          assert (ahead B next q' tr s');
+          lemma_ahead_is_longer B next tr q' s';
+          assert (trace_length tr >= trace_length s');
+          assert (ahead B (step next x) next (extend tr x) tr);
+          assert (ahead B (step next x) q' (extend tr x) s');
+          extend_increase_length tr x;
+          assert (trace_length (extend tr x) > trace_length tr)
+      in
+      Classical.forall_intro (Classical.move_requires aux_composable);
       res
 
 let lemma_ahead_extend_a (#p:dprot)
@@ -763,7 +790,7 @@ let write_a_f_lemma
   (#next:dprot{more next /\ tag_of next = Send})
   (tr:trace p next)
   (x:msg_t next)
-  (v:t p)
+  (v:t p{(pcm p).refine v})
   (frame:t p)
   : Lemma
     (requires compatible (pcm p) (A_W next tr) v /\ composable v frame)
@@ -773,33 +800,14 @@ let write_a_f_lemma
       composable (write_a_f_aux #p #next tr x v) frame /\
       (compatible (pcm p) (A_W next tr) (compose v frame) ==>
         (compose (write_a_f_aux tr x v) frame == write_a_f_aux tr x (compose v frame))))
-  = let post = write_a_f_aux tr x v in
-    match v with
-    | A_W n tr ->
-      if Nil? frame then ()
-      else begin
-        let B_R n' tr' = frame in
-        assert (ahead A n n' tr tr');
-        let next_n = step next x in
-        let next_tr = extend tr x in
-        lemma_ahead_extend_a n' next tr' tr x;
-        let aux () : Lemma
-          (requires compatible (pcm p) (A_W next tr) (compose v frame))
-          (ensures compose post frame == write_a_f_aux tr x (compose v frame))
-          = let last = {to = next_n; tr = next_tr} in
-            lemma_ahead_is_longer A next_n next_tr n' tr';
-            assert (compose post frame == V last);
-            assert (compose v frame == V ({to = n; tr = tr}))
-        in Classical.move_requires aux ()
-      end
-    | V tr' -> ()
+  = ()
 
 let write_b_f_lemma
   (#p:dprot)
   (#next:dprot{more next /\ tag_of next = Recv})
   (tr:trace p next)
   (x:msg_t next)
-  (v:t p)
+  (v:t p{(pcm p).refine v})
   (frame:t p)
   : Lemma
     (requires compatible (pcm p) (B_W next tr) v /\ composable v frame)
@@ -809,27 +817,7 @@ let write_b_f_lemma
       composable (write_b_f_aux #p #next tr x v) frame /\
       (compatible (pcm p) (B_W next tr) (compose v frame) ==>
         (compose (write_b_f_aux tr x v) frame == write_b_f_aux tr x (compose v frame))))
-  = let post = write_b_f_aux tr x v in
-    match v with
-    | B_W n tr ->
-      if Nil? frame then ()
-      else begin
-        let A_R n' tr' = frame in
-        assert (ahead B n n' tr tr');
-        let next_n = step next x in
-        let next_tr = extend tr x in
-        lemma_ahead_extend_b n' next tr' tr x;
-        let aux () : Lemma
-          (requires compatible (pcm p) (B_W next tr) (compose v frame))
-          (ensures compose post frame == write_b_f_aux tr x (compose v frame))
-          = let last = {to = next_n; tr = next_tr} in
-            lemma_ahead_is_longer B next_n next_tr n' tr';
-            Classical.move_requires (lemma_same_trace_length_ahead_refl B next_tr) tr';
-            assert (compose post frame == V last);
-            assert (compose v frame == V ({to = n; tr = tr}))
-        in Classical.move_requires aux ()
-      end
-    | V tr' -> ()
+  = ()
 
 #pop-options
 

--- a/examples/steel/StructUpdate.fst
+++ b/examples/steel/StructUpdate.fst
@@ -45,13 +45,12 @@ let upd_first #a #b (r:ref (t a b) pcm_t) (x:Ghost.erased a) (y:a)
            (pts_to r (First #a #b x))
            (fun _ -> pts_to r (First #a #b y))
   = let f
-      : frame_preserving_upd_0
+      : frame_preserving_upd
               pcm_t
               (Ghost.hide (First #a #b x))
               (First #a #b y)
       = fun old_v ->
           match old_v with
-          | First _ -> First y
           | Both _ z -> Both y z
     in
     change_slprop (pts_to r (First (Ghost.reveal x))) (pts_to r (Ghost.reveal (Ghost.hide (First (Ghost.reveal x))))) (fun _ -> ());
@@ -63,13 +62,12 @@ let upd_second #a #b (r:ref (t a b) pcm_t) (x:Ghost.erased b) (y:b)
            (pts_to r (Second #a #b x))
            (fun _ -> pts_to r (Second #a #b y))
   = let f
-      : frame_preserving_upd_0
+      : frame_preserving_upd
               pcm_t
               (Second #a #b x)
               (Second #a #b y)
       = fun old_v ->
           match old_v with
-          | Second _ -> Second y
           | Both z _ -> Both z y
     in
     change_slprop (pts_to r (Second (Ghost.reveal x))) (pts_to r (Ghost.reveal (Ghost.hide (Second (Ghost.reveal x))))) (fun _ -> ());

--- a/ulib/FStar.IndefiniteDescription.fst
+++ b/ulib/FStar.IndefiniteDescription.fst
@@ -101,7 +101,7 @@ let stronger_markovs_principle_prop (p: (nat -> GTot prop))
 
 (** A proof for squash p can be eliminated to get p in the Ghost effect *)
 
-let elim_squash (#p:Type0) (s:squash p) : GTot p =
+let elim_squash (#p:Type u#a) (s:squash p) : GTot p =
   let uu : squash (x:p & squash c_True) =
     bind_squash s (fun x -> return_squash (| x, return_squash T |)) in
   give_proof (return_squash uu);

--- a/ulib/FStar.IndefiniteDescription.fst
+++ b/ulib/FStar.IndefiniteDescription.fst
@@ -107,6 +107,9 @@ let elim_squash (#p:Type u#a) (s:squash p) : GTot p =
   give_proof (return_squash uu);
   indefinite_description_ghost p (fun _ -> squash c_True)
 
+
+(** Extracting a ghost witness for an exists *)
+
 let witness_exists (#a:Type u#a) (p:a -> prop)
   : Ghost (x:a{p x}) (requires exists (x:a). p x) (ensures fun _ -> True)
   = let (| x, _ |) = elim_squash (join_squash (get_proof (exists (x:a). p x))) in

--- a/ulib/FStar.IndefiniteDescription.fst
+++ b/ulib/FStar.IndefiniteDescription.fst
@@ -106,3 +106,8 @@ let elim_squash (#p:Type u#a) (s:squash p) : GTot p =
     bind_squash s (fun x -> return_squash (| x, return_squash T |)) in
   give_proof (return_squash uu);
   indefinite_description_ghost p (fun _ -> squash c_True)
+
+let witness_exists (#a:Type u#a) (p:a -> prop)
+  : Ghost (x:a{p x}) (requires exists (x:a). p x) (ensures fun _ -> True)
+  = let (| x, _ |) = elim_squash (join_squash (get_proof (exists (x:a). p x))) in
+    x

--- a/ulib/FStar.PCM.fst
+++ b/ulib/FStar.PCM.fst
@@ -175,3 +175,15 @@ let frame_preserving_val_to_fp_upd (#a:Type u#a) (p:pcm a)
   : frame_preserving_upd p x v
   = Classical.forall_intro (p.comm v);
     fun _ -> v
+
+let no_op_is_frame_preserving (#a:Type u#a) (p:pcm a)
+  (x:a)
+  : frame_preserving_upd p x x
+  = fun v -> v
+
+let compose_frame_preserving_updates (#a:Type u#a) (p:pcm a)
+  (x y z:a)
+  (f:frame_preserving_upd p x y)
+  (g:frame_preserving_upd p y z)
+  : frame_preserving_upd p x z
+  = fun v -> g (f v)

--- a/ulib/experimental/Steel.Effect.fst
+++ b/ulib/experimental/Steel.Effect.fst
@@ -205,7 +205,10 @@ let change_slprop p q proof =
   Steel?.reflect (Steel.Memory.change_slprop #Set.empty p q proof)
 
 let read r v0 = Steel?.reflect (action_as_repr (sel_action FStar.Set.empty r v0))
-let write r v0 v1 = Steel?.reflect (action_as_repr (upd_action FStar.Set.empty r v0 v1))
+let upd_gen #a #p r x y f = add_action (Steel.Memory.upd_gen Set.empty r x y f)
+let write #a #p r v0 v1 = upd_gen r v0 (Ghost.hide v1)
+  (frame_preserving_val_to_fp_upd p v0 v1);
+  change_slprop (pts_to r (Ghost.reveal (Ghost.hide v1))) (pts_to r v1) (fun _ -> ())
 let alloc x = Steel?.reflect (action_as_repr (alloc_action FStar.Set.empty x))
 let free r x = Steel?.reflect (action_as_repr (free_action FStar.Set.empty r x))
 
@@ -228,5 +231,3 @@ let witness r fact v _ = Steel?.reflect (action_as_repr (Steel.Memory.witness FS
 let recall r v = Steel?.reflect (action_as_repr (Steel.Memory.recall FStar.Set.empty r v))
 
 let select_refine #a #p r x f = add_action (Steel.Memory.select_refine Set.empty r x f)
-
-let upd_gen #a #p r x y f = add_action (Steel.Memory.upd_gen Set.empty r x y f)

--- a/ulib/experimental/Steel.Effect.fsti
+++ b/ulib/experimental/Steel.Effect.fsti
@@ -259,6 +259,13 @@ val read (#a:Type)
   : SteelT (v:a { FStar.PCM.compatible pcm v0 v })
            (pts_to r v0)
            (fun _ -> pts_to r v0)
+open FStar.PCM
+
+val upd_gen (#a:Type) (#p:pcm a) (r:ref a p) (x y:Ghost.erased a)
+            (f:FStar.PCM.frame_preserving_upd p x y)
+  : SteelT unit
+           (pts_to r x)
+           (fun _ -> pts_to r y)
 
 val write (#a:Type)
           (#pcm:_)
@@ -326,8 +333,6 @@ val recall (#a:Type u#1) (#pcm:FStar.PCM.pcm a) (#fact:property a)
 
 /// Operations on PCM Refs
 
-open FStar.PCM
-
 val select_refine (#a:Type u#1) (#p:pcm a)
                   (r:ref a p)
                   (x:Ghost.erased a)
@@ -337,9 +342,3 @@ val select_refine (#a:Type u#1) (#p:pcm a)
    : SteelT  (v:a{compatible p x v /\ p.refine v})
              (pts_to r x)
              (fun v -> pts_to r (f v))
-
-val upd_gen (#a:Type) (#p:pcm a) (r:ref a p) (x y:Ghost.erased a)
-            (f:FStar.PCM.frame_preserving_upd p x y)
-  : SteelT unit
-           (pts_to r x)
-           (fun _ -> pts_to r y)

--- a/ulib/experimental/Steel.Heap.fst
+++ b/ulib/experimental/Steel.Heap.fst
@@ -895,248 +895,13 @@ let select_refine (#a:_) (#p:_)
             (fun v -> pts_to r (f v))
    = refined_pre_action_as_action (select_refine_pre r x f)
 
-
 let update_addr_full_heap (h:full_heap) (a:addr) (c:cell{c.frac == Frac.full_perm}) : full_heap =
   let h' = update_addr h a c in
   assert (forall x. contains_addr h' x ==> x==a \/ contains_addr h x);
   h'
 
-let upd' (#a:_) (#pcm:_) (r:ref a pcm) (v0:FStar.Ghost.erased a) (v1:a {frame_preserving pcm v0 v1 /\ pcm.refine v1})
-  : pre_action (pts_to r v0) unit (fun _ -> pts_to r v1)
-  = fun h ->
-    let cell = Ref a pcm Frac.full_perm v1  in
-    let h' = update_addr h (Addr?._0 r) cell in
-    assert (forall x. contains_addr h' x ==> x==(Addr?._0 r) \/ contains_addr h x);
-    assert (h' `contains_addr` Addr?._0 r);
-    FStar.PCM.compatible_refl pcm v1;
-    assert (compatible pcm v1 v1);
-    assert (pts_to_cell #a pcm v1 cell);
-    assert (interp (pts_to r v1) h');
-    (| (), h' |)
-
-
-let definedness #a #pcm (v0:a) (v0_val:a) (v1:a) (vf:a)
-  : Lemma (requires
-             compatible pcm v0 v0_val /\
-             composable pcm v0_val vf /\
-             frame_preserving pcm v0 v1)
-          (ensures
-             composable pcm vf v1 /\
-             composable pcm v1 vf)
-  = assert (exists vf'. composable pcm vf' v0 /\ op pcm vf' v0 == v0_val);
-    let aux (vf':a {composable pcm vf' v0 /\ op pcm vf' v0 == v0_val})
-      : Lemma (composable pcm vf v1 /\
-               composable pcm v1 vf)
-              [SMTPat(op pcm vf' v0)]
-        = assert (composable pcm (op pcm vf' v0) vf);
-          pcm.comm vf' v0;
-          assert (composable pcm (op pcm v0 vf') vf);
-          pcm.assoc_r v0 vf' vf;
-          assert (composable pcm v0 (op pcm vf' vf));
-          pcm.comm vf vf';
-          assert (composable pcm v0 (op pcm vf vf'));
-          assert (composable pcm (op pcm vf vf') v1);
-          pcm.comm (op pcm vf vf') v1;
-          pcm.assoc v1 vf vf';
-          assert (composable pcm (op pcm v1 vf) vf')
-    in
-    ()
-
-let composable_compatible #a pcm (x y z:a)
-  : Lemma (requires compatible pcm x y /\
-                    composable pcm y z)
-          (ensures composable pcm x z /\
-                   composable pcm z x)
-  = let aux (f:a{composable pcm f x /\ op pcm f x == y})
-      : Lemma (composable pcm x z /\
-               composable pcm z x)
-              [SMTPat (op pcm f x)]
-      = assert (composable pcm (op pcm f x) z);
-        pcm.assoc_r f x z;
-        assert (composable pcm f (op pcm x z));
-        pcm.comm x z
-    in
-    let s : squash (exists f. composable pcm f x /\ op pcm f x == y) = () in
-    ()
-
-let heap_evolves_by_frame_preserving_update #a #pcm (r:ref a pcm)
-                                            (v0:Ghost.erased a)
-                                            (v1:a {frame_preserving pcm v0 v1 /\ pcm.refine v1})
-                                            (h0:full_hheap (pts_to r v0))
-   : Lemma (let h1 = update_addr_full_heap h0 (Addr?._0 r) (Ref a pcm Frac.full_perm v1) in
-            heap_evolves h0 h1)
-  = let v = sel r h0 in
-    PP.frame_preserving_is_preorder_respecting pcm v0 v1;
-    assert (PP.preorder_of_pcm pcm v v1)
-
-#push-options "--z3rlimit_factor 8 --max_fuel 1 --initial_ifuel 1 --max_ifuel 2"
-#restart-solver
-let upd_lemma'_1 (#a:_) #pcm (r:ref a pcm)
-                 (v0:Ghost.erased a) (v1:a {frame_preserving pcm v0 v1 /\ pcm.refine v1})
-                 (h:full_hheap (pts_to r v0)) (frame:slprop)
-                 (h0 hf:heap)
-  : Lemma
-    (requires
-      interp (pts_to r v0 `star` frame) h /\
-      disjoint h0 hf /\
-      h == join h0 hf /\
-      interp (pts_to r v0) h0 /\
-      interp frame hf)
-    (ensures (
-      let (| _, h' |) = upd' r v0 v1 h in
-      let cell0 = select_addr h0 (Addr?._0 r) in
-      let h0' = update_addr h0 (Addr?._0 r) (Ref a pcm cell0.frac v1) in
-      disjoint h0' hf /\
-      interp (pts_to r v1) h0' /\
-      interp frame hf /\
-      h' == join h0' hf /\
-      heap_evolves h h' /\
-      (forall (hp:hprop frame). hp h == hp h')))
-  = let (| _, h'|) = upd' r v0 v1 h in
-    let cell0 = select_addr h0 (Addr?._0 r) in
-    let cell1 = (Ref a pcm cell0.frac v1) in
-    let h0' = update_addr h0 (Addr?._0 r) cell1 in
-    assert (interp (pts_to r v1) h0');
-    assert (interp frame hf);
-    let aux (a:addr)
-      : Lemma (disjoint_addr h0' hf a )
-              [SMTPat (disjoint_addr h0' hf a)]
-      = if a <> (Addr?._0 r) then ()
-        else match h0 a, h0' a, hf a with
-             | Some (Ref a0 p0 f0 v0_val),
-               Some (Ref a0' p0' f0' v0'),
-               Some (Ref af pf ff vf) ->
-                  assert (a0' == af);
-                  assert (p0' == pf);
-                  assert (v0' == v1);
-                  assert (f0 == f0');
-                  assert (Frac.sum_perm f0 ff `Frac.lesser_equal_perm` Frac.full_perm);
-                  assert (compatible pcm v0 v0_val);
-
-                  compatible_refl pcm vf;
-                  assert (pts_to_cell pcm vf (Some?.v (hf a)));
-                  assert (interp (pts_to r vf) hf);
-
-                  compatible_refl pcm v0_val;
-                  assert (pts_to_cell pcm v0_val (Some?.v (h0 a)));
-                  assert (interp (pts_to r v0_val) h0);
-                  assert (interp (pts_to r v0_val `star` pts_to r vf) h);
-                  pts_to_compatible r v0_val vf h;
-                  assert (composable pcm v0_val vf);
-
-                  assert (interp (pts_to r (op pcm v0_val vf)) h);
-                  pcm.comm v0_val vf;
-                  definedness #_ #pcm v0 v0_val v1 vf;
-                  assert (composable pcm v1 vf);
-                  assert (Frac.sum_perm f0' ff `Frac.lesser_equal_perm` Frac.full_perm);
-                  assert (pcm.refine v1);
-                  assert (exists f0. composable pcm v0 f0 /\ op pcm f0 v0 == v0_val);
-                  assert (exists f0. composable pcm v0 f0 /\ composable pcm (op pcm f0 v0) vf);
-                  let aux f0
-                    : Lemma
-                      (requires
-                        composable pcm v0 f0 /\
-                        composable pcm (op pcm f0 v0) vf)
-                      (ensures
-                        composable pcm vf v0)
-                    [SMTPat (composable pcm v0 f0)]
-                    = pcm.comm v0 f0;
-                      pcm.assoc_r f0 v0 vf;
-                      pcm.comm vf v0
-                  in
-                  assert (composable pcm vf v0);
-                  assert (op pcm vf v1 == v1);
-                  pcm.comm vf v1;
-                  assert (Frac.sum_perm f0' ff == Frac.full_perm ==> pcm.refine (op pcm v1 vf))
-
-             | _ -> ()
-    in
-    assert (disjoint h0' hf);
-    let aux (a:addr)
-         : Lemma (h' a == (join h0' hf) a)
-                 [SMTPat ()]
-         = if a <> (Addr?._0 r)
-           then ()
-           else begin
-             assert (h0' a == Some cell1);
-             match h0 a, hf a with
-             | _, None -> ()
-             | Some (Ref a0 p0 f0 v0_val),
-               Some (Ref af pf ff vf) ->
-               let c0 = Some?.v (h0 a) in
-               let cf = Some?.v (hf a) in
-               assert (a0 == af);
-               assert (p0 == pf);
-               assert (compatible pcm v0 v0_val);
-               assert (disjoint_cells c0 cf);
-               assert (composable pcm v0_val vf);
-               composable_compatible pcm v0 v0_val vf;
-               assert (composable pcm v0 vf);
-               assert (disjoint_cells cell1 cf);
-               assert (composable pcm v1 vf);
-               assert (composable pcm vf v0);
-               assert (op pcm vf v1 == v1);
-               pcm.comm vf v1
-           end
-    in
-    assert (mem_equiv h' (join h0' hf));
-    heap_evolves_by_frame_preserving_update r v0 v1 h;
-    let aux (hp:hprop frame)
-         : Lemma (ensures (hp h == hp h'))
-                 [SMTPat ()]
-         = FStar.PropositionalExtensionality.apply (hp h) (hp h')
-    in
-    assert (forall (hp:hprop frame). hp h == hp h')
-
-let upd_lemma' (#a:_) #pcm (r:ref a pcm)
-               (v0:Ghost.erased a) (v1:a {frame_preserving pcm v0 v1 /\ pcm.refine v1})
-               (h:full_hheap (pts_to r v0)) (frame:slprop)
-  : Lemma
-    (requires
-      interp (pts_to r v0 `star` frame) h)
-    (ensures (
-      (let (| x, h1 |) = upd' r v0 v1 h in
-       interp (pts_to r v1 `star` frame) h1 /\
-       heap_evolves h h1 /\
-       (forall (hp:hprop frame). hp h == hp h1))))
-  = let aux (h0 hf:heap)
-     : Lemma
-       (requires
-         interp (pts_to r v0 `star` frame) h /\
-         disjoint h0 hf /\
-         h == join h0 hf /\
-         interp (pts_to r v0) h0 /\
-         interp frame hf)
-       (ensures (
-         let (| _, h' |) = upd' r v0 v1 h in
-         let cell0 = select_addr h0 (Addr?._0 r) in
-         let h0' = update_addr h0 (Addr?._0 r) (Ref a pcm cell0.frac v1) in
-         disjoint h0' hf /\
-         interp (pts_to r v1) h0' /\
-         interp frame hf /\
-         h' == join h0' hf /\
-         heap_evolves h h' /\
-         (forall (hp:hprop frame). hp h == hp h')))
-       [SMTPat (disjoint h0 hf)]
-     = upd_lemma'_1 r v0 v1 h frame h0 hf
-    in
-    ()
-#pop-options
-
-
-let upd_action (#a:_) (#pcm:_) (r:ref a pcm)
-               (v0:FStar.Ghost.erased a) (v1:a {frame_preserving pcm v0 v1 /\ pcm.refine v1})
-  : action (pts_to r v0) unit (fun _ -> pts_to r v1)
-  = let g : refined_pre_action (pts_to r v0) unit (fun _ -> pts_to r v1)
-      = fun m ->
-          let res = upd' r v0 v1 m in
-          FStar.Classical.forall_intro (FStar.Classical.move_requires (upd_lemma' r v0 v1 m));
-          res
-    in
-    refined_pre_action_as_action g
-
 let partial_pre_action (fp:slprop u#a) (a:Type u#b) (fp':a -> slprop u#a) =
-  hheap fp -> (x:a & hheap (fp' x))
+  full_hheap fp -> (x:a & full_hheap (fp' x))
 
 let upd_gen #a (#p:pcm a)
                (r:ref a p)
@@ -1146,25 +911,19 @@ let upd_gen #a (#p:pcm a)
                        unit
                        (fun _ -> pts_to r v)
   = fun h ->
-     let Ref _ _ frac old_v = select_addr h (Addr?._0 r) in
+     let Ref a p frac old_v = select_addr h (Addr?._0 r) in
      let new_v = f old_v in
      let cell = Ref a p frac new_v in
-     let h' = update_addr h (Addr?._0 r) cell in
+     let h' = update_addr_full_heap h (Addr?._0 r) cell in
      (| (), h' |)
 
 let upd_gen_updates_only_r #a (#p:pcm a) (r:ref a p)
                            (x v:Ghost.erased a)
                            (f: frame_preserving_upd p x v)
-                           (h0:hheap (pts_to r x))
+                           (h0:full_hheap (pts_to r x))
   : Lemma (let (| _, h1 |) = upd_gen r x v f h0 in
            forall s. s <> (Addr?._0 r) ==> h0 s == h1 s)
   = ()
-
-let frame_preserving_is_preorder_respecting_pcm_t #a (p:pcm a) (x y:a)
-  : Lemma (requires frame_preserving p x y)
-          (ensures (PP.preorder_of_pcm p x y))
-  = PP.frame_preserving_is_preorder_respecting p x y;
-    compatible_refl p x
 
 let upd_gen_full_evolution #a (#p:pcm a)
       (r:ref a p)
@@ -1178,8 +937,6 @@ let upd_gen_full_evolution #a (#p:pcm a)
        heap_evolves h h1))
   = let old_v = sel_action' r x h in
     let new_v = f old_v in
-    assert (frame_preserving p old_v new_v);
-    frame_preserving_is_preorder_respecting_pcm_t p old_v new_v;
     assert (PP.preorder_of_pcm p old_v new_v);
     let (| _, h1 |) = upd_gen r x y f h in
     assert (forall a. a<>(Addr?._0 r) ==> h1 a == h a);
@@ -1189,11 +946,11 @@ let upd_gen_full_evolution #a (#p:pcm a)
 
 #push-options "--z3rlimit_factor 8"
 
-let upd_gen_frame_preserving #a (#p:pcm a)
+let upd_gen_frame_preserving (#a:Type u#a) (#p:pcm a)
       (r:ref a p)
       (x y:Ghost.erased a)
       (f:frame_preserving_upd p x y)
-      (h:hheap (pts_to r x))
+      (h:full_hheap (pts_to r x))
       (frame:slprop)
  : Lemma
    (requires interp (pts_to r x `star` frame) h)
@@ -1201,11 +958,12 @@ let upd_gen_frame_preserving #a (#p:pcm a)
      (let (| b, h1 |) = upd_gen r x y f h in
       interp ((pts_to r y) `star` frame) h1 /\
       (forall (hp:hprop frame). hp h == hp h1)))
- = let Ref _ _ frac old_v = select_addr h (Addr?._0 r) in
+ = let Ref a p frac old_v = select_addr h (Addr?._0 r) in
    let old_v : a = old_v in
    let (| _, h1 |) = upd_gen r x y f h in
    let new_v = f old_v in
    assert (forall a. a<>(Addr?._0 r) ==> h1 a == h a);
+   assert (h1 (Addr?._0 r) == Some (Ref a p frac new_v));
    let aux (hl hr:heap)
        : Lemma
          (requires
@@ -1213,39 +971,52 @@ let upd_gen_frame_preserving #a (#p:pcm a)
            h == join hl hr /\
            interp (pts_to r x) hl /\
            interp frame hr)
-         (ensures (
-           let (| _, hl' |) = upd_gen r x y f hl in
+         (ensures
+           exists hl'.
            disjoint hl' hr /\
-           h1 == join hl' hr
-           ))
+           h1 == join hl' hr /\
+           interp (pts_to r y) hl')
          [SMTPat (disjoint hl hr)]
-       = assert (contains_addr hl (Addr?._0 r));
-         let Ref _ _ _ old_v_l = select_addr hl (Addr?._0 r) in
-         let old_v_l : a = old_v_l in
-         let (| _, hl' |) = upd_gen r x y f hl in
-         upd_gen_updates_only_r r x y f hl;
-         assert (forall s. s<>(Addr?._0 r) ==> hl s == hl' s);
-         let Ref _ _ _ new_v_l = select_addr hl' (Addr?._0 r) in
-         let new_v_l : a = new_v_l in
-         if contains_addr hr (Addr?._0 r)
-         then let Ref _ _ _ old_v_r = select_addr hr (Addr?._0 r) in
-              let old_v_r : a = old_v_r in
-              assert (composable p old_v_l old_v_r);
-              assert (op p old_v_l old_v_r == old_v); //old_v_l * old_v_r = old_v
-              assert (new_v_l == f old_v_l);
-              assert (composable p new_v_l old_v_r);
-              assert (op p new_v_l old_v_r == new_v);
-              assert (disjoint hl' hr);
-              mem_equiv_eq h1 (join hl' hr)
-         else begin
-           assert (old_v_l == old_v);
-           assert (new_v == new_v_l);
-           assert (disjoint hl hr);
+       = let r_addr = Addr?._0 r in
+         assert (contains_addr hl r_addr);
+         let Ref a_l p_l frac_l old_v_l = select_addr hl r_addr in
+         if contains_addr hr r_addr then
+           let Ref a_r p_r frac_r old_v_r = select_addr hr r_addr in
+           assert (a_l == a_r /\ a_r == a /\
+                   p_l == p_r /\ p_r == p /\
+                   Frac.sum_perm frac_l frac_r `Frac.lesser_equal_perm` Frac.full_perm /\
+                   Frac.sum_perm frac_l frac_r == frac /\
+                   composable p old_v_l old_v_r /\
+                   op p old_v_l old_v_r == old_v);
+
+           assert (compatible p x old_v_l);
+           let (| frame, _ |) = FStar.IndefiniteDescription.elim_squash
+             (Squash.join_squash (Squash.get_proof (compatible p x old_v_l))) in
+           assert (composable p x frame);
+           assert (op p frame x == old_v_l);
+           p.comm frame x;
+           assert (op p (op p x frame) old_v_r == old_v);
+           p.assoc_r x frame old_v_r;
+           assert (op p x (op p frame old_v_r) == old_v);
+           assert (op p y (op p frame old_v_r) == new_v);
+           p.assoc y frame old_v_r;
+           assert (op p (op p y frame) old_v_r == new_v);
+           let hl' = update_addr hl r_addr (Ref a_l p_l frac_l (op p y frame)) in
            assert (disjoint hl' hr);
-           assert (h1 (Addr?._0 r) == hl' (Addr?._0 r));
-           mem_equiv_eq h1 (join hl' hr);
+           assert (h1 r_addr == (join hl' hr) r_addr);
+           assert (mem_equiv h1 (join hl' hr));
            assert (h1 == join hl' hr);
-           ()
+           p.comm frame y;
+           assert (compatible p y (op p y frame));
+           assert (interp (pts_to r y) hl')
+         else begin
+           assert (a_l == a /\ p_l == p /\ frac_l == frac /\ old_v_l == old_v);
+           let hl' = update_addr hl r_addr (Ref a_l p_l frac_l new_v) in
+           assert (disjoint hl' hr);
+           assert (h1 r_addr == (join hl' hr) r_addr);
+           assert (mem_equiv h1 (join hl' hr));
+           assert (h1 == join hl' hr);
+           assert (interp (pts_to r y) hl')
          end
      in
      let aux (hp:hprop frame)
@@ -1254,6 +1025,7 @@ let upd_gen_frame_preserving #a (#p:pcm a)
        = FStar.PropositionalExtensionality.apply (hp h) (hp h1)
      in
      ()
+ 
 
 let upd_gen_action #a (#p:pcm a) (r:ref a p) (x y:Ghost.erased a) (f:frame_preserving_upd p x y)
   : action (pts_to r x)
@@ -1264,19 +1036,35 @@ let upd_gen_action #a (#p:pcm a) (r:ref a p) (x y:Ghost.erased a) (f:frame_prese
                     unit
                     (fun _ -> pts_to r y)
      = fun h ->
-         let (|u, h1|) = upd_gen r x y f h in
+         let (|u, h1|) = upd_gen #a #p r x y f h in
          FStar.Classical.forall_intro (FStar.Classical.move_requires (upd_gen_frame_preserving r x y f h));
-         upd_gen_full_evolution #a r x y f h;
+         upd_gen_full_evolution r x y f h;
+         let h1 : full_hheap (pts_to r y) = h1 in
+         assert (forall x. contains_addr h1 x ==> contains_addr h x);
+         assert (forall ctr. h `free_above_addr` ctr ==> h1 `free_above_addr` ctr);
          (| (), h1 |)
     in
     refined_pre_action_as_action refined
 
+let upd_action (#a:_) (#pcm:_) (r:ref a pcm)
+               (v0:FStar.Ghost.erased a) (v1:a {frame_preserving pcm v0 v1 /\ pcm.refine v1})
+  : action (pts_to r v0) unit (fun _ -> pts_to r v1)
+  = upd_gen_action r v0 (Ghost.hide v1) (frame_preserving_val_to_fp_upd pcm  v0 v1)
+  
 ////////////////////////////////////////////////////////////////////////////////
 
 let free_action (#a:_) (#pcm:_) (r:ref a pcm) (v0:FStar.Ghost.erased a{exclusive pcm v0 /\ pcm.refine pcm.FStar.PCM.p.one})
   : action (pts_to r v0) unit (fun _ -> pts_to r pcm.FStar.PCM.p.one)
-  = FStar.PCM.exclusive_is_frame_preserving pcm v0;
-    upd_action r v0 pcm.FStar.PCM.p.one
+  = let one = pcm.FStar.PCM.p.one in
+    assume (pcm.refine one);
+    compatible_refl pcm one;
+    assert (compatible pcm one one);
+    assert (forall (frame:a{composable pcm v0 frame}). frame == one);
+    pcm.is_unit one;
+    assert (forall (frame:a{composable pcm v0 frame}). composable pcm one frame);
+    let f : frame_preserving_upd pcm v0 one =
+      fun v -> one in
+    upd_gen_action r v0 one f
 
 ////////////////////////////////////////////////////////////////////////////////
 let split_action #a #pcm r v0 v1

--- a/ulib/experimental/Steel.Heap.fst
+++ b/ulib/experimental/Steel.Heap.fst
@@ -1056,7 +1056,6 @@ let upd_action (#a:_) (#pcm:_) (r:ref a pcm)
 let free_action (#a:_) (#pcm:_) (r:ref a pcm) (v0:FStar.Ghost.erased a{exclusive pcm v0 /\ pcm.refine pcm.FStar.PCM.p.one})
   : action (pts_to r v0) unit (fun _ -> pts_to r pcm.FStar.PCM.p.one)
   = let one = pcm.FStar.PCM.p.one in
-    assume (pcm.refine one);
     compatible_refl pcm one;
     assert (compatible pcm one one);
     assert (forall (frame:a{composable pcm v0 frame}). frame == one);

--- a/ulib/experimental/Steel.Heap.fsti
+++ b/ulib/experimental/Steel.Heap.fsti
@@ -529,6 +529,13 @@ val select_refine (#a:_) (#p:_)
             (fun v -> pts_to r (f v))
 
 
+(** Updating a ref cell for a user-defined PCM *)
+val upd_gen_action (#a:Type) (#p:pcm a) (r:ref a p) (x y:Ghost.erased a)
+                   (f:FStar.PCM.frame_preserving_upd p x y)
+  : action (pts_to r x)
+           unit
+           (fun _ -> pts_to r y)
+
 (**
   The update action needs you to prove that the mutation from [v0] to [v1] is frame-preserving
   with respect to the individual PCM governing the reference [r]. See [FStar.PCM.frame_preserving]
@@ -540,13 +547,6 @@ val upd_action
   (v0:FStar.Ghost.erased a)
   (v1:a {FStar.PCM.frame_preserving pcm v0 v1 /\ pcm.refine v1})
   : action (pts_to r v0) unit (fun _ -> pts_to r v1)
-
-(** Updating a ref cell for a user-defined PCM *)
-val upd_gen_action (#a:Type) (#p:pcm a) (r:ref a p) (x y:Ghost.erased a)
-                   (f:FStar.PCM.frame_preserving_upd p x y)
-  : action (pts_to r x)
-           unit
-           (fun _ -> pts_to r y)
 
 (** Deallocating a reference, by actually replacing its value by the unit of the PCM *)
 val free_action

--- a/ulib/experimental/Steel.MonotonicCounter.fst
+++ b/ulib/experimental/Steel.MonotonicCounter.fst
@@ -42,9 +42,17 @@ let mctr_pcm : pcm nat = {
 let increasing : preorder nat = fun (x y:nat) -> b2t (x <= y)
 
 (** Indeed, the [increasing] preorder is induced by the PCM *)
+#push-options "--warn_error -271"
 let mctr_induces_increases
   : squash (induces_preorder mctr_pcm increasing)
-  = ()
+  = let aux (x y:nat) (f:frame_preserving_upd mctr_pcm x y) (v:nat)
+      : Lemma (requires compatible mctr_pcm x v)
+              (ensures increasing v (f v))
+              [SMTPat ()]
+      = assert (composable mctr_pcm x v)
+    in
+    ()
+#pop-options
 
 (** Small test: two values compatible for the PCM preserve a stable fact for the preorder *)
 let test (x z:nat) (f:(nat -> prop){stable f increasing})

--- a/ulib/experimental/Steel.Preorder.fst
+++ b/ulib/experimental/Steel.Preorder.fst
@@ -27,8 +27,8 @@ open FStar.Preorder
 (**** PCM to preoder *)
 
 (**
-  PCM [p] induces the preorder [q] if for any frame preserving update of [x] to [y] and
-  every element [z] compatible with [x], then [z] is before [y] in the preorder.
+  PCM [p] induces the preorder [q] if for any frame preserving update of [x] to [y],
+  the argument and result of the frame preserving update are related by q
 *)
 let induces_preorder (#a:Type u#a) (p:pcm a) (q:preorder a) =
   forall (x y:a) (f:frame_preserving_upd p x y) (v:a).

--- a/ulib/experimental/Steel.Preorder.fst
+++ b/ulib/experimental/Steel.Preorder.fst
@@ -30,16 +30,23 @@ open FStar.Preorder
   PCM [p] induces the preorder [q] if for any frame preserving update of [x] to [y] and
   every element [z] compatible with [x], then [z] is before [y] in the preorder.
 *)
-let induces_preorder (#a: Type u#a) (p:pcm a) (q:preorder a) =
-  forall (x y:a). frame_preserving p x y
-         ==> (forall (z:a). compatible p x z ==> q z y)
+let induces_preorder (#a:Type u#a) (p:pcm a) (q:preorder a) =
+  forall (x y:a) (f:frame_preserving_upd p x y) (v:a).
+    p.refine v ==> compatible p x v ==> q v (f v)
+
 
 (**
   We can define a canonical preorder from any PCM by taking the quantified conjunction over all the
   preorders [q] induced by this PCM.
 *)
-let preorder_of_pcm (#a: Type u#a) (p:pcm a) : preorder a =
+let preorder_of_pcm (#a:Type u#a) (p:pcm a) : preorder a =
   fun x y -> forall (q:preorder a). induces_preorder p q ==> q x y
+
+let frame_preserving_upd_is_preorder_preserving (#a:Type u#a) (p:pcm a)
+  (x y:a) (f:frame_preserving_upd p x y)
+  (v_old:a{p.refine v_old /\ compatible p x v_old})
+  : Lemma ((preorder_of_pcm p) v_old (f v_old))
+  = ()
 
 (**
   This canonical preorder enjoys the nice property that it preserves fact stability of any
@@ -53,21 +60,21 @@ let stability (#a: Type u#a) (fact:a -> prop) (q:preorder a) (p:pcm a)
   = ()
 
 (** Also, every frame-preserving update to the element of the PCM respects the canonical PCM *)
-let frame_preserving_is_preorder_respecting (#a: Type u#a) (p:pcm a) (x y:a)
-  : Lemma (requires frame_preserving p x y)
-          (ensures (forall z. compatible p x z ==> preorder_of_pcm p z y))
-  = ()
+// let frame_preserving_is_preorder_respecting (#a: Type u#a) (p:pcm a) (x y:a)
+//   : Lemma (requires frame_preserving p x y)
+//           (ensures (forall z. compatible p x z ==> preorder_of_pcm p z y))
+//   = ()
 
-let stable_compatiblity (#a:Type u#a) (fact: a -> prop) (p:pcm a) (v v0 v1:a)
-  : Lemma
-    (requires
-      stable fact (preorder_of_pcm p) /\
-      fact v0 /\
-      frame_preserving p v v1 /\
-      compatible p v v0)
-    (ensures
-      fact v1)
-  = assert (preorder_of_pcm p v0 v1)
+// let stable_compatiblity (#a:Type u#a) (fact: a -> prop) (p:pcm a) (v v0 v1:a)
+//   : Lemma
+//     (requires
+//       stable fact (preorder_of_pcm p) /\
+//       fact v0 /\
+//       frame_preserving p v v1 /\
+//       compatible p v v0)
+//     (ensures
+//       fact v1)
+//   = assert (preorder_of_pcm p v0 v1)
 
 
 
@@ -76,9 +83,9 @@ let stable_compatiblity (#a:Type u#a) (fact: a -> prop) (p:pcm a) (v v0 v1:a)
 (***** Building the preorder *)
 
 (**
-  This predicate tells that the list [l] can represent a trace of elements whose evolution is
-  compatible with the preorder [q]
-*)
+//   This predicate tells that the list [l] can represent a trace of elements whose evolution is
+//   compatible with the preorder [q]
+// *)
 let rec qhistory #a (q:preorder a) (l:list a) =
   match l with
   | []
@@ -115,9 +122,9 @@ let rec extends_length_eq (#a: Type u#a) (#q:preorder a) (h0 h1:hist q)
     | hd::tl -> extends_length_eq tl h1
 
 (**
-  We build our relation of composability for traces by reflexing the extension to ensure
-  symmetry
-*)
+//   We build our relation of composability for traces by reflexing the extension to ensure
+//   symmetry
+// *)
 let p_composable (#a: Type u#a) (q:preorder a) : symrel (hist q) =
     fun x y -> extends x y \/ extends y x
 
@@ -199,10 +206,10 @@ let pcm_of_preorder (#a: Type u#a) (q:preorder a) : pcm (hist q) = {
 (***** Using the preorder *)
 
 (**
-  We check that the preorder derived from the PCM derived from the preorder
-  satisfies the same properties as the original preorder. Here, we get back history
-  extension from frame-preserving updates.
-*)
+//   We check that the preorder derived from the PCM derived from the preorder
+//   satisfies the same properties as the original preorder. Here, we get back history
+//   extension from frame-preserving updates.
+// *)
 let frame_preserving_q_aux (#a : Type u#a) (q:preorder a) (x y:hist q) (z:hist q)
   : Lemma (requires (frame_preserving (pcm_of_preorder q) x y /\ compatible (pcm_of_preorder q) x z))
           (ensures (y `extends` z))
@@ -215,10 +222,10 @@ let vhist (#a: Type u#a) (q:preorder a) = h:hist q{Cons? h}
 let curval (#a: Type u#a) (#q:preorder a) (v:vhist q) = Cons?.hd v
 
 (**
-  Given a frame-preserving update from [x] to [y]
-  for any value of resource [z] (compatible with [x])
-  the new value [y] advances the history [z] in a preorder respecting manner
-*)
+//   Given a frame-preserving update from [x] to [y]
+//   for any value of resource [z] (compatible with [x])
+//   the new value [y] advances the history [z] in a preorder respecting manner
+// *)
 let frame_preserving_q (#a: Type u#a) (q:preorder a) (x y:vhist q)
   : Lemma (requires frame_preserving (pcm_of_preorder q) x y)
           (ensures (forall (z:hist q). compatible (pcm_of_preorder q) x z ==> curval z `q` curval y))
@@ -245,7 +252,7 @@ let frame_preserving_extends2 (#a: Type u#a) (q:preorder a) (x y:hist q)
 
 let pcm_of_preorder_induces_extends (#a: Type u#a) (q:preorder a)
   : Lemma (induces_preorder (pcm_of_preorder q) (flip extends))
-  = ()
+  = admit ()
 
 let extend_history (#a:Type u#a) (#q:preorder a) (h0:vhist q) (v:a{q (curval h0) v})
   : h1:vhist q{h1 `extends` h0}

--- a/ulib/experimental/Steel.Preorder.fst
+++ b/ulib/experimental/Steel.Preorder.fst
@@ -59,23 +59,19 @@ let stability (#a: Type u#a) (fact:a -> prop) (q:preorder a) (p:pcm a)
     (ensures  stable fact (preorder_of_pcm p))
   = ()
 
-(** Also, every frame-preserving update to the element of the PCM respects the canonical PCM *)
-// let frame_preserving_is_preorder_respecting (#a: Type u#a) (p:pcm a) (x y:a)
-//   : Lemma (requires frame_preserving p x y)
-//           (ensures (forall z. compatible p x z ==> preorder_of_pcm p z y))
-//   = ()
-
-// let stable_compatiblity (#a:Type u#a) (fact: a -> prop) (p:pcm a) (v v0 v1:a)
-//   : Lemma
-//     (requires
-//       stable fact (preorder_of_pcm p) /\
-//       fact v0 /\
-//       frame_preserving p v v1 /\
-//       compatible p v v0)
-//     (ensures
-//       fact v1)
-//   = assert (preorder_of_pcm p v0 v1)
-
+let stable_compatiblity (#a:Type u#a) (fact: a -> prop) (p:pcm a) (v v0 v1:a)
+  : Lemma
+    (requires
+      stable fact (preorder_of_pcm p) /\
+      p.refine v0 /\
+      fact v0 /\
+      p.refine v1 /\
+      frame_preserving p v v1 /\
+      compatible p v v0)
+    (ensures
+      fact v1)
+  = let f : frame_preserving_upd p v v1 = frame_preserving_val_to_fp_upd p v v1 in
+    frame_preserving_upd_is_preorder_preserving p v v1 f v0
 
 
 (**** Preorder to PCM *)
@@ -83,9 +79,9 @@ let stability (#a: Type u#a) (fact:a -> prop) (q:preorder a) (p:pcm a)
 (***** Building the preorder *)
 
 (**
-//   This predicate tells that the list [l] can represent a trace of elements whose evolution is
-//   compatible with the preorder [q]
-// *)
+  This predicate tells that the list [l] can represent a trace of elements whose evolution is
+  compatible with the preorder [q]
+*)
 let rec qhistory #a (q:preorder a) (l:list a) =
   match l with
   | []
@@ -122,9 +118,9 @@ let rec extends_length_eq (#a: Type u#a) (#q:preorder a) (h0 h1:hist q)
     | hd::tl -> extends_length_eq tl h1
 
 (**
-//   We build our relation of composability for traces by reflexing the extension to ensure
-//   symmetry
-// *)
+  We build our relation of composability for traces by reflexing the extension to ensure
+  symmetry
+*)
 let p_composable (#a: Type u#a) (q:preorder a) : symrel (hist q) =
     fun x y -> extends x y \/ extends y x
 

--- a/ulib/experimental/Steel.Preorder.fst
+++ b/ulib/experimental/Steel.Preorder.fst
@@ -206,10 +206,10 @@ let pcm_of_preorder (#a: Type u#a) (q:preorder a) : pcm (hist q) = {
 (***** Using the preorder *)
 
 (**
-//   We check that the preorder derived from the PCM derived from the preorder
-//   satisfies the same properties as the original preorder. Here, we get back history
-//   extension from frame-preserving updates.
-// *)
+  We check that the preorder derived from the PCM derived from the preorder
+  satisfies the same properties as the original preorder. Here, we get back history
+  extension from frame-preserving updates.
+*)
 let frame_preserving_q_aux (#a : Type u#a) (q:preorder a) (x y:hist q) (z:hist q)
   : Lemma (requires (frame_preserving (pcm_of_preorder q) x y /\ compatible (pcm_of_preorder q) x z))
           (ensures (y `extends` z))
@@ -222,10 +222,10 @@ let vhist (#a: Type u#a) (q:preorder a) = h:hist q{Cons? h}
 let curval (#a: Type u#a) (#q:preorder a) (v:vhist q) = Cons?.hd v
 
 (**
-//   Given a frame-preserving update from [x] to [y]
-//   for any value of resource [z] (compatible with [x])
-//   the new value [y] advances the history [z] in a preorder respecting manner
-// *)
+  Given a frame-preserving update from [x] to [y]
+  for any value of resource [z] (compatible with [x])
+  the new value [y] advances the history [z] in a preorder respecting manner
+*)
 let frame_preserving_q (#a: Type u#a) (q:preorder a) (x y:vhist q)
   : Lemma (requires frame_preserving (pcm_of_preorder q) x y)
           (ensures (forall (z:hist q). compatible (pcm_of_preorder q) x z ==> curval z `q` curval y))
@@ -250,9 +250,16 @@ let frame_preserving_extends2 (#a: Type u#a) (q:preorder a) (x y:hist q)
           [SMTPat (frame_preserving (pcm_of_preorder q) x y)]
   = ()
 
+#push-options "--warn_error -271"
 let pcm_of_preorder_induces_extends (#a: Type u#a) (q:preorder a)
   : Lemma (induces_preorder (pcm_of_preorder q) (flip extends))
-  = admit ()
+  = let fp_full (x y:hist q) (f:frame_preserving_upd (pcm_of_preorder q) x y) (v:hist q)
+      : Lemma (requires compatible (pcm_of_preorder q) x v)
+              (ensures extends (f v) v)
+              [SMTPat ()]
+      = assert (composable (pcm_of_preorder q) x v) in
+    ()
+#pop-options
 
 let extend_history (#a:Type u#a) (#q:preorder a) (h0:vhist q) (v:a{q (curval h0) v})
   : h1:vhist q{h1 `extends` h0}

--- a/ulib/experimental/Steel.Stepper.fst
+++ b/ulib/experimental/Steel.Stepper.fst
@@ -166,18 +166,16 @@ let upd_even_f (n:even) : FStar.PCM.frame_preserving_upd p
                             (EvenWriteable n)
                             (Even (n + 2))
   = let f
-      : FStar.PCM.frame_preserving_upd_0 p (EvenWriteable n) (Even (n + 2))
+      : FStar.PCM.frame_preserving_upd p (EvenWriteable n) (Even (n + 2))
       = function
-        | EvenWriteable n -> Even (n + 2)
         | V n -> V (n + 1)
     in
     f
 
 let upd_odd_f (n:odd) : FStar.PCM.frame_preserving_upd p (OddWriteable n) (Odd (n + 2))
   = let f
-      : FStar.PCM.frame_preserving_upd_0 p (OddWriteable n) (Odd (n + 2))
+      : FStar.PCM.frame_preserving_upd p (OddWriteable n) (Odd (n + 2))
       = function
-        | OddWriteable n -> Odd (n + 2)
         | V n -> V (n + 1)
     in
     f


### PR DESCRIPTION
This PR tweaks the definition of frame preserving PCM updates. Here is the main change: https://github.com/FStarLang/FStar/commit/483e11d843d8d8c4b1c44df9288b51da8fbeedb7. The new definition allows for more local frame reasoning in updates.

The PR also makes frame preserving updates as the main PCM update operation. This means all the machinery about deriving preorders out of it (in `Steel.Preorder.fst`) is now based on frame preserving updates (as opposed to `FStar.PCM.frame_preserving`).