### PR TITLE
Making record field disambiguation work with refinement types

### DIFF
--- a/src/ocaml-output/FStar_TypeChecker_Cfg.ml
+++ b/src/ocaml-output/FStar_TypeChecker_Cfg.ml
@@ -29,7 +29,8 @@ type fsteps =
   in_full_norm_request: Prims.bool ;
   weakly_reduce_scrutinee: Prims.bool ;
   nbe_step: Prims.bool ;
-  for_extraction: Prims.bool }
+  for_extraction: Prims.bool ;
+  unrefine: Prims.bool }
 let (__proj__Mkfsteps__item__beta : fsteps -> Prims.bool) =
   fun projectee ->
     match projectee with
@@ -39,7 +40,8 @@ let (__proj__Mkfsteps__item__beta : fsteps -> Prims.bool) =
         pure_subterms_within_computations; simplify; erase_universes;
         allow_unbound_universes; reify_; compress_uvars; no_full_norm;
         check_no_uvars; unmeta; unascribe; in_full_norm_request;
-        weakly_reduce_scrutinee; nbe_step; for_extraction;_} -> beta
+        weakly_reduce_scrutinee; nbe_step; for_extraction; unrefine;_} ->
+        beta
 let (__proj__Mkfsteps__item__iota : fsteps -> Prims.bool) =
   fun projectee ->
     match projectee with
@@ -49,7 +51,8 @@ let (__proj__Mkfsteps__item__iota : fsteps -> Prims.bool) =
         pure_subterms_within_computations; simplify; erase_universes;
         allow_unbound_universes; reify_; compress_uvars; no_full_norm;
         check_no_uvars; unmeta; unascribe; in_full_norm_request;
-        weakly_reduce_scrutinee; nbe_step; for_extraction;_} -> iota
+        weakly_reduce_scrutinee; nbe_step; for_extraction; unrefine;_} ->
+        iota
 let (__proj__Mkfsteps__item__zeta : fsteps -> Prims.bool) =
   fun projectee ->
     match projectee with
@@ -59,7 +62,8 @@ let (__proj__Mkfsteps__item__zeta : fsteps -> Prims.bool) =
         pure_subterms_within_computations; simplify; erase_universes;
         allow_unbound_universes; reify_; compress_uvars; no_full_norm;
         check_no_uvars; unmeta; unascribe; in_full_norm_request;
-        weakly_reduce_scrutinee; nbe_step; for_extraction;_} -> zeta
+        weakly_reduce_scrutinee; nbe_step; for_extraction; unrefine;_} ->
+        zeta
 let (__proj__Mkfsteps__item__zeta_full : fsteps -> Prims.bool) =
   fun projectee ->
     match projectee with
@@ -69,7 +73,8 @@ let (__proj__Mkfsteps__item__zeta_full : fsteps -> Prims.bool) =
         pure_subterms_within_computations; simplify; erase_universes;
         allow_unbound_universes; reify_; compress_uvars; no_full_norm;
         check_no_uvars; unmeta; unascribe; in_full_norm_request;
-        weakly_reduce_scrutinee; nbe_step; for_extraction;_} -> zeta_full
+        weakly_reduce_scrutinee; nbe_step; for_extraction; unrefine;_} ->
+        zeta_full
 let (__proj__Mkfsteps__item__weak : fsteps -> Prims.bool) =
   fun projectee ->
     match projectee with
@@ -79,7 +84,8 @@ let (__proj__Mkfsteps__item__weak : fsteps -> Prims.bool) =
         pure_subterms_within_computations; simplify; erase_universes;
         allow_unbound_universes; reify_; compress_uvars; no_full_norm;
         check_no_uvars; unmeta; unascribe; in_full_norm_request;
-        weakly_reduce_scrutinee; nbe_step; for_extraction;_} -> weak
+        weakly_reduce_scrutinee; nbe_step; for_extraction; unrefine;_} ->
+        weak
 let (__proj__Mkfsteps__item__hnf : fsteps -> Prims.bool) =
   fun projectee ->
     match projectee with
@@ -89,7 +95,7 @@ let (__proj__Mkfsteps__item__hnf : fsteps -> Prims.bool) =
         pure_subterms_within_computations; simplify; erase_universes;
         allow_unbound_universes; reify_; compress_uvars; no_full_norm;
         check_no_uvars; unmeta; unascribe; in_full_norm_request;
-        weakly_reduce_scrutinee; nbe_step; for_extraction;_} -> hnf
+        weakly_reduce_scrutinee; nbe_step; for_extraction; unrefine;_} -> hnf
 let (__proj__Mkfsteps__item__primops : fsteps -> Prims.bool) =
   fun projectee ->
     match projectee with
@@ -99,7 +105,8 @@ let (__proj__Mkfsteps__item__primops : fsteps -> Prims.bool) =
         pure_subterms_within_computations; simplify; erase_universes;
         allow_unbound_universes; reify_; compress_uvars; no_full_norm;
         check_no_uvars; unmeta; unascribe; in_full_norm_request;
-        weakly_reduce_scrutinee; nbe_step; for_extraction;_} -> primops
+        weakly_reduce_scrutinee; nbe_step; for_extraction; unrefine;_} ->
+        primops
 let (__proj__Mkfsteps__item__do_not_unfold_pure_lets : fsteps -> Prims.bool)
   =
   fun projectee ->
@@ -110,7 +117,7 @@ let (__proj__Mkfsteps__item__do_not_unfold_pure_lets : fsteps -> Prims.bool)
         pure_subterms_within_computations; simplify; erase_universes;
         allow_unbound_universes; reify_; compress_uvars; no_full_norm;
         check_no_uvars; unmeta; unascribe; in_full_norm_request;
-        weakly_reduce_scrutinee; nbe_step; for_extraction;_} ->
+        weakly_reduce_scrutinee; nbe_step; for_extraction; unrefine;_} ->
         do_not_unfold_pure_lets
 let (__proj__Mkfsteps__item__unfold_until :
   fsteps -> FStar_Syntax_Syntax.delta_depth FStar_Pervasives_Native.option) =
@@ -122,7 +129,8 @@ let (__proj__Mkfsteps__item__unfold_until :
         pure_subterms_within_computations; simplify; erase_universes;
         allow_unbound_universes; reify_; compress_uvars; no_full_norm;
         check_no_uvars; unmeta; unascribe; in_full_norm_request;
-        weakly_reduce_scrutinee; nbe_step; for_extraction;_} -> unfold_until
+        weakly_reduce_scrutinee; nbe_step; for_extraction; unrefine;_} ->
+        unfold_until
 let (__proj__Mkfsteps__item__unfold_only :
   fsteps -> FStar_Ident.lid Prims.list FStar_Pervasives_Native.option) =
   fun projectee ->
@@ -133,7 +141,8 @@ let (__proj__Mkfsteps__item__unfold_only :
         pure_subterms_within_computations; simplify; erase_universes;
         allow_unbound_universes; reify_; compress_uvars; no_full_norm;
         check_no_uvars; unmeta; unascribe; in_full_norm_request;
-        weakly_reduce_scrutinee; nbe_step; for_extraction;_} -> unfold_only
+        weakly_reduce_scrutinee; nbe_step; for_extraction; unrefine;_} ->
+        unfold_only
 let (__proj__Mkfsteps__item__unfold_fully :
   fsteps -> FStar_Ident.lid Prims.list FStar_Pervasives_Native.option) =
   fun projectee ->
@@ -144,7 +153,8 @@ let (__proj__Mkfsteps__item__unfold_fully :
         pure_subterms_within_computations; simplify; erase_universes;
         allow_unbound_universes; reify_; compress_uvars; no_full_norm;
         check_no_uvars; unmeta; unascribe; in_full_norm_request;
-        weakly_reduce_scrutinee; nbe_step; for_extraction;_} -> unfold_fully
+        weakly_reduce_scrutinee; nbe_step; for_extraction; unrefine;_} ->
+        unfold_fully
 let (__proj__Mkfsteps__item__unfold_attr :
   fsteps -> FStar_Ident.lid Prims.list FStar_Pervasives_Native.option) =
   fun projectee ->
