### PR TITLE
A no_method attribute for typeclasses to avoid generating methods for some fields

### DIFF
--- a/src/ocaml-output/FStar_Errors.ml
+++ b/src/ocaml-output/FStar_Errors.ml
@@ -2718,7 +2718,7 @@ let (set_option_warning_callback_range :
   FStar_Compiler_Range.range FStar_Pervasives_Native.option -> unit) =
   fun ropt ->
     FStar_Options.set_option_warning_callback (warn_unsafe_options ropt)
-let (uu___228 :
+let (uu___241 :
   (((Prims.string -> error_setting Prims.list) -> unit) *
     (unit -> error_setting Prims.list)))
   =
@@ -2763,10 +2763,10 @@ let (uu___228 :
   (set_callbacks, get_error_flags)
 let (set_parse_warn_error :
   (Prims.string -> error_setting Prims.list) -> unit) =
-  match uu___228 with
+  match uu___241 with
   | (set_parse_warn_error1, error_flags) -> set_parse_warn_error1
 let (error_flags : unit -> error_setting Prims.list) =
-  match uu___228 with | (set_parse_warn_error1, error_flags1) -> error_flags1
+  match uu___241 with | (set_parse_warn_error1, error_flags1) -> error_flags1
 let (lookup : raw_error -> (raw_error * error_flag * Prims.int)) =
   fun err ->
     let flags = error_flags () in

--- a/src/ocaml-output/FStar_Options.ml
+++ b/src/ocaml-output/FStar_Options.ml
@@ -946,7 +946,7 @@ let (interp_quake_arg : Prims.string -> (Prims.int * Prims.int * Prims.bool))
           let uu___ = ios f1 in let uu___1 = ios f2 in (uu___, uu___1, true)
         else failwith "unexpected value for --quake"
     | uu___ -> failwith "unexpected value for --quake"
-let (uu___403 : (((Prims.string -> unit) -> unit) * (Prims.string -> unit)))
+let (uu___405 : (((Prims.string -> unit) -> unit) * (Prims.string -> unit)))
   =
   let cb = FStar_Compiler_Util.mk_ref FStar_Pervasives_Native.None in
   let set1 f =
@@ -958,11 +958,11 @@ let (uu___403 : (((Prims.string -> unit) -> unit) * (Prims.string -> unit)))
     | FStar_Pervasives_Native.Some f -> f msg in
   (set1, call)
 let (set_option_warning_callback_aux : (Prims.string -> unit) -> unit) =
-  match uu___403 with
+  match uu___405 with
   | (set_option_warning_callback_aux1, option_warning_callback) ->
       set_option_warning_callback_aux1
 let (option_warning_callback : Prims.string -> unit) =
-  match uu___403 with
+  match uu___405 with
   | (set_option_warning_callback_aux1, option_warning_callback1) ->
       option_warning_callback1
 let (set_option_warning_callback : (Prims.string -> unit) -> unit) =
@@ -1451,7 +1451,7 @@ let (settable_specs :
     (FStar_Compiler_List.filter
        (fun uu___ ->
           match uu___ with | (uu___1, x, uu___2, uu___3) -> settable x))
-let (uu___585 :
+let (uu___587 :
   (((unit -> FStar_Getopt.parse_cmdline_res) -> unit) *
     (unit -> FStar_Getopt.parse_cmdline_res)))
   =
@@ -1468,11 +1468,11 @@ let (uu___585 :
   (set1, call)
 let (set_error_flags_callback_aux :
   (unit -> FStar_Getopt.parse_cmdline_res) -> unit) =
-  match uu___585 with
+  match uu___587 with
   | (set_error_flags_callback_aux1, set_error_flags) ->
       set_error_flags_callback_aux1
 let (set_error_flags : unit -> FStar_Getopt.parse_cmdline_res) =
-  match uu___585 with
+  match uu___587 with
   | (set_error_flags_callback_aux1, set_error_flags1) -> set_error_flags1
 let (set_error_flags_callback :
   (unit -> FStar_Getopt.parse_cmdline_res) -> unit) =

--- a/src/ocaml-output/FStar_Parser_Const.ml
+++ b/src/ocaml-output/FStar_Parser_Const.ml
@@ -477,6 +477,8 @@ let (tcresolve_lid : FStar_Ident.lid) =
   fstar_tactics_lid' ["Typeclasses"; "tcresolve"]
 let (tcinstance_lid : FStar_Ident.lid) =
   fstar_tactics_lid' ["Typeclasses"; "tcinstance"]
+let (no_method_lid : FStar_Ident.lid) =
+  fstar_tactics_lid' ["Typeclasses"; "no_method"]
 let (effect_TAC_lid : FStar_Ident.lid) = fstar_tactics_lid' ["Effect"; "TAC"]
 let (effect_Tac_lid : FStar_Ident.lid) = fstar_tactics_lid' ["Effect"; "Tac"]
 let (by_tactic_lid : FStar_Ident.lid) =

--- a/src/ocaml-output/FStar_Reflection_Data.ml
+++ b/src/ocaml-output/FStar_Reflection_Data.ml
@@ -472,63 +472,63 @@ let (mk_inspect_pack_pair : Prims.string -> (refl_constant * refl_constant))
       let uu___ = FStar_Syntax_Syntax.fv_to_tm pack_fv in
       { lid = pack_lid; fv = pack_fv; t = uu___ } in
     (inspect, pack)
-let (uu___91 : (refl_constant * refl_constant)) = mk_inspect_pack_pair "_ln"
+let (uu___105 : (refl_constant * refl_constant)) = mk_inspect_pack_pair "_ln"
 let (fstar_refl_inspect_ln : refl_constant) =
-  match uu___91 with
+  match uu___105 with
   | (fstar_refl_inspect_ln1, fstar_refl_pack_ln) -> fstar_refl_inspect_ln1
 let (fstar_refl_pack_ln : refl_constant) =
-  match uu___91 with
+  match uu___105 with
   | (fstar_refl_inspect_ln1, fstar_refl_pack_ln1) -> fstar_refl_pack_ln1
-let (uu___98 : (refl_constant * refl_constant)) = mk_inspect_pack_pair "_fv"
+let (uu___112 : (refl_constant * refl_constant)) = mk_inspect_pack_pair "_fv"
 let (fstar_refl_inspect_fv : refl_constant) =
-  match uu___98 with
+  match uu___112 with
   | (fstar_refl_inspect_fv1, fstar_refl_pack_fv) -> fstar_refl_inspect_fv1
 let (fstar_refl_pack_fv : refl_constant) =
-  match uu___98 with
+  match uu___112 with
   | (fstar_refl_inspect_fv1, fstar_refl_pack_fv1) -> fstar_refl_pack_fv1
-let (uu___105 : (refl_constant * refl_constant)) = mk_inspect_pack_pair "_bv"
+let (uu___119 : (refl_constant * refl_constant)) = mk_inspect_pack_pair "_bv"
 let (fstar_refl_inspect_bv : refl_constant) =
-  match uu___105 with
+  match uu___119 with
   | (fstar_refl_inspect_bv1, fstar_refl_pack_bv) -> fstar_refl_inspect_bv1
 let (fstar_refl_pack_bv : refl_constant) =
-  match uu___105 with
+  match uu___119 with
   | (fstar_refl_inspect_bv1, fstar_refl_pack_bv1) -> fstar_refl_pack_bv1
-let (uu___112 : (refl_constant * refl_constant)) =
+let (uu___126 : (refl_constant * refl_constant)) =
   mk_inspect_pack_pair "_binder"
 let (fstar_refl_inspect_binder : refl_constant) =
-  match uu___112 with
+  match uu___126 with
   | (fstar_refl_inspect_binder1, fstar_refl_pack_binder) ->
       fstar_refl_inspect_binder1
 let (fstar_refl_pack_binder : refl_constant) =
-  match uu___112 with
+  match uu___126 with
   | (fstar_refl_inspect_binder1, fstar_refl_pack_binder1) ->
       fstar_refl_pack_binder1
-let (uu___119 : (refl_constant * refl_constant)) =
+let (uu___133 : (refl_constant * refl_constant)) =
   mk_inspect_pack_pair "_comp"
 let (fstar_refl_inspect_comp : refl_constant) =
-  match uu___119 with
+  match uu___133 with
   | (fstar_refl_inspect_comp1, fstar_refl_pack_comp) ->
       fstar_refl_inspect_comp1
 let (fstar_refl_pack_comp : refl_constant) =
-  match uu___119 with
+  match uu___133 with
   | (fstar_refl_inspect_comp1, fstar_refl_pack_comp1) ->
       fstar_refl_pack_comp1
-let (uu___126 : (refl_constant * refl_constant)) =
+let (uu___140 : (refl_constant * refl_constant)) =
   mk_inspect_pack_pair "_sigelt"
 let (fstar_refl_inspect_sigelt : refl_constant) =
-  match uu___126 with
+  match uu___140 with
   | (fstar_refl_inspect_sigelt1, fstar_refl_pack_sigelt) ->
       fstar_refl_inspect_sigelt1
 let (fstar_refl_pack_sigelt : refl_constant) =
-  match uu___126 with
+  match uu___140 with
   | (fstar_refl_inspect_sigelt1, fstar_refl_pack_sigelt1) ->
       fstar_refl_pack_sigelt1
-let (uu___133 : (refl_constant * refl_constant)) = mk_inspect_pack_pair "_lb"
+let (uu___147 : (refl_constant * refl_constant)) = mk_inspect_pack_pair "_lb"
 let (fstar_refl_inspect_lb : refl_constant) =
-  match uu___133 with
+  match uu___147 with
   | (fstar_refl_inspect_lb1, fstar_refl_pack_lb) -> fstar_refl_inspect_lb1
 let (fstar_refl_pack_lb : refl_constant) =
-  match uu___133 with
+  match uu___147 with
   | (fstar_refl_inspect_lb1, fstar_refl_pack_lb1) -> fstar_refl_pack_lb1
 let (fstar_refl_env : FStar_Syntax_Syntax.term) =
   mk_refl_types_lid_as_term "env"

--- a/src/ocaml-output/FStar_ToSyntax_ToSyntax.ml
+++ b/src/ocaml-output/FStar_ToSyntax_ToSyntax.ml
@@ -7863,19 +7863,82 @@ and (desugar_decl_noattrs :
                  | FStar_Pervasives_Native.Some id ->
                      let uu___2 = FStar_Syntax_DsEnv.qualify env1 id in
                      [uu___2] in
+               let formals =
+                 let bndl =
+                   FStar_Compiler_Util.try_find
+                     (fun uu___1 ->
+                        match uu___1 with
+                        | {
+                            FStar_Syntax_Syntax.sigel =
+                              FStar_Syntax_Syntax.Sig_bundle uu___2;
+                            FStar_Syntax_Syntax.sigrng = uu___3;
+                            FStar_Syntax_Syntax.sigquals = uu___4;
+                            FStar_Syntax_Syntax.sigmeta = uu___5;
+                            FStar_Syntax_Syntax.sigattrs = uu___6;
+                            FStar_Syntax_Syntax.sigopts = uu___7;_} -> true
+                        | uu___2 -> false) ses in
+                 match bndl with
+                 | FStar_Pervasives_Native.None ->
+                     FStar_Pervasives_Native.None
+                 | FStar_Pervasives_Native.Some bndl1 ->
+                     (match bndl1.FStar_Syntax_Syntax.sigel with
+                      | FStar_Syntax_Syntax.Sig_bundle (ses1, uu___1) ->
+                          FStar_Compiler_Util.find_map ses1
+                            (fun se ->
+                               match se.FStar_Syntax_Syntax.sigel with
+                               | FStar_Syntax_Syntax.Sig_datacon
+                                   (_l, _u, t, uu___2, uu___3, uu___4) ->
+                                   let uu___5 =
+                                     FStar_Syntax_Util.arrow_formals t in
+                                   (match uu___5 with
+                                    | (formals1, uu___6) ->
+                                        FStar_Pervasives_Native.Some formals1)
+                               | uu___2 -> FStar_Pervasives_Native.None)
+                      | uu___1 -> FStar_Pervasives_Native.None) in
                let rec splice_decl meths se =
                  match se.FStar_Syntax_Syntax.sigel with
                  | FStar_Syntax_Syntax.Sig_bundle (ses1, uu___1) ->
                      FStar_Compiler_List.concatMap (splice_decl meths) ses1
                  | FStar_Syntax_Syntax.Sig_inductive_typ
-                     (lid, uu___1, uu___2, uu___3, uu___4, uu___5) ->
-                     let uu___6 =
-                       let uu___7 =
-                         let uu___8 =
-                           let uu___9 = mkclass lid in (meths, uu___9) in
-                         FStar_Syntax_Syntax.Sig_splice uu___8 in
+                     (lid, _univs, _binders, ty, _mutuals, _datas) ->
+                     let formals1 =
+                       match formals with
+                       | FStar_Pervasives_Native.None -> []
+                       | FStar_Pervasives_Native.Some formals2 -> formals2 in
+                     let has_no_method_attr meth =
+                       let i = FStar_Ident.ident_of_lid meth in
+                       FStar_Compiler_Util.for_some
+                         (fun formal ->
+                            let uu___1 =
+                              FStar_Ident.ident_equals i
+                                (formal.FStar_Syntax_Syntax.binder_bv).FStar_Syntax_Syntax.ppname in
+                            if uu___1
+                            then
+                              FStar_Compiler_Util.for_some
+                                (fun attr ->
+                                   let uu___2 =
+                                     let uu___3 =
+                                       FStar_Syntax_Subst.compress attr in
+                                     uu___3.FStar_Syntax_Syntax.n in
+                                   match uu___2 with
+                                   | FStar_Syntax_Syntax.Tm_fvar fv ->
+                                       FStar_Syntax_Syntax.fv_eq_lid fv
+                                         FStar_Parser_Const.no_method_lid
+                                   | uu___3 -> false)
+                                formal.FStar_Syntax_Syntax.binder_attrs
+                            else false) formals1 in
+                     let meths1 =
+                       FStar_Compiler_List.filter
+                         (fun x ->
+                            let uu___1 = has_no_method_attr x in
+                            Prims.op_Negation uu___1) meths in
+                     let uu___1 =
+                       let uu___2 =
+                         let uu___3 =
+                           let uu___4 = mkclass lid in (meths1, uu___4) in
+                         FStar_Syntax_Syntax.Sig_splice uu___3 in
                        {
-                         FStar_Syntax_Syntax.sigel = uu___7;
+                         FStar_Syntax_Syntax.sigel = uu___2;
                          FStar_Syntax_Syntax.sigrng =
                            (d.FStar_Parser_AST.drange);
                          FStar_Syntax_Syntax.sigquals = [];
@@ -7885,7 +7948,7 @@ and (desugar_decl_noattrs :
                          FStar_Syntax_Syntax.sigopts =
                            FStar_Pervasives_Native.None
                        } in
-                     [uu___6]
+                     [uu___1]
                  | uu___1 -> [] in
                let extra =
                  if typeclass

--- a/src/parser/FStar.Parser.Const.fst
+++ b/src/parser/FStar.Parser.Const.fst
@@ -467,6 +467,7 @@ let tactic_lid = fstar_tactics_lid' ["Effect"; "tactic"]
 let mk_class_lid   = fstar_tactics_lid' ["Typeclasses"; "mk_class"]
 let tcresolve_lid  = fstar_tactics_lid' ["Typeclasses"; "tcresolve"]
 let tcinstance_lid = fstar_tactics_lid' ["Typeclasses"; "tcinstance"]
+let no_method_lid = fstar_tactics_lid' ["Typeclasses"; "no_method"]
 
 let effect_TAC_lid = fstar_tactics_lid' ["Effect"; "TAC"] // actual effect
 let effect_Tac_lid = fstar_tactics_lid' ["Effect"; "Tac"] // trivial variant

--- a/ulib/FStar.Tactics.Typeclasses.fst
+++ b/ulib/FStar.Tactics.Typeclasses.fst
@@ -25,6 +25,11 @@ module T = FStar.Tactics
 irreducible
 let tcinstance : unit = ()
 
+(* The attribute that marks class fields
+   to signal that no method should be generated for them *)
+irreducible
+let no_method : unit = ()
+
 let rec first (f : 'a -> Tac 'b) (l : list 'a) : Tac 'b =
     match l with
     | [] -> fail "no cands"
@@ -86,6 +91,23 @@ let rec last (l : list 'a) : Tac 'a =
   | [] -> fail "last: empty list"
   | [x] -> x
   | _::xs -> last xs
+
+let filter_no_method_binders (bs:binders)
+  : binders
+  = let has_no_method_attr (b:binder)
+      : bool
+      = let _, (_, attrs) = inspect_binder b in
+        let is_no_method (t:term)
+          : bool
+          = match inspect_ln t with
+            | Tv_FVar fv  ->
+              let n = flatten_name (inspect_fv fv) in
+              n = `%no_method
+            | _ -> false
+        in
+        List.Tot.existsb is_no_method attrs
+    in
+    List.Tot.filter (fun b -> not (has_no_method_attr b)) bs
 
 [@@plugin]
 let mk_class (nm:string) : Tac decls =
@@ -169,4 +191,4 @@ let mk_class (nm:string) : Tac decls =
                   let se = set_sigelt_attrs attrs se in
                   //dump ("trying to return : " ^ term_to_string (quote se));
                   se
-    ) bs
+    ) (filter_no_method_binders bs)


### PR DESCRIPTION
Sometimes typeclasses have fields that shouldn't be treated as methods. e.g., a base class field; or a field holding some properties about the other methods. You can now annotate these fields with a `[@@@no_method]` attribute