### PR TITLE
QuasiQuotes for F*

### DIFF
--- a/examples/quasiquotes/TemplateLiterals.fst
+++ b/examples/quasiquotes/TemplateLiterals.fst
@@ -1,0 +1,145 @@
+module TemplateLiterals
+
+module T = FStar.Tactics
+open FStar.List.Tot
+
+(**** Generic interface for quasiquoters *)
+noeq type quasiquoter = {
+  t: Type u#t;
+  process: list (either string T.term) -> T.Tac t;
+  make_type:  t -> T.Tac unit;
+  make_value: t -> T.Tac unit;
+}
+
+let synth_quasiquote
+    (qq: quasiquoter u#qq)
+    (input: unit -> T.Tac (list (either string T.term)))
+    (#[(let data = qq.process (input ()) in
+        T.exact (quote data))] data : qq.t)
+    (#[qq.make_type data]    typ  : Type u#t)
+    (#[qq.make_value data]   value:  typ)
+    ()
+    = value
+
+(**** Helpers to unquote terms *)
+let name_of_compview: T.comp_view -> string = function
+  | T.C_Total     _ _     -> "Total"
+  | T.C_GTotal    _ _     -> "GTotal"
+  | T.C_Lemma     _ _ _   -> "Lemma"
+  | T.C_Eff       _ n _ _ -> T.implode_qn n
+
+/// Given [a] a type of any universe and [v] a value of type [a],
+/// [wrapper] is of type unit, and is irreducible. It is a trick so
+/// that we don't have to bother with types and universes when
+/// unquoting terms.
+irreducible let wrapper (a: Type u#a) (v: a): unit = ()
+
+/// [eval_term] evaluates a term [t] in an environment [e], where [t]
+/// is either a [Tot] computation or a [Tac] computation.
+let eval_term (e: T.env) (t: T.term): T.Tac T.term
+  = let open FStar.Tactics in
+    let comp = try tcc e t with | e -> raise e in
+    match inspect_comp comp with
+  | C_Eff _ ["Prims"; "PURE"] _ _ | C_Total _ _ -> t
+  | C_Eff _ ["FStar"; "Tactics"; "Effect"; _] ret _
+      -> // [tac] is [fun (dummy:()) -> wrapper t]
+        let tac: term = mk_abs [fresh_binder_named "dummy" (`unit)] (mk_e_app (`wrapper) [ret; t]) in
+        // thus, we can unquote [tac] as a [unit -> Tac unit] computation, and run it
+        let u: unit = (unquote #(unit -> Tac unit) tac) () in
+        // we normalize the result, that should be of shape [wrapper … result]
+        let fn, args = collect_app (quote u) in
+        begin match args with
+        | [(a,Q_Explicit);(v,Q_Explicit)] -> v // correct shape (TODO: we assume [fn] is [wrapper] here)
+        | _ -> fail "[eval] E0: after evaluation of tactic [t], the normalized result is not of the shape [wrapper … …]"
+        end
+  | cv -> fail ("[eval] E1: effect ["^name_of_compview cv^"] not supported")
+
+(**** A typeclass for showing values of various types *)
+class showTC (a: Type) = { show: a -> string }
+instance _: showTC int = { show = string_of_int; }
+instance _: showTC nat = { show = string_of_int; }
+instance _: showTC string = { show = id; }
+
+instance showList {| showTC 'a |}: showTC (list 'a)
+  = { show = (fun l -> "[" ^ String.concat ", " (map show l) ^ "]"); }
+
+(**** A [str] quasiquoter, a.k.a. template literals *)
+
+let str_qq = {
+    t = string;
+    process = (fun l -> String.concat "" (T.map (function
+                                             | Inl raw -> raw
+                                             | Inr t -> T.unquote (eval_term (T.top_env ()) (`(show (`#t))))
+                                             ) l));
+    make_type = (fun _ -> T.exact (`eqtype_as_type string));
+    make_value = (fun x -> T.exact (quote x)); }
+
+let str = synth_quasiquote str_qq
+
+
+
+let synth_quasiquote'
+    (qq: quasiquoter u#qq)
+    (input: unit -> T.Tac (list (either string T.term)))
+    (#[(let data = qq.process (input ()) in
+        T.exact (quote data))] data : qq.t)
+    (#[qq.make_type data]    typ  : Type u#t)
+    (#[qq.make_value data]   value:  typ)
+    ()
+    = value
+
+let str' = synth_quasiquote' str_qq (fun _ -> [Inl "x"]) ()
+
+(**** Examples *)
+(***** Basic example *)
+let simple =
+  let x = 1 in
+  let y = 2 in
+  let z = "hello" in
+  [str|list=`[x;y] x=`x, y=`y rev=`(rev [x;y]), and z is `z|]
+
+(***** Groceries *)
+let groceries (euros: nat) (items: list (int * string)) =
+  let items = map (fun (n, item) -> [str|`n `item`(if n=1 then "" else "s")|]) items in
+  [str|You want to buy `items, and you have `euros €|]
+
+let _ = T.run_tactic (fun _ -> T.print (groceries 25 [2, "orange"; 6, "apple"; 1, "banana"]))
+(* This prints:
+You want to buy [2 oranges, 6 apples, 1 banana], and you have 25 €
+*)
+
+(***** Showing lists of tasks *)
+let concatMap sep f l = String.concat sep (map f l)
+type priority = | A | B | C
+type task = { title: string
+            ; priority: priority
+            ; details: list string }
+instance _: showTC priority = { show = function | A -> "A" | B -> "B" | C -> "C" }
+
+let showTC_todos (name: string) (tasks: list task): string =
+   [str|Hi `name, today you've got `(length tasks) tasks left:
+`(concatMap "\n" (fun ({title; priority; details}) -> [str| • `title [`priority]:
+`(concatMap "\n" (fun participant -> [str|   ∘ `participant|]) details)|]) tasks)
+
+Good luck!
+|]
+
+let example = showTC_todos "Alice" [
+  {title = "foo"; priority = A; details = ["do X"; "do Y"]};
+  {title = "bar"; priority = C; details = ["do Z"; "something"; "something else"]}
+]
+
+let _ = T.run_tactic (fun _ -> T.print example)
+(* This prints:
+Hi Alice, today you've got 2 tasks left:
+ • foo [A]:
+   ∘ do X
+   ∘ do Y
+ • bar [C]:
+   ∘ do Z
+   ∘ something
+   ∘ something else
+
+Good luck!
+*)
+

--- a/src/parser/ml/FStar_Parser_ParseIt.ml
+++ b/src/parser/ml/FStar_Parser_ParseIt.ml
@@ -114,9 +114,10 @@ let parse fn =
       create s.frag_text s.frag_fname (Z.to_int s.frag_line) (Z.to_int s.frag_col), "<input>"
   in
 
-  let lexer () =
-    let tok = FStar_Parser_LexFStar.token lexbuf in
-    (tok, lexbuf.start_p, lexbuf.cur_p)
+  let lexer =
+    let lexer = FStar_Parser_LexFStar.make_lexer () in
+    fun () -> let tok = lexer lexbuf in
+              (tok, lexbuf.start_p, lexbuf.cur_p)
   in
 
   try

--- a/src/parser/parse.mly
+++ b/src/parser/parse.mly
@@ -65,6 +65,13 @@ let none_to_empty_list x =
 %token <string> AND_OP
 %token <string> MATCH_OP
 
+%token <string> QQ_START
+%token <string> QQ_RAW
+%token <string> QQ_QUOTE
+%token QQ_END
+%token QQ_QUOTE_START
+%token QQ_QUOTE_END
+
 %token FORALL EXISTS ASSUME NEW LOGIC ATTRIBUTES
 %token IRREDUCIBLE UNFOLDABLE INLINE OPAQUE UNFOLD INLINE_FOR_EXTRACTION
 %token NOEXTRACT
@@ -897,6 +904,44 @@ noSeqTerm:
         match xs with
         | [x;y] -> mk_term (ElimAnd(p, q, r, x, y, e)) (rhs2 parseState 1 10) Expr
      }
+  | id=QQ_START chunks=list(qqBody) QQ_END
+    {
+      let entire_range, name_range, body_range
+	= lhs parseState, rhs parseState 1, rhs parseState 2 in
+      (* we prepare some long identifiers (lid) *)
+      let qq_lid = lid_of_ids [mk_ident (id, name_range)] in
+      mkExplicitApp (mk_term (Var qq_lid) entire_range Expr) [
+		      (* Feed the input chunks as the TAC lambda (fun _ -> "chunks").
+		         This allows for arbitrary dynamic quotes inside the quasiquote.
+		       *)
+		      mk_term (Abs ( (* the lambda takes one binder, `_` *)
+				     [mk_pattern (PatWild (None, [])) body_range]
+	                           , (* mkConsList transforms the list of terms
+				     `chunks` into a term representing a list. *)
+				     mkConsList entire_range chunks )
+			      ) body_range Expr
+		      (* last argument is `()` *)
+		    ; mk_term (Const Const_unit) entire_range Expr
+		    ] entire_range
+    }
+
+qqBody:
+  | raw=QQ_RAW
+    {
+      let r = lhs(parseState) in
+      mk_term (Construct(inl_lid, [mk_term (Const (Const_string (raw, r))) r Expr, Nothing])) r Expr
+    }
+  | id=QQ_QUOTE
+    {
+      let r = lhs(parseState) in
+      let t = mk_term (Var (lid_of_ids [mk_ident(id, rhs parseState 1)])) (rhs parseState 1) Expr in
+      mk_term (Construct(inr_lid, [mk_term (Quote (t, Dynamic)) r Expr, Nothing])) r Expr
+    }
+  | QQ_QUOTE_START t=term QQ_QUOTE_END
+    {
+      let r = lhs parseState in
+      mk_term (Construct(inr_lid, [mk_term (Quote (t, Dynamic)) r Expr, Nothing])) r Expr
+    }
 
 singleBinder:
   | bs=binders


### PR DESCRIPTION
Hi,

This (draft) PR adds some support for quasi-quotes in F*, with a syntax similar to [Haskell's quasi-quotes](https://wiki.haskell.org/Quasiquotation). It's quite experimental for now, and I wanted to have some feedback about whether this would be an interesting feature to have or not in F*.

Basically, the syntax `[foo|anything|]` calls the F* meta-program `foo` with the body `anything`. The quasiquote body `anything` consists in a sequence of interleaved (1) raw arbitrary characters or (2) F* quotations.

`foo` is a function that takes as an input a `Tac` computation producing an heterogeneous list of terms and string.
For example, ``[foo|hello `name!|]`` is (more or less) desugared to `foo (fun () -> ["hello "; quote name; "!"])`.

Quasi-quotes allows for quite flexible & custom used-defined domain-specific syntax.

## Examples
### Template literals (or string interpolation)
The file `examples/quasiquotes/TemplateLiterals.fst` defines a quasiquoter that allows the following:
```fstar
let simple = 
  let x = 1 in
  let y = 2 in
  let z = "hello" in
  [str|list=`[x;y] x=`x, y=`y rev=`(rev [x;y]), and z is `z|]
```
This normalizes to the string `"list=[1, 2] x=1, y=2 rev=[2, 1], and z is hello"`.

### List comprehension
Using `string_to_term` from PR #2260 (~that I should revive!~) and a parser library, it's pretty easy to define a (user-land) list comprehension syntax ([_à la_ Haskell](https://wiki.haskell.org/List_comprehension)) for F*. For instance, the following typechecks:
```fstar
open FStar.Mul
let bar = 
  [ Inl 1 ; Inl 2 ; Inl 3 ; Inl 4 ; Inl 5
  ; Inr 11; Inr 12; Inr 13; Inr 14; Inr 15 ]
let example = [lc| x,y | Inl x <- bar, x > 1,
                         let x = x * 1000,
                         Inr y <- bar, y % 2 = 0 |]
let _ = assert_norm ( 
     example
  == [ (2000, 12); (2000, 14); (3000, 12)
     ; (3000, 14); (4000, 12); (4000, 14)
     ; (5000, 12); (5000, 14)
     ])
```

### Other
QQ can be useful for DSLs, for debugging purposes, for FFIs, etc.

## Details and quirks
My current implementation of QQ in F* is quite experimental and have a few quirks.

### Lexing
Quasiquotes require the lexer to be a bit contextual: when lexing inside a quasiquote, every chunk of characters that contains no quotation should be lexed as one big token.
Quasiquotes can also be nested.

### Desugaring
For now, I desguar QQ directly as regular terms right within the parser, which is not really nice. Though it's quite easy to add a constructor to F*'s AST.

### Synthetizing polymorphic QQs
The quasiquote `[foo|body|]` is actually desugared into `foo transformed_body ()`.

The extras `()` are there because of polymorphism.
Consider the list comprehension quasiquote: it is polymorphic in the type of the list to be constructed.
To be able to synthetize values of "tactic-decided" types, I use the following construction:
```fstar
noeq type quasiquoter = {
  t: Type u#t;
  process: list (either string term) -> Tac t;
  make_type:  t -> Tac unit;
  make_value: t -> Tac unit;
}

let synth_quasiquote
    (qq: quasiquoter u#qq)
    (input: unit -> Tac (list (either string term)))
    (#[(let data = qq.process (input ()) in 
        exact (quote data))] data : qq.t)
    (#[qq.make_type data]    typ  : Type u#t)
    (#[qq.make_value data]   value:  typ)
    ()
    = value
```

With this definition, a `quasiquote` first parses and process its inputs with `process`. `synth_quasiquote` runs `process` on some inputs via the meta-argument `data`, then produces some `typ` and `value`.
If I omit the last `unit` parameter, I get a `Variable "data#..." not found` on `qq.make_type data`.

### Ranges
Ranges are not translated correctly in many cases within quasiquotes, so that's something else to fix.

### Patterns and names in general
Introducing names (e.g. something à la Coq like `[tac| intro [a | b] h. |]; something a`) or translating quasiquotes to patterns (i.e. `match Plus 1 2 with | [mydsl|x + y|] -> … x … y | …`) seems impossible to me currently, since this would require incremental desugaring: if I'm not mistaking.

## TODO
 - [ ] Fix ranges translation
    + [x] revive PR #2188
 - [ ] Clean up the lexer
 - [ ] Move desugaring from the parser to the desugaring phase
    + [ ] add `QuasiQuote` node to `FStar.Parser.AST`
 - [x] revive #2260