### PR TITLE
Fix for a bug in the positivity check

### DIFF
--- a/src/ocaml-output/FStar_TypeChecker_TcInductive.ml
+++ b/src/ocaml-output/FStar_TypeChecker_TcInductive.ml
@@ -899,20 +899,6 @@ let (generalize_and_inst_within :
                                                    failwith "Impossible"))
                                      data_types datas in
                              (tcs1, datas1))))))
-let (debug_log :
-  FStar_TypeChecker_Env.env_t -> (unit -> Prims.string) -> unit) =
-  fun env ->
-    fun msg ->
-      let uu___ =
-        FStar_Compiler_Effect.op_Less_Bar (FStar_TypeChecker_Env.debug env)
-          (FStar_Options.Other "Positivity") in
-      if uu___
-      then
-        let uu___1 =
-          let uu___2 = let uu___3 = msg () in Prims.op_Hat uu___3 "\n" in
-          Prims.op_Hat "Positivity::" uu___2 in
-        FStar_Compiler_Util.print_string uu___1
-      else ()
 let (datacon_typ : FStar_Syntax_Syntax.sigelt -> FStar_Syntax_Syntax.term) =
   fun data ->
     match data.FStar_Syntax_Syntax.sigel with

--- a/src/ocaml-output/FStar_TypeChecker_Util.ml
+++ b/src/ocaml-output/FStar_TypeChecker_Util.ml
@@ -7521,7 +7521,11 @@ let rec (ty_strictly_positive_in_type :
                       FStar_Compiler_Effect.op_Bar_Greater fv_us_opt
                         FStar_Compiler_Util.is_none in
                     if uu___4
-                    then true
+                    then
+                      (debug_positivity env
+                         (fun uu___6 ->
+                            "ty is an app node with head that is not an fv, returning false");
+                       false)
                     else
                       (let uu___6 =
                          FStar_Compiler_Effect.op_Bar_Greater fv_us_opt

--- a/src/typechecker/FStar.TypeChecker.TcInductive.fs
+++ b/src/typechecker/FStar.TypeChecker.TcInductive.fs
@@ -284,10 +284,6 @@ let generalize_and_inst_within (env:env_t) (tcs:list<(sigelt * universe)>) (data
         tcs, datas
 
 
-let debug_log (env:env_t) (msg : unit -> string) : unit =
-    if Env.debug env <| Options.Other "Positivity" then
-      BU.print_string ("Positivity::" ^ msg () ^ "\n")
-
 let datacon_typ (data:sigelt) :term =
   match data.sigel with
   | Sig_datacon (_, _, t, _, _, _) -> t

--- a/src/typechecker/FStar.TypeChecker.Util.fs
+++ b/src/typechecker/FStar.TypeChecker.Util.fs
@@ -3383,7 +3383,10 @@ let rec ty_strictly_positive_in_type env (ty_lid:lident) (btype:term) (unfolded:
      | Tm_app (t, args) ->  //the binder type is an application
        //get the head node fv
        let fv_us_opt = try_get_fv t in
-       if fv_us_opt |> is_none then true  //head is not an fv, ok
+       if fv_us_opt |> is_none then begin
+         debug_positivity env (fun () -> "ty is an app node with head that is not an fv, returning false");
+         false  //head is not an fv, ok
+       end
        else
          let fv, us = fv_us_opt |> must in
          //if it's same as ty_lid, then check that ty_lid does not occur in the arguments

--- a/tests/bug-reports/Bug1507.fst
+++ b/tests/bug-reports/Bug1507.fst
@@ -1,5 +1,21 @@
 module Bug1507
 
+(*
+ * This type should be rejected since f may be instantiated with an arrow
+ *   that could lead to proof of False, e.g.
+ *
+ * let f_false : Type0 -> Type0 = fun a -> (a -> squash False)
+ *
+ * let g : f_false (mu f_false) =
+ *   fun x ->
+ *   match x with
+ *   | Mu h -> h x
+ *
+ * let r1 : squash False = g (Mu g)
+ *
+ *)
+
+[@@ expect_failure]
 noeq
 type mu (f: Type -> Type) = 
     | Mu of f (mu f)

--- a/tests/micro-benchmarks/Positivity.fst
+++ b/tests/micro-benchmarks/Positivity.fst
@@ -93,3 +93,24 @@ val t_t19 ([@@@ strictly_positive] a:Type0) : Type0
 let t_t19 a = a -> int
 
 let t_t19 a = list a
+
+(*
+ * This type should be rejected since f may be instantiated with an arrow
+ *   that could lead to proof of False, e.g.
+ *
+ * let f_false : Type0 -> Type0 = fun a -> (a -> squash False)
+ *
+ * let g : f_false (t_t20 f_false) =
+ *   fun x ->
+ *   match x with
+ *   | C201 h -> h x
+ *
+ * let r1 : squash False = g (C201 g)
+ *
+ *)
+
+[@@ expect_failure]
+noeq
+type t_t20 (f:Type0 -> Type0) =
+  | C201 : f (free f) -> free f
+


### PR DESCRIPTION
This works in master:

```
module Test

noeq
type free (f:Type0 → Type0) =
  | Free : f (free f) → free f

let f_false : Type0 → Type0 = λ a → (a → squash ⊥)

let g : f_false (free f_false) =
  λ x →
  match x with
  | Free h → h x

let r1 : squash ⊥ = g (Free g)
```

In the code, when we are checking for positivity in a binder type for a data constructor, when the binder type is an application, and the head node is not an `fvar`, we were returning `true` (meaning positivity check passes).

In this PR, I am switching it to return `false`. The reason is that, just before this check, we are actually normalizing the type until delta constant 0. If after this too, we can't figure out the head term, to be conservative, we should be returning `false`.