### PR TITLE
Fix typos in the current version of the F* book

### DIFF
--- a/doc/book/intro.rst
+++ b/doc/book/intro.rst
@@ -54,7 +54,7 @@ collection of domain-specific languages (DSLs). A common use of F* is
 to embed within it programming languages at different levels of
 abstraction or for specific programming tasks, and for the embedded
 language to be engineered with domain-specific reasoning, proof
-automation, and compilaton backends. Some examples include:
+automation, and compilation backends. Some examples include:
 
 * Low*, an shallowly embedded DSL for sequential programming against a
   C-like memory model including explicit memory management on the
@@ -151,7 +151,7 @@ readers with a background in general-purpose programming languages
 like C# or Scala, but not all dependently typed languages are Turing
 complete, since nontermination can break soundness. However, F*
 supports general recursive functions and non-termination in a safe
-manner, without compromsing soundness.
+manner, without compromising soundness.
 
 Beyond nontermination, F* supports a system of user-defined
 computational effects which can be used to model a variety of
@@ -162,7 +162,7 @@ Here below is some code in an F* dialect called :ref:`Low* <LowStar>`
 which provides a sequential, imperative C-like programming model with
 mutable memory. The function ``malloc_copy_free`` allocates an array
 ``dest``, copies the contents of an array of bytes ``src`` into a
-``dest``, deallocates, ``src`` and returns ``dest``.
+``dest``, deallocates ``src`` and returns ``dest``.
 
 .. literalinclude:: code/MemCpy.fst
    :language: fstar
@@ -178,7 +178,7 @@ full detail, but here are two main points to take away:
     and that it is *correct* (i.e., that it successfully copies
     ``src`` to ``dest`` without modifying any other memory)
 
-  * Given the implementation of a procedure F* actually builds a
+  * Given the implementation of a procedure, F* actually builds a
     mathematical proof that it is safe and correct with respect to its
     signature.
 
@@ -221,7 +221,7 @@ F* seeks to reduce that burden, using a variety of techniques.
 Proving even a simple program often involves proving dozens or
 hundreds of small facts, e.g., proving that bounded arithmetic doesn't
 overflow, or that ill-defined operations like divisions by zero never
-occur. All these little proofs can can quickly overwhelm a user.
+occur. All these little proofs can quickly overwhelm a user.
 
 The main workhorse for proofs in F* is an automated theorem prover,
 known as a *Satisfiability Modulo Theories*, or SMT, solver. The F*
@@ -303,7 +303,7 @@ proof of the theorem.
 
 Tactics are an instance of a more general metaprogramming system in
 F*, which allows an F* program to generate other F* programs. You'll
-learn more about tactics and metaprograming in :ref:`this chapter
+learn more about tactics and metaprogramming in :ref:`this chapter
 <MetaFStar>`.
 
 
@@ -373,7 +373,7 @@ some of the following:
 
   * `Theorem Proving in Lean
     <https://leanprover.github.io/theorem_proving_in_lean/>`_: This is
-    the standard reference for learning abou the Lean theorem prover,
+    the standard reference for learning about the Lean theorem prover,
     though there are several other `resources
     <https://leanprover-community.github.io/learn.html>`_ too.
 
@@ -398,7 +398,7 @@ kinds of mathematics. What sets F* apart from these other languages
 (and more like Nuprl) is its extensional notion of type equality,
 making many programming patterns significantly smoother in F* (cf. the
 :ref:`vector <Intro_Vec>` example). However, this design also makes
-typechecking in F* undedicable. The practical consequences of this are
+typechecking in F* undecidable. The practical consequences of this are
 that F* typechecker can time-out and refuse to accept your
 program. Other dependently typed languages have decidable
 typechecking, though they can, in principle, take arbitrarily long to
@@ -411,7 +411,7 @@ languages with dependent types, though in return, one needs to also
 trust the combination of F* and Z3 to believe in the validity of an F*
 proof. Isabelle/HOL provides similar SMT-assisted automation (in its
 Sledgehammer tool), for the weaker logic provided by HOL, though
