### PR TITLE
added a missing typing axiom in the SMT encoding for Prims.b2t

### DIFF
--- a/src/ocaml-output/FStar_SMTEncoding_Encode.ml
+++ b/src/ocaml-output/FStar_SMTEncoding_Encode.ml
@@ -4355,6 +4355,10 @@ and (encode_sigelt' :
                 let b2t_x = FStar_SMTEncoding_Util.mkApp ("Prims.b2t", [x]) in
                 let valid_b2t_x =
                   FStar_SMTEncoding_Util.mkApp ("Valid", [b2t_x]) in
+                let bool_ty =
+                  let uu___10 =
+                    FStar_Syntax_Syntax.withsort FStar_Parser_Const.bool_lid in
+                  FStar_SMTEncoding_Env.lookup_free_var env1 uu___10 in
                 let decls =
                   let uu___10 =
                     let uu___11 =
@@ -4376,7 +4380,30 @@ and (encode_sigelt' :
                         (uu___13, (FStar_Pervasives_Native.Some "b2t def"),
                           "b2t_def") in
                       FStar_SMTEncoding_Util.mkAssume uu___12 in
-                    [uu___11] in
+                    let uu___12 =
+                      let uu___13 =
+                        let uu___14 =
+                          let uu___15 =
+                            let uu___16 = FStar_Syntax_Syntax.range_of_fv b2t in
+                            let uu___17 =
+                              let uu___18 =
+                                let uu___19 =
+                                  let uu___20 =
+                                    FStar_SMTEncoding_Term.mk_HasType x
+                                      bool_ty in
+                                  let uu___21 =
+                                    FStar_SMTEncoding_Term.mk_HasType b2t_x
+                                      FStar_SMTEncoding_Term.mk_Term_type in
+                                  (uu___20, uu___21) in
+                                FStar_SMTEncoding_Util.mkImp uu___19 in
+                              ([[b2t_x]], [xx], uu___18) in
+                            FStar_SMTEncoding_Term.mkForall uu___16 uu___17 in
+                          (uu___15,
+                            (FStar_Pervasives_Native.Some "b2t typing"),
+                            "b2t_typing") in
+                        FStar_SMTEncoding_Util.mkAssume uu___14 in
+                      [uu___13] in
+                    uu___11 :: uu___12 in
                   (FStar_SMTEncoding_Term.DeclFun
                      (tname, [FStar_SMTEncoding_Term.Term_sort],
                        FStar_SMTEncoding_Term.Term_sort,

--- a/src/smtencoding/FStar.SMTEncoding.Encode.fs
+++ b/src/smtencoding/FStar.SMTEncoding.Encode.fs
@@ -1174,11 +1174,17 @@ and encode_sigelt' (env:env_t) (se:sigelt) : (decls_t * env_t) =
        let x = mkFreeV xx in
        let b2t_x = mkApp("Prims.b2t", [x]) in
        let valid_b2t_x = mkApp("Valid", [b2t_x]) in //NS: Explicitly avoid the Vaild(b2t t) inlining
+       let bool_ty = lookup_free_var env (withsort Const.bool_lid) in
        let decls = [Term.DeclFun(tname, [Term_sort], Term_sort, None);
                     Util.mkAssume(mkForall (S.range_of_fv b2t) ([[b2t_x]], [xx],
                                            mkEq(valid_b2t_x, mkApp(snd boxBoolFun, [x]))),
                                 Some "b2t def",
-                                "b2t_def")] in
+                                "b2t_def");
+                    Util.mkAssume(mkForall (S.range_of_fv b2t) ([[b2t_x]], [xx],
+                                           mkImp(mk_HasType x bool_ty,
+                                                 mk_HasType b2t_x mk_Term_type)),
+                                Some "b2t typing",
+                                "b2t_typing")] in
        decls |> mk_decls_trivial, env
 
     | Sig_let(_, _) when (se.sigquals |> BU.for_some (function Discriminator _ -> true | _ -> false)) ->


### PR DESCRIPTION
Surprisingly, a typing axiom that states that `HasType (b2t b) Type` was missing from the SMT encoding. This PR adds it.