@@ -155,7 +165,8 @@ let (__proj__Mkfsteps__item__unfold_attr :
         pure_subterms_within_computations; simplify; erase_universes;
         allow_unbound_universes; reify_; compress_uvars; no_full_norm;
         check_no_uvars; unmeta; unascribe; in_full_norm_request;
-        weakly_reduce_scrutinee; nbe_step; for_extraction;_} -> unfold_attr
+        weakly_reduce_scrutinee; nbe_step; for_extraction; unrefine;_} ->
+        unfold_attr
 let (__proj__Mkfsteps__item__unfold_qual :
   fsteps -> Prims.string Prims.list FStar_Pervasives_Native.option) =
   fun projectee ->
@@ -166,7 +177,8 @@ let (__proj__Mkfsteps__item__unfold_qual :
         pure_subterms_within_computations; simplify; erase_universes;
         allow_unbound_universes; reify_; compress_uvars; no_full_norm;
         check_no_uvars; unmeta; unascribe; in_full_norm_request;
-        weakly_reduce_scrutinee; nbe_step; for_extraction;_} -> unfold_qual
+        weakly_reduce_scrutinee; nbe_step; for_extraction; unrefine;_} ->
+        unfold_qual
 let (__proj__Mkfsteps__item__unfold_tac : fsteps -> Prims.bool) =
   fun projectee ->
     match projectee with
@@ -176,7 +188,8 @@ let (__proj__Mkfsteps__item__unfold_tac : fsteps -> Prims.bool) =
         pure_subterms_within_computations; simplify; erase_universes;
         allow_unbound_universes; reify_; compress_uvars; no_full_norm;
         check_no_uvars; unmeta; unascribe; in_full_norm_request;
-        weakly_reduce_scrutinee; nbe_step; for_extraction;_} -> unfold_tac
+        weakly_reduce_scrutinee; nbe_step; for_extraction; unrefine;_} ->
+        unfold_tac
 let (__proj__Mkfsteps__item__pure_subterms_within_computations :
   fsteps -> Prims.bool) =
   fun projectee ->
@@ -187,7 +200,7 @@ let (__proj__Mkfsteps__item__pure_subterms_within_computations :
         pure_subterms_within_computations; simplify; erase_universes;
         allow_unbound_universes; reify_; compress_uvars; no_full_norm;
         check_no_uvars; unmeta; unascribe; in_full_norm_request;
-        weakly_reduce_scrutinee; nbe_step; for_extraction;_} ->
+        weakly_reduce_scrutinee; nbe_step; for_extraction; unrefine;_} ->
         pure_subterms_within_computations
 let (__proj__Mkfsteps__item__simplify : fsteps -> Prims.bool) =
   fun projectee ->
@@ -198,7 +211,8 @@ let (__proj__Mkfsteps__item__simplify : fsteps -> Prims.bool) =
         pure_subterms_within_computations; simplify; erase_universes;
         allow_unbound_universes; reify_; compress_uvars; no_full_norm;
         check_no_uvars; unmeta; unascribe; in_full_norm_request;
-        weakly_reduce_scrutinee; nbe_step; for_extraction;_} -> simplify
+        weakly_reduce_scrutinee; nbe_step; for_extraction; unrefine;_} ->
+        simplify
 let (__proj__Mkfsteps__item__erase_universes : fsteps -> Prims.bool) =
   fun projectee ->
     match projectee with
@@ -208,7 +222,7 @@ let (__proj__Mkfsteps__item__erase_universes : fsteps -> Prims.bool) =
         pure_subterms_within_computations; simplify; erase_universes;
         allow_unbound_universes; reify_; compress_uvars; no_full_norm;
         check_no_uvars; unmeta; unascribe; in_full_norm_request;
-        weakly_reduce_scrutinee; nbe_step; for_extraction;_} ->
+        weakly_reduce_scrutinee; nbe_step; for_extraction; unrefine;_} ->
         erase_universes
 let (__proj__Mkfsteps__item__allow_unbound_universes : fsteps -> Prims.bool)
   =
@@ -220,7 +234,7 @@ let (__proj__Mkfsteps__item__allow_unbound_universes : fsteps -> Prims.bool)
         pure_subterms_within_computations; simplify; erase_universes;
         allow_unbound_universes; reify_; compress_uvars; no_full_norm;
         check_no_uvars; unmeta; unascribe; in_full_norm_request;
-        weakly_reduce_scrutinee; nbe_step; for_extraction;_} ->
+        weakly_reduce_scrutinee; nbe_step; for_extraction; unrefine;_} ->
         allow_unbound_universes
 let (__proj__Mkfsteps__item__reify_ : fsteps -> Prims.bool) =
   fun projectee ->
@@ -231,7 +245,8 @@ let (__proj__Mkfsteps__item__reify_ : fsteps -> Prims.bool) =
         pure_subterms_within_computations; simplify; erase_universes;
         allow_unbound_universes; reify_; compress_uvars; no_full_norm;
         check_no_uvars; unmeta; unascribe; in_full_norm_request;
-        weakly_reduce_scrutinee; nbe_step; for_extraction;_} -> reify_
+        weakly_reduce_scrutinee; nbe_step; for_extraction; unrefine;_} ->
+        reify_
 let (__proj__Mkfsteps__item__compress_uvars : fsteps -> Prims.bool) =
   fun projectee ->
     match projectee with
@@ -241,7 +256,7 @@ let (__proj__Mkfsteps__item__compress_uvars : fsteps -> Prims.bool) =
         pure_subterms_within_computations; simplify; erase_universes;
         allow_unbound_universes; reify_; compress_uvars; no_full_norm;
         check_no_uvars; unmeta; unascribe; in_full_norm_request;
-        weakly_reduce_scrutinee; nbe_step; for_extraction;_} ->
+        weakly_reduce_scrutinee; nbe_step; for_extraction; unrefine;_} ->
         compress_uvars
 let (__proj__Mkfsteps__item__no_full_norm : fsteps -> Prims.bool) =
   fun projectee ->
@@ -252,7 +267,8 @@ let (__proj__Mkfsteps__item__no_full_norm : fsteps -> Prims.bool) =
         pure_subterms_within_computations; simplify; erase_universes;
         allow_unbound_universes; reify_; compress_uvars; no_full_norm;
         check_no_uvars; unmeta; unascribe; in_full_norm_request;
-        weakly_reduce_scrutinee; nbe_step; for_extraction;_} -> no_full_norm
+        weakly_reduce_scrutinee; nbe_step; for_extraction; unrefine;_} ->
+        no_full_norm
 let (__proj__Mkfsteps__item__check_no_uvars : fsteps -> Prims.bool) =
   fun projectee ->
     match projectee with
@@ -262,7 +278,7 @@ let (__proj__Mkfsteps__item__check_no_uvars : fsteps -> Prims.bool) =
         pure_subterms_within_computations; simplify; erase_universes;
         allow_unbound_universes; reify_; compress_uvars; no_full_norm;
         check_no_uvars; unmeta; unascribe; in_full_norm_request;
-        weakly_reduce_scrutinee; nbe_step; for_extraction;_} ->
+        weakly_reduce_scrutinee; nbe_step; for_extraction; unrefine;_} ->
         check_no_uvars
 let (__proj__Mkfsteps__item__unmeta : fsteps -> Prims.bool) =
   fun projectee ->
@@ -273,7 +289,8 @@ let (__proj__Mkfsteps__item__unmeta : fsteps -> Prims.bool) =
         pure_subterms_within_computations; simplify; erase_universes;
         allow_unbound_universes; reify_; compress_uvars; no_full_norm;
         check_no_uvars; unmeta; unascribe; in_full_norm_request;
-        weakly_reduce_scrutinee; nbe_step; for_extraction;_} -> unmeta
+        weakly_reduce_scrutinee; nbe_step; for_extraction; unrefine;_} ->
+        unmeta
 let (__proj__Mkfsteps__item__unascribe : fsteps -> Prims.bool) =
   fun projectee ->
     match projectee with
@@ -283,7 +300,8 @@ let (__proj__Mkfsteps__item__unascribe : fsteps -> Prims.bool) =
         pure_subterms_within_computations; simplify; erase_universes;
         allow_unbound_universes; reify_; compress_uvars; no_full_norm;
         check_no_uvars; unmeta; unascribe; in_full_norm_request;
-        weakly_reduce_scrutinee; nbe_step; for_extraction;_} -> unascribe
+        weakly_reduce_scrutinee; nbe_step; for_extraction; unrefine;_} ->
+        unascribe
 let (__proj__Mkfsteps__item__in_full_norm_request : fsteps -> Prims.bool) =
   fun projectee ->
     match projectee with
