### PR TITLE
Positivity of Steel references

### DIFF
--- a/examples/steel/StructUpdate.fst
+++ b/examples/steel/StructUpdate.fst
@@ -41,8 +41,6 @@ open Steel.Effect.Atomic
 open Steel.Effect
 open Steel.PCMReference
 
-let pts_to (#a:Type u#1) (#pcm:pcm a) (r:ref a pcm) (v:a) = to_vprop (Steel.Memory.pts_to r v)
-
 let upd_first (#a #b:Type u#1) (r:ref (t a b) pcm_t) (x:Ghost.erased a) (y:a)
   : SteelT unit 
            (pts_to r (First #a #b x))

--- a/examples/steel/StructUpdate.fst
+++ b/examples/steel/StructUpdate.fst
@@ -41,8 +41,10 @@ open Steel.Effect.Atomic
 open Steel.Effect
 open Steel.PCMReference
 
-let upd_first #a #b (r:ref (t a b) pcm_t) (x:Ghost.erased a) (y:a)
-  : SteelT unit
+let pts_to (#a:Type u#1) (#pcm:pcm a) (r:ref a pcm) (v:a) = to_vprop (Steel.Memory.pts_to r v)
+
+let upd_first (#a #b:Type u#1) (r:ref (t a b) pcm_t) (x:Ghost.erased a) (y:a)
+  : SteelT unit 
            (pts_to r (First #a #b x))
            (fun _ -> pts_to r (First #a #b y))
   = let f
@@ -56,7 +58,7 @@ let upd_first #a #b (r:ref (t a b) pcm_t) (x:Ghost.erased a) (y:a)
     in
     upd_gen r (First #a #b x) (First #a #b y) f
 
-let upd_second #a #b (r:ref (t a b) pcm_t) (x:Ghost.erased b) (y:b)
+let upd_second (#a #b:Type u#1) (r:ref (t a b) pcm_t) (x:Ghost.erased b) (y:b)
   : SteelT unit
            (pts_to r (Second #a #b x))
            (fun _ -> pts_to r (Second #a #b y))

--- a/src/ocaml-output/FStar_TypeChecker_Util.ml
+++ b/src/ocaml-output/FStar_TypeChecker_Util.ml
@@ -473,7 +473,19 @@ let (extract_let_rec_annotation :
                                | (lbtyp, body1, recheck) ->
                                    let uu___9 =
                                      FStar_Syntax_Util.abs bs body1 rcopt in
-                                   (lbtyp, uu___9, recheck))) in
+                                   (lbtyp, uu___9, recheck)))
+                     | uu___6 ->
+                         let uu___7 =
+                           let uu___8 =
+                             let uu___9 =
+                               FStar_Syntax_Print.term_to_string e3 in
+                             FStar_Compiler_Util.format1
+                               "Expected the definition of a 'let rec' to be a function literal; got %s"
+                               uu___9 in
+                           (FStar_Errors.Fatal_UnexpectedComputationTypeForLetRec,
+                             uu___8) in
+                         FStar_Errors.raise_error uu___7
+                           e3.FStar_Syntax_Syntax.pos in
                    aux_lbdef e1 in
                  match t2.FStar_Syntax_Syntax.n with
                  | FStar_Syntax_Syntax.Tm_unknown ->

--- a/src/typechecker/FStar.TypeChecker.Util.fs
+++ b/src/typechecker/FStar.TypeChecker.Util.fs
@@ -332,6 +332,12 @@ let extract_let_rec_annotation env {lbname=lbname; lbunivs=univ_vars; lbtyp=t; l
             in
             let lbtyp, body, recheck = aux_abs_body body in
             lbtyp, U.abs bs body rcopt, recheck
+            
+          | _ ->
+            raise_error (Errors.Fatal_UnexpectedComputationTypeForLetRec,
+                         BU.format1 "Expected the definition of a 'let rec' to be a function literal; got %s"
+                                                   (Print.term_to_string e))
+                              e.pos
       in
       aux_lbdef e
     in

--- a/tests/bug-reports/Bug2414.fst
+++ b/tests/bug-reports/Bug2414.fst
@@ -1,0 +1,45 @@
+module Bug2414
+
+let rec length #a (l:list a)
+  : nat
+  = match l with
+    | [] -> 0
+    | _ :: tl -> 1 + length tl
+
+let total_order (#a:Type) (f: (a -> a -> bool)) =
+    (forall a. f a a)
+    /\ (forall a1 a2. (f a1 a2 /\ a1=!=a2)  <==> not (f a2 a1))
+    /\ (forall a1 a2 a3. f a1 a2 /\ f a2 a3 ==> f a1 a3)
+    /\ (forall a1 a2. f a1 a2 \/ f a2 a1)
+
+let total_order_t (a:Type) = f:(a -> a -> bool) { total_order f }
+
+let rec sorted #a  (f:total_order_t a) (l:list a)
+  : bool
+  = match l with
+    | [] -> true
+    | [x] -> true
+    | x :: y :: xs -> f x y && sorted f (y :: xs)
+
+let rec mem (#a:eqtype) (i:a) (l:list a)
+  : bool
+  = match l with
+    | [] -> false
+    | hd :: tl -> hd = i || mem i tl
+
+let rec sort #a (f:total_order_t a) (l:list a)
+  : Tot (list a) (decreases (length l))
+  = admit()
+
+val sort_correct (#a:eqtype) (f:total_order_t a) (l:list a)
+  : Lemma (ensures (
+           let m = sort f l in
+           sorted f m /\
+           (forall i. mem i l = mem i m)))
+          (decreases (length l))
+[@@expect_failure [184]]
+let rec sort_correct = admit() // Bug: Seems to be OK if I remove 'rec' here
+
+[@@expect_failure [184]]
+let rec f =
+  let g = f in 4

--- a/tests/bug-reports/Bug2478.fst
+++ b/tests/bug-reports/Bug2478.fst
@@ -1,0 +1,46 @@
+module Bug2478
+
+class bytes_like (bytes:Type0) = {
+  toto: unit
+}
+
+assume new type test_type (bytes:Type0) {|bytes_like bytes|} (a:Type)
+assume val bind: #a:Type -> #b:(a -> Type) -> #bytes:Type0 -> {| bytes_like bytes |} -> tt_a:test_type bytes a -> tt_b:(xa:a -> test_type bytes (b xa)) -> (test_type bytes (xa:a&(b xa)))
+assume val tt_bytes: #bytes:Type0 -> {|bytes_like bytes|} -> test_type bytes bytes
+
+// Works fine
+let tt_pair2 (bytes:Type0) {|bytes_like bytes|}: (test_type bytes (x1:bytes & bytes)) =
+    tt_bytes;;
+    tt_bytes
+
+// This hangs.
+// If we remove the `bytes` indirection, it works
+// If we change the dependant pair to a non-dependant pair, it works
+// If we remove the typeclass, it works
+
+let tt_pair3 (bytes:Type0) {|bytes_like bytes|}: Tot (test_type bytes (x1:bytes & (x2:bytes & bytes))) =
+  tt_bytes;;
+  tt_bytes;;
+  tt_bytes
+
+let key0 (bytes:Type0) (#pf: bytes_like bytes) = bytes
+
+// assume
+// val ps_key0: #bytes:Type0 -> (#pf: bytes_like bytes ) -> test_type bytes (key0 bytes #pf)
+
+// //#push-options "--debug Bug2478 --debug_level Rel,RelCheck,Tac --lax"
+// let ps_pair3_0 (bytes:Type0) (#pf: bytes_like bytes ): (test_type bytes (x0:bytes & (x1:bytes & bytes))) =
+//     ps_key0 #_ #_;;
+//     ps_key0 ;;
+//     ps_key0
+
+let key (bytes:Type0) {|bytes_like bytes|} = bytes
+
+
+assume val ps_key: #bytes:Type0 -> {|bytes_like bytes|} -> test_type bytes (key bytes)
+
+// #push-options "--debug Bug2478 --debug_level Rel,RelCheck,Tac --lax"
+let ps_pair3 (bytes:Type0) {| pf: bytes_like bytes|}: (test_type bytes (x0:bytes & (x1:bytes & bytes))) =
+    ps_key #_ #_;;
+    ps_key;;
+    ps_key

--- a/tests/bug-reports/Makefile
+++ b/tests/bug-reports/Makefile
@@ -44,7 +44,7 @@ SHOULD_VERIFY_CLOSED=Bug022.fst Bug024.fst Bug025.fst Bug026.fst Bug026b.fst Bug
   Bug2138.fst Bug2146.fst Bug2074.fst Bug2125a.fst Bug2125b.fst Bug2167.fst Bug2169.fst Bug2169b.fst Bug2066.fst Bug2189.fst Bug2184.fst \
   Bug2211.fst Bug2210.fst Bug2193.fst Bug2257.fst Bug2229.fst Dec.fst Bug2269.fst Bug2352.fst Bug2366.fst Bug2331.fst \
   Bug2398.fst Bug2432.fst Bug2374.fst Bug2438.fst Bug2456.fst Bug2475.fst Bug2477.fst Bug1355.fst \
-  Bug1418.fst Bug171.fst Bug2496.fst
+  Bug1418.fst Bug171.fst Bug2496.fst Bug2478.fst Bug2414.fst
 
 
 SHOULD_VERIFY_INTERFACE_CLOSED=Bug771.fsti Bug771b.fsti

--- a/ulib/FStar.Universe.fsti
+++ b/ulib/FStar.Universe.fsti
@@ -22,7 +22,7 @@ module FStar.Universe
 
 
 (** [raise_t a] is an isomorphic copy of [a] (living in universe 'ua) in universe [max 'ua 'ub] **)
-val raise_t : Type u#a -> Type u#(max a b)
+val raise_t ([@@@ strictly_positive] _ : Type u#a) : Type u#(max a b)
 
 (** [raise_val x] injects a value [x] of type [a] to [raise_t a] **)
 val raise_val : #a:Type u#a -> x:a -> raise_t u#a u#b a

--- a/ulib/experimental/Steel.Heap.fst
+++ b/ulib/experimental/Steel.Heap.fst
@@ -83,7 +83,7 @@ let disjoint_addr (m0 m1:heap u#h) (a:addr)
     | None, None ->
       True
 
-type ref (a:Type u#a) (pcm:pcm a): Type u#0 =
+type core_ref : Type u#0 =
   | Null
   | Addr of addr
 

--- a/ulib/experimental/Steel.Heap.fsti
+++ b/ulib/experimental/Steel.Heap.fsti
@@ -39,8 +39,12 @@ open FStar.PCM
 *)
 val heap  : Type u#(a + 1)
 
-(** A [ref a pcm] is a key into the [heap], containing a value of type [a] governed by the [pcm] *)
-val ref (a:Type u#a) (pcm:pcm a) : Type u#0
+(** A [core_ref] is a key into the [heap] or [null] *)
+val core_ref : Type u#0
+
+(** We index a [core_ref] by the type of its heap contents
+    and a [pcm] governing it, for ease of type inference *)
+let ref (a:Type u#a) (pcm:pcm a) : Type u#0 = core_ref
 
 (** [null] is a specific reference, that is not associated to any value
 *)

--- a/ulib/experimental/Steel.HigherReference.fsti
+++ b/ulib/experimental/Steel.HigherReference.fsti
@@ -30,7 +30,7 @@ module Mem = Steel.Memory
 /// Steel.PCMReference, by instantiating a specific fractional permission PCM
 
 /// An abstract datatype for references
-val ref (a:Type u#1) : Type u#0
+val ref ([@@@strictly_positive] a:Type u#1) : Type u#0
 
 /// The null pointer
 val null (#a:Type u#1) : ref a

--- a/ulib/experimental/Steel.Memory.fsti
+++ b/ulib/experimental/Steel.Memory.fsti
@@ -110,7 +110,9 @@ let slimp (p1 p2 : slprop) : prop =
   forall m. interp p1 m ==> interp p2 m
 
 (** A memory maps a [ref]erence to its associated value *)
-val ref (a:Type u#a) (pcm:pcm a) : Type u#0
+val core_ref : Type u#0
+
+let ref (a:Type u#a) (pcm:pcm a) : Type u#0 = core_ref
 
 (** [null] is a specific reference, that is not associated to any value
 *)

--- a/ulib/experimental/Steel.Reference.fsti
+++ b/ulib/experimental/Steel.Reference.fsti
@@ -35,7 +35,7 @@ module Mem = Steel.Memory
 /// to better separate reasoning about memory safety and functional correctness when handling references.
 
 /// An abstract datatype for references
-val ref (a:Type0) : Type0
+val ref ([@@@strictly_positive] a:Type0) : Type0
 
 /// The null pointer
 val null (#a:Type0) : ref a


### PR DESCRIPTION
Revised Steel.Heap and Steel.Memory changing the ref a pcm
    type to a non-parmeterized version ref, since the params
    are currently present only as an assist for type inference
    not for any semantic reason. This will make positivity
    trivial. We will retain the ref a type at higher
    levels (Steel.HigherReference etc.).


Also fixed #2414 