### PR TITLE
Ensure long identifiers are valid before packing a sigelt

### DIFF
--- a/src/reflection/FStar.Reflection.Basic.fst
+++ b/src/reflection/FStar.Reflection.Basic.fst
@@ -617,6 +617,12 @@ let inspect_sigelt (se : sigelt) : sigelt_view =
         Unk
 
 let pack_sigelt (sv:sigelt_view) : sigelt =
+    let check_lid lid =
+        if List.length (Ident.path_of_lid lid) <= 1
+	then failwith ("pack_sigelt: invalid long identifier \""
+	              ^ Ident.string_of_lid lid
+		      ^ "\" (did you forget a module path?)")
+    in
     match sv with
     | Sg_Let (r, lbs) ->
         let pack_letbinding (lb:letbinding) =
@@ -626,6 +632,7 @@ let pack_sigelt (sv:sigelt_view) : sigelt =
                       | _ -> failwith
                               "impossible: pack_sigelt: bv in toplevel let binding"
             in
+            check_lid lid;
             let s = SS.univ_var_closing us in
             let typ = SS.subst s typ in
             let def = SS.subst s def in
@@ -639,6 +646,7 @@ let pack_sigelt (sv:sigelt_view) : sigelt =
 
     | Sg_Inductive (nm, us_names, param_bs, ty, ctors) ->
       let ind_lid = Ident.lid_of_path nm Range.dummyRange in
+      check_lid ind_lid;
       let s = SS.univ_var_closing us_names in
       let nparam = List.length param_bs in
       let pack_ctor (c:ctor) : sigelt =
@@ -667,6 +675,7 @@ let pack_sigelt (sv:sigelt_view) : sigelt =
 
     | Sg_Val (nm, us_names, ty) ->
         let val_lid = Ident.lid_of_path nm Range.dummyRange in
+        check_lid val_lid;
         let typ = SS.close_univ_vars us_names ty in
         mk_sigelt <| Sig_declare_typ (val_lid, us_names, typ)
 


### PR DESCRIPTION
Hi,

This PR adds a check while packing a `siglet` with `pack_sigelt`, so that invalid names (i.e. names without module names) are rejected with a friendly error. 

Currently, the following code throws the error `impossible` (which comes from using `FStar.Compiler.Util.prefix` on a list of length 0 or 1):
```fstar
%splice[][pack_sigelt (Sg_Let false [pack_lb ({
    lb_fv  = pack_fv ["foo"];
    lb_us  = [];
    lb_typ = `nat;
    lb_def = `0
})])]
```
The PR adds a check in `pack_sigelt` and yields instead the error `pack_sigelt: invalid long identifier "foo" (did you forget a module path?)`