@@ -293,7 +311,7 @@ let (__proj__Mkfsteps__item__in_full_norm_request : fsteps -> Prims.bool) =
         pure_subterms_within_computations; simplify; erase_universes;
         allow_unbound_universes; reify_; compress_uvars; no_full_norm;
         check_no_uvars; unmeta; unascribe; in_full_norm_request;
-        weakly_reduce_scrutinee; nbe_step; for_extraction;_} ->
+        weakly_reduce_scrutinee; nbe_step; for_extraction; unrefine;_} ->
         in_full_norm_request
 let (__proj__Mkfsteps__item__weakly_reduce_scrutinee : fsteps -> Prims.bool)
   =
@@ -305,7 +323,7 @@ let (__proj__Mkfsteps__item__weakly_reduce_scrutinee : fsteps -> Prims.bool)
         pure_subterms_within_computations; simplify; erase_universes;
         allow_unbound_universes; reify_; compress_uvars; no_full_norm;
         check_no_uvars; unmeta; unascribe; in_full_norm_request;
-        weakly_reduce_scrutinee; nbe_step; for_extraction;_} ->
+        weakly_reduce_scrutinee; nbe_step; for_extraction; unrefine;_} ->
         weakly_reduce_scrutinee
 let (__proj__Mkfsteps__item__nbe_step : fsteps -> Prims.bool) =
   fun projectee ->
@@ -316,7 +334,8 @@ let (__proj__Mkfsteps__item__nbe_step : fsteps -> Prims.bool) =
         pure_subterms_within_computations; simplify; erase_universes;
         allow_unbound_universes; reify_; compress_uvars; no_full_norm;
         check_no_uvars; unmeta; unascribe; in_full_norm_request;
-        weakly_reduce_scrutinee; nbe_step; for_extraction;_} -> nbe_step
+        weakly_reduce_scrutinee; nbe_step; for_extraction; unrefine;_} ->
+        nbe_step
 let (__proj__Mkfsteps__item__for_extraction : fsteps -> Prims.bool) =
   fun projectee ->
     match projectee with
@@ -326,8 +345,19 @@ let (__proj__Mkfsteps__item__for_extraction : fsteps -> Prims.bool) =
         pure_subterms_within_computations; simplify; erase_universes;
         allow_unbound_universes; reify_; compress_uvars; no_full_norm;
         check_no_uvars; unmeta; unascribe; in_full_norm_request;
-        weakly_reduce_scrutinee; nbe_step; for_extraction;_} ->
+        weakly_reduce_scrutinee; nbe_step; for_extraction; unrefine;_} ->
         for_extraction
+let (__proj__Mkfsteps__item__unrefine : fsteps -> Prims.bool) =
+  fun projectee ->
+    match projectee with
+    | { beta; iota; zeta; zeta_full; weak; hnf; primops;
+        do_not_unfold_pure_lets; unfold_until; unfold_only; unfold_fully;
+        unfold_attr; unfold_qual; unfold_tac;
+        pure_subterms_within_computations; simplify; erase_universes;
+        allow_unbound_universes; reify_; compress_uvars; no_full_norm;
+        check_no_uvars; unmeta; unascribe; in_full_norm_request;
+        weakly_reduce_scrutinee; nbe_step; for_extraction; unrefine;_} ->
+        unrefine
 let (steps_to_string : fsteps -> Prims.string) =
   fun f ->
     let format_opt f1 o =
@@ -457,7 +487,12 @@ let (steps_to_string : fsteps -> Prims.string) =
                                                             FStar_Compiler_Effect.op_Bar_Greater
                                                               f.for_extraction
                                                               b in
-                                                          [uu___53] in
+                                                          let uu___54 =
+                                                            let uu___55 =
+                                                              FStar_Compiler_Effect.op_Bar_Greater
+                                                                f.unrefine b in
+                                                            [uu___55] in
+                                                          uu___53 :: uu___54 in
                                                         uu___51 :: uu___52 in
                                                       uu___49 :: uu___50 in
                                                     uu___47 :: uu___48 in
@@ -485,7 +520,7 @@ let (steps_to_string : fsteps -> Prims.string) =
         uu___3 :: uu___4 in
       uu___1 :: uu___2 in
     FStar_Compiler_Util.format
-      "{\nbeta = %s;\niota = %s;\nzeta = %s;\nzeta_full = %s;\nweak = %s;\nhnf  = %s;\nprimops = %s;\ndo_not_unfold_pure_lets = %s;\nunfold_until = %s;\nunfold_only = %s;\nunfold_fully = %s;\nunfold_attr = %s;\nunfold_qual = %s;\nunfold_tac = %s;\npure_subterms_within_computations = %s;\nsimplify = %s;\nerase_universes = %s;\nallow_unbound_universes = %s;\nreify_ = %s;\ncompress_uvars = %s;\nno_full_norm = %s;\ncheck_no_uvars = %s;\nunmeta = %s;\nunascribe = %s;\nin_full_norm_request = %s;\nweakly_reduce_scrutinee = %s;\nfor_extraction = %s;\n}"
+      "{\nbeta = %s;\niota = %s;\nzeta = %s;\nzeta_full = %s;\nweak = %s;\nhnf  = %s;\nprimops = %s;\ndo_not_unfold_pure_lets = %s;\nunfold_until = %s;\nunfold_only = %s;\nunfold_fully = %s;\nunfold_attr = %s;\nunfold_qual = %s;\nunfold_tac = %s;\npure_subterms_within_computations = %s;\nsimplify = %s;\nerase_universes = %s;\nallow_unbound_universes = %s;\nreify_ = %s;\ncompress_uvars = %s;\nno_full_norm = %s;\ncheck_no_uvars = %s;\nunmeta = %s;\nunascribe = %s;\nin_full_norm_request = %s;\nweakly_reduce_scrutinee = %s;\nfor_extraction = %s;\nunrefine = %s;\n}"
       uu___
 let (default_steps : fsteps) =
   {
@@ -516,7 +551,8 @@ let (default_steps : fsteps) =
     in_full_norm_request = false;
     weakly_reduce_scrutinee = true;
     nbe_step = false;
-    for_extraction = false
+    for_extraction = false;
+    unrefine = false
   }
 let (fstep_add_one : FStar_TypeChecker_Env.step -> fsteps -> fsteps) =
   fun s ->
@@ -552,7 +588,8 @@ let (fstep_add_one : FStar_TypeChecker_Env.step -> fsteps -> fsteps) =
             in_full_norm_request = (fs.in_full_norm_request);
             weakly_reduce_scrutinee = (fs.weakly_reduce_scrutinee);
             nbe_step = (fs.nbe_step);
