### PR TITLE
Enable subtyping in ctrl_rewrite (and hence, l_to_r)

### DIFF
--- a/src/ocaml-output/FStar_Tactics_CtrlRewrite.ml
+++ b/src/ocaml-output/FStar_Tactics_CtrlRewrite.ml
@@ -168,55 +168,74 @@ let (__do_rewrite :
                  if uu___2
                  then FStar_Tactics_Monad.ret tm
                  else
-                   (let typ = lcomp.FStar_TypeChecker_Common.res_typ in
-                    let uu___4 =
-                      FStar_Tactics_Monad.new_uvar "do_rewrite.rhs" env typ
-                        (rangeof g0) in
+                   (let uu___4 =
+                      let uu___5 =
+                        let uu___6 = FStar_Syntax_Util.type_u () in
+                        FStar_Pervasives_Native.fst uu___6 in
+                      FStar_Tactics_Monad.new_uvar "do_rewrite.eq_ty" env
+                        uu___5 (rangeof g0) in
                     FStar_Tactics_Monad.bind uu___4
                       (fun uu___5 ->
                          match uu___5 with
-                         | (ut, uvar_ut) ->
-                             FStar_Tactics_Monad.mlog
-                               (fun uu___6 ->
-                                  let uu___7 =
-                                    FStar_Syntax_Print.term_to_string tm in
-                                  let uu___8 =
-                                    FStar_Syntax_Print.term_to_string ut in
-                                  FStar_Compiler_Util.print2
-                                    "do_rewrite: making equality\n\t%s ==\n\t%s\n"
-                                    uu___7 uu___8)
-                               (fun uu___6 ->
-                                  let uu___7 =
-                                    let uu___8 =
-                                      let uu___9 =
-                                        env.FStar_TypeChecker_Env.universe_of
-                                          env typ in
-                                      FStar_Syntax_Util.mk_eq2 uu___9 typ tm
-                                        ut in
-                                    FStar_Tactics_Monad.add_irrelevant_goal
-                                      g0 "do_rewrite.eq" env uu___8 in
-                                  FStar_Tactics_Monad.bind uu___7
-                                    (fun uu___8 ->
-                                       let uu___9 =
-                                         FStar_Tactics_Basic.focus rewriter in
-                                       FStar_Tactics_Monad.bind uu___9
-                                         (fun uu___10 ->
-                                            let ut1 =
-                                              FStar_TypeChecker_Normalize.reduce_uvar_solutions
-                                                env ut in
-                                            FStar_Tactics_Monad.mlog
-                                              (fun uu___11 ->
-                                                 let uu___12 =
-                                                   FStar_Syntax_Print.term_to_string
-                                                     tm in
-                                                 let uu___13 =
-                                                   FStar_Syntax_Print.term_to_string
-                                                     ut1 in
-                                                 FStar_Compiler_Util.print2
-                                                   "rewrite_rec: succeeded rewriting\n\t%s to\n\t%s\n"
-                                                   uu___12 uu___13)
-                                              (fun uu___11 ->
-                                                 FStar_Tactics_Monad.ret ut1)))))))
+                         | (typ, uvar_typ) ->
+                             let uu___6 =
+                               FStar_Tactics_Monad.new_uvar "do_rewrite.rhs"
+                                 env typ (rangeof g0) in
+                             FStar_Tactics_Monad.bind uu___6
+                               (fun uu___7 ->
+                                  match uu___7 with
+                                  | (ut, uvar_ut) ->
+                                      FStar_Tactics_Monad.mlog
+                                        (fun uu___8 ->
+                                           let uu___9 =
+                                             FStar_Syntax_Print.term_to_string
+                                               tm in
+                                           let uu___10 =
+                                             FStar_Syntax_Print.term_to_string
+                                               ut in
+                                           FStar_Compiler_Util.print2
+                                             "do_rewrite: making equality\n\t%s ==\n\t%s\n"
+                                             uu___9 uu___10)
+                                        (fun uu___8 ->
+                                           let uu___9 =
+                                             let uu___10 =
+                                               let uu___11 =
+                                                 env.FStar_TypeChecker_Env.universe_of
+                                                   env typ in
+                                               FStar_Syntax_Util.mk_eq2
+                                                 uu___11 typ tm ut in
+                                             FStar_Tactics_Monad.add_irrelevant_goal
+                                               g0 "do_rewrite.eq" env uu___10 in
+                                           FStar_Tactics_Monad.bind uu___9
+                                             (fun uu___10 ->
+                                                let uu___11 =
+                                                  FStar_Tactics_Basic.focus
+                                                    rewriter in
+                                                FStar_Tactics_Monad.bind
+                                                  uu___11
+                                                  (fun uu___12 ->
+                                                     let ut1 =
+                                                       FStar_TypeChecker_Normalize.reduce_uvar_solutions
+                                                         env ut in
+                                                     let uu___13 =
+                                                       FStar_TypeChecker_Rel.subtype_nosmt_force
+                                                         env
+                                                         lcomp.FStar_TypeChecker_Common.res_typ
+                                                         typ in
+                                                     FStar_Tactics_Monad.mlog
+                                                       (fun uu___14 ->
+                                                          let uu___15 =
+                                                            FStar_Syntax_Print.term_to_string
+                                                              tm in
+                                                          let uu___16 =
+                                                            FStar_Syntax_Print.term_to_string
+                                                              ut1 in
+                                                          FStar_Compiler_Util.print2
+                                                            "rewrite_rec: succeeded rewriting\n\t%s to\n\t%s\n"
+                                                            uu___15 uu___16)
+                                                       (fun uu___14 ->
+                                                          FStar_Tactics_Monad.ret
+                                                            ut1))))))))
 let (do_rewrite :
   FStar_Tactics_Types.goal ->
     rewriter_ty ->


### PR DESCRIPTION
#2476 reported issues when using `l_to_r` to perform rewritings.
`l_to_r` is based on the primitive `ctrl_rewrite`, which traverses all subterms `t` of a given term, creates a goal of the shape `t == ?u`, and tries to apply lemma a rewriter lemma provided by the user. The core problem was that the goal created also sets a type for the equality based on the type of t in the environment, i.e. `eq2 #(type_of t) t ?u`. With @TWal and @W95Psp, we observed that this type was sometimes imprecise, for instance, it was often without guards, and led to unification errors when trying to apply the rewriter lemma.

To solve this issue, this PR does not set the type of the eq2 goal, but instead creates a new unification variable for it. Unfortunately, because of the structure of do_rewrite, there is no rollback of the environment when a rewriting fails and uvars created when generating the eq2 goal must be solved. To do so, I'm currently querying the unifier to ensure that the type of the subterm is a subtype of the type indicated in eq2, but there might be a better way to do that.

Fixes #2476 