### PR TITLE
Build F* with sedlex 2.4

### DIFF
--- a/fstar.opam
+++ b/fstar.opam
@@ -15,7 +15,7 @@ depends: [
   "fileutils"
   "menhir" {>= "20161115" build}
   "pprint" {build}
-  "sedlex" {< "2.4" build}
+  "sedlex" {build}
   "ppxlib" {>= "0.22.0"}
   "ppx_deriving"
   "ppx_deriving_yojson"

--- a/src/parser/ml/FStar_Sedlexing.ml
+++ b/src/parser/ml/FStar_Sedlexing.ml
@@ -100,3 +100,14 @@ let source_file b =
 
 let current_line b =
   b.cur_p.Lexing.pos_lnum
+
+(* Since sedlex 2.4, we need to expose Sedlexing.__private_next_int
+   (see #2343)
+
+   From https://github.com/ocaml-communi-ty/sedlex/blob/268c553f474457574e22701679d68f66aa771551/src/lib/sedlexing.mli#L154-L161
+   [next] and [__private__next_int] have the same doc description,
+   the only difference is the return type *)
+let __private__next_int b =
+  match next b with
+  | Some v -> Uchar.to_int v
+  | None -> -1


### PR DESCRIPTION
This PR fixes #2343: F* has long not built with sedlex 2.4.

As @toots pointed out at https://github.com/FStarLang/FStar/issues/2343#issuecomment-962492550 , we are actually "replacing" sedlex's `Sedlexing` module with our own `src/parser/ml/FStar_Sedlexing.ml`, namely by:
https://github.com/FStarLang/FStar/blob/2b830a415628bd3832f3774a8f8c551d13fd1e62/src/parser/ml/FStar_Parser_LexFStar.ml#L7

There, I noticed that `__private__next_int` was not defined in our `FStar_Sedlexing`, but the lexer implementation generated by sedlex 2.4 does use that function. So I add it in this PR.

With this PR, `docker build --pull --file .docker/opam.Dockerfile .` successfully builds a Docker image that installs sedlex 2.4, builds F* against it, and run all F* regression tests.

Thank you Romain for your insights!
