### PR TITLE
Fix deprecated warnings when building F*

### DIFF
--- a/src/basic/ml/FStar_Compiler_Util.ml
+++ b/src/basic/ml/FStar_Compiler_Util.ml
@@ -424,7 +424,7 @@ let pimap_fold (m:'value pimap) f a = ZMap.fold f m a
 (* restore pre-2.11 BatString.nsplit behavior,
    see https://github.com/ocaml-batteries-team/batteries-included/issues/845 *)
 let batstring_nsplit s t =
-  if s = "" then [] else BatString.split_on_string s t
+  if s = "" then [] else BatString.split_on_string t s
 
 let format (fmt:string) (args:string list) =
   let frags = batstring_nsplit fmt "%s" in
@@ -556,7 +556,7 @@ let replace_chars (s:string) c (by:string) =
   BatString.replace_chars (fun x -> if x = Char.chr c then by else BatString.of_char x) s
 let hashcode s = Z.of_int (StringOps.hash s)
 let compare s1 s2 = Z.of_int (BatString.compare s1 s2)
-let split s sep = BatString.split_on_string s sep
+let split s sep = BatString.split_on_string sep s
 let splitlines s = split s "\n"
 
 let iof = int_of_float

--- a/src/basic/ml/FStar_Compiler_Util.ml
+++ b/src/basic/ml/FStar_Compiler_Util.ml
@@ -424,12 +424,12 @@ let pimap_fold (m:'value pimap) f a = ZMap.fold f m a
 (* restore pre-2.11 BatString.nsplit behavior,
    see https://github.com/ocaml-batteries-team/batteries-included/issues/845 *)
 let batstring_nsplit s t =
-  if s = "" then [] else BatString.nsplit s t
-                                    
+  if s = "" then [] else BatString.split_on_string s t
+
 let format (fmt:string) (args:string list) =
   let frags = batstring_nsplit fmt "%s" in
   if BatList.length frags <> BatList.length args + 1 then
-    failwith ("Not enough arguments to format string " ^fmt^ " : expected " ^ (Pervasives.string_of_int (BatList.length frags)) ^ " got [" ^ (BatString.concat ", " args) ^ "] frags are [" ^ (BatString.concat ", " frags) ^ "]")
+    failwith ("Not enough arguments to format string " ^fmt^ " : expected " ^ (Stdlib.string_of_int (BatList.length frags)) ^ " got [" ^ (BatString.concat ", " args) ^ "] frags are [" ^ (BatString.concat ", " frags) ^ "]")
   else
     let args = args@[""] in
     BatList.fold_left2 (fun out frag arg -> out ^ frag ^ arg) "" frags args
@@ -556,7 +556,7 @@ let replace_chars (s:string) c (by:string) =
   BatString.replace_chars (fun x -> if x = Char.chr c then by else BatString.of_char x) s
 let hashcode s = Z.of_int (StringOps.hash s)
 let compare s1 s2 = Z.of_int (BatString.compare s1 s2)
-let split s sep = if s = "" then [""] else BatString.nsplit s sep
+let split s sep = BatString.split_on_string s sep
 let splitlines s = split s "\n"
 
 let iof = int_of_float

--- a/ulib/ml/FStar_Pervasives_Native.ml
+++ b/ulib/ml/FStar_Pervasives_Native.ml
@@ -14,8 +14,8 @@ let __proj__Some__item__v = function Some x -> x | _ -> assert false
 (* 'a * 'b *)
 type ('a,'b) tuple2 = 'a * 'b[@@deriving yojson,show]
 
-let fst = Pervasives.fst
-let snd = Pervasives.snd
+let fst = Stdlib.fst
+let snd = Stdlib.snd
 
 let __proj__Mktuple2__1 = fst
 let __proj__Mktuple2__2 = snd

--- a/ulib/ml/FStar_String.ml
+++ b/ulib/ml/FStar_String.ml
@@ -5,7 +5,7 @@ let op_Hat s t =  strcat s t
 (* restore pre-2.11 BatString.nsplit behavior,
    see https://github.com/ocaml-batteries-team/batteries-included/issues/845 *)
 let batstring_nsplit s t =
-  if s = "" then [] else BatString.split_on_string s t
+  if s = "" then [] else BatString.split_on_string t s
 
 let split seps s =
   let rec repeat_split acc = function

--- a/ulib/ml/FStar_String.ml
+++ b/ulib/ml/FStar_String.ml
@@ -5,7 +5,7 @@ let op_Hat s t =  strcat s t
 (* restore pre-2.11 BatString.nsplit behavior,
    see https://github.com/ocaml-batteries-team/batteries-included/issues/845 *)
 let batstring_nsplit s t =
-  if s = "" then [] else BatString.nsplit s t
+  if s = "" then [] else BatString.split_on_string s t
 
 let split seps s =
   let rec repeat_split acc = function


### PR DESCRIPTION
This PR fixes several warnings from deprecated functions in OCaml libraries that occur during the F* build.
It also simplifies the implementation of `split` in FStar_Compiler_Util`, which seems inherited from an old version of BatString. See the documentation here: https://github.com/ocaml-batteries-team/batteries-included/blob/master/src/batString.mliv#L790.

The use of newer functions is not compatible with versions of OCaml < 4.07.
There are two possibilities, either requiring OCaml >= 4.07, or taking an additional dependency on stdlib-shims. I'd be in favour of the former, as OCaml < 4.07 is starting to be quite old, and KreMLin already requires OCaml >= 4.08.
In both cases, `fstar.opam` will need to be updated before merging this PR.
What do others think? @tahina-pro @nikswamy @aseemr 