-Sledghammer's design ensures that the SMT solver need not be
+Sledgehammer's design ensures that the SMT solver need not be
 trusted. F*'s use of SMT is also similar to what program verifiers
 like Dafny and Liquid Haskell offer. However, unlike their SMT-only
 proof strategies, F*, like Coq and Lean, also provides symbolic

--- a/doc/book/part1/part1_getting_off_the_ground.rst
+++ b/doc/book/part1/part1_getting_off_the_ground.rst
@@ -187,7 +187,7 @@ allow us to:
    *introducing* a refinement type.
 
 2. make use of a term that has a refinement type, e.g., given ``x :
-   even`` we would like to be write ``x + 1``, treating ``x`` as an
+   even`` we would like to be able to write ``x + 1``, treating ``x`` as an
    ``int`` to add ``1`` to it. This is sometimes called *eliminating*
    a refinement type.
 
@@ -257,7 +257,7 @@ Functions
 
 To start writing interesting programs, we need a way to define
 functions. In the core of F*, functions behave like functions in
-math. In other words, they are defined on their entire domain (i.e.,
+maths. In other words, they are defined on their entire domain (i.e.,
 they are total functions and always return a result) and their only
 observable behavior is the result they return (i.e., they don't have
 any side effect, like looping forever, or printing a message etc.).
@@ -270,7 +270,7 @@ simply a *lambda*. The syntax is largely inherited from OCaml, and
 this `OCaml tutorial
 <https://ocaml.org/learn/tutorials/basics.html#Defining-a-function>`_
 provides more details for those unfamiliar with the language. We'll
-assume a basic familiarity with OCaml-like syntax.x
+assume a basic familiarity with OCaml-like syntax.
 
 Lambda terms
 ............
@@ -330,7 +330,7 @@ the ``let rec`` syntax, as shown below.
    :end-before: SNIPPET_END: factorial
 
 This syntax defines a function names ``factorial`` with a single
-parameter ``n:nat``, returning a ``nat``. The definiton of factorial
+parameter ``n:nat``, returning a ``nat``. The definition of factorial
 is allowed to use the ``factorial`` recursively—as we'll see in a
 later chapter, ensuring that the recursion is well-founded (i.e., all
 recursive calls terminate) is key to F*'s soundness. However, in this
@@ -501,7 +501,7 @@ In response ``fstar`` should output::
 This means that F* attempted to verify the module named ``Sample``. In
 doing so, it generated a some "verification conditions", or proof
 obligations, necessary to prove that the module is type correct, and
-that is dischared, or proved, all of them successfully.
+that is discharged, or proved, all of them successfully.
 
 **F\* in emacs**
 
@@ -588,7 +588,7 @@ F* is happy.
 Sometimes, it is convenient to provide a type signature independently
 of a definition. Below, the ``val incr4`` provides only the signature
 and the subsequent ``let incr4`` provides the definition—F* checks
-that the definitions is compatible with the signature.
+that the definition is compatible with the signature.
 
 .. literalinclude:: ../code/Part1.GettingOffTheGround.fst
    :language: fstar
@@ -617,7 +617,7 @@ Provide an implementation of the following signature::
 
   val max (x:int) (y:int) : int
 
-There are many possible implemenations that satisfy this signature,
+There are many possible implementations that satisfy this signature,
 including trivial ones like::
 
   let max x y = 0
@@ -664,7 +664,7 @@ Can you write down some more types for factorial?
 Fibonacci
 .........
 
-Here's a doubly recursive function
+Here's a doubly recursive function::
 
   .. literalinclude:: ../code/Part1.GettingOffTheGround.fst
    :language: fstar

--- a/doc/book/part1/part1_lemmas.rst
+++ b/doc/book/part1/part1_lemmas.rst
@@ -50,7 +50,7 @@ it out in detail:
 * The return type of ``factorial_is_positive`` is a refinement of
   unit, namely ``u:unit{factorial x > 0}``.  That says that the
   function always returns ``()``, but, additionally, when
-  ``factorial_is_postive x`` returns (which it always does, since it
+  ``factorial_is_positive x`` returns (which it always does, since it
   is a total function) it is safe to conclude that ``factorial x >
   0``.
 
@@ -361,7 +361,7 @@ function.  It's possible to *specify* this property in the type of
 
 .. note::
 
-   A subtle point: the refinemnt on ``reverse`` above uses a
+   A subtle point: the refinement on ``reverse`` above uses a
    :ref:`propositional equality
    <Part1_ch2_propositional_equality>`. That's because equality on
    lists of arbitrary types is not decidable, e.g., consider ``list
@@ -439,7 +439,7 @@ previous non-tail-recursive implementation, i.e.,
 
 .. code-block:: fstar
 
-   val rev_is_ok (#a:_) (l:list a) Lemma (rev [] l == reverse l)
+   val rev_is_ok (#a:_) (l:list a) : Lemma (rev [] l == reverse l)
 
 .. container:: toggle
 
@@ -475,7 +475,7 @@ previous non-tail-recursive implementation, i.e.,
        then 1
        else slow_fib (n - 1) + slow_fib (n - 2)
 
-   val fib_is_ok (n:nat) : Lemma (fibonacci n = slow_fib b)
+   val fib_is_ok (n:nat) : Lemma (fibonacci n = slow_fib n)
 
 .. container:: toggle
 

--- a/doc/book/part1/part1_prop_assertions.rst
+++ b/doc/book/part1/part1_prop_assertions.rst
@@ -4,7 +4,7 @@ Interfacing with an SMT solver
 ==============================
 
 As mentioned :ref:`at the start of this section <Part1>`, a type ``t``
-represents a propostion and a term ``e : t`` is a proof of ``t``. In
+represents a proposition and a term ``e : t`` is a proof of ``t``. In
 many other dependently typed languages, exhibiting a term ``e : t`` is
 the only way to prove that ``t`` is valid. In F*, while one can do
 such proofs, it is not the only way to prove a theorem.
@@ -24,7 +24,7 @@ constructing a term representing a proof of ``17 >= 0``.
 This design has many important consequences, including, briefly:
 
 * Trust: F* implicitly trusts its encoding to SMT logic and the
-  correctess of the Z3 solver.
+  correctness of the Z3 solver.
   
 * Proof irrelevance: Since no proof term is constructed for proofs
   done by SMT, a program cannot distinguish between different proofs
@@ -133,7 +133,7 @@ quantifiers.
 Quantifiers
 ...........
 
-A universal quantifer is constructed using the ``forall`` keyword. Its
+A universal quantifier is constructed using the ``forall`` keyword. Its
 syntax has the following shape.
 
 .. code-block:: fstar
@@ -160,7 +160,7 @@ The scope of a quantifier extends as far to the right as possible.
 As usual in F*, the types on the bound variables can be omitted and F*
 will infer them. However, in the case of quantified formulas, it's a
 good idea to write down the types, since the meaning of the quantifier
-can change signicantly depending on the type of the variable. Consider
+can change significantly depending on the type of the variable. Consider
 the two propositions below.
 
 .. code-block:: fstar
@@ -193,7 +193,7 @@ Conjunction, Disjunction, Negation, Implication
 ...............................................
 
 In addition to the quantifiers, you can build propositions by
-combining them with other propositions, using the opertors below, in
+combining them with other propositions, using the operators below, in
 decreasing order of precedence.
 
 **Negation**
@@ -272,7 +272,7 @@ was expected.
 This next bit is quite technical. Don't worry if you didn't understand
 it at first. It's enough to know at this stage that, just like
 automatically converting a boolean to `prop`, F* automatically
-converts any type to ``prop``, when neeeded. So, you can form new
+converts any type to ``prop``, when needed. So, you can form new
 atomic propositions out of types.
 
 Every well-typed term in F* has a type. Even types have types, e.g.,
@@ -286,7 +286,7 @@ For any type ``t : Type``, the type ``_:unit { t } : prop``. We call
 this "squashing" a type. This is so common, that F* provides two
 mechanisms to support this:
 
-1. All the propositonal connectives, like ``p /\ q`` are designed so
+1. All the propositional connectives, like ``p /\ q`` are designed so
    that both ``p`` and ``q`` can be types (i.e., ``p,q : Type``),
    rather than propositions, and they implicitly squash their types.
 

--- a/doc/book/part1/part1_quicksort.rst
+++ b/doc/book/part1/part1_quicksort.rst
@@ -65,7 +65,7 @@ There are a few points worth discussing in detail:
 
 2. We have to prove that ``sort`` terminates. The measure we've
    provided is ``length l``, meaning that at each recursive call,
-   we're claiming that the length of input list is stricly
+   we're claiming that the length of input list is strictly
    decreasing.
 
 3. Why is this true? Well, informally, the recursive calls ``sort lo``
@@ -88,7 +88,7 @@ elements in ``l`` such that the every element in ``l₁`` satisfies
        :start-after: SNIPPET_START: partition
        :end-before: SNIPPET_END: partition
 
-The specification we've given ``parition`` is only partial—we do not
+The specification we've given ``partition`` is only partial—we do not
 say, for instance, that all the elements in ``l₁`` satisfy ``f``. We
 only say that the sum of the lengths of the ``l₁`` and ``l₂`` are
 equal to the length of ``l``. That's because that's the only property
@@ -111,7 +111,7 @@ correct. Here's a proof—it requires three auxiliary lemmas and we'll
 discuss it in detail.
 
 Our first lemma relates ``partition`` to ``mem``: it proves what we
-left out in the intrinsic specifiation of ``partition``, i.e., that
+left out in the intrinsic specification of ``partition``, i.e., that
 all the elements in ``l₁`` satisfy ``f``, the elements in ``l₂`` do
 not, and every element in ``l`` appears in either ``l₁`` or ``l₂``.
 
@@ -167,13 +167,13 @@ itself.
 
     + We also need to prove the ``sorted`` refinements on ``sort lo``
       and ``sort hi`` in order to call ``sorted_concat``, but the
-      recursive calls of the lemma give us those proeprties.
+      recursive calls of the lemma give us those properties.
 
     + After calling ``sorted_concat``, we have proven that the
       resulting list is sorted. What's left is to prove that all the
       elements of the input list are in the result, and ``append_mem``
       does that, using the postcondition of ``partition_mem`` and the
-      induction hyptothesis to relate the elements of ``append (sort
+      induction hypothesis to relate the elements of ``append (sort
       lo) (pivot :: sort hi)`` to the input list ``l``.
 
 Here's another version of the ``sort_correct`` lemma, this time

--- a/doc/book/part1/part1_termination.rst
+++ b/doc/book/part1/part1_termination.rst
@@ -4,7 +4,7 @@ Proofs of termination
 =====================
 
 It's absolutely crucial to the soundness of F*'s core logic that all
-functions terminate. Otherwise, one could non-terminating write
+functions terminate. Otherwise, one could write non-terminating 
 functions like this::
 
   let rec loop (x:unit) : False = loop x
@@ -138,7 +138,7 @@ and everything checks out.
 Lexicographic orderings
 ^^^^^^^^^^^^^^^^^^^^^^^
 
-F* also provides a convenience to enhane the well-founded ordering
+F* also provides a convenience to enhance the well-founded ordering
 ``<<`` to lexicographic combinations of ``<<``. That is, given two
 lists of terms ``v₁, ..., vₙ`` and ``u₁, ..., uₙ``, F* accepts that
 the following lexicographic ordering::
@@ -227,7 +227,7 @@ That is, the default decreases clause for ``ackermann`` is exactly
 needn't write it.
 
 On the other hand, it you were to flip the order of arguments to
-``ackermann``, then the default choise of the measure would not be
+``ackermann``, then the default choice of the measure would not be
 correct—so, you'll have to write it explicitly, as shown below.
 
 .. literalinclude:: ../code/Part1.Termination.fst
@@ -277,7 +277,7 @@ usual.
    again with a smaller argument. You can convince F* of this by
    writing the decreases clauses shown, i.e., when ``bar`` calls
    ``foo``, ``l`` doesn't change, but the second component of the
-   lexicographic rdering does decrease, i.e., ``0 << 1``.
+   lexicographic ordering does decrease, i.e., ``0 << 1``.
 
 
 The termination check, precisely


### PR DESCRIPTION
Thanks for all of the work around the tutorial, it is really helpful.
Should supersede #2318.