### PR TITLE
Cleanup ml extraction Makefile

### DIFF
--- a/ulib/Makefile.extract
+++ b/ulib/Makefile.extract
@@ -1,6 +1,7 @@
 .PHONY: indent extra
 
 FSTAR_HOME=..
+include $(FSTAR_HOME)/.common.mk
 include gmake/z3.mk
 include gmake/fstar.mk
 
@@ -21,13 +22,15 @@ CODEGEN ?= OCaml
 MY_FSTAR=$(FSTAR) $(OTHERFLAGS) --lax --cache_checked_modules --odir $(OUTPUT_DIRECTORY) --cache_dir .cache.lax
 
 %.checked.lax:
-	$(MY_FSTAR) $< --already_cached '*,'-$(basename $(notdir $<))
-	touch -c $@
+	@echo "[LAXCHECK  $(basename $(notdir $@))]"
+	$(Q)$(MY_FSTAR) $(SIL) $< --already_cached '*,'-$(basename $(notdir $<))
+	$(Q)touch -c $@
 
 # And then, in a separate invocation, from each .checked.lax we
 # extract an .ml file
 $(OUTPUT_DIRECTORY)/%.ml:
-	$(MY_FSTAR) $(subst .checked.lax,,$(notdir $<)) --codegen $(CODEGEN) --extract_module $(basename $(notdir $(subst .checked.lax,,$<)))
+	@echo "[EXTRACT   $(basename $(notdir $@))]"
+	$(Q)$(MY_FSTAR) $(SIL) $(subst .checked.lax,,$(notdir $<)) --codegen $(CODEGEN) --extract_module $(basename $(notdir $(subst .checked.lax,,$<)))
 
 .depend.extract:
 	$(Q)mkdir -p .cache.lax


### PR DESCRIPTION
This PR is purely cosmetic, it avoids printing the full output when extracting ulib/ to ml, but instead prints [EXTRACT  Module] and [LAXCHECK Module] similarly to what is done in other Makefiles.
Note, similarly to other Makefiles, this behaviour is overriden if make is run in verbose mode.