### PR TITLE
Do not unfold recursive definitions in the positivity check

### DIFF
--- a/src/ocaml-output/FStar_TypeChecker_Util.ml
+++ b/src/ocaml-output/FStar_TypeChecker_Util.ml
@@ -7701,6 +7701,7 @@ and (ty_strictly_positive_in_type :
                FStar_TypeChecker_Env.HNF;
                FStar_TypeChecker_Env.Weak;
                FStar_TypeChecker_Env.Iota;
+               FStar_TypeChecker_Env.Exclude FStar_TypeChecker_Env.Zeta;
                FStar_TypeChecker_Env.UnfoldUntil
                  FStar_Syntax_Syntax.delta_constant;
                FStar_TypeChecker_Env.ForExtraction;

--- a/src/typechecker/FStar.TypeChecker.Util.fst
+++ b/src/typechecker/FStar.TypeChecker.Util.fst
@@ -3488,6 +3488,7 @@ and ty_strictly_positive_in_type env (ty_lid:lident) (btype:term) (unfolded:unfo
      Env.HNF;
      Env.Weak;
      Env.Iota;
+     Env.Exclude Env.Zeta;
      Env.UnfoldUntil delta_constant;
      Env.ForExtraction;
      Env.Unascribe;

--- a/tests/bug-reports/Bug2601.fst
+++ b/tests/bug-reports/Bug2601.fst
@@ -1,0 +1,17 @@
+module Bug2601
+module Uv = FStar.Universe
+
+let rec arrow_list (src : list (Type u#a)) 
+                   (trg : Type u#b) : Type u#(max a b) =
+  match src with
+  | [] -> Uv.raise_t trg
+  | t :: ts -> t -> arrow_list ts trg
+
+assume
+val arrow_list' (src : list (Type u#a)) (trg : Type u#b) : Type u#(max a b)
+
+[@@expect_failure [3]]
+noeq
+type ind =
+  | Ind0 : ind
+  | Ind1 : (src : list Type) -> (arrow_list src ind) -> ind


### PR DESCRIPTION
See #2601 