### PR TITLE
Update handwritten ml files to remove ocaml warnings

### DIFF
--- a/ulib/ml/FStar_Buffer.ml
+++ b/ulib/ml/FStar_Buffer.ml
@@ -48,7 +48,7 @@ let copy b l = {content = Array.sub b.content b.idx l; idx = 0; length = l}
 let eqb b1 b2 (len:u32) =
   Array.sub b1.content b1.idx (FStar_UInt32.to_native_int len) = Array.sub b2.content b2.idx (FStar_UInt32.to_native_int len)
 
-type ('a, 'b, 'c, 'd) modifies_buf = ()
+type ('a, 'b, 'c, 'd) modifies_buf = unit
 let op_Plus_Plus a b = BatSet.empty
 let only a = BatSet.empty
 

--- a/ulib/ml/FStar_IO.ml
+++ b/ulib/ml/FStar_IO.ml
@@ -76,7 +76,7 @@ let open_read_file = open_in
 let open_write_file = open_out
 let close_read_file = close_in
 let close_write_file = close_out
-let read_line fd = try Pervasives.input_line fd with End_of_file -> raise EOF
+let read_line fd = try Stdlib.input_line fd with End_of_file -> raise EOF
 let write_string = output_string
 
 let debug_print_string s = print_string s; false


### PR DESCRIPTION
This PR does minor changes to handwritten ml files in ulib/ml to remove some warnings raised by the OCaml compiler when running make in ulib/ml. The changes are exactly the ones recommended by the compiler.