### PR TITLE
Now need to set FSTAR_HOME to verify examples

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -137,6 +137,7 @@ commands. (Note: On Windows this requires Cygwin and `make`)
    take a long time, use a lot of resources, and there are also some quirks
    explained in the notes below.
 
+        $ export FSTAR_HOME=/path/to/fstar
         $ make -C examples -j6
         $ echo $?    # non-zero means build failed! scroll up for error message!
 


### PR DESCRIPTION
Without that I'm getting a new error:
```
$ make -C examples
make: Entering directory '/home/hritcu/Projects/fstar/pub/examples'
Makefile.include:11: /home/hritcu/Projects/fstar/pub/bin//../lib/fstar/gmake/fstar.mk: No such file or directory
make: *** No rule to make target '/home/hritcu/Projects/fstar/pub/bin//../lib/fstar/gmake/fstar.mk'.  Stop.
make: Leaving directory '/home/hritcu/Projects/fstar/pub/examples'
```