-            for_extraction = (fs.for_extraction)
+            for_extraction = (fs.for_extraction);
+            unrefine = (fs.unrefine)
           }
       | FStar_TypeChecker_Env.Iota ->
           {
@@ -584,7 +621,8 @@ let (fstep_add_one : FStar_TypeChecker_Env.step -> fsteps -> fsteps) =
             in_full_norm_request = (fs.in_full_norm_request);
             weakly_reduce_scrutinee = (fs.weakly_reduce_scrutinee);
             nbe_step = (fs.nbe_step);
-            for_extraction = (fs.for_extraction)
+            for_extraction = (fs.for_extraction);
+            unrefine = (fs.unrefine)
           }
       | FStar_TypeChecker_Env.Zeta ->
           {
@@ -616,7 +654,8 @@ let (fstep_add_one : FStar_TypeChecker_Env.step -> fsteps -> fsteps) =
             in_full_norm_request = (fs.in_full_norm_request);
             weakly_reduce_scrutinee = (fs.weakly_reduce_scrutinee);
             nbe_step = (fs.nbe_step);
-            for_extraction = (fs.for_extraction)
+            for_extraction = (fs.for_extraction);
+            unrefine = (fs.unrefine)
           }
       | FStar_TypeChecker_Env.ZetaFull ->
           {
@@ -648,7 +687,8 @@ let (fstep_add_one : FStar_TypeChecker_Env.step -> fsteps -> fsteps) =
             in_full_norm_request = (fs.in_full_norm_request);
             weakly_reduce_scrutinee = (fs.weakly_reduce_scrutinee);
             nbe_step = (fs.nbe_step);
-            for_extraction = (fs.for_extraction)
+            for_extraction = (fs.for_extraction);
+            unrefine = (fs.unrefine)
           }
       | FStar_TypeChecker_Env.Exclude (FStar_TypeChecker_Env.Beta) ->
           {
@@ -680,7 +720,8 @@ let (fstep_add_one : FStar_TypeChecker_Env.step -> fsteps -> fsteps) =
             in_full_norm_request = (fs.in_full_norm_request);
             weakly_reduce_scrutinee = (fs.weakly_reduce_scrutinee);
             nbe_step = (fs.nbe_step);
-            for_extraction = (fs.for_extraction)
+            for_extraction = (fs.for_extraction);
+            unrefine = (fs.unrefine)
           }
       | FStar_TypeChecker_Env.Exclude (FStar_TypeChecker_Env.Iota) ->
           {
@@ -712,7 +753,8 @@ let (fstep_add_one : FStar_TypeChecker_Env.step -> fsteps -> fsteps) =
             in_full_norm_request = (fs.in_full_norm_request);
             weakly_reduce_scrutinee = (fs.weakly_reduce_scrutinee);
             nbe_step = (fs.nbe_step);
-            for_extraction = (fs.for_extraction)
+            for_extraction = (fs.for_extraction);
+            unrefine = (fs.unrefine)
           }
       | FStar_TypeChecker_Env.Exclude (FStar_TypeChecker_Env.Zeta) ->
           {
@@ -744,7 +786,8 @@ let (fstep_add_one : FStar_TypeChecker_Env.step -> fsteps -> fsteps) =
             in_full_norm_request = (fs.in_full_norm_request);
             weakly_reduce_scrutinee = (fs.weakly_reduce_scrutinee);
             nbe_step = (fs.nbe_step);
-            for_extraction = (fs.for_extraction)
+            for_extraction = (fs.for_extraction);
+            unrefine = (fs.unrefine)
           }
       | FStar_TypeChecker_Env.Exclude uu___ -> failwith "Bad exclude"
       | FStar_TypeChecker_Env.Weak ->
@@ -777,7 +820,8 @@ let (fstep_add_one : FStar_TypeChecker_Env.step -> fsteps -> fsteps) =
             in_full_norm_request = (fs.in_full_norm_request);
             weakly_reduce_scrutinee = (fs.weakly_reduce_scrutinee);
             nbe_step = (fs.nbe_step);
-            for_extraction = (fs.for_extraction)
+            for_extraction = (fs.for_extraction);
+            unrefine = (fs.unrefine)
           }
       | FStar_TypeChecker_Env.HNF ->
           {
@@ -809,7 +853,8 @@ let (fstep_add_one : FStar_TypeChecker_Env.step -> fsteps -> fsteps) =
             in_full_norm_request = (fs.in_full_norm_request);
             weakly_reduce_scrutinee = (fs.weakly_reduce_scrutinee);
             nbe_step = (fs.nbe_step);
-            for_extraction = (fs.for_extraction)
+            for_extraction = (fs.for_extraction);
+            unrefine = (fs.unrefine)
           }
       | FStar_TypeChecker_Env.Primops ->
           {
@@ -841,7 +886,8 @@ let (fstep_add_one : FStar_TypeChecker_Env.step -> fsteps -> fsteps) =
             in_full_norm_request = (fs.in_full_norm_request);
             weakly_reduce_scrutinee = (fs.weakly_reduce_scrutinee);
             nbe_step = (fs.nbe_step);
-            for_extraction = (fs.for_extraction)
+            for_extraction = (fs.for_extraction);
+            unrefine = (fs.unrefine)
           }
       | FStar_TypeChecker_Env.Eager_unfolding -> fs
       | FStar_TypeChecker_Env.Inlining -> fs
@@ -875,7 +921,8 @@ let (fstep_add_one : FStar_TypeChecker_Env.step -> fsteps -> fsteps) =
             in_full_norm_request = (fs.in_full_norm_request);
             weakly_reduce_scrutinee = (fs.weakly_reduce_scrutinee);
             nbe_step = (fs.nbe_step);
-            for_extraction = (fs.for_extraction)
+            for_extraction = (fs.for_extraction);
+            unrefine = (fs.unrefine)
           }
       | FStar_TypeChecker_Env.UnfoldUntil d ->
           {
@@ -907,7 +954,8 @@ let (fstep_add_one : FStar_TypeChecker_Env.step -> fsteps -> fsteps) =
             in_full_norm_request = (fs.in_full_norm_request);
             weakly_reduce_scrutinee = (fs.weakly_reduce_scrutinee);
             nbe_step = (fs.nbe_step);
-            for_extraction = (fs.for_extraction)
+            for_extraction = (fs.for_extraction);
+            unrefine = (fs.unrefine)
           }
       | FStar_TypeChecker_Env.UnfoldOnly lids ->
           {
@@ -939,7 +987,8 @@ let (fstep_add_one : FStar_TypeChecker_Env.step -> fsteps -> fsteps) =
             in_full_norm_request = (fs.in_full_norm_request);
             weakly_reduce_scrutinee = (fs.weakly_reduce_scrutinee);
             nbe_step = (fs.nbe_step);
-            for_extraction = (fs.for_extraction)
+            for_extraction = (fs.for_extraction);
+            unrefine = (fs.unrefine)
           }
       | FStar_TypeChecker_Env.UnfoldFully lids ->
           {
@@ -971,7 +1020,8 @@ let (fstep_add_one : FStar_TypeChecker_Env.step -> fsteps -> fsteps) =
             in_full_norm_request = (fs.in_full_norm_request);
             weakly_reduce_scrutinee = (fs.weakly_reduce_scrutinee);
             nbe_step = (fs.nbe_step);
-            for_extraction = (fs.for_extraction)
+            for_extraction = (fs.for_extraction);
+            unrefine = (fs.unrefine)
           }
       | FStar_TypeChecker_Env.UnfoldAttr lids ->
           {
@@ -1003,7 +1053,8 @@ let (fstep_add_one : FStar_TypeChecker_Env.step -> fsteps -> fsteps) =
             in_full_norm_request = (fs.in_full_norm_request);
             weakly_reduce_scrutinee = (fs.weakly_reduce_scrutinee);
             nbe_step = (fs.nbe_step);
-            for_extraction = (fs.for_extraction)
+            for_extraction = (fs.for_extraction);
+            unrefine = (fs.unrefine)
           }
       | FStar_TypeChecker_Env.UnfoldQual strs ->
           let fs1 =
@@ -1036,7 +1087,8 @@ let (fstep_add_one : FStar_TypeChecker_Env.step -> fsteps -> fsteps) =
               in_full_norm_request = (fs.in_full_norm_request);
               weakly_reduce_scrutinee = (fs.weakly_reduce_scrutinee);
               nbe_step = (fs.nbe_step);
-              for_extraction = (fs.for_extraction)
+              for_extraction = (fs.for_extraction);
+              unrefine = (fs.unrefine)
             } in
           if
             FStar_Compiler_List.contains "pure_subterms_within_computations"
@@ -1070,7 +1122,8 @@ let (fstep_add_one : FStar_TypeChecker_Env.step -> fsteps -> fsteps) =
               in_full_norm_request = (fs1.in_full_norm_request);
               weakly_reduce_scrutinee = (fs1.weakly_reduce_scrutinee);
               nbe_step = (fs1.nbe_step);
-              for_extraction = (fs1.for_extraction)
+              for_extraction = (fs1.for_extraction);
+              unrefine = (fs1.unrefine)
             }
           else fs1
       | FStar_TypeChecker_Env.UnfoldTac ->
@@ -1103,7 +1156,8 @@ let (fstep_add_one : FStar_TypeChecker_Env.step -> fsteps -> fsteps) =
             in_full_norm_request = (fs.in_full_norm_request);
             weakly_reduce_scrutinee = (fs.weakly_reduce_scrutinee);
             nbe_step = (fs.nbe_step);
