### PR TITLE
Remove some warnings during compiler bootstrapping

### DIFF
--- a/src/ocaml-output/FStar_Extraction_Kremlin.ml
+++ b/src/ocaml-output/FStar_Extraction_Kremlin.ml
@@ -765,27 +765,7 @@ let (list_elements :
       | uu___ ->
           failwith "Argument of FStar.Buffer.createL is not a list literal!" in
     list_elements1 [] e2
-let rec (translate_module :
-  (FStar_Extraction_ML_Syntax.mlpath * (FStar_Extraction_ML_Syntax.mlsig *
-    FStar_Extraction_ML_Syntax.mlmodule) FStar_Pervasives_Native.option *
-    FStar_Extraction_ML_Syntax.mllib) -> file)
-  =
-  fun m ->
-    let uu___ = m in
-    match uu___ with
-    | (module_name, modul, uu___1) ->
-        let module_name1 =
-          FStar_Compiler_List.op_At (FStar_Pervasives_Native.fst module_name)
-            [FStar_Pervasives_Native.snd module_name] in
-        let program1 =
-          match modul with
-          | FStar_Pervasives_Native.Some (_signature, decls) ->
-              FStar_Compiler_List.collect
-                (translate_decl (empty module_name1)) decls
-          | uu___2 ->
-              failwith "Unexpected standalone interface or nested modules" in
-        ((FStar_String.concat "_" module_name1), program1)
-and (translate_flags :
+let (translate_flags :
   FStar_Extraction_ML_Syntax.meta Prims.list -> flag Prims.list) =
   fun flags ->
     FStar_Compiler_List.choose
@@ -820,7 +800,7 @@ and (translate_flags :
          | FStar_Extraction_ML_Syntax.Deprecated s ->
              FStar_Pervasives_Native.Some (Deprecated s)
          | uu___1 -> FStar_Pervasives_Native.None) flags
-and (translate_cc :
+let (translate_cc :
   FStar_Extraction_ML_Syntax.meta Prims.list ->
     cc FStar_Pervasives_Native.option)
   =
@@ -837,348 +817,7 @@ and (translate_cc :
     | "fastcall"::[] -> FStar_Pervasives_Native.Some FastCall
     | "cdecl"::[] -> FStar_Pervasives_Native.Some CDecl
     | uu___1 -> FStar_Pervasives_Native.None
-and (translate_decl :
-  env -> FStar_Extraction_ML_Syntax.mlmodule1 -> decl Prims.list) =
-  fun env1 ->
-    fun d ->
-      match d with
-      | FStar_Extraction_ML_Syntax.MLM_Let (flavor, lbs) ->
-          FStar_Compiler_List.choose (translate_let env1 flavor) lbs
-      | FStar_Extraction_ML_Syntax.MLM_Loc uu___ -> []
-      | FStar_Extraction_ML_Syntax.MLM_Ty tys ->
-          FStar_Compiler_List.choose (translate_type_decl env1) tys
-      | FStar_Extraction_ML_Syntax.MLM_Top uu___ ->
-          failwith "todo: translate_decl [MLM_Top]"
-      | FStar_Extraction_ML_Syntax.MLM_Exn (m, uu___) ->
-          (FStar_Compiler_Util.print1_warning
-             "Not extracting exception %s to KreMLin (exceptions unsupported)\n"
-             m;
-           [])
-and (translate_let :
-  env ->
-    FStar_Extraction_ML_Syntax.mlletflavor ->
-      FStar_Extraction_ML_Syntax.mllb -> decl FStar_Pervasives_Native.option)
-  =
-  fun env1 ->
-    fun flavor ->
-      fun lb ->
-        match lb with
-        | { FStar_Extraction_ML_Syntax.mllb_name = name1;
-            FStar_Extraction_ML_Syntax.mllb_tysc =
-              FStar_Pervasives_Native.Some (tvars, t0);
-            FStar_Extraction_ML_Syntax.mllb_add_unit = uu___;
-            FStar_Extraction_ML_Syntax.mllb_def = e;
-            FStar_Extraction_ML_Syntax.mllb_meta = meta;
-            FStar_Extraction_ML_Syntax.print_typ = uu___1;_} when
-            FStar_Compiler_Util.for_some
-              (fun uu___2 ->
-                 match uu___2 with
-                 | FStar_Extraction_ML_Syntax.Assumed -> true
-                 | uu___3 -> false) meta
-            ->
-            let name2 = ((env1.module_name), name1) in
-            let arg_names =
-              match e.FStar_Extraction_ML_Syntax.expr with
-              | FStar_Extraction_ML_Syntax.MLE_Fun (args, uu___2) ->
-                  FStar_Compiler_List.map FStar_Pervasives_Native.fst args
-              | uu___2 -> [] in
-            if (FStar_Compiler_List.length tvars) = Prims.int_zero
-            then
-              let uu___2 =
-                let uu___3 =
-                  let uu___4 = translate_cc meta in
-                  let uu___5 = translate_flags meta in
-                  let uu___6 = translate_type env1 t0 in
-                  (uu___4, uu___5, name2, uu___6, arg_names) in
-                DExternal uu___3 in
-              FStar_Pervasives_Native.Some uu___2
-            else
-              ((let uu___4 =
-                  FStar_Extraction_ML_Syntax.string_of_mlpath name2 in
-                FStar_Compiler_Util.print1_warning
-                  "Not extracting %s to KreMLin (polymorphic assumes are not supported)\n"
-                  uu___4);
-               FStar_Pervasives_Native.None)
-        | { FStar_Extraction_ML_Syntax.mllb_name = name1;
-            FStar_Extraction_ML_Syntax.mllb_tysc =
-              FStar_Pervasives_Native.Some (tvars, t0);
-            FStar_Extraction_ML_Syntax.mllb_add_unit = uu___;
-            FStar_Extraction_ML_Syntax.mllb_def =
-              {
-                FStar_Extraction_ML_Syntax.expr =
-                  FStar_Extraction_ML_Syntax.MLE_Fun (args, body);
-                FStar_Extraction_ML_Syntax.mlty = uu___1;
-                FStar_Extraction_ML_Syntax.loc = uu___2;_};
-            FStar_Extraction_ML_Syntax.mllb_meta = meta;
-            FStar_Extraction_ML_Syntax.print_typ = uu___3;_} ->
-            if
-              FStar_Compiler_List.mem FStar_Extraction_ML_Syntax.NoExtract
-                meta
-            then FStar_Pervasives_Native.None
-            else
-              (let env2 =
-                 if flavor = FStar_Extraction_ML_Syntax.Rec
-                 then extend env1 name1
-                 else env1 in
-               let env3 =
-                 FStar_Compiler_List.fold_left
-                   (fun env4 -> fun name2 -> extend_t env4 name2) env2 tvars in
-               let rec find_return_type eff i uu___5 =
-                 match uu___5 with
-                 | FStar_Extraction_ML_Syntax.MLTY_Fun (uu___6, eff1, t) when
-                     i > Prims.int_zero ->
-                     find_return_type eff1 (i - Prims.int_one) t
-                 | t -> (i, eff, t) in
-               let name2 = ((env3.module_name), name1) in
-               let uu___5 =
-                 find_return_type FStar_Extraction_ML_Syntax.E_PURE
-                   (FStar_Compiler_List.length args) t0 in
-               match uu___5 with
-               | (i, eff, t) ->
-                   (if i > Prims.int_zero
-                    then
-                      (let msg =
-                         "function type annotation has less arrows than the number of arguments; please mark the return type abbreviation as inline_for_extraction" in
-                       let uu___7 =
-                         FStar_Extraction_ML_Syntax.string_of_mlpath name2 in
-                       FStar_Compiler_Util.print2_warning
-                         "Not extracting %s to KreMLin (%s)\n" uu___7 msg)
-                    else ();
-                    (let t1 = translate_type env3 t in
-                     let binders = translate_binders env3 args in
-                     let env4 = add_binders env3 args in
-                     let cc1 = translate_cc meta in
-                     let meta1 =
-                       match (eff, t1) with
-                       | (FStar_Extraction_ML_Syntax.E_ERASABLE, uu___7) ->
-                           let uu___8 = translate_flags meta in MustDisappear
-                             :: uu___8
-                       | (FStar_Extraction_ML_Syntax.E_PURE, TUnit) ->
-                           let uu___7 = translate_flags meta in MustDisappear
-                             :: uu___7
-                       | uu___7 -> translate_flags meta in
-                     try
-                       (fun uu___7 ->
-                          match () with
-                          | () ->
-                              let body1 = translate_expr env4 body in
-                              FStar_Pervasives_Native.Some
-                                (DFunction
-                                   (cc1, meta1,
-                                     (FStar_Compiler_List.length tvars), t1,
-                                     name2, binders, body1))) ()
-                     with
-                     | e ->
-                         let msg = FStar_Compiler_Util.print_exn e in
-                         ((let uu___9 =
-                             let uu___10 =
-                               let uu___11 =
-                                 FStar_Extraction_ML_Syntax.string_of_mlpath
-                                   name2 in
-                               FStar_Compiler_Util.format2
-                                 "Error while extracting %s to KreMLin (%s)\n"
-                                 uu___11 msg in
-                             (FStar_Errors.Warning_FunctionNotExtacted,
-                               uu___10) in
-                           FStar_Errors.log_issue
-                             FStar_Compiler_Range.dummyRange uu___9);
-                          (let msg1 =
-                             Prims.op_Hat
-                               "This function was not extracted:\n" msg in
-                           FStar_Pervasives_Native.Some
-                             (DFunction
-                                (cc1, meta1,
-                                  (FStar_Compiler_List.length tvars), t1,
-                                  name2, binders, (EAbortS msg1))))))))
-        | { FStar_Extraction_ML_Syntax.mllb_name = name1;
-            FStar_Extraction_ML_Syntax.mllb_tysc =
-              FStar_Pervasives_Native.Some (tvars, t);
-            FStar_Extraction_ML_Syntax.mllb_add_unit = uu___;
-            FStar_Extraction_ML_Syntax.mllb_def = expr1;
-            FStar_Extraction_ML_Syntax.mllb_meta = meta;
-            FStar_Extraction_ML_Syntax.print_typ = uu___1;_} ->
-            if
-              FStar_Compiler_List.mem FStar_Extraction_ML_Syntax.NoExtract
-                meta
-            then FStar_Pervasives_Native.None
-            else
-              (let meta1 = translate_flags meta in
-               let env2 =
-                 FStar_Compiler_List.fold_left
-                   (fun env3 -> fun name2 -> extend_t env3 name2) env1 tvars in
-               let t1 = translate_type env2 t in
-               let name2 = ((env2.module_name), name1) in
-               try
-                 (fun uu___3 ->
-                    match () with
-                    | () ->
-                        let expr2 = translate_expr env2 expr1 in
-                        FStar_Pervasives_Native.Some
-                          (DGlobal
-                             (meta1, name2,
-                               (FStar_Compiler_List.length tvars), t1, expr2)))
-                   ()
-               with
-               | e ->
-                   ((let uu___5 =
-                       let uu___6 =
-                         let uu___7 =
-                           FStar_Extraction_ML_Syntax.string_of_mlpath name2 in
-                         let uu___8 = FStar_Compiler_Util.print_exn e in
-                         FStar_Compiler_Util.format2
-                           "Error extracting %s to KreMLin (%s)\n" uu___7
-                           uu___8 in
-                       (FStar_Errors.Warning_DefinitionNotTranslated, uu___6) in
-                     FStar_Errors.log_issue FStar_Compiler_Range.dummyRange
-                       uu___5);
-                    FStar_Pervasives_Native.Some
-                      (DGlobal
-                         (meta1, name2, (FStar_Compiler_List.length tvars),
-                           t1, EAny))))
-        | { FStar_Extraction_ML_Syntax.mllb_name = name1;
-            FStar_Extraction_ML_Syntax.mllb_tysc = ts;
-            FStar_Extraction_ML_Syntax.mllb_add_unit = uu___;
-            FStar_Extraction_ML_Syntax.mllb_def = uu___1;
-            FStar_Extraction_ML_Syntax.mllb_meta = uu___2;
-            FStar_Extraction_ML_Syntax.print_typ = uu___3;_} ->
-            ((let uu___5 =
-                let uu___6 =
-                  FStar_Compiler_Util.format1
-                    "Not extracting %s to KreMLin\n" name1 in
-                (FStar_Errors.Warning_DefinitionNotTranslated, uu___6) in
-              FStar_Errors.log_issue FStar_Compiler_Range.dummyRange uu___5);
-             (match ts with
-              | FStar_Pervasives_Native.Some (idents, t) ->
-                  let uu___6 =
-                    FStar_Extraction_ML_Code.string_of_mlty ([], "") t in
-                  FStar_Compiler_Util.print2
-                    "Type scheme is: forall %s. %s\n"
-                    (FStar_String.concat ", " idents) uu___6
-              | FStar_Pervasives_Native.None -> ());
-             FStar_Pervasives_Native.None)
-and (translate_type_decl :
-  env ->
-    FStar_Extraction_ML_Syntax.one_mltydecl ->
-      decl FStar_Pervasives_Native.option)
-  =
-  fun env1 ->
-    fun ty ->
-      if
-        FStar_Compiler_List.mem FStar_Extraction_ML_Syntax.NoExtract
-          ty.FStar_Extraction_ML_Syntax.tydecl_meta
-      then FStar_Pervasives_Native.None
-      else
-        (match ty with
-         | { FStar_Extraction_ML_Syntax.tydecl_assumed = assumed;
-             FStar_Extraction_ML_Syntax.tydecl_name = name1;
-             FStar_Extraction_ML_Syntax.tydecl_ignored = uu___1;
-             FStar_Extraction_ML_Syntax.tydecl_parameters = args;
-             FStar_Extraction_ML_Syntax.tydecl_meta = flags;
-             FStar_Extraction_ML_Syntax.tydecl_defn =
-               FStar_Pervasives_Native.Some
-               (FStar_Extraction_ML_Syntax.MLTD_Abbrev t);_}
-             ->
-             let name2 = ((env1.module_name), name1) in
-             let env2 =
-               FStar_Compiler_List.fold_left
-                 (fun env3 -> fun name3 -> extend_t env3 name3) env1 args in
-             if
-               assumed &&
-                 (FStar_Compiler_List.mem
-                    FStar_Extraction_ML_Syntax.CAbstract flags)
-             then FStar_Pervasives_Native.Some (DTypeAbstractStruct name2)
-             else
-               if assumed
-               then
-                 (let name3 =
-                    FStar_Extraction_ML_Syntax.string_of_mlpath name2 in
-                  FStar_Compiler_Util.print1_warning
-                    "Not extracting type definition %s to KreMLin (assumed type)\n"
-                    name3;
-                  FStar_Pervasives_Native.None)
-               else
-                 (let uu___4 =
-                    let uu___5 =
-                      let uu___6 = translate_flags flags in
-                      let uu___7 = translate_type env2 t in
-                      (name2, uu___6, (FStar_Compiler_List.length args),
-                        uu___7) in
-                    DTypeAlias uu___5 in
-                  FStar_Pervasives_Native.Some uu___4)
-         | { FStar_Extraction_ML_Syntax.tydecl_assumed = uu___1;
-             FStar_Extraction_ML_Syntax.tydecl_name = name1;
-             FStar_Extraction_ML_Syntax.tydecl_ignored = uu___2;
-             FStar_Extraction_ML_Syntax.tydecl_parameters = args;
-             FStar_Extraction_ML_Syntax.tydecl_meta = flags;
-             FStar_Extraction_ML_Syntax.tydecl_defn =
-               FStar_Pervasives_Native.Some
-               (FStar_Extraction_ML_Syntax.MLTD_Record fields);_}
-             ->
-             let name2 = ((env1.module_name), name1) in
-             let env2 =
-               FStar_Compiler_List.fold_left
-                 (fun env3 -> fun name3 -> extend_t env3 name3) env1 args in
-             let uu___3 =
-               let uu___4 =
-                 let uu___5 = translate_flags flags in
-                 let uu___6 =
-                   FStar_Compiler_List.map
-                     (fun uu___7 ->
-                        match uu___7 with
-                        | (f, t) ->
-                            let uu___8 =
-                              let uu___9 = translate_type env2 t in
-                              (uu___9, false) in
-                            (f, uu___8)) fields in
-                 (name2, uu___5, (FStar_Compiler_List.length args), uu___6) in
-               DTypeFlat uu___4 in
-             FStar_Pervasives_Native.Some uu___3
-         | { FStar_Extraction_ML_Syntax.tydecl_assumed = uu___1;
-             FStar_Extraction_ML_Syntax.tydecl_name = name1;
-             FStar_Extraction_ML_Syntax.tydecl_ignored = uu___2;
-             FStar_Extraction_ML_Syntax.tydecl_parameters = args;
-             FStar_Extraction_ML_Syntax.tydecl_meta = flags;
-             FStar_Extraction_ML_Syntax.tydecl_defn =
-               FStar_Pervasives_Native.Some
-               (FStar_Extraction_ML_Syntax.MLTD_DType branches1);_}
-             ->
-             let name2 = ((env1.module_name), name1) in
-             let flags1 = translate_flags flags in
-             let env2 = FStar_Compiler_List.fold_left extend_t env1 args in
-             let uu___3 =
-               let uu___4 =
-                 let uu___5 =
-                   FStar_Compiler_List.map
-                     (fun uu___6 ->
-                        match uu___6 with
-                        | (cons, ts) ->
-                            let uu___7 =
-                              FStar_Compiler_List.map
-                                (fun uu___8 ->
-                                   match uu___8 with
-                                   | (name3, t) ->
-                                       let uu___9 =
-                                         let uu___10 = translate_type env2 t in
-                                         (uu___10, false) in
-                                       (name3, uu___9)) ts in
-                            (cons, uu___7)) branches1 in
-                 (name2, flags1, (FStar_Compiler_List.length args), uu___5) in
-               DTypeVariant uu___4 in
-             FStar_Pervasives_Native.Some uu___3
-         | { FStar_Extraction_ML_Syntax.tydecl_assumed = uu___1;
-             FStar_Extraction_ML_Syntax.tydecl_name = name1;
-             FStar_Extraction_ML_Syntax.tydecl_ignored = uu___2;
-             FStar_Extraction_ML_Syntax.tydecl_parameters = uu___3;
-             FStar_Extraction_ML_Syntax.tydecl_meta = uu___4;
-             FStar_Extraction_ML_Syntax.tydecl_defn = uu___5;_} ->
-             ((let uu___7 =
-                 let uu___8 =
-                   FStar_Compiler_Util.format1
-                     "Error extracting type definition %s to KreMLin\n" name1 in
-                 (FStar_Errors.Warning_DefinitionNotTranslated, uu___8) in
-               FStar_Errors.log_issue FStar_Compiler_Range.dummyRange uu___7);
-              FStar_Pervasives_Native.None))
-and (translate_type : env -> FStar_Extraction_ML_Syntax.mlty -> typ) =
+let rec (translate_type : env -> FStar_Extraction_ML_Syntax.mlty -> typ) =
   fun env1 ->
     fun t ->
       match t with
@@ -1360,16 +999,13 @@ and (translate_type : env -> FStar_Extraction_ML_Syntax.mlty -> typ) =
           TTuple uu___
 and (translate_binders :
   env ->
-    (FStar_Extraction_ML_Syntax.mlident * FStar_Extraction_ML_Syntax.mlty)
-      Prims.list -> binder Prims.list)
+    (Prims.string * FStar_Extraction_ML_Syntax.mlty) Prims.list ->
+      binder Prims.list)
   =
   fun env1 ->
     fun args -> FStar_Compiler_List.map (translate_binder env1) args
 and (translate_binder :
-  env ->
-    (FStar_Extraction_ML_Syntax.mlident * FStar_Extraction_ML_Syntax.mlty) ->
-      binder)
-  =
+  env -> (Prims.string * FStar_Extraction_ML_Syntax.mlty) -> binder) =
   fun env1 ->
     fun uu___ ->
       match uu___ with
@@ -3057,6 +2693,367 @@ and (mk_op_app :
             let uu___1 = FStar_Compiler_List.map (translate_expr env1) args in
             ((EOp (op1, w)), uu___1) in
           EApp uu___
+let (translate_type_decl :
+  env ->
+    FStar_Extraction_ML_Syntax.one_mltydecl ->
+      decl FStar_Pervasives_Native.option)
+  =
+  fun env1 ->
+    fun ty ->
+      if
+        FStar_Compiler_List.mem FStar_Extraction_ML_Syntax.NoExtract
+          ty.FStar_Extraction_ML_Syntax.tydecl_meta
+      then FStar_Pervasives_Native.None
+      else
+        (match ty with
+         | { FStar_Extraction_ML_Syntax.tydecl_assumed = assumed;
+             FStar_Extraction_ML_Syntax.tydecl_name = name1;
+             FStar_Extraction_ML_Syntax.tydecl_ignored = uu___1;
+             FStar_Extraction_ML_Syntax.tydecl_parameters = args;
+             FStar_Extraction_ML_Syntax.tydecl_meta = flags;
+             FStar_Extraction_ML_Syntax.tydecl_defn =
+               FStar_Pervasives_Native.Some
+               (FStar_Extraction_ML_Syntax.MLTD_Abbrev t);_}
+             ->
+             let name2 = ((env1.module_name), name1) in
+             let env2 =
+               FStar_Compiler_List.fold_left
+                 (fun env3 -> fun name3 -> extend_t env3 name3) env1 args in
+             if
+               assumed &&
+                 (FStar_Compiler_List.mem
+                    FStar_Extraction_ML_Syntax.CAbstract flags)
+             then FStar_Pervasives_Native.Some (DTypeAbstractStruct name2)
+             else
+               if assumed
+               then
+                 (let name3 =
+                    FStar_Extraction_ML_Syntax.string_of_mlpath name2 in
+                  FStar_Compiler_Util.print1_warning
+                    "Not extracting type definition %s to KreMLin (assumed type)\n"
+                    name3;
+                  FStar_Pervasives_Native.None)
+               else
+                 (let uu___4 =
+                    let uu___5 =
+                      let uu___6 = translate_flags flags in
+                      let uu___7 = translate_type env2 t in
+                      (name2, uu___6, (FStar_Compiler_List.length args),
+                        uu___7) in
+                    DTypeAlias uu___5 in
+                  FStar_Pervasives_Native.Some uu___4)
+         | { FStar_Extraction_ML_Syntax.tydecl_assumed = uu___1;
+             FStar_Extraction_ML_Syntax.tydecl_name = name1;
+             FStar_Extraction_ML_Syntax.tydecl_ignored = uu___2;
+             FStar_Extraction_ML_Syntax.tydecl_parameters = args;
+             FStar_Extraction_ML_Syntax.tydecl_meta = flags;
+             FStar_Extraction_ML_Syntax.tydecl_defn =
+               FStar_Pervasives_Native.Some
+               (FStar_Extraction_ML_Syntax.MLTD_Record fields);_}
+             ->
+             let name2 = ((env1.module_name), name1) in
+             let env2 =
+               FStar_Compiler_List.fold_left
+                 (fun env3 -> fun name3 -> extend_t env3 name3) env1 args in
+             let uu___3 =
+               let uu___4 =
+                 let uu___5 = translate_flags flags in
+                 let uu___6 =
+                   FStar_Compiler_List.map
+                     (fun uu___7 ->
+                        match uu___7 with
+                        | (f, t) ->
+                            let uu___8 =
+                              let uu___9 = translate_type env2 t in
+                              (uu___9, false) in
+                            (f, uu___8)) fields in
+                 (name2, uu___5, (FStar_Compiler_List.length args), uu___6) in
+               DTypeFlat uu___4 in
+             FStar_Pervasives_Native.Some uu___3
+         | { FStar_Extraction_ML_Syntax.tydecl_assumed = uu___1;
+             FStar_Extraction_ML_Syntax.tydecl_name = name1;
+             FStar_Extraction_ML_Syntax.tydecl_ignored = uu___2;
+             FStar_Extraction_ML_Syntax.tydecl_parameters = args;
+             FStar_Extraction_ML_Syntax.tydecl_meta = flags;
+             FStar_Extraction_ML_Syntax.tydecl_defn =
+               FStar_Pervasives_Native.Some
+               (FStar_Extraction_ML_Syntax.MLTD_DType branches1);_}
+             ->
+             let name2 = ((env1.module_name), name1) in
+             let flags1 = translate_flags flags in
+             let env2 = FStar_Compiler_List.fold_left extend_t env1 args in
+             let uu___3 =
+               let uu___4 =
+                 let uu___5 =
+                   FStar_Compiler_List.map
+                     (fun uu___6 ->
+                        match uu___6 with
+                        | (cons, ts) ->
+                            let uu___7 =
+                              FStar_Compiler_List.map
+                                (fun uu___8 ->
+                                   match uu___8 with
+                                   | (name3, t) ->
+                                       let uu___9 =
+                                         let uu___10 = translate_type env2 t in
+                                         (uu___10, false) in
+                                       (name3, uu___9)) ts in
+                            (cons, uu___7)) branches1 in
+                 (name2, flags1, (FStar_Compiler_List.length args), uu___5) in
+               DTypeVariant uu___4 in
+             FStar_Pervasives_Native.Some uu___3
+         | { FStar_Extraction_ML_Syntax.tydecl_assumed = uu___1;
+             FStar_Extraction_ML_Syntax.tydecl_name = name1;
+             FStar_Extraction_ML_Syntax.tydecl_ignored = uu___2;
+             FStar_Extraction_ML_Syntax.tydecl_parameters = uu___3;
+             FStar_Extraction_ML_Syntax.tydecl_meta = uu___4;
+             FStar_Extraction_ML_Syntax.tydecl_defn = uu___5;_} ->
+             ((let uu___7 =
+                 let uu___8 =
+                   FStar_Compiler_Util.format1
+                     "Error extracting type definition %s to KreMLin\n" name1 in
+                 (FStar_Errors.Warning_DefinitionNotTranslated, uu___8) in
+               FStar_Errors.log_issue FStar_Compiler_Range.dummyRange uu___7);
+              FStar_Pervasives_Native.None))
+let (translate_let :
+  env ->
+    FStar_Extraction_ML_Syntax.mlletflavor ->
+      FStar_Extraction_ML_Syntax.mllb -> decl FStar_Pervasives_Native.option)
+  =
+  fun env1 ->
+    fun flavor ->
+      fun lb ->
+        match lb with
+        | { FStar_Extraction_ML_Syntax.mllb_name = name1;
+            FStar_Extraction_ML_Syntax.mllb_tysc =
+              FStar_Pervasives_Native.Some (tvars, t0);
+            FStar_Extraction_ML_Syntax.mllb_add_unit = uu___;
+            FStar_Extraction_ML_Syntax.mllb_def = e;
+            FStar_Extraction_ML_Syntax.mllb_meta = meta;
+            FStar_Extraction_ML_Syntax.print_typ = uu___1;_} when
+            FStar_Compiler_Util.for_some
+              (fun uu___2 ->
+                 match uu___2 with
+                 | FStar_Extraction_ML_Syntax.Assumed -> true
+                 | uu___3 -> false) meta
+            ->
+            let name2 = ((env1.module_name), name1) in
+            let arg_names =
+              match e.FStar_Extraction_ML_Syntax.expr with
+              | FStar_Extraction_ML_Syntax.MLE_Fun (args, uu___2) ->
+                  FStar_Compiler_List.map FStar_Pervasives_Native.fst args
+              | uu___2 -> [] in
+            if (FStar_Compiler_List.length tvars) = Prims.int_zero
+            then
+              let uu___2 =
+                let uu___3 =
+                  let uu___4 = translate_cc meta in
+                  let uu___5 = translate_flags meta in
+                  let uu___6 = translate_type env1 t0 in
+                  (uu___4, uu___5, name2, uu___6, arg_names) in
+                DExternal uu___3 in
+              FStar_Pervasives_Native.Some uu___2
+            else
+              ((let uu___4 =
+                  FStar_Extraction_ML_Syntax.string_of_mlpath name2 in
+                FStar_Compiler_Util.print1_warning
+                  "Not extracting %s to KreMLin (polymorphic assumes are not supported)\n"
+                  uu___4);
+               FStar_Pervasives_Native.None)
+        | { FStar_Extraction_ML_Syntax.mllb_name = name1;
+            FStar_Extraction_ML_Syntax.mllb_tysc =
+              FStar_Pervasives_Native.Some (tvars, t0);
+            FStar_Extraction_ML_Syntax.mllb_add_unit = uu___;
+            FStar_Extraction_ML_Syntax.mllb_def =
+              {
+                FStar_Extraction_ML_Syntax.expr =
+                  FStar_Extraction_ML_Syntax.MLE_Fun (args, body);
+                FStar_Extraction_ML_Syntax.mlty = uu___1;
+                FStar_Extraction_ML_Syntax.loc = uu___2;_};
+            FStar_Extraction_ML_Syntax.mllb_meta = meta;
+            FStar_Extraction_ML_Syntax.print_typ = uu___3;_} ->
+            if
+              FStar_Compiler_List.mem FStar_Extraction_ML_Syntax.NoExtract
+                meta
+            then FStar_Pervasives_Native.None
+            else
+              (let env2 =
+                 if flavor = FStar_Extraction_ML_Syntax.Rec
+                 then extend env1 name1
+                 else env1 in
+               let env3 =
+                 FStar_Compiler_List.fold_left
+                   (fun env4 -> fun name2 -> extend_t env4 name2) env2 tvars in
+               let rec find_return_type eff i uu___5 =
+                 match uu___5 with
+                 | FStar_Extraction_ML_Syntax.MLTY_Fun (uu___6, eff1, t) when
+                     i > Prims.int_zero ->
+                     find_return_type eff1 (i - Prims.int_one) t
+                 | t -> (i, eff, t) in
+               let name2 = ((env3.module_name), name1) in
+               let uu___5 =
+                 find_return_type FStar_Extraction_ML_Syntax.E_PURE
+                   (FStar_Compiler_List.length args) t0 in
+               match uu___5 with
+               | (i, eff, t) ->
+                   (if i > Prims.int_zero
+                    then
+                      (let msg =
+                         "function type annotation has less arrows than the number of arguments; please mark the return type abbreviation as inline_for_extraction" in
+                       let uu___7 =
+                         FStar_Extraction_ML_Syntax.string_of_mlpath name2 in
+                       FStar_Compiler_Util.print2_warning
+                         "Not extracting %s to KreMLin (%s)\n" uu___7 msg)
+                    else ();
+                    (let t1 = translate_type env3 t in
+                     let binders = translate_binders env3 args in
+                     let env4 = add_binders env3 args in
+                     let cc1 = translate_cc meta in
+                     let meta1 =
+                       match (eff, t1) with
+                       | (FStar_Extraction_ML_Syntax.E_ERASABLE, uu___7) ->
+                           let uu___8 = translate_flags meta in MustDisappear
+                             :: uu___8
+                       | (FStar_Extraction_ML_Syntax.E_PURE, TUnit) ->
+                           let uu___7 = translate_flags meta in MustDisappear
+                             :: uu___7
+                       | uu___7 -> translate_flags meta in
+                     try
+                       (fun uu___7 ->
+                          match () with
+                          | () ->
+                              let body1 = translate_expr env4 body in
+                              FStar_Pervasives_Native.Some
+                                (DFunction
+                                   (cc1, meta1,
+                                     (FStar_Compiler_List.length tvars), t1,
+                                     name2, binders, body1))) ()
+                     with
+                     | e ->
+                         let msg = FStar_Compiler_Util.print_exn e in
+                         ((let uu___9 =
+                             let uu___10 =
+                               let uu___11 =
+                                 FStar_Extraction_ML_Syntax.string_of_mlpath
+                                   name2 in
+                               FStar_Compiler_Util.format2
+                                 "Error while extracting %s to KreMLin (%s)\n"
+                                 uu___11 msg in
+                             (FStar_Errors.Warning_FunctionNotExtacted,
+                               uu___10) in
+                           FStar_Errors.log_issue
+                             FStar_Compiler_Range.dummyRange uu___9);
+                          (let msg1 =
+                             Prims.op_Hat
+                               "This function was not extracted:\n" msg in
+                           FStar_Pervasives_Native.Some
+                             (DFunction
+                                (cc1, meta1,
+                                  (FStar_Compiler_List.length tvars), t1,
+                                  name2, binders, (EAbortS msg1))))))))
+        | { FStar_Extraction_ML_Syntax.mllb_name = name1;
+            FStar_Extraction_ML_Syntax.mllb_tysc =
+              FStar_Pervasives_Native.Some (tvars, t);
+            FStar_Extraction_ML_Syntax.mllb_add_unit = uu___;
+            FStar_Extraction_ML_Syntax.mllb_def = expr1;
+            FStar_Extraction_ML_Syntax.mllb_meta = meta;
+            FStar_Extraction_ML_Syntax.print_typ = uu___1;_} ->
+            if
+              FStar_Compiler_List.mem FStar_Extraction_ML_Syntax.NoExtract
+                meta
+            then FStar_Pervasives_Native.None
+            else
+              (let meta1 = translate_flags meta in
+               let env2 =
+                 FStar_Compiler_List.fold_left
+                   (fun env3 -> fun name2 -> extend_t env3 name2) env1 tvars in
+               let t1 = translate_type env2 t in
+               let name2 = ((env2.module_name), name1) in
+               try
+                 (fun uu___3 ->
+                    match () with
+                    | () ->
+                        let expr2 = translate_expr env2 expr1 in
+                        FStar_Pervasives_Native.Some
+                          (DGlobal
+                             (meta1, name2,
+                               (FStar_Compiler_List.length tvars), t1, expr2)))
+                   ()
+               with
+               | uu___3 ->
+                   ((let uu___5 =
+                       let uu___6 =
+                         let uu___7 =
+                           FStar_Extraction_ML_Syntax.string_of_mlpath name2 in
+                         let uu___8 = FStar_Compiler_Util.print_exn uu___3 in
+                         FStar_Compiler_Util.format2
+                           "Error extracting %s to KreMLin (%s)\n" uu___7
+                           uu___8 in
+                       (FStar_Errors.Warning_DefinitionNotTranslated, uu___6) in
+                     FStar_Errors.log_issue FStar_Compiler_Range.dummyRange
+                       uu___5);
+                    FStar_Pervasives_Native.Some
+                      (DGlobal
+                         (meta1, name2, (FStar_Compiler_List.length tvars),
+                           t1, EAny))))
+        | { FStar_Extraction_ML_Syntax.mllb_name = name1;
+            FStar_Extraction_ML_Syntax.mllb_tysc = ts;
+            FStar_Extraction_ML_Syntax.mllb_add_unit = uu___;
+            FStar_Extraction_ML_Syntax.mllb_def = uu___1;
+            FStar_Extraction_ML_Syntax.mllb_meta = uu___2;
+            FStar_Extraction_ML_Syntax.print_typ = uu___3;_} ->
+            ((let uu___5 =
+                let uu___6 =
+                  FStar_Compiler_Util.format1
+                    "Not extracting %s to KreMLin\n" name1 in
+                (FStar_Errors.Warning_DefinitionNotTranslated, uu___6) in
+              FStar_Errors.log_issue FStar_Compiler_Range.dummyRange uu___5);
+             (match ts with
+              | FStar_Pervasives_Native.Some (idents, t) ->
+                  let uu___6 =
+                    FStar_Extraction_ML_Code.string_of_mlty ([], "") t in
+                  FStar_Compiler_Util.print2
+                    "Type scheme is: forall %s. %s\n"
+                    (FStar_String.concat ", " idents) uu___6
+              | FStar_Pervasives_Native.None -> ());
+             FStar_Pervasives_Native.None)
+let (translate_decl :
+  env -> FStar_Extraction_ML_Syntax.mlmodule1 -> decl Prims.list) =
+  fun env1 ->
+    fun d ->
+      match d with
+      | FStar_Extraction_ML_Syntax.MLM_Let (flavor, lbs) ->
+          FStar_Compiler_List.choose (translate_let env1 flavor) lbs
+      | FStar_Extraction_ML_Syntax.MLM_Loc uu___ -> []
+      | FStar_Extraction_ML_Syntax.MLM_Ty tys ->
+          FStar_Compiler_List.choose (translate_type_decl env1) tys
+      | FStar_Extraction_ML_Syntax.MLM_Top uu___ ->
+          failwith "todo: translate_decl [MLM_Top]"
+      | FStar_Extraction_ML_Syntax.MLM_Exn (m, uu___) ->
+          (FStar_Compiler_Util.print1_warning
+             "Not extracting exception %s to KreMLin (exceptions unsupported)\n"
+             m;
+           [])
+let (translate_module :
+  (FStar_Extraction_ML_Syntax.mlpath * (FStar_Extraction_ML_Syntax.mlsig *
+    FStar_Extraction_ML_Syntax.mlmodule) FStar_Pervasives_Native.option *
+    FStar_Extraction_ML_Syntax.mllib) -> file)
+  =
+  fun m ->
+    let uu___ = m in
+    match uu___ with
+    | (module_name, modul, uu___1) ->
+        let module_name1 =
+          FStar_Compiler_List.op_At (FStar_Pervasives_Native.fst module_name)
+            [FStar_Pervasives_Native.snd module_name] in
+        let program1 =
+          match modul with
+          | FStar_Pervasives_Native.Some (_signature, decls) ->
+              FStar_Compiler_List.collect
+                (translate_decl (empty module_name1)) decls
+          | uu___2 ->
+              failwith "Unexpected standalone interface or nested modules" in
+        ((FStar_String.concat "_" module_name1), program1)
 let (translate : FStar_Extraction_ML_Syntax.mllib -> file Prims.list) =
   fun uu___ ->
     match uu___ with

--- a/src/ocaml-output/FStar_SMTEncoding_EncodeTerm.ml
+++ b/src/ocaml-output/FStar_SMTEncoding_EncodeTerm.ml
@@ -750,27 +750,6 @@ and (encode_term_pred :
               let uu___1 =
                 FStar_SMTEncoding_Term.mk_HasTypeWithFuel fuel_opt e t1 in
               (uu___1, decls)
-and (encode_term_pred' :
-  FStar_SMTEncoding_Term.term FStar_Pervasives_Native.option ->
-    FStar_Syntax_Syntax.typ ->
-      FStar_SMTEncoding_Env.env_t ->
-        FStar_SMTEncoding_Term.term ->
-          (FStar_SMTEncoding_Term.term * FStar_SMTEncoding_Term.decls_t))
-  =
-  fun fuel_opt ->
-    fun t ->
-      fun env ->
-        fun e ->
-          let uu___ = encode_term t env in
-          match uu___ with
-          | (t1, decls) ->
-              (match fuel_opt with
-               | FStar_Pervasives_Native.None ->
-                   let uu___1 = FStar_SMTEncoding_Term.mk_HasTypeZ e t1 in
-                   (uu___1, decls)
-               | FStar_Pervasives_Native.Some f ->
-                   let uu___1 = FStar_SMTEncoding_Term.mk_HasTypeFuel f e t1 in
-                   (uu___1, decls))
 and (encode_arith_term :
   FStar_SMTEncoding_Env.env_t ->
     FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
@@ -3306,39 +3285,6 @@ and (encode_args :
                              (FStar_Compiler_List.op_At decls decls'))))
              ([], [])) in
       match uu___ with | (l1, decls) -> ((FStar_Compiler_List.rev l1), decls)
-and (encode_function_type_as_formula :
-  FStar_Syntax_Syntax.typ ->
-    FStar_SMTEncoding_Env.env_t ->
-      (FStar_SMTEncoding_Term.term * FStar_SMTEncoding_Term.decls_t))
-  =
-  fun t ->
-    fun env ->
-      let universe_of_binders binders =
-        FStar_Compiler_List.map (fun uu___ -> FStar_Syntax_Syntax.U_zero)
-          binders in
-      let quant = FStar_Syntax_Util.smt_lemma_as_forall t universe_of_binders in
-      let env1 =
-        {
-          FStar_SMTEncoding_Env.bvar_bindings =
-            (env.FStar_SMTEncoding_Env.bvar_bindings);
-          FStar_SMTEncoding_Env.fvar_bindings =
-            (env.FStar_SMTEncoding_Env.fvar_bindings);
-          FStar_SMTEncoding_Env.depth = (env.FStar_SMTEncoding_Env.depth);
-          FStar_SMTEncoding_Env.tcenv = (env.FStar_SMTEncoding_Env.tcenv);
-          FStar_SMTEncoding_Env.warn = (env.FStar_SMTEncoding_Env.warn);
-          FStar_SMTEncoding_Env.nolabels =
-            (env.FStar_SMTEncoding_Env.nolabels);
-          FStar_SMTEncoding_Env.use_zfuel_name = true;
-          FStar_SMTEncoding_Env.encode_non_total_function_typ =
-            (env.FStar_SMTEncoding_Env.encode_non_total_function_typ);
-          FStar_SMTEncoding_Env.current_module_name =
-            (env.FStar_SMTEncoding_Env.current_module_name);
-          FStar_SMTEncoding_Env.encoding_quantifier =
-            (env.FStar_SMTEncoding_Env.encoding_quantifier);
-          FStar_SMTEncoding_Env.global_cache =
-            (env.FStar_SMTEncoding_Env.global_cache)
-        } in
-      encode_formula quant env1
 and (encode_smt_patterns :
   FStar_Syntax_Syntax.arg Prims.list Prims.list ->
     FStar_SMTEncoding_Env.env_t ->
@@ -3824,3 +3770,36 @@ and (encode_formula :
                    FStar_SMTEncoding_Term.mkExists
                      phi1.FStar_Syntax_Syntax.pos uu___5 in
                  (uu___4, decls))))
+let (encode_function_type_as_formula :
+  FStar_Syntax_Syntax.typ ->
+    FStar_SMTEncoding_Env.env_t ->
+      (FStar_SMTEncoding_Term.term * FStar_SMTEncoding_Term.decls_t))
+  =
+  fun t ->
+    fun env ->
+      let universe_of_binders binders =
+        FStar_Compiler_List.map (fun uu___ -> FStar_Syntax_Syntax.U_zero)
+          binders in
+      let quant = FStar_Syntax_Util.smt_lemma_as_forall t universe_of_binders in
+      let env1 =
+        {
+          FStar_SMTEncoding_Env.bvar_bindings =
+            (env.FStar_SMTEncoding_Env.bvar_bindings);
+          FStar_SMTEncoding_Env.fvar_bindings =
+            (env.FStar_SMTEncoding_Env.fvar_bindings);
+          FStar_SMTEncoding_Env.depth = (env.FStar_SMTEncoding_Env.depth);
+          FStar_SMTEncoding_Env.tcenv = (env.FStar_SMTEncoding_Env.tcenv);
+          FStar_SMTEncoding_Env.warn = (env.FStar_SMTEncoding_Env.warn);
+          FStar_SMTEncoding_Env.nolabels =
+            (env.FStar_SMTEncoding_Env.nolabels);
+          FStar_SMTEncoding_Env.use_zfuel_name = true;
+          FStar_SMTEncoding_Env.encode_non_total_function_typ =
+            (env.FStar_SMTEncoding_Env.encode_non_total_function_typ);
+          FStar_SMTEncoding_Env.current_module_name =
+            (env.FStar_SMTEncoding_Env.current_module_name);
+          FStar_SMTEncoding_Env.encoding_quantifier =
+            (env.FStar_SMTEncoding_Env.encoding_quantifier);
+          FStar_SMTEncoding_Env.global_cache =
+            (env.FStar_SMTEncoding_Env.global_cache)
+        } in
+      encode_formula quant env1

--- a/src/smtencoding/FStar.SMTEncoding.EncodeTerm.fs
+++ b/src/smtencoding/FStar.SMTEncoding.EncodeTerm.fs
@@ -341,7 +341,6 @@ let is_BitVector_primitive head args =
 
     | _ -> false
 
-
 let rec encode_const c env =
     match c with
     | Const_unit -> mk_Term_unit, []
@@ -394,12 +393,6 @@ and encode_binders (fuel_opt:option<term>) (bs:Syntax.binders) (env:env_t) :
 and encode_term_pred (fuel_opt:option<term>) (t:typ) (env:env_t) (e:term) : term * decls_t =
     let t, decls = encode_term t env in
     mk_HasTypeWithFuel fuel_opt e t, decls
-
-and encode_term_pred' (fuel_opt:option<term>) (t:typ) (env:env_t) (e:term) : term * decls_t =
-    let t, decls = encode_term t env in
-    match fuel_opt with
-        | None -> mk_HasTypeZ e t, decls
-        | Some f -> mk_HasTypeFuel f e t, decls
 
 and encode_arith_term env head args_e =
     let arg_tms, decls = encode_args args_e env in
@@ -775,7 +768,7 @@ and encode_term (t:typ) (env:env_t) : (term         (* encoding of t, expects t 
              let t_decls = [tdecl; k_assumption; pre_typing; t_interp] in
              t, decls@decls'@guard_decls@(mk_decls tsym tkey_hash t_decls (decls@decls'@guard_decls))
 
-        else 
+        else
              (*
               * AR: compute a hash for the Non total arrow,
               *       that we will use in the name of the arrow
@@ -794,8 +787,8 @@ and encode_term (t:typ) (env:env_t) : (term         (* encoding of t, expects t 
                  ([], vars, mk_and_l (guards_l@[ct]@effect_args)) in
                let tkey_hash = "Non_total_Tm_arrow" ^ (hash_of_term tkey) ^ "@Effect=" ^
                  (c |> U.comp_effect_name |> string_of_lid) in
-               BU.digest_of_string tkey_hash in                 
-        
+               BU.digest_of_string tkey_hash in
+
              let tsym = "Non_total_Tm_arrow_" ^ tkey_hash in
              let tdecl = Term.DeclFun(tsym, [], Term_sort, None) in
              let t = mkApp(tsym, []) in
@@ -1334,13 +1327,6 @@ and encode_args (l:args) (env:env_t) : (list<term> * decls_t)  =
         ([], []) in
     List.rev l, decls
 
-(* this assumes t is a Lemma *)
-and encode_function_type_as_formula (t:typ) (env:env_t) : term * decls_t =
-    let universe_of_binders binders = List.map (fun _ -> U_zero) binders in
-    let quant = U.smt_lemma_as_forall t universe_of_binders in
-    let env = {env with use_zfuel_name=true} in //see #1028; SMT lemmas should not violate the fuel instrumentation
-    encode_formula quant env
-
 and encode_smt_patterns (pats_l:list<(list<S.arg>)>) env : list<(list<term>)> * decls_t =
     let env = {env with use_zfuel_name=true} in
     let encode_smt_pattern t =
@@ -1546,6 +1532,13 @@ and encode_formula (phi:typ) (env:env_t) : (term * decls_t)  = (* expects phi to
           pats |> List.iter (check_pattern_vars env vars);
           let vars, pats, guard, body, decls = encode_q_body env vars pats body in
           mkExists phi.pos (pats, vars, mkAnd(guard, body)), decls
+
+(* this assumes t is a Lemma *)
+let encode_function_type_as_formula (t:typ) (env:env_t) : term * decls_t =
+    let universe_of_binders binders = List.map (fun _ -> U_zero) binders in
+    let quant = U.smt_lemma_as_forall t universe_of_binders in
+    let env = {env with use_zfuel_name=true} in //see #1028; SMT lemmas should not violate the fuel instrumentation
+    encode_formula quant env
 
 (***************************************************************************************************)
 (* end main encoding of kinds/types/exps/formulae *)


### PR DESCRIPTION
Running `make boot` was raising several warnings related to recursive definitions not being used in their body. This was due to large numbers of mutually recursive definitions, while some of them didn't need to be.
This PR refactors code to remove these warnings. Warnings remain in `FStar.Parser.ToDocument`, where the mutually recursive definitions are more heavily intertwined.