### PR TITLE
Steel effect: Assume requires clause when typechecking ensures

### DIFF
--- a/ulib/experimental/Steel.Effect.Atomic.fst
+++ b/ulib/experimental/Steel.Effect.Atomic.fst
@@ -643,7 +643,7 @@ let new_invariant #uses p =
  *)
 assume val reify_steel_atomic_comp
   (#a:Type) (#framed:bool) (#opened_invariants:inames) (#g:observability)
-  (#pre:pre_t) (#post:post_t a) (#req:req_t pre) (#ens:ens_t pre a post)
+  (#pre:pre_t) (#post:post_t a) (#req:req_t pre) (#ens:ens_t pre req a post)
   ($f:unit -> SteelAtomicBase a framed opened_invariants g pre post req ens)
   : repr a framed opened_invariants g pre post req ens
 
@@ -655,7 +655,7 @@ let with_invariant #a #fp #fp' #opened #p i f =
 
 assume val reify_steel_ghost_comp
   (#a:Type) (#framed:bool) (#opened_invariants:inames)
-  (#pre:pre_t) (#post:post_t a) (#req:req_t pre) (#ens:ens_t pre a post)
+  (#pre:pre_t) (#post:post_t a) (#req:req_t pre) (#ens:ens_t pre req a post)
   ($f:unit -> SteelGhostBase a framed opened_invariants Unobservable pre post req ens)
   : repr a framed opened_invariants Unobservable pre post req ens
 

--- a/ulib/experimental/Steel.Effect.Common.fst
+++ b/ulib/experimental/Steel.Effect.Common.fst
@@ -84,6 +84,7 @@ let lemma_frame_emp h0 h1 p =
   FStar.PropositionalExtensionality.apply True (h0 (VUnit emp') == h1 (VUnit emp'))
 
 let elim_conjunction p1 p1' p2 p2' = ()
+let elim_left a b = ()
 
 let equiv_can_be_split p1 p2 = ()
 let intro_can_be_split_frame p q frame = ()

--- a/ulib/experimental/Steel.Effect.Common.fsti
+++ b/ulib/experimental/Steel.Effect.Common.fsti
@@ -259,8 +259,8 @@ val reveal_mk_rmem (r:vprop) (h:hmem r) (r0:vprop{r `can_be_split` r0})
 (* Logical pre and postconditions can only access the restricted view of the heap *)
 
 type req_t (pre:pre_t) = rmem pre -> Type0
-type ens_t (pre:pre_t) (a:Type) (post:post_t a) =
-  rmem pre -> (x:a) -> rmem (post x) -> Type0
+type ens_t (pre:pre_t) (req:req_t pre) (a:Type) (post:post_t a) =
+  (h0:rmem pre{req h0}) -> (x:a) -> rmem (post x) -> Type0
 
 (* Empty assertion *)
 val emp : vprop

--- a/ulib/experimental/Steel.Effect.Common.fsti
+++ b/ulib/experimental/Steel.Effect.Common.fsti
@@ -2418,7 +2418,7 @@ let ite_soundness_tac () : Tac unit =
 /// Normalization step for VC generation, used in Steel and SteelAtomic subcomps
 /// This tactic is executed after frame inference, and just before sending the query to the SMT
 /// As such, it is a good place to add debugging features to inspect SMT queries when needed
-let vc_norm () : Tac unit = norm normal_steps; trefl(); dump_all false "here"
+let vc_norm () : Tac unit = norm normal_steps; trefl()
 
 ////////////////////////////////////////////////////////////////////////////////
 //Common datatypes for the atomic & ghost effects

--- a/ulib/experimental/Steel.Effect.fst
+++ b/ulib/experimental/Steel.Effect.fst
@@ -66,7 +66,8 @@ let ens_to_act_ens (#pre:pre_t) (#a:Type) (#post:post_t a) (#req:req_t pre) (ens
 = rmem_depends_only_on pre;
   rmem_depends_only_on_post post;
   fun m0 x m1 ->
-    interp (hp_of pre) m0 /\ interp (hp_of (post x)) m1 /\ req (mk_rmem pre m0) /\ ens (mk_rmem pre m0) x (mk_rmem (post x) m1)
+    interp (hp_of pre) m0 /\ interp (hp_of (post x)) m1 /\
+    req (mk_rmem pre m0) /\ ens (mk_rmem pre m0) x (mk_rmem (post x) m1)
 
 let reveal_focus_rmem (#r:vprop) (h:rmem r) (r0:vprop{r `can_be_split` r0}) (r':vprop{r0 `can_be_split` r'})
   : Lemma (

--- a/ulib/experimental/Steel.Effect.fsti
+++ b/ulib/experimental/Steel.Effect.fsti
@@ -285,7 +285,7 @@ unfold
 let bind_pure_steel__ens (#a:Type) (#b:Type)
   (wp:pure_wp a)
   (#pre:pre_t) (#post:post_t b) (#req:a -> req_t pre)
-  (ens:(x:a) -> ens_t pre (req x) b post)
+  (ens:(x:a -> ens_t pre (req x) b post))
 : ens_t pre (bind_pure_steel__req wp req) b post
 = fun m0 r m1 -> (as_requires wp /\ (exists (x:a). as_ensures wp x /\ (req x) m0 /\ ((ens x) m0 r m1)))
 
@@ -294,7 +294,8 @@ val bind_pure_steel_ (a:Type) (b:Type)
   (#[@@@ framing_implicit] wp:pure_wp a)
   (#framed:eqtype_as_type bool)
   (#[@@@ framing_implicit] pre:pre_t) (#[@@@ framing_implicit] post:post_t b)
-  (#[@@@ framing_implicit] req:a -> req_t pre) (#[@@@ framing_implicit] ens:(x:a) -> ens_t pre (req x) b post)
+  (#[@@@ framing_implicit] req:a -> req_t pre)
+  (#[@@@ framing_implicit] ens:(x:a) -> ens_t pre (req x) b post)
   (f:eqtype_as_type unit -> PURE a wp) (g:(x:a -> repr b framed pre post (req x) (ens x)))
 : repr b
     framed

--- a/ulib/experimental/Steel.Primitive.ForkJoin.Unix.fst
+++ b/ulib/experimental/Steel.Primitive.ForkJoin.Unix.fst
@@ -230,7 +230,7 @@ let as_steelk_repr' (a:Type) (pre:pre_t) (post:post_t a) (f:unit -> SteelT a pre
 
 
 let triv_pre (req:vprop) : req_t req = fun _ -> True
-let triv_post (#a:Type) (req:vprop) (ens:post_t a) : ens_t req a ens = fun _ _ _ -> True
+let triv_post (#a:Type) (req:vprop) (ens:post_t a) : ens_t req (triv_pre req) a ens = fun _ _ _ -> True
 
 let as_steelk_repr (a:Type) (pre:pre_t) (post:post_t a)
   (f:repr a false pre post (triv_pre pre) (triv_post pre post))// unit -> SteelT a pre post)

--- a/ulib/experimental/Steel.ST.Effect.AtomicAndGhost.fst
+++ b/ulib/experimental/Steel.ST.Effect.AtomicAndGhost.fst
@@ -54,12 +54,14 @@ let weaken_repr #a #framed #o #g
                 (#pre:pre_t)
                 (#post:post_t a)
                 (#req #req':req_t pre)
-                (#ens #ens':ens_t pre a post)
+                (#ens :ens_t pre req a post)
+                (#ens':ens_t pre req' a post)
                 ($f:SEA.repr a framed o g pre post req ens)
                 (_:squash (forall (h0:hmem pre).
                             req' (mk_rmem _ h0) ==>
                             req (mk_rmem _ h0)))
                 (_:squash (forall (h0:hmem pre) x (h1:hmem (post x)).
+                            req' (mk_rmem _ h0) ==>
                             ens (mk_rmem _ h0)
                                 x
                                 (mk_rmem _ h1) ==>

--- a/ulib/experimental/Steel.ST.Effect.fst
+++ b/ulib/experimental/Steel.ST.Effect.fst
@@ -39,12 +39,14 @@ let weaken_repr a framed
                 (pre:pre_t)
                 (post:post_t a)
                 (req req':req_t pre)
-                (ens ens':ens_t pre a post)
+                (ens:ens_t pre req a post)
+                (ens':ens_t pre req' a post)
                 (f:Steel.Effect.repr a framed pre post req ens)
                 (_:squash (forall (h0:hmem pre).
                             req' (mk_rmem _ h0) ==>
                             req (mk_rmem _ h0)))
                 (_:squash (forall (h0:hmem pre) x (h1:hmem (post x)).
+                            req' (mk_rmem _ h0) ==>
                             ens (mk_rmem _ h0)
                                 x
                                 (mk_rmem _ h1) ==>


### PR DESCRIPTION
Consider the following toy example, as reported by @cmovcc:
```fstar
let test (x: nat)
  : Steel nat
  emp (fun _ -> emp)
  (requires (fun _ -> x > 0))
  (ensures (fun _ r _ -> r = 1 / x))
  =
  return (1 / x)
  ```
While the requires clause is in the logical context when typechecking (and verifying) the body of the function, it is not when typechecking the ensures clause itself. Hence, 
```fstar
val test (x: nat)
  : Steel nat
  emp (fun _ -> emp)
  (requires (fun _ -> x > 0))
  (ensures (fun _ r _ -> r = 1 / x))
```
currently fails to typecheck, because the prover cannot determine that x <> 0 in the ensures clause.

This PR addresses this issue by adopting a similar technique as other existing pure and stateful effects: the type of the ensures clause (`Steel.Effect.Common.ens_t`) now assumes the validity of the requires clause on the initial state.

Most of the PR consists of propagating this change to the different Steel effect combinators.
There is also a minor tweak to the tactic in charge of rewriting frame equalities:
Because of the new refinement on the type of the initial `rmem` state, a refinement subtyping SMT goal is generated during the call to `rewrite_with_tactic`. Unfortunately, `rewrite_with_tactic` fails when goals are remaining instead of passing them to SMT. This should probably be fixed, but in the meantime, the generated SMT goal is taken care of in the `frame_vc_norm` tactic.

Fixes #2435 