-            for_extraction = (fs.for_extraction)
+            for_extraction = (fs.for_extraction);
+            unrefine = (fs.unrefine)
           }
       | FStar_TypeChecker_Env.PureSubtermsWithinComputations ->
           {
@@ -1134,7 +1188,8 @@ let (fstep_add_one : FStar_TypeChecker_Env.step -> fsteps -> fsteps) =
             in_full_norm_request = (fs.in_full_norm_request);
             weakly_reduce_scrutinee = (fs.weakly_reduce_scrutinee);
             nbe_step = (fs.nbe_step);
-            for_extraction = (fs.for_extraction)
+            for_extraction = (fs.for_extraction);
+            unrefine = (fs.unrefine)
           }
       | FStar_TypeChecker_Env.Simplify ->
           {
@@ -1166,7 +1221,8 @@ let (fstep_add_one : FStar_TypeChecker_Env.step -> fsteps -> fsteps) =
             in_full_norm_request = (fs.in_full_norm_request);
             weakly_reduce_scrutinee = (fs.weakly_reduce_scrutinee);
             nbe_step = (fs.nbe_step);
-            for_extraction = (fs.for_extraction)
+            for_extraction = (fs.for_extraction);
+            unrefine = (fs.unrefine)
           }
       | FStar_TypeChecker_Env.EraseUniverses ->
           {
@@ -1198,7 +1254,8 @@ let (fstep_add_one : FStar_TypeChecker_Env.step -> fsteps -> fsteps) =
             in_full_norm_request = (fs.in_full_norm_request);
             weakly_reduce_scrutinee = (fs.weakly_reduce_scrutinee);
             nbe_step = (fs.nbe_step);
-            for_extraction = (fs.for_extraction)
+            for_extraction = (fs.for_extraction);
+            unrefine = (fs.unrefine)
           }
       | FStar_TypeChecker_Env.AllowUnboundUniverses ->
           {
@@ -1230,7 +1287,8 @@ let (fstep_add_one : FStar_TypeChecker_Env.step -> fsteps -> fsteps) =
             in_full_norm_request = (fs.in_full_norm_request);
             weakly_reduce_scrutinee = (fs.weakly_reduce_scrutinee);
             nbe_step = (fs.nbe_step);
-            for_extraction = (fs.for_extraction)
+            for_extraction = (fs.for_extraction);
+            unrefine = (fs.unrefine)
           }
       | FStar_TypeChecker_Env.Reify ->
           {
@@ -1262,7 +1320,8 @@ let (fstep_add_one : FStar_TypeChecker_Env.step -> fsteps -> fsteps) =
             in_full_norm_request = (fs.in_full_norm_request);
             weakly_reduce_scrutinee = (fs.weakly_reduce_scrutinee);
             nbe_step = (fs.nbe_step);
-            for_extraction = (fs.for_extraction)
+            for_extraction = (fs.for_extraction);
+            unrefine = (fs.unrefine)
           }
       | FStar_TypeChecker_Env.CompressUvars ->
           {
@@ -1294,7 +1353,8 @@ let (fstep_add_one : FStar_TypeChecker_Env.step -> fsteps -> fsteps) =
             in_full_norm_request = (fs.in_full_norm_request);
             weakly_reduce_scrutinee = (fs.weakly_reduce_scrutinee);
             nbe_step = (fs.nbe_step);
-            for_extraction = (fs.for_extraction)
+            for_extraction = (fs.for_extraction);
+            unrefine = (fs.unrefine)
           }
       | FStar_TypeChecker_Env.NoFullNorm ->
           {
@@ -1326,7 +1386,8 @@ let (fstep_add_one : FStar_TypeChecker_Env.step -> fsteps -> fsteps) =
             in_full_norm_request = (fs.in_full_norm_request);
             weakly_reduce_scrutinee = (fs.weakly_reduce_scrutinee);
             nbe_step = (fs.nbe_step);
-            for_extraction = (fs.for_extraction)
+            for_extraction = (fs.for_extraction);
+            unrefine = (fs.unrefine)
           }
       | FStar_TypeChecker_Env.CheckNoUvars ->
           {
@@ -1358,7 +1419,8 @@ let (fstep_add_one : FStar_TypeChecker_Env.step -> fsteps -> fsteps) =
             in_full_norm_request = (fs.in_full_norm_request);
             weakly_reduce_scrutinee = (fs.weakly_reduce_scrutinee);
             nbe_step = (fs.nbe_step);
-            for_extraction = (fs.for_extraction)
+            for_extraction = (fs.for_extraction);
+            unrefine = (fs.unrefine)
           }
       | FStar_TypeChecker_Env.Unmeta ->
           {
@@ -1390,7 +1452,8 @@ let (fstep_add_one : FStar_TypeChecker_Env.step -> fsteps -> fsteps) =
             in_full_norm_request = (fs.in_full_norm_request);
             weakly_reduce_scrutinee = (fs.weakly_reduce_scrutinee);
             nbe_step = (fs.nbe_step);
-            for_extraction = (fs.for_extraction)
+            for_extraction = (fs.for_extraction);
+            unrefine = (fs.unrefine)
           }
       | FStar_TypeChecker_Env.Unascribe ->
           {
@@ -1422,7 +1485,8 @@ let (fstep_add_one : FStar_TypeChecker_Env.step -> fsteps -> fsteps) =
             in_full_norm_request = (fs.in_full_norm_request);
             weakly_reduce_scrutinee = (fs.weakly_reduce_scrutinee);
             nbe_step = (fs.nbe_step);
-            for_extraction = (fs.for_extraction)
+            for_extraction = (fs.for_extraction);
+            unrefine = (fs.unrefine)
           }
       | FStar_TypeChecker_Env.NBE ->
           {
@@ -1454,7 +1518,8 @@ let (fstep_add_one : FStar_TypeChecker_Env.step -> fsteps -> fsteps) =
             in_full_norm_request = (fs.in_full_norm_request);
             weakly_reduce_scrutinee = (fs.weakly_reduce_scrutinee);
             nbe_step = true;
-            for_extraction = (fs.for_extraction)
+            for_extraction = (fs.for_extraction);
+            unrefine = (fs.unrefine)
           }
       | FStar_TypeChecker_Env.ForExtraction ->
           {
@@ -1486,7 +1551,41 @@ let (fstep_add_one : FStar_TypeChecker_Env.step -> fsteps -> fsteps) =
             in_full_norm_request = (fs.in_full_norm_request);
             weakly_reduce_scrutinee = (fs.weakly_reduce_scrutinee);
             nbe_step = (fs.nbe_step);
-            for_extraction = true
+            for_extraction = true;
+            unrefine = (fs.unrefine)
+          }
+      | FStar_TypeChecker_Env.Unrefine ->
+          {
+            beta = (fs.beta);
+            iota = (fs.iota);
+            zeta = (fs.zeta);
+            zeta_full = (fs.zeta_full);
+            weak = (fs.weak);
+            hnf = (fs.hnf);
+            primops = (fs.primops);
+            do_not_unfold_pure_lets = (fs.do_not_unfold_pure_lets);
+            unfold_until = (fs.unfold_until);
+            unfold_only = (fs.unfold_only);
+            unfold_fully = (fs.unfold_fully);
+            unfold_attr = (fs.unfold_attr);
+            unfold_qual = (fs.unfold_qual);
+            unfold_tac = (fs.unfold_tac);
+            pure_subterms_within_computations =
+              (fs.pure_subterms_within_computations);
+            simplify = (fs.simplify);
+            erase_universes = (fs.erase_universes);
+            allow_unbound_universes = (fs.allow_unbound_universes);
+            reify_ = (fs.reify_);
+            compress_uvars = (fs.compress_uvars);
+            no_full_norm = (fs.no_full_norm);
+            check_no_uvars = (fs.check_no_uvars);
+            unmeta = (fs.unmeta);
+            unascribe = (fs.unascribe);
+            in_full_norm_request = (fs.in_full_norm_request);
+            weakly_reduce_scrutinee = (fs.weakly_reduce_scrutinee);
+            nbe_step = (fs.nbe_step);
+            for_extraction = (fs.for_extraction);
+            unrefine = true
           }
 let (to_fsteps : FStar_TypeChecker_Env.step Prims.list -> fsteps) =
   fun s -> FStar_Compiler_List.fold_right fstep_add_one s default_steps
@@ -3255,7 +3354,8 @@ let (add_nbe : fsteps -> fsteps) =
         in_full_norm_request = (s.in_full_norm_request);
         weakly_reduce_scrutinee = (s.weakly_reduce_scrutinee);
         nbe_step = true;
