### PR TITLE
Fix typos and exercise file in part 1 of book

### DIFF
--- a/doc/book/code/exercises/Part1.Poly.fst
+++ b/doc/book/code/exercises/Part1.Poly.fst
@@ -16,5 +16,5 @@ val compose (a b c:Type) (f: b -> c) (g : a -> b) : a -> c
 let apply = admit()
 let compose = admit()
 
-val twice (a:Type) (f: a -> a) (x:a) : a
-let twice = admit()
+val twice // write a signature here
+let twice a f x = compose a a a f f x

--- a/doc/book/part1/part1_getting_off_the_ground.rst
+++ b/doc/book/part1/part1_getting_off_the_ground.rst
@@ -187,7 +187,7 @@ allow us to:
    *introducing* a refinement type.
 
 2. make use of a term that has a refinement type, e.g., given ``x :
-   even`` we would like to be write ``x + 1``, treating ``x`` as an
+   even`` we would like to write ``x + 1``, treating ``x`` as an
    ``int`` to add ``1`` to it. This is sometimes called *eliminating*
    a refinement type.
 
@@ -270,7 +270,7 @@ simply a *lambda*. The syntax is largely inherited from OCaml, and
 this `OCaml tutorial
 <https://ocaml.org/learn/tutorials/basics.html#Defining-a-function>`_
 provides more details for those unfamiliar with the language. We'll
-assume a basic familiarity with OCaml-like syntax.x
+assume a basic familiarity with OCaml-like syntax.
 
 Lambda terms
 ............


### PR DESCRIPTION
Not sure if there is a better way to edit the code for `twice`, where an implementation is given and readers are expected to fill in a missing type declaration.