### PR TITLE
Steel: Do not generate framing equalities for emp

### DIFF
--- a/ulib/experimental/Steel.Effect.Common.fst
+++ b/ulib/experimental/Steel.Effect.Common.fst
@@ -51,6 +51,7 @@ let emp':vprop' =
   { hp = emp;
     t = unit;
     sel = fun _ -> ()}
+let emp = VUnit emp'
 
 let reveal_emp () = ()
 
@@ -79,6 +80,9 @@ let lemma_frame_equalities frame h0 h1 p =
   let p2 : prop = frame_equalities' frame h0 h1 in
   lemma_frame_refl' frame h0 h1;
   FStar.PropositionalExtensionality.apply p1 p2
+
+let lemma_frame_emp h0 h1 p =
+  FStar.PropositionalExtensionality.apply True (h0 (VUnit emp') == h1 (VUnit emp'))
 
 let elim_conjunction p1 p1' p2 p2' = ()
 


### PR DESCRIPTION
This PR removes the generation of framing equalities for the empty assertion `emp`.

We previously discussed adding an extra bit to `vprop'` indicating whether its selector
is non-informative, in which case equalities would not be generated.
This would have helped with not generating equalities for `emp`, assuming its definition was fully exposed and available through reduction.
Fully exposing the definition actually interacts badly with the framing tactics, for two reasons:
- The tactic removes unit terms in a term by syntactic matching, comparing it to the fully reducing unit from the commutative monoid. Exposing the definition of emp leads to mismatches in the reduction, and `emp` assertions not being handled properly.
- I attempted having a more fine-grained normalization to retrieve the unit from the commutative monoid. Verification succeeded, but the framing tactic was much slower; since emp is highly pervasive, this is not suitable.

Instead, this PR special cases handling of `emp` frame equalities during VC rewriting.

Adding the extra complexity of the "noninformative bit" for other vprops does not seem needed: other than emp, the most common vprop with non-informative selector is an instance of `to_vprop some_slprop`, which lifts `some_slprop : slprop` to a `vprop` with a unit selector. The definition of `to_vprop` is fully reduced, and as such, any equality on a to_vprop is already normalized to True.

Changes:
* `emp` is now fully hidden behind its interface, not exposing it as `VUnit emp'` anymore.
* Since `emp` is abstract, `frame_equalities emp h0 h1` is not reduced anymore. During equalities rewriting, we rewrite this term to True when it occurs.

