### PR TITLE
Fix for #2475

### DIFF
--- a/src/ocaml-output/FStar_Tactics_Basic.ml
+++ b/src/ocaml-output/FStar_Tactics_Basic.ml
@@ -3897,7 +3897,19 @@ let (uvar_env :
            let uu___ =
              match ty with
              | FStar_Pervasives_Native.Some ty1 ->
-                 FStar_Tactics_Monad.ret ty1
+                 let env2 =
+                   let uu___1 =
+                     let uu___2 = FStar_Syntax_Util.type_u () in
+                     FStar_Compiler_Effect.op_Bar_Greater uu___2
+                       FStar_Pervasives_Native.fst in
+                   FStar_TypeChecker_Env.set_expected_typ env1 uu___1 in
+                 let uu___1 = __tc_ghost env2 ty1 in
+                 FStar_Tactics_Monad.bind uu___1
+                   (fun uu___2 ->
+                      match uu___2 with
+                      | (ty2, uu___3, g) ->
+                          FStar_Tactics_Monad.ret
+                            (ty2, g, (ty2.FStar_Syntax_Syntax.pos)))
              | FStar_Pervasives_Native.None ->
                  let uu___1 =
                    let uu___2 =
@@ -3909,16 +3921,24 @@ let (uvar_env :
                  FStar_Tactics_Monad.bind uu___1
                    (fun uu___2 ->
                       match uu___2 with
-                      | (typ, uvar_typ) -> FStar_Tactics_Monad.ret typ) in
+                      | (typ, uvar_typ) ->
+                          FStar_Tactics_Monad.ret
+                            (typ, FStar_TypeChecker_Env.trivial_guard,
+                              FStar_Compiler_Range.dummyRange)) in
            FStar_Tactics_Monad.bind uu___
-             (fun typ ->
-                let uu___1 =
-                  FStar_Tactics_Monad.new_uvar "uvar_env" env1 typ
-                    ps.FStar_Tactics_Types.entry_range in
-                FStar_Tactics_Monad.bind uu___1
-                  (fun uu___2 ->
-                     match uu___2 with
-                     | (t, uvar_t) -> FStar_Tactics_Monad.ret t)))
+             (fun uu___1 ->
+                match uu___1 with
+                | (typ, g, r) ->
+                    let uu___2 = proc_guard "uvar_env_typ" env1 g r in
+                    FStar_Tactics_Monad.bind uu___2
+                      (fun uu___3 ->
+                         let uu___4 =
+                           FStar_Tactics_Monad.new_uvar "uvar_env" env1 typ
+                             ps.FStar_Tactics_Types.entry_range in
+                         FStar_Tactics_Monad.bind uu___4
+                           (fun uu___5 ->
+                              match uu___5 with
+                              | (t, uvar_t) -> FStar_Tactics_Monad.ret t))))
 let (unshelve : FStar_Syntax_Syntax.term -> unit FStar_Tactics_Monad.tac) =
   fun t ->
     let uu___ =

--- a/tests/bug-reports/Bug2475.fst
+++ b/tests/bug-reports/Bug2475.fst
@@ -1,0 +1,39 @@
+module Bug2475
+
+open FStar.Tactics
+
+// Some dumb function and dumb lemmas
+let f_inv_unsquash (#a:Type0) (f:(a -> a)) = ((forall (x:a). f (f x) == x))
+let f_inv (#a:Type0) (f:(a -> a)) = squash (f_inv_unsquash f)
+
+val f: (int & int) -> (int & int)
+let f (a, b) = (b, a)
+
+// Theorem to work with `apply_lemma` to split a forall on a pair
+val tuple2_ind: #a:Type0 -> #b:Type0 -> p:((a & b) -> Type0) -> squash (forall (x:a) (y:b). p (x, y)) -> Lemma (forall xy. p xy)
+let tuple2_ind #a #b p _ = ()
+
+// First test, get a goal using `assert` (things work fine)
+let test_direct () =
+  assert(f_inv_unsquash f) by (
+    compute ();
+    apply_lemma (`tuple2_ind)
+  )
+
+let test_unshelve () =
+  assert(True) by (
+    // Construct the proof state
+    let proof = uvar_env (top_env ()) (Some (mk_app (`f_inv) [(`(int & int)), Q_Implicit;  (`f), Q_Explicit])) in
+    unshelve proof;
+    // Work on the goal
+    compute ();
+    apply_lemma (`tuple2_ind)
+  )
+
+let test_unshelve_workaround () =
+  assert(True) by (
+    let proof = uvar_env (top_env ()) (Some (mk_app (`f_inv) [(`(tuple2 u#0 u#0 int int)), Q_Implicit;  (`f), Q_Explicit])) in
+    unshelve proof;
+    compute ();
+    apply_lemma (`tuple2_ind)
+  )

--- a/tests/bug-reports/Makefile
+++ b/tests/bug-reports/Makefile
@@ -43,7 +43,7 @@ SHOULD_VERIFY_CLOSED=Bug022.fst Bug024.fst Bug025.fst Bug026.fst Bug026b.fst Bug
   Bug379.fst Bug1182a.fst Bug1182b.fst Bug1901.fst Bug1902.fst Bug258.fst Bug2055.fst Bug2081.fst Bug2099.fst Bug2106.fst Bug2132.fst \
   Bug2138.fst Bug2146.fst Bug2074.fst Bug2125a.fst Bug2125b.fst Bug2167.fst Bug2169.fst Bug2169b.fst Bug2066.fst Bug2189.fst Bug2184.fst \
   Bug2211.fst Bug2210.fst Bug2193.fst Bug2257.fst Bug2229.fst Dec.fst Bug2269.fst Bug2352.fst Bug2366.fst Bug2331.fst \
-  Bug2398.fst Bug2432.fst Bug2374.fst Bug2438.fst Bug2456.fst
+  Bug2398.fst Bug2432.fst Bug2374.fst Bug2438.fst Bug2456.fst Bug2475.fst
 
 SHOULD_VERIFY_INTERFACE_CLOSED=Bug771.fsti Bug771b.fsti
 SHOULD_VERIFY_AND_WARN_CLOSED=Bug016.fst


### PR DESCRIPTION
This PR adds typechecking of the (optional) type argument in the `uvar_env` tactics builtin. This fixes #2475.