### PR TITLE
Unlock OCaml >= 4.13

### DIFF
--- a/fstar.opam
+++ b/fstar.opam
@@ -5,7 +5,7 @@ authors: "Nik Swamy <nswamy@microsoft.com>,Jonathan Protzenko <protz@microsoft.c
 homepage: "http://fstar-lang.org"
 license: "Apache-2.0"
 depends: [
-  "ocaml" {>= "4.04.1" & < "4.13.0" }
+  "ocaml" {>= "4.04.1"}
   "ocamlfind"
   "batteries"
   "zarith"


### PR DESCRIPTION
Tested locally on macOS/arm64 it compiles fine on both OCaml 4.13 and 4.14