### PR TITLE
add FStar.Classical.Lemmas module

### DIFF
--- a/ulib/FStar.Classical.Lemmas.fst
+++ b/ulib/FStar.Classical.Lemmas.fst
@@ -1,0 +1,60 @@
+(*
+   Copyright 2021 Microsoft Research
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*)
+
+module FStar.Classical.Lemmas
+
+(*** Implication *)
+
+let impl_intro_lemma #p #q h =
+  let lem (x:p) : Lemma (q) = h () in
+  FStar.Classical.impl_intro lem
+
+(*** Universal quantification *)
+
+let forall_intro_lemma #a #p #q h =
+  let q' = fun (x:a) -> fun (_:unit) -> q x in
+  FStar.Classical.ghost_lemma h
+
+let forall_intro_2_lemma #a #b #p #q h =
+  let p' = fun (tup: a * b) -> p (fst tup) (snd tup) in
+  let q' = fun (tup: a * b) -> q (fst tup) (snd tup) in
+  let h' (tup: a * b) : Lemma (requires p' tup) (ensures q' tup) =
+    h (fst tup) (snd tup) in
+  forall_intro_lemma h';
+  assert (forall (tup: a * b). p' tup ==> q' tup);
+  let lem (x: a) (y: b) : Lemma (p x y ==> q x y) =
+    (let tup = (x, y) in assert (p' tup ==> q' tup)) in
+  FStar.Classical.forall_intro_2 lem
+
+(*** Existential quantification *)
+
+let exists_elim_lemma #a #goal #property existence instance_implies_goal =
+  let existence' = existence () in
+  let instance_implies_goal':(x:a{property x} -> squash goal) = fun (x:a{property x}) -> instance_implies_goal x in
+  FStar.Classical.exists_elim goal #a #property existence' instance_implies_goal'
+
+(*** Disjunction *)
+
+let or_elim_lemma #l #r #goal hl hr =
+  let goal':(squash (l \/ r) -> ubool) = fun _ -> goal in
+  let hl':(squash l -> Lemma (goal)) = fun _ -> hl () in
+  let hr':(squash r -> Lemma (goal)) = fun _ -> hr () in
+  FStar.Classical.or_elim #l #r #goal' hl' hr'
+
+let or_elim_3_lemma #l #m #r #goal hl hm hr =
+  or_elim_lemma hl hm;
+  let hl' () : Lemma (requires l \/ m) (ensures goal) = () in
+  or_elim_lemma hl' hr

--- a/ulib/FStar.Classical.Lemmas.fsti
+++ b/ulib/FStar.Classical.Lemmas.fsti
@@ -1,0 +1,92 @@
+(*
+   Copyright 2021 Microsoft Research
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*)
+
+module FStar.Classical.Lemmas
+
+/// This module provides alternatives to utilities in FStar.Classical.
+/// The alternatives here take lemmas instead of squashes as input.
+
+(* ubool represents a non-necessarily-decidable boolean, i.e., a
+   [Type0] used as a logical proposition *)
+
+type ubool = Type0
+
+(* impl_intro_lemma introduces the fact [p ==> q].  It takes as input a
+   lemma requiring [p] and ensuring [q]. *)
+
+val impl_intro_lemma
+  (#p: ubool)
+  (#q: ubool)
+  ($h: (unit -> Lemma (requires p) (ensures q)))
+  : Lemma (p ==> q)
+
+(* forall_intro_lemma introduces the fact [forall (x: a). p x ==> q x].  It
+   takes as input a lemma that takes an [x:a], requires [p x], and
+   ensures [q x]. *)
+
+val forall_intro_lemma
+  (#a: Type)
+  (#p: (a -> ubool))
+  (#q: (a -> ubool))
+  ($h: (x: a -> Lemma (requires p x) (ensures (q x))))
+  : Lemma (forall (x: a). p x ==> q x)
+
+(* forall_intro_2_lemma introduces the fact [forall (x: a) (y: b). p x y
+   ==> q x y].  It takes as input a lemma that takes an [x:a] and
+   [y:b], requires [p x y], and ensures [q x y]. *)
+
+val forall_intro_2_lemma
+  (#a: Type)
+  (#b: Type)
+  (#p: (a -> b -> ubool))
+  (#q: (a -> b -> ubool))
+  ($h: (x: a -> y: b -> Lemma (requires p x y) (ensures (q x y))))
+  : Lemma (forall (x: a) (y: b). p x y ==> q x y)
+
+(* exists_elim_lemma establishes [goal] using two input lemmas.  The
+   first lemma, [existence], establishes that [exists (x: a). property x].
+   The second lemma, [instance_implies_goal], takes an [x:a] as input,
+   requires [property x], and ensures [goal]. *)
+
+val exists_elim_lemma
+  (#a:Type)
+  (#goal:ubool)
+  (#property:a -> ubool)
+  ($existence:(unit -> Lemma (ensures exists (x: a). property x)))
+  ($instance_implies_goal:(x:a -> Lemma (requires property x) (ensures goal)))
+  : Lemma (goal)
+
+(* or_elim_lemma establishes [l \/ r ==> goal] using two input lemmas.
+   The first lemma requires [l] and ensures [goal].  The second lemma
+   requires [r] and ensures [goal]. *)
+
+val or_elim_lemma
+  (#l #r #goal: ubool)
+  ($hl:(unit -> Lemma (requires l) (ensures goal)))
+  ($hr:(unit -> Lemma (requires r) (ensures goal)))
+  : Lemma ((l \/ r) ==> goal)
+
+(* or_elim_3_lemma establishes [l \/ m \/ r ==> goal] using three input
+   lemmas.  The first lemma requires [l] and ensures [goal].  The
+   second lemma requires [m] and ensures [goal].  The third lemma
+   requires [r] and ensures [goal]. *)
+
+val or_elim_3_lemma
+  (#l #m #r #goal:ubool)
+  ($hl:(unit -> Lemma (requires l) (ensures goal)))
+  ($hm:(unit -> Lemma (requires m) (ensures goal)))
+  ($hr:(unit -> Lemma (requires r) (ensures goal)))
+  : Lemma (l \/ m \/ r ==> goal)


### PR DESCRIPTION
This adds a module FStar.Classical.Lemmas that provides alternatives to FStar.Classical.  These alternatives take lemmas instead of squashes as inputs, making them potentially easier to use.