### PR TITLE
Add support for data constructors attributes

### DIFF
--- a/src/ocaml-output/FStar_Parser_AST.ml
+++ b/src/ocaml-output/FStar_Parser_AST.ml
@@ -571,11 +571,11 @@ type tycon =
   | TyconAbbrev of (FStar_Ident.ident * binder Prims.list * knd
   FStar_Pervasives_Native.option * term) 
   | TyconRecord of (FStar_Ident.ident * binder Prims.list * knd
-  FStar_Pervasives_Native.option * (FStar_Ident.ident * aqual * attributes_ *
-  term) Prims.list) 
+  FStar_Pervasives_Native.option * attributes_ * (FStar_Ident.ident * aqual *
+  attributes_ * term) Prims.list) 
   | TyconVariant of (FStar_Ident.ident * binder Prims.list * knd
   FStar_Pervasives_Native.option * (FStar_Ident.ident * term
-  FStar_Pervasives_Native.option * Prims.bool) Prims.list) 
+  FStar_Pervasives_Native.option * Prims.bool * attributes_) Prims.list) 
 let (uu___is_TyconAbstract : tycon -> Prims.bool) =
   fun projectee ->
     match projectee with | TyconAbstract _0 -> true | uu___ -> false
@@ -598,8 +598,8 @@ let (uu___is_TyconRecord : tycon -> Prims.bool) =
 let (__proj__TyconRecord__item___0 :
   tycon ->
     (FStar_Ident.ident * binder Prims.list * knd
-      FStar_Pervasives_Native.option * (FStar_Ident.ident * aqual *
-      attributes_ * term) Prims.list))
+      FStar_Pervasives_Native.option * attributes_ * (FStar_Ident.ident *
+      aqual * attributes_ * term) Prims.list))
   = fun projectee -> match projectee with | TyconRecord _0 -> _0
 let (uu___is_TyconVariant : tycon -> Prims.bool) =
   fun projectee ->
@@ -608,7 +608,7 @@ let (__proj__TyconVariant__item___0 :
   tycon ->
     (FStar_Ident.ident * binder Prims.list * knd
       FStar_Pervasives_Native.option * (FStar_Ident.ident * term
-      FStar_Pervasives_Native.option * Prims.bool) Prims.list))
+      FStar_Pervasives_Native.option * Prims.bool * attributes_) Prims.list))
   = fun projectee -> match projectee with | TyconVariant _0 -> _0
 type qualifier =
   | Private 
@@ -2239,7 +2239,8 @@ let (id_of_tycon : tycon -> Prims.string) =
     match uu___ with
     | TyconAbstract (i, uu___1, uu___2) -> FStar_Ident.string_of_id i
     | TyconAbbrev (i, uu___1, uu___2, uu___3) -> FStar_Ident.string_of_id i
-    | TyconRecord (i, uu___1, uu___2, uu___3) -> FStar_Ident.string_of_id i
+    | TyconRecord (i, uu___1, uu___2, uu___3, uu___4) ->
+        FStar_Ident.string_of_id i
     | TyconVariant (i, uu___1, uu___2, uu___3) -> FStar_Ident.string_of_id i
 let (decl_to_string : decl -> Prims.string) =
   fun d ->

--- a/src/ocaml-output/FStar_Parser_Const.ml
+++ b/src/ocaml-output/FStar_Parser_Const.ml
@@ -333,6 +333,8 @@ let (binder_strictly_positive_attr : FStar_Ident.lident) =
 let (no_auto_projectors_attr : FStar_Ident.lident) =
   psconst "no_auto_projectors"
 let (no_subtping_attr_lid : FStar_Ident.lident) = psconst "no_subtyping"
+let (attr_substitute_lid : FStar_Ident.lident) =
+  p2l ["FStar"; "Pervasives"; "Substitute"]
 let (well_founded_relation_lid : FStar_Ident.lident) =
   p2l ["FStar"; "WellFounded"; "well_founded_relation"]
 let (gen_reset : ((unit -> Prims.int) * (unit -> unit))) =

