### PR TITLE
WIP: Hook to rewrite terms by tactic

### DIFF
--- a/src/ocaml-output/FStar_Parser_Const.ml
+++ b/src/ocaml-output/FStar_Parser_Const.ml
@@ -438,6 +438,8 @@ let (effect_TAC_lid : FStar_Ident.lid) = fstar_tactics_lid' ["Effect"; "TAC"]
 let (effect_Tac_lid : FStar_Ident.lid) = fstar_tactics_lid' ["Effect"; "Tac"]
 let (by_tactic_lid : FStar_Ident.lid) =
   fstar_tactics_lid' ["Effect"; "with_tactic"]
+let (process_with_tactic_lid : FStar_Ident.lid) =
+  fstar_tactics_lid' ["Effect"; "process_with_tactic"]
 let (synth_lid : FStar_Ident.lid) =
   fstar_tactics_lid' ["Effect"; "synth_by_tactic"]
 let (assert_by_tactic_lid : FStar_Ident.lid) =

--- a/src/ocaml-output/FStar_Tactics_Hooks.ml
+++ b/src/ocaml-output/FStar_Tactics_Hooks.ml
@@ -122,6 +122,26 @@ let (by_tactic_interp :
                            Dual (assertion, FStar_Syntax_Util.t_true, gs))
                   | Neg -> Simplified (assertion, []))
              | (FStar_Syntax_Syntax.Tm_fvar fv,
+                (tactic, FStar_Pervasives_Native.None)::(assertion,
+                                                         FStar_Pervasives_Native.None)::[])
+                 when
+                 FStar_Syntax_Syntax.fv_eq_lid fv
+                   FStar_Parser_Const.process_with_tactic_lid
+                 ->
+                 let uu___2 =
+                   run_tactic_on_typ tactic.FStar_Syntax_Syntax.pos
+                     assertion.FStar_Syntax_Syntax.pos tactic e assertion in
+                 (match uu___2 with
+                  | (gs, uu___3) ->
+                      (match gs with
+                       | hd1::[] ->
+                           let uu___4 =
+                             let uu___5 = FStar_Tactics_Types.goal_type hd1 in
+                             (uu___5, []) in
+                           Simplified uu___4
+                       | uu___4 ->
+                           failwith "process_with_tactic: not a single goal"))
+             | (FStar_Syntax_Syntax.Tm_fvar fv,
                 (assertion, FStar_Pervasives_Native.None)::[]) when
                  FStar_Syntax_Syntax.fv_eq_lid fv
                    FStar_Parser_Const.spinoff_lid

--- a/src/parser/FStar.Parser.Const.fs
+++ b/src/parser/FStar.Parser.Const.fs
@@ -441,6 +441,7 @@ let effect_TAC_lid = fstar_tactics_lid' ["Effect"; "TAC"] // actual effect
 let effect_Tac_lid = fstar_tactics_lid' ["Effect"; "Tac"] // trivial variant
 
 let by_tactic_lid = fstar_tactics_lid' ["Effect"; "with_tactic"]
+let process_with_tactic_lid = fstar_tactics_lid' ["Effect"; "process_with_tactic"]
 let synth_lid = fstar_tactics_lid' ["Effect"; "synth_by_tactic"]
 let assert_by_tactic_lid = fstar_tactics_lid' ["Effect"; "assert_by_tactic"]
 let fstar_syntax_syntax_term = FStar.Ident.lid_of_str "FStar.Syntax.Syntax.term"

--- a/src/tactics/FStar.Tactics.Hooks.fs
+++ b/src/tactics/FStar.Tactics.Hooks.fs
@@ -100,6 +100,15 @@ let by_tactic_interp (pol:pol) (e:Env.env) (t:term) : tres =
             Simplified (assertion, [])
         end
 
+    // process_with_tactic marker
+    | Tm_fvar fv, [(tactic, None); (assertion, None)]
+            when S.fv_eq_lid fv PC.process_with_tactic_lid ->
+        let gs, _ = run_tactic_on_typ tactic.pos assertion.pos tactic e assertion in
+        begin match gs with
+        | [hd] -> Simplified (goal_type hd, [])
+        | _ -> failwith "process_with_tactic: not a single goal"
+        end
+
     // spinoff marker: simply spin off a query independently.
     // So, equivalent to `with_tactic idtac` without importing the (somewhat heavy) tactics module
     | Tm_fvar fv, [(assertion, None)]

--- a/ulib/FStar.Tactics.Effect.fst
+++ b/ulib/FStar.Tactics.Effect.fst
@@ -21,6 +21,8 @@ open FStar.Tactics.Result
 
 let with_tactic _ p = p
 
+let process_with_tactic _ p = p
+
 let synth_by_tactic #_ _ = admit ()
 
 #push-options "--smtencoding.valid_intro true --smtencoding.valid_elim true"
@@ -38,3 +40,5 @@ let postprocess_for_extraction_with _ = ()
 #set-options "--no_tactics"
 
 let unfold_with_tactic _ _ = ()
+
+let unfold_process_with_tactic _ _ = ()

--- a/ulib/FStar.Tactics.Effect.fsti
+++ b/ulib/FStar.Tactics.Effect.fsti
@@ -113,6 +113,8 @@ let raise (#a:Type) (e:exn) = TAC?.__raise a e
 
 val with_tactic (t : unit -> Tac unit) (p:Type u#a) : Type u#a
 
+val process_with_tactic (t : unit -> Tac unit) (p:Type u#a) : Type u#a
+
 (* This will run the tactic in order to (try to) produce a term of type
  * t. Note that the type looks dangerous from a logical perspective. It
  * should not lead to any inconsistency, however, as any time this term
@@ -166,3 +168,7 @@ val postprocess_for_extraction_with (tau : unit -> Tac unit) : Tot unit
 val unfold_with_tactic (t:unit -> Tac unit) (p:Type)
   : Lemma (requires p)
           (ensures (with_tactic t p))
+
+val unfold_process_with_tactic (t:unit -> Tac unit) (p:Type)
+  : Lemma (requires p)
+          (ensures (process_with_tactic t p))


### PR DESCRIPTION
This PR proposes a new feature, `process_with_tactic t p`, that rewrites term `p` using tactic `t`.
This feature is very similar to the `with_tactic t p` hook, and its implementation follows the same structure.
The main difference is that instead of creating a new goal for `p`, it runs tactic `t` on `p`, before replacing it in its original context.

A few questions:
- How to ensure that the resulting goal from applying `t` actually corresponds to a transformed version of the initial `p`?
- How to provide better error reporting when there are more than one goal remaining?
