### PR TITLE
A patch to the unifier to treat arithmetic and boolean operators as interpreted symbols

### DIFF
--- a/src/ocaml-output/FStar_TypeChecker_Env.ml
+++ b/src/ocaml-output/FStar_TypeChecker_Env.ml
@@ -3802,7 +3802,9 @@ let (is_interpreted : env -> FStar_Syntax_Syntax.term -> Prims.bool) =
       | FStar_Syntax_Syntax.Tm_fvar fv ->
           (match fv.FStar_Syntax_Syntax.fv_delta with
            | FStar_Syntax_Syntax.Delta_equational_at_level uu___1 -> true
-           | uu___1 -> false)
+           | uu___1 -> false) ||
+            (fv_has_attr env1 fv
+               FStar_Parser_Const.smt_theory_symbol_attr_lid)
       | uu___1 -> false
 let (is_irreducible : env -> FStar_Ident.lident -> Prims.bool) =
   fun env1 ->

--- a/src/ocaml-output/FStar_TypeChecker_Env.ml
+++ b/src/ocaml-output/FStar_TypeChecker_Env.ml
@@ -3803,8 +3803,10 @@ let (is_interpreted : env -> FStar_Syntax_Syntax.term -> Prims.bool) =
           (match fv.FStar_Syntax_Syntax.fv_delta with
            | FStar_Syntax_Syntax.Delta_equational_at_level uu___1 -> true
            | uu___1 -> false) ||
-            (fv_has_attr env1 fv
-               FStar_Parser_Const.smt_theory_symbol_attr_lid)
+            (FStar_Compiler_Util.for_some
+               (FStar_Ident.lid_equals
+                  (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v)
+               interpreted_symbols)
       | uu___1 -> false
 let (is_irreducible : env -> FStar_Ident.lident -> Prims.bool) =
   fun env1 ->

--- a/src/typechecker/FStar.TypeChecker.Env.fs
+++ b/src/typechecker/FStar.TypeChecker.Env.fs
@@ -1101,7 +1101,8 @@ let is_interpreted =
         | Tm_fvar fv ->
             (match fv.fv_delta with
              | Delta_equational_at_level _ -> true
-             | _ -> false)
+             | _ -> false) ||
+            (fv_has_attr env fv Const.smt_theory_symbol_attr_lid)
             //U.for_some (Ident.lid_equals fv.fv_name.v) interpreted_symbols
         | _ -> false
 

--- a/src/typechecker/FStar.TypeChecker.Env.fs
+++ b/src/typechecker/FStar.TypeChecker.Env.fs
@@ -1102,8 +1102,7 @@ let is_interpreted =
             (match fv.fv_delta with
              | Delta_equational_at_level _ -> true
              | _ -> false) ||
-            (fv_has_attr env fv Const.smt_theory_symbol_attr_lid)
-            //U.for_some (Ident.lid_equals fv.fv_name.v) interpreted_symbols
+            BU.for_some (Ident.lid_equals fv.fv_name.v) interpreted_symbols
         | _ -> false
 
 let is_irreducible env l =

--- a/tests/micro-benchmarks/UnifierArith.fst
+++ b/tests/micro-benchmarks/UnifierArith.fst
@@ -1,0 +1,17 @@
+module UnifierArith
+assume
+val vec (n:int) : Type
+assume
+val n :int
+assume
+val m :int
+assume
+val nnn : squash (n <= m /\ n <> 0)
+assume
+val v:vec (m - n)
+
+// A bug in the unifier which was treating (-) structurally rather
+// than as an interpreted symbol would cause it to generate a VC to
+// prove that `m - n == (m - 1) - (n - 1)` by equating `m = m - 1` and
+// `n = n - 1`, which of course fails.
+let v' : vec ((m - 1) - (n - 1)) = v


### PR DESCRIPTION
See UnifierArith.fst for a test case illustrating the bug which this 1 liner PR fixes.

It also has an Everest green