--- a/src/ocaml-output/FStar_Parser_Dep.ml
+++ b/src/ocaml-output/FStar_Parser_Dep.ml
@@ -1291,14 +1291,14 @@ let (collect_one :
                  (collect_binders binders;
                   FStar_Compiler_Util.iter_opt k collect_term;
                   collect_term t)
-             | FStar_Parser_AST.TyconRecord (uu___3, binders, k, identterms)
-                 ->
+             | FStar_Parser_AST.TyconRecord
+                 (uu___3, binders, k, uu___4, identterms) ->
                  (collect_binders binders;
                   FStar_Compiler_Util.iter_opt k collect_term;
                   FStar_Compiler_List.iter
-                    (fun uu___6 ->
-                       match uu___6 with
-                       | (uu___7, aq, attrs, t) ->
+                    (fun uu___7 ->
+                       match uu___7 with
+                       | (uu___8, aq, attrs, t) ->
                            (collect_aqual aq;
                             FStar_Compiler_Effect.op_Bar_Greater attrs
                               (FStar_Compiler_List.iter collect_term);
@@ -1310,7 +1310,7 @@ let (collect_one :
                   FStar_Compiler_List.iter
                     (fun uu___6 ->
                        match uu___6 with
-                       | (uu___7, t, uu___8) ->
+                       | (uu___7, t, uu___8, uu___9) ->
                            FStar_Compiler_Util.iter_opt t collect_term)
                     identterms)
            and collect_effect_decl uu___2 =

--- a/src/ocaml-output/FStar_Parser_ToDocument.ml
+++ b/src/ocaml-output/FStar_Parser_ToDocument.ml
@@ -994,31 +994,36 @@ let rec (p_decl : FStar_Parser_AST.decl -> FStar_Pprint.document) =
             FStar_Pprint.op_Hat_Hat uu___2 FStar_Pprint.space
           else p_qualifiers d.FStar_Parser_AST.quals
       | uu___ -> p_qualifiers d.FStar_Parser_AST.quals in
-    let uu___ = p_attributes d.FStar_Parser_AST.attrs in
+    let uu___ = p_attributes true d.FStar_Parser_AST.attrs in
     let uu___1 =
       let uu___2 = p_rawDecl d in FStar_Pprint.op_Hat_Hat qualifiers uu___2 in
     FStar_Pprint.op_Hat_Hat uu___ uu___1
-and (p_attributes : FStar_Parser_AST.attributes_ -> FStar_Pprint.document) =
-  fun attrs ->
-    match attrs with
-    | [] -> FStar_Pprint.empty
-    | uu___ ->
-        let uu___1 =
-          let uu___2 = str "@@ " in
-          let uu___3 =
-            let uu___4 =
-              let uu___5 =
-                let uu___6 =
-                  let uu___7 = str "; " in
-                  let uu___8 =
-                    FStar_Compiler_List.map
-                      (p_noSeqTermAndComment false false) attrs in
-                  FStar_Pprint.flow uu___7 uu___8 in
-                FStar_Pprint.op_Hat_Hat uu___6 FStar_Pprint.rbracket in
-              FStar_Pprint.align uu___5 in
-            FStar_Pprint.op_Hat_Hat uu___4 FStar_Pprint.hardline in
-          FStar_Pprint.op_Hat_Hat uu___2 uu___3 in
-        FStar_Pprint.op_Hat_Hat FStar_Pprint.lbracket uu___1
+and (p_attributes :
+  Prims.bool -> FStar_Parser_AST.attributes_ -> FStar_Pprint.document) =
+  fun isTopLevel ->
+    fun attrs ->
+      match attrs with
+      | [] -> FStar_Pprint.empty
+      | uu___ ->
+          let uu___1 =
+            let uu___2 = str (if isTopLevel then "@@ " else "@@@ ") in
+            let uu___3 =
+              let uu___4 =
+                let uu___5 =
+                  let uu___6 =
+                    let uu___7 = str "; " in
+                    let uu___8 =
+                      FStar_Compiler_List.map
+                        (p_noSeqTermAndComment false false) attrs in
+                    FStar_Pprint.flow uu___7 uu___8 in
+                  FStar_Pprint.op_Hat_Hat uu___6 FStar_Pprint.rbracket in
+                FStar_Pprint.align uu___5 in
+              FStar_Pprint.op_Hat_Hat uu___4
+                (if isTopLevel
+                 then FStar_Pprint.hardline
+                 else FStar_Pprint.empty) in
+            FStar_Pprint.op_Hat_Hat uu___2 uu___3 in
+          FStar_Pprint.op_Hat_Hat FStar_Pprint.lbracket uu___1
 and (p_justSig : FStar_Parser_AST.decl -> FStar_Pprint.document) =
   fun d ->
     match d.FStar_Parser_AST.d with
@@ -1334,34 +1339,37 @@ and (p_typeDecl :
            | (comm, doc) ->
                let uu___2 = p_typeDeclPrefix pre true lid bs typ_opt in
                (comm, uu___2, doc, jump2))
-      | FStar_Parser_AST.TyconRecord (lid, bs, typ_opt, record_field_decls)
-          ->
+      | FStar_Parser_AST.TyconRecord
+          (lid, bs, typ_opt, attrs, record_field_decls) ->
           let p_recordField ps uu___1 =
             match uu___1 with
-            | (lid1, aq, attrs, t) ->
+            | (lid1, aq, attrs1, t) ->
                 let uu___2 =
                   let uu___3 =
                     FStar_Compiler_Range.extend_to_end_of_line
                       t.FStar_Parser_AST.range in
                   with_comment_sep (p_recordFieldDecl ps)
-                    (lid1, aq, attrs, t) uu___3 in
+                    (lid1, aq, attrs1, t) uu___3 in
                 (match uu___2 with
                  | (comm, field) ->
                      let sep =
                        if ps then FStar_Pprint.semi else FStar_Pprint.empty in
                      inline_comment_or_above comm field sep) in
           let p_fields =
-            let uu___1 =
-              separate_map_last FStar_Pprint.hardline p_recordField
-                record_field_decls in
-            braces_with_nesting uu___1 in
+            let uu___1 = p_attributes false attrs in
+            let uu___2 =
+              let uu___3 =
+                separate_map_last FStar_Pprint.hardline p_recordField
+                  record_field_decls in
+              braces_with_nesting uu___3 in
+            FStar_Pprint.op_Hat_Hat uu___1 uu___2 in
           let uu___1 = p_typeDeclPrefix pre true lid bs typ_opt in
           (FStar_Pprint.empty, uu___1, p_fields,
             ((fun d -> FStar_Pprint.op_Hat_Hat FStar_Pprint.space d)))
       | FStar_Parser_AST.TyconVariant (lid, bs, typ_opt, ct_decls) ->
           let p_constructorBranchAndComments uu___1 =
             match uu___1 with
-            | (uid, t_opt, use_of) ->
+            | (uid, t_opt, use_of, attrs) ->
                 let range =
                   let uu___2 =
                     let uu___3 = FStar_Ident.range_of_id uid in
@@ -1371,8 +1379,8 @@ and (p_typeDecl :
                     FStar_Compiler_Util.dflt uu___3 uu___4 in
                   FStar_Compiler_Range.extend_to_end_of_line uu___2 in
                 let uu___2 =
-                  with_comment_sep p_constructorBranch (uid, t_opt, use_of)
-                    range in
+                  with_comment_sep p_constructorBranch
+                    (uid, t_opt, use_of, attrs) range in
                 (match uu___2 with
                  | (comm, ctor) ->
                      inline_comment_or_above comm ctor FStar_Pprint.empty) in
@@ -1435,7 +1443,7 @@ and (p_recordFieldDecl :
           let uu___1 =
             let uu___2 = FStar_Pprint.optional p_aqual aq in
             let uu___3 =
-              let uu___4 = p_attributes attrs in
+              let uu___4 = p_attributes false attrs in
               let uu___5 =
                 let uu___6 = p_lident lid in
                 let uu___7 =
@@ -1447,16 +1455,19 @@ and (p_recordFieldDecl :
           FStar_Pprint.group uu___1
 and (p_constructorBranch :
   (FStar_Ident.ident * FStar_Parser_AST.term FStar_Pervasives_Native.option *
-    Prims.bool) -> FStar_Pprint.document)
+    Prims.bool * FStar_Parser_AST.attributes_) -> FStar_Pprint.document)
   =
   fun uu___ ->
     match uu___ with
-    | (uid, t_opt, use_of) ->
+    | (uid, t_opt, use_of, attrs) ->
         let sep = if use_of then str "of" else FStar_Pprint.colon in
         let uid_doc =
           let uu___1 =
             let uu___2 =
-              let uu___3 = p_uident uid in
+              let uu___3 =
+                let uu___4 = p_attributes false attrs in
+                let uu___5 = p_uident uid in
+                FStar_Pprint.op_Hat_Hat uu___4 uu___5 in
               FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu___3 in
             FStar_Pprint.op_Hat_Hat FStar_Pprint.bar uu___2 in
           FStar_Pprint.group uu___1 in
@@ -1928,7 +1939,7 @@ and (p_atomicPattern : FStar_Parser_AST.pattern -> FStar_Pprint.document) =
     | FStar_Parser_AST.PatWild (aqual, attrs) ->
         let uu___ = FStar_Pprint.optional p_aqual aqual in
         let uu___1 =
-          let uu___2 = p_attributes attrs in
+          let uu___2 = p_attributes false attrs in
           FStar_Pprint.op_Hat_Hat uu___2 FStar_Pprint.underscore in
         FStar_Pprint.op_Hat_Hat uu___ uu___1
     | FStar_Parser_AST.PatConst c -> p_constant c
@@ -1941,7 +1952,7 @@ and (p_atomicPattern : FStar_Parser_AST.pattern -> FStar_Pprint.document) =
     | FStar_Parser_AST.PatVar (lid, aqual, attrs) ->
         let uu___ = FStar_Pprint.optional p_aqual aqual in
         let uu___1 =
-          let uu___2 = p_attributes attrs in
+          let uu___2 = p_attributes false attrs in
           let uu___3 = p_lident lid in FStar_Pprint.op_Hat_Hat uu___2 uu___3 in
         FStar_Pprint.op_Hat_Hat uu___ uu___1
     | FStar_Parser_AST.PatName uid -> p_quident uid
@@ -1975,7 +1986,7 @@ and (p_binder :
   Prims.bool -> FStar_Parser_AST.binder -> FStar_Pprint.document) =
   fun is_atomic ->
     fun b ->
-      let uu___ = p_binder' is_atomic b in
+      let uu___ = p_binder' false is_atomic b in
       match uu___ with
       | (b', t', catf1) ->
           (match t' with
@@ -1983,102 +1994,128 @@ and (p_binder :
            | FStar_Pervasives_Native.None -> b')
 and (p_binder' :
   Prims.bool ->
-    FStar_Parser_AST.binder ->
-      (FStar_Pprint.document * FStar_Pprint.document
-        FStar_Pervasives_Native.option * catf))
+    Prims.bool ->
+      FStar_Parser_AST.binder ->
+        (FStar_Pprint.document * FStar_Pprint.document
+          FStar_Pervasives_Native.option * catf))
   =
-  fun is_atomic ->
-    fun b ->
-      match b.FStar_Parser_AST.b with
-      | FStar_Parser_AST.Variable lid ->
-          let uu___ =
-            let uu___1 =
-              FStar_Pprint.optional p_aqual b.FStar_Parser_AST.aqual in
-            let uu___2 = p_lident lid in
-            FStar_Pprint.op_Hat_Hat uu___1 uu___2 in
-          (uu___, FStar_Pervasives_Native.None, cat_with_colon)
-      | FStar_Parser_AST.TVariable lid ->
-          let uu___ = p_lident lid in
-          (uu___, FStar_Pervasives_Native.None, cat_with_colon)
-      | FStar_Parser_AST.Annotated (lid, t) ->
-          let uu___ =
-            match t.FStar_Parser_AST.tm with
-            | FStar_Parser_AST.Refine
-                ({
-                   FStar_Parser_AST.b = FStar_Parser_AST.Annotated (lid', t1);
-                   FStar_Parser_AST.brange = uu___1;
-                   FStar_Parser_AST.blevel = uu___2;
-                   FStar_Parser_AST.aqual = uu___3;
-                   FStar_Parser_AST.battributes = uu___4;_},
-                 phi)
-                when
-                let uu___5 = FStar_Ident.string_of_id lid in
-                let uu___6 = FStar_Ident.string_of_id lid' in uu___5 = uu___6
-                ->
-                let uu___5 = p_lident lid in
-                p_refinement' b.FStar_Parser_AST.aqual
-                  b.FStar_Parser_AST.battributes uu___5 t1 phi
-            | uu___1 ->
-                let t' =
-                  let uu___2 = is_typ_tuple t in
-                  if uu___2
-                  then
-                    let uu___3 = p_tmFormula t in
-                    soft_parens_with_nesting uu___3
-                  else p_tmFormula t in
-                let uu___2 =
-                  let uu___3 =
-                    FStar_Pprint.optional p_aqual b.FStar_Parser_AST.aqual in
-                  let uu___4 = p_lident lid in
-                  FStar_Pprint.op_Hat_Hat uu___3 uu___4 in
-                (uu___2, t') in
-          (match uu___ with
-           | (b', t') ->
-               let catf1 =
-                 let uu___1 =
-                   is_atomic || (is_meta_qualifier b.FStar_Parser_AST.aqual) in
-                 if uu___1
+  fun no_pars ->
+    fun is_atomic ->
+      fun b ->
+        match b.FStar_Parser_AST.b with
+        | FStar_Parser_AST.Variable lid ->
+            let uu___ =
+              let uu___1 =
+                FStar_Pprint.optional p_aqual b.FStar_Parser_AST.aqual in
+              let uu___2 =
+                let uu___3 =
+                  p_attributes false b.FStar_Parser_AST.battributes in
+                let uu___4 = p_lident lid in
+                FStar_Pprint.op_Hat_Hat uu___3 uu___4 in
+              FStar_Pprint.op_Hat_Hat uu___1 uu___2 in
+            (uu___, FStar_Pervasives_Native.None, cat_with_colon)
+        | FStar_Parser_AST.TVariable lid ->
+            let uu___ =
+              let uu___1 = p_attributes false b.FStar_Parser_AST.battributes in
+              let uu___2 = p_lident lid in
+              FStar_Pprint.op_Hat_Hat uu___1 uu___2 in
+            (uu___, FStar_Pervasives_Native.None, cat_with_colon)
+        | FStar_Parser_AST.Annotated (lid, t) ->
+            let uu___ =
+              match t.FStar_Parser_AST.tm with
+              | FStar_Parser_AST.Refine
+                  ({
+                     FStar_Parser_AST.b = FStar_Parser_AST.Annotated
+                       (lid', t1);
+                     FStar_Parser_AST.brange = uu___1;
+                     FStar_Parser_AST.blevel = uu___2;
+                     FStar_Parser_AST.aqual = uu___3;
+                     FStar_Parser_AST.battributes = uu___4;_},
+                   phi)
+                  when
+                  let uu___5 = FStar_Ident.string_of_id lid in
+                  let uu___6 = FStar_Ident.string_of_id lid' in
+                  uu___5 = uu___6 ->
+                  let uu___5 = p_lident lid in
+                  p_refinement' b.FStar_Parser_AST.aqual
+                    b.FStar_Parser_AST.battributes uu___5 t1 phi
+              | uu___1 ->
+                  let t' =
+                    let uu___2 = is_typ_tuple t in
+                    if uu___2
+                    then
+                      let uu___3 = p_tmFormula t in
+                      soft_parens_with_nesting uu___3
+                    else p_tmFormula t in
+                  let uu___2 =
+                    let uu___3 =
+                      FStar_Pprint.optional p_aqual b.FStar_Parser_AST.aqual in
+                    let uu___4 =
+                      let uu___5 =
+                        p_attributes false b.FStar_Parser_AST.battributes in
+                      let uu___6 = p_lident lid in
+                      FStar_Pprint.op_Hat_Hat uu___5 uu___6 in
+                    FStar_Pprint.op_Hat_Hat uu___3 uu___4 in
+                  (uu___2, t') in
+            (match uu___ with
+             | (b', t') ->
+                 let catf1 =
+                   let uu___1 =
+                     is_atomic ||
+                       ((is_meta_qualifier b.FStar_Parser_AST.aqual) &&
+                          (Prims.op_Negation no_pars)) in
+                   if uu___1
+                   then
+                     fun x ->
+                       fun y ->
+                         let uu___2 =
+                           let uu___3 =
+                             let uu___4 = cat_with_colon x y in
+                             FStar_Pprint.op_Hat_Hat uu___4
+                               FStar_Pprint.rparen in
+                           FStar_Pprint.op_Hat_Hat FStar_Pprint.lparen uu___3 in
+                         FStar_Pprint.group uu___2
+                   else
+                     (fun x ->
+                        fun y ->
+                          let uu___3 = cat_with_colon x y in
+                          FStar_Pprint.group uu___3) in
+                 (b', (FStar_Pervasives_Native.Some t'), catf1))
+        | FStar_Parser_AST.TAnnotated uu___ ->
+            failwith "Is this still used ?"
+        | FStar_Parser_AST.NoName t ->
+            (match t.FStar_Parser_AST.tm with
+             | FStar_Parser_AST.Refine
+                 ({ FStar_Parser_AST.b = FStar_Parser_AST.NoName t1;
+                    FStar_Parser_AST.brange = uu___;
+                    FStar_Parser_AST.blevel = uu___1;
+                    FStar_Parser_AST.aqual = uu___2;
+                    FStar_Parser_AST.battributes = uu___3;_},
+                  phi)
+                 ->
+                 let uu___4 =
+                   p_refinement' b.FStar_Parser_AST.aqual
+                     b.FStar_Parser_AST.battributes FStar_Pprint.underscore
+                     t1 phi in
+                 (match uu___4 with
+                  | (b', t') ->
+                      (b', (FStar_Pervasives_Native.Some t'), cat_with_colon))
+             | uu___ ->
+                 if is_atomic
                  then
-                   fun x ->
-                     fun y ->
-                       let uu___2 =
-                         let uu___3 =
-                           let uu___4 = cat_with_colon x y in
-                           FStar_Pprint.op_Hat_Hat uu___4 FStar_Pprint.rparen in
-                         FStar_Pprint.op_Hat_Hat FStar_Pprint.lparen uu___3 in
-                       FStar_Pprint.group uu___2
+                   let uu___1 =
+                     let uu___2 =
+                       p_attributes false b.FStar_Parser_AST.battributes in
+                     let uu___3 = p_atomicTerm t in
+                     FStar_Pprint.op_Hat_Hat uu___2 uu___3 in
+                   (uu___1, FStar_Pervasives_Native.None, cat_with_colon)
                  else
-                   (fun x ->
-                      fun y ->
-                        let uu___3 = cat_with_colon x y in
-                        FStar_Pprint.group uu___3) in
-               (b', (FStar_Pervasives_Native.Some t'), catf1))
-      | FStar_Parser_AST.TAnnotated uu___ -> failwith "Is this still used ?"
-      | FStar_Parser_AST.NoName t ->
-          (match t.FStar_Parser_AST.tm with
-           | FStar_Parser_AST.Refine
-               ({ FStar_Parser_AST.b = FStar_Parser_AST.NoName t1;
-                  FStar_Parser_AST.brange = uu___;
-                  FStar_Parser_AST.blevel = uu___1;
-                  FStar_Parser_AST.aqual = uu___2;
-                  FStar_Parser_AST.battributes = uu___3;_},
-                phi)
-               ->
-               let uu___4 =
-                 p_refinement' b.FStar_Parser_AST.aqual
-                   b.FStar_Parser_AST.battributes FStar_Pprint.underscore t1
-                   phi in
-               (match uu___4 with
-                | (b', t') ->
-                    (b', (FStar_Pervasives_Native.Some t'), cat_with_colon))
-           | uu___ ->
-               if is_atomic
-               then
-                 let uu___1 = p_atomicTerm t in
-                 (uu___1, FStar_Pervasives_Native.None, cat_with_colon)
-               else
-                 (let uu___2 = p_appTerm t in
-                  (uu___2, FStar_Pervasives_Native.None, cat_with_colon)))
+                   (let uu___2 =
+                      let uu___3 =
+                        p_attributes false b.FStar_Parser_AST.battributes in
+                      let uu___4 = p_appTerm t in
+                      FStar_Pprint.op_Hat_Hat uu___3 uu___4 in
+                    (uu___2, FStar_Pervasives_Native.None, cat_with_colon)))
 and (p_refinement :
   FStar_Parser_AST.arg_qualifier FStar_Pervasives_Native.option ->
     FStar_Parser_AST.term Prims.list ->
@@ -2127,7 +2164,7 @@ and (p_refinement' :
                 let uu___1 =
                   let uu___2 = FStar_Pprint.optional p_aqual aqual_opt in
                   let uu___3 =
-                    let uu___4 = p_attributes attrs in
+                    let uu___4 = p_attributes false attrs in
                     FStar_Pprint.op_Hat_Hat uu___4 binder in
                   FStar_Pprint.op_Hat_Hat uu___2 uu___3 in
                 let uu___2 =
@@ -2689,7 +2726,7 @@ and (p_noSeqTerm' :
             let p_lb q1 uu___ is_last =
               match uu___ with
               | (a, (pat, e2)) ->
-                  let attrs = p_attrs_opt a in
+                  let attrs = p_attrs_opt true a in
                   let doc_let_or_and =
                     match q1 with
                     | FStar_Pervasives_Native.Some (FStar_Parser_AST.Rec) ->
@@ -3316,24 +3353,26 @@ and (p_calcStep :
             FStar_Pprint.op_Hat_Hat uu___3 uu___4 in
           FStar_Pprint.group uu___2
 and (p_attrs_opt :
-  FStar_Parser_AST.term Prims.list FStar_Pervasives_Native.option ->
-    FStar_Pprint.document)
+  Prims.bool ->
+    FStar_Parser_AST.term Prims.list FStar_Pervasives_Native.option ->
+      FStar_Pprint.document)
   =
-  fun uu___ ->
-    match uu___ with
-    | FStar_Pervasives_Native.None -> FStar_Pprint.empty
-    | FStar_Pervasives_Native.Some terms ->
-        let uu___1 =
-          let uu___2 = str "[@@" in
-          let uu___3 =
-            let uu___4 =
-              let uu___5 = str "; " in
-              FStar_Pprint.separate_map uu___5
-                (p_noSeqTermAndComment false false) terms in
-            let uu___5 = str "]" in
-            FStar_Pprint.op_Hat_Slash_Hat uu___4 uu___5 in
-          FStar_Pprint.op_Hat_Slash_Hat uu___2 uu___3 in
-        FStar_Pprint.group uu___1
+  fun isTopLevel ->
+    fun uu___ ->
+      match uu___ with
+      | FStar_Pervasives_Native.None -> FStar_Pprint.empty
+      | FStar_Pervasives_Native.Some terms ->
+          let uu___1 =
+            let uu___2 = str (if isTopLevel then "[@@" else "[@@@") in
+            let uu___3 =
+              let uu___4 =
+                let uu___5 = str "; " in
+                FStar_Pprint.separate_map uu___5
+                  (p_noSeqTermAndComment false false) terms in
+              let uu___5 = str "]" in
+              FStar_Pprint.op_Hat_Slash_Hat uu___4 uu___5 in
+            FStar_Pprint.op_Hat_Slash_Hat uu___2 uu___3 in
+          FStar_Pprint.group uu___1
 and (p_typ :
   Prims.bool -> Prims.bool -> FStar_Parser_AST.term -> FStar_Pprint.document)
   =
@@ -3510,7 +3549,7 @@ and (pats_as_binders_if_possible :
                  let uu___2 =
                    let uu___3 = FStar_Pprint.optional p_aqual aqual in
                    let uu___4 =
-                     let uu___5 = p_attributes attrs in
+                     let uu___5 = p_attributes false attrs in
                      let uu___6 = p_ident lid in
                      FStar_Pprint.op_Hat_Hat uu___5 uu___6 in
                    FStar_Pprint.op_Hat_Hat uu___3 uu___4 in
@@ -3874,7 +3913,7 @@ and (collapse_binders :
         match e1.FStar_Parser_AST.tm with
         | FStar_Parser_AST.Product (bs, tgt) ->
             let uu___ =
-              FStar_Compiler_List.map (fun b -> p_binder' false b) bs in
+              FStar_Compiler_List.map (fun b -> p_binder' true false b) bs in
             let uu___1 = accumulate_binders p_Tm1 tgt in
             FStar_Compiler_List.op_At uu___ uu___1
         | uu___ ->

--- a/src/ocaml-output/FStar_Syntax_Resugar.ml
+++ b/src/ocaml-output/FStar_Syntax_Resugar.ml
@@ -2430,7 +2430,11 @@ let (resugar_typ :
                          resugar_datacon_as_fields [] current_datacons in
                      let uu___4 =
                        let uu___5 = FStar_Ident.ident_of_lid tylid in
-                       (uu___5, bs2, FStar_Pervasives_Native.None, fields) in
+                       let uu___6 =
+                         FStar_Compiler_List.map (resugar_term' env)
+                           se.FStar_Syntax_Syntax.sigattrs in
+                       (uu___5, bs2, FStar_Pervasives_Native.None, uu___6,
+                         fields) in
                      FStar_Parser_AST.TyconRecord uu___4
                    else
                      (let resugar_datacon constructors se1 =
@@ -2442,7 +2446,10 @@ let (resugar_typ :
                               let uu___8 =
                                 let uu___9 = resugar_term' env term in
                                 FStar_Pervasives_Native.Some uu___9 in
-                              (uu___7, uu___8, false) in
+                              let uu___9 =
+                                FStar_Compiler_List.map (resugar_term' env)
+                                  se1.FStar_Syntax_Syntax.sigattrs in
+                              (uu___7, uu___8, false, uu___9) in
                             c :: constructors
                         | uu___5 -> failwith "unexpected" in
                       let constructors =

--- a/src/ocaml-output/FStar_Syntax_Util.ml
+++ b/src/ocaml-output/FStar_Syntax_Util.ml
@@ -2193,11 +2193,8 @@ let (attr_substitute : FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax)
   =
   let uu___ =
     let uu___1 =
-      let uu___2 =
-        FStar_Ident.lid_of_path ["FStar"; "Pervasives"; "Substitute"]
-          FStar_Compiler_Range.dummyRange in
-      FStar_Syntax_Syntax.lid_as_fv uu___2 FStar_Syntax_Syntax.delta_constant
-        FStar_Pervasives_Native.None in
+      FStar_Syntax_Syntax.lid_as_fv FStar_Parser_Const.attr_substitute_lid
+        FStar_Syntax_Syntax.delta_constant FStar_Pervasives_Native.None in
     FStar_Syntax_Syntax.Tm_fvar uu___1 in
   FStar_Syntax_Syntax.mk uu___ FStar_Compiler_Range.dummyRange
 let (exp_true_bool : FStar_Syntax_Syntax.term) =

--- a/src/ocaml-output/FStar_ToSyntax_Interleave.ml
+++ b/src/ocaml-output/FStar_ToSyntax_Interleave.ml
@@ -39,8 +39,9 @@ let (definition_lids :
                 match uu___2 with
                 | FStar_Parser_AST.TyconAbbrev (id, uu___3, uu___4, uu___5)
                     -> let uu___6 = FStar_Ident.lid_of_ids [id] in [uu___6]
-                | FStar_Parser_AST.TyconRecord (id, uu___3, uu___4, uu___5)
-                    -> let uu___6 = FStar_Ident.lid_of_ids [id] in [uu___6]
+                | FStar_Parser_AST.TyconRecord
+                    (id, uu___3, uu___4, uu___5, uu___6) ->
+                    let uu___7 = FStar_Ident.lid_of_ids [id] in [uu___7]
                 | FStar_Parser_AST.TyconVariant (id, uu___3, uu___4, uu___5)
                     -> let uu___6 = FStar_Ident.lid_of_ids [id] in [uu___6]
                 | uu___3 -> []))

--- a/src/ocaml-output/FStar_ToSyntax_ToSyntax.ml
+++ b/src/ocaml-output/FStar_ToSyntax_ToSyntax.ml
@@ -6036,7 +6036,8 @@ let rec (desugar_tycon :
             match uu___ with
             | FStar_Parser_AST.TyconAbstract (id, uu___1, uu___2) -> id
             | FStar_Parser_AST.TyconAbbrev (id, uu___1, uu___2, uu___3) -> id
-            | FStar_Parser_AST.TyconRecord (id, uu___1, uu___2, uu___3) -> id
+            | FStar_Parser_AST.TyconRecord
+                (id, uu___1, uu___2, uu___3, uu___4) -> id
             | FStar_Parser_AST.TyconVariant (id, uu___1, uu___2, uu___3) ->
                 id in
           let binder_to_term b =
@@ -6090,7 +6091,8 @@ let rec (desugar_tycon :
                      out.FStar_Parser_AST.level) t binders in
           let tycon_record_as_variant uu___ =
             match uu___ with
-            | FStar_Parser_AST.TyconRecord (id, parms, kopt, fields) ->
+            | FStar_Parser_AST.TyconRecord (id, parms, kopt, attrs, fields)
+                ->
                 let constrName =
                   let uu___1 =
                     let uu___2 =
@@ -6103,11 +6105,11 @@ let rec (desugar_tycon :
                   FStar_Compiler_List.map
                     (fun uu___1 ->
                        match uu___1 with
-                       | (x, q, attrs, t) ->
+                       | (x, q, attrs1, t) ->
                            let uu___2 = FStar_Ident.range_of_id x in
                            FStar_Parser_AST.mk_binder_with_attrs
                              (FStar_Parser_AST.Annotated (x, t)) uu___2
-                             FStar_Parser_AST.Expr q attrs) fields in
+                             FStar_Parser_AST.Expr q attrs1) fields in
                 let result =
                   let uu___1 =
                     let uu___2 =
@@ -6152,8 +6154,8 @@ let rec (desugar_tycon :
                   ((FStar_Parser_AST.TyconVariant
                       (id, parms, kopt,
                         [(constrName,
-                           (FStar_Pervasives_Native.Some constrTyp), false)])),
-                    uu___2)))
+                           (FStar_Pervasives_Native.Some constrTyp), false,
+                           attrs)])), uu___2)))
             | uu___1 -> failwith "impossible" in
           let desugar_abstract_tc quals1 _env mutuals uu___ =
             match uu___ with
@@ -6586,8 +6588,8 @@ let rec (desugar_tycon :
                                             (FStar_Compiler_List.map
                                                (fun uu___12 ->
                                                   match uu___12 with
-                                                  | (id, topt, of_notation)
-                                                      ->
+                                                  | (id, topt, of_notation,
+                                                     cons_attrs) ->
                                                       let t =
                                                         if of_notation
                                                         then
@@ -6663,6 +6665,18 @@ let rec (desugar_tycon :
                                                                 mutuals1) in
                                                             FStar_Syntax_Syntax.Sig_datacon
                                                               uu___16 in
+                                                          let uu___16 =
+                                                            let uu___17 =
+                                                              let uu___18 =
+                                                                FStar_Compiler_List.map
+                                                                  (desugar_term
+                                                                    env1)
+                                                                  cons_attrs in
+                                                              FStar_Compiler_List.op_At
+                                                                attrs uu___18 in
+                                                            FStar_Compiler_List.op_At
+                                                              val_attrs
+                                                              uu___17 in
                                                           {
                                                             FStar_Syntax_Syntax.sigel
                                                               = uu___15;
@@ -6674,10 +6688,7 @@ let rec (desugar_tycon :
                                                               =
                                                               FStar_Syntax_Syntax.default_sigmeta;
                                                             FStar_Syntax_Syntax.sigattrs
-                                                              =
-                                                              (FStar_Compiler_List.op_At
-                                                                 val_attrs
-                                                                 attrs);
+                                                              = uu___16;
                                                             FStar_Syntax_Syntax.sigopts
                                                               =
                                                               FStar_Pervasives_Native.None

--- a/src/ocaml-output/FStar_TypeChecker_Normalize.ml
+++ b/src/ocaml-output/FStar_TypeChecker_Normalize.ml
@@ -8465,16 +8465,20 @@ let rec (elim_uvars :
   =
   fun env1 ->
     fun s ->
-      let s1 =
+      let sigattrs =
         let uu___ =
-          FStar_Compiler_List.map FStar_Syntax_Subst.deep_compress
+          FStar_Compiler_List.map (elim_uvars_aux_t env1 [] [])
             s.FStar_Syntax_Syntax.sigattrs in
+        FStar_Compiler_Effect.op_Less_Bar
+          (FStar_Compiler_List.map
+             FStar_Pervasives_Native.__proj__Mktuple3__item___3) uu___ in
+      let s1 =
         {
           FStar_Syntax_Syntax.sigel = (s.FStar_Syntax_Syntax.sigel);
           FStar_Syntax_Syntax.sigrng = (s.FStar_Syntax_Syntax.sigrng);
           FStar_Syntax_Syntax.sigquals = (s.FStar_Syntax_Syntax.sigquals);
           FStar_Syntax_Syntax.sigmeta = (s.FStar_Syntax_Syntax.sigmeta);
-          FStar_Syntax_Syntax.sigattrs = uu___;
+          FStar_Syntax_Syntax.sigattrs = sigattrs;
           FStar_Syntax_Syntax.sigopts = (s.FStar_Syntax_Syntax.sigopts)
         } in
       match s1.FStar_Syntax_Syntax.sigel with

--- a/src/ocaml-output/FStar_TypeChecker_Tc.ml
+++ b/src/ocaml-output/FStar_TypeChecker_Tc.ml
@@ -301,6 +301,36 @@ let (tc_assume :
           FStar_Compiler_Effect.op_Bar_Greater uu___1
             FStar_Pervasives_Native.fst in
         tc_type_common env ts uu___ r
+let (tc_decl_attributes :
+  FStar_TypeChecker_Env.env ->
+    FStar_Syntax_Syntax.sigelt -> FStar_Syntax_Syntax.sigelt)
+  =
+  fun env ->
+    fun se ->
+      let uu___ =
+        let uu___1 =
+          FStar_TypeChecker_Env.lid_exists env
+            FStar_Parser_Const.attr_substitute_lid in
+        if uu___1
+        then ([], (se.FStar_Syntax_Syntax.sigattrs))
+        else
+          FStar_Compiler_List.partition
+            ((=) FStar_Syntax_Util.attr_substitute)
+            se.FStar_Syntax_Syntax.sigattrs in
+      match uu___ with
+      | (blacklisted_attrs, other_attrs) ->
+          let uu___1 =
+            let uu___2 =
+              FStar_TypeChecker_TcTerm.tc_attributes env other_attrs in
+            FStar_Compiler_List.op_At blacklisted_attrs uu___2 in
+          {
+            FStar_Syntax_Syntax.sigel = (se.FStar_Syntax_Syntax.sigel);
+            FStar_Syntax_Syntax.sigrng = (se.FStar_Syntax_Syntax.sigrng);
+            FStar_Syntax_Syntax.sigquals = (se.FStar_Syntax_Syntax.sigquals);
+            FStar_Syntax_Syntax.sigmeta = (se.FStar_Syntax_Syntax.sigmeta);
+            FStar_Syntax_Syntax.sigattrs = uu___1;
+            FStar_Syntax_Syntax.sigopts = (se.FStar_Syntax_Syntax.sigopts)
+          }
 let (tc_inductive' :
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.sigelt Prims.list ->
@@ -324,9 +354,10 @@ let (tc_inductive' :
                FStar_Compiler_Util.print1 ">>>>>>>>>>>>>>tc_inductive %s\n"
                  uu___2
              else ());
-            (let uu___1 =
+            (let ses1 = FStar_Compiler_List.map (tc_decl_attributes env) ses in
+             let uu___1 =
                FStar_TypeChecker_TcInductive.check_inductive_well_typedness
-                 env ses quals lids in
+                 env ses1 quals lids in
              match uu___1 with
              | (sig_bndle, tcs, datas) ->
                  let attrs' =
@@ -448,7 +479,7 @@ let (tc_inductive' :
                        (let is_unopteq =
                           FStar_Compiler_List.existsb
                             (fun q -> q = FStar_Syntax_Syntax.Unopteq) quals in
-                        let ses1 =
+                        let ses2 =
                           if is_unopteq
                           then
                             FStar_TypeChecker_TcInductive.unoptimized_haseq_scheme
@@ -457,7 +488,7 @@ let (tc_inductive' :
                             FStar_TypeChecker_TcInductive.optimized_haseq_scheme
                               sig_bndle tcs datas env in
                         (sig_bndle,
-                          (FStar_Compiler_List.op_At ses1 data_ops_ses))) in
+                          (FStar_Compiler_List.op_At ses2 data_ops_ses))) in
                    res)))
 let (tc_inductive :
   FStar_TypeChecker_Env.env ->
@@ -667,55 +698,15 @@ let (handle_postprocess_with_attr :
   =
   fun env ->
     fun ats ->
-      let tc_and_elab_tactic env1 tau =
-        let uu___ =
-          FStar_TypeChecker_TcTerm.tc_tactic FStar_Syntax_Syntax.t_unit
-            FStar_Syntax_Syntax.t_unit env1 tau in
-        match uu___ with
-        | (tau1, uu___1, g_tau) ->
-            (FStar_TypeChecker_Rel.force_trivial_guard env1 g_tau; tau1) in
-      let ats1 =
-        let uu___ =
-          FStar_Syntax_Util.extract_attr'
-            FStar_Parser_Const.postprocess_extr_with ats in
-        match uu___ with
-        | FStar_Pervasives_Native.None -> ats
-        | FStar_Pervasives_Native.Some
-            (ats2, (tau, FStar_Pervasives_Native.None)::[]) ->
-            let tau1 = tc_and_elab_tactic env tau in
-            let tau2 = FStar_Syntax_Subst.deep_compress tau1 in
-            let uu___1 =
-              let uu___2 =
-                FStar_Syntax_Syntax.tabbrev
-                  FStar_Parser_Const.postprocess_extr_with in
-              FStar_Syntax_Util.mk_app uu___2
-                [(tau2, FStar_Pervasives_Native.None)] in
-            uu___1 :: ats2
-        | FStar_Pervasives_Native.Some
-            (ats2, (tau, FStar_Pervasives_Native.None)::[]) ->
-            ((let uu___2 = FStar_TypeChecker_Env.get_range env in
-              let uu___3 =
-                let uu___4 =
-                  let uu___5 =
-                    FStar_Ident.string_of_lid
-                      FStar_Parser_Const.postprocess_extr_with in
-                  FStar_Compiler_Util.format1
-                    "Ill-formed application of `%s`" uu___5 in
-                (FStar_Errors.Warning_UnrecognizedAttribute, uu___4) in
-              FStar_Errors.log_issue uu___2 uu___3);
-             ats2) in
       let uu___ =
         FStar_Syntax_Util.extract_attr' FStar_Parser_Const.postprocess_with
-          ats1 in
+          ats in
       match uu___ with
-      | FStar_Pervasives_Native.None -> (ats1, FStar_Pervasives_Native.None)
+      | FStar_Pervasives_Native.None -> (ats, FStar_Pervasives_Native.None)
       | FStar_Pervasives_Native.Some
-          (ats2, (tau, FStar_Pervasives_Native.None)::[]) ->
-          let uu___1 =
-            let uu___2 = tc_and_elab_tactic env tau in
-            FStar_Pervasives_Native.Some uu___2 in
-          (ats2, uu___1)
-      | FStar_Pervasives_Native.Some (ats2, args) ->
+          (ats1, (tau, FStar_Pervasives_Native.None)::[]) ->
+          (ats1, (FStar_Pervasives_Native.Some tau))
+      | FStar_Pervasives_Native.Some (ats1, args) ->
           ((let uu___2 = FStar_TypeChecker_Env.get_range env in
             let uu___3 =
               let uu___4 =
@@ -726,7 +717,7 @@ let (handle_postprocess_with_attr :
                   uu___5 in
               (FStar_Errors.Warning_UnrecognizedAttribute, uu___4) in
             FStar_Errors.log_issue uu___2 uu___3);
-           (ats2, FStar_Pervasives_Native.None))
+           (ats1, FStar_Pervasives_Native.None))
 let (store_sigopts :
   FStar_Syntax_Syntax.sigelt -> FStar_Syntax_Syntax.sigelt) =
   fun se ->
@@ -1932,14 +1923,18 @@ let (tc_decl' :
   fun env0 ->
     fun se ->
       let env = env0 in
-      FStar_TypeChecker_Util.check_sigelt_quals env se;
-      proc_check_with se.FStar_Syntax_Syntax.sigattrs
+      let se1 =
+        match se.FStar_Syntax_Syntax.sigel with
+        | FStar_Syntax_Syntax.Sig_fail uu___ -> se
+        | uu___ -> tc_decl_attributes env se in
+      FStar_TypeChecker_Util.check_sigelt_quals env se1;
+      proc_check_with se1.FStar_Syntax_Syntax.sigattrs
         (fun uu___1 ->
-           let r = se.FStar_Syntax_Syntax.sigrng in
-           let se1 =
+           let r = se1.FStar_Syntax_Syntax.sigrng in
+           let se2 =
              let uu___2 = FStar_Options.record_options () in
-             if uu___2 then store_sigopts se else se in
-           match se1.FStar_Syntax_Syntax.sigel with
+             if uu___2 then store_sigopts se1 else se1 in
+           match se2.FStar_Syntax_Syntax.sigel with
            | FStar_Syntax_Syntax.Sig_inductive_typ uu___2 ->
                failwith "Impossible bare data-constructor"
            | FStar_Syntax_Syntax.Sig_datacon uu___2 ->
@@ -2107,7 +2102,7 @@ let (tc_decl' :
                             (FStar_Compiler_List.iter
                                FStar_Errors.print_issue errs;
                              FStar_Errors.log_issue
-                               se1.FStar_Syntax_Syntax.sigrng
+                               se2.FStar_Syntax_Syntax.sigrng
                                (FStar_Errors.Error_DidNotFail,
                                  "This top-level definition was expected to fail, but it succeeded"))
                         | uu___8 ->
@@ -2147,7 +2142,7 @@ let (tc_decl' :
                                        (FStar_Errors.Error_DidNotFail,
                                          uu___12) in
                                      FStar_Errors.log_issue
-                                       se1.FStar_Syntax_Syntax.sigrng uu___11)))
+                                       se2.FStar_Syntax_Syntax.sigrng uu___11)))
                             else ());
                        ([], [], env)))))
            | FStar_Syntax_Syntax.Sig_bundle (ses, lids) ->
@@ -2266,8 +2261,8 @@ let (tc_decl' :
                                FStar_TypeChecker_Env.rel_query_for_apply_tac_uvar
                                  =
                                  (env1.FStar_TypeChecker_Env.rel_query_for_apply_tac_uvar)
-                             } ses se1.FStar_Syntax_Syntax.sigquals
-                             se1.FStar_Syntax_Syntax.sigattrs lids in
+                             } ses se2.FStar_Syntax_Syntax.sigquals
+                             se2.FStar_Syntax_Syntax.sigattrs lids in
                          FStar_Compiler_Effect.op_Bar_Greater uu___5
                            FStar_Pervasives_Native.fst in
                        FStar_Compiler_Effect.op_Bar_Greater uu___4
@@ -2286,15 +2281,15 @@ let (tc_decl' :
                              FStar_Syntax_Syntax.sigel =
                                (FStar_Syntax_Syntax.Sig_bundle (ses2, lids));
                              FStar_Syntax_Syntax.sigrng =
-                               (se1.FStar_Syntax_Syntax.sigrng);
+                               (se2.FStar_Syntax_Syntax.sigrng);
                              FStar_Syntax_Syntax.sigquals =
-                               (se1.FStar_Syntax_Syntax.sigquals);
+                               (se2.FStar_Syntax_Syntax.sigquals);
                              FStar_Syntax_Syntax.sigmeta =
-                               (se1.FStar_Syntax_Syntax.sigmeta);
+                               (se2.FStar_Syntax_Syntax.sigmeta);
                              FStar_Syntax_Syntax.sigattrs =
-                               (se1.FStar_Syntax_Syntax.sigattrs);
+                               (se2.FStar_Syntax_Syntax.sigattrs);
                              FStar_Syntax_Syntax.sigopts =
-                               (se1.FStar_Syntax_Syntax.sigopts)
+                               (se2.FStar_Syntax_Syntax.sigopts)
                            } in
                        FStar_Compiler_Util.print1
                          "Inductive after phase 1: %s\n" uu___5
@@ -2302,8 +2297,8 @@ let (tc_decl' :
                     ses2)
                  else ses in
                let uu___2 =
-                 tc_inductive env1 ses1 se1.FStar_Syntax_Syntax.sigquals
-                   se1.FStar_Syntax_Syntax.sigattrs lids in
+                 tc_inductive env1 ses1 se2.FStar_Syntax_Syntax.sigquals
+                   se2.FStar_Syntax_Syntax.sigattrs lids in
                (match uu___2 with
                 | (sigbndle, projectors_ses) ->
                     let sigbndle1 =
@@ -2317,13 +2312,13 @@ let (tc_decl' :
                         FStar_Syntax_Syntax.sigmeta =
                           (sigbndle.FStar_Syntax_Syntax.sigmeta);
                         FStar_Syntax_Syntax.sigattrs =
-                          (se1.FStar_Syntax_Syntax.sigattrs);
+                          (se2.FStar_Syntax_Syntax.sigattrs);
                         FStar_Syntax_Syntax.sigopts =
                           (sigbndle.FStar_Syntax_Syntax.sigopts)
                       } in
                     ([sigbndle1], projectors_ses, env0))
            | FStar_Syntax_Syntax.Sig_pragma p ->
-               (FStar_Syntax_Util.process_pragma p r; ([se1], [], env0))
+               (FStar_Syntax_Util.process_pragma p r; ([se2], [], env0))
            | FStar_Syntax_Syntax.Sig_new_effect ne ->
                let is_unelaborated_dm4f =
                  match ne.FStar_Syntax_Syntax.combinators with
@@ -2357,15 +2352,15 @@ let (tc_decl' :
                                FStar_Syntax_Syntax.sigel =
                                  (FStar_Syntax_Syntax.Sig_new_effect ne1);
                                FStar_Syntax_Syntax.sigrng =
-                                 (se1.FStar_Syntax_Syntax.sigrng);
+                                 (se2.FStar_Syntax_Syntax.sigrng);
                                FStar_Syntax_Syntax.sigquals =
-                                 (se1.FStar_Syntax_Syntax.sigquals);
+                                 (se2.FStar_Syntax_Syntax.sigquals);
                                FStar_Syntax_Syntax.sigmeta =
-                                 (se1.FStar_Syntax_Syntax.sigmeta);
+                                 (se2.FStar_Syntax_Syntax.sigmeta);
                                FStar_Syntax_Syntax.sigattrs =
-                                 (se1.FStar_Syntax_Syntax.sigattrs);
+                                 (se2.FStar_Syntax_Syntax.sigattrs);
                                FStar_Syntax_Syntax.sigopts =
-                                 (se1.FStar_Syntax_Syntax.sigopts)
+                                 (se2.FStar_Syntax_Syntax.sigopts)
                              };
                             lift]
                         | FStar_Pervasives_Native.None ->
@@ -2373,15 +2368,15 @@ let (tc_decl' :
                                FStar_Syntax_Syntax.sigel =
                                  (FStar_Syntax_Syntax.Sig_new_effect ne1);
                                FStar_Syntax_Syntax.sigrng =
-                                 (se1.FStar_Syntax_Syntax.sigrng);
+                                 (se2.FStar_Syntax_Syntax.sigrng);
                                FStar_Syntax_Syntax.sigquals =
-                                 (se1.FStar_Syntax_Syntax.sigquals);
+                                 (se2.FStar_Syntax_Syntax.sigquals);
                                FStar_Syntax_Syntax.sigmeta =
-                                 (se1.FStar_Syntax_Syntax.sigmeta);
+                                 (se2.FStar_Syntax_Syntax.sigmeta);
                                FStar_Syntax_Syntax.sigattrs =
-                                 (se1.FStar_Syntax_Syntax.sigattrs);
+                                 (se2.FStar_Syntax_Syntax.sigattrs);
                                FStar_Syntax_Syntax.sigopts =
-                                 (se1.FStar_Syntax_Syntax.sigopts)
+                                 (se2.FStar_Syntax_Syntax.sigopts)
                              }] in
                       let effect_and_lift_ses1 =
                         FStar_Compiler_Effect.op_Bar_Greater
@@ -2538,8 +2533,8 @@ let (tc_decl' :
                                     FStar_TypeChecker_Env.rel_query_for_apply_tac_uvar
                                       =
                                       (env.FStar_TypeChecker_Env.rel_query_for_apply_tac_uvar)
-                                  } ne se1.FStar_Syntax_Syntax.sigquals
-                                  se1.FStar_Syntax_Syntax.sigattrs in
+                                  } ne se2.FStar_Syntax_Syntax.sigquals
+                                  se2.FStar_Syntax_Syntax.sigattrs in
                               FStar_Compiler_Effect.op_Bar_Greater uu___7
                                 FStar_Pervasives_Native.fst in
                             FStar_Compiler_Effect.op_Bar_Greater uu___6
@@ -2548,15 +2543,15 @@ let (tc_decl' :
                                    FStar_Syntax_Syntax.sigel =
                                      (FStar_Syntax_Syntax.Sig_new_effect ne3);
                                    FStar_Syntax_Syntax.sigrng =
-                                     (se1.FStar_Syntax_Syntax.sigrng);
+                                     (se2.FStar_Syntax_Syntax.sigrng);
                                    FStar_Syntax_Syntax.sigquals =
-                                     (se1.FStar_Syntax_Syntax.sigquals);
+                                     (se2.FStar_Syntax_Syntax.sigquals);
                                    FStar_Syntax_Syntax.sigmeta =
-                                     (se1.FStar_Syntax_Syntax.sigmeta);
+                                     (se2.FStar_Syntax_Syntax.sigmeta);
                                    FStar_Syntax_Syntax.sigattrs =
-                                     (se1.FStar_Syntax_Syntax.sigattrs);
+                                     (se2.FStar_Syntax_Syntax.sigattrs);
                                    FStar_Syntax_Syntax.sigopts =
-                                     (se1.FStar_Syntax_Syntax.sigopts)
+                                     (se2.FStar_Syntax_Syntax.sigopts)
                                  }) in
                           FStar_Compiler_Effect.op_Bar_Greater uu___5
                             (FStar_TypeChecker_Normalize.elim_uvars env) in
@@ -2574,15 +2569,15 @@ let (tc_decl' :
                                 FStar_Syntax_Syntax.sigel =
                                   (FStar_Syntax_Syntax.Sig_new_effect ne2);
                                 FStar_Syntax_Syntax.sigrng =
-                                  (se1.FStar_Syntax_Syntax.sigrng);
+                                  (se2.FStar_Syntax_Syntax.sigrng);
                                 FStar_Syntax_Syntax.sigquals =
-                                  (se1.FStar_Syntax_Syntax.sigquals);
+                                  (se2.FStar_Syntax_Syntax.sigquals);
                                 FStar_Syntax_Syntax.sigmeta =
-                                  (se1.FStar_Syntax_Syntax.sigmeta);
+                                  (se2.FStar_Syntax_Syntax.sigmeta);
                                 FStar_Syntax_Syntax.sigattrs =
-                                  (se1.FStar_Syntax_Syntax.sigattrs);
+                                  (se2.FStar_Syntax_Syntax.sigattrs);
                                 FStar_Syntax_Syntax.sigopts =
-                                  (se1.FStar_Syntax_Syntax.sigopts)
+                                  (se2.FStar_Syntax_Syntax.sigopts)
                               } in
                           FStar_Compiler_Util.print1
                             "Effect decl after phase 1: %s\n" uu___6
@@ -2591,44 +2586,44 @@ let (tc_decl' :
                     else ne in
                   let uu___3 =
                     FStar_TypeChecker_TcEffect.tc_eff_decl env ne1
-                      se1.FStar_Syntax_Syntax.sigquals
-                      se1.FStar_Syntax_Syntax.sigattrs in
+                      se2.FStar_Syntax_Syntax.sigquals
+                      se2.FStar_Syntax_Syntax.sigattrs in
                   match uu___3 with
                   | (ne2, ses) ->
-                      let se2 =
+                      let se3 =
                         {
                           FStar_Syntax_Syntax.sigel =
                             (FStar_Syntax_Syntax.Sig_new_effect ne2);
                           FStar_Syntax_Syntax.sigrng =
-                            (se1.FStar_Syntax_Syntax.sigrng);
+                            (se2.FStar_Syntax_Syntax.sigrng);
                           FStar_Syntax_Syntax.sigquals =
-                            (se1.FStar_Syntax_Syntax.sigquals);
+                            (se2.FStar_Syntax_Syntax.sigquals);
                           FStar_Syntax_Syntax.sigmeta =
-                            (se1.FStar_Syntax_Syntax.sigmeta);
+                            (se2.FStar_Syntax_Syntax.sigmeta);
                           FStar_Syntax_Syntax.sigattrs =
-                            (se1.FStar_Syntax_Syntax.sigattrs);
+                            (se2.FStar_Syntax_Syntax.sigattrs);
                           FStar_Syntax_Syntax.sigopts =
-                            (se1.FStar_Syntax_Syntax.sigopts)
+                            (se2.FStar_Syntax_Syntax.sigopts)
                         } in
-                      ([se2], ses, env0))
+                      ([se3], ses, env0))
            | FStar_Syntax_Syntax.Sig_sub_effect sub ->
                let sub1 = FStar_TypeChecker_TcEffect.tc_lift env sub r in
-               let se2 =
+               let se3 =
                  {
                    FStar_Syntax_Syntax.sigel =
                      (FStar_Syntax_Syntax.Sig_sub_effect sub1);
                    FStar_Syntax_Syntax.sigrng =
-                     (se1.FStar_Syntax_Syntax.sigrng);
+                     (se2.FStar_Syntax_Syntax.sigrng);
                    FStar_Syntax_Syntax.sigquals =
-                     (se1.FStar_Syntax_Syntax.sigquals);
+                     (se2.FStar_Syntax_Syntax.sigquals);
                    FStar_Syntax_Syntax.sigmeta =
-                     (se1.FStar_Syntax_Syntax.sigmeta);
+                     (se2.FStar_Syntax_Syntax.sigmeta);
                    FStar_Syntax_Syntax.sigattrs =
-                     (se1.FStar_Syntax_Syntax.sigattrs);
+                     (se2.FStar_Syntax_Syntax.sigattrs);
                    FStar_Syntax_Syntax.sigopts =
-                     (se1.FStar_Syntax_Syntax.sigopts)
+                     (se2.FStar_Syntax_Syntax.sigopts)
                  } in
-               ([se2], [], env)
+               ([se3], [], env)
            | FStar_Syntax_Syntax.Sig_effect_abbrev (lid, uvs, tps, c, flags)
                ->
                let uu___2 =
@@ -2752,21 +2747,21 @@ let (tc_decl' :
                                     (FStar_Syntax_Syntax.Sig_effect_abbrev
                                        (lid1, uvs1, tps1, c1, flags));
                                   FStar_Syntax_Syntax.sigrng =
-                                    (se1.FStar_Syntax_Syntax.sigrng);
+                                    (se2.FStar_Syntax_Syntax.sigrng);
                                   FStar_Syntax_Syntax.sigquals =
-                                    (se1.FStar_Syntax_Syntax.sigquals);
+                                    (se2.FStar_Syntax_Syntax.sigquals);
                                   FStar_Syntax_Syntax.sigmeta =
-                                    (se1.FStar_Syntax_Syntax.sigmeta);
+                                    (se2.FStar_Syntax_Syntax.sigmeta);
                                   FStar_Syntax_Syntax.sigattrs =
-                                    (se1.FStar_Syntax_Syntax.sigattrs);
+                                    (se2.FStar_Syntax_Syntax.sigattrs);
                                   FStar_Syntax_Syntax.sigopts =
-                                    (se1.FStar_Syntax_Syntax.sigopts)
+                                    (se2.FStar_Syntax_Syntax.sigopts)
                                 }) in
                      FStar_Compiler_Effect.op_Bar_Greater uu___5
                        (FStar_TypeChecker_Normalize.elim_uvars env) in
                    FStar_Compiler_Effect.op_Bar_Greater uu___4
-                     (fun se2 ->
-                        match se2.FStar_Syntax_Syntax.sigel with
+                     (fun se3 ->
+                        match se3.FStar_Syntax_Syntax.sigel with
                         | FStar_Syntax_Syntax.Sig_effect_abbrev
                             (lid1, uvs1, tps1, c1, uu___5) ->
                             (lid1, uvs1, tps1, c1)
@@ -2781,27 +2776,27 @@ let (tc_decl' :
                         (lid1, uvs1, tps1, c1) r in
                     (match uu___3 with
                      | (lid2, uvs2, tps2, c2) ->
-                         let se2 =
+                         let se3 =
                            {
                              FStar_Syntax_Syntax.sigel =
                                (FStar_Syntax_Syntax.Sig_effect_abbrev
                                   (lid2, uvs2, tps2, c2, flags));
                              FStar_Syntax_Syntax.sigrng =
-                               (se1.FStar_Syntax_Syntax.sigrng);
+                               (se2.FStar_Syntax_Syntax.sigrng);
                              FStar_Syntax_Syntax.sigquals =
-                               (se1.FStar_Syntax_Syntax.sigquals);
+                               (se2.FStar_Syntax_Syntax.sigquals);
                              FStar_Syntax_Syntax.sigmeta =
-                               (se1.FStar_Syntax_Syntax.sigmeta);
+                               (se2.FStar_Syntax_Syntax.sigmeta);
                              FStar_Syntax_Syntax.sigattrs =
-                               (se1.FStar_Syntax_Syntax.sigattrs);
+                               (se2.FStar_Syntax_Syntax.sigattrs);
                              FStar_Syntax_Syntax.sigopts =
-                               (se1.FStar_Syntax_Syntax.sigopts)
+                               (se2.FStar_Syntax_Syntax.sigopts)
                            } in
-                         ([se2], [], env0)))
+                         ([se3], [], env0)))
            | FStar_Syntax_Syntax.Sig_declare_typ (uu___2, uu___3, uu___4)
                when
                FStar_Compiler_Effect.op_Bar_Greater
-                 se1.FStar_Syntax_Syntax.sigquals
+                 se2.FStar_Syntax_Syntax.sigquals
                  (FStar_Compiler_Util.for_some
                     (fun uu___5 ->
                        match uu___5 with
@@ -2810,7 +2805,7 @@ let (tc_decl' :
                -> ([], [], env0)
            | FStar_Syntax_Syntax.Sig_let (uu___2, uu___3) when
                FStar_Compiler_Effect.op_Bar_Greater
-                 se1.FStar_Syntax_Syntax.sigquals
+                 se2.FStar_Syntax_Syntax.sigquals
                  (FStar_Compiler_Util.for_some
                     (fun uu___4 ->
                        match uu___4 with
@@ -2941,7 +2936,7 @@ let (tc_decl' :
                            FStar_TypeChecker_Env.rel_query_for_apply_tac_uvar
                              =
                              (env1.FStar_TypeChecker_Env.rel_query_for_apply_tac_uvar)
-                         } (uvs, t) se1.FStar_Syntax_Syntax.sigrng in
+                         } (uvs, t) se2.FStar_Syntax_Syntax.sigrng in
                      match uu___5 with
                      | (uvs1, t1) ->
                          ((let uu___7 =
@@ -2964,7 +2959,7 @@ let (tc_decl' :
                  | (uvs1, t1) ->
                      let uu___4 =
                        tc_declare_typ env1 (uvs1, t1)
-                         se1.FStar_Syntax_Syntax.sigrng in
+                         se2.FStar_Syntax_Syntax.sigrng in
                      (match uu___4 with
                       | (uvs2, t2) ->
                           ([{
@@ -2972,15 +2967,15 @@ let (tc_decl' :
                                 (FStar_Syntax_Syntax.Sig_declare_typ
                                    (lid, uvs2, t2));
                               FStar_Syntax_Syntax.sigrng =
-                                (se1.FStar_Syntax_Syntax.sigrng);
+                                (se2.FStar_Syntax_Syntax.sigrng);
                               FStar_Syntax_Syntax.sigquals =
-                                (se1.FStar_Syntax_Syntax.sigquals);
+                                (se2.FStar_Syntax_Syntax.sigquals);
                               FStar_Syntax_Syntax.sigmeta =
-                                (se1.FStar_Syntax_Syntax.sigmeta);
+                                (se2.FStar_Syntax_Syntax.sigmeta);
                               FStar_Syntax_Syntax.sigattrs =
-                                (se1.FStar_Syntax_Syntax.sigattrs);
+                                (se2.FStar_Syntax_Syntax.sigattrs);
                               FStar_Syntax_Syntax.sigopts =
-                                (se1.FStar_Syntax_Syntax.sigopts)
+                                (se2.FStar_Syntax_Syntax.sigopts)
                             }], [], env0))))
            | FStar_Syntax_Syntax.Sig_assume (lid, uvs, t) ->
                ((let uu___3 =
@@ -3100,7 +3095,7 @@ let (tc_decl' :
                            FStar_TypeChecker_Env.rel_query_for_apply_tac_uvar
                              =
                              (env1.FStar_TypeChecker_Env.rel_query_for_apply_tac_uvar)
-                         } (uvs, t) se1.FStar_Syntax_Syntax.sigrng in
+                         } (uvs, t) se2.FStar_Syntax_Syntax.sigrng in
                      match uu___5 with
                      | (uvs1, t1) ->
                          ((let uu___7 =
@@ -3123,7 +3118,7 @@ let (tc_decl' :
                  | (uvs1, t1) ->
                      let uu___4 =
                        tc_assume env1 (uvs1, t1)
-                         se1.FStar_Syntax_Syntax.sigrng in
+                         se2.FStar_Syntax_Syntax.sigrng in
                      (match uu___4 with
                       | (uvs2, t2) ->
                           ([{
@@ -3131,15 +3126,15 @@ let (tc_decl' :
                                 (FStar_Syntax_Syntax.Sig_assume
                                    (lid, uvs2, t2));
                               FStar_Syntax_Syntax.sigrng =
-                                (se1.FStar_Syntax_Syntax.sigrng);
+                                (se2.FStar_Syntax_Syntax.sigrng);
                               FStar_Syntax_Syntax.sigquals =
-                                (se1.FStar_Syntax_Syntax.sigquals);
+                                (se2.FStar_Syntax_Syntax.sigquals);
                               FStar_Syntax_Syntax.sigmeta =
-                                (se1.FStar_Syntax_Syntax.sigmeta);
+                                (se2.FStar_Syntax_Syntax.sigmeta);
                               FStar_Syntax_Syntax.sigattrs =
-                                (se1.FStar_Syntax_Syntax.sigattrs);
+                                (se2.FStar_Syntax_Syntax.sigattrs);
                               FStar_Syntax_Syntax.sigopts =
-                                (se1.FStar_Syntax_Syntax.sigopts)
+                                (se2.FStar_Syntax_Syntax.sigopts)
                             }], [], env0))))
            | FStar_Syntax_Syntax.Sig_splice (lids, t) ->
                ((let uu___3 = FStar_Options.debug_any () in
@@ -3161,7 +3156,7 @@ let (tc_decl' :
                      (FStar_TypeChecker_Rel.force_trivial_guard env g;
                       (let ses =
                          env.FStar_TypeChecker_Env.splice env
-                           se1.FStar_Syntax_Syntax.sigrng t1 in
+                           se2.FStar_Syntax_Syntax.sigrng t1 in
                        let lids' =
                          FStar_Compiler_List.collect
                            FStar_Syntax_Util.lids_of_sigelt ses in
@@ -3322,7 +3317,7 @@ let (tc_decl' :
                    FStar_Ident.string_of_lid uu___4 in
                  FStar_Pervasives_Native.Some uu___3 in
                FStar_Profiling.profile
-                 (fun uu___3 -> tc_sig_let env r se1 lbs lids) uu___2
+                 (fun uu___3 -> tc_sig_let env r se2 lbs lids) uu___2
                  "FStar.TypeChecker.Tc.tc_sig_let"
            | FStar_Syntax_Syntax.Sig_polymonadic_bind (m, n, p, t, uu___2) ->
                let t1 =
@@ -3449,21 +3444,21 @@ let (tc_decl' :
                                       (FStar_Syntax_Syntax.Sig_polymonadic_bind
                                          (m, n, p, t2, ty));
                                     FStar_Syntax_Syntax.sigrng =
-                                      (se1.FStar_Syntax_Syntax.sigrng);
+                                      (se2.FStar_Syntax_Syntax.sigrng);
                                     FStar_Syntax_Syntax.sigquals =
-                                      (se1.FStar_Syntax_Syntax.sigquals);
+                                      (se2.FStar_Syntax_Syntax.sigquals);
                                     FStar_Syntax_Syntax.sigmeta =
-                                      (se1.FStar_Syntax_Syntax.sigmeta);
+                                      (se2.FStar_Syntax_Syntax.sigmeta);
                                     FStar_Syntax_Syntax.sigattrs =
-                                      (se1.FStar_Syntax_Syntax.sigattrs);
+                                      (se2.FStar_Syntax_Syntax.sigattrs);
                                     FStar_Syntax_Syntax.sigopts =
-                                      (se1.FStar_Syntax_Syntax.sigopts)
+                                      (se2.FStar_Syntax_Syntax.sigopts)
                                   }) in
                        FStar_Compiler_Effect.op_Bar_Greater uu___6
                          (FStar_TypeChecker_Normalize.elim_uvars env) in
                      FStar_Compiler_Effect.op_Bar_Greater uu___5
-                       (fun se2 ->
-                          match se2.FStar_Syntax_Syntax.sigel with
+                       (fun se3 ->
+                          match se3.FStar_Syntax_Syntax.sigel with
                           | FStar_Syntax_Syntax.Sig_polymonadic_bind
                               (uu___6, uu___7, uu___8, t2, ty) -> (t2, ty)
                           | uu___6 ->
@@ -3484,15 +3479,15 @@ let (tc_decl' :
                                    (FStar_Syntax_Syntax.Sig_polymonadic_bind
                                       (m, n, p, t2, ty));
                                  FStar_Syntax_Syntax.sigrng =
-                                   (se1.FStar_Syntax_Syntax.sigrng);
+                                   (se2.FStar_Syntax_Syntax.sigrng);
                                  FStar_Syntax_Syntax.sigquals =
-                                   (se1.FStar_Syntax_Syntax.sigquals);
+                                   (se2.FStar_Syntax_Syntax.sigquals);
                                  FStar_Syntax_Syntax.sigmeta =
-                                   (se1.FStar_Syntax_Syntax.sigmeta);
+                                   (se2.FStar_Syntax_Syntax.sigmeta);
                                  FStar_Syntax_Syntax.sigattrs =
-                                   (se1.FStar_Syntax_Syntax.sigattrs);
+                                   (se2.FStar_Syntax_Syntax.sigattrs);
                                  FStar_Syntax_Syntax.sigopts =
-                                   (se1.FStar_Syntax_Syntax.sigopts)
+                                   (se2.FStar_Syntax_Syntax.sigopts)
                                } in
                            FStar_Compiler_Util.print1
                              "Polymonadic bind after phase 1: %s\n" uu___7
@@ -3503,23 +3498,23 @@ let (tc_decl' :
                  FStar_TypeChecker_TcEffect.tc_polymonadic_bind env m n p t1 in
                (match uu___3 with
                 | (t2, ty) ->
-                    let se2 =
+                    let se3 =
                       {
                         FStar_Syntax_Syntax.sigel =
                           (FStar_Syntax_Syntax.Sig_polymonadic_bind
                              (m, n, p, t2, ty));
                         FStar_Syntax_Syntax.sigrng =
-                          (se1.FStar_Syntax_Syntax.sigrng);
+                          (se2.FStar_Syntax_Syntax.sigrng);
                         FStar_Syntax_Syntax.sigquals =
-                          (se1.FStar_Syntax_Syntax.sigquals);
+                          (se2.FStar_Syntax_Syntax.sigquals);
                         FStar_Syntax_Syntax.sigmeta =
-                          (se1.FStar_Syntax_Syntax.sigmeta);
+                          (se2.FStar_Syntax_Syntax.sigmeta);
                         FStar_Syntax_Syntax.sigattrs =
-                          (se1.FStar_Syntax_Syntax.sigattrs);
+                          (se2.FStar_Syntax_Syntax.sigattrs);
                         FStar_Syntax_Syntax.sigopts =
-                          (se1.FStar_Syntax_Syntax.sigopts)
+                          (se2.FStar_Syntax_Syntax.sigopts)
                       } in
-                    ([se2], [], env0))
+                    ([se3], [], env0))
            | FStar_Syntax_Syntax.Sig_polymonadic_subcomp (m, n, t, uu___2) ->
                let t1 =
                  let uu___3 = do_two_phases env in
@@ -3645,21 +3640,21 @@ let (tc_decl' :
                                       (FStar_Syntax_Syntax.Sig_polymonadic_subcomp
                                          (m, n, t2, ty));
                                     FStar_Syntax_Syntax.sigrng =
-                                      (se1.FStar_Syntax_Syntax.sigrng);
+                                      (se2.FStar_Syntax_Syntax.sigrng);
                                     FStar_Syntax_Syntax.sigquals =
-                                      (se1.FStar_Syntax_Syntax.sigquals);
+                                      (se2.FStar_Syntax_Syntax.sigquals);
                                     FStar_Syntax_Syntax.sigmeta =
-                                      (se1.FStar_Syntax_Syntax.sigmeta);
+                                      (se2.FStar_Syntax_Syntax.sigmeta);
                                     FStar_Syntax_Syntax.sigattrs =
-                                      (se1.FStar_Syntax_Syntax.sigattrs);
+                                      (se2.FStar_Syntax_Syntax.sigattrs);
                                     FStar_Syntax_Syntax.sigopts =
-                                      (se1.FStar_Syntax_Syntax.sigopts)
+                                      (se2.FStar_Syntax_Syntax.sigopts)
                                   }) in
                        FStar_Compiler_Effect.op_Bar_Greater uu___6
                          (FStar_TypeChecker_Normalize.elim_uvars env) in
                      FStar_Compiler_Effect.op_Bar_Greater uu___5
-                       (fun se2 ->
-                          match se2.FStar_Syntax_Syntax.sigel with
+                       (fun se3 ->
+                          match se3.FStar_Syntax_Syntax.sigel with
                           | FStar_Syntax_Syntax.Sig_polymonadic_subcomp
                               (uu___6, uu___7, t2, ty) -> (t2, ty)
                           | uu___6 ->
@@ -3680,15 +3675,15 @@ let (tc_decl' :
                                    (FStar_Syntax_Syntax.Sig_polymonadic_subcomp
                                       (m, n, t2, ty));
                                  FStar_Syntax_Syntax.sigrng =
-                                   (se1.FStar_Syntax_Syntax.sigrng);
+                                   (se2.FStar_Syntax_Syntax.sigrng);
                                  FStar_Syntax_Syntax.sigquals =
-                                   (se1.FStar_Syntax_Syntax.sigquals);
+                                   (se2.FStar_Syntax_Syntax.sigquals);
                                  FStar_Syntax_Syntax.sigmeta =
-                                   (se1.FStar_Syntax_Syntax.sigmeta);
+                                   (se2.FStar_Syntax_Syntax.sigmeta);
                                  FStar_Syntax_Syntax.sigattrs =
-                                   (se1.FStar_Syntax_Syntax.sigattrs);
+                                   (se2.FStar_Syntax_Syntax.sigattrs);
                                  FStar_Syntax_Syntax.sigopts =
-                                   (se1.FStar_Syntax_Syntax.sigopts)
+                                   (se2.FStar_Syntax_Syntax.sigopts)
                                } in
                            FStar_Compiler_Util.print1
                              "Polymonadic subcomp after phase 1: %s\n" uu___7
@@ -3699,23 +3694,23 @@ let (tc_decl' :
                  FStar_TypeChecker_TcEffect.tc_polymonadic_subcomp env m n t1 in
                (match uu___3 with
                 | (t2, ty) ->
-                    let se2 =
+                    let se3 =
                       {
                         FStar_Syntax_Syntax.sigel =
                           (FStar_Syntax_Syntax.Sig_polymonadic_subcomp
                              (m, n, t2, ty));
                         FStar_Syntax_Syntax.sigrng =
-                          (se1.FStar_Syntax_Syntax.sigrng);
+                          (se2.FStar_Syntax_Syntax.sigrng);
                         FStar_Syntax_Syntax.sigquals =
-                          (se1.FStar_Syntax_Syntax.sigquals);
+                          (se2.FStar_Syntax_Syntax.sigquals);
                         FStar_Syntax_Syntax.sigmeta =
-                          (se1.FStar_Syntax_Syntax.sigmeta);
+                          (se2.FStar_Syntax_Syntax.sigmeta);
                         FStar_Syntax_Syntax.sigattrs =
-                          (se1.FStar_Syntax_Syntax.sigattrs);
+                          (se2.FStar_Syntax_Syntax.sigattrs);
                         FStar_Syntax_Syntax.sigopts =
-                          (se1.FStar_Syntax_Syntax.sigopts)
+                          (se2.FStar_Syntax_Syntax.sigopts)
                       } in
-                    ([se2], [], env0)))
+                    ([se3], [], env0)))
 let (tc_decl :
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.sigelt ->
@@ -4451,7 +4446,7 @@ let (tc_decls :
                ([], env) ses) in
       match uu___ with
       | (ses1, env1) -> ((FStar_Compiler_List.rev_append ses1 []), env1)
-let (uu___906 : unit) =
+let (uu___890 : unit) =
   FStar_Compiler_Effect.op_Colon_Equals tc_decls_knot
     (FStar_Pervasives_Native.Some tc_decls)
 let (snapshot_context :

--- a/src/ocaml-output/FStar_TypeChecker_TcTerm.ml
+++ b/src/ocaml-output/FStar_TypeChecker_TcTerm.ml
@@ -11510,15 +11510,7 @@ and (tc_binder :
                        | uu___6 -> (imp, FStar_TypeChecker_Env.trivial_guard) in
                      (match uu___5 with
                       | (imp1, g') ->
-                          let attrs1 =
-                            FStar_Compiler_Effect.op_Bar_Greater attrs
-                              (FStar_Compiler_List.map
-                                 (fun attr ->
-                                    let uu___6 =
-                                      tc_check_tot_or_gtot_term env attr
-                                        FStar_Syntax_Syntax.t_unit "" in
-                                    match uu___6 with
-                                    | (attr1, uu___7, uu___8) -> attr1)) in
+                          let attrs1 = tc_attributes env attrs in
                           (check_erasable_binder_attributes env attrs1 t;
                            (let x1 =
                               FStar_Syntax_Syntax.mk_binder_with_attrs
@@ -11724,6 +11716,119 @@ and (tc_trivial_guard :
       match uu___ with
       | (t1, c, g) ->
           (FStar_TypeChecker_Rel.force_trivial_guard env g; (t1, c))
+and (tc_attributes :
+  FStar_TypeChecker_Env.env ->
+    FStar_Syntax_Syntax.term Prims.list ->
+      FStar_Syntax_Syntax.term Prims.list)
+  =
+  fun env ->
+    fun attrs ->
+      let env1 =
+        let uu___ = FStar_Compiler_Util.smap_create (Prims.of_int (100)) in
+        {
+          FStar_TypeChecker_Env.solver = (env.FStar_TypeChecker_Env.solver);
+          FStar_TypeChecker_Env.range = (env.FStar_TypeChecker_Env.range);
+          FStar_TypeChecker_Env.curmodule =
+            (env.FStar_TypeChecker_Env.curmodule);
+          FStar_TypeChecker_Env.gamma = [];
+          FStar_TypeChecker_Env.gamma_sig = [];
+          FStar_TypeChecker_Env.gamma_cache = uu___;
+          FStar_TypeChecker_Env.modules = (env.FStar_TypeChecker_Env.modules);
+          FStar_TypeChecker_Env.expected_typ =
+            (env.FStar_TypeChecker_Env.expected_typ);
+          FStar_TypeChecker_Env.sigtab = (env.FStar_TypeChecker_Env.sigtab);
+          FStar_TypeChecker_Env.attrtab = (env.FStar_TypeChecker_Env.attrtab);
+          FStar_TypeChecker_Env.instantiate_imp =
+            (env.FStar_TypeChecker_Env.instantiate_imp);
+          FStar_TypeChecker_Env.effects = (env.FStar_TypeChecker_Env.effects);
+          FStar_TypeChecker_Env.generalize =
+            (env.FStar_TypeChecker_Env.generalize);
+          FStar_TypeChecker_Env.letrecs = (env.FStar_TypeChecker_Env.letrecs);
+          FStar_TypeChecker_Env.top_level =
+            (env.FStar_TypeChecker_Env.top_level);
+          FStar_TypeChecker_Env.check_uvars =
+            (env.FStar_TypeChecker_Env.check_uvars);
+          FStar_TypeChecker_Env.use_eq_strict =
+            (env.FStar_TypeChecker_Env.use_eq_strict);
+          FStar_TypeChecker_Env.is_iface =
+            (env.FStar_TypeChecker_Env.is_iface);
+          FStar_TypeChecker_Env.admit = (env.FStar_TypeChecker_Env.admit);
+          FStar_TypeChecker_Env.lax = (env.FStar_TypeChecker_Env.lax);
+          FStar_TypeChecker_Env.lax_universes =
+            (env.FStar_TypeChecker_Env.lax_universes);
+          FStar_TypeChecker_Env.phase1 = (env.FStar_TypeChecker_Env.phase1);
+          FStar_TypeChecker_Env.failhard =
+            (env.FStar_TypeChecker_Env.failhard);
+          FStar_TypeChecker_Env.nosynth = (env.FStar_TypeChecker_Env.nosynth);
+          FStar_TypeChecker_Env.uvar_subtyping =
+            (env.FStar_TypeChecker_Env.uvar_subtyping);
+          FStar_TypeChecker_Env.tc_term = (env.FStar_TypeChecker_Env.tc_term);
+          FStar_TypeChecker_Env.typeof_tot_or_gtot_term =
+            (env.FStar_TypeChecker_Env.typeof_tot_or_gtot_term);
+          FStar_TypeChecker_Env.universe_of =
+            (env.FStar_TypeChecker_Env.universe_of);
+          FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term =
+            (env.FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term);
+          FStar_TypeChecker_Env.teq_nosmt_force =
+            (env.FStar_TypeChecker_Env.teq_nosmt_force);
+          FStar_TypeChecker_Env.subtype_nosmt_force =
+            (env.FStar_TypeChecker_Env.subtype_nosmt_force);
+          FStar_TypeChecker_Env.use_bv_sorts =
+            (env.FStar_TypeChecker_Env.use_bv_sorts);
+          FStar_TypeChecker_Env.qtbl_name_and_index =
+            (env.FStar_TypeChecker_Env.qtbl_name_and_index);
+          FStar_TypeChecker_Env.normalized_eff_names =
+            (env.FStar_TypeChecker_Env.normalized_eff_names);
+          FStar_TypeChecker_Env.fv_delta_depths =
+            (env.FStar_TypeChecker_Env.fv_delta_depths);
+          FStar_TypeChecker_Env.proof_ns =
+            (env.FStar_TypeChecker_Env.proof_ns);
+          FStar_TypeChecker_Env.synth_hook =
+            (env.FStar_TypeChecker_Env.synth_hook);
+          FStar_TypeChecker_Env.try_solve_implicits_hook =
+            (env.FStar_TypeChecker_Env.try_solve_implicits_hook);
+          FStar_TypeChecker_Env.splice = (env.FStar_TypeChecker_Env.splice);
+          FStar_TypeChecker_Env.mpreprocess =
+            (env.FStar_TypeChecker_Env.mpreprocess);
+          FStar_TypeChecker_Env.postprocess =
+            (env.FStar_TypeChecker_Env.postprocess);
+          FStar_TypeChecker_Env.identifier_info =
+            (env.FStar_TypeChecker_Env.identifier_info);
+          FStar_TypeChecker_Env.tc_hooks =
+            (env.FStar_TypeChecker_Env.tc_hooks);
+          FStar_TypeChecker_Env.dsenv = (env.FStar_TypeChecker_Env.dsenv);
+          FStar_TypeChecker_Env.nbe = (env.FStar_TypeChecker_Env.nbe);
+          FStar_TypeChecker_Env.strict_args_tab =
+            (env.FStar_TypeChecker_Env.strict_args_tab);
+          FStar_TypeChecker_Env.erasable_types_tab =
+            (env.FStar_TypeChecker_Env.erasable_types_tab);
+          FStar_TypeChecker_Env.enable_defer_to_tac =
+            (env.FStar_TypeChecker_Env.enable_defer_to_tac);
+          FStar_TypeChecker_Env.unif_allow_ref_guards =
+            (env.FStar_TypeChecker_Env.unif_allow_ref_guards);
+          FStar_TypeChecker_Env.erase_erasable_args =
+            (env.FStar_TypeChecker_Env.erase_erasable_args);
+          FStar_TypeChecker_Env.rel_query_for_apply_tac_uvar =
+            (env.FStar_TypeChecker_Env.rel_query_for_apply_tac_uvar)
+        } in
+      try
+        (fun uu___ ->
+           match () with
+           | () ->
+               FStar_Compiler_List.map
+                 (fun attr ->
+                    let uu___1 = tc_trivial_guard env1 attr in
+                    FStar_Pervasives_Native.fst uu___1) attrs) ()
+      with
+      | FStar_Errors.Error
+          (FStar_Errors.Fatal_VariableNotFound, msg, rng, ctx) ->
+          FStar_Compiler_Effect.raise
+            (FStar_Errors.Error
+               (FStar_Errors.Fatal_VariableNotFound,
+                 (Prims.op_Hat msg
+                    ". Hint: local names are not allowed in attributes."),
+                 rng, ctx))
+      | e -> FStar_Compiler_Effect.raise e
 let (tc_check_trivial_guard :
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.term ->

--- a/src/parser/FStar.Parser.AST.fst
+++ b/src/parser/FStar.Parser.AST.fst
@@ -156,8 +156,8 @@ type expr = term
 type tycon =
   | TyconAbstract of ident * list binder * option knd
   | TyconAbbrev   of ident * list binder * option knd * term
-  | TyconRecord   of ident * list binder * option knd * list (ident * aqual * attributes_ * term)
-  | TyconVariant  of ident * list binder * option knd * list (ident * option term * bool) (* bool is whether it's using 'of' notation *)
+  | TyconRecord   of ident * list binder * option knd * attributes_ * list (ident * aqual * attributes_ * term)
+  | TyconVariant  of ident * list binder * option knd * list (ident * option term * bool * attributes_) (* bool is whether it's using 'of' notation *)
 
 type qualifier =
   | Private
@@ -905,7 +905,7 @@ let lids_of_let defs =  defs |> List.collect (fun (p, _) -> head_id_of_pat p)
 let id_of_tycon = function
   | TyconAbstract(i, _, _)
   | TyconAbbrev(i, _, _, _)
-  | TyconRecord(i, _, _, _)
+  | TyconRecord(i, _, _, _, _)
   | TyconVariant(i, _, _, _) -> (string_of_id i)
 
 let decl_to_string (d:decl) = match d.d with

--- a/src/parser/FStar.Parser.Const.fst
+++ b/src/parser/FStar.Parser.Const.fst
@@ -366,6 +366,7 @@ let bind_has_range_args_attr = psconst "bind_has_range_args"
 let binder_strictly_positive_attr = psconst "strictly_positive"
 let no_auto_projectors_attr = psconst "no_auto_projectors"
 let no_subtping_attr_lid = psconst "no_subtyping"
+let attr_substitute_lid = p2l ["FStar"; "Pervasives"; "Substitute"]
 
 
 //the type of well-founded relations, used for decreases clauses with relations

--- a/src/parser/FStar.Parser.Dep.fst
+++ b/src/parser/FStar.Parser.Dep.fst
@@ -822,7 +822,7 @@ let collect_one
             collect_binders binders;
             iter_opt k collect_term;
             collect_term t
-        | TyconRecord (_, binders, k, identterms) ->
+        | TyconRecord (_, binders, k, _, identterms) ->
             collect_binders binders;
             iter_opt k collect_term;
             List.iter (fun (_, aq, attrs, t) -> 
@@ -832,7 +832,7 @@ let collect_one
         | TyconVariant (_, binders, k, identterms) ->
             collect_binders binders;
             iter_opt k collect_term;
-            List.iter (fun (_, t, _) -> iter_opt t collect_term) identterms
+            List.iter (fun (_, t, _, _) -> iter_opt t collect_term) identterms
 
       and collect_effect_decl = function
         | DefineEffect (_, binders, t, decls) ->

--- a/src/parser/FStar.Parser.ToDocument.fst
+++ b/src/parser/FStar.Parser.ToDocument.fst
@@ -1684,7 +1684,7 @@ and format_sig style terms no_last_op flat_space =
         n, ln, terms', space ^^ rarrow ^^ break1, rarrow ^^ space
     | Binders (n, ln, parens) ->
         n, ln,
-        (if parens then List.map soft_parens_with_nesting terms' else terms'), // HERE!!!
+        (if parens then List.map soft_parens_with_nesting terms' else terms'),
         break1, colon ^^ space
   in
   let last = List.hd last in

--- a/src/parser/FStar.Parser.ToDocument.fst
+++ b/src/parser/FStar.Parser.ToDocument.fst
@@ -659,15 +659,15 @@ let rec p_decl (d: decl): document =
         p_qualifiers d.quals
     | _ -> p_qualifiers d.quals
   in
-  p_attributes d.attrs ^^
+  p_attributes true d.attrs ^^
   qualifiers ^^
   p_rawDecl d
 
-and p_attributes attrs =
+and p_attributes isTopLevel attrs =
     match attrs with
     | [] -> empty
-    | _ -> lbracket ^^ str "@@ " ^^
-             align ((flow (str "; ") (List.map (p_noSeqTermAndComment false false) attrs)) ^^ rbracket) ^^ hardline
+    | _ -> lbracket ^^ str (if isTopLevel then "@@ " else "@@@ ") ^^
+             align ((flow (str "; ") (List.map (p_noSeqTermAndComment false false) attrs)) ^^ rbracket) ^^ (if isTopLevel then hardline else empty)
 
 and p_justSig d = match d.d with
   | Val (lid, t) ->
@@ -769,7 +769,7 @@ and p_typeDecl pre = function
   | TyconAbbrev (lid, bs, typ_opt, t) ->
     let comm, doc = p_typ_sep false false t in
     comm, p_typeDeclPrefix pre true lid bs typ_opt, doc, jump2
-  | TyconRecord (lid, bs, typ_opt, record_field_decls) ->
+  | TyconRecord (lid, bs, typ_opt, attrs, record_field_decls) ->
     let p_recordField (ps: bool) (lid, aq, attrs, t) =
       let comm, field =
         with_comment_sep (p_recordFieldDecl ps) (lid, aq, attrs, t)
@@ -777,14 +777,14 @@ and p_typeDecl pre = function
       let sep = if ps then semi else empty in
       inline_comment_or_above comm field sep
     in
-    let p_fields = braces_with_nesting (
+    let p_fields = p_attributes false attrs ^^ braces_with_nesting (
         separate_map_last hardline p_recordField record_field_decls)
     in
     empty, p_typeDeclPrefix pre true lid bs typ_opt, p_fields, (fun d -> space ^^ d)
   | TyconVariant (lid, bs, typ_opt, ct_decls) ->
-    let p_constructorBranchAndComments (uid, t_opt, use_of) =
+    let p_constructorBranchAndComments (uid, t_opt, use_of, attrs) =
         let range = extend_to_end_of_line (dflt (range_of_id uid) (map_opt t_opt (fun t -> t.range))) in
-        let comm, ctor = with_comment_sep p_constructorBranch (uid, t_opt, use_of) range in
+        let comm, ctor = with_comment_sep p_constructorBranch (uid, t_opt, use_of, attrs) range in
         inline_comment_or_above comm ctor empty
     in
     (* Beware of side effects with comments printing *)
@@ -813,11 +813,11 @@ and p_typeDeclPrefix kw eq lid bs typ_opt =
     with_kw (fun n -> prefix2 (prefix2 n (flow break1 binders)) typ)
 
 and p_recordFieldDecl ps (lid, aq, attrs, t) =
-  group (optional p_aqual aq ^^ p_attributes attrs ^^ p_lident lid ^^ colon ^^ p_typ ps false t)
+  group (optional p_aqual aq ^^ p_attributes false attrs ^^ p_lident lid ^^ colon ^^ p_typ ps false t)
 
-and p_constructorBranch (uid, t_opt, use_of) =
+and p_constructorBranch (uid, t_opt, use_of, attrs) =
   let sep = if use_of then str "of" else colon in
-  let uid_doc = group (bar ^^ space ^^ p_uident uid) in
+  let uid_doc = group (bar ^^ space ^^ p_attributes false attrs ^^ p_uident uid) in
   default_or_map uid_doc (fun t -> (group (uid_doc ^^ space ^^ sep ^^ space ^^ p_typ false false t))) t_opt
 
 and p_letlhs kw (pat, _) inner_let =
@@ -1022,12 +1022,12 @@ and p_atomicPattern p = match p.pat with
   | PatOp op ->
     lparen ^^ space ^^ str (Ident.string_of_id op) ^^ space ^^ rparen
   | PatWild (aqual, attrs) ->
-    optional p_aqual aqual ^^ p_attributes attrs ^^ underscore
+    optional p_aqual aqual ^^ p_attributes false attrs ^^ underscore
   | PatConst c ->
     p_constant c
   | PatVQuote e -> group (str "`%" ^^ p_noSeqTermAndComment false false e)
   | PatVar (lid, aqual, attrs) ->
-    optional p_aqual aqual ^^ p_attributes attrs ^^ p_lident lid
+    optional p_aqual aqual ^^ p_attributes false attrs ^^ p_lident lid
   | PatName uid ->
       p_quident uid
   | PatOr _ -> failwith "Inner or pattern !"
@@ -1048,16 +1048,16 @@ and is_meta_qualifier aq =
   | _ -> false
 
 and p_binder is_atomic b =
-  let b', t', catf = p_binder' is_atomic b in
+  let b', t', catf = p_binder' false is_atomic b in
   match t' with
   | Some typ -> catf b' typ
   | None -> b'
 
 (* is_atomic is true if the binder must be parsed atomically *)
-and p_binder' (is_atomic: bool) (b: binder): document * option document * catf =
+and p_binder' (no_pars: bool) (is_atomic: bool) (b: binder): document * option document * catf =
   match b.b with
-  | Variable lid -> optional p_aqual b.aqual ^^ p_lident lid, None, cat_with_colon
-  | TVariable lid -> p_lident lid, None, cat_with_colon
+  | Variable lid -> optional p_aqual b.aqual ^^ p_attributes false b.battributes ^^ p_lident lid, None, cat_with_colon
+  | TVariable lid -> p_attributes false b.battributes ^^ p_lident lid, None, cat_with_colon
   | Annotated (lid, t) ->
       let b', t' =
         match t.tm with
@@ -1069,10 +1069,10 @@ and p_binder' (is_atomic: bool) (b: binder): document * option document * catf =
           else
             p_tmFormula t
           in
-          optional p_aqual b.aqual ^^ p_lident lid, t'
+          optional p_aqual b.aqual ^^ p_attributes false b.battributes ^^ p_lident lid, t'
         in
         let catf =
-          if is_atomic || (is_meta_qualifier b.aqual) then
+          if is_atomic || (is_meta_qualifier b.aqual && not no_pars) then
             (fun x y -> group (lparen ^^ (cat_with_colon x y) ^^ rparen))
           else
             (fun x y -> group (cat_with_colon x y))
@@ -1086,9 +1086,9 @@ and p_binder' (is_atomic: bool) (b: binder): document * option document * catf =
         b', Some t', cat_with_colon
       | _ ->
         if is_atomic
-        then p_atomicTerm t, None, cat_with_colon (* t is a type but it might need some parenthesis *)
-        else p_appTerm t, None, cat_with_colon (* This choice seems valid (used in p_tmNoEq') *)
-    end
+        then p_attributes false b.battributes ^^ p_atomicTerm t, None, cat_with_colon (* t is a type but it might need some parenthesis *)
+        else p_attributes false b.battributes ^^ p_appTerm t, None, cat_with_colon (* This choice seems valid (used in p_tmNoEq') *)
+    end 
 
 and p_refinement aqual_opt attrs binder t phi =
   let b, typ = p_refinement' aqual_opt attrs binder t phi in
@@ -1108,7 +1108,7 @@ and p_refinement' aqual_opt attrs binder t phi =
    * If t can be displayed on a single line, tightly surround it with braces,
    * otherwise pad with a space. *)
   let jump_break = if is_t_atomic then 0 else 1 in
-  (optional p_aqual aqual_opt ^^ p_attributes attrs ^^ binder),
+  (optional p_aqual aqual_opt ^^ p_attributes false attrs ^^ binder),
     (p_appTerm t ^^
       (jump 2 jump_break (group ((ifflat
         (soft_braces_with_nesting_tight phi) (soft_braces_with_nesting phi))))))
@@ -1350,7 +1350,7 @@ and p_noSeqTerm' ps pb e = match e.tm with
      * in
      * ... *)
     let p_lb q (a, (pat, e)) is_last =
-      let attrs = p_attrs_opt a in
+      let attrs = p_attrs_opt true a in
       let doc_let_or_and = match q with
         | Some Rec -> group (str "let" ^/^ str "rec")
         | Some NoLetQualifier -> str "let"
@@ -1496,10 +1496,10 @@ and p_calcStep _ (CalcStep (rel, just, next)) =
   group (p_noSeqTermAndComment false false rel ^^ space ^^ lbrace ^^ space ^^ p_noSeqTermAndComment false false just ^^ space ^^ rbrace ^^ hardline
          ^^ p_noSeqTermAndComment false false next ^^ str ";")
 
-and p_attrs_opt = function
+and p_attrs_opt (isTopLevel: bool) = function
   | None -> empty
   | Some terms ->
-    group (str "[@@" ^/^
+    group (str (if isTopLevel then "[@@" else "[@@@") ^/^
            (separate_map (str "; ")
                          (p_noSeqTermAndComment false false)
                          terms) ^/^
@@ -1566,7 +1566,7 @@ and pats_as_binders_if_possible pats =
        when (string_of_id lid) = (string_of_id lid') ->
          Some (p_refinement' aqual attrs (p_ident lid) t phi)
      | PatVar (lid, aqual, attrs), _ ->
-       Some (optional p_aqual aqual ^^ p_attributes attrs ^^  p_ident lid, p_tmEqNoRefinement t)
+       Some (optional p_aqual aqual ^^ p_attributes false attrs ^^  p_ident lid, p_tmEqNoRefinement t)
      | _ -> None)
   | _ -> None
   in
@@ -1684,7 +1684,7 @@ and format_sig style terms no_last_op flat_space =
         n, ln, terms', space ^^ rarrow ^^ break1, rarrow ^^ space
     | Binders (n, ln, parens) ->
         n, ln,
-        (if parens then List.map soft_parens_with_nesting terms' else terms'),
+        (if parens then List.map soft_parens_with_nesting terms' else terms'), // HERE!!!
         break1, colon ^^ space
   in
   let last = List.hd last in
@@ -1723,7 +1723,7 @@ and p_tmArrow' p_Tm e =
 and collapse_binders (p_Tm: term -> document) (e: term): list document =
   let rec accumulate_binders p_Tm e: list (document * option document * catf) =
     match e.tm with
-    | Product(bs, tgt) -> (List.map (fun b -> p_binder' false b) bs) @ (accumulate_binders p_Tm tgt)
+    | Product(bs, tgt) -> (List.map (fun b -> p_binder' true false b) bs) @ (accumulate_binders p_Tm tgt)
     | _ -> [(p_Tm e, None, cat_with_colon)]
   in
   let fold_fun (bs: list (list document * option document * catf)) (x: document * option document * catf) =
@@ -2165,3 +2165,4 @@ let modul_with_comments_to_document (m:modul) comments =
   let comments = !comment_stack in
   comment_stack := [] ;
   (initial_comment ^^ doc, comments)
+

--- a/src/parser/parse.mly
+++ b/src/parser/parse.mly
@@ -293,10 +293,10 @@ typeDefinition:
   | EQUALS t=typ
       { (fun id binders kopt ->  check_id id; TyconAbbrev(id, binders, kopt, t)) }
   /* A documentation on the first branch creates a conflict with { x with a = ... }/{ a = ... } */
-  | EQUALS LBRACE
+  | EQUALS attrs_opt=ioption(binderAttributes) LBRACE
       record_field_decls=right_flexible_nonempty_list(SEMICOLON, recordFieldDecl)
    RBRACE
-      { (fun id binders kopt -> check_id id; TyconRecord(id, binders, kopt, record_field_decls)) }
+      { (fun id binders kopt -> check_id id; TyconRecord(id, binders, kopt, none_to_empty_list attrs_opt, record_field_decls)) }
   (* having the first BAR optional using left-flexible list creates a s/r on FSDOC since any decl can be preceded by a FSDOC *)
   | EQUALS ct_decls=list(constructorDecl)
       { (fun id binders kopt -> check_id id; TyconVariant(id, binders, kopt, ct_decls)) }
@@ -309,8 +309,8 @@ recordFieldDecl:
       }
 
 constructorDecl:
-  | BAR uid=uident COLON t=typ                { (uid, Some t, false) }
-  | BAR uid=uident t_opt=option(OF t=typ {t}) { (uid, t_opt, true) }
+  | BAR attrs_opt=ioption(binderAttributes) uid=uident COLON t=typ                { (uid, Some t, false, none_to_empty_list attrs_opt) }
+  | BAR attrs_opt=ioption(binderAttributes) uid=uident t_opt=option(OF t=typ {t}) { (uid, t_opt, true, none_to_empty_list attrs_opt) }
 
 attr_letbinding:
   | attr=ioption(attribute) AND lb=letbinding

--- a/src/syntax/FStar.Syntax.Resugar.fst
+++ b/src/syntax/FStar.Syntax.Resugar.fst
@@ -1259,13 +1259,13 @@ let resugar_typ env datacon_ses se : sigelts * A.tycon =
             | _ -> failwith "unexpected"
           in
           let fields =  List.fold_left resugar_datacon_as_fields [] current_datacons in
-          A.TyconRecord(ident_of_lid tylid, bs, None, fields)
+          A.TyconRecord(ident_of_lid tylid, bs, None, map (resugar_term' env) se.sigattrs, fields)
         else
           (* Resugar as a variant *)
           let resugar_datacon constructors se = match se.sigel with
             | Sig_datacon (l, univs, term, _, num, _) ->
               (* Todo: resugar univs *)
-              let c = (ident_of_lid l, Some (resugar_term' env term), false)  in
+              let c = (ident_of_lid l, Some (resugar_term' env term), false, map (resugar_term' env) se.sigattrs)  in
               c::constructors
             | _ -> failwith "unexpected"
           in

--- a/src/syntax/FStar.Syntax.Util.fst
+++ b/src/syntax/FStar.Syntax.Util.fst
@@ -1234,7 +1234,7 @@ let attr_eq a a' =
    | _ -> false
 
 let attr_substitute =
-    mk (Tm_fvar (lid_as_fv (lid_of_path ["FStar"; "Pervasives"; "Substitute"] Range.dummyRange)
+    mk (Tm_fvar (lid_as_fv PC.attr_substitute_lid
                            delta_constant
                            None))
        Range.dummyRange

--- a/src/tosyntax/FStar.ToSyntax.Interleave.fst
+++ b/src/tosyntax/FStar.ToSyntax.Interleave.fst
@@ -46,7 +46,7 @@ let definition_lids d =
     | Tycon(_, _, tys) ->
         tys |> List.collect (function
                 | TyconAbbrev (id, _, _, _)
-                | TyconRecord (id, _, _, _)
+                | TyconRecord (id, _, _, _, _)
                 | TyconVariant(id, _, _, _) ->
                   [Ident.lid_of_ids [id]]
                 | _ -> [])

--- a/src/typechecker/FStar.TypeChecker.Normalize.fst
+++ b/src/typechecker/FStar.TypeChecker.Normalize.fst
@@ -3198,9 +3198,12 @@ let elim_uvars_aux_c env univ_names binders c =
    let univ_names, binders, tc = elim_uvars_aux_tc env univ_names binders (Inr c) in
    univ_names, binders, BU.right tc
 
-// GM: Maybe this should take a pass over the attributes just to be safe?
 let rec elim_uvars (env:Env.env) (s:sigelt) =
-    let s = { s with sigattrs = List.map deep_compress s.sigattrs } in
+    let sigattrs = List.map (fun attr ->
+      let _, _, attr = elim_uvars_aux_t env [] [] attr in
+      deep_compress attr
+    ) s.sigattrs in
+    let s = { s with sigattrs } in
     match s.sigel with
     | Sig_inductive_typ (lid, univ_names, binders, typ, lids, lids') ->
       let univ_names, binders, typ = elim_uvars_aux_t env univ_names binders typ in

--- a/src/typechecker/FStar.TypeChecker.Normalize.fst
+++ b/src/typechecker/FStar.TypeChecker.Normalize.fst
@@ -3199,10 +3199,7 @@ let elim_uvars_aux_c env univ_names binders c =
    univ_names, binders, BU.right tc
 
 let rec elim_uvars (env:Env.env) (s:sigelt) =
-    let sigattrs = List.map (fun attr ->
-      let _, _, attr = elim_uvars_aux_t env [] [] attr in
-      deep_compress attr
-    ) s.sigattrs in
+    let sigattrs = List.map Mktuple3?._3 <| List.map (elim_uvars_aux_t env [] []) s.sigattrs in
     let s = { s with sigattrs } in
     match s.sigel with
     | Sig_inductive_typ (lid, univ_names, binders, typ, lids, lids') ->

--- a/src/typechecker/FStar.TypeChecker.Tc.fst
+++ b/src/typechecker/FStar.TypeChecker.Tc.fst
@@ -632,6 +632,7 @@ let tc_sig_let env r se lbs lids : list sigelt * list sigelt * Env.env =
 
 let tc_decl' env0 se: list sigelt * list sigelt * Env.env =
   let env = env0 in
+  let se = tc_decl_attributes env se in
   TcUtil.check_sigelt_quals env se;
   proc_check_with se.sigattrs (fun () ->
   let r = se.sigrng in
@@ -909,18 +910,15 @@ let tc_decl env se: list sigelt * list sigelt * Env.env =
      BU.print1 "Processing %s\n" (U.lids_of_sigelt se |> List.map string_of_lid |> String.concat ", ");
    if Env.debug env Options.Low then
      BU.print1 ">>>>>>>>>>>>>>tc_decl %s\n" (Print.sigelt_to_string se);
-   let tc_ses, new_ses, env'
-     = if se.sigmeta.sigmeta_admit
-       then begin
-         let old = Options.admit_smt_queries () in
-         Options.set_admit_smt_queries true;
-         let result = tc_decl' env se in
-         Options.set_admit_smt_queries old;
-         result
-       end
-       else tc_decl' env se in
-   // Typecheck attributes
-   List.map (tc_decl_attributes env) tc_ses, new_ses, env'
+   if se.sigmeta.sigmeta_admit
+   then begin
+     let old = Options.admit_smt_queries () in
+     Options.set_admit_smt_queries true;
+     let result = tc_decl' env se in
+     Options.set_admit_smt_queries old;
+     result
+   end
+   else tc_decl' env se
 
 
 (* adds the typechecked sigelt to the env, also performs any processing required in the env (such as reset options) *)

--- a/src/typechecker/FStar.TypeChecker.Tc.fst
+++ b/src/typechecker/FStar.TypeChecker.Tc.fst
@@ -605,7 +605,14 @@ let tc_sig_let env r se lbs lids : list sigelt * list sigelt * Env.env =
 
 let tc_decl' env0 se: list sigelt * list sigelt * Env.env =
   let env = env0 in
-  let se = tc_decl_attributes env se in
+  let se = match se.sigel with
+         // Disable typechecking attributes for [Sig_fail] bundles, so
+         // that typechecking is wrapped in [Errors.catch_errors]
+         // below, thus allowing using [expect_failure] to mark that
+         // an attribute will fail typechecking.
+         | Sig_fail _ -> se
+         | _ -> tc_decl_attributes env se
+  in
   TcUtil.check_sigelt_quals env se;
   proc_check_with se.sigattrs (fun () ->
   let r = se.sigrng in

--- a/src/typechecker/FStar.TypeChecker.Tc.fst
+++ b/src/typechecker/FStar.TypeChecker.Tc.fst
@@ -325,38 +325,11 @@ let proc_check_with (attrs:list attribute) (kont : unit -> 'a) : 'a =
 
 let handle_postprocess_with_attr (env:Env.env) (ats:list attribute)
     : (list attribute * option term)
-=
-    (* We find postprocess_for_extraction_with attrs, which we don't
-     * have to handle here, but we typecheck the tactic
-     * and elaborate it. *)
-    let tc_and_elab_tactic (env:Env.env) (tau:term) : term =
-        let tau, _, g_tau = tc_tactic t_unit t_unit env tau in
-        Rel.force_trivial_guard env g_tau;
-        tau
-    in
-    let ats =
-      match U.extract_attr' PC.postprocess_extr_with ats with
-      | None -> ats
-      | Some (ats, [tau, None]) ->
-        let tau = tc_and_elab_tactic env tau in
-        (* Further, give it a spin through deep_compress to remove uvar nodes,
-         * since this term will be picked up at extraction time when
-         * the UF graph is blown away. *)
-        let tau = SS.deep_compress tau in
-        (U.mk_app (S.tabbrev PC.postprocess_extr_with) [tau, None])
-           :: ats
-      | Some (ats, [tau, None]) ->
-        Errors.log_issue (Env.get_range env)
-                         (Errors.Warning_UnrecognizedAttribute,
-                            BU.format1 "Ill-formed application of `%s`"
-                                       (string_of_lid PC.postprocess_extr_with));
-        ats
-    in
-    (* Now extract the postprocess_with, if any, and also check it *)
+=   (* Extract the postprocess_with *)
     match U.extract_attr' PC.postprocess_with ats with
     | None -> ats, None
     | Some (ats, [tau, None]) ->
-        ats, Some (tc_and_elab_tactic env tau)
+        ats, Some tau
     | Some (ats, args) ->
         Errors.log_issue (Env.get_range env)
                          (Errors.Warning_UnrecognizedAttribute,

--- a/src/typechecker/FStar.TypeChecker.TcTerm.fst
+++ b/src/typechecker/FStar.TypeChecker.TcTerm.fst
@@ -4264,12 +4264,7 @@ and tc_binder env ({binder_bv=x;binder_qual=imp;binder_attrs=attrs}) =
           Some (Meta tau), g
         | _ -> imp, Env.trivial_guard
     in
-    let attrs =
-      attrs |> List.map
-      (fun attr ->
-        let attr, _, _ = tc_check_tot_or_gtot_term env attr t_unit "" in
-        attr)
-    in
+    let attrs = tc_attributes env attrs in
     check_erasable_binder_attributes env attrs t;
     let x = S.mk_binder_with_attrs ({x with sort=t}) imp attrs in
     if Env.debug env Options.High
@@ -4337,6 +4332,18 @@ and tc_trivial_guard env t =
   let t, c, g = tc_tot_or_gtot_term env t in
   Rel.force_trivial_guard env g;
   t,c
+
+and tc_attributes env attrs =
+  // we don't want attributes to depend on local names (otherwise,
+  // this would imply dependent attributes, substitutions within
+  // attributes...) hence we get rid of [gamma] (the local names)
+  // below.
+  let env = { env with gamma = []; gamma_sig = []; gamma_cache = BU.smap_create 100 } in
+  try List.map (fun attr -> fst (tc_trivial_guard env attr)) attrs
+  with Error (e, msg, rng, ctx) -> // adding small hint for the user
+    raise (Error ( Fatal_VariableNotFound
+                 , msg ^ ". Hint: local names are not allowed in attributes."
+                 , rng, ctx))
 
 let tc_check_trivial_guard env t k =
   let t, _, g = tc_check_tot_or_gtot_term env t k "" in

--- a/src/typechecker/FStar.TypeChecker.TcTerm.fst
+++ b/src/typechecker/FStar.TypeChecker.TcTerm.fst
@@ -4340,10 +4340,11 @@ and tc_attributes env attrs =
   // below.
   let env = { env with gamma = []; gamma_sig = []; gamma_cache = BU.smap_create 100 } in
   try List.map (fun attr -> fst (tc_trivial_guard env attr)) attrs
-  with Error (e, msg, rng, ctx) -> // adding small hint for the user
-    raise (Error ( Fatal_VariableNotFound
-                 , msg ^ ". Hint: local names are not allowed in attributes."
-                 , rng, ctx))
+  with | Error (Fatal_VariableNotFound, msg, rng, ctx) -> // adding small hint for the user
+           raise (Error ( Fatal_VariableNotFound
+                        , msg ^ ". Hint: local names are not allowed in attributes."
+                        , rng, ctx))
+       | e -> raise e
 
 let tc_check_trivial_guard env t k =
   let t, _, g = tc_check_tot_or_gtot_term env t k "" in

--- a/src/typechecker/FStar.TypeChecker.TcTerm.fsti
+++ b/src/typechecker/FStar.TypeChecker.TcTerm.fsti
@@ -48,6 +48,7 @@ val tc_tot_or_gtot_term: env -> term -> term * lcomp * guard_t
 val tc_check_tot_or_gtot_term: env -> term -> typ -> string -> term * lcomp * guard_t
 val tc_tactic : typ -> typ -> env -> term -> term * lcomp * guard_t
 val tc_trivial_guard: env -> term -> term * lcomp
+val tc_attributes: env -> list term -> list term
 val tc_check_trivial_guard: env -> term -> term -> term
 
 val value_check_expected_typ: env -> term -> either typ lcomp -> guard_t -> term * lcomp * guard_t

--- a/tests/bug-reports/Bug2132.fst
+++ b/tests/bug-reports/Bug2132.fst
@@ -9,11 +9,11 @@ is universe polymorGhic in two levels. *)
 let unroll t1 t2 () : Tac unit =
   T.trefl()
 
-[@@ expect_failure [12];
+[@@ expect_failure [12; 66];
     postprocess_with (unroll (`%int))]
 let test0 () : int = 42
 
-[@@ expect_failure [12];
+[@@ expect_failure [12; 66];
     postprocess_for_extraction_with (unroll (`%int))]
 let test1 () : int = 42
 
@@ -23,5 +23,5 @@ let test2 () : int = 42
 [@@ postprocess_for_extraction_with (unroll () (`%int))]
 let test3 () : int = 42
 
-(* [@@ postprocess_for_extraction_with (unroll (raise_val ()) (`%int))] *)
-(* let test4 () : int = 42 *)
+[@@ postprocess_for_extraction_with (unroll (raise_val ()) (`%int))]
+let test4 () : int = 42

--- a/tests/micro-benchmarks/BinderAttributes.fst
+++ b/tests/micro-benchmarks/BinderAttributes.fst
@@ -21,6 +21,10 @@ let f (#[@@@ description "x_imp"] x_imp:int) ([@@@ description "y"] y:string) : 
 let f2 (#[@@@ description "x_imp"]x_imp [@@@ description "y"]y : int) : Tot unit =
     ()
 
+[@@expect_failure [230]]
+let local_names_in_attributes_are_forbidden
+  = x:unit -> [@@@x]y:unit -> unit
+
 type binder =
     {
         qual : string;

--- a/tests/micro-benchmarks/ConstructorAttributes.fst
+++ b/tests/micro-benchmarks/ConstructorAttributes.fst
@@ -11,8 +11,13 @@ type test0 =
 
 type test1 = [@@@ a1 u#12] { foo: int; }
 
-[@expect_failure 230]
+[@@ expect_failure [66]]
 type test2 = [@@@ id] { bar: int; }
+
+// The attribute [expect_failure] can be used when a failure is
+// expected in an attribute
+[@@ expect_failure [189]; 1 + ()]
+let test3: unit = unit
 
 let lookup_sigelt (name: string): Tac sigelt
   = match lookup_typ (top_env ()) (explode_qn name) with

--- a/tests/micro-benchmarks/ConstructorAttributes.fst
+++ b/tests/micro-benchmarks/ConstructorAttributes.fst
@@ -1,0 +1,40 @@
+module ConstructorAttributes
+open FStar.Tactics
+
+let meta_implicit (#[exact (`1)]x: int) = x
+
+let a1 (t: Type u#n) (x: t) = ()
+
+type test0 =
+  | [@@@ meta_implicit; 123 + 456] A
+  | [@@@ "B"; id 3] B: int -> test0
+
+type test1 = [@@@ a1 u#12] { foo: int; }
+
+[@expect_failure 230]
+type test2 = [@@@ id] { bar: int; }
+
+let lookup_sigelt (name: string): Tac sigelt
+  = match lookup_typ (top_env ()) (explode_qn name) with
+  | Some se -> se
+  | _       -> fail ("lookup_sigelt: sigelt '"^name^"' not found")
+
+let lookup_sigelt_attrs (name: string): Tac (list term) =
+  sigelt_attrs (lookup_sigelt name)
+
+open FStar.List.Tot
+let terms_eq (x y: list term): bool
+  = length x = length y
+ && fold_left ( && ) true
+              (map (fun (x, y) -> term_eq x y) (FStar.List.Pure.zip x y))
+
+let _ =
+  run_tactic (fun _ ->
+        let ( ==. ) = terms_eq in
+        guard (lookup_sigelt_attrs (`%A) ==. [`(meta_implicit #1); `(123 + 456)]);
+        guard (lookup_sigelt_attrs (`%B) ==. [`"B"; `id #int 3]);
+        guard (lookup_sigelt_attrs (`%Mktest1) ==. [`(a1 u#12)]);
+	// // binders are typechecked, thus [id 3] is actually turned into `id #int 3`.
+	// // consequently:
+        guard (not (lookup_sigelt_attrs (`%A) ==. [`"B"; `id 3]))
+  )

--- a/tests/micro-benchmarks/Test.QuickCode.fst
+++ b/tests/micro-benchmarks/Test.QuickCode.fst
@@ -86,7 +86,7 @@ unfold let normal (x:Type0) : Type0 =
   norm [iota; zeta; simplify; primops; delta_attr [`%qattr]; delta_only normal_steps] x
 
 
-[@@ "opaque_to_smt" qattr]
+[@@ "opaque_to_smt"; qattr]
 let wp_compute_ghash_incremental (x:int) (s0:state) (k:(state -> Type0)) : Type0 =
   let sM = s0 in
 // COMMENT OUT 1-3 OF THE FOLLOWING LINES TO SPEED UP:

--- a/tests/micro-benchmarks/TestHasEq.fst
+++ b/tests/micro-benchmarks/TestHasEq.fst
@@ -84,6 +84,6 @@ type erasable_t =
 let test (x:erasable_t{C_erasable_t? x}) (y:erasable_t{D_erasable_t? y}) : Tot (n:int{n == 1}) =
   if x = y then 0 else 1  //this would extract to if () = () then 0 else 1 if we allowed equality on erasable_t
 
-[@@erasable expect_failure]
+[@@erasable; expect_failure]
 unopteq type erasable_t2 =
   | C_erasable_2 : erasable_t2

--- a/tests/prettyprinting/Arrows.fst
+++ b/tests/prettyprinting/Arrows.fst
@@ -70,10 +70,12 @@ val last (a b: int) : Tot (array a)
 [@@ one; two; three; four; five; six; seven; eight; nine; ten; eleven; ten; eleven; ten; eleven; ten; eleven; ten; here;
     eleven; ten; eleven; ten; eleven; ten; eleven]
 type t =
-  | A : int -> t
+  | [@@@ 123] A : int -> t
   | B
   | C : int -> int -> t
   | D of int
+
+type r = [@@@ ()] { [@@@ 123] field: int }
 
 type signatureScheme =
   | RSA_PKCS1_SHA256
@@ -108,4 +110,7 @@ val gf128_add_pure_loop (#n: pos) (a: seq (bv_t 8) {length a = n}) (b: seq (bv_t
       seq (bv_t 8)
         { length r = n /\
           (forall (i: nat{i < n}). equal (index r i) (logxor_vec (index a i) (index b i))) })
+
+let binder_attrs ([@@@()]y: nat): unit = ()
+val binder_collapse_parenthesis: (x: int) -> (#[@@@()]y: nat) -> unit
 

--- a/tests/prettyprinting/Arrows.fst.expected
+++ b/tests/prettyprinting/Arrows.fst.expected
@@ -69,10 +69,12 @@ val last (a b: int) : Tot (array a)
 
 [@@ one; two; three; four; five; six; seven; eight; nine; ten; eleven; ten; eleven; ten; eleven; ten; eleven; ten; here; eleven; ten; eleven; ten; eleven; ten; eleven]
 type t =
-  | A : int -> t
+  | [@@@ 123]A : int -> t
   | B
   | C : int -> int -> t
   | D of int
+
+type r = [@@@ ()]{ [@@@ 123]field:int }
 
 type signatureScheme =
   | RSA_PKCS1_SHA256
@@ -107,4 +109,7 @@ val gf128_add_pure_loop (#n: pos) (a: seq (bv_t 8) {length a = n}) (b: seq (bv_t
       seq (bv_t 8)
         { length r = n /\
           (forall (i: nat{i < n}). equal (index r i) (logxor_vec (index a i) (index b i))) })
+
+let binder_attrs ([@@@ ()]y: nat) : unit = ()
+val binder_collapse_parenthesis (x: int) (#[@@@ ()]y: nat) : unit
 

--- a/ulib/FStar.Pervasives.fst
+++ b/ulib/FStar.Pervasives.fst
@@ -164,7 +164,7 @@ let noextract_to _ = ()
 
 let normalize_for_extraction _ = ()
 
-let ite_soundness_by = ()
+let ite_soundness_by _ = ()
 
 let default_effect _ = ()
 let top_level_effect _ = ()

--- a/ulib/FStar.Pervasives.fsti
+++ b/ulib/FStar.Pervasives.fsti
@@ -1045,7 +1045,7 @@ val normalize_for_extraction (steps:list norm_step) : Tot unit
 
     See examples/layeredeffects/IteSoundess.fst for a few examples
   *)
-val ite_soundness_by : unit
+val ite_soundness_by (attribute: unit): Tot unit
 
 (** By-default functions that have a layered effect, need to have a type
     annotation for their bodies


### PR DESCRIPTION
Hi,

This PR adds support for decorating data constructors (and records) with attributes, as @TWal was suggesting a few days ago on Slack.
The syntax follows the one for binders, that is:
```fstar
type test0 =
  | [@@@ someAttribute1; someAttribute2] A
  | ...
type test1 = [@@@ someAttribute] { foo: int; }
```

This PR also adds prettyprinting for attributes on binders & constructors.
It also adds two test modules: one functional test `ConstructorAttributes` and one prettyprinting test.

Most of the changes are about adding a `_` to `TyconRecord` or constructors.

Is there a reason attributes on binders are typechecked as `unit` specifically, while top-level attributes are just untyped terms?
~For now, I didn't add any such checks for binders on constructors. Should I change that?~

EDIT: the [CI fail](https://github.com/FStarLang/FStar/runs/6912982006?check_suite_focus=true#step:5:1432), but that's because I changed `parse.mly`. I'll push an ocaml snapshot, but I guess that's not ideal for merging afterward.