### PR TITLE
Steel: Enable framing in subcomp and if_then_else

### DIFF
--- a/examples/steel/PingPong.fst
+++ b/examples/steel/PingPong.fst
@@ -119,4 +119,4 @@ let rec join_all (threads:list (T.thread emp))
 let rec many (n:nat) (threads:list (T.thread emp))
   : SteelT unit emp (fun _ -> emp)
   = if n = 0 then join_all threads
-    else T.fork client_server (fun t _ -> many (n-1) (t::threads))
+    else T.fork #_ #_ #emp client_server (fun t _ -> many (n-1) (t::threads))

--- a/examples/steel/TwoLockQueue.fst
+++ b/examples/steel/TwoLockQueue.fst
@@ -84,7 +84,10 @@ let intro_lock_inv #a #u (ptr:ref (Q.t a)) (ghost:ghost_ref (Q.t a))
   : SteelGhostT unit u
     (h_exists (fun v -> pts_to ptr full v `star` ghost_pts_to ghost half v))
     (fun _ -> lock_inv ptr ghost)
-  = rewrite_slprop _ _ (fun _ -> assert_norm (lock_inv ptr ghost == h_exists (fun v -> pts_to ptr full v `star` ghost_pts_to ghost half v)))
+  = rewrite_slprop
+      (h_exists (fun v -> pts_to ptr full v `star` ghost_pts_to ghost half v))
+      (lock_inv _ _)
+      (fun _ -> assert_norm (lock_inv ptr ghost == h_exists (fun v -> pts_to ptr full v `star` ghost_pts_to ghost half v)))
 
 /// The type of a queue pointer.
 /// Contains the concrete pointer [ptr], the pointer to ghost state [ghost],

