### PR TITLE
Protz m1

### DIFF
--- a/src/ocaml-output/Makefile
+++ b/src/ocaml-output/Makefile
@@ -119,9 +119,11 @@ $(FSTAR_MAIN_NATIVE): $(GENERATED_FILES)
 	$(Q)$(OCAMLBUILD) $(notdir $(FSTAR_MAIN_NATIVE)) FStar_Syntax_Syntax.inferred.mli
 
 ../../bin/fstar.exe: $(FSTAR_MAIN_NATIVE)
+	rm $@
 	$(Q)cp $^ $@
 
 ../../bin/fstar.ocaml: $(FSTAR_MAIN_NATIVE)
+	rm $@
 	$(Q)cp $^ $@
 
 install-compiler-lib: $(FSTAR_MAIN_NATIVE)

--- a/src/ocaml-output/Makefile
+++ b/src/ocaml-output/Makefile
@@ -119,11 +119,11 @@ $(FSTAR_MAIN_NATIVE): $(GENERATED_FILES)
 	$(Q)$(OCAMLBUILD) $(notdir $(FSTAR_MAIN_NATIVE)) FStar_Syntax_Syntax.inferred.mli
 
 ../../bin/fstar.exe: $(FSTAR_MAIN_NATIVE)
-	rm $@
+	$(Q)rm -f $@
 	$(Q)cp $^ $@
 
 ../../bin/fstar.ocaml: $(FSTAR_MAIN_NATIVE)
-	rm $@
+	$(Q)rm -f $@
 	$(Q)cp $^ $@
 
 install-compiler-lib: $(FSTAR_MAIN_NATIVE)


### PR DESCRIPTION
https://stackoverflow.com/questions/67378106/mac-m1-cping-binary-over-another-results-in-crash has the details, but basically cp'ing is not cool anymore and the target file needs to be removed first so that a new inode can be allocated.