### PR TITLE
Clarify documentation on layered and indexed effects examples

### DIFF
--- a/examples/indexed_effects/README.md
+++ b/examples/indexed_effects/README.md
@@ -1,0 +1,1 @@
+The examples in this directory use a deprecated approach to indexed effects. Instead look to the [examples on layered effects](https://github.com/FStarLang/FStar/tree/master/examples/layeredeffects) for examples on creating and using indexed effects. Note that the current state of the repo uses the terms layered effects and indexed effects interchangeably.

--- a/examples/layeredeffects/README.txt
+++ b/examples/layeredeffects/README.txt
@@ -1,3 +1,7 @@
+These examples show how to create and use layered_effects in F*. These
+effects could be more appropriately called indexed effects (the terms are
+currently used synonymously in F*). For more information on these effects see
+the paper at https://www.fstar-lang.org/papers/indexedeffects.
 
 Section 4: correct binary formatting
 


### PR DESCRIPTION
As mentioned on slack, layered effects in F* are essentially indexed effects. The indexed_effects examples are a deprecated way of creating indexed effects. This PR adds README info to both the indexed_effects and layeredeffects examples to clarify these points. It also adds a link to the relevant paper describing layered effects in F*.