### PR TITLE
Set correct universe for squash hypothesis when using a destruct on an inductive type

### DIFF
--- a/src/ocaml-output/FStar_Tactics_Basic.ml
+++ b/src/ocaml-output/FStar_Tactics_Basic.ml
@@ -4973,7 +4973,7 @@ let (t_destruct :
                                                                     s_tm1
                                                                     pat_t in
                                                                     FStar_Syntax_Util.mk_squash
-                                                                    equ
+                                                                    FStar_Syntax_Syntax.U_zero
                                                                     uu___31 in
                                                                     FStar_Syntax_Syntax.gen_bv
                                                                     "breq"

--- a/src/tactics/FStar.Tactics.Basic.fst
+++ b/src/tactics/FStar.Tactics.Basic.fst
@@ -882,7 +882,7 @@ let t_apply_lemma (noinst:bool) (noinst_lhs:bool)
         bind (match (Rel.simplify_guard env (Env.guard_of_guard_formula (NonTrivial pre))).guard_f with
               | Trivial -> ret ()
               | NonTrivial _ -> add_irrelevant_goal goal "apply_lemma precondition" env pre) //AR: should we use the normalized pre instead?
-        
+
              (fun _ -> add_goals sub_goals)))))))))))
 
 let split_env (bvar : bv) (e : env) : option (env * bv * list bv) =
@@ -1467,7 +1467,7 @@ let t_destruct (s_tm : term) : tac (list (fv * Z.t)) = wrap_err "destruct" <|
                         let equ = env.universe_of env s_ty in
                         (* Typecheck the pattern, to fill-in the universes and get an expression out of it *)
                         let _ , _, _, _, pat_t, _, _guard_pat, _erasable = TcTerm.tc_pat ({ env with lax = true }) s_ty pat in
-                        let eq_b = S.gen_bv "breq" None (U.mk_squash equ (U.mk_eq2 equ s_ty s_tm pat_t)) in
+                        let eq_b = S.gen_bv "breq" None (U.mk_squash S.U_zero (U.mk_eq2 equ s_ty s_tm pat_t)) in
                         let cod = U.arrow [S.mk_binder eq_b] (mk_Total cod) in
 
                         let nty = U.arrow bs (mk_Total cod) in

--- a/tests/bug-reports/Bug2622.fst
+++ b/tests/bug-reports/Bug2622.fst
@@ -1,0 +1,15 @@
+module Bug2622
+
+open FStar.Tactics
+
+type ind : Type u#1 = | A
+
+assume val p : prop
+
+assume val ep : squash p
+
+let test0 (x:ind) =
+    assert (match x with | A -> p)
+        by (branch_on_match ();
+            guard (List.length (goals ()) = 1);
+            exact (`ep))

--- a/tests/bug-reports/Makefile
+++ b/tests/bug-reports/Makefile
@@ -46,7 +46,7 @@ SHOULD_VERIFY_CLOSED=Bug022.fst Bug024.fst Bug025.fst Bug026.fst Bug026b.fst Bug
   Bug2398.fst Bug2432.fst Bug2374.fst Bug2438.fst Bug2456.fst Bug2475.fst Bug2477.fst Bug1355.fst \
   Bug1418.fst Bug171.fst Bug2496.fst Bug2478.fst Bug2414.fst Bug2515.fst \
   Bug2535.fst Bug2557.fst Bug2572.fst Bug2522.fst Bug2486.fst \
-  Bug2552.fst Bug2597.fst Bug2471_B.fst Bug2605.fst
+  Bug2552.fst Bug2597.fst Bug2471_B.fst Bug2605.fst Bug2614.fst Bug2622.fst
 
 SHOULD_VERIFY_INTERFACE_CLOSED=Bug771.fsti Bug771b.fsti
 SHOULD_VERIFY_AND_WARN_CLOSED=Bug016.fst


### PR DESCRIPTION
This PR fixes #2622. As reported in the issue, when calling `t_destruct` on an value of an inductive type `t`, hypotheses generated were of the shape `squash u#t (x == inductive_case)`, where `u#t` is the universe of `t`.
This is ill-typed when u#t <> u#0

This PR sets the universe of the generated squash to U_zero.