-        for_extraction = (s.for_extraction)
+        for_extraction = (s.for_extraction);
+        unrefine = (s.unrefine)
       }
     else s
 let (config' :

--- a/src/ocaml-output/FStar_TypeChecker_Env.ml
+++ b/src/ocaml-output/FStar_TypeChecker_Env.ml
@@ -29,6 +29,7 @@ type step =
   | Unascribe 
   | NBE 
   | ForExtraction 
+  | Unrefine 
 let (uu___is_Beta : step -> Prims.bool) =
   fun projectee -> match projectee with | Beta -> true | uu___ -> false
 let (uu___is_Iota : step -> Prims.bool) =
@@ -114,6 +115,8 @@ let (uu___is_NBE : step -> Prims.bool) =
 let (uu___is_ForExtraction : step -> Prims.bool) =
   fun projectee ->
     match projectee with | ForExtraction -> true | uu___ -> false
+let (uu___is_Unrefine : step -> Prims.bool) =
+  fun projectee -> match projectee with | Unrefine -> true | uu___ -> false
 type steps = step Prims.list
 let rec (eq_step : step -> step -> Prims.bool) =
   fun s1 ->
@@ -142,6 +145,7 @@ let rec (eq_step : step -> step -> Prims.bool) =
       | (Unmeta, Unmeta) -> true
       | (Unascribe, Unascribe) -> true
       | (NBE, NBE) -> true
+      | (Unrefine, Unrefine) -> true
       | (Exclude s11, Exclude s21) -> eq_step s11 s21
       | (UnfoldUntil s11, UnfoldUntil s21) -> s11 = s21
       | (UnfoldOnly lids1, UnfoldOnly lids2) ->

--- a/src/ocaml-output/FStar_TypeChecker_NBE.ml
+++ b/src/ocaml-output/FStar_TypeChecker_NBE.ml
@@ -209,7 +209,9 @@ let (zeta_false : config -> config) =
                FStar_TypeChecker_Cfg.nbe_step =
                  (uu___.FStar_TypeChecker_Cfg.nbe_step);
                FStar_TypeChecker_Cfg.for_extraction =
-                 (uu___.FStar_TypeChecker_Cfg.for_extraction)
+                 (uu___.FStar_TypeChecker_Cfg.for_extraction);
+               FStar_TypeChecker_Cfg.unrefine =
+                 (uu___.FStar_TypeChecker_Cfg.unrefine)
              });
           FStar_TypeChecker_Cfg.tcenv =
             (cfg_core.FStar_TypeChecker_Cfg.tcenv);
@@ -665,6 +667,8 @@ let rec (translate :
          | FStar_Syntax_Syntax.Tm_refine (bv, tm) ->
              if
                ((cfg.core_cfg).FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.for_extraction
+                 ||
+                 ((cfg.core_cfg).FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.unrefine
              then translate cfg bs bv.FStar_Syntax_Syntax.sort
              else
                FStar_Compiler_Effect.op_Less_Bar mk_t1
@@ -3130,7 +3134,9 @@ let (normalize :
                    FStar_TypeChecker_Cfg.nbe_step =
                      (uu___.FStar_TypeChecker_Cfg.nbe_step);
                    FStar_TypeChecker_Cfg.for_extraction =
-                     (uu___.FStar_TypeChecker_Cfg.for_extraction)
+                     (uu___.FStar_TypeChecker_Cfg.for_extraction);
+                   FStar_TypeChecker_Cfg.unrefine =
+                     (uu___.FStar_TypeChecker_Cfg.unrefine)
                  });
               FStar_TypeChecker_Cfg.tcenv = (cfg.FStar_TypeChecker_Cfg.tcenv);
               FStar_TypeChecker_Cfg.debug = (cfg.FStar_TypeChecker_Cfg.debug);
@@ -3236,7 +3242,9 @@ let (normalize_for_unit_test :
                  FStar_TypeChecker_Cfg.nbe_step =
                    (uu___.FStar_TypeChecker_Cfg.nbe_step);
                  FStar_TypeChecker_Cfg.for_extraction =
-                   (uu___.FStar_TypeChecker_Cfg.for_extraction)
+                   (uu___.FStar_TypeChecker_Cfg.for_extraction);
+                 FStar_TypeChecker_Cfg.unrefine =
+                   (uu___.FStar_TypeChecker_Cfg.unrefine)
                });
             FStar_TypeChecker_Cfg.tcenv = (cfg.FStar_TypeChecker_Cfg.tcenv);
             FStar_TypeChecker_Cfg.debug = (cfg.FStar_TypeChecker_Cfg.debug);

--- a/src/ocaml-output/FStar_TypeChecker_Normalize.ml
+++ b/src/ocaml-output/FStar_TypeChecker_Normalize.ml
@@ -596,6 +596,8 @@ let rec (inline_closure_env :
                          rebuild_closure cfg env1 stack1 t1)
                 | FStar_Syntax_Syntax.Tm_refine (x, uu___2) when
                     (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.for_extraction
+                      ||
+                      (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.unrefine
                     ->
                     inline_closure_env cfg env1 stack1
                       x.FStar_Syntax_Syntax.sort
@@ -1516,7 +1518,9 @@ let (reduce_equality :
                 FStar_TypeChecker_Cfg.nbe_step =
                   (FStar_TypeChecker_Cfg.default_steps.FStar_TypeChecker_Cfg.nbe_step);
                 FStar_TypeChecker_Cfg.for_extraction =
-                  (FStar_TypeChecker_Cfg.default_steps.FStar_TypeChecker_Cfg.for_extraction)
+                  (FStar_TypeChecker_Cfg.default_steps.FStar_TypeChecker_Cfg.for_extraction);
+                FStar_TypeChecker_Cfg.unrefine =
+                  (FStar_TypeChecker_Cfg.default_steps.FStar_TypeChecker_Cfg.unrefine)
               };
             FStar_TypeChecker_Cfg.tcenv = (cfg.FStar_TypeChecker_Cfg.tcenv);
             FStar_TypeChecker_Cfg.debug = (cfg.FStar_TypeChecker_Cfg.debug);
@@ -2499,7 +2503,9 @@ let decide_unfolding :
                            FStar_TypeChecker_Cfg.nbe_step =
                              (uu___.FStar_TypeChecker_Cfg.nbe_step);
                            FStar_TypeChecker_Cfg.for_extraction =
-                             (uu___.FStar_TypeChecker_Cfg.for_extraction)
+                             (uu___.FStar_TypeChecker_Cfg.for_extraction);
+                           FStar_TypeChecker_Cfg.unrefine =
+                             (uu___.FStar_TypeChecker_Cfg.unrefine)
                          });
                       FStar_TypeChecker_Cfg.tcenv =
                         (cfg.FStar_TypeChecker_Cfg.tcenv);
@@ -2844,7 +2850,9 @@ let rec (norm :
                           FStar_TypeChecker_Cfg.nbe_step =
                             (uu___3.FStar_TypeChecker_Cfg.nbe_step);
                           FStar_TypeChecker_Cfg.for_extraction =
-                            (uu___3.FStar_TypeChecker_Cfg.for_extraction)
+                            (uu___3.FStar_TypeChecker_Cfg.for_extraction);
+                          FStar_TypeChecker_Cfg.unrefine =
+                            (uu___3.FStar_TypeChecker_Cfg.unrefine)
                         });
                      FStar_TypeChecker_Cfg.tcenv =
                        (cfg.FStar_TypeChecker_Cfg.tcenv);
