### PR TITLE
Making vprop arguments as non-erased

### DIFF
--- a/examples/steel/Duplex.PCM.fst
+++ b/examples/steel/Duplex.PCM.fst
@@ -1188,26 +1188,26 @@ let new_channel' (p:dprot)
   let rA = HR.alloc v in
   let rB = HR.alloc v in
   let c = new_chan p in
-  slassert (HR.pts_to rA Perm.full_perm (hide v) `star`
+  slassert (HR.pts_to rA Perm.full_perm v `star`
             pure (eq2_prop #dprot (dfst v) p) `star`
             endpoint A c p (empty_trace p) `star`
-            (HR.pts_to rB Perm.full_perm (hide v) `star`
+            (HR.pts_to rB Perm.full_perm v `star`
              pure (eq2_prop #dprot (dfst v) p) `star`
              endpoint B c p (empty_trace p)));
   let cA : channel p = (c, rA) in
   let cB : channel p = (c, rB) in
-  rewrite_slprop ((HR.pts_to rA Perm.full_perm (hide v) `star`
+  rewrite_slprop ((HR.pts_to rA Perm.full_perm v `star`
                  pure (eq2_prop #dprot (dfst v) p) `star`
                  endpoint A c p (empty_trace p)) `star`
-                (HR.pts_to rB Perm.full_perm (hide v) `star`
+                (HR.pts_to rB Perm.full_perm v `star`
                  pure (eq2_prop #dprot (dfst v) p) `star`
                  endpoint B c p (empty_trace p)))
                 (endpt_pred A cA p v `star`
                  endpt_pred B cB p v)
-                (fun _ -> reveal_equiv ((HR.pts_to rA Perm.full_perm (hide v) `star`
+                (fun _ -> reveal_equiv ((HR.pts_to rA Perm.full_perm v `star`
                  pure (eq2_prop #dprot (dfst v) p) `star`
                  endpoint A c p (empty_trace p)) `star`
-                (HR.pts_to rB Perm.full_perm (hide v) `star`
+                (HR.pts_to rB Perm.full_perm v `star`
                  pure (eq2_prop #dprot (dfst v) p) `star`
                  endpoint B c p (empty_trace p)))
                                  (endpt_pred A cA p v `star`

--- a/examples/steel/OWGCounter.fst
+++ b/examples/steel/OWGCounter.fst
@@ -284,13 +284,4 @@ let incr_main (#v:G.erased int) (r:ref int)
     rewrite_slprop (pts_to r full_perm (fst w + snd w))
                    (pts_to r full_perm (v + 2))
                    (fun _ -> ())
- r1; sladmit ()
 
-    drop (ghost_pts_to r1 half_perm 1);
-    drop (ghost_pts_to r2 half_perm (v + 1));
-    drop (ghost_pts_to r1 _ _);
-    drop (ghost_pts_to r2 _ _);
-
-    rewrite_slprop (pts_to r full_perm (fst w + snd w))
-                   (pts_to r full_perm (v + 2))
-                   (fun _ -> ())

--- a/examples/steel/OWGCounterInv.fst
+++ b/examples/steel/OWGCounterInv.fst
@@ -100,7 +100,7 @@ let half_perm = P.half_perm full_perm
 
 [@@ __reduce__]
 let inv_pred (r:ref int) (r1 r2:ghost_ref int) =
-  fun (w:G.erased int & G.erased int) ->
+  fun (w:int & int) ->
     ghost_pts_to r1 (P.half_perm full_perm) (fst w) `star`
     ghost_pts_to r2 (P.half_perm full_perm) (snd w) `star`
     pts_to r full_perm (fst w + snd w)
@@ -125,27 +125,27 @@ let inv_equiv_lemma (r:ref int) (r1 r2:ghost_ref int)
           (ensures interp (hp_of (inv_slprop r r2 r1)) m)
           [SMTPat ()]
       = assert (
-          Steel.Memory.h_exists #(G.erased int & G.erased int) (fun x -> hp_of (inv_pred r r1 r2 x)) ==
-          h_exists_sl #(G.erased int & G.erased int) (inv_pred r r1 r2))
+          Steel.Memory.h_exists #(int & int) (fun x -> hp_of (inv_pred r r1 r2 x)) ==
+          h_exists_sl #(int & int) (inv_pred r r1 r2))
           by (FStar.Tactics.norm [delta_only [`%h_exists_sl]]);
 
 
-        let w : G.erased (G.erased int & G.erased int) = id_elim_exists (fun x -> hp_of (inv_pred r r1 r2 x)) m in
+        let w : G.erased (int & int) = id_elim_exists (fun x -> hp_of (inv_pred r r1 r2 x)) m in
 
         assert ((ghost_pts_to r1 half_perm (snd (snd w, fst w)) `star`
                  ghost_pts_to r2 half_perm (fst (snd w, fst w)) `star`
-                 pts_to r full_perm (G.hide (G.reveal (fst (snd w, fst w)) + G.reveal (snd (snd w, fst w))))) `equiv`
+                 pts_to r full_perm (fst (snd w, fst w) + snd (snd w, fst w))) `equiv`
                 (ghost_pts_to r2 half_perm (fst (snd w, fst w)) `star`
                  ghost_pts_to r1 half_perm (snd (snd w, fst w)) `star`
-                 pts_to r full_perm (G.hide (G.reveal (fst (snd w, fst w)) + G.reveal (snd (snd w, fst w)))))) by (FStar.Tactics.norm [delta_attr [`%__steel_reduce__]]; canon' false (`true_p) (`true_p));
+                 pts_to r full_perm (fst (snd w, fst w) + snd (snd w, fst w)))) by (FStar.Tactics.norm [delta_attr [`%__steel_reduce__]]; canon' false (`true_p) (`true_p));
 
         reveal_equiv
           (ghost_pts_to r1 half_perm (snd (snd w, fst w)) `star`
                  ghost_pts_to r2 half_perm (fst (snd w, fst w)) `star`
-                 pts_to r full_perm (G.hide (G.reveal (fst (snd w, fst w)) + G.reveal (snd (snd w, fst w)))))
+                 pts_to r full_perm (fst (snd w, fst w) + snd (snd w, fst w)))
           (ghost_pts_to r2 half_perm (fst (snd w, fst w)) `star`
                  ghost_pts_to r1 half_perm (snd (snd w, fst w)) `star`
-                 pts_to r full_perm (G.hide (G.reveal (fst (snd w, fst w)) + G.reveal (snd (snd w, fst w)))));
+                 pts_to r full_perm (fst (snd w, fst w) + snd (snd w, fst w)));
 
         assert (interp (hp_of (inv_pred r r2 r1 (snd w, fst w))) m);
 
@@ -153,8 +153,8 @@ let inv_equiv_lemma (r:ref int) (r1 r2:ghost_ref int)
         assert (interp (Steel.Memory.h_exists (fun x -> hp_of (inv_pred r r2 r1 x))) m);
 
         assert (
-          Steel.Memory.h_exists #(G.erased int & G.erased int) (fun x -> hp_of (inv_pred r r2 r1 x)) ==
-          h_exists_sl #(G.erased int & G.erased int) (inv_pred r r2 r1))
+          Steel.Memory.h_exists #(int & int) (fun x -> hp_of (inv_pred r r2 r1 x)) ==
+          h_exists_sl #(int & int) (inv_pred r r2 r1))
           by (FStar.Tactics.norm [delta_only [`%h_exists_sl]]) in
 
   reveal_equiv (inv_slprop r r1 r2) (inv_slprop r r2 r1)
@@ -220,12 +220,12 @@ let incr_with_inv_slprop
   = //get inv_slprop in the context
     rewrite_slprop (inv_slprop_conditional _ _ _ _)
                    (inv_slprop _ _ _) (fun _ -> Classical.forall_intro_2 reveal_equiv);
-    let w : G.erased (G.erased int & G.erased int) = witness_exists () in
+    let w : G.erased (int & int) = witness_exists () in
     incr_atomic r;
     incr_ghost_contrib #_ #n_ghost #(fst w) r_mine;
 
     //restore inv_slprop, by first writing r to a form expected by the invariant
-    intro_exists (incr (fst w), snd w) (inv_pred r r_mine r_other);
+    intro_exists (fst w+1, snd w) (inv_pred r r_mine r_other);
     rewrite_slprop (inv_slprop _ _ _)
                    (inv_slprop_conditional _ _ _ _)
                    (fun _ -> Classical.forall_intro_2 reveal_equiv)
@@ -261,7 +261,7 @@ let incr_main (#v:G.erased int) (r:ref int)
 
     //create the invariant
 
-    intro_exists (G.hide 0, v) (inv_pred r r1 r2);
+    intro_exists (0, G.reveal v) (inv_pred r r1 r2);
     let i = new_inv (inv_slprop r r1 r2) in
 
     //split the invariant permission

--- a/examples/steel/Queue.fst
+++ b/examples/steel/Queue.fst
@@ -265,7 +265,7 @@ let enqueue
   return ()
 
 assume
-val read_next (#a: _) (#u: _) (#v: _) (x:t a)
+val read_next (#a: _) (#u: _) (#v: Ghost.erased (cell a)) (x:t a)
     : SteelAtomic (t a) u (pts_to x v)
                             (fun _ -> pts_to x v)
                             (requires (fun _ -> True))
@@ -320,6 +320,6 @@ let dequeue
     intro_exists_erased ltl (queue_lc p tl l2);
     intro_exists_erased l2 (queue_l p tl);
     intro_pure (Ghost.reveal p == (Ghost.reveal (Ghost.hide (snd lhd))).next);
-    intro_exists (Ghost.hide (snd lhd)) (fun (c: Ghost.erased (cell a)) -> pts_to hd c `star` pure (Ghost.reveal p == c.next) `star` queue p tl);
+    intro_exists (snd lhd) (fun (c: (cell a)) -> pts_to hd c `star` pure (Ghost.reveal p == c.next) `star` queue p tl);
     return (Some p)
   end

--- a/examples/steel/Queue.fsti
+++ b/examples/steel/Queue.fsti
@@ -13,12 +13,12 @@ module U = Steel.Utils
 
 /// This library does not allow sharing ownership of the queue. As such, fractional permissions
 /// in this module will not be useful, and we use this wrapper to avoid specifying them
-let pts_to (#a:_) (x:t a) ([@@@smt_fallback]v: Ghost.erased (cell a)) = pts_to x full_perm v
+let pts_to (#a:_) (x:t a) ([@@@smt_fallback]v: cell a) = pts_to x full_perm v
 
 /// The core queue separation logic predicate.
 /// It is indexed by a head and tail pointer.
-val queue (#a:_) ([@@@smt_fallback] hd:Ghost.erased (t a))
-                 ([@@@smt_fallback] tl:Ghost.erased (t a)) : vprop
+val queue (#a:_) ([@@@smt_fallback] hd:t a)
+                 ([@@@smt_fallback] tl:t a) : vprop
 
 /// Creating a new queue containing element [v].
 val new_queue (#a:_) (v:a) :
@@ -69,7 +69,7 @@ assume atomic field update primitive:
 let dequeue_post_success (#a:_) ([@@@smt_fallback]tl:Ghost.erased (t a))
                                 ([@@@smt_fallback]hd:t a)
                                 ([@@@smt_fallback]p:t a) =
-      h_exists (fun (c:Ghost.erased (cell a)) -> pts_to hd c `star` pure (Ghost.reveal p == c.next) `star` queue p tl)
+      h_exists (fun (c:cell a) -> pts_to hd c `star` pure (p == c.next) `star` queue p tl)
 
 let dequeue_post (#a:_) ([@@@smt_fallback]tl:Ghost.erased (t a))
                         ([@@@smt_fallback]hd:t a)

--- a/examples/steel/Selectors.PtrLList.fst
+++ b/examples/steel/Selectors.PtrLList.fst
@@ -349,7 +349,7 @@ let lemma_cons_not_null (#a:Type) (ptr:t a) (l:list a) (m:mem) : Lemma
       | (hd, v)::tl ->
           let p = pts_to_sl ptr full_perm (hide hd) `Mem.star`
             llist_ptr_sl' (next hd) tl `Mem.star`
-            pts_to_sl (data hd) full_perm (hide v) in
+            pts_to_sl (data hd) full_perm v in
           pure_star_interp p (ptr =!= null_llist) m
 
 let cons_is_not_null #a ptr =

--- a/ulib/experimental/Steel.Array.fst
+++ b/ulib/experimental/Steel.Array.fst
@@ -28,7 +28,7 @@ let length #t (x:array t) = dfst x
 let is_array r = ptr (dsnd r)
 let array_sel r = ptr_sel (dsnd r)
 
-let varray_pts_to (#t:Type) (a:array t) (x:elseq t (length a))
+let varray_pts_to (#t:Type) (a:array t) (x:Seq.lseq t (length a))
   : vprop
   = Steel.Reference.pts_to (dsnd a) Steel.FractionalPermission.full_perm x
 
@@ -447,24 +447,12 @@ let compare_pts (#t:eqtype)
         then (
           R.write_pt ctr (Some U32.(i +^ 1ul));
           extend_equal_up_to l i;
-          assert_spinoff
-            (pure (equal_up_to s0 s1 (Some (U32.(i +^ 1ul)))) ==
-             pure (equal_up_to s0 s1 (Ghost.hide (Some (U32.(i +^ 1ul))))));
-          AT.change_equal_slprop
-            (pure (equal_up_to s0 s1 (Some (U32.(i +^ 1ul)))))
-            (pure (equal_up_to s0 s1 (Ghost.hide (Some (U32.(i +^ 1ul))))));
-          intro_exists_inv a0 a1 l ctr _
+          intro_exists_inv a0 a1 l ctr (Ghost.hide (Some (U32.(i +^ 1ul))))
         )
         else (
           R.write_pt ctr None;
           extend_equal_up_to_neg l i;
-          assert_spinoff
-            (pure (equal_up_to s0 s1 None) ==
-             pure (equal_up_to s0 s1 (Ghost.hide None)));
-          AT.change_equal_slprop
-            (pure (equal_up_to s0 s1 None))
-            (pure (equal_up_to s0 s1 (Ghost.hide None)));
-          intro_exists_inv a0 a1 l ctr _
+          intro_exists_inv a0 a1 l ctr (Ghost.hide None)
         )
     in
     init_inv a0 a1 l ctr;

--- a/ulib/experimental/Steel.Array.fsti
+++ b/ulib/experimental/Steel.Array.fsti
@@ -61,15 +61,12 @@ let asel (#a:Type) (#p:vprop) (r:array a)
 
 /// We also provide an indexed assertion to represent an array
 /// without a selector
-///
-///   - I would like to remove the erased here, but doing that would
-///     be much more convenient once we merge the reveal/hide rewrites
-///     in the normalizer
-let elseq a (n:nat) = Ghost.erased (Seq.lseq a n)
 
 /// The main indexed assertion
-val varray_pts_to (#t:Type) (a:array t) (x:elseq t (length a))
+val varray_pts_to (#t:Type) (a:array t) (x:Seq.lseq t (length a))
   : vprop
+
+type elseq a (n:nat) = Ghost.erased (Seq.lseq a n)
 
 /// Converting a `varray` into a `varray_pts_to`
 val intro_varray_pts_to (#t:_)

--- a/ulib/experimental/Steel.Channel.Simplex.fst
+++ b/ulib/experimental/Steel.Channel.Simplex.fst
@@ -222,14 +222,14 @@ let new_chan (p:prot) : SteelT (chan p) emp (fun c -> sender c p `star` receiver
     H.share recv;
     H.share send;
     (* TODO: use smt_fallback *)
-    rewrite_slprop (pts_to send (half_perm full_perm) (Ghost.hide v) `star`
-                   pts_to send (half_perm full_perm) (Ghost.hide v) `star`
-                   pts_to recv (half_perm full_perm) (Ghost.hide v) `star`
-                   pts_to recv (half_perm full_perm) (Ghost.hide v))
-                  (pts_to send half (Ghost.hide vp) `star`
-                   pts_to send half (Ghost.hide vp) `star`
-                   pts_to recv half (Ghost.hide vp) `star`
-                   pts_to recv half (Ghost.hide vp))
+    rewrite_slprop (pts_to send (half_perm full_perm) v `star`
+                   pts_to send (half_perm full_perm) v `star`
+                   pts_to recv (half_perm full_perm) v `star`
+                   pts_to recv (half_perm full_perm) v)
+                  (pts_to send half vp `star`
+                   pts_to send half vp `star`
+                   pts_to recv half vp `star`
+                   pts_to recv half vp)
                   (fun _ -> ());
     let c = mk_chan send recv vp in
     intro_in_state send p vp;

--- a/ulib/experimental/Steel.DisposableInvariant.fst
+++ b/ulib/experimental/Steel.DisposableInvariant.fst
@@ -28,7 +28,7 @@ open Steel.Reference
 [@@__reduce__]
 let conditional_inv (r:ghost_ref bool) (p:vprop) =
       (fun (b:bool) ->
-         ghost_pts_to r (half_perm full_perm) (hide b) `star`
+         ghost_pts_to r (half_perm full_perm) b `star`
          (if b then p else emp))
 
 [@@__reduce__]
@@ -42,7 +42,7 @@ let gref (#p:_) (i:inv p) = dfst i
 
 [@@__reduce__]
 let active (#p:_) ([@@@smt_fallback]f:perm) (i:inv p) =
-  ghost_pts_to (gref i) (half_perm f) (hide true)
+  ghost_pts_to (gref i) (half_perm f) true
 
 let new_inv #u p =
   let r = ghost_alloc_pt (Ghost.hide true) in
@@ -50,12 +50,12 @@ let new_inv #u p =
   intro_exists true (conditional_inv r p);
   let i = new_invariant (ex_conditional_inv r p) in
   rewrite_slprop
-    (ghost_pts_to r (half_perm full_perm) (hide true))
-    (ghost_pts_to (gref (hide (| r, i |))) (half_perm full_perm) (hide true))
+    (ghost_pts_to r (half_perm full_perm) true)
+    (ghost_pts_to (gref (hide (| r, i |))) (half_perm full_perm) true)
     (fun _ -> ());
   (| r, i |)
 
-let share #p #f #u i = ghost_share_pt (gref i)
+let share #p #f #u i = ghost_share_pt #_ #_ #_ #(hide true) (gref i)
 
 let gather #p #f0 #f1 #u i =
   ghost_gather_pt #_ #_ #(half_perm f0) (gref i);

--- a/ulib/experimental/Steel.HigherReference.fst
+++ b/ulib/experimental/Steel.HigherReference.fst
@@ -95,7 +95,7 @@ let pts_to_ref_injective
       (#a: Type u#1)
       (r: ref a)
       (p0 p1:perm)
-      (v0 v1: erased a)
+      (v0 v1:a)
       (m:mem)
     : Lemma
       (requires
@@ -115,7 +115,7 @@ let pts_to_ref_injective
 let pts_to_not_null (#a:Type u#1)
                     (r:ref a)
                     (p:perm)
-                    (v: erased a)
+                    (v:a)
                     (m:mem)
   : Lemma (requires interp (pts_to_sl r p v) m)
           (ensures r =!= null)
@@ -153,7 +153,7 @@ let alloc #a x =
   assert (FStar.PCM.composable pcm_frac v None);
   assert (compatible pcm_frac v v);
   let r = RP.alloc v in
-  rewrite_slprop (RP.pts_to r v) (pts_to r full_perm (hide x))
+  rewrite_slprop (RP.pts_to r v) (pts_to r full_perm x)
     (fun m ->
       emp_unit (hp_of (pts_to_raw r full_perm x));
       pure_star_interp (hp_of (pts_to_raw r full_perm x)) (perm_ok full_perm) m
@@ -364,7 +364,7 @@ let cas_action (#t:Type) (eq: (x:t -> y:t -> b:bool{b <==> (x == y)}))
 let ghost_ref a = erased (ref a)
 
 [@@__reduce__]
-let ghost_pts_to_sl #a (r:ghost_ref a) (p:perm) (x:erased a) = pts_to_sl (reveal r) p x
+let ghost_pts_to_sl #a (r:ghost_ref a) (p:perm) (x:a) = pts_to_sl (reveal r) p x
 
 let ghost_pts_to_witinv (#a:Type) (r:ghost_ref a) (p:perm) : Lemma (is_witness_invariant (ghost_pts_to_sl r p)) =
   let aux (x y : erased a) (m:mem)
@@ -391,7 +391,6 @@ let ghost_alloc_aux (#a:Type) (#u:_) (x:a)
 
 let ghost_alloc x =
   let r = ghost_alloc_aux (reveal x) in
-  rewrite_slprop (pts_to r full_perm (hide (reveal x))) (ghost_pts_to r full_perm x) (fun _ -> ());
   hide r
 
 let ghost_free #a #u #v r =

--- a/ulib/experimental/Steel.HigherReference.fsti
+++ b/ulib/experimental/Steel.HigherReference.fsti
@@ -41,11 +41,11 @@ val is_null (#a:Type u#1) (r:ref a) : (b:bool{b <==> r == null})
 /// The standard points to separation logic assertion, expressing that
 /// reference [r] is valid in memory, stores value [v], and that we have
 /// permission [p] on it.
-val pts_to_sl (#a:Type u#1) (r:ref a) (p:perm) (v:erased a) : slprop u#1
+val pts_to_sl (#a:Type u#1) (r:ref a) (p:perm) (v:a) : slprop u#1
 
 /// Lifting the standard points to predicate to vprop, with a non-informative selector
 [@@ __steel_reduce__]
-unfold let pts_to (#a:Type u#1) (r:ref a) (p:perm) (v:erased a) : vprop =
+unfold let pts_to (#a:Type u#1) (r:ref a) (p:perm) (v:a) : vprop =
   to_vprop (pts_to_sl r p v)
 
 /// If two pts_to predicates on the same reference [r] are valid in the memory [m],
@@ -54,7 +54,7 @@ val pts_to_ref_injective
       (#a: Type u#1)
       (r: ref a)
       (p0 p1:perm)
-      (v0 v1: erased a)
+      (v0 v1:a)
       (m:mem)
     : Lemma
       (requires
@@ -65,7 +65,7 @@ val pts_to_ref_injective
 val pts_to_not_null (#a:Type u#1)
                     (x:ref a)
                     (p:perm)
-                    (v: erased a)
+                    (v:a)
                     (m:mem)
   : Lemma (requires interp (pts_to_sl x p v) m)
           (ensures x =!= null)
@@ -133,7 +133,7 @@ val gather (#a:Type) (#uses:_) (#p0:perm) (#p1:perm) (#v0 #v1:erased a) (r:ref a
 val cas_action (#t:Type) (eq: (x:t -> y:t -> b:bool{b <==> (x == y)}))
                (#uses:inames)
                (r:ref t)
-               (v:Ghost.erased t)
+               (v:erased t)
                (v_old:t)
                (v_new:t)
    : action_except (b:bool{b <==> (Ghost.reveal v == v_old)})
@@ -152,10 +152,10 @@ val cas_action (#t:Type) (eq: (x:t -> y:t -> b:bool{b <==> (x == y)}))
 [@@ erasable]
 val ghost_ref (a:Type u#1) : Type u#0
 
-val ghost_pts_to_sl (#a:_) (r:ghost_ref a) (p:perm) (x:erased a) : slprop u#1
+val ghost_pts_to_sl (#a:_) (r:ghost_ref a) (p:perm) (x:a) : slprop u#1
 
 [@@ __steel_reduce__]
-unfold let ghost_pts_to (#a:_) (r:ghost_ref a) (p:perm) (x:erased a) : vprop =
+unfold let ghost_pts_to (#a:_) (r:ghost_ref a) (p:perm) (x:a) : vprop =
   to_vprop (ghost_pts_to_sl r p x)
 
 val ghost_pts_to_witinv (#a:Type) (r:ghost_ref a) (p:perm) : Lemma (is_witness_invariant (ghost_pts_to_sl r p))

--- a/ulib/experimental/Steel.Reference.fsti
+++ b/ulib/experimental/Steel.Reference.fsti
@@ -47,13 +47,13 @@ val is_null (#a:Type0) (r:ref a) : (b:bool{b <==> r == null})
 /// The standard points to separation logic assertion, expressing that
 /// reference [r] is valid in memory, stores value [v], and that we have
 /// permission [p] on it.
-val pts_to_sl (#a:Type0) (r:ref a) (p:perm) (v:erased a) : slprop u#1
+val pts_to_sl (#a:Type0) (r:ref a) (p:perm) (v:a) : slprop u#1
 
 /// Lifting the standard points to predicate to vprop, with a non-informative selector.
 /// The permission [p] and the value [v] are annotated with the smt_fallback attribute,
 /// enabling SMT rewriting on them during frame inference
 [@@ __steel_reduce__]
-let pts_to (#a:Type0) (r:ref a) ([@@@smt_fallback] p:perm) ([@@@ smt_fallback] v:erased a)
+let pts_to (#a:Type0) (r:ref a) ([@@@smt_fallback] p:perm) ([@@@ smt_fallback] v:a)
   = to_vprop (pts_to_sl r p v)
 
 /// If two pts_to predicates on the same reference [r] are valid in the memory [m],
@@ -62,7 +62,7 @@ val pts_to_ref_injective
       (#a: Type u#0)
       (r: ref a)
       (p0 p1:perm)
-      (v0 v1: erased a)
+      (v0 v1:a)
       (m:mem)
     : Lemma
       (requires
@@ -73,7 +73,7 @@ val pts_to_ref_injective
 val pts_to_not_null (#a:Type u#0)
                     (x:ref a)
                     (p:perm)
-                    (v: erased a)
+                    (v:a)
                     (m:mem)
   : Lemma (requires interp (pts_to_sl x p v) m)
           (ensures x =!= null)
@@ -325,13 +325,13 @@ val ghost_ref (a:Type u#0) : Type u#0
 
 (* Textbook separation logic version of ghost references *)
 
-val ghost_pts_to_sl (#a:_) (r:ghost_ref a) (p:perm) (v:erased a) : slprop u#1
+val ghost_pts_to_sl (#a:_) (r:ghost_ref a) (p:perm) (v:a) : slprop u#1
 
 [@@ __steel_reduce__]
 let ghost_pts_to (#a:Type0)
   (r:ghost_ref a)
   ([@@@smt_fallback] p:perm)
-  ([@@@ smt_fallback] v:erased a)
+  ([@@@ smt_fallback] v:a)
   : vprop
   = to_vprop (ghost_pts_to_sl r p v)
 

--- a/ulib/experimental/Steel.SpinLock.fst
+++ b/ulib/experimental/Steel.SpinLock.fst
@@ -28,7 +28,7 @@ let available = false
 let locked = true
 
 let lockinv (p:vprop) (r:ref bool) : vprop =
-  h_exists (fun b -> pts_to r full_perm (Ghost.hide b) `star` (if b then emp else p))
+  h_exists (fun b -> pts_to r full_perm b `star` (if b then emp else p))
 
 let lock_t = ref bool & erased iname
 
@@ -43,13 +43,13 @@ val intro_lockinv_locked (#uses:inames) (p:vprop) (r:ref bool)
 let intro_lockinv_available #uses p r =
   intro_exists false
     (fun (b: bool) ->
-      pts_to r full_perm (Ghost.hide b) `star`
+      pts_to r full_perm b `star`
         (if b then emp else p)
     )
 
 let intro_lockinv_locked #uses p r =
   intro_exists true
-    (fun b -> pts_to r full_perm (Ghost.hide b) `star`
+    (fun b -> pts_to r full_perm b `star`
           (if b then emp else p))
 
 let new_lock (p:vprop)


### PR DESCRIPTION
This PR changes the signature of vprop arguments in the steel references and array libraries so that they are non-erased. E.g. the signature of `pts_to` is `#a -> ref a -> a`, as opposed to `#a -> ref a -> erased a`. With `reveal (hide x) ~> x` normalization, this style works well and simplifies a lot of `hide/reveal` reasoning in vprops.