--- a/ulib/experimental/Steel.Effect.Atomic.fst
+++ b/ulib/experimental/Steel.Effect.Atomic.fst
@@ -279,24 +279,29 @@ let norm_repr (#a:Type) (#framed:bool) (#opened:inames) (#obs:observability)
 let bind a b opened o1 o2 #framed_f #framed_g #pre_f #post_f #req_f #ens_f #pre_g #post_g #req_g #ens_g #frame_f #frame_g #post #_ #_ #p #p2 f g
   = norm_repr (bind_opaque a b opened o1 o2 #framed_f #framed_g #pre_f #post_f #req_f #ens_f #pre_g #post_g #req_g #ens_g #frame_f #frame_g #post #_ #_ #p #p2 f g)
 
-let subcomp a opened o1 o2 #framed_f #framed_g #pre_f #post_f #req_f #ens_f #pre_g #post_g #req_g #ens_g #p1 #p2 f =
+let subcomp a opened o1 o2 #framed_f #framed_g #pre_f #post_f #req_f #ens_f #pre_g #post_g #req_g #ens_g #fr #_ #p1 #p2 f =
   fun frame ->
     let m0:full_mem = NMSTTotal.get () in
     let h0 = mk_rmem pre_g (core_mem m0) in
-    focus_is_restrict_mk_rmem pre_g pre_f (core_mem m0);
 
-    can_be_split_3_interp (hp_of pre_g) (hp_of pre_f) frame (locks_invariant opened m0) m0;
+    can_be_split_3_interp (hp_of pre_g) (hp_of (pre_f `star` fr)) frame (locks_invariant opened m0) m0;
 
     lemma_unfold_subcomp_pre req_f ens_f req_g ens_g p1 p2;
 
-    let x = f frame in
+    can_be_split_trans pre_g (pre_f `star` fr) pre_f;
+
+    focus_replace pre_g (pre_f `star` fr) pre_f (core_mem m0);
+
+    let x = frame00 f fr frame in
 
     let m1:full_mem = NMSTTotal.get () in
     let h1 = mk_rmem (post_g x) (core_mem m1) in
 
-    focus_is_restrict_mk_rmem (post_g x) (post_f x) (core_mem m1);
+    can_be_split_trans (post_g x) (post_f x `star` fr) (post_f x);
 
-    can_be_split_3_interp (hp_of (post_f x)) (hp_of (post_g x)) frame (locks_invariant opened m1) m1;
+    can_be_split_3_interp (hp_of (post_f x `star` fr)) (hp_of (post_g x)) frame (locks_invariant opened m1) m1;
+
+    focus_replace (post_g x) (post_f x `star` fr) (post_f x) (core_mem m1);
 
     x
 

--- a/ulib/experimental/Steel.Effect.Common.fst
+++ b/ulib/experimental/Steel.Effect.Common.fst
@@ -89,6 +89,7 @@ let elim_conjunction p1 p1' p2 p2' = ()
 let equiv_can_be_split p1 p2 = ()
 let intro_can_be_split_frame p q frame = ()
 let can_be_split_post_elim t1 t2 = ()
+let equiv_forall_refl t = ()
 let equiv_forall_elim t1 t2 = ()
 
 let equiv_refl x = ()

--- a/ulib/experimental/Steel.Effect.Common.fsti
+++ b/ulib/experimental/Steel.Effect.Common.fsti
@@ -423,6 +423,9 @@ val can_be_split_post_elim (#a #b:Type) (t1:a -> post_t b) (t2:post_t b)
   : Lemma (requires (forall (x:a) (y:b). t1 x y `equiv` t2 y))
           (ensures t1 `can_be_split_post` t2)
 
+val equiv_forall_refl (#a:Type) (t:post_t a)
+  : Lemma (t `equiv_forall` t)
+
 val equiv_forall_elim (#a:Type) (t1 t2:post_t a)
   : Lemma (requires (forall (x:a). t1 x `equiv` t2 x))
           (ensures t1 `equiv_forall` t2)
@@ -2175,12 +2178,11 @@ let ite_soundness_tac () : Tac unit =
   match goals () with
   | [] -> fail "should not happen"
   | _::tl -> set_goals tl;
-  // These two goals are the separation logic equiv_forall and can_be_split.
-  // For the if branch, they can be solve by reflexivity.
-  // For the else branch, they need to call hypotheses in the context.
-  // These proofs are very simple, and can be handled by SMT, so we avoid
-  // writing tactics for it
-  smt ();
+
+  or_else (fun _ -> apply_lemma (`equiv_forall_refl)) assumption;
+  or_else (fun _ -> apply_lemma (`can_be_split_refl)) assumption;
+
+  // Discharging the maybe_emp by SMT
   smt ();
   // Now propagating all equalities for the requires/ensures
   set_goals loggoals;

--- a/ulib/experimental/Steel.Effect.fsti
+++ b/ulib/experimental/Steel.Effect.fsti
@@ -142,17 +142,20 @@ unfold
 let subcomp_pre (#a:Type)
   (#pre_f:pre_t) (#post_f:post_t a) (req_f:req_t pre_f) (ens_f:ens_t pre_f a post_f)
   (#pre_g:pre_t) (#post_g:post_t a) (req_g:req_t pre_g) (ens_g:ens_t pre_g a post_g)
-  (_:squash (can_be_split pre_g pre_f))
-  (_:squash (equiv_forall post_f post_g))
-: pure_pre
+  (#frame:vprop)
+  (_:squash (can_be_split pre_g (pre_f `star` frame)))
+  (_:squash (equiv_forall post_g (fun x -> post_f x `star` frame)))
+  : pure_pre
 // The call to with_tactic allows us to reduce VCs in a controlled way, once all
 // uvars have been resolved.
 // To ensure an SMT-friendly encoding of the VC, it needs to be encapsulated in a squash call
 = T.rewrite_with_tactic vc_norm (squash (
+  can_be_split_trans pre_g (pre_f `star` frame) pre_f;
   (forall (h0:hmem pre_g). req_g (mk_rmem pre_g h0) ==> req_f (focus_rmem (mk_rmem pre_g h0) pre_f)) /\
-  (forall (h0:hmem pre_g) (x:a) (h1:hmem (post_g x)).
+  (forall (h0:hmem pre_g) (x:a) (h1:hmem (post_g x)). (
+     can_be_split_trans (post_g x) (post_f x `star` frame) (post_f x);
      ens_f (focus_rmem (mk_rmem pre_g h0) pre_f) x (focus_rmem (mk_rmem (post_g x) h1) (post_f x)) ==> ens_g (mk_rmem pre_g h0) x (mk_rmem (post_g x) h1)
-  )
+  ))
 ))
 
 /// Subtyping combinator for Steel computations.
@@ -166,8 +169,10 @@ val subcomp (a:Type)
   (#[@@@ framing_implicit] req_f:req_t pre_f) (#[@@@ framing_implicit] ens_f:ens_t pre_f a post_f)
   (#[@@@ framing_implicit] pre_g:pre_t) (#[@@@ framing_implicit] post_g:post_t a)
   (#[@@@ framing_implicit] req_g:req_t pre_g) (#[@@@ framing_implicit] ens_g:ens_t pre_g a post_g)
-  (#[@@@ framing_implicit] p1:squash (can_be_split pre_g pre_f))
-  (#[@@@ framing_implicit] p2:squash (equiv_forall post_f post_g))
+  (#[@@@ framing_implicit] frame:vprop)
+  (#[@@@ framing_implicit] _ : squash (maybe_emp framed_f frame))
+  (#[@@@ framing_implicit] p1:squash (can_be_split pre_g (pre_f `star` frame)))
+  (#[@@@ framing_implicit] p2:squash (equiv_forall post_g (fun x -> post_f x `star` frame)))
   (f:repr a framed_f pre_f post_f req_f ens_f)
 : Pure (repr a framed_g pre_g post_g req_g ens_g)
   (requires subcomp_pre req_f ens_f req_g ens_g p1 p2)
@@ -176,12 +181,13 @@ val subcomp (a:Type)
 /// Logical precondition for the if_then_else combinator
 unfold
 let if_then_else_req
-  (#pre_f:pre_t) (#pre_g:pre_t)
-  (s: squash (can_be_split pre_f pre_g))
+  (#pre_f:pre_t) (#pre_g:pre_t) (#frame_f #frame_g:vprop)
+  (s_pre: squash (can_be_split (pre_f `star` frame_f) (pre_g `star` frame_g)))
   (req_then:req_t pre_f) (req_else:req_t pre_g)
   (p:Type0)
-: req_t pre_f
+: req_t (pre_f `star` frame_f)
 = fun h ->
+    can_be_split_trans (pre_f `star` frame_f) (pre_g `star` frame_g) pre_g;
     (p ==> req_then (focus_rmem h pre_f)) /\
     ((~ p) ==> req_else (focus_rmem h pre_g))
 
@@ -189,12 +195,15 @@ let if_then_else_req
 unfold
 let if_then_else_ens (#a:Type)
   (#pre_f:pre_t) (#pre_g:pre_t) (#post_f:post_t a) (#post_g:post_t a)
-  (s1 : squash (can_be_split pre_f pre_g))
-  (s2 : squash (equiv_forall post_f post_g))
+  (#frame_f #frame_g:vprop)
+  (s1: squash (can_be_split (pre_f `star` frame_f) (pre_g `star` frame_g)))
+  (s2: squash (equiv_forall (fun x -> post_f x `star` frame_f) (fun x -> post_g x `star` frame_g)))
   (ens_then:ens_t pre_f a post_f) (ens_else:ens_t pre_g a post_g)
   (p:Type0)
-: ens_t pre_f a post_f
+: ens_t (pre_f `star` frame_f) a (fun x -> post_f x `star` frame_f)
 = fun h0 x h1 ->
+    can_be_split_trans (pre_f `star` frame_f) (pre_g `star` frame_g) pre_g;
+    can_be_split_trans (post_f x `star` frame_f) (post_g x `star` frame_g) (post_g x);
     (p ==> ens_then (focus_rmem h0 pre_f) x (focus_rmem h1 (post_f x))) /\
     ((~ p) ==> ens_else (focus_rmem h0 pre_g) x (focus_rmem h1 (post_g x)))
 
@@ -202,18 +211,23 @@ let if_then_else_ens (#a:Type)
 /// The soundness of this combinator is automatically proven with respect to the subcomp
 /// subtyping combinator defined above by the F* layered effects framework
 let if_then_else (a:Type)
-  (#framed:eqtype_as_type bool)
+  (#framed_f:eqtype_as_type bool)
+  (#framed_g:eqtype_as_type bool)
   (#[@@@ framing_implicit] pre_f:pre_t) (#[@@@ framing_implicit] pre_g:pre_t)
   (#[@@@ framing_implicit] post_f:post_t a) (#[@@@ framing_implicit] post_g:post_t a)
   (#[@@@ framing_implicit] req_then:req_t pre_f) (#[@@@ framing_implicit] ens_then:ens_t pre_f a post_f)
   (#[@@@ framing_implicit] req_else:req_t pre_g) (#[@@@ framing_implicit] ens_else:ens_t pre_g a post_g)
-  (#[@@@ framing_implicit] s_pre: squash (can_be_split pre_f pre_g))
-  (#[@@@ framing_implicit] s_post: squash (equiv_forall post_f post_g))
-  (f:repr a framed pre_f post_f req_then ens_then)
-  (g:repr a framed pre_g post_g req_else ens_else)
+  (#[@@@ framing_implicit] frame_f : vprop)
+  (#[@@@ framing_implicit] frame_g : vprop)
+  (#[@@@ framing_implicit] me1 : squash (maybe_emp framed_f frame_f))
+  (#[@@@ framing_implicit] me2 : squash (maybe_emp framed_g frame_g))
+  (#[@@@ framing_implicit] s_pre: squash (can_be_split (pre_f `star` frame_f) (pre_g `star` frame_g)))
+  (#[@@@ framing_implicit] s_post: squash (equiv_forall (fun x -> post_f x `star` frame_f) (fun x -> post_g x `star` frame_g)))
+  (f:repr a framed_f pre_f post_f req_then ens_then)
+  (g:repr a framed_g pre_g post_g req_else ens_else)
   (p:bool)
 : Type
-= repr a framed pre_f post_f
+= repr a true (pre_f `star` frame_f) (fun x -> post_f x `star` frame_f)
     (if_then_else_req s_pre req_then req_else p)
     (if_then_else_ens s_pre s_post ens_then ens_else p)
 

--- a/ulib/experimental/Steel.FramingTestSuite.fst
+++ b/ulib/experimental/Steel.FramingTestSuite.fst
@@ -100,6 +100,11 @@ let test7 (_:unit) : SteelT ref emp ptr
     write r 0;
     r
 
+let test8 (b1 b2 b3:ref) : SteelT unit
+  (ptr b1 `star` ptr b2 `star` ptr b3)
+  (fun _ -> ptr b2 `star` ptr b1 `star` ptr b3)
+  = write b2 0
+
 open Steel.Effect.Atomic
 
 let test_if1 (b:bool) : SteelT unit emp (fun _ -> emp)
@@ -109,12 +114,10 @@ let test_if2 (b:bool) (r: ref) : SteelT unit (ptr r) (fun _ -> ptr r)
   = if b then write r 0 else write r 1
 
 let test_if3 (b:bool) (r:ref) : SteelT unit (ptr r) (fun _ -> ptr r)
-  = if b then noop () else noop ();
-    () // Mandatory until we have a framing subcomp
+  = if b then noop () else noop ()
 
-(* Need a bind in the else branch, else we have SteelF and Steel which cannot be composed *)
 let test_if4 (b:bool) : SteelT unit emp (fun _ -> emp)
-  = if b then (let r = alloc 0 in free r) else (noop (); ())
+  = if b then (let r = alloc 0 in free r) else (noop ())
 
 let test_if5 (b:bool) : SteelT ref emp (fun r -> ptr r)
   = if b then alloc 0 else alloc 1
@@ -136,16 +139,16 @@ let test_if7 (b:bool) (r1 r2: ref) : SteelT unit
 let test_if8 (b:bool) (r1 r2: ref) : SteelT unit
   (ptr r1 `star` ptr r2)
   (fun _ -> ptr r1 `star` ptr r2)
-  = if b then (write r1 0; write r2 0) else (write r2 0; ());
+  = if b then (write r1 0; write r2 0) else (write r2 0);
     write r2 0
 
 let test_if9 (b:bool) (r1 r2: ref) : SteelT unit
   (ptr r1 `star` ptr r2)
   (fun _ -> ptr r1 `star` ptr r2)
   = write r1 0;
-    if b then (write r1 0; ()) else (write r2 0; ());
+    if b then (write r1 0) else (write r2 0);
     write r2 0;
-    if b then (write r1 0; ()) else (write r2 0; ());
+    if b then (write r1 0) else (write r2 0);
     write r1 0
 
 (* Leave out some extra slprop outside of if_then_else *)
@@ -158,7 +161,7 @@ let test_if10 (b:bool) (r1 r2 r3: ref) : SteelT unit
 (* Tests if_then_else depending on previously created local var *)
 let test_if11 () : SteelT ref emp ptr =
   let r = alloc 0 in
-  if true then (noop (); return r) else (noop (); return r)
+  if true then return r else return r
 
 // Test for refinement types in return values. cf PR 2227
 assume

--- a/ulib/experimental/Steel.HigherReference.fst
+++ b/ulib/experimental/Steel.HigherReference.fst
@@ -406,7 +406,8 @@ let ghost_free #a #u #v r =
 let ghost_share r = share (reveal r)
 let ghost_gather r = gather (reveal r)
 
-let ghost_pts_to_injective_eq r v0 v1 = higher_ref_pts_to_injective_eq (reveal r)
+let ghost_pts_to_injective_eq #_ #_ #p0 #p1 r v0 v1 =
+  higher_ref_pts_to_injective_eq #_ #_ #p0 #p1 #v0 #v1 (reveal r)
 
 let ghost_read #a #u #p #v r
   = let v1 : erased (fractional a) = Ghost.hide (Some (Ghost.reveal v, p)) in

--- a/ulib/experimental/Steel.MonotonicHigherReference.fst
+++ b/ulib/experimental/Steel.MonotonicHigherReference.fst
@@ -199,7 +199,7 @@ let intro_pure #a #p #f
   : SteelT unit
            (PR.pts_to r h)
            (fun _ -> pts_to_body r f v h)
-  = rewrite_slprop _ _ (fun m ->
+  = rewrite_slprop (PR.pts_to r h) (pts_to_body _ _ _ _) (fun m ->
       emp_unit (M.pts_to r h);
       pure_star_interp (M.pts_to r h) (history_val h v f) m)
 

--- a/ulib/experimental/Steel.Primitive.ForkJoin.Unix.fst
+++ b/ulib/experimental/Steel.Primitive.ForkJoin.Unix.fst
@@ -125,8 +125,8 @@ let subcomp (a:Type)
   (f:steelK a framed_f pre_f post_f)
 : Tot (steelK a framed_g pre_g post_g)
 = fun #frame #postf (k:(x:a -> SteelT unit (frame `star` post_g x) (fun _ -> postf))) ->
-    change_slprop_imp pre_g pre_f (); f
-      ((fun x -> change_slprop_imp (frame `star` post_f x) (frame `star` post_g x)
+    change_slprop_imp pre_g pre_f ();
+    f #frame #postf ((fun x -> change_slprop_imp (frame `star` post_f x) (frame `star` post_g x)
                             (can_be_split_forall_frame post_f post_g frame x);
                k x) <: (x:a -> SteelT unit (frame `star` post_f x) (fun _ -> postf)))
 
@@ -173,7 +173,7 @@ let bind_tot_steelK_ (a:Type) (b:Type)
     post
   = fun #frame #postf (k:(x:b -> SteelT unit (frame `star` post x) (fun _ -> postf))) ->
       let x = f () in
-      g x k
+      g x #frame #postf k
 
 polymonadic_bind (PURE, SteelKBase) |> SteelKBase = bind_tot_steelK_
 

--- a/ulib/experimental/Steel.Reference.fst
+++ b/ulib/experimental/Steel.Reference.fst
@@ -373,7 +373,7 @@ let ghost_pts_to_injective_eq (#a:_) (#u:_) (#p #q:_) (r:ghost_ref a) (v0 v1:Gho
     (fun _ -> ghost_pts_to r p v0 `star` ghost_pts_to r q v0)
     (requires fun _ -> True)
     (ensures fun _ _ _ -> v0 == v1)
-  = H.ghost_pts_to_injective_eq r (raise_erased v0) (raise_erased v1)
+  = H.ghost_pts_to_injective_eq #_ #_ #p #q r (raise_erased v0) (raise_erased v1)
 
 let ghost_read_pt #a #u #p #v r =
   let x = H.ghost_read r in


### PR DESCRIPTION
This PR adds support for framing subcomp and if_then_else.

Concretely, this enables to write the following:
```
let test8 (b1 b2 b3:ref) : SteelT unit
  (ptr b1 `star` ptr b2 `star` ptr b3)
  (fun _ -> ptr b2 `star` ptr b1 `star` ptr b3)
  = write b2 0
```
Previously, a trailing unit was required to force framing, which only occured in a bind.

Building upon this, framing also occurs in branching, enabling for instance to have a Steel and a SteelF branch, also removing the need for artificial unit values returned or noop calls, for instance
```
let test_if4 (b:bool) : SteelT unit emp (fun _ -> emp)
  = if b then (let r = alloc 0 in free r) else (noop () // No trailing unit needed anymore)
```

To reach this, this PR uses the same approach as for bind, and adds frame implicits and their corresponding squashed goals to the subcomp and if_then_else effect combinators for Steel and SteelAtomic/Ghost.
Soundness of the if_then_else combinator w.r.t. subcomp is proven by tactic, expanding the previously existing tactic.

Some minor changes to existing code were required. These changes exclusively consisted of implicit annotations for Steel computations that only consist of a subcomp: By adding a frame, the framing tactic is now triggered instead of direct unification.