### PR TITLE
Support dependent `introduce exists` and `eliminate forall`

### DIFF
--- a/src/ocaml-output/FStar_ToSyntax_ToSyntax.ml
+++ b/src/ocaml-output/FStar_ToSyntax_ToSyntax.ml
@@ -4182,8 +4182,11 @@ and (desugar_term_maybe_top :
                    | (b::bs3, v::vs3) ->
                        let x = unqual_bv_of_binder b in
                        let token1 =
-                         aux bs3 vs3 ((FStar_Syntax_Syntax.NT (x, v)) :: sub)
-                           token in
+                         let uu___2 =
+                           FStar_Syntax_Subst.subst_binders
+                             ((FStar_Syntax_Syntax.NT (x, v)) :: sub) bs3 in
+                         aux uu___2 vs3 ((FStar_Syntax_Syntax.NT (x, v)) ::
+                           sub) token in
                        let token2 =
                          let uu___2 =
                            let uu___3 =
@@ -4342,7 +4345,8 @@ and (desugar_term_maybe_top :
                          mk_forall_elim x.FStar_Syntax_Syntax.sort uu___2 v
                            token in
                        let sub1 = (FStar_Syntax_Syntax.NT (x, v)) :: sub in
-                       aux bs3 vs3 sub1 token1
+                       let uu___2 = FStar_Syntax_Subst.subst_binders sub1 bs3 in
+                       aux uu___2 vs3 sub1 token1
                    | uu___2 ->
                        FStar_Errors.raise_error
                          (FStar_Errors.Fatal_UnexpectedTerm,

--- a/src/tosyntax/FStar.ToSyntax.ToSyntax.fst
+++ b/src/tosyntax/FStar.ToSyntax.ToSyntax.fst
@@ -1938,7 +1938,7 @@ and desugar_term_maybe_top (top_level:bool) (env:env_t) (top:term) : S.term * an
         | [], [] -> token
         | b::bs, v::vs ->
           let x = unqual_bv_of_binder b in
-          let token = aux bs vs (NT(x, v)::sub) token in
+          let token = aux (SS.subst_binders (NT(x, v)::sub) bs) vs (NT(x, v)::sub) token in
           let token =
             mk_exists_intro
               x.sort
@@ -2022,7 +2022,7 @@ and desugar_term_maybe_top (top_level:bool) (env:env_t) (top:term) : S.term * an
               token
           in
           let sub = NT(x, v)::sub in
-          aux bs vs sub token
+          aux (SS.subst_binders sub bs) vs sub token
         | _ ->
           raise_error (Fatal_UnexpectedTerm, "Unexpected number of instantiations in _elim_forall_") top.range
       in

--- a/tests/bug-reports/Bug2614.fst
+++ b/tests/bug-reports/Bug2614.fst
@@ -1,0 +1,41 @@
+module Bug2614
+
+assume val t: int -> Type0
+assume val p: x:int -> y:t x -> prop
+
+// Previously led to
+//(Error 230) Variable "a#59" not found
+let test_exists_intro (x:int) (y:t x) (_:squash (p x y)) =
+  introduce exists (a:int) (b:t a). p a b
+  with x y
+  and ()
+
+//Ugly workaround
+let test_exists_intro_workaround (x:int) (y:t x) (_:squash (p x y)) =
+  introduce exists (a:int). (exists (b:t a). p a b)
+  with x and (
+    introduce exists (b:t x). p x b
+    with y and ()
+  )
+
+let test_exists_elim (_:squash(exists (x:int) (y:t x). p x y)) =
+  eliminate exists (x:int) (y:t x). p x y
+  returns True
+  with _. ()
+
+let test_forall_intro (f:(x:int -> y:t x -> squash (p x y))) =
+  introduce forall (x:int) (y: t x). p x y
+  with f x y
+
+// Previously led to
+//(Error 230) Variable "x#1492" not found
+let test_forall_elim (a:int) (b:t a) (_:squash(forall (x:int) (y:t x). p x y)) =
+  eliminate forall (x:int) (y:t x). p x y
+  with a b
+
+// //Ugly workaround
+let test_forall_elim_workaround (a:int) (b:t a) (_:squash(forall (x:int) (y:t x). p x y)) =
+  eliminate forall (x:int). (forall (y:t x). p x y)
+  with a;
+  eliminate forall (y:t a). p a y
+  with b


### PR DESCRIPTION
This PR fixes #2614. 

The issue was that, when eliminating the first forall quantifier in, say, `forall (x:t) xs. p`, replacing `x` by `a`, the substitution `a/x` was only performed in the body `p`, and not in the binders `xs` (and hence not in their types), which led to errors during typechecking if the `xs` depend on `x`.
A similar error occured during `introduce exists`.