### PR TITLE
Ignore VS and Ionide settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,3 +89,8 @@ nubuild.progress
 
 # Z3/F* nightly/weekly files
 /nightly
+
+# IDE per-user settings files
+.ionide/
+.vs/
+


### PR DESCRIPTION
This is binary, per-user settings, and have them constantly in Git window is a noise.