@@ -3013,7 +3021,9 @@ let rec (norm :
                            FStar_TypeChecker_Cfg.nbe_step =
                              (uu___5.FStar_TypeChecker_Cfg.nbe_step);
                            FStar_TypeChecker_Cfg.for_extraction =
-                             ((cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.for_extraction)
+                             ((cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.for_extraction);
+                           FStar_TypeChecker_Cfg.unrefine =
+                             (uu___5.FStar_TypeChecker_Cfg.unrefine)
                          } in
                        {
                          FStar_TypeChecker_Cfg.steps = uu___4;
@@ -3860,6 +3870,8 @@ let rec (norm :
                        rebuild cfg env1 stack1 term))
            | FStar_Syntax_Syntax.Tm_refine (x, uu___2) when
                (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.for_extraction
+                 ||
+                 (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.unrefine
                -> norm cfg env1 stack1 x.FStar_Syntax_Syntax.sort
            | FStar_Syntax_Syntax.Tm_refine (x, f) ->
                if
@@ -4093,7 +4105,9 @@ let rec (norm :
                           FStar_TypeChecker_Cfg.nbe_step =
                             (uu___2.FStar_TypeChecker_Cfg.nbe_step);
                           FStar_TypeChecker_Cfg.for_extraction =
-                            (uu___2.FStar_TypeChecker_Cfg.for_extraction)
+                            (uu___2.FStar_TypeChecker_Cfg.for_extraction);
+                          FStar_TypeChecker_Cfg.unrefine =
+                            (uu___2.FStar_TypeChecker_Cfg.unrefine)
                         });
                      FStar_TypeChecker_Cfg.tcenv =
                        (cfg.FStar_TypeChecker_Cfg.tcenv);
@@ -7351,7 +7365,9 @@ and (rebuild :
                                 FStar_TypeChecker_Cfg.nbe_step =
                                   (uu___7.FStar_TypeChecker_Cfg.nbe_step);
                                 FStar_TypeChecker_Cfg.for_extraction =
-                                  (uu___7.FStar_TypeChecker_Cfg.for_extraction)
+                                  (uu___7.FStar_TypeChecker_Cfg.for_extraction);
+                                FStar_TypeChecker_Cfg.unrefine =
+                                  (uu___7.FStar_TypeChecker_Cfg.unrefine)
                               } in
                             {
                               FStar_TypeChecker_Cfg.steps = steps;
@@ -7634,7 +7650,9 @@ and (rebuild :
                                             (uu___10.FStar_TypeChecker_Cfg.nbe_step);
                                           FStar_TypeChecker_Cfg.for_extraction
                                             =
-                                            (uu___10.FStar_TypeChecker_Cfg.for_extraction)
+                                            (uu___10.FStar_TypeChecker_Cfg.for_extraction);
+                                          FStar_TypeChecker_Cfg.unrefine =
+                                            (uu___10.FStar_TypeChecker_Cfg.unrefine)
                                         });
                                      FStar_TypeChecker_Cfg.tcenv =
                                        (cfg1.FStar_TypeChecker_Cfg.tcenv);

--- a/src/ocaml-output/FStar_TypeChecker_TcTerm.ml
+++ b/src/ocaml-output/FStar_TypeChecker_TcTerm.ml
@@ -3008,7 +3008,11 @@ and (tc_maybe_toplevel_term :
                   FStar_TypeChecker_Normalize.unfold_whnf env1
                     lc.FStar_TypeChecker_Common.res_typ in
                 let uu___8 =
-                  let uu___9 = FStar_Syntax_Util.unmeta t0 in
+                  let uu___9 =
+                    let uu___10 =
+                      let uu___11 = FStar_Syntax_Util.unmeta t0 in
+                      FStar_Syntax_Util.unrefine uu___11 in
+                    FStar_Syntax_Util.unmeta uu___10 in
                   FStar_Syntax_Util.head_and_args uu___9 in
                 (match uu___8 with
                  | (thead, uu___9) ->

--- a/src/ocaml-output/FStar_TypeChecker_TcTerm.ml
+++ b/src/ocaml-output/FStar_TypeChecker_TcTerm.ml
@@ -3005,15 +3005,12 @@ and (tc_maybe_toplevel_term :
            (match uu___5 with
             | (uu___6, lc, uu___7) ->
                 let t0 =
-                  FStar_TypeChecker_Normalize.unfold_whnf env1
+                  FStar_TypeChecker_Normalize.unfold_whnf'
+                    [FStar_TypeChecker_Env.Unascribe;
+                    FStar_TypeChecker_Env.Unmeta;
+                    FStar_TypeChecker_Env.Unrefine] env1
                     lc.FStar_TypeChecker_Common.res_typ in
-                let uu___8 =
-                  let uu___9 =
-                    let uu___10 =
-                      let uu___11 = FStar_Syntax_Util.unmeta t0 in
-                      FStar_Syntax_Util.unrefine uu___11 in
-                    FStar_Syntax_Util.unmeta uu___10 in
-                  FStar_Syntax_Util.head_and_args uu___9 in
+                let uu___8 = FStar_Syntax_Util.head_and_args t0 in
                 (match uu___8 with
                  | (thead, uu___9) ->
                      ((let uu___11 =

--- a/src/ocaml-output/FStar_TypeChecker_Util.ml
+++ b/src/ocaml-output/FStar_TypeChecker_Util.ml
@@ -7167,7 +7167,11 @@ let (find_record_or_dc_from_typ :
                 let uu___ =
                   let uu___1 =
                     let uu___2 =
-                      FStar_TypeChecker_Normalize.unfold_whnf env t1 in
+                      let uu___3 =
+                        let uu___4 =
+                          FStar_TypeChecker_Normalize.unfold_whnf env t1 in
+                        FStar_Syntax_Util.unmeta uu___4 in
+                      FStar_Syntax_Util.unrefine uu___3 in
                     FStar_Syntax_Util.unmeta uu___2 in
                   FStar_Syntax_Util.head_and_args uu___1 in
                 (match uu___ with

--- a/src/ocaml-output/FStar_TypeChecker_Util.ml
+++ b/src/ocaml-output/FStar_TypeChecker_Util.ml
@@ -7166,13 +7166,10 @@ let (find_record_or_dc_from_typ :
             | FStar_Pervasives_Native.Some t1 ->
                 let uu___ =
                   let uu___1 =
-                    let uu___2 =
-                      let uu___3 =
-                        let uu___4 =
-                          FStar_TypeChecker_Normalize.unfold_whnf env t1 in
-                        FStar_Syntax_Util.unmeta uu___4 in
-                      FStar_Syntax_Util.unrefine uu___3 in
-                    FStar_Syntax_Util.unmeta uu___2 in
+                    FStar_TypeChecker_Normalize.unfold_whnf'
+                      [FStar_TypeChecker_Env.Unascribe;
+                      FStar_TypeChecker_Env.Unmeta;
+                      FStar_TypeChecker_Env.Unrefine] env t1 in
                   FStar_Syntax_Util.head_and_args uu___1 in
                 (match uu___ with
                  | (thead, uu___1) ->

--- a/src/typechecker/FStar.TypeChecker.Cfg.fs
+++ b/src/typechecker/FStar.TypeChecker.Cfg.fs
@@ -52,6 +52,7 @@ type fsteps = {
      weakly_reduce_scrutinee:bool;
      nbe_step:bool;
      for_extraction:bool;
+     unrefine : bool;
 }
 
 let steps_to_string f =
@@ -90,6 +91,7 @@ let steps_to_string f =
     in_full_norm_request = %s;\n\
     weakly_reduce_scrutinee = %s;\n\
     for_extraction = %s;\n\
+    unrefine = %s;\n\
   }"
   [ f.beta |> b;
     f.iota |> b;
@@ -118,6 +120,7 @@ let steps_to_string f =
     f.in_full_norm_request |> b;
     f.weakly_reduce_scrutinee |> b;
     f.for_extraction |> b;
+    f.unrefine |> b;
    ]
 
 let default_steps : fsteps = {
@@ -149,6 +152,7 @@ let default_steps : fsteps = {
     weakly_reduce_scrutinee = true;
     nbe_step = false;
     for_extraction = false;
+    unrefine = false;
 }
 
 let fstep_add_one s fs =
@@ -189,6 +193,7 @@ let fstep_add_one s fs =
     | Unascribe ->  { fs with unascribe = true }
     | NBE -> {fs with nbe_step = true }
     | ForExtraction -> {fs with for_extraction = true }
+    | Unrefine -> {fs with unrefine = true }
 
 let to_fsteps (s : list<step>) : fsteps =
     List.fold_right fstep_add_one s default_steps

--- a/src/typechecker/FStar.TypeChecker.Cfg.fsi
+++ b/src/typechecker/FStar.TypeChecker.Cfg.fsi
@@ -55,6 +55,7 @@ type fsteps = {
      weakly_reduce_scrutinee:bool;
      nbe_step:bool;
      for_extraction:bool;
+     unrefine:bool;
 }
 
 val default_steps : fsteps

--- a/src/typechecker/FStar.TypeChecker.Env.fs
+++ b/src/typechecker/FStar.TypeChecker.Env.fs
@@ -69,6 +69,7 @@ type step =
   | Unascribe
   | NBE
   | ForExtraction //marking an invocation of the normalizer for extraction
+  | Unrefine
 and steps = list<step>
 
 let rec eq_step s1 s2 =
@@ -94,7 +95,8 @@ let rec eq_step s1 s2 =
   | CheckNoUvars, CheckNoUvars
   | Unmeta, Unmeta
   | Unascribe, Unascribe
-  | NBE, NBE -> true
+  | NBE, NBE
+  | Unrefine, Unrefine -> true
   | Exclude s1, Exclude s2 -> eq_step s1 s2
   | UnfoldUntil s1, UnfoldUntil s2 -> s1 = s2
   | UnfoldOnly lids1, UnfoldOnly lids2

--- a/src/typechecker/FStar.TypeChecker.Env.fsi
+++ b/src/typechecker/FStar.TypeChecker.Env.fsi
@@ -57,6 +57,7 @@ type step =
   | Unascribe
   | NBE
   | ForExtraction   //marking an invocation of the normalizer for extraction
+  | Unrefine
 and steps = list<step>
 
 val eq_step : step -> step -> bool

--- a/src/typechecker/FStar.TypeChecker.NBE.fs
+++ b/src/typechecker/FStar.TypeChecker.NBE.fs
@@ -438,6 +438,7 @@ let rec translate (cfg:config) (bs:list<t>) (e:term) : t =
 
     | Tm_refine (bv, tm) ->
       if cfg.core_cfg.steps.for_extraction
+      ||  cfg.core_cfg.steps.unrefine
       then translate cfg bs bv.sort //if we're only extracting, then drop the refinement
       else mk_t <| Refinement ((fun (y:t) -> translate cfg (y::bs) tm),
                               (fun () -> as_arg (translate cfg bs bv.sort))) // XXX: Bogus type?

--- a/src/typechecker/FStar.TypeChecker.Normalize.fs
+++ b/src/typechecker/FStar.TypeChecker.Normalize.fs
@@ -339,7 +339,9 @@ let rec inline_closure_env cfg (env:env) stack t =
         let t = mk (Tm_arrow(bs, c)) t.pos in
         rebuild_closure cfg env stack t
 
-      | Tm_refine(x, _) when cfg.steps.for_extraction ->
+      | Tm_refine(x, _)
+          when cfg.steps.for_extraction
+             || cfg.steps.unrefine ->
         inline_closure_env cfg env stack x.sort
 
       | Tm_refine(x, phi) ->
@@ -1363,7 +1365,9 @@ let rec norm : cfg -> env -> stack -> term -> term =
                    rebuild cfg env stack term
             end
 
-          | Tm_refine(x, _) when cfg.steps.for_extraction ->
+          | Tm_refine(x, _)
+              when cfg.steps.for_extraction
+                 || cfg.steps.unrefine ->
             norm cfg env stack x.sort
 
           | Tm_refine(x, f) -> //non tail-recursive; the alternative is to keep marks on the stack to rebuild the term ... but that's very heavy

--- a/src/typechecker/FStar.TypeChecker.TcTerm.fs
+++ b/src/typechecker/FStar.TypeChecker.TcTerm.fs
@@ -1055,8 +1055,8 @@ and tc_maybe_toplevel_term env (e:term) : term                  (* type-checked 
       tc_term env e
     in
     begin
-    let t0 = N.unfold_whnf env lc.res_typ in
-    let thead, _ = U.head_and_args (U.unmeta (U.unrefine (U.unmeta t0))) in
+    let t0 = N.unfold_whnf' [Unascribe; Unmeta; Unrefine] env lc.res_typ in
+    let thead, _ = U.head_and_args t0 in
     if Env.debug env <| Options.Other "RFD"
     then (
       BU.print3 "Got lc.res_typ=%s; t0 = %s; thead = %s\n"

--- a/src/typechecker/FStar.TypeChecker.TcTerm.fs
+++ b/src/typechecker/FStar.TypeChecker.TcTerm.fs
@@ -1056,7 +1056,7 @@ and tc_maybe_toplevel_term env (e:term) : term                  (* type-checked 
     in
     begin
     let t0 = N.unfold_whnf env lc.res_typ in
-    let thead, _ = U.head_and_args (U.unmeta t0) in
+    let thead, _ = U.head_and_args (U.unmeta (U.unrefine (U.unmeta t0))) in
     if Env.debug env <| Options.Other "RFD"
     then (
       BU.print3 "Got lc.res_typ=%s; t0 = %s; thead = %s\n"

--- a/src/typechecker/FStar.TypeChecker.Util.fs
+++ b/src/typechecker/FStar.TypeChecker.Util.fs
@@ -3184,8 +3184,7 @@ let find_record_or_dc_from_typ env (t:option<typ>) (uc:unresolved_constructor) r
       | None -> default_rdc()
       | Some t ->
         let thead, _ = 
-          U.head_and_args 
-            (U.unmeta (U.unrefine (U.unmeta (N.unfold_whnf env t))))
+          U.head_and_args (N.unfold_whnf' [Unascribe; Unmeta; Unrefine] env t)
         in
         match (SS.compress (U.un_uinst thead)).n with
         | Tm_fvar type_name ->

--- a/src/typechecker/FStar.TypeChecker.Util.fs
+++ b/src/typechecker/FStar.TypeChecker.Util.fs
@@ -3183,7 +3183,10 @@ let find_record_or_dc_from_typ env (t:option<typ>) (uc:unresolved_constructor) r
       match t with
       | None -> default_rdc()
       | Some t ->
-        let thead, _ = U.head_and_args (U.unmeta (N.unfold_whnf env t)) in
+        let thead, _ = 
+          U.head_and_args 
+            (U.unmeta (U.unrefine (U.unmeta (N.unfold_whnf env t))))
+        in
         match (SS.compress (U.un_uinst thead)).n with
         | Tm_fvar type_name ->
           begin

--- a/tests/bug-reports/Bug2374.fst
+++ b/tests/bug-reports/Bug2374.fst
@@ -1,0 +1,17 @@
+module Bug2374
+
+type r1 = { a: bool }
+type r2 = { a: bool }
+let r1_refined = x:r1{x.a == true}
+
+let test_refine_1 (): r1_refined =
+  ({a = true})
+
+let test_refine_1_fix (): r1_refined =
+  ({a = true} <: r1)
+
+let test_refine_2 (x:r1_refined): bool =
+  x.a
+
+let test_refine_2_fix (x:r1_refined): bool =
+  (x <: r1).a

--- a/tests/bug-reports/Bug2374.fst
+++ b/tests/bug-reports/Bug2374.fst
@@ -15,3 +15,19 @@ let test_refine_2 (x:r1_refined): bool =
 
 let test_refine_2_fix (x:r1_refined): bool =
   (x <: r1).a
+
+//nested refinement
+let r1_refined' = x:r1_refined{x.a == true}
+
+let test_refine_1' (): r1_refined' =
+  ({a = true})
+
+let test_refine_2' (x:r1_refined'): bool =
+  x.a
+
+//nested refinement after reduction
+let test_refine_1'' (): ((fun x -> x) r1_refined') =
+  ({a = true})
+
+let test_refine_2'' (x:((fun x -> x) r1_refined')): bool =
+  x.a

--- a/tests/bug-reports/Makefile
+++ b/tests/bug-reports/Makefile
@@ -43,7 +43,7 @@ SHOULD_VERIFY_CLOSED=Bug022.fst Bug024.fst Bug025.fst Bug026.fst Bug026b.fst Bug
   Bug379.fst Bug1182a.fst Bug1182b.fst Bug1901.fst Bug1902.fst Bug258.fst Bug2055.fst Bug2081.fst Bug2099.fst Bug2106.fst Bug2132.fst \
   Bug2138.fst Bug2146.fst Bug2074.fst Bug2125a.fst Bug2125b.fst Bug2167.fst Bug2169.fst Bug2169b.fst Bug2066.fst Bug2189.fst Bug2184.fst \
   Bug2211.fst Bug2210.fst Bug2193.fst Bug2257.fst Bug2229.fst Dec.fst Bug2269.fst Bug2352.fst Bug2366.fst Bug2331.fst \
-  Bug2398.fst Bug2432.fst
+  Bug2398.fst Bug2432.fst Bug2374.fst
 
 SHOULD_VERIFY_INTERFACE_CLOSED=Bug771.fsti Bug771b.fsti
 SHOULD_VERIFY_AND_WARN_CLOSED=Bug016.fst


### PR DESCRIPTION
Theophile Wallez reported in #2347 that record field disambiguation doesn't work when the annotated type is a refinement of a record type.

This PR normalizes the annotated type while removing all refinements to get at the head type, which more robustly determines what record type is being used in a record constructor or in a projector.

This involved adding a new internal step to the normalizer "Unrefine" to make it strip away refinements (as it was already doing for extraction)

See Bug2374.fst for examples