### PR TITLE
Correct extraction of Steel.Array.index

### DIFF
--- a/src/extraction/FStar.Extraction.Krml.fst
+++ b/src/extraction/FStar.Extraction.Krml.fst
@@ -535,8 +535,11 @@ and translate_expr env e: expr =
     when string_of_mlpath p = "FStar.Buffer.index" || string_of_mlpath p = "FStar.Buffer.op_Array_Access"
       || string_of_mlpath p = "LowStar.Monotonic.Buffer.index"
       || string_of_mlpath p = "LowStar.UninitializedBuffer.uindex"
-      || string_of_mlpath p = "LowStar.ConstBuffer.index"
-      || string_of_mlpath p = "Steel.Array.index" ->
+      || string_of_mlpath p = "LowStar.ConstBuffer.index" ->
+      EBufRead (translate_expr env e1, translate_expr env e2)
+
+  | MLE_App ({ expr = MLE_TApp({ expr = MLE_Name p }, _) }, [ _perm; e1; e2 ])
+    when string_of_mlpath p = "Steel.Array.index" ->
       EBufRead (translate_expr env e1, translate_expr env e2)
 
   | MLE_App ({ expr = MLE_TApp({ expr = MLE_Name p }, _) }, [ _perm; e1; _seq; e2 ])

--- a/src/ocaml-output/FStar_Extraction_Krml.ml
+++ b/src/ocaml-output/FStar_Extraction_Krml.ml
@@ -1190,23 +1190,40 @@ and (translate_expr : env -> FStar_Extraction_ML_Syntax.mlexpr -> expr) =
              FStar_Extraction_ML_Syntax.loc = uu___4;_},
            e1::e2::[])
           when
-          (((((let uu___5 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
-               uu___5 = "FStar.Buffer.index") ||
-                (let uu___5 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
-                 uu___5 = "FStar.Buffer.op_Array_Access"))
-               ||
+          ((((let uu___5 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+              uu___5 = "FStar.Buffer.index") ||
                (let uu___5 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
-                uu___5 = "LowStar.Monotonic.Buffer.index"))
+                uu___5 = "FStar.Buffer.op_Array_Access"))
               ||
               (let uu___5 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
-               uu___5 = "LowStar.UninitializedBuffer.uindex"))
+               uu___5 = "LowStar.Monotonic.Buffer.index"))
              ||
              (let uu___5 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
-              uu___5 = "LowStar.ConstBuffer.index"))
+              uu___5 = "LowStar.UninitializedBuffer.uindex"))
             ||
             (let uu___5 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
-             uu___5 = "Steel.Array.index")
+             uu___5 = "LowStar.ConstBuffer.index")
           ->
+          let uu___5 =
+            let uu___6 = translate_expr env1 e1 in
+            let uu___7 = translate_expr env1 e2 in (uu___6, uu___7) in
+          EBufRead uu___5
+      | FStar_Extraction_ML_Syntax.MLE_App
+          ({
+             FStar_Extraction_ML_Syntax.expr =
+               FStar_Extraction_ML_Syntax.MLE_TApp
+               ({
+                  FStar_Extraction_ML_Syntax.expr =
+                    FStar_Extraction_ML_Syntax.MLE_Name p;
+                  FStar_Extraction_ML_Syntax.mlty = uu___;
+                  FStar_Extraction_ML_Syntax.loc = uu___1;_},
+                uu___2);
+             FStar_Extraction_ML_Syntax.mlty = uu___3;
+             FStar_Extraction_ML_Syntax.loc = uu___4;_},
+           _perm::e1::e2::[])
+          when
+          let uu___5 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+          uu___5 = "Steel.Array.index" ->
           let uu___5 =
             let uu___6 = translate_expr env1 e1 in
             let uu___7 = translate_expr env1 e2 in (uu___6, uu___7) in


### PR DESCRIPTION
The file `FStar.Extraction.Krml.fst` had not been updated when fractional permissions were added to Steel.Array in #2411, leading to errors when attempting to compile the Karamel-extracted C code (undefined reference to Steel.Array.index).
This PR fixes it by pattern-matching on the correct number of arguments when facing a Steel.Array.index node.