### PR TITLE
Fixing the use of unifier in the tactic engine

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -31,6 +31,19 @@ Guidelines for the changelog:
      ...
     ```
 
+  * Bug2635, reported by Benjamin Bonneau, revealed an unsoundness in
+    the way the tactic engine was using the unifier. In some cases, it
+    would enable terms at a weaker type to be accepted as solutions
+    for a goal at a refinement type, without presenting any goals for
+    the refinement formula itself. This is now fixed by adding a phase
+    at the end of tactic evaluation that checks that any
+    as-yet-unchecked solution actually has the type of the goal. If
+    this check fails, F* reports Error 217 and suggests to use the new
+    primitive tactic
+    `gather_or_solve_explicit_guards_for_resolved_goals` which
+    collects all those refinement goals and presents them to the user
+    tactic for furhter processing.
+
 ## Typeclass argument syntax
 
   * The syntax for a typeclass argument (a.k.a. constraint) is now `{| ... |}`

--- a/examples/layeredeffects/AlgForAll.fst
+++ b/examples/layeredeffects/AlgForAll.fst
@@ -230,8 +230,13 @@ let rec interp_sem #a (t : rwtree a) (s0:state)
       interp_sem (k s0) s0
     | Op Write i k ->
       interp_sem (k ()) i
-    
+
+let extract #a #w (c:repr a w)
+  : Lemma (w `stronger` interp_as_wp c)
+  = ()
+  
 let soundness #a #wp (t : unit -> AlgWP a wp)
   : Tot (s0:state -> ID5.ID (a & state) (as_pure_wp (wp s0)))
   = let c = reify (t ()) in
+    extract c; //this became necessary after a fix to #2635, though it seems unrelated
     interp_sem c

--- a/examples/layeredeffects/AlgHeap.fst
+++ b/examples/layeredeffects/AlgHeap.fst
@@ -457,10 +457,17 @@ let rec interp_sem #a (t : rwtree a) (s0:state)
     | Op Write i k ->
       interp_sem (k ()) i
     
+
+let extract #a #w (c:repr a w)
+  : Lemma (w `stronger` interp_as_wp c)
+  = ()
+
 let soundness #a #wp (t : unit -> AlgWP a wp)
   : Tot (s0:state -> ID5.ID (a & state) (as_pure_wp (wp s0)))
   = let c = reify (t ()) in
+    extract c;
     interp_sem c
+
 
 (* Same as above, but one doesn't have to think about WPs *)
 let soundnessPP #a #pre #post (t : unit -> AlgPP a pre post)

--- a/examples/layeredeffects/ID5.fst
+++ b/examples/layeredeffects/ID5.fst
@@ -47,9 +47,11 @@ let bind (a b : Type) (wp_v : wp a) (wp_f: a -> wp b)
 
 irreducible let refine : unit = ()
 
-let subcomp (a:Type u#uu) (w1 w2:wp a) (#[@@@ refine] u:squash (forall p. w2 p ==> w1 p))
+let subcomp (a:Type u#uu) (w1 w2:wp a)
     (f : repr a w1)
-: repr a w2
+: Pure (repr a w2)
+       (requires forall p. w2 p ==> w1 p)
+       (ensures fun _ -> True)
 = f
 
 // useful?

--- a/src/extraction/FStar.Extraction.ML.Term.fst
+++ b/src/extraction/FStar.Extraction.ML.Term.fst
@@ -217,7 +217,8 @@ let rec is_type_aux env t =
     | Tm_fvar fv ->
       UEnv.is_type_name env fv
 
-    | Tm_uvar ({ctx_uvar_typ=t}, s) ->
+    | Tm_uvar (u, s) ->
+      let t= U.ctx_uvar_typ u in
       is_arity env (SS.subst' s t)
 
     | Tm_bvar ({sort=t})

--- a/src/fstar/FStar.Universal.fst
+++ b/src/fstar/FStar.Universal.fst
@@ -124,6 +124,7 @@ let init_env deps : TcEnv.env =
         TcTerm.typeof_tot_or_gtot_term
         TcTerm.typeof_tot_or_gtot_term_fastpath
         TcTerm.universe_of
+        Rel.subtype_nosmt_force
         solver
         Const.prims_lid
         (NBE.normalize

--- a/src/ocaml-output/FStar_Extraction_ML_Modul.ml
+++ b/src/ocaml-output/FStar_Extraction_ML_Modul.ml
@@ -2144,6 +2144,8 @@ let rec (extract_sig :
                            FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term
                              =
                              (env.FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term);
+                           FStar_TypeChecker_Env.subtype_nosmt_force =
+                             (env.FStar_TypeChecker_Env.subtype_nosmt_force);
                            FStar_TypeChecker_Env.use_bv_sorts =
                              (env.FStar_TypeChecker_Env.use_bv_sorts);
                            FStar_TypeChecker_Env.qtbl_name_and_index =

--- a/src/ocaml-output/FStar_Extraction_ML_Term.ml
+++ b/src/ocaml-output/FStar_Extraction_ML_Term.ml
@@ -261,17 +261,9 @@ let rec (is_type_aux :
           FStar_Syntax_Syntax.fv_eq_lid fv uu___ -> false
       | FStar_Syntax_Syntax.Tm_fvar fv ->
           FStar_Extraction_ML_UEnv.is_type_name env fv
-      | FStar_Syntax_Syntax.Tm_uvar
-          ({ FStar_Syntax_Syntax.ctx_uvar_head = uu___;
-             FStar_Syntax_Syntax.ctx_uvar_gamma = uu___1;
-             FStar_Syntax_Syntax.ctx_uvar_binders = uu___2;
-             FStar_Syntax_Syntax.ctx_uvar_typ = t2;
-             FStar_Syntax_Syntax.ctx_uvar_reason = uu___3;
-             FStar_Syntax_Syntax.ctx_uvar_range = uu___4;
-             FStar_Syntax_Syntax.ctx_uvar_meta = uu___5;_},
-           s)
-          ->
-          let uu___6 = FStar_Syntax_Subst.subst' s t2 in is_arity env uu___6
+      | FStar_Syntax_Syntax.Tm_uvar (u, s) ->
+          let t2 = FStar_Syntax_Util.ctx_uvar_typ u in
+          let uu___ = FStar_Syntax_Subst.subst' s t2 in is_arity env uu___
       | FStar_Syntax_Syntax.Tm_bvar
           { FStar_Syntax_Syntax.ppname = uu___;
             FStar_Syntax_Syntax.index = uu___1;

--- a/src/ocaml-output/FStar_Extraction_ML_Term.ml
+++ b/src/ocaml-output/FStar_Extraction_ML_Term.ml
@@ -267,12 +267,11 @@ let rec (is_type_aux :
              FStar_Syntax_Syntax.ctx_uvar_binders = uu___2;
              FStar_Syntax_Syntax.ctx_uvar_typ = t2;
              FStar_Syntax_Syntax.ctx_uvar_reason = uu___3;
-             FStar_Syntax_Syntax.ctx_uvar_should_check = uu___4;
-             FStar_Syntax_Syntax.ctx_uvar_range = uu___5;
-             FStar_Syntax_Syntax.ctx_uvar_meta = uu___6;_},
+             FStar_Syntax_Syntax.ctx_uvar_range = uu___4;
+             FStar_Syntax_Syntax.ctx_uvar_meta = uu___5;_},
            s)
           ->
-          let uu___7 = FStar_Syntax_Subst.subst' s t2 in is_arity env uu___7
+          let uu___6 = FStar_Syntax_Subst.subst' s t2 in is_arity env uu___6
       | FStar_Syntax_Syntax.Tm_bvar
           { FStar_Syntax_Syntax.ppname = uu___;
             FStar_Syntax_Syntax.index = uu___1;

--- a/src/ocaml-output/FStar_Interactive_Ide.ml
+++ b/src/ocaml-output/FStar_Interactive_Ide.ml
@@ -1581,6 +1581,8 @@ let run_push_without_deps :
                  (uu___.FStar_TypeChecker_Env.universe_of);
                FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term =
                  (uu___.FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term);
+               FStar_TypeChecker_Env.subtype_nosmt_force =
+                 (uu___.FStar_TypeChecker_Env.subtype_nosmt_force);
                FStar_TypeChecker_Env.use_bv_sorts =
                  (uu___.FStar_TypeChecker_Env.use_bv_sorts);
                FStar_TypeChecker_Env.qtbl_name_and_index =

--- a/src/ocaml-output/FStar_Interactive_Legacy.ml
+++ b/src/ocaml-output/FStar_Interactive_Legacy.ml
@@ -103,6 +103,8 @@ let (push_with_kind :
                 (env.FStar_TypeChecker_Env.universe_of);
               FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term =
                 (env.FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term);
+              FStar_TypeChecker_Env.subtype_nosmt_force =
+                (env.FStar_TypeChecker_Env.subtype_nosmt_force);
               FStar_TypeChecker_Env.use_bv_sorts =
                 (env.FStar_TypeChecker_Env.use_bv_sorts);
               FStar_TypeChecker_Env.qtbl_name_and_index =

--- a/src/ocaml-output/FStar_Interactive_PushHelper.ml
+++ b/src/ocaml-output/FStar_Interactive_PushHelper.ml
@@ -103,6 +103,8 @@ let (set_check_kind :
           (env.FStar_TypeChecker_Env.universe_of);
         FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term =
           (env.FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term);
+        FStar_TypeChecker_Env.subtype_nosmt_force =
+          (env.FStar_TypeChecker_Env.subtype_nosmt_force);
         FStar_TypeChecker_Env.use_bv_sorts =
           (env.FStar_TypeChecker_Env.use_bv_sorts);
         FStar_TypeChecker_Env.qtbl_name_and_index =

--- a/src/ocaml-output/FStar_SMTEncoding_Encode.ml
+++ b/src/ocaml-output/FStar_SMTEncoding_Encode.ml
@@ -1619,6 +1619,9 @@ let (encode_free_var :
                                      FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term
                                        =
                                        (uu___8.FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term);
+                                     FStar_TypeChecker_Env.subtype_nosmt_force
+                                       =
+                                       (uu___8.FStar_TypeChecker_Env.subtype_nosmt_force);
                                      FStar_TypeChecker_Env.use_bv_sorts =
                                        (uu___8.FStar_TypeChecker_Env.use_bv_sorts);
                                      FStar_TypeChecker_Env.qtbl_name_and_index
@@ -2504,6 +2507,8 @@ let (encode_top_level_let :
                     (uu___1.FStar_TypeChecker_Env.universe_of);
                   FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term =
                     (uu___1.FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term);
+                  FStar_TypeChecker_Env.subtype_nosmt_force =
+                    (uu___1.FStar_TypeChecker_Env.subtype_nosmt_force);
                   FStar_TypeChecker_Env.use_bv_sorts =
                     (uu___1.FStar_TypeChecker_Env.use_bv_sorts);
                   FStar_TypeChecker_Env.qtbl_name_and_index =

--- a/src/ocaml-output/FStar_SMTEncoding_EncodeTerm.ml
+++ b/src/ocaml-output/FStar_SMTEncoding_EncodeTerm.ml
@@ -2006,8 +2006,8 @@ and (encode_term :
                  uv.FStar_Syntax_Syntax.ctx_uvar_head in
              FStar_SMTEncoding_Util.mk_Term_uvar uu___2 in
            let uu___2 =
-             encode_term_pred FStar_Pervasives_Native.None
-               uv.FStar_Syntax_Syntax.ctx_uvar_typ env ttm in
+             let uu___3 = FStar_Syntax_Util.ctx_uvar_typ uv in
+             encode_term_pred FStar_Pervasives_Native.None uu___3 env ttm in
            (match uu___2 with
             | (t_has_k, decls) ->
                 let d =

--- a/src/ocaml-output/FStar_SMTEncoding_EncodeTerm.ml
+++ b/src/ocaml-output/FStar_SMTEncoding_EncodeTerm.ml
@@ -1435,6 +1435,8 @@ and (encode_term :
                               FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term
                                 =
                                 (uu___6.FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term);
+                              FStar_TypeChecker_Env.subtype_nosmt_force =
+                                (uu___6.FStar_TypeChecker_Env.subtype_nosmt_force);
                               FStar_TypeChecker_Env.use_bv_sorts =
                                 (uu___6.FStar_TypeChecker_Env.use_bv_sorts);
                               FStar_TypeChecker_Env.qtbl_name_and_index =

--- a/src/ocaml-output/FStar_Syntax_Free.ml
+++ b/src/ocaml-output/FStar_Syntax_Free.ml
@@ -1,4 +1,13 @@
 open Prims
+let (ctx_uvar_typ :
+  FStar_Syntax_Syntax.ctx_uvar ->
+    FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax)
+  =
+  fun u ->
+    let uu___ =
+      FStar_Syntax_Unionfind.find_decoration
+        u.FStar_Syntax_Syntax.ctx_uvar_head in
+    uu___.FStar_Syntax_Syntax.uvar_decoration_typ
 type use_cache_t =
   | Def 
   | NoCache 
@@ -156,8 +165,8 @@ let rec (free_names_and_uvs' :
           let uu___1 =
             if use_cache = Full
             then
-              free_names_and_uvars uv.FStar_Syntax_Syntax.ctx_uvar_typ
-                use_cache
+              let uu___2 = ctx_uvar_typ uv in
+              free_names_and_uvars uu___2 use_cache
             else no_free_vars in
           union (singleton_uv uv) uu___1
       | FStar_Syntax_Syntax.Tm_type u -> free_univs u

--- a/src/ocaml-output/FStar_Syntax_Print.ml
+++ b/src/ocaml-output/FStar_Syntax_Print.ml
@@ -733,8 +733,13 @@ and (ctx_uvar_to_string_aux :
         binders_to_string ", " ctx_uvar.FStar_Syntax_Syntax.ctx_uvar_binders in
       let uu___1 = uvar_to_string ctx_uvar.FStar_Syntax_Syntax.ctx_uvar_head in
       let uu___2 = term_to_string ctx_uvar.FStar_Syntax_Syntax.ctx_uvar_typ in
-      FStar_Compiler_Util.format4 "%s(%s |- %s : %s)" reason_string uu___
+      FStar_Compiler_Util.format5 "%s(%s |- %s : %s) %s" reason_string uu___
         uu___1 uu___2
+        (match ctx_uvar.FStar_Syntax_Syntax.ctx_uvar_should_check with
+         | FStar_Syntax_Syntax.Allow_unresolved -> "Allow_unresolved"
+         | FStar_Syntax_Syntax.Allow_untyped -> "Allow_untyped"
+         | FStar_Syntax_Syntax.Allow_ghost -> "Allow_ghost"
+         | FStar_Syntax_Syntax.Strict -> "Strict")
 and (subst_elt_to_string : FStar_Syntax_Syntax.subst_elt -> Prims.string) =
   fun uu___ ->
     match uu___ with

--- a/src/ocaml-output/FStar_Syntax_Print.ml
+++ b/src/ocaml-output/FStar_Syntax_Print.ml
@@ -732,7 +732,9 @@ and (ctx_uvar_to_string_aux :
       let uu___ =
         binders_to_string ", " ctx_uvar.FStar_Syntax_Syntax.ctx_uvar_binders in
       let uu___1 = uvar_to_string ctx_uvar.FStar_Syntax_Syntax.ctx_uvar_head in
-      let uu___2 = term_to_string ctx_uvar.FStar_Syntax_Syntax.ctx_uvar_typ in
+      let uu___2 =
+        let uu___3 = FStar_Syntax_Util.ctx_uvar_typ ctx_uvar in
+        term_to_string uu___3 in
       let uu___3 =
         let uu___4 = FStar_Syntax_Util.ctx_uvar_should_check ctx_uvar in
         match uu___4 with

--- a/src/ocaml-output/FStar_Syntax_Print.ml
+++ b/src/ocaml-output/FStar_Syntax_Print.ml
@@ -733,13 +733,15 @@ and (ctx_uvar_to_string_aux :
         binders_to_string ", " ctx_uvar.FStar_Syntax_Syntax.ctx_uvar_binders in
       let uu___1 = uvar_to_string ctx_uvar.FStar_Syntax_Syntax.ctx_uvar_head in
       let uu___2 = term_to_string ctx_uvar.FStar_Syntax_Syntax.ctx_uvar_typ in
+      let uu___3 =
+        let uu___4 = FStar_Syntax_Util.ctx_uvar_should_check ctx_uvar in
+        match uu___4 with
+        | FStar_Syntax_Syntax.Allow_unresolved -> "Allow_unresolved"
+        | FStar_Syntax_Syntax.Allow_untyped -> "Allow_untyped"
+        | FStar_Syntax_Syntax.Allow_ghost -> "Allow_ghost"
+        | FStar_Syntax_Syntax.Strict -> "Strict" in
       FStar_Compiler_Util.format5 "%s(%s |- %s : %s) %s" reason_string uu___
-        uu___1 uu___2
-        (match ctx_uvar.FStar_Syntax_Syntax.ctx_uvar_should_check with
-         | FStar_Syntax_Syntax.Allow_unresolved -> "Allow_unresolved"
-         | FStar_Syntax_Syntax.Allow_untyped -> "Allow_untyped"
-         | FStar_Syntax_Syntax.Allow_ghost -> "Allow_ghost"
-         | FStar_Syntax_Syntax.Strict -> "Strict")
+        uu___1 uu___2 uu___3
 and (subst_elt_to_string : FStar_Syntax_Syntax.subst_elt -> Prims.string) =
   fun uu___ ->
     match uu___ with

--- a/src/ocaml-output/FStar_Syntax_Subst.ml
+++ b/src/ocaml-output/FStar_Syntax_Subst.ml
@@ -1040,6 +1040,26 @@ let (subst_decreasing_order :
   =
   fun s ->
     fun dec -> subst_dec_order' ([s], FStar_Syntax_Syntax.NoUseRange) dec
+let (subst_residual_comp :
+  FStar_Syntax_Syntax.subst_elt Prims.list ->
+    FStar_Syntax_Syntax.residual_comp -> FStar_Syntax_Syntax.residual_comp)
+  =
+  fun s ->
+    fun rc ->
+      match rc.FStar_Syntax_Syntax.residual_typ with
+      | FStar_Pervasives_Native.None -> rc
+      | FStar_Pervasives_Native.Some t ->
+          let uu___ =
+            let uu___1 = subst s t in
+            FStar_Compiler_Effect.op_Bar_Greater uu___1
+              (fun uu___2 -> FStar_Pervasives_Native.Some uu___2) in
+          {
+            FStar_Syntax_Syntax.residual_effect =
+              (rc.FStar_Syntax_Syntax.residual_effect);
+            FStar_Syntax_Syntax.residual_typ = uu___;
+            FStar_Syntax_Syntax.residual_flags =
+              (rc.FStar_Syntax_Syntax.residual_flags)
+          }
 let (closing_subst :
   FStar_Syntax_Syntax.binders -> FStar_Syntax_Syntax.subst_elt Prims.list) =
   fun bs ->

--- a/src/ocaml-output/FStar_Syntax_Subst.ml
+++ b/src/ocaml-output/FStar_Syntax_Subst.ml
@@ -91,19 +91,18 @@ let rec (force_uvar' :
            FStar_Syntax_Syntax.ctx_uvar_binders = uu___1;
            FStar_Syntax_Syntax.ctx_uvar_typ = uu___2;
            FStar_Syntax_Syntax.ctx_uvar_reason = uu___3;
-           FStar_Syntax_Syntax.ctx_uvar_should_check = uu___4;
-           FStar_Syntax_Syntax.ctx_uvar_range = uu___5;
-           FStar_Syntax_Syntax.ctx_uvar_meta = uu___6;_},
+           FStar_Syntax_Syntax.ctx_uvar_range = uu___4;
+           FStar_Syntax_Syntax.ctx_uvar_meta = uu___5;_},
          s)
         ->
-        let uu___7 = FStar_Syntax_Unionfind.find uv in
-        (match uu___7 with
+        let uu___6 = FStar_Syntax_Unionfind.find uv in
+        (match uu___6 with
          | FStar_Pervasives_Native.Some t' ->
-             let uu___8 =
-               let uu___9 = let uu___10 = delay t' s in force_uvar' uu___10 in
-               FStar_Pervasives_Native.fst uu___9 in
-             (uu___8, true)
-         | uu___8 -> (t, false))
+             let uu___7 =
+               let uu___8 = let uu___9 = delay t' s in force_uvar' uu___9 in
+               FStar_Pervasives_Native.fst uu___8 in
+             (uu___7, true)
+         | uu___7 -> (t, false))
     | uu___ -> (t, false)
 let (force_uvar :
   FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->

--- a/src/ocaml-output/FStar_Syntax_Subst.ml
+++ b/src/ocaml-output/FStar_Syntax_Subst.ml
@@ -89,20 +89,19 @@ let rec (force_uvar' :
         ({ FStar_Syntax_Syntax.ctx_uvar_head = uv;
            FStar_Syntax_Syntax.ctx_uvar_gamma = uu___;
            FStar_Syntax_Syntax.ctx_uvar_binders = uu___1;
-           FStar_Syntax_Syntax.ctx_uvar_typ = uu___2;
-           FStar_Syntax_Syntax.ctx_uvar_reason = uu___3;
-           FStar_Syntax_Syntax.ctx_uvar_range = uu___4;
-           FStar_Syntax_Syntax.ctx_uvar_meta = uu___5;_},
+           FStar_Syntax_Syntax.ctx_uvar_reason = uu___2;
+           FStar_Syntax_Syntax.ctx_uvar_range = uu___3;
+           FStar_Syntax_Syntax.ctx_uvar_meta = uu___4;_},
          s)
         ->
-        let uu___6 = FStar_Syntax_Unionfind.find uv in
-        (match uu___6 with
+        let uu___5 = FStar_Syntax_Unionfind.find uv in
+        (match uu___5 with
          | FStar_Pervasives_Native.Some t' ->
-             let uu___7 =
-               let uu___8 = let uu___9 = delay t' s in force_uvar' uu___9 in
-               FStar_Pervasives_Native.fst uu___8 in
-             (uu___7, true)
-         | uu___7 -> (t, false))
+             let uu___6 =
+               let uu___7 = let uu___8 = delay t' s in force_uvar' uu___8 in
+               FStar_Pervasives_Native.fst uu___7 in
+             (uu___6, true)
+         | uu___6 -> (t, false))
     | uu___ -> (t, false)
 let (force_uvar :
   FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->

--- a/src/ocaml-output/FStar_Syntax_Syntax.ml
+++ b/src/ocaml-output/FStar_Syntax_Syntax.ml
@@ -213,7 +213,6 @@ and ctx_uvar =
     ;
   ctx_uvar_gamma: binding Prims.list ;
   ctx_uvar_binders: binder Prims.list ;
-  ctx_uvar_typ: term' syntax ;
   ctx_uvar_reason: Prims.string ;
   ctx_uvar_range: FStar_Compiler_Range.range ;
   ctx_uvar_meta: ctx_uvar_meta_t FStar_Pervasives_Native.option }
@@ -476,42 +475,37 @@ let (__proj__Mkctx_uvar__item__ctx_uvar_head :
   =
   fun projectee ->
     match projectee with
-    | { ctx_uvar_head; ctx_uvar_gamma; ctx_uvar_binders; ctx_uvar_typ;
-        ctx_uvar_reason; ctx_uvar_range; ctx_uvar_meta;_} -> ctx_uvar_head
+    | { ctx_uvar_head; ctx_uvar_gamma; ctx_uvar_binders; ctx_uvar_reason;
+        ctx_uvar_range; ctx_uvar_meta;_} -> ctx_uvar_head
 let (__proj__Mkctx_uvar__item__ctx_uvar_gamma :
   ctx_uvar -> binding Prims.list) =
   fun projectee ->
     match projectee with
-    | { ctx_uvar_head; ctx_uvar_gamma; ctx_uvar_binders; ctx_uvar_typ;
-        ctx_uvar_reason; ctx_uvar_range; ctx_uvar_meta;_} -> ctx_uvar_gamma
+    | { ctx_uvar_head; ctx_uvar_gamma; ctx_uvar_binders; ctx_uvar_reason;
+        ctx_uvar_range; ctx_uvar_meta;_} -> ctx_uvar_gamma
 let (__proj__Mkctx_uvar__item__ctx_uvar_binders :
   ctx_uvar -> binder Prims.list) =
   fun projectee ->
     match projectee with
-    | { ctx_uvar_head; ctx_uvar_gamma; ctx_uvar_binders; ctx_uvar_typ;
-        ctx_uvar_reason; ctx_uvar_range; ctx_uvar_meta;_} -> ctx_uvar_binders
-let (__proj__Mkctx_uvar__item__ctx_uvar_typ : ctx_uvar -> term' syntax) =
-  fun projectee ->
-    match projectee with
-    | { ctx_uvar_head; ctx_uvar_gamma; ctx_uvar_binders; ctx_uvar_typ;
-        ctx_uvar_reason; ctx_uvar_range; ctx_uvar_meta;_} -> ctx_uvar_typ
+    | { ctx_uvar_head; ctx_uvar_gamma; ctx_uvar_binders; ctx_uvar_reason;
+        ctx_uvar_range; ctx_uvar_meta;_} -> ctx_uvar_binders
 let (__proj__Mkctx_uvar__item__ctx_uvar_reason : ctx_uvar -> Prims.string) =
   fun projectee ->
     match projectee with
-    | { ctx_uvar_head; ctx_uvar_gamma; ctx_uvar_binders; ctx_uvar_typ;
-        ctx_uvar_reason; ctx_uvar_range; ctx_uvar_meta;_} -> ctx_uvar_reason
+    | { ctx_uvar_head; ctx_uvar_gamma; ctx_uvar_binders; ctx_uvar_reason;
+        ctx_uvar_range; ctx_uvar_meta;_} -> ctx_uvar_reason
 let (__proj__Mkctx_uvar__item__ctx_uvar_range :
   ctx_uvar -> FStar_Compiler_Range.range) =
   fun projectee ->
     match projectee with
-    | { ctx_uvar_head; ctx_uvar_gamma; ctx_uvar_binders; ctx_uvar_typ;
-        ctx_uvar_reason; ctx_uvar_range; ctx_uvar_meta;_} -> ctx_uvar_range
+    | { ctx_uvar_head; ctx_uvar_gamma; ctx_uvar_binders; ctx_uvar_reason;
+        ctx_uvar_range; ctx_uvar_meta;_} -> ctx_uvar_range
 let (__proj__Mkctx_uvar__item__ctx_uvar_meta :
   ctx_uvar -> ctx_uvar_meta_t FStar_Pervasives_Native.option) =
   fun projectee ->
     match projectee with
-    | { ctx_uvar_head; ctx_uvar_gamma; ctx_uvar_binders; ctx_uvar_typ;
-        ctx_uvar_reason; ctx_uvar_range; ctx_uvar_meta;_} -> ctx_uvar_meta
+    | { ctx_uvar_head; ctx_uvar_gamma; ctx_uvar_binders; ctx_uvar_reason;
+        ctx_uvar_range; ctx_uvar_meta;_} -> ctx_uvar_meta
 let (uu___is_Ctx_uvar_meta_tac : ctx_uvar_meta_t -> Prims.bool) =
   fun projectee ->
     match projectee with | Ctx_uvar_meta_tac _0 -> true | uu___ -> false

--- a/src/ocaml-output/FStar_Syntax_Syntax.ml
+++ b/src/ocaml-output/FStar_Syntax_Syntax.ml
@@ -208,19 +208,22 @@ type term' =
 and ctx_uvar =
   {
   ctx_uvar_head:
-    (term' syntax FStar_Pervasives_Native.option FStar_Unionfind.p_uvar *
-      version * FStar_Compiler_Range.range)
+    ((term' syntax FStar_Pervasives_Native.option * uvar_decoration)
+      FStar_Unionfind.p_uvar * version * FStar_Compiler_Range.range)
     ;
   ctx_uvar_gamma: binding Prims.list ;
   ctx_uvar_binders: binder Prims.list ;
   ctx_uvar_typ: term' syntax ;
   ctx_uvar_reason: Prims.string ;
-  ctx_uvar_should_check: should_check_uvar ;
   ctx_uvar_range: FStar_Compiler_Range.range ;
   ctx_uvar_meta: ctx_uvar_meta_t FStar_Pervasives_Native.option }
 and ctx_uvar_meta_t =
   | Ctx_uvar_meta_tac of (FStar_Compiler_Dyn.dyn * term' syntax) 
   | Ctx_uvar_meta_attr of term' syntax 
+and uvar_decoration =
+  {
+  uvar_decoration_typ: term' syntax ;
+  uvar_decoration_should_check: should_check_uvar }
 and pat' =
   | Pat_constant of sconst 
   | Pat_cons of (fv * (pat' withinfo_t * Prims.bool) Prims.list) 
@@ -468,61 +471,47 @@ let (uu___is_Tm_unknown : term' -> Prims.bool) =
   fun projectee -> match projectee with | Tm_unknown -> true | uu___ -> false
 let (__proj__Mkctx_uvar__item__ctx_uvar_head :
   ctx_uvar ->
-    (term' syntax FStar_Pervasives_Native.option FStar_Unionfind.p_uvar *
-      version * FStar_Compiler_Range.range))
+    ((term' syntax FStar_Pervasives_Native.option * uvar_decoration)
+      FStar_Unionfind.p_uvar * version * FStar_Compiler_Range.range))
   =
   fun projectee ->
     match projectee with
     | { ctx_uvar_head; ctx_uvar_gamma; ctx_uvar_binders; ctx_uvar_typ;
-        ctx_uvar_reason; ctx_uvar_should_check; ctx_uvar_range;
-        ctx_uvar_meta;_} -> ctx_uvar_head
+        ctx_uvar_reason; ctx_uvar_range; ctx_uvar_meta;_} -> ctx_uvar_head
 let (__proj__Mkctx_uvar__item__ctx_uvar_gamma :
   ctx_uvar -> binding Prims.list) =
   fun projectee ->
     match projectee with
     | { ctx_uvar_head; ctx_uvar_gamma; ctx_uvar_binders; ctx_uvar_typ;
-        ctx_uvar_reason; ctx_uvar_should_check; ctx_uvar_range;
-        ctx_uvar_meta;_} -> ctx_uvar_gamma
+        ctx_uvar_reason; ctx_uvar_range; ctx_uvar_meta;_} -> ctx_uvar_gamma
 let (__proj__Mkctx_uvar__item__ctx_uvar_binders :
   ctx_uvar -> binder Prims.list) =
   fun projectee ->
     match projectee with
     | { ctx_uvar_head; ctx_uvar_gamma; ctx_uvar_binders; ctx_uvar_typ;
-        ctx_uvar_reason; ctx_uvar_should_check; ctx_uvar_range;
-        ctx_uvar_meta;_} -> ctx_uvar_binders
+        ctx_uvar_reason; ctx_uvar_range; ctx_uvar_meta;_} -> ctx_uvar_binders
 let (__proj__Mkctx_uvar__item__ctx_uvar_typ : ctx_uvar -> term' syntax) =
   fun projectee ->
     match projectee with
     | { ctx_uvar_head; ctx_uvar_gamma; ctx_uvar_binders; ctx_uvar_typ;
-        ctx_uvar_reason; ctx_uvar_should_check; ctx_uvar_range;
-        ctx_uvar_meta;_} -> ctx_uvar_typ
+        ctx_uvar_reason; ctx_uvar_range; ctx_uvar_meta;_} -> ctx_uvar_typ
 let (__proj__Mkctx_uvar__item__ctx_uvar_reason : ctx_uvar -> Prims.string) =
   fun projectee ->
     match projectee with
     | { ctx_uvar_head; ctx_uvar_gamma; ctx_uvar_binders; ctx_uvar_typ;
-        ctx_uvar_reason; ctx_uvar_should_check; ctx_uvar_range;
-        ctx_uvar_meta;_} -> ctx_uvar_reason
-let (__proj__Mkctx_uvar__item__ctx_uvar_should_check :
-  ctx_uvar -> should_check_uvar) =
-  fun projectee ->
-    match projectee with
-    | { ctx_uvar_head; ctx_uvar_gamma; ctx_uvar_binders; ctx_uvar_typ;
-        ctx_uvar_reason; ctx_uvar_should_check; ctx_uvar_range;
-        ctx_uvar_meta;_} -> ctx_uvar_should_check
+        ctx_uvar_reason; ctx_uvar_range; ctx_uvar_meta;_} -> ctx_uvar_reason
 let (__proj__Mkctx_uvar__item__ctx_uvar_range :
   ctx_uvar -> FStar_Compiler_Range.range) =
   fun projectee ->
     match projectee with
     | { ctx_uvar_head; ctx_uvar_gamma; ctx_uvar_binders; ctx_uvar_typ;
-        ctx_uvar_reason; ctx_uvar_should_check; ctx_uvar_range;
-        ctx_uvar_meta;_} -> ctx_uvar_range
+        ctx_uvar_reason; ctx_uvar_range; ctx_uvar_meta;_} -> ctx_uvar_range
 let (__proj__Mkctx_uvar__item__ctx_uvar_meta :
   ctx_uvar -> ctx_uvar_meta_t FStar_Pervasives_Native.option) =
   fun projectee ->
     match projectee with
     | { ctx_uvar_head; ctx_uvar_gamma; ctx_uvar_binders; ctx_uvar_typ;
-        ctx_uvar_reason; ctx_uvar_should_check; ctx_uvar_range;
-        ctx_uvar_meta;_} -> ctx_uvar_meta
+        ctx_uvar_reason; ctx_uvar_range; ctx_uvar_meta;_} -> ctx_uvar_meta
 let (uu___is_Ctx_uvar_meta_tac : ctx_uvar_meta_t -> Prims.bool) =
   fun projectee ->
     match projectee with | Ctx_uvar_meta_tac _0 -> true | uu___ -> false
@@ -534,6 +523,18 @@ let (uu___is_Ctx_uvar_meta_attr : ctx_uvar_meta_t -> Prims.bool) =
     match projectee with | Ctx_uvar_meta_attr _0 -> true | uu___ -> false
 let (__proj__Ctx_uvar_meta_attr__item___0 : ctx_uvar_meta_t -> term' syntax)
   = fun projectee -> match projectee with | Ctx_uvar_meta_attr _0 -> _0
+let (__proj__Mkuvar_decoration__item__uvar_decoration_typ :
+  uvar_decoration -> term' syntax) =
+  fun projectee ->
+    match projectee with
+    | { uvar_decoration_typ; uvar_decoration_should_check;_} ->
+        uvar_decoration_typ
+let (__proj__Mkuvar_decoration__item__uvar_decoration_should_check :
+  uvar_decoration -> should_check_uvar) =
+  fun projectee ->
+    match projectee with
+    | { uvar_decoration_typ; uvar_decoration_should_check;_} ->
+        uvar_decoration_should_check
 let (uu___is_Pat_constant : pat' -> Prims.bool) =
   fun projectee ->
     match projectee with | Pat_constant _0 -> true | uu___ -> false
@@ -960,8 +961,8 @@ type ctx_uvar_and_subst =
   (ctx_uvar * (subst_elt Prims.list Prims.list * maybe_set_use_range))
 type term = term' syntax
 type uvar =
-  (term' syntax FStar_Pervasives_Native.option FStar_Unionfind.p_uvar *
-    version * FStar_Compiler_Range.range)
+  ((term' syntax FStar_Pervasives_Native.option * uvar_decoration)
+    FStar_Unionfind.p_uvar * version * FStar_Compiler_Range.range)
 type uvars = ctx_uvar FStar_Compiler_Util.set
 type comp = comp' syntax
 type ascription =

--- a/src/ocaml-output/FStar_Syntax_Util.ml
+++ b/src/ocaml-output/FStar_Syntax_Util.ml
@@ -4742,3 +4742,12 @@ let (ctx_uvar_should_check :
       FStar_Syntax_Unionfind.find_decoration
         u.FStar_Syntax_Syntax.ctx_uvar_head in
     uu___.FStar_Syntax_Syntax.uvar_decoration_should_check
+let (ctx_uvar_typ :
+  FStar_Syntax_Syntax.ctx_uvar ->
+    FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax)
+  =
+  fun u ->
+    let uu___ =
+      FStar_Syntax_Unionfind.find_decoration
+        u.FStar_Syntax_Syntax.ctx_uvar_head in
+    uu___.FStar_Syntax_Syntax.uvar_decoration_typ

--- a/src/ocaml-output/FStar_Syntax_Util.ml
+++ b/src/ocaml-output/FStar_Syntax_Util.ml
@@ -4735,3 +4735,10 @@ let (check_mutual_universes :
                    "Mutually recursive definitions do not abstract over the same universes")
                  lb1.FStar_Syntax_Syntax.lbpos
              else ()) lbs1
+let (ctx_uvar_should_check :
+  FStar_Syntax_Syntax.ctx_uvar -> FStar_Syntax_Syntax.should_check_uvar) =
+  fun u ->
+    let uu___ =
+      FStar_Syntax_Unionfind.find_decoration
+        u.FStar_Syntax_Syntax.ctx_uvar_head in
+    uu___.FStar_Syntax_Syntax.uvar_decoration_should_check

--- a/src/ocaml-output/FStar_Tactics_Basic.ml
+++ b/src/ocaml-output/FStar_Tactics_Basic.ml
@@ -67,31 +67,7 @@ let (goal_with_type :
   fun g ->
     fun t ->
       let u = g.FStar_Tactics_Types.goal_ctx_uvar in
-      set_uvar_expected_typ u t;
-      (let u1 =
-         {
-           FStar_Syntax_Syntax.ctx_uvar_head =
-             (u.FStar_Syntax_Syntax.ctx_uvar_head);
-           FStar_Syntax_Syntax.ctx_uvar_gamma =
-             (u.FStar_Syntax_Syntax.ctx_uvar_gamma);
-           FStar_Syntax_Syntax.ctx_uvar_binders =
-             (u.FStar_Syntax_Syntax.ctx_uvar_binders);
-           FStar_Syntax_Syntax.ctx_uvar_typ = t;
-           FStar_Syntax_Syntax.ctx_uvar_reason =
-             (u.FStar_Syntax_Syntax.ctx_uvar_reason);
-           FStar_Syntax_Syntax.ctx_uvar_range =
-             (u.FStar_Syntax_Syntax.ctx_uvar_range);
-           FStar_Syntax_Syntax.ctx_uvar_meta =
-             (u.FStar_Syntax_Syntax.ctx_uvar_meta)
-         } in
-       {
-         FStar_Tactics_Types.goal_main_env =
-           (g.FStar_Tactics_Types.goal_main_env);
-         FStar_Tactics_Types.goal_ctx_uvar = u1;
-         FStar_Tactics_Types.opts = (g.FStar_Tactics_Types.opts);
-         FStar_Tactics_Types.is_guard = (g.FStar_Tactics_Types.is_guard);
-         FStar_Tactics_Types.label = (g.FStar_Tactics_Types.label)
-       })
+      set_uvar_expected_typ u t; g
 let (bnorm_goal : FStar_Tactics_Types.goal -> FStar_Tactics_Types.goal) =
   fun g ->
     let uu___ =
@@ -138,7 +114,7 @@ let (do_dump_ps : Prims.string -> FStar_Tactics_Types.proofstate -> unit) =
     fun ps ->
       let psc = ps.FStar_Tactics_Types.psc in
       let subst = FStar_TypeChecker_Cfg.psc_subst psc in
-      let uu___ = FStar_Tactics_Types.subst_proof_state subst ps in
+      let uu___ = FStar_Tactics_Types.subst_proof_display_state subst ps in
       FStar_Tactics_Printing.do_dump_proofstate uu___ msg
 let (dump : Prims.string -> unit FStar_Tactics_Monad.tac) =
   fun msg ->
@@ -1765,6 +1741,9 @@ let (intro_rec :
                                             (goal.FStar_Tactics_Types.goal_main_env);
                                           FStar_Tactics_Types.goal_ctx_uvar =
                                             ctx_uvar_u;
+                                          FStar_Tactics_Types.goal_display_type
+                                            =
+                                            (goal.FStar_Tactics_Types.goal_display_type);
                                           FStar_Tactics_Types.opts =
                                             (goal.FStar_Tactics_Types.opts);
                                           FStar_Tactics_Types.is_guard =
@@ -2302,6 +2281,8 @@ let (check_apply_implicits_solutions :
                                       (gl.FStar_Tactics_Types.goal_main_env);
                                     FStar_Tactics_Types.goal_ctx_uvar =
                                       ctx_uvar1;
+                                    FStar_Tactics_Types.goal_display_type =
+                                      (gl.FStar_Tactics_Types.goal_display_type);
                                     FStar_Tactics_Types.opts =
                                       (gl.FStar_Tactics_Types.opts);
                                     FStar_Tactics_Types.is_guard =
@@ -2323,9 +2304,11 @@ let (check_apply_implicits_solutions :
                                      debug_prefix uu___6 uu___7)
                                 (fun uu___5 ->
                                    let g_typ =
+                                     let uu___6 =
+                                       FStar_Syntax_Util.ctx_uvar_typ
+                                         ctx_uvar in
                                      check_implicits_solution env1 term
-                                       ctx_uvar.FStar_Syntax_Syntax.ctx_uvar_typ
-                                       must_tot in
+                                       uu___6 must_tot in
                                    let uu___6 =
                                      let uu___7 =
                                        if debug_on
@@ -2442,8 +2425,12 @@ let (t_apply :
                                                                uu___10, uv)
                                                                 ->
                                                                 let uu___11 =
+                                                                  let uu___12
+                                                                    =
+                                                                    FStar_Syntax_Util.ctx_uvar_typ
+                                                                    uv in
                                                                   FStar_Syntax_Free.uvars
-                                                                    uv.FStar_Syntax_Syntax.ctx_uvar_typ in
+                                                                    uu___12 in
                                                                 FStar_Compiler_Util.set_union
                                                                   s uu___11)
                                                        uvs uu___7 in
@@ -2514,6 +2501,9 @@ let (t_apply :
                                                                     (goal.FStar_Tactics_Types.goal_main_env);
                                                                     FStar_Tactics_Types.goal_ctx_uvar
                                                                     = uv;
+                                                                    FStar_Tactics_Types.goal_display_type
+                                                                    =
+                                                                    (goal.FStar_Tactics_Types.goal_display_type);
                                                                     FStar_Tactics_Types.opts
                                                                     =
                                                                     (goal.FStar_Tactics_Types.opts);
@@ -3685,6 +3675,8 @@ let (dup : unit -> unit FStar_Tactics_Monad.tac) =
                       FStar_Tactics_Types.goal_main_env =
                         (g.FStar_Tactics_Types.goal_main_env);
                       FStar_Tactics_Types.goal_ctx_uvar = u_uvar;
+                      FStar_Tactics_Types.goal_display_type =
+                        (g.FStar_Tactics_Types.goal_display_type);
                       FStar_Tactics_Types.opts = (g.FStar_Tactics_Types.opts);
                       FStar_Tactics_Types.is_guard =
                         (g.FStar_Tactics_Types.is_guard);
@@ -3968,6 +3960,8 @@ let (set_options : Prims.string -> unit FStar_Tactics_Monad.tac) =
                        (g.FStar_Tactics_Types.goal_main_env);
                      FStar_Tactics_Types.goal_ctx_uvar =
                        (g.FStar_Tactics_Types.goal_ctx_uvar);
+                     FStar_Tactics_Types.goal_display_type =
+                       (g.FStar_Tactics_Types.goal_display_type);
                      FStar_Tactics_Types.opts = opts';
                      FStar_Tactics_Types.is_guard =
                        (g.FStar_Tactics_Types.is_guard);

--- a/src/ocaml-output/FStar_Tactics_Basic.ml
+++ b/src/ocaml-output/FStar_Tactics_Basic.ml
@@ -6178,8 +6178,7 @@ let (proofstate_of_all_implicits :
             FStar_Tactics_Types.smt_goals = [];
             FStar_Tactics_Types.depth = Prims.int_zero;
             FStar_Tactics_Types.__dump =
-              (fun ps1 ->
-                 fun msg -> FStar_Tactics_Printing.do_dump_proofstate ps1 msg);
+              FStar_Tactics_Printing.do_dump_proofstate;
             FStar_Tactics_Types.psc = FStar_TypeChecker_Cfg.null_psc;
             FStar_Tactics_Types.entry_range = rng;
             FStar_Tactics_Types.guard_policy = FStar_Tactics_Types.SMT;

--- a/src/ocaml-output/FStar_Tactics_Basic.ml
+++ b/src/ocaml-output/FStar_Tactics_Basic.ml
@@ -2441,130 +2441,194 @@ let (check_apply_implicits_solutions :
                 (FStar_Tactics_Monad.mapM check_one_implicit)
 let (t_apply :
   Prims.bool ->
-    Prims.bool -> FStar_Syntax_Syntax.term -> unit FStar_Tactics_Monad.tac)
+    Prims.bool ->
+      Prims.bool -> FStar_Syntax_Syntax.term -> unit FStar_Tactics_Monad.tac)
   =
   fun uopt ->
     fun only_match ->
-      fun tm ->
-        let uu___ =
-          FStar_Tactics_Monad.mlog
-            (fun uu___1 ->
-               let uu___2 = FStar_Syntax_Print.term_to_string tm in
-               FStar_Compiler_Util.print1 "t_apply: tm = %s\n" uu___2)
-            (fun uu___1 ->
-               FStar_Tactics_Monad.bind FStar_Tactics_Monad.get
-                 (fun ps ->
-                    FStar_Tactics_Monad.bind FStar_Tactics_Monad.cur_goal
-                      (fun goal ->
-                         let e = FStar_Tactics_Types.goal_env goal in
-                         FStar_Tactics_Monad.mlog
-                           (fun uu___2 ->
-                              let uu___3 =
-                                FStar_Syntax_Print.term_to_string tm in
-                              let uu___4 =
-                                FStar_Tactics_Printing.goal_to_string_verbose
-                                  goal in
-                              let uu___5 =
-                                FStar_TypeChecker_Env.print_gamma
-                                  e.FStar_TypeChecker_Env.gamma in
-                              FStar_Compiler_Util.print3
-                                "t_apply: tm = %s\nt_apply: goal = %s\nenv.gamma=%s\n"
-                                uu___3 uu___4 uu___5)
-                           (fun uu___2 ->
-                              let uu___3 = __tc e tm in
-                              FStar_Tactics_Monad.bind uu___3
-                                (fun uu___4 ->
-                                   match uu___4 with
-                                   | (tm1, typ, guard) ->
-                                       let typ1 = bnorm e typ in
-                                       let uu___5 =
-                                         let uu___6 =
-                                           FStar_Tactics_Types.goal_type goal in
-                                         try_unify_by_application only_match
-                                           e typ1 uu___6 (rangeof goal) in
-                                       FStar_Tactics_Monad.bind uu___5
-                                         (fun uvs ->
-                                            FStar_Tactics_Monad.mlog
-                                              (fun uu___6 ->
-                                                 let uu___7 =
-                                                   FStar_Common.string_of_list
-                                                     (fun uu___8 ->
-                                                        match uu___8 with
-                                                        | (t, uu___9,
-                                                           uu___10) ->
-                                                            FStar_Syntax_Print.term_to_string
-                                                              t) uvs in
-                                                 FStar_Compiler_Util.print1
-                                                   "t_apply: found args = %s\n"
-                                                   uu___7)
-                                              (fun uu___6 ->
-                                                 let w =
-                                                   FStar_Compiler_List.fold_right
-                                                     (fun uu___7 ->
-                                                        fun w1 ->
-                                                          match uu___7 with
-                                                          | (uvt, q, uu___8)
-                                                              ->
-                                                              FStar_Syntax_Util.mk_app
-                                                                w1 [(uvt, q)])
-                                                     uvs tm1 in
-                                                 let uvset =
+      fun tc_resolved_uvars ->
+        fun tm ->
+          let uu___ =
+            FStar_Tactics_Monad.mlog
+              (fun uu___1 ->
+                 let uu___2 = FStar_Compiler_Util.string_of_bool uopt in
+                 let uu___3 = FStar_Compiler_Util.string_of_bool only_match in
+                 let uu___4 =
+                   FStar_Compiler_Util.string_of_bool tc_resolved_uvars in
+                 let uu___5 = FStar_Syntax_Print.term_to_string tm in
+                 FStar_Compiler_Util.print4
+                   "t_apply: uopt %s, only_match %s, tc_resolved_uvars %s, tm = %s\n"
+                   uu___2 uu___3 uu___4 uu___5)
+              (fun uu___1 ->
+                 FStar_Tactics_Monad.bind FStar_Tactics_Monad.get
+                   (fun ps ->
+                      FStar_Tactics_Monad.bind FStar_Tactics_Monad.cur_goal
+                        (fun goal ->
+                           let e = FStar_Tactics_Types.goal_env goal in
+                           FStar_Tactics_Monad.mlog
+                             (fun uu___2 ->
+                                let uu___3 =
+                                  FStar_Syntax_Print.term_to_string tm in
+                                let uu___4 =
+                                  FStar_Tactics_Printing.goal_to_string_verbose
+                                    goal in
+                                let uu___5 =
+                                  FStar_TypeChecker_Env.print_gamma
+                                    e.FStar_TypeChecker_Env.gamma in
+                                FStar_Compiler_Util.print3
+                                  "t_apply: tm = %s\nt_apply: goal = %s\nenv.gamma=%s\n"
+                                  uu___3 uu___4 uu___5)
+                             (fun uu___2 ->
+                                let uu___3 = __tc e tm in
+                                FStar_Tactics_Monad.bind uu___3
+                                  (fun uu___4 ->
+                                     match uu___4 with
+                                     | (tm1, typ, guard) ->
+                                         let typ1 = bnorm e typ in
+                                         let uu___5 =
+                                           let uu___6 =
+                                             FStar_Tactics_Types.goal_type
+                                               goal in
+                                           try_unify_by_application
+                                             only_match e typ1 uu___6
+                                             (rangeof goal) in
+                                         FStar_Tactics_Monad.bind uu___5
+                                           (fun uvs ->
+                                              FStar_Tactics_Monad.mlog
+                                                (fun uu___6 ->
                                                    let uu___7 =
-                                                     FStar_Syntax_Free.new_uv_set
-                                                       () in
-                                                   FStar_Compiler_List.fold_right
-                                                     (fun uu___8 ->
-                                                        fun s ->
+                                                     FStar_Common.string_of_list
+                                                       (fun uu___8 ->
                                                           match uu___8 with
-                                                          | (uu___9, uu___10,
-                                                             uv) ->
-                                                              let uu___11 =
-                                                                FStar_Syntax_Free.uvars
-                                                                  uv.FStar_Syntax_Syntax.ctx_uvar_typ in
-                                                              FStar_Compiler_Util.set_union
-                                                                s uu___11)
-                                                     uvs uu___7 in
-                                                 let free_in_some_goal uv =
-                                                   FStar_Compiler_Util.set_mem
-                                                     uv uvset in
-                                                 let uu___7 = solve' goal w in
-                                                 FStar_Tactics_Monad.bind
-                                                   uu___7
-                                                   (fun uu___8 ->
-                                                      let uu___9 =
-                                                        let uu___10 =
-                                                          FStar_Compiler_Effect.op_Bar_Greater
-                                                            uvs
-                                                            (FStar_Compiler_List.map
-                                                               (fun uu___11
-                                                                  ->
-                                                                  match uu___11
-                                                                  with
-                                                                  | (uvt, _q,
+                                                          | (t, uu___9,
+                                                             uu___10) ->
+                                                              FStar_Syntax_Print.term_to_string
+                                                                t) uvs in
+                                                   FStar_Compiler_Util.print1
+                                                     "t_apply: found args = %s\n"
+                                                     uu___7)
+                                                (fun uu___6 ->
+                                                   let w =
+                                                     FStar_Compiler_List.fold_right
+                                                       (fun uu___7 ->
+                                                          fun w1 ->
+                                                            match uu___7 with
+                                                            | (uvt, q,
+                                                               uu___8) ->
+                                                                FStar_Syntax_Util.mk_app
+                                                                  w1
+                                                                  [(uvt, q)])
+                                                       uvs tm1 in
+                                                   let uvset =
+                                                     let uu___7 =
+                                                       FStar_Syntax_Free.new_uv_set
+                                                         () in
+                                                     FStar_Compiler_List.fold_right
+                                                       (fun uu___8 ->
+                                                          fun s ->
+                                                            match uu___8 with
+                                                            | (uu___9,
+                                                               uu___10, uv)
+                                                                ->
+                                                                let uu___11 =
+                                                                  FStar_Syntax_Free.uvars
+                                                                    uv.FStar_Syntax_Syntax.ctx_uvar_typ in
+                                                                FStar_Compiler_Util.set_union
+                                                                  s uu___11)
+                                                       uvs uu___7 in
+                                                   let free_in_some_goal uv =
+                                                     FStar_Compiler_Util.set_mem
+                                                       uv uvset in
+                                                   let uu___7 = solve' goal w in
+                                                   FStar_Tactics_Monad.bind
+                                                     uu___7
+                                                     (fun uu___8 ->
+                                                        let uu___9 =
+                                                          let uu___10 =
+                                                            FStar_Compiler_Effect.op_Bar_Greater
+                                                              uvs
+                                                              (FStar_Compiler_List.map
+                                                                 (fun uu___11
+                                                                    ->
+                                                                    match uu___11
+                                                                    with
+                                                                    | 
+                                                                    (uvt, _q,
                                                                     uv) ->
                                                                     (uvt, uv))) in
-                                                        FStar_Compiler_Effect.op_Bar_Greater
-                                                          uu___10
-                                                          (let must_tot =
-                                                             true in
-                                                           check_apply_implicits_solutions
-                                                             e goal
-                                                             ps.FStar_Tactics_Types.tac_verb_dbg
-                                                             "apply" must_tot) in
-                                                      FStar_Tactics_Monad.bind
-                                                        uu___9
-                                                        (fun subgoals ->
-                                                           let uu___10 =
-                                                             let uu___11 =
-                                                               let uu___12 =
+                                                          FStar_Compiler_Effect.op_Bar_Greater
+                                                            uu___10
+                                                            (if
+                                                               tc_resolved_uvars
+                                                             then
+                                                               let must_tot =
+                                                                 true in
+                                                               check_apply_implicits_solutions
+                                                                 e goal
+                                                                 ps.FStar_Tactics_Types.tac_verb_dbg
+                                                                 "apply"
+                                                                 must_tot
+                                                             else
+                                                               (fun l ->
+                                                                  let uu___12
+                                                                    =
+                                                                    FStar_Compiler_Effect.op_Bar_Greater
+                                                                    l
+                                                                    (FStar_Compiler_List.map
+                                                                    (fun
+                                                                    uu___13
+                                                                    ->
+                                                                    match uu___13
+                                                                    with
+                                                                    | 
+                                                                    (uu___14,
+                                                                    uv) ->
+                                                                    let uu___15
+                                                                    =
+                                                                    FStar_Syntax_Unionfind.find
+                                                                    uv.FStar_Syntax_Syntax.ctx_uvar_head in
+                                                                    (match uu___15
+                                                                    with
+                                                                    | 
+                                                                    FStar_Pervasives_Native.Some
+                                                                    uu___16
+                                                                    -> []
+                                                                    | 
+                                                                    FStar_Pervasives_Native.None
+                                                                    ->
+                                                                    [
+                                                                    {
+                                                                    FStar_Tactics_Types.goal_main_env
+                                                                    =
+                                                                    (goal.FStar_Tactics_Types.goal_main_env);
+                                                                    FStar_Tactics_Types.goal_ctx_uvar
+                                                                    = uv;
+                                                                    FStar_Tactics_Types.opts
+                                                                    =
+                                                                    (goal.FStar_Tactics_Types.opts);
+                                                                    FStar_Tactics_Types.is_guard
+                                                                    = false;
+                                                                    FStar_Tactics_Types.label
+                                                                    =
+                                                                    (goal.FStar_Tactics_Types.label)
+                                                                    }]))) in
+                                                                  FStar_Compiler_Effect.op_Bar_Greater
+                                                                    uu___12
+                                                                    FStar_Tactics_Monad.ret)) in
+                                                        FStar_Tactics_Monad.bind
+                                                          uu___9
+                                                          (fun subgoals ->
+                                                             let uu___10 =
+                                                               let uu___11 =
+                                                                 let uu___12
+                                                                   =
+                                                                   FStar_Compiler_Effect.op_Bar_Greater
+                                                                    subgoals
+                                                                    FStar_Compiler_List.flatten in
                                                                  FStar_Compiler_Effect.op_Bar_Greater
-                                                                   subgoals
-                                                                   FStar_Compiler_List.flatten in
-                                                               FStar_Compiler_Effect.op_Bar_Greater
-                                                                 uu___12
-                                                                 (FStar_Compiler_List.filter
-                                                                    (
-                                                                    fun g ->
+                                                                   uu___12
+                                                                   (FStar_Compiler_List.filter
+                                                                    (fun g ->
                                                                     let uu___13
                                                                     =
                                                                     uopt &&
@@ -2572,39 +2636,26 @@ let (t_apply :
                                                                     g.FStar_Tactics_Types.goal_ctx_uvar) in
                                                                     Prims.op_Negation
                                                                     uu___13)) in
-                                                             FStar_Compiler_Effect.op_Bar_Greater
-                                                               uu___11
-                                                               (FStar_Tactics_Monad.mapM
-                                                                  (fun g ->
-                                                                    bnorm_goal
-                                                                    {
-                                                                    FStar_Tactics_Types.goal_main_env
-                                                                    =
-                                                                    (g.FStar_Tactics_Types.goal_main_env);
-                                                                    FStar_Tactics_Types.goal_ctx_uvar
-                                                                    =
-                                                                    (g.FStar_Tactics_Types.goal_ctx_uvar);
-                                                                    FStar_Tactics_Types.opts
-                                                                    =
-                                                                    (g.FStar_Tactics_Types.opts);
-                                                                    FStar_Tactics_Types.is_guard
-                                                                    = false;
-                                                                    FStar_Tactics_Types.label
-                                                                    =
-                                                                    (g.FStar_Tactics_Types.label)
-                                                                    })) in
-                                                           FStar_Tactics_Monad.bind
-                                                             uu___10
-                                                             (fun subgoals1
-                                                                ->
-                                                                let uu___11 =
-                                                                  FStar_Tactics_Monad.add_goals
+                                                               FStar_Compiler_Effect.op_Bar_Greater
+                                                                 uu___11
+                                                                 (FStar_Tactics_Monad.mapM
                                                                     (
-                                                                    FStar_Compiler_List.rev
+                                                                    fun g ->
+                                                                    bnorm_goal
+                                                                    g)) in
+                                                             FStar_Tactics_Monad.bind
+                                                               uu___10
+                                                               (fun subgoals1
+                                                                  ->
+                                                                  let uu___11
+                                                                    =
+                                                                    FStar_Tactics_Monad.add_goals
+                                                                    (FStar_Compiler_List.rev
                                                                     subgoals1) in
-                                                                FStar_Tactics_Monad.bind
-                                                                  uu___11
-                                                                  (fun
+                                                                  FStar_Tactics_Monad.bind
+                                                                    uu___11
+                                                                    (
+                                                                    fun
                                                                     uu___12
                                                                     ->
                                                                     proc_guard
@@ -2612,8 +2663,8 @@ let (t_apply :
                                                                     e guard
                                                                     (rangeof
                                                                     goal)))))))))))) in
-        FStar_Compiler_Effect.op_Less_Bar
-          (FStar_Tactics_Monad.wrap_err "apply") uu___
+          FStar_Compiler_Effect.op_Less_Bar
+            (FStar_Tactics_Monad.wrap_err "apply") uu___
 let (lemma_or_sq :
   FStar_Syntax_Syntax.comp ->
     (FStar_Syntax_Syntax.term * FStar_Syntax_Syntax.term)

--- a/src/ocaml-output/FStar_Tactics_Basic.ml
+++ b/src/ocaml-output/FStar_Tactics_Basic.ml
@@ -1245,136 +1245,150 @@ let with_policy :
                      let uu___3 = set_guard_policy old_pol in
                      FStar_Tactics_Monad.bind uu___3
                        (fun uu___4 -> FStar_Tactics_Monad.ret r))))
+let (proc_guard' :
+  Prims.bool ->
+    Prims.string ->
+      env ->
+        FStar_TypeChecker_Common.guard_t ->
+          FStar_Compiler_Range.range -> unit FStar_Tactics_Monad.tac)
+  =
+  fun simplify ->
+    fun reason ->
+      fun e ->
+        fun g ->
+          fun rng ->
+            FStar_Tactics_Monad.mlog
+              (fun uu___ ->
+                 let uu___1 = FStar_TypeChecker_Rel.guard_to_string e g in
+                 FStar_Compiler_Util.print2 "Processing guard (%s:%s)\n"
+                   reason uu___1)
+              (fun uu___ ->
+                 let uu___1 =
+                   FStar_Tactics_Monad.add_implicits
+                     g.FStar_TypeChecker_Common.implicits in
+                 FStar_Tactics_Monad.bind uu___1
+                   (fun uu___2 ->
+                      let guard_f =
+                        if simplify
+                        then
+                          let uu___3 =
+                            FStar_TypeChecker_Rel.simplify_guard e g in
+                          uu___3.FStar_TypeChecker_Common.guard_f
+                        else g.FStar_TypeChecker_Common.guard_f in
+                      match guard_f with
+                      | FStar_TypeChecker_Common.Trivial ->
+                          FStar_Tactics_Monad.ret ()
+                      | FStar_TypeChecker_Common.NonTrivial f ->
+                          FStar_Tactics_Monad.bind FStar_Tactics_Monad.get
+                            (fun ps ->
+                               match ps.FStar_Tactics_Types.guard_policy with
+                               | FStar_Tactics_Types.Drop ->
+                                   ((let uu___4 =
+                                       let uu___5 =
+                                         let uu___6 =
+                                           FStar_TypeChecker_Rel.guard_to_string
+                                             e g in
+                                         FStar_Compiler_Util.format1
+                                           "Tactics admitted guard <%s>\n\n"
+                                           uu___6 in
+                                       (FStar_Errors.Warning_TacAdmit,
+                                         uu___5) in
+                                     FStar_Errors.log_issue
+                                       e.FStar_TypeChecker_Env.range uu___4);
+                                    FStar_Tactics_Monad.ret ())
+                               | FStar_Tactics_Types.Goal ->
+                                   FStar_Tactics_Monad.mlog
+                                     (fun uu___3 ->
+                                        let uu___4 =
+                                          FStar_TypeChecker_Rel.guard_to_string
+                                            e g in
+                                        FStar_Compiler_Util.print2
+                                          "Making guard (%s:%s) into a goal\n"
+                                          reason uu___4)
+                                     (fun uu___3 ->
+                                        let uu___4 =
+                                          FStar_Tactics_Monad.goal_of_guard
+                                            reason e f rng in
+                                        FStar_Tactics_Monad.bind uu___4
+                                          (fun g1 ->
+                                             FStar_Tactics_Monad.push_goals
+                                               [g1]))
+                               | FStar_Tactics_Types.SMT ->
+                                   FStar_Tactics_Monad.mlog
+                                     (fun uu___3 ->
+                                        let uu___4 =
+                                          FStar_TypeChecker_Rel.guard_to_string
+                                            e g in
+                                        FStar_Compiler_Util.print2
+                                          "Sending guard (%s:%s) to SMT goal\n"
+                                          reason uu___4)
+                                     (fun uu___3 ->
+                                        let uu___4 =
+                                          FStar_Tactics_Monad.goal_of_guard
+                                            reason e f rng in
+                                        FStar_Tactics_Monad.bind uu___4
+                                          (fun g1 ->
+                                             FStar_Tactics_Monad.push_smt_goals
+                                               [g1]))
+                               | FStar_Tactics_Types.Force ->
+                                   FStar_Tactics_Monad.mlog
+                                     (fun uu___3 ->
+                                        let uu___4 =
+                                          FStar_TypeChecker_Rel.guard_to_string
+                                            e g in
+                                        FStar_Compiler_Util.print2
+                                          "Forcing guard (%s:%s)\n" reason
+                                          uu___4)
+                                     (fun uu___3 ->
+                                        try
+                                          (fun uu___4 ->
+                                             match () with
+                                             | () ->
+                                                 let uu___5 =
+                                                   let uu___6 =
+                                                     let uu___7 =
+                                                       FStar_TypeChecker_Rel.discharge_guard_no_smt
+                                                         e g in
+                                                     FStar_Compiler_Effect.op_Less_Bar
+                                                       FStar_TypeChecker_Env.is_trivial
+                                                       uu___7 in
+                                                   Prims.op_Negation uu___6 in
+                                                 if uu___5
+                                                 then
+                                                   FStar_Tactics_Monad.mlog
+                                                     (fun uu___6 ->
+                                                        let uu___7 =
+                                                          FStar_TypeChecker_Rel.guard_to_string
+                                                            e g in
+                                                        FStar_Compiler_Util.print1
+                                                          "guard = %s\n"
+                                                          uu___7)
+                                                     (fun uu___6 ->
+                                                        fail1
+                                                          "Forcing the guard failed (%s)"
+                                                          reason)
+                                                 else
+                                                   FStar_Tactics_Monad.ret ())
+                                            ()
+                                        with
+                                        | uu___4 ->
+                                            FStar_Tactics_Monad.mlog
+                                              (fun uu___5 ->
+                                                 let uu___6 =
+                                                   FStar_TypeChecker_Rel.guard_to_string
+                                                     e g in
+                                                 FStar_Compiler_Util.print1
+                                                   "guard = %s\n" uu___6)
+                                              (fun uu___5 ->
+                                                 fail1
+                                                   "Forcing the guard failed (%s)"
+                                                   reason)))))
 let (proc_guard :
   Prims.string ->
     env ->
       FStar_TypeChecker_Common.guard_t ->
         FStar_Compiler_Range.range -> unit FStar_Tactics_Monad.tac)
-  =
-  fun reason ->
-    fun e ->
-      fun g ->
-        fun rng ->
-          FStar_Tactics_Monad.mlog
-            (fun uu___ ->
-               let uu___1 = FStar_TypeChecker_Rel.guard_to_string e g in
-               FStar_Compiler_Util.print2 "Processing guard (%s:%s)\n" reason
-                 uu___1)
-            (fun uu___ ->
-               let uu___1 =
-                 FStar_Tactics_Monad.add_implicits
-                   g.FStar_TypeChecker_Common.implicits in
-               FStar_Tactics_Monad.bind uu___1
-                 (fun uu___2 ->
-                    let uu___3 =
-                      let uu___4 = FStar_TypeChecker_Rel.simplify_guard e g in
-                      uu___4.FStar_TypeChecker_Common.guard_f in
-                    match uu___3 with
-                    | FStar_TypeChecker_Common.Trivial ->
-                        FStar_Tactics_Monad.ret ()
-                    | FStar_TypeChecker_Common.NonTrivial f ->
-                        FStar_Tactics_Monad.bind FStar_Tactics_Monad.get
-                          (fun ps ->
-                             match ps.FStar_Tactics_Types.guard_policy with
-                             | FStar_Tactics_Types.Drop ->
-                                 ((let uu___5 =
-                                     let uu___6 =
-                                       let uu___7 =
-                                         FStar_TypeChecker_Rel.guard_to_string
-                                           e g in
-                                       FStar_Compiler_Util.format1
-                                         "Tactics admitted guard <%s>\n\n"
-                                         uu___7 in
-                                     (FStar_Errors.Warning_TacAdmit, uu___6) in
-                                   FStar_Errors.log_issue
-                                     e.FStar_TypeChecker_Env.range uu___5);
-                                  FStar_Tactics_Monad.ret ())
-                             | FStar_Tactics_Types.Goal ->
-                                 FStar_Tactics_Monad.mlog
-                                   (fun uu___4 ->
-                                      let uu___5 =
-                                        FStar_TypeChecker_Rel.guard_to_string
-                                          e g in
-                                      FStar_Compiler_Util.print2
-                                        "Making guard (%s:%s) into a goal\n"
-                                        reason uu___5)
-                                   (fun uu___4 ->
-                                      let uu___5 =
-                                        FStar_Tactics_Monad.goal_of_guard
-                                          reason e f rng in
-                                      FStar_Tactics_Monad.bind uu___5
-                                        (fun g1 ->
-                                           FStar_Tactics_Monad.push_goals
-                                             [g1]))
-                             | FStar_Tactics_Types.SMT ->
-                                 FStar_Tactics_Monad.mlog
-                                   (fun uu___4 ->
-                                      let uu___5 =
-                                        FStar_TypeChecker_Rel.guard_to_string
-                                          e g in
-                                      FStar_Compiler_Util.print2
-                                        "Sending guard (%s:%s) to SMT goal\n"
-                                        reason uu___5)
-                                   (fun uu___4 ->
-                                      let uu___5 =
-                                        FStar_Tactics_Monad.goal_of_guard
-                                          reason e f rng in
-                                      FStar_Tactics_Monad.bind uu___5
-                                        (fun g1 ->
-                                           FStar_Tactics_Monad.push_smt_goals
-                                             [g1]))
-                             | FStar_Tactics_Types.Force ->
-                                 FStar_Tactics_Monad.mlog
-                                   (fun uu___4 ->
-                                      let uu___5 =
-                                        FStar_TypeChecker_Rel.guard_to_string
-                                          e g in
-                                      FStar_Compiler_Util.print2
-                                        "Forcing guard (%s:%s)\n" reason
-                                        uu___5)
-                                   (fun uu___4 ->
-                                      try
-                                        (fun uu___5 ->
-                                           match () with
-                                           | () ->
-                                               let uu___6 =
-                                                 let uu___7 =
-                                                   let uu___8 =
-                                                     FStar_TypeChecker_Rel.discharge_guard_no_smt
-                                                       e g in
-                                                   FStar_Compiler_Effect.op_Less_Bar
-                                                     FStar_TypeChecker_Env.is_trivial
-                                                     uu___8 in
-                                                 Prims.op_Negation uu___7 in
-                                               if uu___6
-                                               then
-                                                 FStar_Tactics_Monad.mlog
-                                                   (fun uu___7 ->
-                                                      let uu___8 =
-                                                        FStar_TypeChecker_Rel.guard_to_string
-                                                          e g in
-                                                      FStar_Compiler_Util.print1
-                                                        "guard = %s\n" uu___8)
-                                                   (fun uu___7 ->
-                                                      fail1
-                                                        "Forcing the guard failed (%s)"
-                                                        reason)
-                                               else
-                                                 FStar_Tactics_Monad.ret ())
-                                          ()
-                                      with
-                                      | uu___5 ->
-                                          FStar_Tactics_Monad.mlog
-                                            (fun uu___6 ->
-                                               let uu___7 =
-                                                 FStar_TypeChecker_Rel.guard_to_string
-                                                   e g in
-                                               FStar_Compiler_Util.print1
-                                                 "guard = %s\n" uu___7)
-                                            (fun uu___6 ->
-                                               fail1
-                                                 "Forcing the guard failed (%s)"
-                                                 reason)))))
+  = proc_guard' true
 let (tcc :
   env ->
     FStar_Syntax_Syntax.term ->
@@ -2123,210 +2137,225 @@ let (try_unify_by_application :
         fun ty2 ->
           fun rng -> __try_unify_by_application only_match [] e ty1 ty2 rng
 let (check_apply_implicits_solutions :
-  FStar_TypeChecker_Env.env ->
-    FStar_Tactics_Types.goal ->
-      Prims.bool ->
-        Prims.string ->
-          Prims.bool ->
-            (FStar_Syntax_Syntax.term * FStar_Syntax_Syntax.ctx_uvar)
-              Prims.list ->
-              FStar_Tactics_Types.goal Prims.list Prims.list
-                FStar_Tactics_Monad.tac)
+  Prims.bool ->
+    FStar_TypeChecker_Env.env ->
+      FStar_Tactics_Types.goal FStar_Pervasives_Native.option ->
+        Prims.bool ->
+          Prims.string ->
+            Prims.bool ->
+              (FStar_Syntax_Syntax.term * FStar_Syntax_Syntax.ctx_uvar)
+                Prims.list ->
+                FStar_Tactics_Types.goal Prims.list Prims.list
+                  FStar_Tactics_Monad.tac)
   =
-  fun env1 ->
-    fun gl ->
-      fun debug_on ->
-        fun debug_prefix ->
-          fun must_tot ->
-            fun imps ->
-              let check_implicits_solution env2 t k must_tot1 =
-                let env3 =
-                  FStar_TypeChecker_Env.set_expected_typ
-                    {
-                      FStar_TypeChecker_Env.solver =
-                        (env2.FStar_TypeChecker_Env.solver);
-                      FStar_TypeChecker_Env.range =
-                        (env2.FStar_TypeChecker_Env.range);
-                      FStar_TypeChecker_Env.curmodule =
-                        (env2.FStar_TypeChecker_Env.curmodule);
-                      FStar_TypeChecker_Env.gamma =
-                        (env2.FStar_TypeChecker_Env.gamma);
-                      FStar_TypeChecker_Env.gamma_sig =
-                        (env2.FStar_TypeChecker_Env.gamma_sig);
-                      FStar_TypeChecker_Env.gamma_cache =
-                        (env2.FStar_TypeChecker_Env.gamma_cache);
-                      FStar_TypeChecker_Env.modules =
-                        (env2.FStar_TypeChecker_Env.modules);
-                      FStar_TypeChecker_Env.expected_typ =
-                        (env2.FStar_TypeChecker_Env.expected_typ);
-                      FStar_TypeChecker_Env.sigtab =
-                        (env2.FStar_TypeChecker_Env.sigtab);
-                      FStar_TypeChecker_Env.attrtab =
-                        (env2.FStar_TypeChecker_Env.attrtab);
-                      FStar_TypeChecker_Env.instantiate_imp =
-                        (env2.FStar_TypeChecker_Env.instantiate_imp);
-                      FStar_TypeChecker_Env.effects =
-                        (env2.FStar_TypeChecker_Env.effects);
-                      FStar_TypeChecker_Env.generalize =
-                        (env2.FStar_TypeChecker_Env.generalize);
-                      FStar_TypeChecker_Env.letrecs =
-                        (env2.FStar_TypeChecker_Env.letrecs);
-                      FStar_TypeChecker_Env.top_level =
-                        (env2.FStar_TypeChecker_Env.top_level);
-                      FStar_TypeChecker_Env.check_uvars =
-                        (env2.FStar_TypeChecker_Env.check_uvars);
-                      FStar_TypeChecker_Env.use_eq_strict =
-                        (env2.FStar_TypeChecker_Env.use_eq_strict);
-                      FStar_TypeChecker_Env.is_iface =
-                        (env2.FStar_TypeChecker_Env.is_iface);
-                      FStar_TypeChecker_Env.admit =
-                        (env2.FStar_TypeChecker_Env.admit);
-                      FStar_TypeChecker_Env.lax =
-                        (env2.FStar_TypeChecker_Env.lax);
-                      FStar_TypeChecker_Env.lax_universes =
-                        (env2.FStar_TypeChecker_Env.lax_universes);
-                      FStar_TypeChecker_Env.phase1 =
-                        (env2.FStar_TypeChecker_Env.phase1);
-                      FStar_TypeChecker_Env.failhard =
-                        (env2.FStar_TypeChecker_Env.failhard);
-                      FStar_TypeChecker_Env.nosynth =
-                        (env2.FStar_TypeChecker_Env.nosynth);
-                      FStar_TypeChecker_Env.uvar_subtyping =
-                        (env2.FStar_TypeChecker_Env.uvar_subtyping);
-                      FStar_TypeChecker_Env.tc_term =
-                        (env2.FStar_TypeChecker_Env.tc_term);
-                      FStar_TypeChecker_Env.typeof_tot_or_gtot_term =
-                        (env2.FStar_TypeChecker_Env.typeof_tot_or_gtot_term);
-                      FStar_TypeChecker_Env.universe_of =
-                        (env2.FStar_TypeChecker_Env.universe_of);
-                      FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term
-                        =
-                        (env2.FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term);
-                      FStar_TypeChecker_Env.subtype_nosmt_force =
-                        (env2.FStar_TypeChecker_Env.subtype_nosmt_force);
-                      FStar_TypeChecker_Env.use_bv_sorts = true;
-                      FStar_TypeChecker_Env.qtbl_name_and_index =
-                        (env2.FStar_TypeChecker_Env.qtbl_name_and_index);
-                      FStar_TypeChecker_Env.normalized_eff_names =
-                        (env2.FStar_TypeChecker_Env.normalized_eff_names);
-                      FStar_TypeChecker_Env.fv_delta_depths =
-                        (env2.FStar_TypeChecker_Env.fv_delta_depths);
-                      FStar_TypeChecker_Env.proof_ns =
-                        (env2.FStar_TypeChecker_Env.proof_ns);
-                      FStar_TypeChecker_Env.synth_hook =
-                        (env2.FStar_TypeChecker_Env.synth_hook);
-                      FStar_TypeChecker_Env.try_solve_implicits_hook =
-                        (env2.FStar_TypeChecker_Env.try_solve_implicits_hook);
-                      FStar_TypeChecker_Env.splice =
-                        (env2.FStar_TypeChecker_Env.splice);
-                      FStar_TypeChecker_Env.mpreprocess =
-                        (env2.FStar_TypeChecker_Env.mpreprocess);
-                      FStar_TypeChecker_Env.postprocess =
-                        (env2.FStar_TypeChecker_Env.postprocess);
-                      FStar_TypeChecker_Env.identifier_info =
-                        (env2.FStar_TypeChecker_Env.identifier_info);
-                      FStar_TypeChecker_Env.tc_hooks =
-                        (env2.FStar_TypeChecker_Env.tc_hooks);
-                      FStar_TypeChecker_Env.dsenv =
-                        (env2.FStar_TypeChecker_Env.dsenv);
-                      FStar_TypeChecker_Env.nbe =
-                        (env2.FStar_TypeChecker_Env.nbe);
-                      FStar_TypeChecker_Env.strict_args_tab =
-                        (env2.FStar_TypeChecker_Env.strict_args_tab);
-                      FStar_TypeChecker_Env.erasable_types_tab =
-                        (env2.FStar_TypeChecker_Env.erasable_types_tab);
-                      FStar_TypeChecker_Env.enable_defer_to_tac =
-                        (env2.FStar_TypeChecker_Env.enable_defer_to_tac);
-                      FStar_TypeChecker_Env.unif_allow_ref_guards =
-                        (env2.FStar_TypeChecker_Env.unif_allow_ref_guards);
-                      FStar_TypeChecker_Env.erase_erasable_args =
-                        (env2.FStar_TypeChecker_Env.erase_erasable_args)
-                    } k in
-                let slow_path uu___ =
-                  let uu___1 =
-                    FStar_TypeChecker_TcTerm.typeof_tot_or_gtot_term env3 t
-                      must_tot1 in
-                  match uu___1 with | (uu___2, uu___3, g) -> g in
-                let uu___ =
-                  FStar_TypeChecker_TcTerm.typeof_tot_or_gtot_term_fastpath
-                    env3 t must_tot1 in
-                match uu___ with
-                | FStar_Pervasives_Native.None -> slow_path ()
-                | FStar_Pervasives_Native.Some k' ->
+  fun simplify_guard ->
+    fun env1 ->
+      fun gl ->
+        fun debug_on ->
+          fun debug_prefix ->
+            fun must_tot ->
+              fun imps ->
+                let check_implicits_solution env2 t k must_tot1 =
+                  let env3 =
+                    FStar_TypeChecker_Env.set_expected_typ
+                      {
+                        FStar_TypeChecker_Env.solver =
+                          (env2.FStar_TypeChecker_Env.solver);
+                        FStar_TypeChecker_Env.range =
+                          (env2.FStar_TypeChecker_Env.range);
+                        FStar_TypeChecker_Env.curmodule =
+                          (env2.FStar_TypeChecker_Env.curmodule);
+                        FStar_TypeChecker_Env.gamma =
+                          (env2.FStar_TypeChecker_Env.gamma);
+                        FStar_TypeChecker_Env.gamma_sig =
+                          (env2.FStar_TypeChecker_Env.gamma_sig);
+                        FStar_TypeChecker_Env.gamma_cache =
+                          (env2.FStar_TypeChecker_Env.gamma_cache);
+                        FStar_TypeChecker_Env.modules =
+                          (env2.FStar_TypeChecker_Env.modules);
+                        FStar_TypeChecker_Env.expected_typ =
+                          (env2.FStar_TypeChecker_Env.expected_typ);
+                        FStar_TypeChecker_Env.sigtab =
+                          (env2.FStar_TypeChecker_Env.sigtab);
+                        FStar_TypeChecker_Env.attrtab =
+                          (env2.FStar_TypeChecker_Env.attrtab);
+                        FStar_TypeChecker_Env.instantiate_imp =
+                          (env2.FStar_TypeChecker_Env.instantiate_imp);
+                        FStar_TypeChecker_Env.effects =
+                          (env2.FStar_TypeChecker_Env.effects);
+                        FStar_TypeChecker_Env.generalize =
+                          (env2.FStar_TypeChecker_Env.generalize);
+                        FStar_TypeChecker_Env.letrecs =
+                          (env2.FStar_TypeChecker_Env.letrecs);
+                        FStar_TypeChecker_Env.top_level =
+                          (env2.FStar_TypeChecker_Env.top_level);
+                        FStar_TypeChecker_Env.check_uvars =
+                          (env2.FStar_TypeChecker_Env.check_uvars);
+                        FStar_TypeChecker_Env.use_eq_strict =
+                          (env2.FStar_TypeChecker_Env.use_eq_strict);
+                        FStar_TypeChecker_Env.is_iface =
+                          (env2.FStar_TypeChecker_Env.is_iface);
+                        FStar_TypeChecker_Env.admit =
+                          (env2.FStar_TypeChecker_Env.admit);
+                        FStar_TypeChecker_Env.lax =
+                          (env2.FStar_TypeChecker_Env.lax);
+                        FStar_TypeChecker_Env.lax_universes =
+                          (env2.FStar_TypeChecker_Env.lax_universes);
+                        FStar_TypeChecker_Env.phase1 =
+                          (env2.FStar_TypeChecker_Env.phase1);
+                        FStar_TypeChecker_Env.failhard =
+                          (env2.FStar_TypeChecker_Env.failhard);
+                        FStar_TypeChecker_Env.nosynth =
+                          (env2.FStar_TypeChecker_Env.nosynth);
+                        FStar_TypeChecker_Env.uvar_subtyping =
+                          (env2.FStar_TypeChecker_Env.uvar_subtyping);
+                        FStar_TypeChecker_Env.tc_term =
+                          (env2.FStar_TypeChecker_Env.tc_term);
+                        FStar_TypeChecker_Env.typeof_tot_or_gtot_term =
+                          (env2.FStar_TypeChecker_Env.typeof_tot_or_gtot_term);
+                        FStar_TypeChecker_Env.universe_of =
+                          (env2.FStar_TypeChecker_Env.universe_of);
+                        FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term
+                          =
+                          (env2.FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term);
+                        FStar_TypeChecker_Env.subtype_nosmt_force =
+                          (env2.FStar_TypeChecker_Env.subtype_nosmt_force);
+                        FStar_TypeChecker_Env.use_bv_sorts = true;
+                        FStar_TypeChecker_Env.qtbl_name_and_index =
+                          (env2.FStar_TypeChecker_Env.qtbl_name_and_index);
+                        FStar_TypeChecker_Env.normalized_eff_names =
+                          (env2.FStar_TypeChecker_Env.normalized_eff_names);
+                        FStar_TypeChecker_Env.fv_delta_depths =
+                          (env2.FStar_TypeChecker_Env.fv_delta_depths);
+                        FStar_TypeChecker_Env.proof_ns =
+                          (env2.FStar_TypeChecker_Env.proof_ns);
+                        FStar_TypeChecker_Env.synth_hook =
+                          (env2.FStar_TypeChecker_Env.synth_hook);
+                        FStar_TypeChecker_Env.try_solve_implicits_hook =
+                          (env2.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                        FStar_TypeChecker_Env.splice =
+                          (env2.FStar_TypeChecker_Env.splice);
+                        FStar_TypeChecker_Env.mpreprocess =
+                          (env2.FStar_TypeChecker_Env.mpreprocess);
+                        FStar_TypeChecker_Env.postprocess =
+                          (env2.FStar_TypeChecker_Env.postprocess);
+                        FStar_TypeChecker_Env.identifier_info =
+                          (env2.FStar_TypeChecker_Env.identifier_info);
+                        FStar_TypeChecker_Env.tc_hooks =
+                          (env2.FStar_TypeChecker_Env.tc_hooks);
+                        FStar_TypeChecker_Env.dsenv =
+                          (env2.FStar_TypeChecker_Env.dsenv);
+                        FStar_TypeChecker_Env.nbe =
+                          (env2.FStar_TypeChecker_Env.nbe);
+                        FStar_TypeChecker_Env.strict_args_tab =
+                          (env2.FStar_TypeChecker_Env.strict_args_tab);
+                        FStar_TypeChecker_Env.erasable_types_tab =
+                          (env2.FStar_TypeChecker_Env.erasable_types_tab);
+                        FStar_TypeChecker_Env.enable_defer_to_tac =
+                          (env2.FStar_TypeChecker_Env.enable_defer_to_tac);
+                        FStar_TypeChecker_Env.unif_allow_ref_guards =
+                          (env2.FStar_TypeChecker_Env.unif_allow_ref_guards);
+                        FStar_TypeChecker_Env.erase_erasable_args =
+                          (env2.FStar_TypeChecker_Env.erase_erasable_args)
+                      } k in
+                  let slow_path uu___ =
                     let uu___1 =
-                      FStar_TypeChecker_Rel.subtype_nosmt env3 k' k in
-                    (match uu___1 with
-                     | FStar_Pervasives_Native.None -> slow_path ()
-                     | FStar_Pervasives_Native.Some g -> g) in
-              let check_one_implicit uu___ =
-                match uu___ with
-                | (term, ctx_uvar) ->
-                    let uu___1 = FStar_Syntax_Util.head_and_args term in
-                    (match uu___1 with
-                     | (hd, uu___2) ->
-                         let uu___3 =
-                           let uu___4 = FStar_Syntax_Subst.compress hd in
-                           uu___4.FStar_Syntax_Syntax.n in
-                         (match uu___3 with
-                          | FStar_Syntax_Syntax.Tm_uvar (ctx_uvar1, uu___4)
-                              ->
-                              let gl1 =
-                                bnorm_goal
-                                  {
-                                    FStar_Tactics_Types.goal_main_env =
-                                      (gl.FStar_Tactics_Types.goal_main_env);
-                                    FStar_Tactics_Types.goal_ctx_uvar =
-                                      ctx_uvar1;
-                                    FStar_Tactics_Types.opts =
-                                      (gl.FStar_Tactics_Types.opts);
-                                    FStar_Tactics_Types.is_guard =
-                                      (gl.FStar_Tactics_Types.is_guard);
-                                    FStar_Tactics_Types.label =
-                                      (gl.FStar_Tactics_Types.label)
-                                  } in
-                              FStar_Tactics_Monad.ret [gl1]
-                          | uu___4 ->
-                              FStar_Tactics_Monad.mlog
-                                (fun uu___5 ->
-                                   let uu___6 =
-                                     FStar_Syntax_Print.uvar_to_string
-                                       ctx_uvar.FStar_Syntax_Syntax.ctx_uvar_head in
-                                   let uu___7 =
-                                     FStar_Syntax_Print.term_to_string term in
-                                   FStar_Compiler_Util.print3
-                                     "%s: arg %s unified to (%s)\n"
-                                     debug_prefix uu___6 uu___7)
-                                (fun uu___5 ->
-                                   let g_typ =
+                      FStar_TypeChecker_TcTerm.typeof_tot_or_gtot_term env3 t
+                        must_tot1 in
+                    match uu___1 with | (uu___2, uu___3, g) -> g in
+                  let uu___ =
+                    FStar_TypeChecker_TcTerm.typeof_tot_or_gtot_term_fastpath
+                      env3 t must_tot1 in
+                  match uu___ with
+                  | FStar_Pervasives_Native.None -> slow_path ()
+                  | FStar_Pervasives_Native.Some k' ->
+                      let uu___1 =
+                        FStar_TypeChecker_Rel.subtype_nosmt env3 k' k in
+                      (match uu___1 with
+                       | FStar_Pervasives_Native.None -> slow_path ()
+                       | FStar_Pervasives_Native.Some g -> g) in
+                let check_one_implicit uu___ =
+                  match uu___ with
+                  | (term, ctx_uvar) ->
+                      let uu___1 = FStar_Syntax_Util.head_and_args term in
+                      (match uu___1 with
+                       | (hd, uu___2) ->
+                           let uu___3 =
+                             let uu___4 = FStar_Syntax_Subst.compress hd in
+                             uu___4.FStar_Syntax_Syntax.n in
+                           (match uu___3 with
+                            | FStar_Syntax_Syntax.Tm_uvar (ctx_uvar1, uu___4)
+                                ->
+                                let gl1 =
+                                  match gl with
+                                  | FStar_Pervasives_Native.None ->
+                                      let uu___5 = FStar_Options.peek () in
+                                      FStar_Tactics_Types.mk_goal env1
+                                        ctx_uvar1 uu___5 true
+                                        "goal for unsolved implicit"
+                                  | FStar_Pervasives_Native.Some gl2 ->
+                                      {
+                                        FStar_Tactics_Types.goal_main_env =
+                                          (gl2.FStar_Tactics_Types.goal_main_env);
+                                        FStar_Tactics_Types.goal_ctx_uvar =
+                                          ctx_uvar1;
+                                        FStar_Tactics_Types.opts =
+                                          (gl2.FStar_Tactics_Types.opts);
+                                        FStar_Tactics_Types.is_guard =
+                                          (gl2.FStar_Tactics_Types.is_guard);
+                                        FStar_Tactics_Types.label =
+                                          (gl2.FStar_Tactics_Types.label)
+                                      } in
+                                let gl2 = bnorm_goal gl1 in
+                                FStar_Tactics_Monad.ret [gl2]
+                            | uu___4 ->
+                                FStar_Tactics_Monad.mlog
+                                  (fun uu___5 ->
                                      let uu___6 =
-                                       FStar_Syntax_Util.ctx_uvar_typ
-                                         ctx_uvar in
-                                     check_implicits_solution env1 term
-                                       uu___6 must_tot in
-                                   let uu___6 =
+                                       FStar_Syntax_Print.uvar_to_string
+                                         ctx_uvar.FStar_Syntax_Syntax.ctx_uvar_head in
                                      let uu___7 =
-                                       if debug_on
-                                       then
-                                         let uu___8 =
-                                           FStar_Syntax_Print.ctx_uvar_to_string
-                                             ctx_uvar in
-                                         let uu___9 =
-                                           FStar_Syntax_Print.term_to_string
-                                             term in
-                                         FStar_Compiler_Util.format3
-                                           "%s solved arg %s to %s\n"
-                                           debug_prefix uu___8 uu___9
-                                       else
-                                         FStar_Compiler_Util.format1
-                                           "%s solved arg" debug_prefix in
-                                     proc_guard uu___7 env1 g_typ
-                                       (rangeof gl) in
-                                   FStar_Tactics_Monad.bind uu___6
-                                     (fun uu___7 ->
-                                        mark_uvar_as_allow_untyped ctx_uvar;
-                                        FStar_Tactics_Monad.ret [])))) in
-              FStar_Compiler_Effect.op_Bar_Greater imps
-                (FStar_Tactics_Monad.mapM check_one_implicit)
+                                       FStar_Syntax_Print.term_to_string term in
+                                     FStar_Compiler_Util.print3
+                                       "%s: arg %s unified to (%s)\n"
+                                       debug_prefix uu___6 uu___7)
+                                  (fun uu___5 ->
+                                     let g_typ =
+                                       let uu___6 =
+                                         FStar_Syntax_Util.ctx_uvar_typ
+                                           ctx_uvar in
+                                       check_implicits_solution env1 term
+                                         uu___6 must_tot in
+                                     let rng =
+                                       match gl with
+                                       | FStar_Pervasives_Native.None ->
+                                           ctx_uvar.FStar_Syntax_Syntax.ctx_uvar_range
+                                       | FStar_Pervasives_Native.Some gl1 ->
+                                           rangeof gl1 in
+                                     let uu___6 =
+                                       let uu___7 =
+                                         if debug_on
+                                         then
+                                           let uu___8 =
+                                             FStar_Syntax_Print.ctx_uvar_to_string
+                                               ctx_uvar in
+                                           let uu___9 =
+                                             FStar_Syntax_Print.term_to_string
+                                               term in
+                                           FStar_Compiler_Util.format3
+                                             "%s solved arg %s to %s\n"
+                                             debug_prefix uu___8 uu___9
+                                         else
+                                           FStar_Compiler_Util.format1
+                                             "%s solved arg" debug_prefix in
+                                       proc_guard' simplify_guard uu___7 env1
+                                         g_typ rng in
+                                     FStar_Tactics_Monad.bind uu___6
+                                       (fun uu___7 ->
+                                          mark_uvar_as_allow_untyped ctx_uvar;
+                                          FStar_Tactics_Monad.ret [])))) in
+                FStar_Compiler_Effect.op_Bar_Greater imps
+                  (FStar_Tactics_Monad.mapM check_one_implicit)
 let (t_apply :
   Prims.bool ->
     Prims.bool ->
@@ -2456,7 +2485,9 @@ let (t_apply :
                                                                let must_tot =
                                                                  true in
                                                                check_apply_implicits_solutions
-                                                                 e goal
+                                                                 true e
+                                                                 (FStar_Pervasives_Native.Some
+                                                                    goal)
                                                                  ps.FStar_Tactics_Types.tac_verb_dbg
                                                                  "apply"
                                                                  must_tot
@@ -2859,7 +2890,9 @@ let (t_apply_lemma :
                                                                     FStar_Compiler_Effect.op_Bar_Greater
                                                                     implicits2
                                                                     (check_apply_implicits_solutions
-                                                                    env1 goal
+                                                                    true env1
+                                                                    (FStar_Pervasives_Native.Some
+                                                                    goal)
                                                                     ps.FStar_Tactics_Types.tac_verb_dbg
                                                                     "apply_lemma"
                                                                     must_tot) in
@@ -5265,6 +5298,51 @@ let (t_destruct :
                                                   "not an inductive type")))))) in
     FStar_Compiler_Effect.op_Less_Bar
       (FStar_Tactics_Monad.wrap_err "destruct") uu___
+let (gather_explicit_guards_for_resolved_goals :
+  unit -> unit FStar_Tactics_Monad.tac) =
+  fun uu___ ->
+    let uu___1 =
+      let uu___2 =
+        FStar_Tactics_Monad.bind FStar_Tactics_Monad.get
+          (fun ps ->
+             let goals_of_resolved_implicits =
+               FStar_Compiler_List.filter_map
+                 (fun i ->
+                    let uu___3 =
+                      (FStar_TypeChecker_Rel.is_implicit_resolved
+                         ps.FStar_Tactics_Types.main_context i)
+                        &&
+                        (let uu___4 =
+                           FStar_TypeChecker_Rel.check_implicit_solution_for_tac
+                             ps.FStar_Tactics_Types.main_context i in
+                         FStar_Pervasives_Native.uu___is_Some uu___4) in
+                    if uu___3
+                    then
+                      let g =
+                        FStar_Tactics_Types.goal_of_implicit
+                          ps.FStar_Tactics_Types.main_context i in
+                      let uu___4 =
+                        let uu___5 = FStar_Tactics_Types.goal_witness g in
+                        (uu___5, (g.FStar_Tactics_Types.goal_ctx_uvar)) in
+                      FStar_Pervasives_Native.Some uu___4
+                    else FStar_Pervasives_Native.None)
+                 ps.FStar_Tactics_Types.all_implicits in
+             let uu___3 =
+               check_apply_implicits_solutions false
+                 ps.FStar_Tactics_Types.main_context
+                 FStar_Pervasives_Native.None
+                 ps.FStar_Tactics_Types.tac_verb_dbg
+                 "gather_explicit_guards_for_resolved_goals" true
+                 goals_of_resolved_implicits in
+             FStar_Tactics_Monad.bind uu___3
+               (fun sub_goals ->
+                  let sub_goals1 = FStar_Compiler_List.flatten sub_goals in
+                  FStar_Tactics_Monad.add_goals sub_goals1)) in
+      FStar_Compiler_Effect.op_Less_Bar
+        (with_policy FStar_Tactics_Types.Goal) uu___2 in
+    FStar_Compiler_Effect.op_Less_Bar
+      (FStar_Tactics_Monad.wrap_err
+         "gather_explicit_guards_for_resolved_goals") uu___1
 let rec last : 'a . 'a Prims.list -> 'a =
   fun l ->
     match l with

--- a/src/ocaml-output/FStar_Tactics_Basic.ml
+++ b/src/ocaml-output/FStar_Tactics_Basic.ml
@@ -1892,42 +1892,46 @@ let (refine_intro : unit -> unit FStar_Tactics_Monad.tac) =
            | (uu___3, FStar_Pervasives_Native.None) ->
                FStar_Tactics_Monad.fail "not a refinement"
            | (t, FStar_Pervasives_Native.Some (bv, phi)) ->
-               let g1 = FStar_Tactics_Types.goal_with_type g t in
-               let uu___3 =
-                 let uu___4 =
-                   let uu___5 =
-                     let uu___6 = FStar_Syntax_Syntax.mk_binder bv in
-                     [uu___6] in
-                   FStar_Syntax_Subst.open_term uu___5 phi in
-                 match uu___4 with
-                 | (bvs, phi1) ->
-                     let uu___5 =
-                       let uu___6 = FStar_Compiler_List.hd bvs in
-                       uu___6.FStar_Syntax_Syntax.binder_bv in
-                     (uu___5, phi1) in
-               (match uu___3 with
-                | (bv1, phi1) ->
-                    let uu___4 =
-                      let uu___5 = FStar_Tactics_Types.goal_env g in
+               let uu___3 = mark_goal_implicit_allow_untyped g in
+               FStar_Tactics_Monad.bind uu___3
+                 (fun uu___4 ->
+                    let g1 = FStar_Tactics_Types.goal_with_type g t in
+                    let uu___5 =
                       let uu___6 =
                         let uu___7 =
+                          let uu___8 = FStar_Syntax_Syntax.mk_binder bv in
+                          [uu___8] in
+                        FStar_Syntax_Subst.open_term uu___7 phi in
+                      match uu___6 with
+                      | (bvs, phi1) ->
+                          let uu___7 =
+                            let uu___8 = FStar_Compiler_List.hd bvs in
+                            uu___8.FStar_Syntax_Syntax.binder_bv in
+                          (uu___7, phi1) in
+                    match uu___5 with
+                    | (bv1, phi1) ->
+                        let uu___6 =
+                          let uu___7 = FStar_Tactics_Types.goal_env g in
                           let uu___8 =
                             let uu___9 =
                               let uu___10 =
-                                FStar_Tactics_Types.goal_witness g in
-                              (bv1, uu___10) in
-                            FStar_Syntax_Syntax.NT uu___9 in
-                          [uu___8] in
-                        FStar_Syntax_Subst.subst uu___7 phi1 in
-                      FStar_Tactics_Monad.mk_irrelevant_goal
-                        "refine_intro refinement" uu___5 uu___6 (rangeof g)
-                        g.FStar_Tactics_Types.opts
-                        g.FStar_Tactics_Types.label in
-                    FStar_Tactics_Monad.bind uu___4
-                      (fun g2 ->
-                         FStar_Tactics_Monad.bind FStar_Tactics_Monad.dismiss
-                           (fun uu___5 ->
-                              FStar_Tactics_Monad.add_goals [g1; g2])))) in
+                                let uu___11 =
+                                  let uu___12 =
+                                    FStar_Tactics_Types.goal_witness g in
+                                  (bv1, uu___12) in
+                                FStar_Syntax_Syntax.NT uu___11 in
+                              [uu___10] in
+                            FStar_Syntax_Subst.subst uu___9 phi1 in
+                          FStar_Tactics_Monad.mk_irrelevant_goal
+                            "refine_intro refinement" uu___7 uu___8
+                            (rangeof g) g.FStar_Tactics_Types.opts
+                            g.FStar_Tactics_Types.label in
+                        FStar_Tactics_Monad.bind uu___6
+                          (fun g2 ->
+                             FStar_Tactics_Monad.bind
+                               FStar_Tactics_Monad.dismiss
+                               (fun uu___7 ->
+                                  FStar_Tactics_Monad.add_goals [g1; g2])))) in
     FStar_Compiler_Effect.op_Less_Bar
       (FStar_Tactics_Monad.wrap_err "refine_intro") uu___1
 let (__exact_now :
@@ -1985,7 +1989,15 @@ let (__exact_now :
                                    FStar_Tactics_Monad.bind uu___6
                                      (fun b ->
                                         if b
-                                        then solve goal t1
+                                        then
+                                          let uu___7 =
+                                            if set_expected_typ
+                                            then
+                                              mark_goal_implicit_allow_untyped
+                                                goal
+                                            else FStar_Tactics_Monad.ret () in
+                                          FStar_Tactics_Monad.bind uu___7
+                                            (fun uu___8 -> solve goal t1)
                                         else
                                           (let uu___8 =
                                              let uu___9 =

--- a/src/ocaml-output/FStar_Tactics_Basic.ml
+++ b/src/ocaml-output/FStar_Tactics_Basic.ml
@@ -120,11 +120,8 @@ let (find_and_map_implicit :
            let imps =
              FStar_Compiler_List.map
                (fun i ->
-                  let uu___ =
-                    ((i.FStar_TypeChecker_Common.imp_uvar).FStar_Syntax_Syntax.ctx_uvar_should_check
-                       <> FStar_Syntax_Syntax.Allow_untyped)
-                      && (is_ctx_uvar_for_implicit u i) in
-                  if uu___ then mark_implicit_as_allow_untyped i else f i)
+                  let uu___ = is_ctx_uvar_for_implicit u i in
+                  if uu___ then f i else i)
                ps.FStar_Tactics_Types.all_implicits in
            FStar_Tactics_Monad.set
              {
@@ -2859,10 +2856,9 @@ let (t_apply_lemma :
                                                                     FStar_Tactics_Monad.bind
                                                                     uu___19
                                                                     (fun
-                                                                    uu___20
-                                                                    ->
+                                                                    goal1 ->
                                                                     FStar_Tactics_Monad.ret
-                                                                    [goal])
+                                                                    [goal1])
                                                                     | 
                                                                     uu___18
                                                                     ->

--- a/src/ocaml-output/FStar_Tactics_Basic.ml
+++ b/src/ocaml-output/FStar_Tactics_Basic.ml
@@ -2231,6 +2231,214 @@ let (try_unify_by_application :
       fun ty1 ->
         fun ty2 ->
           fun rng -> __try_unify_by_application only_match [] e ty1 ty2 rng
+let (check_apply_implicits_solutions :
+  FStar_TypeChecker_Env.env ->
+    FStar_Tactics_Types.goal ->
+      Prims.bool ->
+        Prims.string ->
+          Prims.bool ->
+            (FStar_Syntax_Syntax.term * FStar_Syntax_Syntax.ctx_uvar)
+              Prims.list ->
+              FStar_Tactics_Types.goal Prims.list Prims.list
+                FStar_Tactics_Monad.tac)
+  =
+  fun env1 ->
+    fun gl ->
+      fun debug_on ->
+        fun debug_prefix ->
+          fun must_tot ->
+            fun imps ->
+              let check_implicits_solution env2 t k must_tot1 =
+                let env3 =
+                  FStar_TypeChecker_Env.set_expected_typ
+                    {
+                      FStar_TypeChecker_Env.solver =
+                        (env2.FStar_TypeChecker_Env.solver);
+                      FStar_TypeChecker_Env.range =
+                        (env2.FStar_TypeChecker_Env.range);
+                      FStar_TypeChecker_Env.curmodule =
+                        (env2.FStar_TypeChecker_Env.curmodule);
+                      FStar_TypeChecker_Env.gamma =
+                        (env2.FStar_TypeChecker_Env.gamma);
+                      FStar_TypeChecker_Env.gamma_sig =
+                        (env2.FStar_TypeChecker_Env.gamma_sig);
+                      FStar_TypeChecker_Env.gamma_cache =
+                        (env2.FStar_TypeChecker_Env.gamma_cache);
+                      FStar_TypeChecker_Env.modules =
+                        (env2.FStar_TypeChecker_Env.modules);
+                      FStar_TypeChecker_Env.expected_typ =
+                        (env2.FStar_TypeChecker_Env.expected_typ);
+                      FStar_TypeChecker_Env.sigtab =
+                        (env2.FStar_TypeChecker_Env.sigtab);
+                      FStar_TypeChecker_Env.attrtab =
+                        (env2.FStar_TypeChecker_Env.attrtab);
+                      FStar_TypeChecker_Env.instantiate_imp =
+                        (env2.FStar_TypeChecker_Env.instantiate_imp);
+                      FStar_TypeChecker_Env.effects =
+                        (env2.FStar_TypeChecker_Env.effects);
+                      FStar_TypeChecker_Env.generalize =
+                        (env2.FStar_TypeChecker_Env.generalize);
+                      FStar_TypeChecker_Env.letrecs =
+                        (env2.FStar_TypeChecker_Env.letrecs);
+                      FStar_TypeChecker_Env.top_level =
+                        (env2.FStar_TypeChecker_Env.top_level);
+                      FStar_TypeChecker_Env.check_uvars =
+                        (env2.FStar_TypeChecker_Env.check_uvars);
+                      FStar_TypeChecker_Env.use_eq_strict =
+                        (env2.FStar_TypeChecker_Env.use_eq_strict);
+                      FStar_TypeChecker_Env.is_iface =
+                        (env2.FStar_TypeChecker_Env.is_iface);
+                      FStar_TypeChecker_Env.admit =
+                        (env2.FStar_TypeChecker_Env.admit);
+                      FStar_TypeChecker_Env.lax =
+                        (env2.FStar_TypeChecker_Env.lax);
+                      FStar_TypeChecker_Env.lax_universes =
+                        (env2.FStar_TypeChecker_Env.lax_universes);
+                      FStar_TypeChecker_Env.phase1 =
+                        (env2.FStar_TypeChecker_Env.phase1);
+                      FStar_TypeChecker_Env.failhard =
+                        (env2.FStar_TypeChecker_Env.failhard);
+                      FStar_TypeChecker_Env.nosynth =
+                        (env2.FStar_TypeChecker_Env.nosynth);
+                      FStar_TypeChecker_Env.uvar_subtyping =
+                        (env2.FStar_TypeChecker_Env.uvar_subtyping);
+                      FStar_TypeChecker_Env.tc_term =
+                        (env2.FStar_TypeChecker_Env.tc_term);
+                      FStar_TypeChecker_Env.typeof_tot_or_gtot_term =
+                        (env2.FStar_TypeChecker_Env.typeof_tot_or_gtot_term);
+                      FStar_TypeChecker_Env.universe_of =
+                        (env2.FStar_TypeChecker_Env.universe_of);
+                      FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term
+                        =
+                        (env2.FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term);
+                      FStar_TypeChecker_Env.subtype_nosmt_force =
+                        (env2.FStar_TypeChecker_Env.subtype_nosmt_force);
+                      FStar_TypeChecker_Env.use_bv_sorts = true;
+                      FStar_TypeChecker_Env.qtbl_name_and_index =
+                        (env2.FStar_TypeChecker_Env.qtbl_name_and_index);
+                      FStar_TypeChecker_Env.normalized_eff_names =
+                        (env2.FStar_TypeChecker_Env.normalized_eff_names);
+                      FStar_TypeChecker_Env.fv_delta_depths =
+                        (env2.FStar_TypeChecker_Env.fv_delta_depths);
+                      FStar_TypeChecker_Env.proof_ns =
+                        (env2.FStar_TypeChecker_Env.proof_ns);
+                      FStar_TypeChecker_Env.synth_hook =
+                        (env2.FStar_TypeChecker_Env.synth_hook);
+                      FStar_TypeChecker_Env.try_solve_implicits_hook =
+                        (env2.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                      FStar_TypeChecker_Env.splice =
+                        (env2.FStar_TypeChecker_Env.splice);
+                      FStar_TypeChecker_Env.mpreprocess =
+                        (env2.FStar_TypeChecker_Env.mpreprocess);
+                      FStar_TypeChecker_Env.postprocess =
+                        (env2.FStar_TypeChecker_Env.postprocess);
+                      FStar_TypeChecker_Env.identifier_info =
+                        (env2.FStar_TypeChecker_Env.identifier_info);
+                      FStar_TypeChecker_Env.tc_hooks =
+                        (env2.FStar_TypeChecker_Env.tc_hooks);
+                      FStar_TypeChecker_Env.dsenv =
+                        (env2.FStar_TypeChecker_Env.dsenv);
+                      FStar_TypeChecker_Env.nbe =
+                        (env2.FStar_TypeChecker_Env.nbe);
+                      FStar_TypeChecker_Env.strict_args_tab =
+                        (env2.FStar_TypeChecker_Env.strict_args_tab);
+                      FStar_TypeChecker_Env.erasable_types_tab =
+                        (env2.FStar_TypeChecker_Env.erasable_types_tab);
+                      FStar_TypeChecker_Env.enable_defer_to_tac =
+                        (env2.FStar_TypeChecker_Env.enable_defer_to_tac);
+                      FStar_TypeChecker_Env.unif_allow_ref_guards =
+                        (env2.FStar_TypeChecker_Env.unif_allow_ref_guards);
+                      FStar_TypeChecker_Env.erase_erasable_args =
+                        (env2.FStar_TypeChecker_Env.erase_erasable_args)
+                    } k in
+                let slow_path uu___ =
+                  let uu___1 =
+                    FStar_TypeChecker_TcTerm.typeof_tot_or_gtot_term env3 t
+                      must_tot1 in
+                  match uu___1 with | (uu___2, uu___3, g) -> g in
+                let uu___ =
+                  FStar_TypeChecker_TcTerm.typeof_tot_or_gtot_term_fastpath
+                    env3 t must_tot1 in
+                match uu___ with
+                | FStar_Pervasives_Native.None -> slow_path ()
+                | FStar_Pervasives_Native.Some k' ->
+                    let uu___1 =
+                      FStar_TypeChecker_Rel.subtype_nosmt env3 k' k in
+                    (match uu___1 with
+                     | FStar_Pervasives_Native.None -> slow_path ()
+                     | FStar_Pervasives_Native.Some g -> g) in
+              let check_one_implicit uu___ =
+                match uu___ with
+                | (term, ctx_uvar) ->
+                    let uu___1 = FStar_Syntax_Util.head_and_args term in
+                    (match uu___1 with
+                     | (hd, uu___2) ->
+                         let uu___3 =
+                           let uu___4 = FStar_Syntax_Subst.compress hd in
+                           uu___4.FStar_Syntax_Syntax.n in
+                         (match uu___3 with
+                          | FStar_Syntax_Syntax.Tm_uvar (ctx_uvar1, uu___4)
+                              ->
+                              let uu___5 =
+                                bnorm_goal
+                                  {
+                                    FStar_Tactics_Types.goal_main_env =
+                                      (gl.FStar_Tactics_Types.goal_main_env);
+                                    FStar_Tactics_Types.goal_ctx_uvar =
+                                      ctx_uvar1;
+                                    FStar_Tactics_Types.opts =
+                                      (gl.FStar_Tactics_Types.opts);
+                                    FStar_Tactics_Types.is_guard =
+                                      (gl.FStar_Tactics_Types.is_guard);
+                                    FStar_Tactics_Types.label =
+                                      (gl.FStar_Tactics_Types.label)
+                                  } in
+                              FStar_Tactics_Monad.bind uu___5
+                                (fun gl1 -> FStar_Tactics_Monad.ret [gl1])
+                          | uu___4 ->
+                              FStar_Tactics_Monad.mlog
+                                (fun uu___5 ->
+                                   let uu___6 =
+                                     FStar_Syntax_Print.uvar_to_string
+                                       ctx_uvar.FStar_Syntax_Syntax.ctx_uvar_head in
+                                   let uu___7 =
+                                     FStar_Syntax_Print.term_to_string term in
+                                   FStar_Compiler_Util.print3
+                                     "%s: arg %s unified to (%s)\n"
+                                     debug_prefix uu___6 uu___7)
+                                (fun uu___5 ->
+                                   let g_typ =
+                                     check_implicits_solution env1 term
+                                       ctx_uvar.FStar_Syntax_Syntax.ctx_uvar_typ
+                                       must_tot in
+                                   let uu___6 =
+                                     let uu___7 =
+                                       if debug_on
+                                       then
+                                         let uu___8 =
+                                           FStar_Syntax_Print.ctx_uvar_to_string
+                                             ctx_uvar in
+                                         let uu___9 =
+                                           FStar_Syntax_Print.term_to_string
+                                             term in
+                                         FStar_Compiler_Util.format3
+                                           "%s solved arg %s to %s\n"
+                                           debug_prefix uu___8 uu___9
+                                       else
+                                         FStar_Compiler_Util.format1
+                                           "%s solved arg" debug_prefix in
+                                     proc_guard uu___7 env1 g_typ
+                                       (rangeof gl) in
+                                   FStar_Tactics_Monad.bind uu___6
+                                     (fun uu___7 ->
+                                        let uu___8 =
+                                          find_and_mark_implicit_as_allow_untyped
+                                            ctx_uvar in
+                                        FStar_Tactics_Monad.bind uu___8
+                                          (fun uu___9 ->
+                                             FStar_Tactics_Monad.ret []))))) in
+              FStar_Compiler_Effect.op_Bar_Greater imps
+                (FStar_Tactics_Monad.mapM check_one_implicit)
 let (t_apply :
   Prims.bool ->
     Prims.bool -> FStar_Syntax_Syntax.term -> unit FStar_Tactics_Monad.tac)
@@ -2244,134 +2452,166 @@ let (t_apply :
                let uu___2 = FStar_Syntax_Print.term_to_string tm in
                FStar_Compiler_Util.print1 "t_apply: tm = %s\n" uu___2)
             (fun uu___1 ->
-               FStar_Tactics_Monad.bind FStar_Tactics_Monad.cur_goal
-                 (fun goal ->
-                    let e = FStar_Tactics_Types.goal_env goal in
-                    FStar_Tactics_Monad.mlog
-                      (fun uu___2 ->
-                         let uu___3 = FStar_Syntax_Print.term_to_string tm in
-                         let uu___4 =
-                           FStar_Tactics_Printing.goal_to_string_verbose goal in
-                         let uu___5 =
-                           FStar_TypeChecker_Env.print_gamma
-                             e.FStar_TypeChecker_Env.gamma in
-                         FStar_Compiler_Util.print3
-                           "t_apply: tm = %s\nt_apply: goal = %s\nenv.gamma=%s\n"
-                           uu___3 uu___4 uu___5)
-                      (fun uu___2 ->
-                         let uu___3 = __tc e tm in
-                         FStar_Tactics_Monad.bind uu___3
-                           (fun uu___4 ->
-                              match uu___4 with
-                              | (tm1, typ, guard) ->
-                                  let typ1 = bnorm e typ in
-                                  let uu___5 =
-                                    let uu___6 =
-                                      FStar_Tactics_Types.goal_type goal in
-                                    try_unify_by_application only_match e
-                                      typ1 uu___6 (rangeof goal) in
-                                  FStar_Tactics_Monad.bind uu___5
-                                    (fun uvs ->
-                                       FStar_Tactics_Monad.mlog
-                                         (fun uu___6 ->
-                                            let uu___7 =
-                                              FStar_Common.string_of_list
-                                                (fun uu___8 ->
-                                                   match uu___8 with
-                                                   | (t, uu___9, uu___10) ->
-                                                       FStar_Syntax_Print.term_to_string
-                                                         t) uvs in
-                                            FStar_Compiler_Util.print1
-                                              "t_apply: found args = %s\n"
-                                              uu___7)
-                                         (fun uu___6 ->
-                                            let w =
-                                              FStar_Compiler_List.fold_right
-                                                (fun uu___7 ->
-                                                   fun w1 ->
-                                                     match uu___7 with
-                                                     | (uvt, q, uu___8) ->
-                                                         FStar_Syntax_Util.mk_app
-                                                           w1 [(uvt, q)]) uvs
-                                                tm1 in
-                                            let uvset =
-                                              let uu___7 =
-                                                FStar_Syntax_Free.new_uv_set
-                                                  () in
-                                              FStar_Compiler_List.fold_right
-                                                (fun uu___8 ->
-                                                   fun s ->
-                                                     match uu___8 with
-                                                     | (uu___9, uu___10, uv)
-                                                         ->
-                                                         let uu___11 =
-                                                           FStar_Syntax_Free.uvars
-                                                             uv.FStar_Syntax_Syntax.ctx_uvar_typ in
-                                                         FStar_Compiler_Util.set_union
-                                                           s uu___11) uvs
-                                                uu___7 in
-                                            let free_in_some_goal uv =
-                                              FStar_Compiler_Util.set_mem uv
-                                                uvset in
-                                            let uu___7 = solve' goal w in
-                                            FStar_Tactics_Monad.bind uu___7
-                                              (fun uu___8 ->
-                                                 let uu___9 =
-                                                   FStar_Tactics_Monad.mapM
-                                                     (fun uu___10 ->
-                                                        match uu___10 with
-                                                        | (uvt, q, uv) ->
-                                                            let uu___11 =
-                                                              FStar_Syntax_Unionfind.find
-                                                                uv.FStar_Syntax_Syntax.ctx_uvar_head in
-                                                            (match uu___11
-                                                             with
-                                                             | FStar_Pervasives_Native.Some
-                                                                 uu___12 ->
-                                                                 FStar_Tactics_Monad.ret
-                                                                   ()
-                                                             | FStar_Pervasives_Native.None
-                                                                 ->
-                                                                 let uu___12
-                                                                   =
-                                                                   uopt &&
-                                                                    (free_in_some_goal
-                                                                    uv) in
-                                                                 if uu___12
-                                                                 then
-                                                                   FStar_Tactics_Monad.ret
-                                                                    ()
-                                                                 else
-                                                                   (let uu___14
+               FStar_Tactics_Monad.bind FStar_Tactics_Monad.get
+                 (fun ps ->
+                    FStar_Tactics_Monad.bind FStar_Tactics_Monad.cur_goal
+                      (fun goal ->
+                         let e = FStar_Tactics_Types.goal_env goal in
+                         FStar_Tactics_Monad.mlog
+                           (fun uu___2 ->
+                              let uu___3 =
+                                FStar_Syntax_Print.term_to_string tm in
+                              let uu___4 =
+                                FStar_Tactics_Printing.goal_to_string_verbose
+                                  goal in
+                              let uu___5 =
+                                FStar_TypeChecker_Env.print_gamma
+                                  e.FStar_TypeChecker_Env.gamma in
+                              FStar_Compiler_Util.print3
+                                "t_apply: tm = %s\nt_apply: goal = %s\nenv.gamma=%s\n"
+                                uu___3 uu___4 uu___5)
+                           (fun uu___2 ->
+                              let uu___3 = __tc e tm in
+                              FStar_Tactics_Monad.bind uu___3
+                                (fun uu___4 ->
+                                   match uu___4 with
+                                   | (tm1, typ, guard) ->
+                                       let typ1 = bnorm e typ in
+                                       let uu___5 =
+                                         let uu___6 =
+                                           FStar_Tactics_Types.goal_type goal in
+                                         try_unify_by_application only_match
+                                           e typ1 uu___6 (rangeof goal) in
+                                       FStar_Tactics_Monad.bind uu___5
+                                         (fun uvs ->
+                                            FStar_Tactics_Monad.mlog
+                                              (fun uu___6 ->
+                                                 let uu___7 =
+                                                   FStar_Common.string_of_list
+                                                     (fun uu___8 ->
+                                                        match uu___8 with
+                                                        | (t, uu___9,
+                                                           uu___10) ->
+                                                            FStar_Syntax_Print.term_to_string
+                                                              t) uvs in
+                                                 FStar_Compiler_Util.print1
+                                                   "t_apply: found args = %s\n"
+                                                   uu___7)
+                                              (fun uu___6 ->
+                                                 let w =
+                                                   FStar_Compiler_List.fold_right
+                                                     (fun uu___7 ->
+                                                        fun w1 ->
+                                                          match uu___7 with
+                                                          | (uvt, q, uu___8)
+                                                              ->
+                                                              FStar_Syntax_Util.mk_app
+                                                                w1 [(uvt, q)])
+                                                     uvs tm1 in
+                                                 let uvset =
+                                                   let uu___7 =
+                                                     FStar_Syntax_Free.new_uv_set
+                                                       () in
+                                                   FStar_Compiler_List.fold_right
+                                                     (fun uu___8 ->
+                                                        fun s ->
+                                                          match uu___8 with
+                                                          | (uu___9, uu___10,
+                                                             uv) ->
+                                                              let uu___11 =
+                                                                FStar_Syntax_Free.uvars
+                                                                  uv.FStar_Syntax_Syntax.ctx_uvar_typ in
+                                                              FStar_Compiler_Util.set_union
+                                                                s uu___11)
+                                                     uvs uu___7 in
+                                                 let free_in_some_goal uv =
+                                                   FStar_Compiler_Util.set_mem
+                                                     uv uvset in
+                                                 let uu___7 = solve' goal w in
+                                                 FStar_Tactics_Monad.bind
+                                                   uu___7
+                                                   (fun uu___8 ->
+                                                      let uu___9 =
+                                                        let uu___10 =
+                                                          FStar_Compiler_Effect.op_Bar_Greater
+                                                            uvs
+                                                            (FStar_Compiler_List.map
+                                                               (fun uu___11
+                                                                  ->
+                                                                  match uu___11
+                                                                  with
+                                                                  | (uvt, _q,
+                                                                    uv) ->
+                                                                    (uvt, uv))) in
+                                                        FStar_Compiler_Effect.op_Bar_Greater
+                                                          uu___10
+                                                          (let must_tot =
+                                                             true in
+                                                           check_apply_implicits_solutions
+                                                             e goal
+                                                             ps.FStar_Tactics_Types.tac_verb_dbg
+                                                             "apply" must_tot) in
+                                                      FStar_Tactics_Monad.bind
+                                                        uu___9
+                                                        (fun subgoals ->
+                                                           let uu___10 =
+                                                             let uu___11 =
+                                                               let uu___12 =
+                                                                 FStar_Compiler_Effect.op_Bar_Greater
+                                                                   subgoals
+                                                                   FStar_Compiler_List.flatten in
+                                                               FStar_Compiler_Effect.op_Bar_Greater
+                                                                 uu___12
+                                                                 (FStar_Compiler_List.filter
+                                                                    (
+                                                                    fun g ->
+                                                                    let uu___13
                                                                     =
+                                                                    uopt &&
+                                                                    (free_in_some_goal
+                                                                    g.FStar_Tactics_Types.goal_ctx_uvar) in
+                                                                    Prims.op_Negation
+                                                                    uu___13)) in
+                                                             FStar_Compiler_Effect.op_Bar_Greater
+                                                               uu___11
+                                                               (FStar_Tactics_Monad.mapM
+                                                                  (fun g ->
                                                                     bnorm_goal
                                                                     {
                                                                     FStar_Tactics_Types.goal_main_env
                                                                     =
-                                                                    (goal.FStar_Tactics_Types.goal_main_env);
+                                                                    (g.FStar_Tactics_Types.goal_main_env);
                                                                     FStar_Tactics_Types.goal_ctx_uvar
-                                                                    = uv;
+                                                                    =
+                                                                    (g.FStar_Tactics_Types.goal_ctx_uvar);
                                                                     FStar_Tactics_Types.opts
                                                                     =
-                                                                    (goal.FStar_Tactics_Types.opts);
+                                                                    (g.FStar_Tactics_Types.opts);
                                                                     FStar_Tactics_Types.is_guard
                                                                     = false;
                                                                     FStar_Tactics_Types.label
                                                                     =
-                                                                    (goal.FStar_Tactics_Types.label)
-                                                                    } in
-                                                                    FStar_Tactics_Monad.bind
-                                                                    uu___14
-                                                                    (fun g ->
-                                                                    FStar_Tactics_Monad.add_goals
-                                                                    [g]))))
-                                                     uvs in
-                                                 FStar_Tactics_Monad.bind
-                                                   uu___9
-                                                   (fun uu___10 ->
-                                                      proc_guard
-                                                        "apply guard" e guard
-                                                        (rangeof goal))))))))) in
+                                                                    (g.FStar_Tactics_Types.label)
+                                                                    })) in
+                                                           FStar_Tactics_Monad.bind
+                                                             uu___10
+                                                             (fun subgoals1
+                                                                ->
+                                                                let uu___11 =
+                                                                  FStar_Tactics_Monad.add_goals
+                                                                    (
+                                                                    FStar_Compiler_List.rev
+                                                                    subgoals1) in
+                                                                FStar_Tactics_Monad.bind
+                                                                  uu___11
+                                                                  (fun
+                                                                    uu___12
+                                                                    ->
+                                                                    proc_guard
+                                                                    "apply guard"
+                                                                    e guard
+                                                                    (rangeof
+                                                                    goal)))))))))))) in
         FStar_Compiler_Effect.op_Less_Bar
           (FStar_Tactics_Monad.wrap_err "apply") uu___
 let (lemma_or_sq :
@@ -2427,128 +2667,6 @@ let rec fold_left :
         | x::xs1 ->
             let uu___ = f x e in
             FStar_Tactics_Monad.bind uu___ (fun e' -> fold_left f e' xs1)
-let (check_lemma_implicits_solution :
-  FStar_TypeChecker_Env.env ->
-    FStar_Syntax_Syntax.term ->
-      FStar_Reflection_Data.typ -> FStar_TypeChecker_Common.guard_t)
-  =
-  fun env1 ->
-    fun t ->
-      fun k ->
-        let env2 =
-          FStar_TypeChecker_Env.set_expected_typ
-            {
-              FStar_TypeChecker_Env.solver =
-                (env1.FStar_TypeChecker_Env.solver);
-              FStar_TypeChecker_Env.range =
-                (env1.FStar_TypeChecker_Env.range);
-              FStar_TypeChecker_Env.curmodule =
-                (env1.FStar_TypeChecker_Env.curmodule);
-              FStar_TypeChecker_Env.gamma =
-                (env1.FStar_TypeChecker_Env.gamma);
-              FStar_TypeChecker_Env.gamma_sig =
-                (env1.FStar_TypeChecker_Env.gamma_sig);
-              FStar_TypeChecker_Env.gamma_cache =
-                (env1.FStar_TypeChecker_Env.gamma_cache);
-              FStar_TypeChecker_Env.modules =
-                (env1.FStar_TypeChecker_Env.modules);
-              FStar_TypeChecker_Env.expected_typ =
-                (env1.FStar_TypeChecker_Env.expected_typ);
-              FStar_TypeChecker_Env.sigtab =
-                (env1.FStar_TypeChecker_Env.sigtab);
-              FStar_TypeChecker_Env.attrtab =
-                (env1.FStar_TypeChecker_Env.attrtab);
-              FStar_TypeChecker_Env.instantiate_imp =
-                (env1.FStar_TypeChecker_Env.instantiate_imp);
-              FStar_TypeChecker_Env.effects =
-                (env1.FStar_TypeChecker_Env.effects);
-              FStar_TypeChecker_Env.generalize =
-                (env1.FStar_TypeChecker_Env.generalize);
-              FStar_TypeChecker_Env.letrecs =
-                (env1.FStar_TypeChecker_Env.letrecs);
-              FStar_TypeChecker_Env.top_level =
-                (env1.FStar_TypeChecker_Env.top_level);
-              FStar_TypeChecker_Env.check_uvars =
-                (env1.FStar_TypeChecker_Env.check_uvars);
-              FStar_TypeChecker_Env.use_eq_strict =
-                (env1.FStar_TypeChecker_Env.use_eq_strict);
-              FStar_TypeChecker_Env.is_iface =
-                (env1.FStar_TypeChecker_Env.is_iface);
-              FStar_TypeChecker_Env.admit =
-                (env1.FStar_TypeChecker_Env.admit);
-              FStar_TypeChecker_Env.lax = (env1.FStar_TypeChecker_Env.lax);
-              FStar_TypeChecker_Env.lax_universes =
-                (env1.FStar_TypeChecker_Env.lax_universes);
-              FStar_TypeChecker_Env.phase1 =
-                (env1.FStar_TypeChecker_Env.phase1);
-              FStar_TypeChecker_Env.failhard =
-                (env1.FStar_TypeChecker_Env.failhard);
-              FStar_TypeChecker_Env.nosynth =
-                (env1.FStar_TypeChecker_Env.nosynth);
-              FStar_TypeChecker_Env.uvar_subtyping =
-                (env1.FStar_TypeChecker_Env.uvar_subtyping);
-              FStar_TypeChecker_Env.tc_term =
-                (env1.FStar_TypeChecker_Env.tc_term);
-              FStar_TypeChecker_Env.typeof_tot_or_gtot_term =
-                (env1.FStar_TypeChecker_Env.typeof_tot_or_gtot_term);
-              FStar_TypeChecker_Env.universe_of =
-                (env1.FStar_TypeChecker_Env.universe_of);
-              FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term =
-                (env1.FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term);
-              FStar_TypeChecker_Env.subtype_nosmt_force =
-                (env1.FStar_TypeChecker_Env.subtype_nosmt_force);
-              FStar_TypeChecker_Env.use_bv_sorts = true;
-              FStar_TypeChecker_Env.qtbl_name_and_index =
-                (env1.FStar_TypeChecker_Env.qtbl_name_and_index);
-              FStar_TypeChecker_Env.normalized_eff_names =
-                (env1.FStar_TypeChecker_Env.normalized_eff_names);
-              FStar_TypeChecker_Env.fv_delta_depths =
-                (env1.FStar_TypeChecker_Env.fv_delta_depths);
-              FStar_TypeChecker_Env.proof_ns =
-                (env1.FStar_TypeChecker_Env.proof_ns);
-              FStar_TypeChecker_Env.synth_hook =
-                (env1.FStar_TypeChecker_Env.synth_hook);
-              FStar_TypeChecker_Env.try_solve_implicits_hook =
-                (env1.FStar_TypeChecker_Env.try_solve_implicits_hook);
-              FStar_TypeChecker_Env.splice =
-                (env1.FStar_TypeChecker_Env.splice);
-              FStar_TypeChecker_Env.mpreprocess =
-                (env1.FStar_TypeChecker_Env.mpreprocess);
-              FStar_TypeChecker_Env.postprocess =
-                (env1.FStar_TypeChecker_Env.postprocess);
-              FStar_TypeChecker_Env.identifier_info =
-                (env1.FStar_TypeChecker_Env.identifier_info);
-              FStar_TypeChecker_Env.tc_hooks =
-                (env1.FStar_TypeChecker_Env.tc_hooks);
-              FStar_TypeChecker_Env.dsenv =
-                (env1.FStar_TypeChecker_Env.dsenv);
-              FStar_TypeChecker_Env.nbe = (env1.FStar_TypeChecker_Env.nbe);
-              FStar_TypeChecker_Env.strict_args_tab =
-                (env1.FStar_TypeChecker_Env.strict_args_tab);
-              FStar_TypeChecker_Env.erasable_types_tab =
-                (env1.FStar_TypeChecker_Env.erasable_types_tab);
-              FStar_TypeChecker_Env.enable_defer_to_tac =
-                (env1.FStar_TypeChecker_Env.enable_defer_to_tac);
-              FStar_TypeChecker_Env.unif_allow_ref_guards =
-                (env1.FStar_TypeChecker_Env.unif_allow_ref_guards);
-              FStar_TypeChecker_Env.erase_erasable_args =
-                (env1.FStar_TypeChecker_Env.erase_erasable_args)
-            } k in
-        let slow_path uu___ =
-          let must_tot = false in
-          let uu___1 =
-            FStar_TypeChecker_TcTerm.typeof_tot_or_gtot_term env2 t must_tot in
-          match uu___1 with | (uu___2, uu___3, g) -> g in
-        let uu___ =
-          FStar_TypeChecker_TcTerm.typeof_tot_or_gtot_term_fastpath env2 t
-            false in
-        match uu___ with
-        | FStar_Pervasives_Native.None -> slow_path ()
-        | FStar_Pervasives_Native.Some k' ->
-            let uu___1 = FStar_TypeChecker_Rel.subtype_nosmt env2 k' k in
-            (match uu___1 with
-             | FStar_Pervasives_Native.None -> slow_path ()
-             | FStar_Pervasives_Native.Some g -> g)
 let (t_apply_lemma :
   Prims.bool ->
     Prims.bool -> FStar_Syntax_Syntax.term -> unit FStar_Tactics_Monad.tac)
@@ -2796,139 +2914,15 @@ let (t_apply_lemma :
                                                                     -> false) in
                                                                     let uu___13
                                                                     =
+                                                                    let must_tot
+                                                                    = false in
                                                                     FStar_Compiler_Effect.op_Bar_Greater
                                                                     implicits2
-                                                                    (FStar_Tactics_Monad.mapM
-                                                                    (fun imp
-                                                                    ->
-                                                                    let uu___14
-                                                                    = imp in
-                                                                    match uu___14
-                                                                    with
-                                                                    | 
-                                                                    (term,
-                                                                    ctx_uvar)
-                                                                    ->
-                                                                    let uu___15
-                                                                    =
-                                                                    FStar_Syntax_Util.head_and_args
-                                                                    term in
-                                                                    (match uu___15
-                                                                    with
-                                                                    | 
-                                                                    (hd,
-                                                                    uu___16)
-                                                                    ->
-                                                                    let uu___17
-                                                                    =
-                                                                    let uu___18
-                                                                    =
-                                                                    FStar_Syntax_Subst.compress
-                                                                    hd in
-                                                                    uu___18.FStar_Syntax_Syntax.n in
-                                                                    (match uu___17
-                                                                    with
-                                                                    | 
-                                                                    FStar_Syntax_Syntax.Tm_uvar
-                                                                    (ctx_uvar1,
-                                                                    uu___18)
-                                                                    ->
-                                                                    let uu___19
-                                                                    =
-                                                                    bnorm_goal
-                                                                    {
-                                                                    FStar_Tactics_Types.goal_main_env
-                                                                    =
-                                                                    (goal.FStar_Tactics_Types.goal_main_env);
-                                                                    FStar_Tactics_Types.goal_ctx_uvar
-                                                                    =
-                                                                    ctx_uvar1;
-                                                                    FStar_Tactics_Types.opts
-                                                                    =
-                                                                    (goal.FStar_Tactics_Types.opts);
-                                                                    FStar_Tactics_Types.is_guard
-                                                                    =
-                                                                    (goal.FStar_Tactics_Types.is_guard);
-                                                                    FStar_Tactics_Types.label
-                                                                    =
-                                                                    (goal.FStar_Tactics_Types.label)
-                                                                    } in
-                                                                    FStar_Tactics_Monad.bind
-                                                                    uu___19
-                                                                    (fun
-                                                                    goal1 ->
-                                                                    FStar_Tactics_Monad.ret
-                                                                    [goal1])
-                                                                    | 
-                                                                    uu___18
-                                                                    ->
-                                                                    FStar_Tactics_Monad.mlog
-                                                                    (fun
-                                                                    uu___19
-                                                                    ->
-                                                                    let uu___20
-                                                                    =
-                                                                    FStar_Syntax_Print.uvar_to_string
-                                                                    ctx_uvar.FStar_Syntax_Syntax.ctx_uvar_head in
-                                                                    let uu___21
-                                                                    =
-                                                                    FStar_Syntax_Print.term_to_string
-                                                                    term in
-                                                                    FStar_Compiler_Util.print2
-                                                                    "apply_lemma: arg %s unified to (%s)\n"
-                                                                    uu___20
-                                                                    uu___21)
-                                                                    (fun
-                                                                    uu___19
-                                                                    ->
-                                                                    let g_typ
-                                                                    =
-                                                                    check_lemma_implicits_solution
-                                                                    env1 term
-                                                                    ctx_uvar.FStar_Syntax_Syntax.ctx_uvar_typ in
-                                                                    let uu___20
-                                                                    =
-                                                                    let uu___21
-                                                                    =
-                                                                    if
+                                                                    (check_apply_implicits_solutions
+                                                                    env1 goal
                                                                     ps.FStar_Tactics_Types.tac_verb_dbg
-                                                                    then
-                                                                    let uu___22
-                                                                    =
-                                                                    FStar_Syntax_Print.ctx_uvar_to_string
-                                                                    ctx_uvar in
-                                                                    let uu___23
-                                                                    =
-                                                                    FStar_Syntax_Print.term_to_string
-                                                                    term in
-                                                                    FStar_Compiler_Util.format2
-                                                                    "apply_lemma solved arg %s to %s\n"
-                                                                    uu___22
-                                                                    uu___23
-                                                                    else
-                                                                    "apply_lemma solved arg" in
-                                                                    proc_guard
-                                                                    uu___21
-                                                                    env1
-                                                                    g_typ
-                                                                    (rangeof
-                                                                    goal) in
-                                                                    FStar_Tactics_Monad.bind
-                                                                    uu___20
-                                                                    (fun
-                                                                    uu___21
-                                                                    ->
-                                                                    let uu___22
-                                                                    =
-                                                                    find_and_mark_implicit_as_allow_untyped
-                                                                    ctx_uvar in
-                                                                    FStar_Tactics_Monad.bind
-                                                                    uu___22
-                                                                    (fun
-                                                                    uu___23
-                                                                    ->
-                                                                    FStar_Tactics_Monad.ret
-                                                                    []))))))) in
+                                                                    "apply_lemma"
+                                                                    must_tot) in
                                                                     FStar_Tactics_Monad.bind
                                                                     uu___13
                                                                     (fun

--- a/src/ocaml-output/FStar_Tactics_Basic.ml
+++ b/src/ocaml-output/FStar_Tactics_Basic.ml
@@ -31,146 +31,68 @@ let (term_to_string :
   fun e ->
     fun t ->
       FStar_Syntax_Print.term_to_string' e.FStar_TypeChecker_Env.dsenv t
-let (is_ctx_uvar_for_implicit :
-  FStar_Syntax_Syntax.ctx_uvar ->
-    FStar_TypeChecker_Common.implicit -> Prims.bool)
-  =
+let (set_uvar_expected_typ :
+  FStar_Syntax_Syntax.ctx_uvar -> FStar_Reflection_Data.typ -> unit) =
   fun u ->
-    fun i ->
-      FStar_Syntax_Unionfind.equiv u.FStar_Syntax_Syntax.ctx_uvar_head
-        (i.FStar_TypeChecker_Common.imp_uvar).FStar_Syntax_Syntax.ctx_uvar_head
-let (is_implicit_for_goal :
-  FStar_Tactics_Types.goal -> FStar_TypeChecker_Common.implicit -> Prims.bool)
-  =
-  fun g ->
-    fun i -> is_ctx_uvar_for_implicit g.FStar_Tactics_Types.goal_ctx_uvar i
-let (mark_implicit_as_allow_untyped :
-  FStar_TypeChecker_Common.implicit -> FStar_TypeChecker_Common.implicit) =
-  fun i ->
-    let uvar =
-      let uu___ = i.FStar_TypeChecker_Common.imp_uvar in
-      {
-        FStar_Syntax_Syntax.ctx_uvar_head =
-          (uu___.FStar_Syntax_Syntax.ctx_uvar_head);
-        FStar_Syntax_Syntax.ctx_uvar_gamma =
-          (uu___.FStar_Syntax_Syntax.ctx_uvar_gamma);
-        FStar_Syntax_Syntax.ctx_uvar_binders =
-          (uu___.FStar_Syntax_Syntax.ctx_uvar_binders);
-        FStar_Syntax_Syntax.ctx_uvar_typ =
-          (uu___.FStar_Syntax_Syntax.ctx_uvar_typ);
-        FStar_Syntax_Syntax.ctx_uvar_reason =
-          (uu___.FStar_Syntax_Syntax.ctx_uvar_reason);
-        FStar_Syntax_Syntax.ctx_uvar_should_check =
-          FStar_Syntax_Syntax.Allow_untyped;
-        FStar_Syntax_Syntax.ctx_uvar_range =
-          (uu___.FStar_Syntax_Syntax.ctx_uvar_range);
-        FStar_Syntax_Syntax.ctx_uvar_meta =
-          (uu___.FStar_Syntax_Syntax.ctx_uvar_meta)
-      } in
-    {
-      FStar_TypeChecker_Common.imp_reason =
-        (i.FStar_TypeChecker_Common.imp_reason);
-      FStar_TypeChecker_Common.imp_uvar = uvar;
-      FStar_TypeChecker_Common.imp_tm = (i.FStar_TypeChecker_Common.imp_tm);
-      FStar_TypeChecker_Common.imp_range =
-        (i.FStar_TypeChecker_Common.imp_range)
-    }
-let (set_implicit_uvar_typ :
-  FStar_Reflection_Data.typ ->
-    FStar_TypeChecker_Common.implicit -> FStar_TypeChecker_Common.implicit)
-  =
-  fun t ->
-    fun i ->
-      let uvar =
-        let uu___ = i.FStar_TypeChecker_Common.imp_uvar in
+    fun t ->
+      let dec =
+        FStar_Syntax_Unionfind.find_decoration
+          u.FStar_Syntax_Syntax.ctx_uvar_head in
+      FStar_Syntax_Unionfind.change_decoration
+        u.FStar_Syntax_Syntax.ctx_uvar_head
         {
-          FStar_Syntax_Syntax.ctx_uvar_head =
-            (uu___.FStar_Syntax_Syntax.ctx_uvar_head);
-          FStar_Syntax_Syntax.ctx_uvar_gamma =
-            (uu___.FStar_Syntax_Syntax.ctx_uvar_gamma);
-          FStar_Syntax_Syntax.ctx_uvar_binders =
-            (uu___.FStar_Syntax_Syntax.ctx_uvar_binders);
-          FStar_Syntax_Syntax.ctx_uvar_typ = t;
-          FStar_Syntax_Syntax.ctx_uvar_reason =
-            (uu___.FStar_Syntax_Syntax.ctx_uvar_reason);
-          FStar_Syntax_Syntax.ctx_uvar_should_check =
-            (uu___.FStar_Syntax_Syntax.ctx_uvar_should_check);
-          FStar_Syntax_Syntax.ctx_uvar_range =
-            (uu___.FStar_Syntax_Syntax.ctx_uvar_range);
-          FStar_Syntax_Syntax.ctx_uvar_meta =
-            (uu___.FStar_Syntax_Syntax.ctx_uvar_meta)
-        } in
-      {
-        FStar_TypeChecker_Common.imp_reason =
-          (i.FStar_TypeChecker_Common.imp_reason);
-        FStar_TypeChecker_Common.imp_uvar = uvar;
-        FStar_TypeChecker_Common.imp_tm = (i.FStar_TypeChecker_Common.imp_tm);
-        FStar_TypeChecker_Common.imp_range =
-          (i.FStar_TypeChecker_Common.imp_range)
-      }
-let (find_and_map_implicit :
-  FStar_Syntax_Syntax.ctx_uvar ->
-    (FStar_TypeChecker_Common.implicit -> FStar_TypeChecker_Common.implicit)
-      -> unit FStar_Tactics_Monad.tac)
-  =
+          FStar_Syntax_Syntax.uvar_decoration_typ = t;
+          FStar_Syntax_Syntax.uvar_decoration_should_check =
+            (dec.FStar_Syntax_Syntax.uvar_decoration_should_check)
+        }
+let (mark_uvar_as_allow_untyped : FStar_Syntax_Syntax.ctx_uvar -> unit) =
   fun u ->
-    fun f ->
-      FStar_Tactics_Monad.bind FStar_Tactics_Monad.get
-        (fun ps ->
-           let imps =
-             FStar_Compiler_List.map
-               (fun i ->
-                  let uu___ = is_ctx_uvar_for_implicit u i in
-                  if uu___ then f i else i)
-               ps.FStar_Tactics_Types.all_implicits in
-           FStar_Tactics_Monad.set
-             {
-               FStar_Tactics_Types.main_context =
-                 (ps.FStar_Tactics_Types.main_context);
-               FStar_Tactics_Types.all_implicits = imps;
-               FStar_Tactics_Types.goals = (ps.FStar_Tactics_Types.goals);
-               FStar_Tactics_Types.smt_goals =
-                 (ps.FStar_Tactics_Types.smt_goals);
-               FStar_Tactics_Types.depth = (ps.FStar_Tactics_Types.depth);
-               FStar_Tactics_Types.__dump = (ps.FStar_Tactics_Types.__dump);
-               FStar_Tactics_Types.psc = (ps.FStar_Tactics_Types.psc);
-               FStar_Tactics_Types.entry_range =
-                 (ps.FStar_Tactics_Types.entry_range);
-               FStar_Tactics_Types.guard_policy =
-                 (ps.FStar_Tactics_Types.guard_policy);
-               FStar_Tactics_Types.freshness =
-                 (ps.FStar_Tactics_Types.freshness);
-               FStar_Tactics_Types.tac_verb_dbg =
-                 (ps.FStar_Tactics_Types.tac_verb_dbg);
-               FStar_Tactics_Types.local_state =
-                 (ps.FStar_Tactics_Types.local_state);
-               FStar_Tactics_Types.urgency = (ps.FStar_Tactics_Types.urgency)
-             })
-let (find_and_mark_implicit_as_allow_untyped :
-  FStar_Syntax_Syntax.ctx_uvar -> unit FStar_Tactics_Monad.tac) =
-  fun u -> find_and_map_implicit u mark_implicit_as_allow_untyped
-let (mark_goal_implicit_allow_untyped :
-  FStar_Tactics_Types.goal -> unit FStar_Tactics_Monad.tac) =
-  fun g ->
-    find_and_mark_implicit_as_allow_untyped
-      g.FStar_Tactics_Types.goal_ctx_uvar
+    let dec =
+      FStar_Syntax_Unionfind.find_decoration
+        u.FStar_Syntax_Syntax.ctx_uvar_head in
+    FStar_Syntax_Unionfind.change_decoration
+      u.FStar_Syntax_Syntax.ctx_uvar_head
+      {
+        FStar_Syntax_Syntax.uvar_decoration_typ =
+          (dec.FStar_Syntax_Syntax.uvar_decoration_typ);
+        FStar_Syntax_Syntax.uvar_decoration_should_check =
+          FStar_Syntax_Syntax.Allow_untyped
+      }
+let (mark_goal_implicit_allow_untyped : FStar_Tactics_Types.goal -> unit) =
+  fun g -> mark_uvar_as_allow_untyped g.FStar_Tactics_Types.goal_ctx_uvar
 let (goal_with_type :
   FStar_Tactics_Types.goal ->
-    FStar_Reflection_Data.typ ->
-      FStar_Tactics_Types.goal FStar_Tactics_Monad.tac)
+    FStar_Reflection_Data.typ -> FStar_Tactics_Types.goal)
   =
   fun g ->
     fun t ->
-      let g' = FStar_Tactics_Types.goal_with_type_pure g t in
-      let uu___ =
-        find_and_map_implicit g.FStar_Tactics_Types.goal_ctx_uvar
-          (set_implicit_uvar_typ t) in
-      FStar_Tactics_Monad.bind uu___
-        (fun uu___1 -> FStar_Tactics_Monad.ret g')
-let (bnorm_goal :
-  FStar_Tactics_Types.goal ->
-    FStar_Tactics_Types.goal FStar_Tactics_Monad.tac)
-  =
+      let u = g.FStar_Tactics_Types.goal_ctx_uvar in
+      set_uvar_expected_typ u t;
+      (let u1 =
+         {
+           FStar_Syntax_Syntax.ctx_uvar_head =
+             (u.FStar_Syntax_Syntax.ctx_uvar_head);
+           FStar_Syntax_Syntax.ctx_uvar_gamma =
+             (u.FStar_Syntax_Syntax.ctx_uvar_gamma);
+           FStar_Syntax_Syntax.ctx_uvar_binders =
+             (u.FStar_Syntax_Syntax.ctx_uvar_binders);
+           FStar_Syntax_Syntax.ctx_uvar_typ = t;
+           FStar_Syntax_Syntax.ctx_uvar_reason =
+             (u.FStar_Syntax_Syntax.ctx_uvar_reason);
+           FStar_Syntax_Syntax.ctx_uvar_range =
+             (u.FStar_Syntax_Syntax.ctx_uvar_range);
+           FStar_Syntax_Syntax.ctx_uvar_meta =
+             (u.FStar_Syntax_Syntax.ctx_uvar_meta)
+         } in
+       {
+         FStar_Tactics_Types.goal_main_env =
+           (g.FStar_Tactics_Types.goal_main_env);
+         FStar_Tactics_Types.goal_ctx_uvar = u1;
+         FStar_Tactics_Types.opts = (g.FStar_Tactics_Types.opts);
+         FStar_Tactics_Types.is_guard = (g.FStar_Tactics_Types.is_guard);
+         FStar_Tactics_Types.label = (g.FStar_Tactics_Types.label)
+       })
+let (bnorm_goal : FStar_Tactics_Types.goal -> FStar_Tactics_Types.goal) =
   fun g ->
     let uu___ =
       let uu___1 = FStar_Tactics_Types.goal_env g in
@@ -624,9 +546,8 @@ let (set_solution :
           (FStar_Syntax_Unionfind.change
              (goal.FStar_Tactics_Types.goal_ctx_uvar).FStar_Syntax_Syntax.ctx_uvar_head
              solution;
-           (let uu___2 = mark_goal_implicit_allow_untyped goal in
-            FStar_Tactics_Monad.bind uu___2
-              (fun uu___3 -> FStar_Tactics_Monad.ret ())))
+           mark_goal_implicit_allow_untyped goal;
+           FStar_Tactics_Monad.ret ())
 let (trysolve :
   FStar_Tactics_Types.goal ->
     FStar_Syntax_Syntax.term -> Prims.bool FStar_Tactics_Monad.tac)
@@ -1705,12 +1626,11 @@ let (seq :
 let (should_check_goal_uvar :
   FStar_Tactics_Types.goal -> FStar_Syntax_Syntax.should_check_uvar) =
   fun g ->
-    (g.FStar_Tactics_Types.goal_ctx_uvar).FStar_Syntax_Syntax.ctx_uvar_should_check
+    FStar_Syntax_Util.ctx_uvar_should_check
+      g.FStar_Tactics_Types.goal_ctx_uvar
 let (bnorm_and_replace :
   FStar_Tactics_Types.goal -> unit FStar_Tactics_Monad.tac) =
-  fun g ->
-    let uu___ = bnorm_goal g in
-    FStar_Tactics_Monad.bind uu___ FStar_Tactics_Monad.replace_cur
+  fun g -> let uu___ = bnorm_goal g in FStar_Tactics_Monad.replace_cur uu___
 let (intro : unit -> FStar_Syntax_Syntax.binder FStar_Tactics_Monad.tac) =
   fun uu___ ->
     let uu___1 =
@@ -1735,9 +1655,11 @@ let (intro : unit -> FStar_Syntax_Syntax.binder FStar_Tactics_Monad.tac) =
                     FStar_TypeChecker_Env.push_binders uu___5 [b] in
                   let typ' = FStar_Syntax_Util.comp_result c in
                   let uu___5 =
-                    FStar_Tactics_Monad.new_uvar "intro" env' typ'
-                      (FStar_Pervasives_Native.Some
-                         (should_check_goal_uvar goal)) (rangeof goal) in
+                    let uu___6 =
+                      let uu___7 = should_check_goal_uvar goal in
+                      FStar_Pervasives_Native.Some uu___7 in
+                    FStar_Tactics_Monad.new_uvar "intro" env' typ' uu___6
+                      (rangeof goal) in
                   FStar_Tactics_Monad.bind uu___5
                     (fun uu___6 ->
                        match uu___6 with
@@ -1802,10 +1724,11 @@ let (intro_rec :
                    let uu___6 = FStar_Tactics_Types.goal_env goal in
                    FStar_TypeChecker_Env.push_binders uu___6 bs in
                  let uu___6 =
+                   let uu___7 =
+                     let uu___8 = should_check_goal_uvar goal in
+                     FStar_Pervasives_Native.Some uu___8 in
                    FStar_Tactics_Monad.new_uvar "intro_rec" env'
-                     (FStar_Syntax_Util.comp_result c)
-                     (FStar_Pervasives_Native.Some
-                        (should_check_goal_uvar goal)) (rangeof goal) in
+                     (FStar_Syntax_Util.comp_result c) uu___7 (rangeof goal) in
                  FStar_Tactics_Monad.bind uu___6
                    (fun uu___7 ->
                       match uu___7 with
@@ -1886,8 +1809,7 @@ let (norm :
                 let uu___2 = FStar_Tactics_Types.goal_type goal in
                 normalize steps uu___1 uu___2 in
               let uu___1 = goal_with_type goal t in
-              FStar_Tactics_Monad.bind uu___1
-                (fun g -> FStar_Tactics_Monad.replace_cur g)))
+              FStar_Tactics_Monad.replace_cur uu___1))
 let (norm_term_env :
   env ->
     FStar_Syntax_Embeddings.norm_step Prims.list ->
@@ -1946,48 +1868,44 @@ let (refine_intro : unit -> unit FStar_Tactics_Monad.tac) =
            | (uu___3, FStar_Pervasives_Native.None) ->
                FStar_Tactics_Monad.fail "not a refinement"
            | (t, FStar_Pervasives_Native.Some (bv, phi)) ->
-               let uu___3 = mark_goal_implicit_allow_untyped g in
-               FStar_Tactics_Monad.bind uu___3
-                 (fun uu___4 ->
-                    let uu___5 = goal_with_type g t in
-                    FStar_Tactics_Monad.bind uu___5
-                      (fun g1 ->
-                         let uu___6 =
-                           let uu___7 =
-                             let uu___8 =
-                               let uu___9 = FStar_Syntax_Syntax.mk_binder bv in
-                               [uu___9] in
-                             FStar_Syntax_Subst.open_term uu___8 phi in
-                           match uu___7 with
-                           | (bvs, phi1) ->
-                               let uu___8 =
-                                 let uu___9 = FStar_Compiler_List.hd bvs in
-                                 uu___9.FStar_Syntax_Syntax.binder_bv in
-                               (uu___8, phi1) in
-                         match uu___6 with
-                         | (bv1, phi1) ->
-                             let uu___7 =
-                               let uu___8 = FStar_Tactics_Types.goal_env g in
-                               let uu___9 =
-                                 let uu___10 =
-                                   let uu___11 =
-                                     let uu___12 =
-                                       let uu___13 =
-                                         FStar_Tactics_Types.goal_witness g in
-                                       (bv1, uu___13) in
-                                     FStar_Syntax_Syntax.NT uu___12 in
-                                   [uu___11] in
-                                 FStar_Syntax_Subst.subst uu___10 phi1 in
-                               FStar_Tactics_Monad.mk_irrelevant_goal
-                                 "refine_intro refinement" uu___8 uu___9
-                                 (rangeof g) g.FStar_Tactics_Types.opts
-                                 g.FStar_Tactics_Types.label in
-                             FStar_Tactics_Monad.bind uu___7
-                               (fun g2 ->
-                                  FStar_Tactics_Monad.bind
-                                    FStar_Tactics_Monad.dismiss
-                                    (fun uu___8 ->
-                                       FStar_Tactics_Monad.add_goals [g1; g2]))))) in
+               (mark_goal_implicit_allow_untyped g;
+                (let g1 = goal_with_type g t in
+                 let uu___4 =
+                   let uu___5 =
+                     let uu___6 =
+                       let uu___7 = FStar_Syntax_Syntax.mk_binder bv in
+                       [uu___7] in
+                     FStar_Syntax_Subst.open_term uu___6 phi in
+                   match uu___5 with
+                   | (bvs, phi1) ->
+                       let uu___6 =
+                         let uu___7 = FStar_Compiler_List.hd bvs in
+                         uu___7.FStar_Syntax_Syntax.binder_bv in
+                       (uu___6, phi1) in
+                 match uu___4 with
+                 | (bv1, phi1) ->
+                     let uu___5 =
+                       let uu___6 = FStar_Tactics_Types.goal_env g in
+                       let uu___7 =
+                         let uu___8 =
+                           let uu___9 =
+                             let uu___10 =
+                               let uu___11 =
+                                 FStar_Tactics_Types.goal_witness g in
+                               (bv1, uu___11) in
+                             FStar_Syntax_Syntax.NT uu___10 in
+                           [uu___9] in
+                         FStar_Syntax_Subst.subst uu___8 phi1 in
+                       FStar_Tactics_Monad.mk_irrelevant_goal
+                         "refine_intro refinement" uu___6 uu___7 (rangeof g)
+                         g.FStar_Tactics_Types.opts
+                         g.FStar_Tactics_Types.label in
+                     FStar_Tactics_Monad.bind uu___5
+                       (fun g2 ->
+                          FStar_Tactics_Monad.bind
+                            FStar_Tactics_Monad.dismiss
+                            (fun uu___6 ->
+                               FStar_Tactics_Monad.add_goals [g1; g2]))))) in
     FStar_Compiler_Effect.op_Less_Bar
       (FStar_Tactics_Monad.wrap_err "refine_intro") uu___1
 let (__exact_now :
@@ -2046,14 +1964,12 @@ let (__exact_now :
                                      (fun b ->
                                         if b
                                         then
-                                          let uu___7 =
-                                            if set_expected_typ
-                                            then
-                                              mark_goal_implicit_allow_untyped
-                                                goal
-                                            else FStar_Tactics_Monad.ret () in
-                                          FStar_Tactics_Monad.bind uu___7
-                                            (fun uu___8 -> solve goal t1)
+                                          (if set_expected_typ
+                                           then
+                                             mark_goal_implicit_allow_untyped
+                                               goal
+                                           else ();
+                                           solve goal t1)
                                         else
                                           (let uu___8 =
                                              let uu___9 =
@@ -2379,7 +2295,7 @@ let (check_apply_implicits_solutions :
                          (match uu___3 with
                           | FStar_Syntax_Syntax.Tm_uvar (ctx_uvar1, uu___4)
                               ->
-                              let uu___5 =
+                              let gl1 =
                                 bnorm_goal
                                   {
                                     FStar_Tactics_Types.goal_main_env =
@@ -2393,8 +2309,7 @@ let (check_apply_implicits_solutions :
                                     FStar_Tactics_Types.label =
                                       (gl.FStar_Tactics_Types.label)
                                   } in
-                              FStar_Tactics_Monad.bind uu___5
-                                (fun gl1 -> FStar_Tactics_Monad.ret [gl1])
+                              FStar_Tactics_Monad.ret [gl1]
                           | uu___4 ->
                               FStar_Tactics_Monad.mlog
                                 (fun uu___5 ->
@@ -2431,12 +2346,8 @@ let (check_apply_implicits_solutions :
                                        (rangeof gl) in
                                    FStar_Tactics_Monad.bind uu___6
                                      (fun uu___7 ->
-                                        let uu___8 =
-                                          find_and_mark_implicit_as_allow_untyped
-                                            ctx_uvar in
-                                        FStar_Tactics_Monad.bind uu___8
-                                          (fun uu___9 ->
-                                             FStar_Tactics_Monad.ret []))))) in
+                                        mark_uvar_as_allow_untyped ctx_uvar;
+                                        FStar_Tactics_Monad.ret [])))) in
               FStar_Compiler_Effect.op_Bar_Greater imps
                 (FStar_Tactics_Monad.mapM check_one_implicit)
 let (t_apply :
@@ -2622,47 +2533,44 @@ let (t_apply :
                                                                let uu___11 =
                                                                  let uu___12
                                                                    =
-                                                                   FStar_Compiler_Effect.op_Bar_Greater
+                                                                   let uu___13
+                                                                    =
+                                                                    let uu___14
+                                                                    =
+                                                                    FStar_Compiler_Effect.op_Bar_Greater
                                                                     subgoals
                                                                     FStar_Compiler_List.flatten in
-                                                                 FStar_Compiler_Effect.op_Bar_Greater
-                                                                   uu___12
-                                                                   (FStar_Compiler_List.filter
+                                                                    FStar_Compiler_Effect.op_Bar_Greater
+                                                                    uu___14
+                                                                    (FStar_Compiler_List.filter
                                                                     (fun g ->
-                                                                    let uu___13
+                                                                    let uu___15
                                                                     =
                                                                     uopt &&
                                                                     (free_in_some_goal
                                                                     g.FStar_Tactics_Types.goal_ctx_uvar) in
                                                                     Prims.op_Negation
-                                                                    uu___13)) in
+                                                                    uu___15)) in
+                                                                   FStar_Compiler_Effect.op_Bar_Greater
+                                                                    uu___13
+                                                                    (FStar_Compiler_List.map
+                                                                    bnorm_goal) in
+                                                                 FStar_Compiler_Effect.op_Bar_Greater
+                                                                   uu___12
+                                                                   FStar_Compiler_List.rev in
                                                                FStar_Compiler_Effect.op_Bar_Greater
                                                                  uu___11
-                                                                 (FStar_Tactics_Monad.mapM
-                                                                    (
-                                                                    fun g ->
-                                                                    bnorm_goal
-                                                                    g)) in
+                                                                 FStar_Tactics_Monad.add_goals in
                                                              FStar_Tactics_Monad.bind
                                                                uu___10
-                                                               (fun subgoals1
+                                                               (fun uu___11
                                                                   ->
-                                                                  let uu___11
-                                                                    =
-                                                                    FStar_Tactics_Monad.add_goals
-                                                                    (FStar_Compiler_List.rev
-                                                                    subgoals1) in
-                                                                  FStar_Tactics_Monad.bind
-                                                                    uu___11
-                                                                    (
-                                                                    fun
-                                                                    uu___12
-                                                                    ->
-                                                                    proc_guard
+                                                                  proc_guard
                                                                     "apply guard"
                                                                     e guard
-                                                                    (rangeof
-                                                                    goal)))))))))))) in
+                                                                    (
+                                                                    rangeof
+                                                                    goal))))))))))) in
           FStar_Compiler_Effect.op_Less_Bar
             (FStar_Tactics_Monad.wrap_err "apply") uu___
 let (lemma_or_sq :
@@ -3154,9 +3062,11 @@ let (subst_goal :
                             (fun b -> b.FStar_Syntax_Syntax.binder_bv) bs'' in
                         push_bvs e0 uu___3 in
                       let uu___3 =
+                        let uu___4 =
+                          let uu___5 = should_check_goal_uvar g in
+                          FStar_Pervasives_Native.Some uu___5 in
                         FStar_Tactics_Monad.new_uvar "subst_goal" new_env t''
-                          (FStar_Pervasives_Native.Some
-                             (should_check_goal_uvar g)) (rangeof g) in
+                          uu___4 (rangeof g) in
                       FStar_Tactics_Monad.bind uu___3
                         (fun uu___4 ->
                            match uu___4 with
@@ -3264,11 +3174,15 @@ let (rewrite : FStar_Syntax_Syntax.binder -> unit FStar_Tactics_Monad.tac) =
                                                  bv1 :: uu___9 in
                                                push_bvs e0 uu___8 in
                                              let uu___8 =
+                                               let uu___9 =
+                                                 let uu___10 =
+                                                   should_check_goal_uvar
+                                                     goal in
+                                                 FStar_Pervasives_Native.Some
+                                                   uu___10 in
                                                FStar_Tactics_Monad.new_uvar
-                                                 "rewrite" new_env t''
-                                                 (FStar_Pervasives_Native.Some
-                                                    (should_check_goal_uvar
-                                                       goal)) (rangeof goal) in
+                                                 "rewrite" new_env t'' uu___9
+                                                 (rangeof goal) in
                                              FStar_Tactics_Monad.bind uu___8
                                                (fun uu___9 ->
                                                   match uu___9 with
@@ -3385,9 +3299,11 @@ let (binder_retype :
                (match uu___2 with
                 | (ty, u) ->
                     let uu___3 =
+                      let uu___4 =
+                        let uu___5 = should_check_goal_uvar goal in
+                        FStar_Pervasives_Native.Some uu___5 in
                       FStar_Tactics_Monad.new_uvar "binder_retype" e0 ty
-                        (FStar_Pervasives_Native.Some
-                           (should_check_goal_uvar goal)) (rangeof goal) in
+                        uu___4 (rangeof goal) in
                     FStar_Tactics_Monad.bind uu___3
                       (fun uu___4 ->
                          match uu___4 with
@@ -3425,31 +3341,26 @@ let (binder_retype :
                              FStar_Tactics_Monad.bind
                                FStar_Tactics_Monad.dismiss
                                (fun uu___5 ->
-                                  let uu___6 =
-                                    let uu___7 =
+                                  let new_goal =
+                                    let uu___6 =
                                       FStar_Tactics_Types.goal_with_env goal
                                         env' in
-                                    let uu___8 =
-                                      let uu___9 =
+                                    let uu___7 =
+                                      let uu___8 =
                                         FStar_Tactics_Types.goal_type goal in
-                                      FStar_Syntax_Subst.subst s uu___9 in
-                                    goal_with_type uu___7 uu___8 in
+                                      FStar_Syntax_Subst.subst s uu___8 in
+                                    goal_with_type uu___6 uu___7 in
+                                  let uu___6 =
+                                    FStar_Tactics_Monad.add_goals [new_goal] in
                                   FStar_Tactics_Monad.bind uu___6
-                                    (fun new_goal ->
-                                       let uu___7 =
-                                         FStar_Tactics_Monad.add_goals
-                                           [new_goal] in
-                                       FStar_Tactics_Monad.bind uu___7
-                                         (fun uu___8 ->
-                                            let uu___9 =
-                                              FStar_Syntax_Util.mk_eq2
-                                                (FStar_Syntax_Syntax.U_succ u)
-                                                ty
-                                                bv1.FStar_Syntax_Syntax.sort
-                                                t' in
-                                            FStar_Tactics_Monad.add_irrelevant_goal
-                                              goal "binder_retype equation"
-                                              e0 uu___9)))))) in
+                                    (fun uu___7 ->
+                                       let uu___8 =
+                                         FStar_Syntax_Util.mk_eq2
+                                           (FStar_Syntax_Syntax.U_succ u) ty
+                                           bv1.FStar_Syntax_Syntax.sort t' in
+                                       FStar_Tactics_Monad.add_irrelevant_goal
+                                         goal "binder_retype equation" e0
+                                         uu___8))))) in
     FStar_Compiler_Effect.op_Less_Bar
       (FStar_Tactics_Monad.wrap_err "binder_retype") uu___
 let (norm_binder_type :
@@ -3508,8 +3419,10 @@ let (revert : unit -> unit FStar_Tactics_Monad.tac) =
                  FStar_Syntax_Syntax.mk_Total uu___4 in
                FStar_Syntax_Util.arrow uu___2 uu___3 in
              let uu___2 =
-               FStar_Tactics_Monad.new_uvar "revert" env' typ'
-                 (FStar_Pervasives_Native.Some (should_check_goal_uvar goal))
+               let uu___3 =
+                 let uu___4 = should_check_goal_uvar goal in
+                 FStar_Pervasives_Native.Some uu___4 in
+               FStar_Tactics_Monad.new_uvar "revert" env' typ' uu___3
                  (rangeof goal) in
              FStar_Tactics_Monad.bind uu___2
                (fun uu___3 ->
@@ -3597,11 +3510,11 @@ let (clear : FStar_Syntax_Syntax.binder -> unit FStar_Tactics_Monad.tac) =
                           let env' = push_bvs e' bvs in
                           let uu___6 =
                             let uu___7 = FStar_Tactics_Types.goal_type goal in
+                            let uu___8 =
+                              let uu___9 = should_check_goal_uvar goal in
+                              FStar_Pervasives_Native.Some uu___9 in
                             FStar_Tactics_Monad.new_uvar "clear.witness" env'
-                              uu___7
-                              (FStar_Pervasives_Native.Some
-                                 (should_check_goal_uvar goal))
-                              (rangeof goal) in
+                              uu___7 uu___8 (rangeof goal) in
                           FStar_Tactics_Monad.bind uu___6
                             (fun uu___7 ->
                                match uu___7 with
@@ -3759,9 +3672,10 @@ let (dup : unit -> unit FStar_Tactics_Monad.tac) =
          let env1 = FStar_Tactics_Types.goal_env g in
          let uu___1 =
            let uu___2 = FStar_Tactics_Types.goal_type g in
-           FStar_Tactics_Monad.new_uvar "dup" env1 uu___2
-             (FStar_Pervasives_Native.Some (should_check_goal_uvar g))
-             (rangeof g) in
+           let uu___3 =
+             let uu___4 = should_check_goal_uvar g in
+             FStar_Pervasives_Native.Some uu___4 in
+           FStar_Tactics_Monad.new_uvar "dup" env1 uu___2 uu___3 (rangeof g) in
          FStar_Tactics_Monad.bind uu___1
            (fun uu___2 ->
               match uu___2 with
@@ -4311,9 +4225,7 @@ let (unshelve : FStar_Syntax_Syntax.term -> unit FStar_Tactics_Monad.tac) =
                  } in
                let g =
                  FStar_Tactics_Types.mk_goal env2 ctx_uvar opts false "" in
-               let uu___6 = bnorm_goal g in
-               FStar_Tactics_Monad.bind uu___6
-                 (fun g1 -> FStar_Tactics_Monad.add_goals [g1])
+               let g1 = bnorm_goal g in FStar_Tactics_Monad.add_goals [g1]
            | uu___2 -> FStar_Tactics_Monad.fail "not a uvar") in
     FStar_Compiler_Effect.op_Less_Bar
       (FStar_Tactics_Monad.wrap_err "unshelve") uu___
@@ -4562,8 +4474,7 @@ let (change : FStar_Reflection_Data.typ -> unit FStar_Tactics_Monad.tac) =
                                    if bb
                                    then
                                      let uu___8 = goal_with_type g ty1 in
-                                     FStar_Tactics_Monad.bind uu___8
-                                       FStar_Tactics_Monad.replace_cur
+                                     FStar_Tactics_Monad.replace_cur uu___8
                                    else
                                      (let steps =
                                         [FStar_TypeChecker_Env.AllowUnboundUniverses;
@@ -4590,8 +4501,8 @@ let (change : FStar_Reflection_Data.typ -> unit FStar_Tactics_Monad.tac) =
                                            then
                                              let uu___10 =
                                                goal_with_type g ty1 in
-                                             FStar_Tactics_Monad.bind uu___10
-                                               FStar_Tactics_Monad.replace_cur
+                                             FStar_Tactics_Monad.replace_cur
+                                               uu___10
                                            else
                                              FStar_Tactics_Monad.fail
                                                "not convertible"))))))) in
@@ -5354,23 +5265,17 @@ let (t_destruct :
                                                                     (fun
                                                                     uu___16
                                                                     ->
-                                                                    let uu___17
-                                                                    =
                                                                     mark_goal_implicit_allow_untyped
-                                                                    g in
-                                                                    FStar_Tactics_Monad.bind
-                                                                    uu___17
-                                                                    (fun
-                                                                    uu___18
-                                                                    ->
-                                                                    let uu___19
+                                                                    g;
+                                                                    (
+                                                                    let uu___18
                                                                     =
                                                                     FStar_Tactics_Monad.add_goals
                                                                     goals in
                                                                     FStar_Tactics_Monad.bind
-                                                                    uu___19
+                                                                    uu___18
                                                                     (fun
-                                                                    uu___20
+                                                                    uu___19
                                                                     ->
                                                                     FStar_Tactics_Monad.ret
                                                                     infos))))))

--- a/src/ocaml-output/FStar_Tactics_Basic.ml
+++ b/src/ocaml-output/FStar_Tactics_Basic.ml
@@ -114,8 +114,7 @@ let (do_dump_ps : Prims.string -> FStar_Tactics_Types.proofstate -> unit) =
     fun ps ->
       let psc = ps.FStar_Tactics_Types.psc in
       let subst = FStar_TypeChecker_Cfg.psc_subst psc in
-      let uu___ = FStar_Tactics_Types.subst_proof_display_state subst ps in
-      FStar_Tactics_Printing.do_dump_proofstate uu___ msg
+      FStar_Tactics_Printing.do_dump_proofstate ps msg
 let (dump : Prims.string -> unit FStar_Tactics_Monad.tac) =
   fun msg ->
     FStar_Tactics_Monad.mk_tac
@@ -1741,9 +1740,6 @@ let (intro_rec :
                                             (goal.FStar_Tactics_Types.goal_main_env);
                                           FStar_Tactics_Types.goal_ctx_uvar =
                                             ctx_uvar_u;
-                                          FStar_Tactics_Types.goal_display_type
-                                            =
-                                            (goal.FStar_Tactics_Types.goal_display_type);
                                           FStar_Tactics_Types.opts =
                                             (goal.FStar_Tactics_Types.opts);
                                           FStar_Tactics_Types.is_guard =
@@ -2281,8 +2277,6 @@ let (check_apply_implicits_solutions :
                                       (gl.FStar_Tactics_Types.goal_main_env);
                                     FStar_Tactics_Types.goal_ctx_uvar =
                                       ctx_uvar1;
-                                    FStar_Tactics_Types.goal_display_type =
-                                      (gl.FStar_Tactics_Types.goal_display_type);
                                     FStar_Tactics_Types.opts =
                                       (gl.FStar_Tactics_Types.opts);
                                     FStar_Tactics_Types.is_guard =
@@ -2501,9 +2495,6 @@ let (t_apply :
                                                                     (goal.FStar_Tactics_Types.goal_main_env);
                                                                     FStar_Tactics_Types.goal_ctx_uvar
                                                                     = uv;
-                                                                    FStar_Tactics_Types.goal_display_type
-                                                                    =
-                                                                    (goal.FStar_Tactics_Types.goal_display_type);
                                                                     FStar_Tactics_Types.opts
                                                                     =
                                                                     (goal.FStar_Tactics_Types.opts);
@@ -3675,8 +3666,6 @@ let (dup : unit -> unit FStar_Tactics_Monad.tac) =
                       FStar_Tactics_Types.goal_main_env =
                         (g.FStar_Tactics_Types.goal_main_env);
                       FStar_Tactics_Types.goal_ctx_uvar = u_uvar;
-                      FStar_Tactics_Types.goal_display_type =
-                        (g.FStar_Tactics_Types.goal_display_type);
                       FStar_Tactics_Types.opts = (g.FStar_Tactics_Types.opts);
                       FStar_Tactics_Types.is_guard =
                         (g.FStar_Tactics_Types.is_guard);
@@ -3960,8 +3949,6 @@ let (set_options : Prims.string -> unit FStar_Tactics_Monad.tac) =
                        (g.FStar_Tactics_Types.goal_main_env);
                      FStar_Tactics_Types.goal_ctx_uvar =
                        (g.FStar_Tactics_Types.goal_ctx_uvar);
-                     FStar_Tactics_Types.goal_display_type =
-                       (g.FStar_Tactics_Types.goal_display_type);
                      FStar_Tactics_Types.opts = opts';
                      FStar_Tactics_Types.is_guard =
                        (g.FStar_Tactics_Types.is_guard);

--- a/src/ocaml-output/FStar_Tactics_CtrlRewrite.ml
+++ b/src/ocaml-output/FStar_Tactics_CtrlRewrite.ml
@@ -725,10 +725,10 @@ let (ctrl_rewrite :
                                FStar_Tactics_Monad.bind uu___6
                                  (fun uu___7 ->
                                     let uu___8 =
-                                      let uu___9 =
-                                        FStar_Tactics_Types.goal_with_type g
-                                          gt' in
-                                      [uu___9] in
-                                    FStar_Tactics_Monad.add_goals uu___8)))))) in
+                                      FStar_Tactics_Basic.goal_with_type g
+                                        gt' in
+                                    FStar_Tactics_Monad.bind uu___8
+                                      (fun g1 ->
+                                         FStar_Tactics_Monad.add_goals [g1]))))))) in
         FStar_Compiler_Effect.op_Less_Bar
           (FStar_Tactics_Monad.wrap_err "ctrl_rewrite") uu___

--- a/src/ocaml-output/FStar_Tactics_CtrlRewrite.ml
+++ b/src/ocaml-output/FStar_Tactics_CtrlRewrite.ml
@@ -104,6 +104,9 @@ let (__do_rewrite :
                                    FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term
                                      =
                                      (env.FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term);
+                                   FStar_TypeChecker_Env.subtype_nosmt_force
+                                     =
+                                     (env.FStar_TypeChecker_Env.subtype_nosmt_force);
                                    FStar_TypeChecker_Env.use_bv_sorts =
                                      (env.FStar_TypeChecker_Env.use_bv_sorts);
                                    FStar_TypeChecker_Env.qtbl_name_and_index
@@ -169,7 +172,7 @@ let (__do_rewrite :
                    (let typ = lcomp.FStar_TypeChecker_Common.res_typ in
                     let uu___4 =
                       FStar_Tactics_Monad.new_uvar "do_rewrite.rhs" env typ
-                        (rangeof g0) in
+                        FStar_Pervasives_Native.None (rangeof g0) in
                     FStar_Tactics_Monad.bind uu___4
                       (fun uu___5 ->
                          match uu___5 with

--- a/src/ocaml-output/FStar_Tactics_CtrlRewrite.ml
+++ b/src/ocaml-output/FStar_Tactics_CtrlRewrite.ml
@@ -375,9 +375,9 @@ and (recurse_option_residual_comp :
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.residual_comp FStar_Pervasives_Native.option ->
       (FStar_TypeChecker_Env.env ->
-         FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
-           (FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax *
-             FStar_Tactics_Types.ctrl_flag) FStar_Tactics_Monad.tac)
+         FStar_Syntax_Syntax.term ->
+           (FStar_Syntax_Syntax.term * FStar_Tactics_Types.ctrl_flag)
+             FStar_Tactics_Monad.tac)
         ->
         (FStar_Syntax_Syntax.residual_comp FStar_Pervasives_Native.option *
           FStar_Tactics_Types.ctrl_flag) FStar_Tactics_Monad.tac)
@@ -385,32 +385,8 @@ and (recurse_option_residual_comp :
   fun env ->
     fun rc_opt ->
       fun recurse ->
-        match rc_opt with
-        | FStar_Pervasives_Native.None ->
-            FStar_Tactics_Monad.ret
-              (FStar_Pervasives_Native.None, FStar_Tactics_Types.Continue)
-        | FStar_Pervasives_Native.Some rc ->
-            (match rc.FStar_Syntax_Syntax.residual_typ with
-             | FStar_Pervasives_Native.None ->
-                 FStar_Tactics_Monad.ret
-                   ((FStar_Pervasives_Native.Some rc),
-                     FStar_Tactics_Types.Continue)
-             | FStar_Pervasives_Native.Some t ->
-                 let uu___ = recurse env t in
-                 FStar_Tactics_Monad.bind uu___
-                   (fun uu___1 ->
-                      match uu___1 with
-                      | (t1, flag) ->
-                          FStar_Tactics_Monad.ret
-                            ((FStar_Pervasives_Native.Some
-                                {
-                                  FStar_Syntax_Syntax.residual_effect =
-                                    (rc.FStar_Syntax_Syntax.residual_effect);
-                                  FStar_Syntax_Syntax.residual_typ =
-                                    (FStar_Pervasives_Native.Some t1);
-                                  FStar_Syntax_Syntax.residual_flags =
-                                    (rc.FStar_Syntax_Syntax.residual_flags)
-                                }), flag)))
+        FStar_Tactics_Monad.ret
+          (FStar_Pervasives_Native.None, FStar_Tactics_Types.Continue)
 and (on_subterms :
   FStar_Tactics_Types.goal ->
     FStar_Tactics_Types.direction ->

--- a/src/ocaml-output/FStar_Tactics_CtrlRewrite.ml
+++ b/src/ocaml-output/FStar_Tactics_CtrlRewrite.ml
@@ -172,7 +172,8 @@ let (__do_rewrite :
                    (let typ = lcomp.FStar_TypeChecker_Common.res_typ in
                     let uu___4 =
                       FStar_Tactics_Monad.new_uvar "do_rewrite.rhs" env typ
-                        FStar_Pervasives_Native.None (rangeof g0) in
+                        (FStar_Pervasives_Native.Some
+                           FStar_Syntax_Syntax.Allow_untyped) (rangeof g0) in
                     FStar_Tactics_Monad.bind uu___4
                       (fun uu___5 ->
                          match uu___5 with

--- a/src/ocaml-output/FStar_Tactics_CtrlRewrite.ml
+++ b/src/ocaml-output/FStar_Tactics_CtrlRewrite.ml
@@ -788,11 +788,9 @@ let (ctrl_rewrite :
                               (let uu___6 = FStar_Tactics_Monad.push_goals gs in
                                FStar_Tactics_Monad.bind uu___6
                                  (fun uu___7 ->
-                                    let uu___8 =
+                                    let g1 =
                                       FStar_Tactics_Basic.goal_with_type g
                                         gt' in
-                                    FStar_Tactics_Monad.bind uu___8
-                                      (fun g1 ->
-                                         FStar_Tactics_Monad.add_goals [g1]))))))) in
+                                    FStar_Tactics_Monad.add_goals [g1])))))) in
         FStar_Compiler_Effect.op_Less_Bar
           (FStar_Tactics_Monad.wrap_err "ctrl_rewrite") uu___

--- a/src/ocaml-output/FStar_Tactics_CtrlRewrite.ml
+++ b/src/ocaml-output/FStar_Tactics_CtrlRewrite.ml
@@ -172,8 +172,7 @@ let (__do_rewrite :
                    (let typ = lcomp.FStar_TypeChecker_Common.res_typ in
                     let uu___4 =
                       FStar_Tactics_Monad.new_uvar "do_rewrite.rhs" env typ
-                        (FStar_Pervasives_Native.Some
-                           FStar_Syntax_Syntax.Allow_untyped) (rangeof g0) in
+                        FStar_Pervasives_Native.None (rangeof g0) in
                     FStar_Tactics_Monad.bind uu___4
                       (fun uu___5 ->
                          match uu___5 with

--- a/src/ocaml-output/FStar_Tactics_CtrlRewrite.ml
+++ b/src/ocaml-output/FStar_Tactics_CtrlRewrite.ml
@@ -375,9 +375,9 @@ and (recurse_option_residual_comp :
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.residual_comp FStar_Pervasives_Native.option ->
       (FStar_TypeChecker_Env.env ->
-         FStar_Syntax_Syntax.term ->
-           (FStar_Syntax_Syntax.term * FStar_Tactics_Types.ctrl_flag)
-             FStar_Tactics_Monad.tac)
+         FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
+           (FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax *
+             FStar_Tactics_Types.ctrl_flag) FStar_Tactics_Monad.tac)
         ->
         (FStar_Syntax_Syntax.residual_comp FStar_Pervasives_Native.option *
           FStar_Tactics_Types.ctrl_flag) FStar_Tactics_Monad.tac)
@@ -385,8 +385,32 @@ and (recurse_option_residual_comp :
   fun env ->
     fun rc_opt ->
       fun recurse ->
-        FStar_Tactics_Monad.ret
-          (FStar_Pervasives_Native.None, FStar_Tactics_Types.Continue)
+        match rc_opt with
+        | FStar_Pervasives_Native.None ->
+            FStar_Tactics_Monad.ret
+              (FStar_Pervasives_Native.None, FStar_Tactics_Types.Continue)
+        | FStar_Pervasives_Native.Some rc ->
+            (match rc.FStar_Syntax_Syntax.residual_typ with
+             | FStar_Pervasives_Native.None ->
+                 FStar_Tactics_Monad.ret
+                   ((FStar_Pervasives_Native.Some rc),
+                     FStar_Tactics_Types.Continue)
+             | FStar_Pervasives_Native.Some t ->
+                 let uu___ = recurse env t in
+                 FStar_Tactics_Monad.bind uu___
+                   (fun uu___1 ->
+                      match uu___1 with
+                      | (t1, flag) ->
+                          FStar_Tactics_Monad.ret
+                            ((FStar_Pervasives_Native.Some
+                                {
+                                  FStar_Syntax_Syntax.residual_effect =
+                                    (rc.FStar_Syntax_Syntax.residual_effect);
+                                  FStar_Syntax_Syntax.residual_typ =
+                                    (FStar_Pervasives_Native.Some t1);
+                                  FStar_Syntax_Syntax.residual_flags =
+                                    (rc.FStar_Syntax_Syntax.residual_flags)
+                                }), flag)))
 and (on_subterms :
   FStar_Tactics_Types.goal ->
     FStar_Tactics_Types.direction ->

--- a/src/ocaml-output/FStar_Tactics_Hooks.ml
+++ b/src/ocaml-output/FStar_Tactics_Hooks.ml
@@ -228,12 +228,11 @@ let (by_tactic_interp :
                                    (FStar_Errors.Fatal_OpenGoalsInSynthesis,
                                      "rewrite_with_tactic left open goals")
                                    typ.FStar_Syntax_Syntax.pos);
-                            (let g_imp1 =
+                            (let tagged_imps =
                                FStar_TypeChecker_Rel.resolve_implicits_tac e
                                  g_imp in
                              FStar_Tactics_Interpreter.report_implicits
-                               tm.FStar_Syntax_Syntax.pos
-                               g_imp1.FStar_TypeChecker_Common.implicits;
+                               tm.FStar_Syntax_Syntax.pos tagged_imps;
                              Simplified (uvtm, [])))))
              | uu___2 -> Unchanged t)
 let explode :
@@ -1819,10 +1818,9 @@ let (postprocess :
                                         (FStar_Errors.Fatal_OpenGoalsInSynthesis,
                                           "postprocessing left open goals")
                                         typ.FStar_Syntax_Syntax.pos) gs;
-                             (let g_imp1 =
+                             (let tagged_imps =
                                 FStar_TypeChecker_Rel.resolve_implicits_tac
                                   env g_imp in
                               FStar_Tactics_Interpreter.report_implicits
-                                tm.FStar_Syntax_Syntax.pos
-                                g_imp1.FStar_TypeChecker_Common.implicits;
+                                tm.FStar_Syntax_Syntax.pos tagged_imps;
                               uvtm))))))

--- a/src/ocaml-output/FStar_Tactics_Hooks.ml
+++ b/src/ocaml-output/FStar_Tactics_Hooks.ml
@@ -848,6 +848,8 @@ let rec (traverse_for_spinoff :
                              FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term
                                =
                                (env2.FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term);
+                             FStar_TypeChecker_Env.subtype_nosmt_force =
+                               (env2.FStar_TypeChecker_Env.subtype_nosmt_force);
                              FStar_TypeChecker_Env.use_bv_sorts =
                                (env2.FStar_TypeChecker_Env.use_bv_sorts);
                              FStar_TypeChecker_Env.qtbl_name_and_index =

--- a/src/ocaml-output/FStar_Tactics_Interpreter.ml
+++ b/src/ocaml-output/FStar_Tactics_Interpreter.ml
@@ -1455,7 +1455,23 @@ let (uu___143 : unit) =
                                                                     FStar_Tactics_Basic.t_commute_applied_match
                                                                     FStar_TypeChecker_NBETerm.e_unit
                                                                     FStar_TypeChecker_NBETerm.e_unit in
-                                                                    [uu___138] in
+                                                                    let uu___139
+                                                                    =
+                                                                    let uu___140
+                                                                    =
+                                                                    FStar_Tactics_InterpFuns.mk_tac_step_1
+                                                                    Prims.int_zero
+                                                                    "gather_or_solve_explicit_guards_for_resolved_goals"
+                                                                    FStar_Tactics_Basic.gather_explicit_guards_for_resolved_goals
+                                                                    FStar_Syntax_Embeddings.e_unit
+                                                                    FStar_Syntax_Embeddings.e_unit
+                                                                    FStar_Tactics_Basic.gather_explicit_guards_for_resolved_goals
+                                                                    FStar_TypeChecker_NBETerm.e_unit
+                                                                    FStar_TypeChecker_NBETerm.e_unit in
+                                                                    [uu___140] in
+                                                                    uu___138
+                                                                    ::
+                                                                    uu___139 in
                                                                     uu___136
                                                                     ::
                                                                     uu___137 in
@@ -1713,7 +1729,7 @@ let (report_implicits :
                            let uu___6 = FStar_Syntax_Print.term_to_string tm in
                            let uu___7 = FStar_Syntax_Print.term_to_string ty in
                            FStar_Compiler_Util.format4
-                             "Tactic solved goal %s of type %s to %s : %s, but it has a non-trivial typing guard"
+                             "Tactic solved goal %s of type %s to %s : %s, but it has a non-trivial typing guard. Use gather_or_solve_explicit_guards_for_resolved_goals to inspect and prove these goals"
                              uu___4 uu___5 uu___6 uu___7 in
                          (FStar_Errors.Error_UninstantiatedUnificationVarInTactic,
                            uu___3) in

--- a/src/ocaml-output/FStar_Tactics_Interpreter.ml
+++ b/src/ocaml-output/FStar_Tactics_Interpreter.ml
@@ -1751,51 +1751,53 @@ let run_tactic_on_ps' :
                                        ps1.FStar_Tactics_Types.smt_goals in
                                    (FStar_Compiler_List.iter
                                       (fun g1 ->
-                                         let uu___11 =
-                                           FStar_Tactics_Types.is_irrelevant
-                                             g1 in
-                                         if uu___11
-                                         then
-                                           ((let uu___13 =
-                                               FStar_Compiler_Effect.op_Bang
-                                                 tacdbg in
-                                             if uu___13
-                                             then
-                                               let uu___14 =
-                                                 let uu___15 =
-                                                   FStar_Tactics_Types.goal_witness
-                                                     g1 in
-                                                 FStar_Syntax_Print.term_to_string
-                                                   uu___15 in
-                                               FStar_Compiler_Util.print1
-                                                 "Assigning irrelevant goal %s\n"
-                                                 uu___14
-                                             else ());
-                                            (let uu___13 =
-                                               let uu___14 =
-                                                 FStar_Tactics_Types.goal_env
-                                                   g1 in
-                                               let uu___15 =
-                                                 FStar_Tactics_Types.goal_witness
-                                                   g1 in
-                                               FStar_TypeChecker_Rel.teq_nosmt_force
-                                                 uu___14 uu___15
-                                                 FStar_Syntax_Util.exp_unit in
-                                             if uu___13
-                                             then ()
-                                             else
-                                               (let uu___15 =
+                                         FStar_Tactics_Basic.mark_goal_implicit_allow_untyped
+                                           g1;
+                                         (let uu___12 =
+                                            FStar_Tactics_Types.is_irrelevant
+                                              g1 in
+                                          if uu___12
+                                          then
+                                            ((let uu___14 =
+                                                FStar_Compiler_Effect.op_Bang
+                                                  tacdbg in
+                                              if uu___14
+                                              then
+                                                let uu___15 =
                                                   let uu___16 =
-                                                    let uu___17 =
-                                                      FStar_Tactics_Types.goal_witness
-                                                        g1 in
-                                                    FStar_Syntax_Print.term_to_string
-                                                      uu___17 in
-                                                  FStar_Compiler_Util.format1
-                                                    "Irrelevant tactic witness does not unify with (): %s"
+                                                    FStar_Tactics_Types.goal_witness
+                                                      g1 in
+                                                  FStar_Syntax_Print.term_to_string
                                                     uu___16 in
-                                                failwith uu___15)))
-                                         else ()) remaining_smt_goals;
+                                                FStar_Compiler_Util.print1
+                                                  "Assigning irrelevant goal %s\n"
+                                                  uu___15
+                                              else ());
+                                             (let uu___14 =
+                                                let uu___15 =
+                                                  FStar_Tactics_Types.goal_env
+                                                    g1 in
+                                                let uu___16 =
+                                                  FStar_Tactics_Types.goal_witness
+                                                    g1 in
+                                                FStar_TypeChecker_Rel.teq_nosmt_force
+                                                  uu___15 uu___16
+                                                  FStar_Syntax_Util.exp_unit in
+                                              if uu___14
+                                              then ()
+                                              else
+                                                (let uu___16 =
+                                                   let uu___17 =
+                                                     let uu___18 =
+                                                       FStar_Tactics_Types.goal_witness
+                                                         g1 in
+                                                     FStar_Syntax_Print.term_to_string
+                                                       uu___18 in
+                                                   FStar_Compiler_Util.format1
+                                                     "Irrelevant tactic witness does not unify with (): %s"
+                                                     uu___17 in
+                                                 failwith uu___16)))
+                                          else ())) remaining_smt_goals;
                                     (let uu___12 =
                                        FStar_Compiler_Effect.op_Bang tacdbg in
                                      if uu___12
@@ -1810,26 +1812,7 @@ let run_tactic_on_ps' :
                                          "About to check tactic implicits: %s\n"
                                          uu___13
                                      else ());
-                                    (let is_smt_implicit i =
-                                       FStar_Compiler_Util.for_some
-                                         (fun g1 ->
-                                            FStar_Tactics_Basic.is_implicit_for_goal
-                                              g1 i) remaining_smt_goals in
-                                     let all_implicits =
-                                       FStar_Compiler_List.map
-                                         (fun i ->
-                                            let uu___12 =
-                                              ((i.FStar_TypeChecker_Common.imp_uvar).FStar_Syntax_Syntax.ctx_uvar_should_check
-                                                 <>
-                                                 FStar_Syntax_Syntax.Allow_untyped)
-                                                && (is_smt_implicit i) in
-                                            if uu___12
-                                            then
-                                              FStar_Tactics_Basic.mark_implicit_as_allow_untyped
-                                                i
-                                            else i)
-                                         ps1.FStar_Tactics_Types.all_implicits in
-                                     let g1 =
+                                    (let g1 =
                                        {
                                          FStar_TypeChecker_Common.guard_f =
                                            (FStar_TypeChecker_Env.trivial_guard.FStar_TypeChecker_Common.guard_f);
@@ -1842,7 +1825,7 @@ let run_tactic_on_ps' :
                                            =
                                            (FStar_TypeChecker_Env.trivial_guard.FStar_TypeChecker_Common.univ_ineqs);
                                          FStar_TypeChecker_Common.implicits =
-                                           all_implicits
+                                           (ps1.FStar_Tactics_Types.all_implicits)
                                        } in
                                      let g2 =
                                        FStar_TypeChecker_Rel.solve_deferred_constraints

--- a/src/ocaml-output/FStar_Tactics_Interpreter.ml
+++ b/src/ocaml-output/FStar_Tactics_Interpreter.ml
@@ -1650,28 +1650,74 @@ let e_tactic_1_alt :
         FStar_Syntax_Embeddings.term_as_fv FStar_Syntax_Syntax.t_unit in
       FStar_Syntax_Embeddings.mk_emb em un uu___
 let (report_implicits :
-  FStar_Compiler_Range.range -> FStar_TypeChecker_Env.implicits -> unit) =
+  FStar_Compiler_Range.range ->
+    FStar_TypeChecker_Rel.tagged_implicits -> unit)
+  =
   fun rng ->
     fun is ->
       FStar_Compiler_Effect.op_Bar_Greater is
         (FStar_Compiler_List.iter
-           (fun imp ->
-              let uu___1 =
-                let uu___2 =
-                  let uu___3 =
-                    FStar_Syntax_Print.uvar_to_string
-                      (imp.FStar_TypeChecker_Common.imp_uvar).FStar_Syntax_Syntax.ctx_uvar_head in
-                  let uu___4 =
-                    let uu___5 =
-                      FStar_Syntax_Util.ctx_uvar_typ
-                        imp.FStar_TypeChecker_Common.imp_uvar in
-                    FStar_Syntax_Print.term_to_string uu___5 in
-                  FStar_Compiler_Util.format3
-                    "Tactic left uninstantiated unification variable %s of type %s (reason = \"%s\")"
-                    uu___3 uu___4 imp.FStar_TypeChecker_Common.imp_reason in
-                (FStar_Errors.Error_UninstantiatedUnificationVarInTactic,
-                  uu___2) in
-              FStar_Errors.log_issue rng uu___1));
+           (fun uu___1 ->
+              match uu___1 with
+              | (imp, tag) ->
+                  (match tag with
+                   | FStar_TypeChecker_Rel.Implicit_unresolved ->
+                       let uu___2 =
+                         let uu___3 =
+                           let uu___4 =
+                             FStar_Syntax_Print.uvar_to_string
+                               (imp.FStar_TypeChecker_Common.imp_uvar).FStar_Syntax_Syntax.ctx_uvar_head in
+                           let uu___5 =
+                             let uu___6 =
+                               FStar_Syntax_Util.ctx_uvar_typ
+                                 imp.FStar_TypeChecker_Common.imp_uvar in
+                             FStar_Syntax_Print.term_to_string uu___6 in
+                           FStar_Compiler_Util.format3
+                             "Tactic left uninstantiated unification variable %s of type %s (reason = \"%s\")"
+                             uu___4 uu___5
+                             imp.FStar_TypeChecker_Common.imp_reason in
+                         (FStar_Errors.Error_UninstantiatedUnificationVarInTactic,
+                           uu___3) in
+                       FStar_Errors.log_issue rng uu___2
+                   | FStar_TypeChecker_Rel.Implicit_checking_defers_univ_constraint
+                       ->
+                       let uu___2 =
+                         let uu___3 =
+                           let uu___4 =
+                             FStar_Syntax_Print.uvar_to_string
+                               (imp.FStar_TypeChecker_Common.imp_uvar).FStar_Syntax_Syntax.ctx_uvar_head in
+                           let uu___5 =
+                             let uu___6 =
+                               FStar_Syntax_Util.ctx_uvar_typ
+                                 imp.FStar_TypeChecker_Common.imp_uvar in
+                             FStar_Syntax_Print.term_to_string uu___6 in
+                           FStar_Compiler_Util.format3
+                             "Tactic left uninstantiated unification variable %s of type %s (reason = \"%s\")"
+                             uu___4 uu___5
+                             imp.FStar_TypeChecker_Common.imp_reason in
+                         (FStar_Errors.Error_UninstantiatedUnificationVarInTactic,
+                           uu___3) in
+                       FStar_Errors.log_issue rng uu___2
+                   | FStar_TypeChecker_Rel.Implicit_has_typing_guard 
+                       (tm, ty) ->
+                       let uu___2 =
+                         let uu___3 =
+                           let uu___4 =
+                             FStar_Syntax_Print.uvar_to_string
+                               (imp.FStar_TypeChecker_Common.imp_uvar).FStar_Syntax_Syntax.ctx_uvar_head in
+                           let uu___5 =
+                             let uu___6 =
+                               FStar_Syntax_Util.ctx_uvar_typ
+                                 imp.FStar_TypeChecker_Common.imp_uvar in
+                             FStar_Syntax_Print.term_to_string uu___6 in
+                           let uu___6 = FStar_Syntax_Print.term_to_string tm in
+                           let uu___7 = FStar_Syntax_Print.term_to_string ty in
+                           FStar_Compiler_Util.format4
+                             "Tactic solved goal %s of type %s to %s : %s, but it has a non-trivial typing guard"
+                             uu___4 uu___5 uu___6 uu___7 in
+                         (FStar_Errors.Error_UninstantiatedUnificationVarInTactic,
+                           uu___3) in
+                       FStar_Errors.log_issue rng uu___2)));
       FStar_Errors.stop_if_err ()
 let run_tactic_on_ps' :
   'a 'b .
@@ -1850,7 +1896,7 @@ let run_tactic_on_ps' :
                                           "Checked %s implicits (1): %s\n"
                                           uu___14 uu___15
                                       else ());
-                                     (let g3 =
+                                     (let tagged_implicits =
                                         FStar_TypeChecker_Rel.resolve_implicits_tac
                                           env g2 in
                                       (let uu___14 =
@@ -1872,7 +1918,7 @@ let run_tactic_on_ps' :
                                            uu___15 uu___16
                                        else ());
                                       report_implicits rng_goal
-                                        g3.FStar_TypeChecker_Common.implicits;
+                                        tagged_implicits;
                                       (let uu___16 =
                                          FStar_Compiler_Effect.op_Bang tacdbg in
                                        if uu___16

--- a/src/ocaml-output/FStar_Tactics_Interpreter.ml
+++ b/src/ocaml-output/FStar_Tactics_Interpreter.ml
@@ -804,15 +804,17 @@ let (uu___143 : unit) =
                                                                   FStar_TypeChecker_NBETerm.e_unit in
                                                               let uu___59 =
                                                                 let uu___60 =
-                                                                  FStar_Tactics_InterpFuns.mk_tac_step_3
+                                                                  FStar_Tactics_InterpFuns.mk_tac_step_4
                                                                     Prims.int_zero
                                                                     "t_apply"
                                                                     FStar_Tactics_Basic.t_apply
                                                                     FStar_Syntax_Embeddings.e_bool
                                                                     FStar_Syntax_Embeddings.e_bool
+                                                                    FStar_Syntax_Embeddings.e_bool
                                                                     FStar_Reflection_Embeddings.e_term
                                                                     FStar_Syntax_Embeddings.e_unit
                                                                     FStar_Tactics_Basic.t_apply
+                                                                    FStar_TypeChecker_NBETerm.e_bool
                                                                     FStar_TypeChecker_NBETerm.e_bool
                                                                     FStar_TypeChecker_NBETerm.e_bool
                                                                     FStar_Reflection_NBEEmbeddings.e_term

--- a/src/ocaml-output/FStar_Tactics_Interpreter.ml
+++ b/src/ocaml-output/FStar_Tactics_Interpreter.ml
@@ -1877,28 +1877,16 @@ let run_tactic_on_ps' :
                                          FStar_Compiler_Effect.op_Bang tacdbg in
                                        if uu___16
                                        then
-                                         let uu___17 =
-                                           let uu___18 =
-                                             FStar_TypeChecker_Cfg.psc_subst
-                                               ps1.FStar_Tactics_Types.psc in
-                                           FStar_Tactics_Types.subst_proof_display_state
-                                             uu___18 ps1 in
                                          FStar_Tactics_Printing.do_dump_proofstate
-                                           uu___17 "at the finish line"
+                                           ps1 "at the finish line"
                                        else ());
                                       ((FStar_Compiler_List.op_At
                                           ps1.FStar_Tactics_Types.goals
                                           ps1.FStar_Tactics_Types.smt_goals),
                                         ret))))
                                | FStar_Tactics_Result.Failed (e, ps1) ->
-                                   ((let uu___11 =
-                                       let uu___12 =
-                                         FStar_TypeChecker_Cfg.psc_subst
-                                           ps1.FStar_Tactics_Types.psc in
-                                       FStar_Tactics_Types.subst_proof_display_state
-                                         uu___12 ps1 in
-                                     FStar_Tactics_Printing.do_dump_proofstate
-                                       uu___11 "at the time of failure");
+                                   (FStar_Tactics_Printing.do_dump_proofstate
+                                      ps1 "at the time of failure";
                                     (let texn_to_string e1 =
                                        match e1 with
                                        | FStar_Tactics_Common.TacticFailure s

--- a/src/ocaml-output/FStar_Tactics_Interpreter.ml
+++ b/src/ocaml-output/FStar_Tactics_Interpreter.ml
@@ -1662,8 +1662,10 @@ let (report_implicits :
                     FStar_Syntax_Print.uvar_to_string
                       (imp.FStar_TypeChecker_Common.imp_uvar).FStar_Syntax_Syntax.ctx_uvar_head in
                   let uu___4 =
-                    FStar_Syntax_Print.term_to_string
-                      (imp.FStar_TypeChecker_Common.imp_uvar).FStar_Syntax_Syntax.ctx_uvar_typ in
+                    let uu___5 =
+                      FStar_Syntax_Util.ctx_uvar_typ
+                        imp.FStar_TypeChecker_Common.imp_uvar in
+                    FStar_Syntax_Print.term_to_string uu___5 in
                   FStar_Compiler_Util.format3
                     "Tactic left uninstantiated unification variable %s of type %s (reason = \"%s\")"
                     uu___3 uu___4 imp.FStar_TypeChecker_Common.imp_reason in
@@ -1879,7 +1881,7 @@ let run_tactic_on_ps' :
                                            let uu___18 =
                                              FStar_TypeChecker_Cfg.psc_subst
                                                ps1.FStar_Tactics_Types.psc in
-                                           FStar_Tactics_Types.subst_proof_state
+                                           FStar_Tactics_Types.subst_proof_display_state
                                              uu___18 ps1 in
                                          FStar_Tactics_Printing.do_dump_proofstate
                                            uu___17 "at the finish line"
@@ -1893,7 +1895,7 @@ let run_tactic_on_ps' :
                                        let uu___12 =
                                          FStar_TypeChecker_Cfg.psc_subst
                                            ps1.FStar_Tactics_Types.psc in
-                                       FStar_Tactics_Types.subst_proof_state
+                                       FStar_Tactics_Types.subst_proof_display_state
                                          uu___12 ps1 in
                                      FStar_Tactics_Printing.do_dump_proofstate
                                        uu___11 "at the time of failure");

--- a/src/ocaml-output/FStar_Tactics_Monad.ml
+++ b/src/ocaml-output/FStar_Tactics_Monad.ml
@@ -681,15 +681,16 @@ let (compress_implicits : unit tac) =
              (FStar_TypeChecker_Env.trivial_guard.FStar_TypeChecker_Common.univ_ineqs);
            FStar_TypeChecker_Common.implicits = imps
          } in
-       let g1 =
+       let imps1 =
          FStar_TypeChecker_Rel.resolve_implicits_tac
            ps.FStar_Tactics_Types.main_context g in
        let ps' =
+         let uu___ =
+           FStar_Compiler_List.map FStar_Pervasives_Native.fst imps1 in
          {
            FStar_Tactics_Types.main_context =
              (ps.FStar_Tactics_Types.main_context);
-           FStar_Tactics_Types.all_implicits =
-             (g1.FStar_TypeChecker_Common.implicits);
+           FStar_Tactics_Types.all_implicits = uu___;
            FStar_Tactics_Types.goals = (ps.FStar_Tactics_Types.goals);
            FStar_Tactics_Types.smt_goals = (ps.FStar_Tactics_Types.smt_goals);
            FStar_Tactics_Types.depth = (ps.FStar_Tactics_Types.depth);

--- a/src/ocaml-output/FStar_Tactics_Monad.ml
+++ b/src/ocaml-output/FStar_Tactics_Monad.ml
@@ -640,8 +640,6 @@ let (goal_of_guard :
                           (goal.FStar_Tactics_Types.goal_main_env);
                         FStar_Tactics_Types.goal_ctx_uvar =
                           (goal.FStar_Tactics_Types.goal_ctx_uvar);
-                        FStar_Tactics_Types.goal_display_type =
-                          (goal.FStar_Tactics_Types.goal_display_type);
                         FStar_Tactics_Types.opts =
                           (goal.FStar_Tactics_Types.opts);
                         FStar_Tactics_Types.is_guard = true;

--- a/src/ocaml-output/FStar_Tactics_Monad.ml
+++ b/src/ocaml-output/FStar_Tactics_Monad.ml
@@ -531,34 +531,20 @@ let (new_uvar :
               match sc_opt with
               | FStar_Pervasives_Native.Some sc -> sc
               | uu___ ->
-                  let is_base_typ =
-                    let t = FStar_TypeChecker_Normalize.unfold_whnf env typ in
-                    let uu___1 = FStar_Syntax_Util.head_and_args t in
-                    match uu___1 with
-                    | (head, args) ->
-                        let uu___2 =
-                          let uu___3 =
-                            let uu___4 = FStar_Syntax_Util.un_uinst head in
-                            FStar_Syntax_Util.unascribe uu___4 in
-                          uu___3.FStar_Syntax_Syntax.n in
-                        (match uu___2 with
-                         | FStar_Syntax_Syntax.Tm_name uu___3 -> true
-                         | FStar_Syntax_Syntax.Tm_fvar uu___3 -> true
-                         | FStar_Syntax_Syntax.Tm_type uu___3 -> true
-                         | uu___3 -> false) in
-                  if is_base_typ
+                  let uu___1 = FStar_TypeChecker_Rel.is_base_type env typ in
+                  if uu___1
                   then FStar_Syntax_Syntax.Allow_untyped
                   else
-                    ((let uu___3 =
+                    ((let uu___4 =
                         FStar_Compiler_Effect.op_Less_Bar
                           (FStar_TypeChecker_Env.debug env)
                           (FStar_Options.Other "2635") in
-                      if uu___3
+                      if uu___4
                       then
-                        let uu___4 = FStar_Syntax_Print.term_to_string typ in
+                        let uu___5 = FStar_Syntax_Print.term_to_string typ in
                         FStar_Compiler_Util.print2
                           "Tactic introduced a strict uvar for %s\n\\%s\n"
-                          uu___4 ""
+                          uu___5 ""
                       else ());
                      FStar_Syntax_Syntax.Strict) in
             let uu___ =

--- a/src/ocaml-output/FStar_Tactics_Monad.ml
+++ b/src/ocaml-output/FStar_Tactics_Monad.ml
@@ -640,6 +640,8 @@ let (goal_of_guard :
                           (goal.FStar_Tactics_Types.goal_main_env);
                         FStar_Tactics_Types.goal_ctx_uvar =
                           (goal.FStar_Tactics_Types.goal_ctx_uvar);
+                        FStar_Tactics_Types.goal_display_type =
+                          (goal.FStar_Tactics_Types.goal_display_type);
                         FStar_Tactics_Types.opts =
                           (goal.FStar_Tactics_Types.opts);
                         FStar_Tactics_Types.is_guard = true;

--- a/src/ocaml-output/FStar_Tactics_Monad.ml
+++ b/src/ocaml-output/FStar_Tactics_Monad.ml
@@ -517,41 +517,66 @@ let (new_uvar :
   Prims.string ->
     FStar_TypeChecker_Env.env ->
       FStar_Syntax_Syntax.typ ->
-        FStar_Compiler_Range.range ->
-          (FStar_Syntax_Syntax.term * FStar_Syntax_Syntax.ctx_uvar) tac)
+        FStar_Syntax_Syntax.should_check_uvar FStar_Pervasives_Native.option
+          ->
+          FStar_Compiler_Range.range ->
+            (FStar_Syntax_Syntax.term * FStar_Syntax_Syntax.ctx_uvar) tac)
   =
   fun reason ->
     fun env ->
       fun typ ->
-        fun rng ->
-          let is_base_typ =
-            let t = FStar_TypeChecker_Normalize.unfold_whnf env typ in
-            let uu___ = FStar_Syntax_Util.head_and_args t in
+        fun sc_opt ->
+          fun rng ->
+            let should_check =
+              match sc_opt with
+              | FStar_Pervasives_Native.Some sc -> sc
+              | uu___ ->
+                  let is_base_typ =
+                    let t = FStar_TypeChecker_Normalize.unfold_whnf env typ in
+                    let uu___1 = FStar_Syntax_Util.head_and_args t in
+                    match uu___1 with
+                    | (head, args) ->
+                        let uu___2 =
+                          let uu___3 =
+                            let uu___4 = FStar_Syntax_Util.un_uinst head in
+                            FStar_Syntax_Util.unascribe uu___4 in
+                          uu___3.FStar_Syntax_Syntax.n in
+                        (match uu___2 with
+                         | FStar_Syntax_Syntax.Tm_name uu___3 -> true
+                         | FStar_Syntax_Syntax.Tm_fvar uu___3 -> true
+                         | FStar_Syntax_Syntax.Tm_type uu___3 -> true
+                         | uu___3 -> false) in
+                  if is_base_typ
+                  then FStar_Syntax_Syntax.Allow_untyped
+                  else
+                    ((let uu___3 =
+                        FStar_Compiler_Effect.op_Less_Bar
+                          (FStar_TypeChecker_Env.debug env)
+                          (FStar_Options.Other "2635") in
+                      if uu___3
+                      then
+                        let uu___4 = FStar_Syntax_Print.term_to_string typ in
+                        let uu___5 = FStar_Compiler_Util.stack_dump () in
+                        FStar_Compiler_Util.print2
+                          "Tactic introduced a strict uvar for %s\n\\%s\n"
+                          uu___4 uu___5
+                      else ());
+                     FStar_Syntax_Syntax.Strict) in
+            let uu___ =
+              FStar_TypeChecker_Env.new_implicit_var_aux reason rng env typ
+                should_check FStar_Pervasives_Native.None in
             match uu___ with
-            | (head, args) ->
+            | (u, ctx_uvar, g_u) ->
                 let uu___1 =
-                  let uu___2 = FStar_Syntax_Util.un_uinst head in
-                  uu___2.FStar_Syntax_Syntax.n in
-                (match uu___1 with
-                 | FStar_Syntax_Syntax.Tm_fvar uu___2 -> true
-                 | uu___2 -> false) in
-          let uu___ =
-            FStar_TypeChecker_Env.new_implicit_var_aux reason rng env typ
-              (if is_base_typ
-               then FStar_Syntax_Syntax.Allow_untyped
-               else FStar_Syntax_Syntax.Strict) FStar_Pervasives_Native.None in
-          match uu___ with
-          | (u, ctx_uvar, g_u) ->
-              let uu___1 =
-                add_implicits g_u.FStar_TypeChecker_Common.implicits in
-              bind uu___1
-                (fun uu___2 ->
-                   let uu___3 =
-                     let uu___4 =
-                       let uu___5 = FStar_Compiler_List.hd ctx_uvar in
-                       FStar_Pervasives_Native.fst uu___5 in
-                     (u, uu___4) in
-                   ret uu___3)
+                  add_implicits g_u.FStar_TypeChecker_Common.implicits in
+                bind uu___1
+                  (fun uu___2 ->
+                     let uu___3 =
+                       let uu___4 =
+                         let uu___5 = FStar_Compiler_List.hd ctx_uvar in
+                         FStar_Pervasives_Native.fst uu___5 in
+                       (u, uu___4) in
+                     ret uu___3)
 let (mk_irrelevant_goal :
   Prims.string ->
     FStar_TypeChecker_Env.env ->
@@ -569,7 +594,10 @@ let (mk_irrelevant_goal :
               let typ =
                 let uu___ = env.FStar_TypeChecker_Env.universe_of env phi in
                 FStar_Syntax_Util.mk_squash uu___ phi in
-              let uu___ = new_uvar reason env typ rng in
+              let uu___ =
+                new_uvar reason env typ
+                  (FStar_Pervasives_Native.Some
+                     FStar_Syntax_Syntax.Allow_untyped) rng in
               bind uu___
                 (fun uu___1 ->
                    match uu___1 with

--- a/src/ocaml-output/FStar_Tactics_Monad.ml
+++ b/src/ocaml-output/FStar_Tactics_Monad.ml
@@ -524,9 +524,22 @@ let (new_uvar :
     fun env ->
       fun typ ->
         fun rng ->
+          let is_base_typ =
+            let t = FStar_TypeChecker_Normalize.unfold_whnf env typ in
+            let uu___ = FStar_Syntax_Util.head_and_args t in
+            match uu___ with
+            | (head, args) ->
+                let uu___1 =
+                  let uu___2 = FStar_Syntax_Util.un_uinst head in
+                  uu___2.FStar_Syntax_Syntax.n in
+                (match uu___1 with
+                 | FStar_Syntax_Syntax.Tm_fvar uu___2 -> true
+                 | uu___2 -> false) in
           let uu___ =
             FStar_TypeChecker_Env.new_implicit_var_aux reason rng env typ
-              FStar_Syntax_Syntax.Allow_untyped FStar_Pervasives_Native.None in
+              (if is_base_typ
+               then FStar_Syntax_Syntax.Allow_untyped
+               else FStar_Syntax_Syntax.Strict) FStar_Pervasives_Native.None in
           match uu___ with
           | (u, ctx_uvar, g_u) ->
               let uu___1 =

--- a/src/ocaml-output/FStar_Tactics_Monad.ml
+++ b/src/ocaml-output/FStar_Tactics_Monad.ml
@@ -556,10 +556,9 @@ let (new_uvar :
                       if uu___3
                       then
                         let uu___4 = FStar_Syntax_Print.term_to_string typ in
-                        let uu___5 = FStar_Compiler_Util.stack_dump () in
                         FStar_Compiler_Util.print2
                           "Tactic introduced a strict uvar for %s\n\\%s\n"
-                          uu___4 uu___5
+                          uu___4 ""
                       else ());
                      FStar_Syntax_Syntax.Strict) in
             let uu___ =

--- a/src/ocaml-output/FStar_Tactics_Printing.ml
+++ b/src/ocaml-output/FStar_Tactics_Printing.ml
@@ -115,8 +115,7 @@ let (goal_to_string :
             | l -> Prims.op_Hat " (" (Prims.op_Hat l ")") in
           let goal_binders =
             (g.FStar_Tactics_Types.goal_ctx_uvar).FStar_Syntax_Syntax.ctx_uvar_binders in
-          let goal_ty =
-            (g.FStar_Tactics_Types.goal_ctx_uvar).FStar_Syntax_Syntax.ctx_uvar_typ in
+          let goal_ty = g.FStar_Tactics_Types.goal_display_type in
           let uu___ = unshadow goal_binders goal_ty in
           match uu___ with
           | (goal_binders1, goal_ty1) ->

--- a/src/ocaml-output/FStar_Tactics_Printing.ml
+++ b/src/ocaml-output/FStar_Tactics_Printing.ml
@@ -113,25 +113,71 @@ let (goal_to_string :
             match g.FStar_Tactics_Types.label with
             | "" -> ""
             | l -> Prims.op_Hat " (" (Prims.op_Hat l ")") in
-          let goal_binders =
-            (g.FStar_Tactics_Types.goal_ctx_uvar).FStar_Syntax_Syntax.ctx_uvar_binders in
-          let goal_ty = g.FStar_Tactics_Types.goal_display_type in
-          let uu___ = unshadow goal_binders goal_ty in
+          let uu___ =
+            let rename_binders subst bs =
+              FStar_Compiler_Effect.op_Bar_Greater bs
+                (FStar_Compiler_List.map
+                   (fun uu___1 ->
+                      let x = uu___1.FStar_Syntax_Syntax.binder_bv in
+                      let y =
+                        let uu___2 = FStar_Syntax_Syntax.bv_to_name x in
+                        FStar_Syntax_Subst.subst subst uu___2 in
+                      let uu___2 =
+                        let uu___3 = FStar_Syntax_Subst.compress y in
+                        uu___3.FStar_Syntax_Syntax.n in
+                      match uu___2 with
+                      | FStar_Syntax_Syntax.Tm_name y1 ->
+                          let uu___3 =
+                            let uu___4 = uu___1.FStar_Syntax_Syntax.binder_bv in
+                            let uu___5 =
+                              FStar_Syntax_Subst.subst subst
+                                x.FStar_Syntax_Syntax.sort in
+                            {
+                              FStar_Syntax_Syntax.ppname =
+                                (uu___4.FStar_Syntax_Syntax.ppname);
+                              FStar_Syntax_Syntax.index =
+                                (uu___4.FStar_Syntax_Syntax.index);
+                              FStar_Syntax_Syntax.sort = uu___5
+                            } in
+                          {
+                            FStar_Syntax_Syntax.binder_bv = uu___3;
+                            FStar_Syntax_Syntax.binder_qual =
+                              (uu___1.FStar_Syntax_Syntax.binder_qual);
+                            FStar_Syntax_Syntax.binder_attrs =
+                              (uu___1.FStar_Syntax_Syntax.binder_attrs)
+                          }
+                      | uu___3 -> failwith "Not a renaming")) in
+            let goal_binders =
+              (g.FStar_Tactics_Types.goal_ctx_uvar).FStar_Syntax_Syntax.ctx_uvar_binders in
+            let goal_ty = FStar_Tactics_Types.goal_type g in
+            let uu___1 = FStar_Options.tactic_raw_binders () in
+            if uu___1
+            then (goal_binders, goal_ty)
+            else
+              (let subst =
+                 FStar_TypeChecker_Cfg.psc_subst ps.FStar_Tactics_Types.psc in
+               let binders = rename_binders subst goal_binders in
+               let ty = FStar_Syntax_Subst.subst subst goal_ty in
+               (binders, ty)) in
           match uu___ with
-          | (goal_binders1, goal_ty1) ->
-              let actual_goal =
-                if ps.FStar_Tactics_Types.tac_verb_dbg
-                then goal_to_string_verbose g
-                else
-                  (let uu___2 =
-                     FStar_Syntax_Print.binders_to_string ", " goal_binders1 in
-                   let uu___3 =
-                     let uu___4 = FStar_Tactics_Types.goal_env g in
-                     term_to_string uu___4 goal_ty1 in
-                   FStar_Compiler_Util.format3 "%s |- %s : %s\n" uu___2 w
-                     uu___3) in
-              FStar_Compiler_Util.format4 "%s%s%s:\n%s\n" kind num
-                maybe_label actual_goal
+          | (goal_binders, goal_ty) ->
+              let uu___1 = unshadow goal_binders goal_ty in
+              (match uu___1 with
+               | (goal_binders1, goal_ty1) ->
+                   let actual_goal =
+                     if ps.FStar_Tactics_Types.tac_verb_dbg
+                     then goal_to_string_verbose g
+                     else
+                       (let uu___3 =
+                          FStar_Syntax_Print.binders_to_string ", "
+                            goal_binders1 in
+                        let uu___4 =
+                          let uu___5 = FStar_Tactics_Types.goal_env g in
+                          term_to_string uu___5 goal_ty1 in
+                        FStar_Compiler_Util.format3 "%s |- %s : %s\n" uu___3
+                          w uu___4) in
+                   FStar_Compiler_Util.format4 "%s%s%s:\n%s\n" kind num
+                     maybe_label actual_goal)
 let (ps_to_string :
   (Prims.string * FStar_Tactics_Types.proofstate) -> Prims.string) =
   fun uu___ ->

--- a/src/ocaml-output/FStar_Tactics_Types.ml
+++ b/src/ocaml-output/FStar_Tactics_Types.ml
@@ -3,7 +3,6 @@ type goal =
   {
   goal_main_env: FStar_TypeChecker_Env.env ;
   goal_ctx_uvar: FStar_Syntax_Syntax.ctx_uvar ;
-  goal_display_type: FStar_Syntax_Syntax.typ ;
   opts: FStar_Options.optionstate ;
   is_guard: Prims.bool ;
   label: Prims.string }
@@ -11,35 +10,26 @@ let (__proj__Mkgoal__item__goal_main_env : goal -> FStar_TypeChecker_Env.env)
   =
   fun projectee ->
     match projectee with
-    | { goal_main_env; goal_ctx_uvar; goal_display_type; opts; is_guard;
-        label;_} -> goal_main_env
+    | { goal_main_env; goal_ctx_uvar; opts; is_guard; label;_} ->
+        goal_main_env
 let (__proj__Mkgoal__item__goal_ctx_uvar :
   goal -> FStar_Syntax_Syntax.ctx_uvar) =
   fun projectee ->
     match projectee with
-    | { goal_main_env; goal_ctx_uvar; goal_display_type; opts; is_guard;
-        label;_} -> goal_ctx_uvar
-let (__proj__Mkgoal__item__goal_display_type :
-  goal -> FStar_Syntax_Syntax.typ) =
-  fun projectee ->
-    match projectee with
-    | { goal_main_env; goal_ctx_uvar; goal_display_type; opts; is_guard;
-        label;_} -> goal_display_type
+    | { goal_main_env; goal_ctx_uvar; opts; is_guard; label;_} ->
+        goal_ctx_uvar
 let (__proj__Mkgoal__item__opts : goal -> FStar_Options.optionstate) =
   fun projectee ->
     match projectee with
-    | { goal_main_env; goal_ctx_uvar; goal_display_type; opts; is_guard;
-        label;_} -> opts
+    | { goal_main_env; goal_ctx_uvar; opts; is_guard; label;_} -> opts
 let (__proj__Mkgoal__item__is_guard : goal -> Prims.bool) =
   fun projectee ->
     match projectee with
-    | { goal_main_env; goal_ctx_uvar; goal_display_type; opts; is_guard;
-        label;_} -> is_guard
+    | { goal_main_env; goal_ctx_uvar; opts; is_guard; label;_} -> is_guard
 let (__proj__Mkgoal__item__label : goal -> Prims.string) =
   fun projectee ->
     match projectee with
-    | { goal_main_env; goal_ctx_uvar; goal_display_type; opts; is_guard;
-        label;_} -> label
+    | { goal_main_env; goal_ctx_uvar; opts; is_guard; label;_} -> label
 type guard_policy =
   | Goal 
   | SMT 
@@ -183,7 +173,6 @@ let (goal_with_env : goal -> FStar_TypeChecker_Env.env -> goal) =
       {
         goal_main_env = env;
         goal_ctx_uvar = c';
-        goal_display_type = (g.goal_display_type);
         opts = (g.opts);
         is_guard = (g.is_guard);
         label = (g.label)
@@ -194,7 +183,6 @@ let (goal_of_ctx_uvar : goal -> FStar_Syntax_Syntax.ctx_uvar -> goal) =
       {
         goal_main_env = (g.goal_main_env);
         goal_ctx_uvar = ctx_u;
-        goal_display_type = (g.goal_display_type);
         opts = (g.opts);
         is_guard = (g.is_guard);
         label = (g.label)
@@ -209,11 +197,9 @@ let (mk_goal :
       fun o ->
         fun b ->
           fun l ->
-            let uu___ = FStar_Syntax_Util.ctx_uvar_typ u in
             {
               goal_main_env = env;
               goal_ctx_uvar = u;
-              goal_display_type = uu___;
               opts = o;
               is_guard = b;
               label = l
@@ -329,100 +315,6 @@ let (goal_of_implicit :
             (env.FStar_TypeChecker_Env.erase_erasable_args)
         } i.FStar_TypeChecker_Common.imp_uvar uu___ false
         i.FStar_TypeChecker_Common.imp_reason
-let (rename_binders :
-  FStar_Syntax_Syntax.subst_elt Prims.list ->
-    FStar_Syntax_Syntax.binder Prims.list ->
-      FStar_Syntax_Syntax.binder Prims.list)
-  =
-  fun subst ->
-    fun bs ->
-      FStar_Compiler_Effect.op_Bar_Greater bs
-        (FStar_Compiler_List.map
-           (fun uu___ ->
-              let x = uu___.FStar_Syntax_Syntax.binder_bv in
-              let y =
-                let uu___1 = FStar_Syntax_Syntax.bv_to_name x in
-                FStar_Syntax_Subst.subst subst uu___1 in
-              let uu___1 =
-                let uu___2 = FStar_Syntax_Subst.compress y in
-                uu___2.FStar_Syntax_Syntax.n in
-              match uu___1 with
-              | FStar_Syntax_Syntax.Tm_name y1 ->
-                  let uu___2 =
-                    let uu___3 = uu___.FStar_Syntax_Syntax.binder_bv in
-                    let uu___4 =
-                      FStar_Syntax_Subst.subst subst
-                        x.FStar_Syntax_Syntax.sort in
-                    {
-                      FStar_Syntax_Syntax.ppname =
-                        (uu___3.FStar_Syntax_Syntax.ppname);
-                      FStar_Syntax_Syntax.index =
-                        (uu___3.FStar_Syntax_Syntax.index);
-                      FStar_Syntax_Syntax.sort = uu___4
-                    } in
-                  {
-                    FStar_Syntax_Syntax.binder_bv = uu___2;
-                    FStar_Syntax_Syntax.binder_qual =
-                      (uu___.FStar_Syntax_Syntax.binder_qual);
-                    FStar_Syntax_Syntax.binder_attrs =
-                      (uu___.FStar_Syntax_Syntax.binder_attrs)
-                  }
-              | uu___2 -> failwith "Not a renaming"))
-let (subst_goal : FStar_Syntax_Syntax.subst_elt Prims.list -> goal -> goal) =
-  fun subst ->
-    fun goal1 ->
-      let g = goal1.goal_ctx_uvar in
-      let ctx_uvar =
-        let uu___ =
-          FStar_TypeChecker_Env.rename_gamma subst
-            g.FStar_Syntax_Syntax.ctx_uvar_gamma in
-        let uu___1 =
-          rename_binders subst g.FStar_Syntax_Syntax.ctx_uvar_binders in
-        {
-          FStar_Syntax_Syntax.ctx_uvar_head =
-            (g.FStar_Syntax_Syntax.ctx_uvar_head);
-          FStar_Syntax_Syntax.ctx_uvar_gamma = uu___;
-          FStar_Syntax_Syntax.ctx_uvar_binders = uu___1;
-          FStar_Syntax_Syntax.ctx_uvar_reason =
-            (g.FStar_Syntax_Syntax.ctx_uvar_reason);
-          FStar_Syntax_Syntax.ctx_uvar_range =
-            (g.FStar_Syntax_Syntax.ctx_uvar_range);
-          FStar_Syntax_Syntax.ctx_uvar_meta =
-            (g.FStar_Syntax_Syntax.ctx_uvar_meta)
-        } in
-      let uu___ = FStar_Syntax_Subst.subst subst goal1.goal_display_type in
-      {
-        goal_main_env = (goal1.goal_main_env);
-        goal_ctx_uvar = ctx_uvar;
-        goal_display_type = uu___;
-        opts = (goal1.opts);
-        is_guard = (goal1.is_guard);
-        label = (goal1.label)
-      }
-let (subst_proof_display_state :
-  FStar_Syntax_Syntax.subst_t -> proofstate -> proofstate) =
-  fun subst ->
-    fun ps ->
-      let uu___ = FStar_Options.tactic_raw_binders () in
-      if uu___
-      then ps
-      else
-        (let uu___2 = FStar_Compiler_List.map (subst_goal subst) ps.goals in
-         {
-           main_context = (ps.main_context);
-           all_implicits = (ps.all_implicits);
-           goals = uu___2;
-           smt_goals = (ps.smt_goals);
-           depth = (ps.depth);
-           __dump = (ps.__dump);
-           psc = (ps.psc);
-           entry_range = (ps.entry_range);
-           guard_policy = (ps.guard_policy);
-           freshness = (ps.freshness);
-           tac_verb_dbg = (ps.tac_verb_dbg);
-           local_state = (ps.local_state);
-           urgency = (ps.urgency)
-         })
 let (decr_depth : proofstate -> proofstate) =
   fun ps ->
     {
@@ -484,11 +376,7 @@ let (tracepoint_with_psc :
            (let uu___2 = FStar_Options.tactic_trace_d () in
             ps.depth <= uu___2) in
        if uu___1
-       then
-         let ps1 = set_ps_psc psc ps in
-         let subst = FStar_TypeChecker_Cfg.psc_subst ps1.psc in
-         let uu___2 = subst_proof_display_state subst ps1 in
-         ps1.__dump uu___2 "TRACE"
+       then let ps1 = set_ps_psc psc ps in ps1.__dump ps1 "TRACE"
        else ());
       true
 let (tracepoint : proofstate -> Prims.bool) =
@@ -496,12 +384,7 @@ let (tracepoint : proofstate -> Prims.bool) =
     (let uu___1 =
        (FStar_Options.tactic_trace ()) ||
          (let uu___2 = FStar_Options.tactic_trace_d () in ps.depth <= uu___2) in
-     if uu___1
-     then
-       let subst = FStar_TypeChecker_Cfg.psc_subst ps.psc in
-       let uu___2 = subst_proof_display_state subst ps in
-       ps.__dump uu___2 "TRACE"
-     else ());
+     if uu___1 then ps.__dump ps "TRACE" else ());
     true
 let (set_proofstate_range :
   proofstate -> FStar_Compiler_Range.range -> proofstate) =
@@ -535,7 +418,6 @@ let (set_label : Prims.string -> goal -> goal) =
       {
         goal_main_env = (g.goal_main_env);
         goal_ctx_uvar = (g.goal_ctx_uvar);
-        goal_display_type = (g.goal_display_type);
         opts = (g.opts);
         is_guard = (g.is_guard);
         label = l

--- a/src/ocaml-output/FStar_Tactics_Types.ml
+++ b/src/ocaml-output/FStar_Tactics_Types.ml
@@ -151,35 +151,6 @@ let (goal_witness : goal -> FStar_Syntax_Syntax.term) =
       FStar_Compiler_Range.dummyRange
 let (goal_type : goal -> FStar_Syntax_Syntax.term) =
   fun g -> (g.goal_ctx_uvar).FStar_Syntax_Syntax.ctx_uvar_typ
-let (goal_with_type_pure : goal -> FStar_Syntax_Syntax.term -> goal) =
-  fun g ->
-    fun t ->
-      let c = g.goal_ctx_uvar in
-      let c' =
-        {
-          FStar_Syntax_Syntax.ctx_uvar_head =
-            (c.FStar_Syntax_Syntax.ctx_uvar_head);
-          FStar_Syntax_Syntax.ctx_uvar_gamma =
-            (c.FStar_Syntax_Syntax.ctx_uvar_gamma);
-          FStar_Syntax_Syntax.ctx_uvar_binders =
-            (c.FStar_Syntax_Syntax.ctx_uvar_binders);
-          FStar_Syntax_Syntax.ctx_uvar_typ = t;
-          FStar_Syntax_Syntax.ctx_uvar_reason =
-            (c.FStar_Syntax_Syntax.ctx_uvar_reason);
-          FStar_Syntax_Syntax.ctx_uvar_should_check =
-            (c.FStar_Syntax_Syntax.ctx_uvar_should_check);
-          FStar_Syntax_Syntax.ctx_uvar_range =
-            (c.FStar_Syntax_Syntax.ctx_uvar_range);
-          FStar_Syntax_Syntax.ctx_uvar_meta =
-            (c.FStar_Syntax_Syntax.ctx_uvar_meta)
-        } in
-      {
-        goal_main_env = (g.goal_main_env);
-        goal_ctx_uvar = c';
-        opts = (g.opts);
-        is_guard = (g.is_guard);
-        label = (g.label)
-      }
 let (goal_with_env : goal -> FStar_TypeChecker_Env.env -> goal) =
   fun g ->
     fun env ->
@@ -196,8 +167,6 @@ let (goal_with_env : goal -> FStar_TypeChecker_Env.env -> goal) =
             (c.FStar_Syntax_Syntax.ctx_uvar_typ);
           FStar_Syntax_Syntax.ctx_uvar_reason =
             (c.FStar_Syntax_Syntax.ctx_uvar_reason);
-          FStar_Syntax_Syntax.ctx_uvar_should_check =
-            (c.FStar_Syntax_Syntax.ctx_uvar_should_check);
           FStar_Syntax_Syntax.ctx_uvar_range =
             (c.FStar_Syntax_Syntax.ctx_uvar_range);
           FStar_Syntax_Syntax.ctx_uvar_meta =
@@ -407,8 +376,6 @@ let (subst_goal : FStar_Syntax_Syntax.subst_elt Prims.list -> goal -> goal) =
           FStar_Syntax_Syntax.ctx_uvar_typ = uu___2;
           FStar_Syntax_Syntax.ctx_uvar_reason =
             (g.FStar_Syntax_Syntax.ctx_uvar_reason);
-          FStar_Syntax_Syntax.ctx_uvar_should_check =
-            (g.FStar_Syntax_Syntax.ctx_uvar_should_check);
           FStar_Syntax_Syntax.ctx_uvar_range =
             (g.FStar_Syntax_Syntax.ctx_uvar_range);
           FStar_Syntax_Syntax.ctx_uvar_meta =

--- a/src/ocaml-output/FStar_Tactics_Types.ml
+++ b/src/ocaml-output/FStar_Tactics_Types.ml
@@ -151,7 +151,7 @@ let (goal_witness : goal -> FStar_Syntax_Syntax.term) =
       FStar_Compiler_Range.dummyRange
 let (goal_type : goal -> FStar_Syntax_Syntax.term) =
   fun g -> (g.goal_ctx_uvar).FStar_Syntax_Syntax.ctx_uvar_typ
-let (goal_with_type : goal -> FStar_Syntax_Syntax.term -> goal) =
+let (goal_with_type_pure : goal -> FStar_Syntax_Syntax.term -> goal) =
   fun g ->
     fun t ->
       let c = g.goal_ctx_uvar in

--- a/src/ocaml-output/FStar_Tactics_Types.ml
+++ b/src/ocaml-output/FStar_Tactics_Types.ml
@@ -309,6 +309,8 @@ let (goal_of_implicit :
             (env.FStar_TypeChecker_Env.universe_of);
           FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term =
             (env.FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term);
+          FStar_TypeChecker_Env.subtype_nosmt_force =
+            (env.FStar_TypeChecker_Env.subtype_nosmt_force);
           FStar_TypeChecker_Env.use_bv_sorts =
             (env.FStar_TypeChecker_Env.use_bv_sorts);
           FStar_TypeChecker_Env.qtbl_name_and_index =

--- a/src/ocaml-output/FStar_Tests_Pars.ml
+++ b/src/ocaml-output/FStar_Tests_Pars.ml
@@ -80,7 +80,8 @@ let (init_once : unit -> unit) =
         FStar_TypeChecker_TcTerm.tc_term
         FStar_TypeChecker_TcTerm.typeof_tot_or_gtot_term
         FStar_TypeChecker_TcTerm.typeof_tot_or_gtot_term_fastpath
-        FStar_TypeChecker_TcTerm.universe_of solver
+        FStar_TypeChecker_TcTerm.universe_of
+        FStar_TypeChecker_Rel.subtype_nosmt_force solver
         FStar_Parser_Const.prims_lid
         FStar_TypeChecker_NBE.normalize_for_unit_test in
     (env.FStar_TypeChecker_Env.solver).FStar_TypeChecker_Env.init env;
@@ -146,6 +147,8 @@ let (init_once : unit -> unit) =
                (env.FStar_TypeChecker_Env.universe_of);
              FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term =
                (env.FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term);
+             FStar_TypeChecker_Env.subtype_nosmt_force =
+               (env.FStar_TypeChecker_Env.subtype_nosmt_force);
              FStar_TypeChecker_Env.use_bv_sorts =
                (env.FStar_TypeChecker_Env.use_bv_sorts);
              FStar_TypeChecker_Env.qtbl_name_and_index =
@@ -246,6 +249,8 @@ let (init_once : unit -> unit) =
                     (env2.FStar_TypeChecker_Env.universe_of);
                   FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term =
                     (env2.FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term);
+                  FStar_TypeChecker_Env.subtype_nosmt_force =
+                    (env2.FStar_TypeChecker_Env.subtype_nosmt_force);
                   FStar_TypeChecker_Env.use_bv_sorts =
                     (env2.FStar_TypeChecker_Env.use_bv_sorts);
                   FStar_TypeChecker_Env.qtbl_name_and_index =
@@ -389,6 +394,8 @@ let (tc' :
           (tcenv.FStar_TypeChecker_Env.universe_of);
         FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term =
           (tcenv.FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term);
+        FStar_TypeChecker_Env.subtype_nosmt_force =
+          (tcenv.FStar_TypeChecker_Env.subtype_nosmt_force);
         FStar_TypeChecker_Env.use_bv_sorts =
           (tcenv.FStar_TypeChecker_Env.use_bv_sorts);
         FStar_TypeChecker_Env.qtbl_name_and_index =
@@ -484,6 +491,8 @@ let (tc_nbe_term : FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term) =
           (tcenv.FStar_TypeChecker_Env.universe_of);
         FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term =
           (tcenv.FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term);
+        FStar_TypeChecker_Env.subtype_nosmt_force =
+          (tcenv.FStar_TypeChecker_Env.subtype_nosmt_force);
         FStar_TypeChecker_Env.use_bv_sorts =
           (tcenv.FStar_TypeChecker_Env.use_bv_sorts);
         FStar_TypeChecker_Env.qtbl_name_and_index =

--- a/src/ocaml-output/FStar_TypeChecker_DeferredImplicits.ml
+++ b/src/ocaml-output/FStar_TypeChecker_DeferredImplicits.ml
@@ -410,6 +410,8 @@ let solve_goals_with_tac :
                 (env.FStar_TypeChecker_Env.universe_of);
               FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term =
                 (env.FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term);
+              FStar_TypeChecker_Env.subtype_nosmt_force =
+                (env.FStar_TypeChecker_Env.subtype_nosmt_force);
               FStar_TypeChecker_Env.use_bv_sorts =
                 (env.FStar_TypeChecker_Env.use_bv_sorts);
               FStar_TypeChecker_Env.qtbl_name_and_index =
@@ -530,6 +532,8 @@ let (solve_deferred_to_tactic_goals :
                              FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term
                                =
                                (env1.FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term);
+                             FStar_TypeChecker_Env.subtype_nosmt_force =
+                               (env1.FStar_TypeChecker_Env.subtype_nosmt_force);
                              FStar_TypeChecker_Env.use_bv_sorts =
                                (env1.FStar_TypeChecker_Env.use_bv_sorts);
                              FStar_TypeChecker_Env.qtbl_name_and_index =
@@ -629,6 +633,8 @@ let (solve_deferred_to_tactic_goals :
                              FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term
                                =
                                (env2.FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term);
+                             FStar_TypeChecker_Env.subtype_nosmt_force =
+                               (env2.FStar_TypeChecker_Env.subtype_nosmt_force);
                              FStar_TypeChecker_Env.use_bv_sorts = true;
                              FStar_TypeChecker_Env.qtbl_name_and_index =
                                (env2.FStar_TypeChecker_Env.qtbl_name_and_index);

--- a/src/ocaml-output/FStar_TypeChecker_Env.ml
+++ b/src/ocaml-output/FStar_TypeChecker_Env.ml
@@ -1694,21 +1694,7 @@ let (initial_env :
                                | FStar_Pervasives_Native.None ->
                                    let uu___12 =
                                      typeof_tot_or_gtot_term env1 t must_tot1 in
-                                   (match uu___12 with
-                                    | (t', k, g) ->
-                                        ((let uu___14 =
-                                            FStar_Syntax_Print.term_to_string
-                                              t in
-                                          let uu___15 =
-                                            FStar_Syntax_Print.term_to_string
-                                              t' in
-                                          let uu___16 =
-                                            FStar_Syntax_Print.term_to_string
-                                              k in
-                                          FStar_Compiler_Util.print3
-                                            "typeof_well_typed_tot_or_gtot_term took slow path: %s was types as %s at type %s\n"
-                                            uu___14 uu___15 uu___16);
-                                         (k, g))));
+                                   (match uu___12 with | (t', k, g) -> (k, g)));
                       subtype_nosmt_force;
                       use_bv_sorts = false;
                       qtbl_name_and_index = uu___3;

--- a/src/ocaml-output/FStar_TypeChecker_Env.ml
+++ b/src/ocaml-output/FStar_TypeChecker_Env.ml
@@ -6264,65 +6264,56 @@ let (uvars_for_binders :
                             let sort =
                               FStar_Syntax_Subst.subst substs1
                                 (b.FStar_Syntax_Syntax.binder_bv).FStar_Syntax_Syntax.sort in
-                            let uu___2 =
+                            let ctx_uvar_meta_t =
                               match ((b.FStar_Syntax_Syntax.binder_qual),
                                       (b.FStar_Syntax_Syntax.binder_attrs))
                               with
                               | (FStar_Pervasives_Native.Some
                                  (FStar_Syntax_Syntax.Meta t), []) ->
-                                  let uu___3 =
-                                    let uu___4 =
-                                      let uu___5 =
-                                        let uu___6 =
-                                          FStar_Compiler_Dyn.mkdyn env1 in
-                                        (uu___6, t) in
-                                      FStar_Syntax_Syntax.Ctx_uvar_meta_tac
-                                        uu___5 in
-                                    FStar_Pervasives_Native.Some uu___4 in
-                                  (uu___3, false)
-                              | (uu___3, t::uu___4) ->
-                                  ((FStar_Pervasives_Native.Some
-                                      (FStar_Syntax_Syntax.Ctx_uvar_meta_attr
-                                         t)), false)
-                              | uu___3 ->
-                                  (FStar_Pervasives_Native.None, false) in
+                                  let uu___2 =
+                                    let uu___3 =
+                                      let uu___4 =
+                                        FStar_Compiler_Dyn.mkdyn env1 in
+                                      (uu___4, t) in
+                                    FStar_Syntax_Syntax.Ctx_uvar_meta_tac
+                                      uu___3 in
+                                  FStar_Pervasives_Native.Some uu___2
+                              | (uu___2, t::uu___3) ->
+                                  FStar_Pervasives_Native.Some
+                                    (FStar_Syntax_Syntax.Ctx_uvar_meta_attr t)
+                              | uu___2 -> FStar_Pervasives_Native.None in
+                            let uu___2 =
+                              let uu___3 = reason b in
+                              new_implicit_var_aux uu___3 r env1 sort
+                                FStar_Syntax_Syntax.Allow_untyped
+                                ctx_uvar_meta_t in
                             (match uu___2 with
-                             | (ctx_uvar_meta_t, strict) ->
-                                 let uu___3 =
-                                   let uu___4 = reason b in
-                                   new_implicit_var_aux uu___4 r env1 sort
-                                     (if strict
-                                      then FStar_Syntax_Syntax.Strict
-                                      else FStar_Syntax_Syntax.Allow_untyped)
-                                     ctx_uvar_meta_t in
-                                 (match uu___3 with
-                                  | (t, l_ctx_uvars, g_t) ->
-                                      ((let uu___5 =
-                                          FStar_Compiler_Effect.op_Less_Bar
-                                            (debug env1)
-                                            (FStar_Options.Other
-                                               "LayeredEffectsEqns") in
-                                        if uu___5
-                                        then
-                                          FStar_Compiler_List.iter
-                                            (fun uu___6 ->
-                                               match uu___6 with
-                                               | (ctx_uvar, uu___7) ->
-                                                   let uu___8 =
-                                                     FStar_Syntax_Print.ctx_uvar_to_string_no_reason
-                                                       ctx_uvar in
-                                                   FStar_Compiler_Util.print1
-                                                     "Layered Effect uvar : %s\n"
-                                                     uu___8) l_ctx_uvars
-                                        else ());
-                                       (let uu___5 = conj_guard g g_t in
-                                        ((FStar_Compiler_List.op_At substs1
-                                            [FStar_Syntax_Syntax.NT
-                                               ((b.FStar_Syntax_Syntax.binder_bv),
-                                                 t)]),
-                                          (FStar_Compiler_List.op_At uvars
-                                             [t]), uu___5))))))
-                   (substs, [], trivial_guard)) in
+                             | (t, l_ctx_uvars, g_t) ->
+                                 ((let uu___4 =
+                                     FStar_Compiler_Effect.op_Less_Bar
+                                       (debug env1)
+                                       (FStar_Options.Other
+                                          "LayeredEffectsEqns") in
+                                   if uu___4
+                                   then
+                                     FStar_Compiler_List.iter
+                                       (fun uu___5 ->
+                                          match uu___5 with
+                                          | (ctx_uvar, uu___6) ->
+                                              let uu___7 =
+                                                FStar_Syntax_Print.ctx_uvar_to_string_no_reason
+                                                  ctx_uvar in
+                                              FStar_Compiler_Util.print1
+                                                "Layered Effect uvar : %s\n"
+                                                uu___7) l_ctx_uvars
+                                   else ());
+                                  (let uu___4 = conj_guard g g_t in
+                                   ((FStar_Compiler_List.op_At substs1
+                                       [FStar_Syntax_Syntax.NT
+                                          ((b.FStar_Syntax_Syntax.binder_bv),
+                                            t)]),
+                                     (FStar_Compiler_List.op_At uvars [t]),
+                                     uu___4))))) (substs, [], trivial_guard)) in
             FStar_Compiler_Effect.op_Bar_Greater uu___
               (fun uu___1 ->
                  match uu___1 with | (uu___2, uvars, g) -> (uvars, g))

--- a/src/ocaml-output/FStar_TypeChecker_Env.ml
+++ b/src/ocaml-output/FStar_TypeChecker_Env.ml
@@ -1695,7 +1695,20 @@ let (initial_env :
                                    let uu___12 =
                                      typeof_tot_or_gtot_term env1 t must_tot1 in
                                    (match uu___12 with
-                                    | (uu___13, k, g) -> (k, g)));
+                                    | (t', k, g) ->
+                                        ((let uu___14 =
+                                            FStar_Syntax_Print.term_to_string
+                                              t in
+                                          let uu___15 =
+                                            FStar_Syntax_Print.term_to_string
+                                              t' in
+                                          let uu___16 =
+                                            FStar_Syntax_Print.term_to_string
+                                              k in
+                                          FStar_Compiler_Util.print3
+                                            "typeof_well_typed_tot_or_gtot_term took slow path: %s was types as %s at type %s\n"
+                                            uu___14 uu___15 uu___16);
+                                         (k, g))));
                       subtype_nosmt_force;
                       use_bv_sorts = false;
                       qtbl_name_and_index = uu___3;
@@ -5837,9 +5850,10 @@ let (is_trivial : guard_t -> Prims.bool) =
         FStar_Compiler_Effect.op_Bar_Greater i
           (FStar_Compiler_Util.for_all
              (fun imp ->
-                ((imp.FStar_TypeChecker_Common.imp_uvar).FStar_Syntax_Syntax.ctx_uvar_should_check
-                   = FStar_Syntax_Syntax.Allow_unresolved)
-                  ||
+                (let uu___1 =
+                   FStar_Syntax_Util.ctx_uvar_should_check
+                     imp.FStar_TypeChecker_Common.imp_uvar in
+                 uu___1 = FStar_Syntax_Syntax.Allow_unresolved) ||
                   (let uu___1 =
                      FStar_Syntax_Unionfind.find
                        (imp.FStar_TypeChecker_Common.imp_uvar).FStar_Syntax_Syntax.ctx_uvar_head in
@@ -6173,16 +6187,20 @@ let (new_implicit_var_aux :
               | uu___1 ->
                   let binders = all_binders env1 in
                   let gamma = env1.gamma in
+                  let decoration =
+                    {
+                      FStar_Syntax_Syntax.uvar_decoration_typ = k;
+                      FStar_Syntax_Syntax.uvar_decoration_should_check =
+                        should_check
+                    } in
                   let ctx_uvar =
-                    let uu___2 = FStar_Syntax_Unionfind.fresh r in
+                    let uu___2 = FStar_Syntax_Unionfind.fresh decoration r in
                     {
                       FStar_Syntax_Syntax.ctx_uvar_head = uu___2;
                       FStar_Syntax_Syntax.ctx_uvar_gamma = gamma;
                       FStar_Syntax_Syntax.ctx_uvar_binders = binders;
                       FStar_Syntax_Syntax.ctx_uvar_typ = k;
                       FStar_Syntax_Syntax.ctx_uvar_reason = reason;
-                      FStar_Syntax_Syntax.ctx_uvar_should_check =
-                        should_check;
                       FStar_Syntax_Syntax.ctx_uvar_range = r;
                       FStar_Syntax_Syntax.ctx_uvar_meta = meta
                     } in

--- a/src/ocaml-output/FStar_TypeChecker_Env.ml
+++ b/src/ocaml-output/FStar_TypeChecker_Env.ml
@@ -292,6 +292,8 @@ and env =
         must_tot ->
           (FStar_Syntax_Syntax.typ * FStar_TypeChecker_Common.guard_t)
     ;
+  subtype_nosmt_force:
+    env -> FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term -> Prims.bool ;
   use_bv_sorts: Prims.bool ;
   qtbl_name_and_index:
     (Prims.int FStar_Compiler_Util.smap * (FStar_Ident.lident * Prims.int)
@@ -461,12 +463,12 @@ let (__proj__Mkenv__item__solver : env -> solver_t) =
         generalize; letrecs; top_level; check_uvars; use_eq_strict; is_iface;
         admit; lax; lax_universes; phase1; failhard; nosynth; uvar_subtyping;
         tc_term; typeof_tot_or_gtot_term; universe_of;
-        typeof_well_typed_tot_or_gtot_term; use_bv_sorts;
-        qtbl_name_and_index; normalized_eff_names; fv_delta_depths; proof_ns;
-        synth_hook; try_solve_implicits_hook; splice; mpreprocess;
-        postprocess; identifier_info; tc_hooks; dsenv; nbe; strict_args_tab;
-        erasable_types_tab; enable_defer_to_tac; unif_allow_ref_guards;
-        erase_erasable_args;_} -> solver
+        typeof_well_typed_tot_or_gtot_term; subtype_nosmt_force;
+        use_bv_sorts; qtbl_name_and_index; normalized_eff_names;
+        fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
+        splice; mpreprocess; postprocess; identifier_info; tc_hooks; 
+        dsenv; nbe; strict_args_tab; erasable_types_tab; enable_defer_to_tac;
+        unif_allow_ref_guards; erase_erasable_args;_} -> solver
 let (__proj__Mkenv__item__range : env -> FStar_Compiler_Range.range) =
   fun projectee ->
     match projectee with
@@ -475,12 +477,12 @@ let (__proj__Mkenv__item__range : env -> FStar_Compiler_Range.range) =
         generalize; letrecs; top_level; check_uvars; use_eq_strict; is_iface;
         admit; lax; lax_universes; phase1; failhard; nosynth; uvar_subtyping;
         tc_term; typeof_tot_or_gtot_term; universe_of;
-        typeof_well_typed_tot_or_gtot_term; use_bv_sorts;
-        qtbl_name_and_index; normalized_eff_names; fv_delta_depths; proof_ns;
-        synth_hook; try_solve_implicits_hook; splice; mpreprocess;
-        postprocess; identifier_info; tc_hooks; dsenv; nbe; strict_args_tab;
-        erasable_types_tab; enable_defer_to_tac; unif_allow_ref_guards;
-        erase_erasable_args;_} -> range
+        typeof_well_typed_tot_or_gtot_term; subtype_nosmt_force;
+        use_bv_sorts; qtbl_name_and_index; normalized_eff_names;
+        fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
+        splice; mpreprocess; postprocess; identifier_info; tc_hooks; 
+        dsenv; nbe; strict_args_tab; erasable_types_tab; enable_defer_to_tac;
+        unif_allow_ref_guards; erase_erasable_args;_} -> range
 let (__proj__Mkenv__item__curmodule : env -> FStar_Ident.lident) =
   fun projectee ->
     match projectee with
@@ -489,12 +491,12 @@ let (__proj__Mkenv__item__curmodule : env -> FStar_Ident.lident) =
         generalize; letrecs; top_level; check_uvars; use_eq_strict; is_iface;
         admit; lax; lax_universes; phase1; failhard; nosynth; uvar_subtyping;
         tc_term; typeof_tot_or_gtot_term; universe_of;
-        typeof_well_typed_tot_or_gtot_term; use_bv_sorts;
-        qtbl_name_and_index; normalized_eff_names; fv_delta_depths; proof_ns;
-        synth_hook; try_solve_implicits_hook; splice; mpreprocess;
-        postprocess; identifier_info; tc_hooks; dsenv; nbe; strict_args_tab;
-        erasable_types_tab; enable_defer_to_tac; unif_allow_ref_guards;
-        erase_erasable_args;_} -> curmodule
+        typeof_well_typed_tot_or_gtot_term; subtype_nosmt_force;
+        use_bv_sorts; qtbl_name_and_index; normalized_eff_names;
+        fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
+        splice; mpreprocess; postprocess; identifier_info; tc_hooks; 
+        dsenv; nbe; strict_args_tab; erasable_types_tab; enable_defer_to_tac;
+        unif_allow_ref_guards; erase_erasable_args;_} -> curmodule
 let (__proj__Mkenv__item__gamma :
   env -> FStar_Syntax_Syntax.binding Prims.list) =
   fun projectee ->
@@ -504,12 +506,12 @@ let (__proj__Mkenv__item__gamma :
         generalize; letrecs; top_level; check_uvars; use_eq_strict; is_iface;
         admit; lax; lax_universes; phase1; failhard; nosynth; uvar_subtyping;
         tc_term; typeof_tot_or_gtot_term; universe_of;
-        typeof_well_typed_tot_or_gtot_term; use_bv_sorts;
-        qtbl_name_and_index; normalized_eff_names; fv_delta_depths; proof_ns;
-        synth_hook; try_solve_implicits_hook; splice; mpreprocess;
-        postprocess; identifier_info; tc_hooks; dsenv; nbe; strict_args_tab;
-        erasable_types_tab; enable_defer_to_tac; unif_allow_ref_guards;
-        erase_erasable_args;_} -> gamma
+        typeof_well_typed_tot_or_gtot_term; subtype_nosmt_force;
+        use_bv_sorts; qtbl_name_and_index; normalized_eff_names;
+        fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
+        splice; mpreprocess; postprocess; identifier_info; tc_hooks; 
+        dsenv; nbe; strict_args_tab; erasable_types_tab; enable_defer_to_tac;
+        unif_allow_ref_guards; erase_erasable_args;_} -> gamma
 let (__proj__Mkenv__item__gamma_sig : env -> sig_binding Prims.list) =
   fun projectee ->
     match projectee with
@@ -518,12 +520,12 @@ let (__proj__Mkenv__item__gamma_sig : env -> sig_binding Prims.list) =
         generalize; letrecs; top_level; check_uvars; use_eq_strict; is_iface;
         admit; lax; lax_universes; phase1; failhard; nosynth; uvar_subtyping;
         tc_term; typeof_tot_or_gtot_term; universe_of;
-        typeof_well_typed_tot_or_gtot_term; use_bv_sorts;
-        qtbl_name_and_index; normalized_eff_names; fv_delta_depths; proof_ns;
-        synth_hook; try_solve_implicits_hook; splice; mpreprocess;
-        postprocess; identifier_info; tc_hooks; dsenv; nbe; strict_args_tab;
-        erasable_types_tab; enable_defer_to_tac; unif_allow_ref_guards;
-        erase_erasable_args;_} -> gamma_sig
+        typeof_well_typed_tot_or_gtot_term; subtype_nosmt_force;
+        use_bv_sorts; qtbl_name_and_index; normalized_eff_names;
+        fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
+        splice; mpreprocess; postprocess; identifier_info; tc_hooks; 
+        dsenv; nbe; strict_args_tab; erasable_types_tab; enable_defer_to_tac;
+        unif_allow_ref_guards; erase_erasable_args;_} -> gamma_sig
 let (__proj__Mkenv__item__gamma_cache :
   env -> cached_elt FStar_Compiler_Util.smap) =
   fun projectee ->
@@ -533,12 +535,12 @@ let (__proj__Mkenv__item__gamma_cache :
         generalize; letrecs; top_level; check_uvars; use_eq_strict; is_iface;
         admit; lax; lax_universes; phase1; failhard; nosynth; uvar_subtyping;
         tc_term; typeof_tot_or_gtot_term; universe_of;
-        typeof_well_typed_tot_or_gtot_term; use_bv_sorts;
-        qtbl_name_and_index; normalized_eff_names; fv_delta_depths; proof_ns;
-        synth_hook; try_solve_implicits_hook; splice; mpreprocess;
-        postprocess; identifier_info; tc_hooks; dsenv; nbe; strict_args_tab;
-        erasable_types_tab; enable_defer_to_tac; unif_allow_ref_guards;
-        erase_erasable_args;_} -> gamma_cache
+        typeof_well_typed_tot_or_gtot_term; subtype_nosmt_force;
+        use_bv_sorts; qtbl_name_and_index; normalized_eff_names;
+        fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
+        splice; mpreprocess; postprocess; identifier_info; tc_hooks; 
+        dsenv; nbe; strict_args_tab; erasable_types_tab; enable_defer_to_tac;
+        unif_allow_ref_guards; erase_erasable_args;_} -> gamma_cache
 let (__proj__Mkenv__item__modules :
   env -> FStar_Syntax_Syntax.modul Prims.list) =
   fun projectee ->
@@ -548,12 +550,12 @@ let (__proj__Mkenv__item__modules :
         generalize; letrecs; top_level; check_uvars; use_eq_strict; is_iface;
         admit; lax; lax_universes; phase1; failhard; nosynth; uvar_subtyping;
         tc_term; typeof_tot_or_gtot_term; universe_of;
-        typeof_well_typed_tot_or_gtot_term; use_bv_sorts;
-        qtbl_name_and_index; normalized_eff_names; fv_delta_depths; proof_ns;
-        synth_hook; try_solve_implicits_hook; splice; mpreprocess;
-        postprocess; identifier_info; tc_hooks; dsenv; nbe; strict_args_tab;
-        erasable_types_tab; enable_defer_to_tac; unif_allow_ref_guards;
-        erase_erasable_args;_} -> modules
+        typeof_well_typed_tot_or_gtot_term; subtype_nosmt_force;
+        use_bv_sorts; qtbl_name_and_index; normalized_eff_names;
+        fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
+        splice; mpreprocess; postprocess; identifier_info; tc_hooks; 
+        dsenv; nbe; strict_args_tab; erasable_types_tab; enable_defer_to_tac;
+        unif_allow_ref_guards; erase_erasable_args;_} -> modules
 let (__proj__Mkenv__item__expected_typ :
   env ->
     (FStar_Syntax_Syntax.typ * Prims.bool) FStar_Pervasives_Native.option)
@@ -565,12 +567,12 @@ let (__proj__Mkenv__item__expected_typ :
         generalize; letrecs; top_level; check_uvars; use_eq_strict; is_iface;
         admit; lax; lax_universes; phase1; failhard; nosynth; uvar_subtyping;
         tc_term; typeof_tot_or_gtot_term; universe_of;
-        typeof_well_typed_tot_or_gtot_term; use_bv_sorts;
-        qtbl_name_and_index; normalized_eff_names; fv_delta_depths; proof_ns;
-        synth_hook; try_solve_implicits_hook; splice; mpreprocess;
-        postprocess; identifier_info; tc_hooks; dsenv; nbe; strict_args_tab;
-        erasable_types_tab; enable_defer_to_tac; unif_allow_ref_guards;
-        erase_erasable_args;_} -> expected_typ
+        typeof_well_typed_tot_or_gtot_term; subtype_nosmt_force;
+        use_bv_sorts; qtbl_name_and_index; normalized_eff_names;
+        fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
+        splice; mpreprocess; postprocess; identifier_info; tc_hooks; 
+        dsenv; nbe; strict_args_tab; erasable_types_tab; enable_defer_to_tac;
+        unif_allow_ref_guards; erase_erasable_args;_} -> expected_typ
 let (__proj__Mkenv__item__sigtab :
   env -> FStar_Syntax_Syntax.sigelt FStar_Compiler_Util.smap) =
   fun projectee ->
@@ -580,12 +582,12 @@ let (__proj__Mkenv__item__sigtab :
         generalize; letrecs; top_level; check_uvars; use_eq_strict; is_iface;
         admit; lax; lax_universes; phase1; failhard; nosynth; uvar_subtyping;
         tc_term; typeof_tot_or_gtot_term; universe_of;
-        typeof_well_typed_tot_or_gtot_term; use_bv_sorts;
-        qtbl_name_and_index; normalized_eff_names; fv_delta_depths; proof_ns;
-        synth_hook; try_solve_implicits_hook; splice; mpreprocess;
-        postprocess; identifier_info; tc_hooks; dsenv; nbe; strict_args_tab;
-        erasable_types_tab; enable_defer_to_tac; unif_allow_ref_guards;
-        erase_erasable_args;_} -> sigtab
+        typeof_well_typed_tot_or_gtot_term; subtype_nosmt_force;
+        use_bv_sorts; qtbl_name_and_index; normalized_eff_names;
+        fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
+        splice; mpreprocess; postprocess; identifier_info; tc_hooks; 
+        dsenv; nbe; strict_args_tab; erasable_types_tab; enable_defer_to_tac;
+        unif_allow_ref_guards; erase_erasable_args;_} -> sigtab
 let (__proj__Mkenv__item__attrtab :
   env -> FStar_Syntax_Syntax.sigelt Prims.list FStar_Compiler_Util.smap) =
   fun projectee ->
@@ -595,12 +597,12 @@ let (__proj__Mkenv__item__attrtab :
         generalize; letrecs; top_level; check_uvars; use_eq_strict; is_iface;
         admit; lax; lax_universes; phase1; failhard; nosynth; uvar_subtyping;
         tc_term; typeof_tot_or_gtot_term; universe_of;
-        typeof_well_typed_tot_or_gtot_term; use_bv_sorts;
-        qtbl_name_and_index; normalized_eff_names; fv_delta_depths; proof_ns;
-        synth_hook; try_solve_implicits_hook; splice; mpreprocess;
-        postprocess; identifier_info; tc_hooks; dsenv; nbe; strict_args_tab;
-        erasable_types_tab; enable_defer_to_tac; unif_allow_ref_guards;
-        erase_erasable_args;_} -> attrtab
+        typeof_well_typed_tot_or_gtot_term; subtype_nosmt_force;
+        use_bv_sorts; qtbl_name_and_index; normalized_eff_names;
+        fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
+        splice; mpreprocess; postprocess; identifier_info; tc_hooks; 
+        dsenv; nbe; strict_args_tab; erasable_types_tab; enable_defer_to_tac;
+        unif_allow_ref_guards; erase_erasable_args;_} -> attrtab
 let (__proj__Mkenv__item__instantiate_imp : env -> Prims.bool) =
   fun projectee ->
     match projectee with
@@ -609,12 +611,12 @@ let (__proj__Mkenv__item__instantiate_imp : env -> Prims.bool) =
         generalize; letrecs; top_level; check_uvars; use_eq_strict; is_iface;
         admit; lax; lax_universes; phase1; failhard; nosynth; uvar_subtyping;
         tc_term; typeof_tot_or_gtot_term; universe_of;
-        typeof_well_typed_tot_or_gtot_term; use_bv_sorts;
-        qtbl_name_and_index; normalized_eff_names; fv_delta_depths; proof_ns;
-        synth_hook; try_solve_implicits_hook; splice; mpreprocess;
-        postprocess; identifier_info; tc_hooks; dsenv; nbe; strict_args_tab;
-        erasable_types_tab; enable_defer_to_tac; unif_allow_ref_guards;
-        erase_erasable_args;_} -> instantiate_imp
+        typeof_well_typed_tot_or_gtot_term; subtype_nosmt_force;
+        use_bv_sorts; qtbl_name_and_index; normalized_eff_names;
+        fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
+        splice; mpreprocess; postprocess; identifier_info; tc_hooks; 
+        dsenv; nbe; strict_args_tab; erasable_types_tab; enable_defer_to_tac;
+        unif_allow_ref_guards; erase_erasable_args;_} -> instantiate_imp
 let (__proj__Mkenv__item__effects : env -> effects) =
   fun projectee ->
     match projectee with
@@ -623,12 +625,12 @@ let (__proj__Mkenv__item__effects : env -> effects) =
         generalize; letrecs; top_level; check_uvars; use_eq_strict; is_iface;
         admit; lax; lax_universes; phase1; failhard; nosynth; uvar_subtyping;
         tc_term; typeof_tot_or_gtot_term; universe_of;
-        typeof_well_typed_tot_or_gtot_term; use_bv_sorts;
-        qtbl_name_and_index; normalized_eff_names; fv_delta_depths; proof_ns;
-        synth_hook; try_solve_implicits_hook; splice; mpreprocess;
-        postprocess; identifier_info; tc_hooks; dsenv; nbe; strict_args_tab;
-        erasable_types_tab; enable_defer_to_tac; unif_allow_ref_guards;
-        erase_erasable_args;_} -> effects1
+        typeof_well_typed_tot_or_gtot_term; subtype_nosmt_force;
+        use_bv_sorts; qtbl_name_and_index; normalized_eff_names;
+        fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
+        splice; mpreprocess; postprocess; identifier_info; tc_hooks; 
+        dsenv; nbe; strict_args_tab; erasable_types_tab; enable_defer_to_tac;
+        unif_allow_ref_guards; erase_erasable_args;_} -> effects1
 let (__proj__Mkenv__item__generalize : env -> Prims.bool) =
   fun projectee ->
     match projectee with
@@ -637,12 +639,12 @@ let (__proj__Mkenv__item__generalize : env -> Prims.bool) =
         generalize; letrecs; top_level; check_uvars; use_eq_strict; is_iface;
         admit; lax; lax_universes; phase1; failhard; nosynth; uvar_subtyping;
         tc_term; typeof_tot_or_gtot_term; universe_of;
-        typeof_well_typed_tot_or_gtot_term; use_bv_sorts;
-        qtbl_name_and_index; normalized_eff_names; fv_delta_depths; proof_ns;
-        synth_hook; try_solve_implicits_hook; splice; mpreprocess;
-        postprocess; identifier_info; tc_hooks; dsenv; nbe; strict_args_tab;
-        erasable_types_tab; enable_defer_to_tac; unif_allow_ref_guards;
-        erase_erasable_args;_} -> generalize
+        typeof_well_typed_tot_or_gtot_term; subtype_nosmt_force;
+        use_bv_sorts; qtbl_name_and_index; normalized_eff_names;
+        fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
+        splice; mpreprocess; postprocess; identifier_info; tc_hooks; 
+        dsenv; nbe; strict_args_tab; erasable_types_tab; enable_defer_to_tac;
+        unif_allow_ref_guards; erase_erasable_args;_} -> generalize
 let (__proj__Mkenv__item__letrecs :
   env ->
     (FStar_Syntax_Syntax.lbname * Prims.int * FStar_Syntax_Syntax.typ *
@@ -655,12 +657,12 @@ let (__proj__Mkenv__item__letrecs :
         generalize; letrecs; top_level; check_uvars; use_eq_strict; is_iface;
         admit; lax; lax_universes; phase1; failhard; nosynth; uvar_subtyping;
         tc_term; typeof_tot_or_gtot_term; universe_of;
-        typeof_well_typed_tot_or_gtot_term; use_bv_sorts;
-        qtbl_name_and_index; normalized_eff_names; fv_delta_depths; proof_ns;
-        synth_hook; try_solve_implicits_hook; splice; mpreprocess;
-        postprocess; identifier_info; tc_hooks; dsenv; nbe; strict_args_tab;
-        erasable_types_tab; enable_defer_to_tac; unif_allow_ref_guards;
-        erase_erasable_args;_} -> letrecs
+        typeof_well_typed_tot_or_gtot_term; subtype_nosmt_force;
+        use_bv_sorts; qtbl_name_and_index; normalized_eff_names;
+        fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
+        splice; mpreprocess; postprocess; identifier_info; tc_hooks; 
+        dsenv; nbe; strict_args_tab; erasable_types_tab; enable_defer_to_tac;
+        unif_allow_ref_guards; erase_erasable_args;_} -> letrecs
 let (__proj__Mkenv__item__top_level : env -> Prims.bool) =
   fun projectee ->
     match projectee with
@@ -669,12 +671,12 @@ let (__proj__Mkenv__item__top_level : env -> Prims.bool) =
         generalize; letrecs; top_level; check_uvars; use_eq_strict; is_iface;
         admit; lax; lax_universes; phase1; failhard; nosynth; uvar_subtyping;
         tc_term; typeof_tot_or_gtot_term; universe_of;
-        typeof_well_typed_tot_or_gtot_term; use_bv_sorts;
-        qtbl_name_and_index; normalized_eff_names; fv_delta_depths; proof_ns;
-        synth_hook; try_solve_implicits_hook; splice; mpreprocess;
-        postprocess; identifier_info; tc_hooks; dsenv; nbe; strict_args_tab;
-        erasable_types_tab; enable_defer_to_tac; unif_allow_ref_guards;
-        erase_erasable_args;_} -> top_level
+        typeof_well_typed_tot_or_gtot_term; subtype_nosmt_force;
+        use_bv_sorts; qtbl_name_and_index; normalized_eff_names;
+        fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
+        splice; mpreprocess; postprocess; identifier_info; tc_hooks; 
+        dsenv; nbe; strict_args_tab; erasable_types_tab; enable_defer_to_tac;
+        unif_allow_ref_guards; erase_erasable_args;_} -> top_level
 let (__proj__Mkenv__item__check_uvars : env -> Prims.bool) =
   fun projectee ->
     match projectee with
@@ -683,12 +685,12 @@ let (__proj__Mkenv__item__check_uvars : env -> Prims.bool) =
         generalize; letrecs; top_level; check_uvars; use_eq_strict; is_iface;
         admit; lax; lax_universes; phase1; failhard; nosynth; uvar_subtyping;
         tc_term; typeof_tot_or_gtot_term; universe_of;
-        typeof_well_typed_tot_or_gtot_term; use_bv_sorts;
-        qtbl_name_and_index; normalized_eff_names; fv_delta_depths; proof_ns;
-        synth_hook; try_solve_implicits_hook; splice; mpreprocess;
-        postprocess; identifier_info; tc_hooks; dsenv; nbe; strict_args_tab;
-        erasable_types_tab; enable_defer_to_tac; unif_allow_ref_guards;
-        erase_erasable_args;_} -> check_uvars
+        typeof_well_typed_tot_or_gtot_term; subtype_nosmt_force;
+        use_bv_sorts; qtbl_name_and_index; normalized_eff_names;
+        fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
+        splice; mpreprocess; postprocess; identifier_info; tc_hooks; 
+        dsenv; nbe; strict_args_tab; erasable_types_tab; enable_defer_to_tac;
+        unif_allow_ref_guards; erase_erasable_args;_} -> check_uvars
 let (__proj__Mkenv__item__use_eq_strict : env -> Prims.bool) =
   fun projectee ->
     match projectee with
@@ -697,12 +699,12 @@ let (__proj__Mkenv__item__use_eq_strict : env -> Prims.bool) =
         generalize; letrecs; top_level; check_uvars; use_eq_strict; is_iface;
         admit; lax; lax_universes; phase1; failhard; nosynth; uvar_subtyping;
         tc_term; typeof_tot_or_gtot_term; universe_of;
-        typeof_well_typed_tot_or_gtot_term; use_bv_sorts;
-        qtbl_name_and_index; normalized_eff_names; fv_delta_depths; proof_ns;
-        synth_hook; try_solve_implicits_hook; splice; mpreprocess;
-        postprocess; identifier_info; tc_hooks; dsenv; nbe; strict_args_tab;
-        erasable_types_tab; enable_defer_to_tac; unif_allow_ref_guards;
-        erase_erasable_args;_} -> use_eq_strict
+        typeof_well_typed_tot_or_gtot_term; subtype_nosmt_force;
+        use_bv_sorts; qtbl_name_and_index; normalized_eff_names;
+        fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
+        splice; mpreprocess; postprocess; identifier_info; tc_hooks; 
+        dsenv; nbe; strict_args_tab; erasable_types_tab; enable_defer_to_tac;
+        unif_allow_ref_guards; erase_erasable_args;_} -> use_eq_strict
 let (__proj__Mkenv__item__is_iface : env -> Prims.bool) =
   fun projectee ->
     match projectee with
@@ -711,12 +713,12 @@ let (__proj__Mkenv__item__is_iface : env -> Prims.bool) =
         generalize; letrecs; top_level; check_uvars; use_eq_strict; is_iface;
         admit; lax; lax_universes; phase1; failhard; nosynth; uvar_subtyping;
         tc_term; typeof_tot_or_gtot_term; universe_of;
-        typeof_well_typed_tot_or_gtot_term; use_bv_sorts;
-        qtbl_name_and_index; normalized_eff_names; fv_delta_depths; proof_ns;
-        synth_hook; try_solve_implicits_hook; splice; mpreprocess;
-        postprocess; identifier_info; tc_hooks; dsenv; nbe; strict_args_tab;
-        erasable_types_tab; enable_defer_to_tac; unif_allow_ref_guards;
-        erase_erasable_args;_} -> is_iface
+        typeof_well_typed_tot_or_gtot_term; subtype_nosmt_force;
+        use_bv_sorts; qtbl_name_and_index; normalized_eff_names;
+        fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
+        splice; mpreprocess; postprocess; identifier_info; tc_hooks; 
+        dsenv; nbe; strict_args_tab; erasable_types_tab; enable_defer_to_tac;
+        unif_allow_ref_guards; erase_erasable_args;_} -> is_iface
 let (__proj__Mkenv__item__admit : env -> Prims.bool) =
   fun projectee ->
     match projectee with
@@ -725,12 +727,12 @@ let (__proj__Mkenv__item__admit : env -> Prims.bool) =
         generalize; letrecs; top_level; check_uvars; use_eq_strict; is_iface;
         admit; lax; lax_universes; phase1; failhard; nosynth; uvar_subtyping;
         tc_term; typeof_tot_or_gtot_term; universe_of;
-        typeof_well_typed_tot_or_gtot_term; use_bv_sorts;
-        qtbl_name_and_index; normalized_eff_names; fv_delta_depths; proof_ns;
-        synth_hook; try_solve_implicits_hook; splice; mpreprocess;
-        postprocess; identifier_info; tc_hooks; dsenv; nbe; strict_args_tab;
-        erasable_types_tab; enable_defer_to_tac; unif_allow_ref_guards;
-        erase_erasable_args;_} -> admit
+        typeof_well_typed_tot_or_gtot_term; subtype_nosmt_force;
+        use_bv_sorts; qtbl_name_and_index; normalized_eff_names;
+        fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
+        splice; mpreprocess; postprocess; identifier_info; tc_hooks; 
+        dsenv; nbe; strict_args_tab; erasable_types_tab; enable_defer_to_tac;
+        unif_allow_ref_guards; erase_erasable_args;_} -> admit
 let (__proj__Mkenv__item__lax : env -> Prims.bool) =
   fun projectee ->
     match projectee with
@@ -739,12 +741,12 @@ let (__proj__Mkenv__item__lax : env -> Prims.bool) =
         generalize; letrecs; top_level; check_uvars; use_eq_strict; is_iface;
         admit; lax; lax_universes; phase1; failhard; nosynth; uvar_subtyping;
         tc_term; typeof_tot_or_gtot_term; universe_of;
-        typeof_well_typed_tot_or_gtot_term; use_bv_sorts;
-        qtbl_name_and_index; normalized_eff_names; fv_delta_depths; proof_ns;
-        synth_hook; try_solve_implicits_hook; splice; mpreprocess;
-        postprocess; identifier_info; tc_hooks; dsenv; nbe; strict_args_tab;
-        erasable_types_tab; enable_defer_to_tac; unif_allow_ref_guards;
-        erase_erasable_args;_} -> lax
+        typeof_well_typed_tot_or_gtot_term; subtype_nosmt_force;
+        use_bv_sorts; qtbl_name_and_index; normalized_eff_names;
+        fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
+        splice; mpreprocess; postprocess; identifier_info; tc_hooks; 
+        dsenv; nbe; strict_args_tab; erasable_types_tab; enable_defer_to_tac;
+        unif_allow_ref_guards; erase_erasable_args;_} -> lax
 let (__proj__Mkenv__item__lax_universes : env -> Prims.bool) =
   fun projectee ->
     match projectee with
@@ -753,12 +755,12 @@ let (__proj__Mkenv__item__lax_universes : env -> Prims.bool) =
         generalize; letrecs; top_level; check_uvars; use_eq_strict; is_iface;
         admit; lax; lax_universes; phase1; failhard; nosynth; uvar_subtyping;
         tc_term; typeof_tot_or_gtot_term; universe_of;
-        typeof_well_typed_tot_or_gtot_term; use_bv_sorts;
-        qtbl_name_and_index; normalized_eff_names; fv_delta_depths; proof_ns;
-        synth_hook; try_solve_implicits_hook; splice; mpreprocess;
-        postprocess; identifier_info; tc_hooks; dsenv; nbe; strict_args_tab;
-        erasable_types_tab; enable_defer_to_tac; unif_allow_ref_guards;
-        erase_erasable_args;_} -> lax_universes
+        typeof_well_typed_tot_or_gtot_term; subtype_nosmt_force;
+        use_bv_sorts; qtbl_name_and_index; normalized_eff_names;
+        fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
+        splice; mpreprocess; postprocess; identifier_info; tc_hooks; 
+        dsenv; nbe; strict_args_tab; erasable_types_tab; enable_defer_to_tac;
+        unif_allow_ref_guards; erase_erasable_args;_} -> lax_universes
 let (__proj__Mkenv__item__phase1 : env -> Prims.bool) =
   fun projectee ->
     match projectee with
@@ -767,12 +769,12 @@ let (__proj__Mkenv__item__phase1 : env -> Prims.bool) =
         generalize; letrecs; top_level; check_uvars; use_eq_strict; is_iface;
         admit; lax; lax_universes; phase1; failhard; nosynth; uvar_subtyping;
         tc_term; typeof_tot_or_gtot_term; universe_of;
-        typeof_well_typed_tot_or_gtot_term; use_bv_sorts;
-        qtbl_name_and_index; normalized_eff_names; fv_delta_depths; proof_ns;
-        synth_hook; try_solve_implicits_hook; splice; mpreprocess;
-        postprocess; identifier_info; tc_hooks; dsenv; nbe; strict_args_tab;
-        erasable_types_tab; enable_defer_to_tac; unif_allow_ref_guards;
-        erase_erasable_args;_} -> phase1
+        typeof_well_typed_tot_or_gtot_term; subtype_nosmt_force;
+        use_bv_sorts; qtbl_name_and_index; normalized_eff_names;
+        fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
+        splice; mpreprocess; postprocess; identifier_info; tc_hooks; 
+        dsenv; nbe; strict_args_tab; erasable_types_tab; enable_defer_to_tac;
+        unif_allow_ref_guards; erase_erasable_args;_} -> phase1
 let (__proj__Mkenv__item__failhard : env -> Prims.bool) =
   fun projectee ->
     match projectee with
@@ -781,12 +783,12 @@ let (__proj__Mkenv__item__failhard : env -> Prims.bool) =
         generalize; letrecs; top_level; check_uvars; use_eq_strict; is_iface;
         admit; lax; lax_universes; phase1; failhard; nosynth; uvar_subtyping;
         tc_term; typeof_tot_or_gtot_term; universe_of;
-        typeof_well_typed_tot_or_gtot_term; use_bv_sorts;
-        qtbl_name_and_index; normalized_eff_names; fv_delta_depths; proof_ns;
-        synth_hook; try_solve_implicits_hook; splice; mpreprocess;
-        postprocess; identifier_info; tc_hooks; dsenv; nbe; strict_args_tab;
-        erasable_types_tab; enable_defer_to_tac; unif_allow_ref_guards;
-        erase_erasable_args;_} -> failhard
+        typeof_well_typed_tot_or_gtot_term; subtype_nosmt_force;
+        use_bv_sorts; qtbl_name_and_index; normalized_eff_names;
+        fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
+        splice; mpreprocess; postprocess; identifier_info; tc_hooks; 
+        dsenv; nbe; strict_args_tab; erasable_types_tab; enable_defer_to_tac;
+        unif_allow_ref_guards; erase_erasable_args;_} -> failhard
 let (__proj__Mkenv__item__nosynth : env -> Prims.bool) =
   fun projectee ->
     match projectee with
@@ -795,12 +797,12 @@ let (__proj__Mkenv__item__nosynth : env -> Prims.bool) =
         generalize; letrecs; top_level; check_uvars; use_eq_strict; is_iface;
         admit; lax; lax_universes; phase1; failhard; nosynth; uvar_subtyping;
         tc_term; typeof_tot_or_gtot_term; universe_of;
-        typeof_well_typed_tot_or_gtot_term; use_bv_sorts;
-        qtbl_name_and_index; normalized_eff_names; fv_delta_depths; proof_ns;
-        synth_hook; try_solve_implicits_hook; splice; mpreprocess;
-        postprocess; identifier_info; tc_hooks; dsenv; nbe; strict_args_tab;
-        erasable_types_tab; enable_defer_to_tac; unif_allow_ref_guards;
-        erase_erasable_args;_} -> nosynth
+        typeof_well_typed_tot_or_gtot_term; subtype_nosmt_force;
+        use_bv_sorts; qtbl_name_and_index; normalized_eff_names;
+        fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
+        splice; mpreprocess; postprocess; identifier_info; tc_hooks; 
+        dsenv; nbe; strict_args_tab; erasable_types_tab; enable_defer_to_tac;
+        unif_allow_ref_guards; erase_erasable_args;_} -> nosynth
 let (__proj__Mkenv__item__uvar_subtyping : env -> Prims.bool) =
   fun projectee ->
     match projectee with
@@ -809,12 +811,12 @@ let (__proj__Mkenv__item__uvar_subtyping : env -> Prims.bool) =
         generalize; letrecs; top_level; check_uvars; use_eq_strict; is_iface;
         admit; lax; lax_universes; phase1; failhard; nosynth; uvar_subtyping;
         tc_term; typeof_tot_or_gtot_term; universe_of;
-        typeof_well_typed_tot_or_gtot_term; use_bv_sorts;
-        qtbl_name_and_index; normalized_eff_names; fv_delta_depths; proof_ns;
-        synth_hook; try_solve_implicits_hook; splice; mpreprocess;
-        postprocess; identifier_info; tc_hooks; dsenv; nbe; strict_args_tab;
-        erasable_types_tab; enable_defer_to_tac; unif_allow_ref_guards;
-        erase_erasable_args;_} -> uvar_subtyping
+        typeof_well_typed_tot_or_gtot_term; subtype_nosmt_force;
+        use_bv_sorts; qtbl_name_and_index; normalized_eff_names;
+        fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
+        splice; mpreprocess; postprocess; identifier_info; tc_hooks; 
+        dsenv; nbe; strict_args_tab; erasable_types_tab; enable_defer_to_tac;
+        unif_allow_ref_guards; erase_erasable_args;_} -> uvar_subtyping
 let (__proj__Mkenv__item__tc_term :
   env ->
     env ->
@@ -829,12 +831,12 @@ let (__proj__Mkenv__item__tc_term :
         generalize; letrecs; top_level; check_uvars; use_eq_strict; is_iface;
         admit; lax; lax_universes; phase1; failhard; nosynth; uvar_subtyping;
         tc_term; typeof_tot_or_gtot_term; universe_of;
-        typeof_well_typed_tot_or_gtot_term; use_bv_sorts;
-        qtbl_name_and_index; normalized_eff_names; fv_delta_depths; proof_ns;
-        synth_hook; try_solve_implicits_hook; splice; mpreprocess;
-        postprocess; identifier_info; tc_hooks; dsenv; nbe; strict_args_tab;
-        erasable_types_tab; enable_defer_to_tac; unif_allow_ref_guards;
-        erase_erasable_args;_} -> tc_term
+        typeof_well_typed_tot_or_gtot_term; subtype_nosmt_force;
+        use_bv_sorts; qtbl_name_and_index; normalized_eff_names;
+        fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
+        splice; mpreprocess; postprocess; identifier_info; tc_hooks; 
+        dsenv; nbe; strict_args_tab; erasable_types_tab; enable_defer_to_tac;
+        unif_allow_ref_guards; erase_erasable_args;_} -> tc_term
 let (__proj__Mkenv__item__typeof_tot_or_gtot_term :
   env ->
     env ->
@@ -850,12 +852,13 @@ let (__proj__Mkenv__item__typeof_tot_or_gtot_term :
         generalize; letrecs; top_level; check_uvars; use_eq_strict; is_iface;
         admit; lax; lax_universes; phase1; failhard; nosynth; uvar_subtyping;
         tc_term; typeof_tot_or_gtot_term; universe_of;
-        typeof_well_typed_tot_or_gtot_term; use_bv_sorts;
-        qtbl_name_and_index; normalized_eff_names; fv_delta_depths; proof_ns;
-        synth_hook; try_solve_implicits_hook; splice; mpreprocess;
-        postprocess; identifier_info; tc_hooks; dsenv; nbe; strict_args_tab;
-        erasable_types_tab; enable_defer_to_tac; unif_allow_ref_guards;
-        erase_erasable_args;_} -> typeof_tot_or_gtot_term
+        typeof_well_typed_tot_or_gtot_term; subtype_nosmt_force;
+        use_bv_sorts; qtbl_name_and_index; normalized_eff_names;
+        fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
+        splice; mpreprocess; postprocess; identifier_info; tc_hooks; 
+        dsenv; nbe; strict_args_tab; erasable_types_tab; enable_defer_to_tac;
+        unif_allow_ref_guards; erase_erasable_args;_} ->
+        typeof_tot_or_gtot_term
 let (__proj__Mkenv__item__universe_of :
   env -> env -> FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.universe) =
   fun projectee ->
@@ -865,12 +868,12 @@ let (__proj__Mkenv__item__universe_of :
         generalize; letrecs; top_level; check_uvars; use_eq_strict; is_iface;
         admit; lax; lax_universes; phase1; failhard; nosynth; uvar_subtyping;
         tc_term; typeof_tot_or_gtot_term; universe_of;
-        typeof_well_typed_tot_or_gtot_term; use_bv_sorts;
-        qtbl_name_and_index; normalized_eff_names; fv_delta_depths; proof_ns;
-        synth_hook; try_solve_implicits_hook; splice; mpreprocess;
-        postprocess; identifier_info; tc_hooks; dsenv; nbe; strict_args_tab;
-        erasable_types_tab; enable_defer_to_tac; unif_allow_ref_guards;
-        erase_erasable_args;_} -> universe_of
+        typeof_well_typed_tot_or_gtot_term; subtype_nosmt_force;
+        use_bv_sorts; qtbl_name_and_index; normalized_eff_names;
+        fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
+        splice; mpreprocess; postprocess; identifier_info; tc_hooks; 
+        dsenv; nbe; strict_args_tab; erasable_types_tab; enable_defer_to_tac;
+        unif_allow_ref_guards; erase_erasable_args;_} -> universe_of
 let (__proj__Mkenv__item__typeof_well_typed_tot_or_gtot_term :
   env ->
     env ->
@@ -885,12 +888,30 @@ let (__proj__Mkenv__item__typeof_well_typed_tot_or_gtot_term :
         generalize; letrecs; top_level; check_uvars; use_eq_strict; is_iface;
         admit; lax; lax_universes; phase1; failhard; nosynth; uvar_subtyping;
         tc_term; typeof_tot_or_gtot_term; universe_of;
-        typeof_well_typed_tot_or_gtot_term; use_bv_sorts;
-        qtbl_name_and_index; normalized_eff_names; fv_delta_depths; proof_ns;
-        synth_hook; try_solve_implicits_hook; splice; mpreprocess;
-        postprocess; identifier_info; tc_hooks; dsenv; nbe; strict_args_tab;
-        erasable_types_tab; enable_defer_to_tac; unif_allow_ref_guards;
-        erase_erasable_args;_} -> typeof_well_typed_tot_or_gtot_term
+        typeof_well_typed_tot_or_gtot_term; subtype_nosmt_force;
+        use_bv_sorts; qtbl_name_and_index; normalized_eff_names;
+        fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
+        splice; mpreprocess; postprocess; identifier_info; tc_hooks; 
+        dsenv; nbe; strict_args_tab; erasable_types_tab; enable_defer_to_tac;
+        unif_allow_ref_guards; erase_erasable_args;_} ->
+        typeof_well_typed_tot_or_gtot_term
+let (__proj__Mkenv__item__subtype_nosmt_force :
+  env ->
+    env -> FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term -> Prims.bool)
+  =
+  fun projectee ->
+    match projectee with
+    | { solver; range; curmodule; gamma; gamma_sig; gamma_cache; modules;
+        expected_typ; sigtab; attrtab; instantiate_imp; effects = effects1;
+        generalize; letrecs; top_level; check_uvars; use_eq_strict; is_iface;
+        admit; lax; lax_universes; phase1; failhard; nosynth; uvar_subtyping;
+        tc_term; typeof_tot_or_gtot_term; universe_of;
+        typeof_well_typed_tot_or_gtot_term; subtype_nosmt_force;
+        use_bv_sorts; qtbl_name_and_index; normalized_eff_names;
+        fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
+        splice; mpreprocess; postprocess; identifier_info; tc_hooks; 
+        dsenv; nbe; strict_args_tab; erasable_types_tab; enable_defer_to_tac;
+        unif_allow_ref_guards; erase_erasable_args;_} -> subtype_nosmt_force
 let (__proj__Mkenv__item__use_bv_sorts : env -> Prims.bool) =
   fun projectee ->
     match projectee with
@@ -899,12 +920,12 @@ let (__proj__Mkenv__item__use_bv_sorts : env -> Prims.bool) =
         generalize; letrecs; top_level; check_uvars; use_eq_strict; is_iface;
         admit; lax; lax_universes; phase1; failhard; nosynth; uvar_subtyping;
         tc_term; typeof_tot_or_gtot_term; universe_of;
-        typeof_well_typed_tot_or_gtot_term; use_bv_sorts;
-        qtbl_name_and_index; normalized_eff_names; fv_delta_depths; proof_ns;
-        synth_hook; try_solve_implicits_hook; splice; mpreprocess;
-        postprocess; identifier_info; tc_hooks; dsenv; nbe; strict_args_tab;
-        erasable_types_tab; enable_defer_to_tac; unif_allow_ref_guards;
-        erase_erasable_args;_} -> use_bv_sorts
+        typeof_well_typed_tot_or_gtot_term; subtype_nosmt_force;
+        use_bv_sorts; qtbl_name_and_index; normalized_eff_names;
+        fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
+        splice; mpreprocess; postprocess; identifier_info; tc_hooks; 
+        dsenv; nbe; strict_args_tab; erasable_types_tab; enable_defer_to_tac;
+        unif_allow_ref_guards; erase_erasable_args;_} -> use_bv_sorts
 let (__proj__Mkenv__item__qtbl_name_and_index :
   env ->
     (Prims.int FStar_Compiler_Util.smap * (FStar_Ident.lident * Prims.int)
@@ -917,12 +938,12 @@ let (__proj__Mkenv__item__qtbl_name_and_index :
         generalize; letrecs; top_level; check_uvars; use_eq_strict; is_iface;
         admit; lax; lax_universes; phase1; failhard; nosynth; uvar_subtyping;
         tc_term; typeof_tot_or_gtot_term; universe_of;
-        typeof_well_typed_tot_or_gtot_term; use_bv_sorts;
-        qtbl_name_and_index; normalized_eff_names; fv_delta_depths; proof_ns;
-        synth_hook; try_solve_implicits_hook; splice; mpreprocess;
-        postprocess; identifier_info; tc_hooks; dsenv; nbe; strict_args_tab;
-        erasable_types_tab; enable_defer_to_tac; unif_allow_ref_guards;
-        erase_erasable_args;_} -> qtbl_name_and_index
+        typeof_well_typed_tot_or_gtot_term; subtype_nosmt_force;
+        use_bv_sorts; qtbl_name_and_index; normalized_eff_names;
+        fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
+        splice; mpreprocess; postprocess; identifier_info; tc_hooks; 
+        dsenv; nbe; strict_args_tab; erasable_types_tab; enable_defer_to_tac;
+        unif_allow_ref_guards; erase_erasable_args;_} -> qtbl_name_and_index
 let (__proj__Mkenv__item__normalized_eff_names :
   env -> FStar_Ident.lident FStar_Compiler_Util.smap) =
   fun projectee ->
@@ -932,12 +953,12 @@ let (__proj__Mkenv__item__normalized_eff_names :
         generalize; letrecs; top_level; check_uvars; use_eq_strict; is_iface;
         admit; lax; lax_universes; phase1; failhard; nosynth; uvar_subtyping;
         tc_term; typeof_tot_or_gtot_term; universe_of;
-        typeof_well_typed_tot_or_gtot_term; use_bv_sorts;
-        qtbl_name_and_index; normalized_eff_names; fv_delta_depths; proof_ns;
-        synth_hook; try_solve_implicits_hook; splice; mpreprocess;
-        postprocess; identifier_info; tc_hooks; dsenv; nbe; strict_args_tab;
-        erasable_types_tab; enable_defer_to_tac; unif_allow_ref_guards;
-        erase_erasable_args;_} -> normalized_eff_names
+        typeof_well_typed_tot_or_gtot_term; subtype_nosmt_force;
+        use_bv_sorts; qtbl_name_and_index; normalized_eff_names;
+        fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
+        splice; mpreprocess; postprocess; identifier_info; tc_hooks; 
+        dsenv; nbe; strict_args_tab; erasable_types_tab; enable_defer_to_tac;
+        unif_allow_ref_guards; erase_erasable_args;_} -> normalized_eff_names
 let (__proj__Mkenv__item__fv_delta_depths :
   env -> FStar_Syntax_Syntax.delta_depth FStar_Compiler_Util.smap) =
   fun projectee ->
@@ -947,12 +968,12 @@ let (__proj__Mkenv__item__fv_delta_depths :
         generalize; letrecs; top_level; check_uvars; use_eq_strict; is_iface;
         admit; lax; lax_universes; phase1; failhard; nosynth; uvar_subtyping;
         tc_term; typeof_tot_or_gtot_term; universe_of;
-        typeof_well_typed_tot_or_gtot_term; use_bv_sorts;
-        qtbl_name_and_index; normalized_eff_names; fv_delta_depths; proof_ns;
-        synth_hook; try_solve_implicits_hook; splice; mpreprocess;
-        postprocess; identifier_info; tc_hooks; dsenv; nbe; strict_args_tab;
-        erasable_types_tab; enable_defer_to_tac; unif_allow_ref_guards;
-        erase_erasable_args;_} -> fv_delta_depths
+        typeof_well_typed_tot_or_gtot_term; subtype_nosmt_force;
+        use_bv_sorts; qtbl_name_and_index; normalized_eff_names;
+        fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
+        splice; mpreprocess; postprocess; identifier_info; tc_hooks; 
+        dsenv; nbe; strict_args_tab; erasable_types_tab; enable_defer_to_tac;
+        unif_allow_ref_guards; erase_erasable_args;_} -> fv_delta_depths
 let (__proj__Mkenv__item__proof_ns : env -> proof_namespace) =
   fun projectee ->
     match projectee with
@@ -961,12 +982,12 @@ let (__proj__Mkenv__item__proof_ns : env -> proof_namespace) =
         generalize; letrecs; top_level; check_uvars; use_eq_strict; is_iface;
         admit; lax; lax_universes; phase1; failhard; nosynth; uvar_subtyping;
         tc_term; typeof_tot_or_gtot_term; universe_of;
-        typeof_well_typed_tot_or_gtot_term; use_bv_sorts;
-        qtbl_name_and_index; normalized_eff_names; fv_delta_depths; proof_ns;
-        synth_hook; try_solve_implicits_hook; splice; mpreprocess;
-        postprocess; identifier_info; tc_hooks; dsenv; nbe; strict_args_tab;
-        erasable_types_tab; enable_defer_to_tac; unif_allow_ref_guards;
-        erase_erasable_args;_} -> proof_ns
+        typeof_well_typed_tot_or_gtot_term; subtype_nosmt_force;
+        use_bv_sorts; qtbl_name_and_index; normalized_eff_names;
+        fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
+        splice; mpreprocess; postprocess; identifier_info; tc_hooks; 
+        dsenv; nbe; strict_args_tab; erasable_types_tab; enable_defer_to_tac;
+        unif_allow_ref_guards; erase_erasable_args;_} -> proof_ns
 let (__proj__Mkenv__item__synth_hook :
   env ->
     env ->
@@ -980,12 +1001,12 @@ let (__proj__Mkenv__item__synth_hook :
         generalize; letrecs; top_level; check_uvars; use_eq_strict; is_iface;
         admit; lax; lax_universes; phase1; failhard; nosynth; uvar_subtyping;
         tc_term; typeof_tot_or_gtot_term; universe_of;
-        typeof_well_typed_tot_or_gtot_term; use_bv_sorts;
-        qtbl_name_and_index; normalized_eff_names; fv_delta_depths; proof_ns;
-        synth_hook; try_solve_implicits_hook; splice; mpreprocess;
-        postprocess; identifier_info; tc_hooks; dsenv; nbe; strict_args_tab;
-        erasable_types_tab; enable_defer_to_tac; unif_allow_ref_guards;
-        erase_erasable_args;_} -> synth_hook
+        typeof_well_typed_tot_or_gtot_term; subtype_nosmt_force;
+        use_bv_sorts; qtbl_name_and_index; normalized_eff_names;
+        fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
+        splice; mpreprocess; postprocess; identifier_info; tc_hooks; 
+        dsenv; nbe; strict_args_tab; erasable_types_tab; enable_defer_to_tac;
+        unif_allow_ref_guards; erase_erasable_args;_} -> synth_hook
 let (__proj__Mkenv__item__try_solve_implicits_hook :
   env ->
     env ->
@@ -998,12 +1019,13 @@ let (__proj__Mkenv__item__try_solve_implicits_hook :
         generalize; letrecs; top_level; check_uvars; use_eq_strict; is_iface;
         admit; lax; lax_universes; phase1; failhard; nosynth; uvar_subtyping;
         tc_term; typeof_tot_or_gtot_term; universe_of;
-        typeof_well_typed_tot_or_gtot_term; use_bv_sorts;
-        qtbl_name_and_index; normalized_eff_names; fv_delta_depths; proof_ns;
-        synth_hook; try_solve_implicits_hook; splice; mpreprocess;
-        postprocess; identifier_info; tc_hooks; dsenv; nbe; strict_args_tab;
-        erasable_types_tab; enable_defer_to_tac; unif_allow_ref_guards;
-        erase_erasable_args;_} -> try_solve_implicits_hook
+        typeof_well_typed_tot_or_gtot_term; subtype_nosmt_force;
+        use_bv_sorts; qtbl_name_and_index; normalized_eff_names;
+        fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
+        splice; mpreprocess; postprocess; identifier_info; tc_hooks; 
+        dsenv; nbe; strict_args_tab; erasable_types_tab; enable_defer_to_tac;
+        unif_allow_ref_guards; erase_erasable_args;_} ->
+        try_solve_implicits_hook
 let (__proj__Mkenv__item__splice :
   env ->
     env ->
@@ -1017,12 +1039,12 @@ let (__proj__Mkenv__item__splice :
         generalize; letrecs; top_level; check_uvars; use_eq_strict; is_iface;
         admit; lax; lax_universes; phase1; failhard; nosynth; uvar_subtyping;
         tc_term; typeof_tot_or_gtot_term; universe_of;
-        typeof_well_typed_tot_or_gtot_term; use_bv_sorts;
-        qtbl_name_and_index; normalized_eff_names; fv_delta_depths; proof_ns;
-        synth_hook; try_solve_implicits_hook; splice; mpreprocess;
-        postprocess; identifier_info; tc_hooks; dsenv; nbe; strict_args_tab;
-        erasable_types_tab; enable_defer_to_tac; unif_allow_ref_guards;
-        erase_erasable_args;_} -> splice
+        typeof_well_typed_tot_or_gtot_term; subtype_nosmt_force;
+        use_bv_sorts; qtbl_name_and_index; normalized_eff_names;
+        fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
+        splice; mpreprocess; postprocess; identifier_info; tc_hooks; 
+        dsenv; nbe; strict_args_tab; erasable_types_tab; enable_defer_to_tac;
+        unif_allow_ref_guards; erase_erasable_args;_} -> splice
 let (__proj__Mkenv__item__mpreprocess :
   env ->
     env ->
@@ -1036,12 +1058,12 @@ let (__proj__Mkenv__item__mpreprocess :
         generalize; letrecs; top_level; check_uvars; use_eq_strict; is_iface;
         admit; lax; lax_universes; phase1; failhard; nosynth; uvar_subtyping;
         tc_term; typeof_tot_or_gtot_term; universe_of;
-        typeof_well_typed_tot_or_gtot_term; use_bv_sorts;
-        qtbl_name_and_index; normalized_eff_names; fv_delta_depths; proof_ns;
-        synth_hook; try_solve_implicits_hook; splice; mpreprocess;
-        postprocess; identifier_info; tc_hooks; dsenv; nbe; strict_args_tab;
-        erasable_types_tab; enable_defer_to_tac; unif_allow_ref_guards;
-        erase_erasable_args;_} -> mpreprocess
+        typeof_well_typed_tot_or_gtot_term; subtype_nosmt_force;
+        use_bv_sorts; qtbl_name_and_index; normalized_eff_names;
+        fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
+        splice; mpreprocess; postprocess; identifier_info; tc_hooks; 
+        dsenv; nbe; strict_args_tab; erasable_types_tab; enable_defer_to_tac;
+        unif_allow_ref_guards; erase_erasable_args;_} -> mpreprocess
 let (__proj__Mkenv__item__postprocess :
   env ->
     env ->
@@ -1056,12 +1078,12 @@ let (__proj__Mkenv__item__postprocess :
         generalize; letrecs; top_level; check_uvars; use_eq_strict; is_iface;
         admit; lax; lax_universes; phase1; failhard; nosynth; uvar_subtyping;
         tc_term; typeof_tot_or_gtot_term; universe_of;
-        typeof_well_typed_tot_or_gtot_term; use_bv_sorts;
-        qtbl_name_and_index; normalized_eff_names; fv_delta_depths; proof_ns;
-        synth_hook; try_solve_implicits_hook; splice; mpreprocess;
-        postprocess; identifier_info; tc_hooks; dsenv; nbe; strict_args_tab;
-        erasable_types_tab; enable_defer_to_tac; unif_allow_ref_guards;
-        erase_erasable_args;_} -> postprocess
+        typeof_well_typed_tot_or_gtot_term; subtype_nosmt_force;
+        use_bv_sorts; qtbl_name_and_index; normalized_eff_names;
+        fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
+        splice; mpreprocess; postprocess; identifier_info; tc_hooks; 
+        dsenv; nbe; strict_args_tab; erasable_types_tab; enable_defer_to_tac;
+        unif_allow_ref_guards; erase_erasable_args;_} -> postprocess
 let (__proj__Mkenv__item__identifier_info :
   env -> FStar_TypeChecker_Common.id_info_table FStar_Compiler_Effect.ref) =
   fun projectee ->
@@ -1071,12 +1093,12 @@ let (__proj__Mkenv__item__identifier_info :
         generalize; letrecs; top_level; check_uvars; use_eq_strict; is_iface;
         admit; lax; lax_universes; phase1; failhard; nosynth; uvar_subtyping;
         tc_term; typeof_tot_or_gtot_term; universe_of;
-        typeof_well_typed_tot_or_gtot_term; use_bv_sorts;
-        qtbl_name_and_index; normalized_eff_names; fv_delta_depths; proof_ns;
-        synth_hook; try_solve_implicits_hook; splice; mpreprocess;
-        postprocess; identifier_info; tc_hooks; dsenv; nbe; strict_args_tab;
-        erasable_types_tab; enable_defer_to_tac; unif_allow_ref_guards;
-        erase_erasable_args;_} -> identifier_info
+        typeof_well_typed_tot_or_gtot_term; subtype_nosmt_force;
+        use_bv_sorts; qtbl_name_and_index; normalized_eff_names;
+        fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
+        splice; mpreprocess; postprocess; identifier_info; tc_hooks; 
+        dsenv; nbe; strict_args_tab; erasable_types_tab; enable_defer_to_tac;
+        unif_allow_ref_guards; erase_erasable_args;_} -> identifier_info
 let (__proj__Mkenv__item__tc_hooks : env -> tcenv_hooks) =
   fun projectee ->
     match projectee with
@@ -1085,12 +1107,12 @@ let (__proj__Mkenv__item__tc_hooks : env -> tcenv_hooks) =
         generalize; letrecs; top_level; check_uvars; use_eq_strict; is_iface;
         admit; lax; lax_universes; phase1; failhard; nosynth; uvar_subtyping;
         tc_term; typeof_tot_or_gtot_term; universe_of;
-        typeof_well_typed_tot_or_gtot_term; use_bv_sorts;
-        qtbl_name_and_index; normalized_eff_names; fv_delta_depths; proof_ns;
-        synth_hook; try_solve_implicits_hook; splice; mpreprocess;
-        postprocess; identifier_info; tc_hooks; dsenv; nbe; strict_args_tab;
-        erasable_types_tab; enable_defer_to_tac; unif_allow_ref_guards;
-        erase_erasable_args;_} -> tc_hooks
+        typeof_well_typed_tot_or_gtot_term; subtype_nosmt_force;
+        use_bv_sorts; qtbl_name_and_index; normalized_eff_names;
+        fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
+        splice; mpreprocess; postprocess; identifier_info; tc_hooks; 
+        dsenv; nbe; strict_args_tab; erasable_types_tab; enable_defer_to_tac;
+        unif_allow_ref_guards; erase_erasable_args;_} -> tc_hooks
 let (__proj__Mkenv__item__dsenv : env -> FStar_Syntax_DsEnv.env) =
   fun projectee ->
     match projectee with
@@ -1099,12 +1121,12 @@ let (__proj__Mkenv__item__dsenv : env -> FStar_Syntax_DsEnv.env) =
         generalize; letrecs; top_level; check_uvars; use_eq_strict; is_iface;
         admit; lax; lax_universes; phase1; failhard; nosynth; uvar_subtyping;
         tc_term; typeof_tot_or_gtot_term; universe_of;
-        typeof_well_typed_tot_or_gtot_term; use_bv_sorts;
-        qtbl_name_and_index; normalized_eff_names; fv_delta_depths; proof_ns;
-        synth_hook; try_solve_implicits_hook; splice; mpreprocess;
-        postprocess; identifier_info; tc_hooks; dsenv; nbe; strict_args_tab;
-        erasable_types_tab; enable_defer_to_tac; unif_allow_ref_guards;
-        erase_erasable_args;_} -> dsenv
+        typeof_well_typed_tot_or_gtot_term; subtype_nosmt_force;
+        use_bv_sorts; qtbl_name_and_index; normalized_eff_names;
+        fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
+        splice; mpreprocess; postprocess; identifier_info; tc_hooks; 
+        dsenv; nbe; strict_args_tab; erasable_types_tab; enable_defer_to_tac;
+        unif_allow_ref_guards; erase_erasable_args;_} -> dsenv
 let (__proj__Mkenv__item__nbe :
   env ->
     step Prims.list ->
@@ -1117,12 +1139,12 @@ let (__proj__Mkenv__item__nbe :
         generalize; letrecs; top_level; check_uvars; use_eq_strict; is_iface;
         admit; lax; lax_universes; phase1; failhard; nosynth; uvar_subtyping;
         tc_term; typeof_tot_or_gtot_term; universe_of;
-        typeof_well_typed_tot_or_gtot_term; use_bv_sorts;
-        qtbl_name_and_index; normalized_eff_names; fv_delta_depths; proof_ns;
-        synth_hook; try_solve_implicits_hook; splice; mpreprocess;
-        postprocess; identifier_info; tc_hooks; dsenv; nbe; strict_args_tab;
-        erasable_types_tab; enable_defer_to_tac; unif_allow_ref_guards;
-        erase_erasable_args;_} -> nbe
+        typeof_well_typed_tot_or_gtot_term; subtype_nosmt_force;
+        use_bv_sorts; qtbl_name_and_index; normalized_eff_names;
+        fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
+        splice; mpreprocess; postprocess; identifier_info; tc_hooks; 
+        dsenv; nbe; strict_args_tab; erasable_types_tab; enable_defer_to_tac;
+        unif_allow_ref_guards; erase_erasable_args;_} -> nbe
 let (__proj__Mkenv__item__strict_args_tab :
   env ->
     Prims.int Prims.list FStar_Pervasives_Native.option
@@ -1135,12 +1157,12 @@ let (__proj__Mkenv__item__strict_args_tab :
         generalize; letrecs; top_level; check_uvars; use_eq_strict; is_iface;
         admit; lax; lax_universes; phase1; failhard; nosynth; uvar_subtyping;
         tc_term; typeof_tot_or_gtot_term; universe_of;
-        typeof_well_typed_tot_or_gtot_term; use_bv_sorts;
-        qtbl_name_and_index; normalized_eff_names; fv_delta_depths; proof_ns;
-        synth_hook; try_solve_implicits_hook; splice; mpreprocess;
-        postprocess; identifier_info; tc_hooks; dsenv; nbe; strict_args_tab;
-        erasable_types_tab; enable_defer_to_tac; unif_allow_ref_guards;
-        erase_erasable_args;_} -> strict_args_tab
+        typeof_well_typed_tot_or_gtot_term; subtype_nosmt_force;
+        use_bv_sorts; qtbl_name_and_index; normalized_eff_names;
+        fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
+        splice; mpreprocess; postprocess; identifier_info; tc_hooks; 
+        dsenv; nbe; strict_args_tab; erasable_types_tab; enable_defer_to_tac;
+        unif_allow_ref_guards; erase_erasable_args;_} -> strict_args_tab
 let (__proj__Mkenv__item__erasable_types_tab :
   env -> Prims.bool FStar_Compiler_Util.smap) =
   fun projectee ->
@@ -1150,12 +1172,12 @@ let (__proj__Mkenv__item__erasable_types_tab :
         generalize; letrecs; top_level; check_uvars; use_eq_strict; is_iface;
         admit; lax; lax_universes; phase1; failhard; nosynth; uvar_subtyping;
         tc_term; typeof_tot_or_gtot_term; universe_of;
-        typeof_well_typed_tot_or_gtot_term; use_bv_sorts;
-        qtbl_name_and_index; normalized_eff_names; fv_delta_depths; proof_ns;
-        synth_hook; try_solve_implicits_hook; splice; mpreprocess;
-        postprocess; identifier_info; tc_hooks; dsenv; nbe; strict_args_tab;
-        erasable_types_tab; enable_defer_to_tac; unif_allow_ref_guards;
-        erase_erasable_args;_} -> erasable_types_tab
+        typeof_well_typed_tot_or_gtot_term; subtype_nosmt_force;
+        use_bv_sorts; qtbl_name_and_index; normalized_eff_names;
+        fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
+        splice; mpreprocess; postprocess; identifier_info; tc_hooks; 
+        dsenv; nbe; strict_args_tab; erasable_types_tab; enable_defer_to_tac;
+        unif_allow_ref_guards; erase_erasable_args;_} -> erasable_types_tab
 let (__proj__Mkenv__item__enable_defer_to_tac : env -> Prims.bool) =
   fun projectee ->
     match projectee with
@@ -1164,12 +1186,12 @@ let (__proj__Mkenv__item__enable_defer_to_tac : env -> Prims.bool) =
         generalize; letrecs; top_level; check_uvars; use_eq_strict; is_iface;
         admit; lax; lax_universes; phase1; failhard; nosynth; uvar_subtyping;
         tc_term; typeof_tot_or_gtot_term; universe_of;
-        typeof_well_typed_tot_or_gtot_term; use_bv_sorts;
-        qtbl_name_and_index; normalized_eff_names; fv_delta_depths; proof_ns;
-        synth_hook; try_solve_implicits_hook; splice; mpreprocess;
-        postprocess; identifier_info; tc_hooks; dsenv; nbe; strict_args_tab;
-        erasable_types_tab; enable_defer_to_tac; unif_allow_ref_guards;
-        erase_erasable_args;_} -> enable_defer_to_tac
+        typeof_well_typed_tot_or_gtot_term; subtype_nosmt_force;
+        use_bv_sorts; qtbl_name_and_index; normalized_eff_names;
+        fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
+        splice; mpreprocess; postprocess; identifier_info; tc_hooks; 
+        dsenv; nbe; strict_args_tab; erasable_types_tab; enable_defer_to_tac;
+        unif_allow_ref_guards; erase_erasable_args;_} -> enable_defer_to_tac
 let (__proj__Mkenv__item__unif_allow_ref_guards : env -> Prims.bool) =
   fun projectee ->
     match projectee with
@@ -1178,12 +1200,13 @@ let (__proj__Mkenv__item__unif_allow_ref_guards : env -> Prims.bool) =
         generalize; letrecs; top_level; check_uvars; use_eq_strict; is_iface;
         admit; lax; lax_universes; phase1; failhard; nosynth; uvar_subtyping;
         tc_term; typeof_tot_or_gtot_term; universe_of;
-        typeof_well_typed_tot_or_gtot_term; use_bv_sorts;
-        qtbl_name_and_index; normalized_eff_names; fv_delta_depths; proof_ns;
-        synth_hook; try_solve_implicits_hook; splice; mpreprocess;
-        postprocess; identifier_info; tc_hooks; dsenv; nbe; strict_args_tab;
-        erasable_types_tab; enable_defer_to_tac; unif_allow_ref_guards;
-        erase_erasable_args;_} -> unif_allow_ref_guards
+        typeof_well_typed_tot_or_gtot_term; subtype_nosmt_force;
+        use_bv_sorts; qtbl_name_and_index; normalized_eff_names;
+        fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
+        splice; mpreprocess; postprocess; identifier_info; tc_hooks; 
+        dsenv; nbe; strict_args_tab; erasable_types_tab; enable_defer_to_tac;
+        unif_allow_ref_guards; erase_erasable_args;_} ->
+        unif_allow_ref_guards
 let (__proj__Mkenv__item__erase_erasable_args : env -> Prims.bool) =
   fun projectee ->
     match projectee with
@@ -1192,12 +1215,12 @@ let (__proj__Mkenv__item__erase_erasable_args : env -> Prims.bool) =
         generalize; letrecs; top_level; check_uvars; use_eq_strict; is_iface;
         admit; lax; lax_universes; phase1; failhard; nosynth; uvar_subtyping;
         tc_term; typeof_tot_or_gtot_term; universe_of;
-        typeof_well_typed_tot_or_gtot_term; use_bv_sorts;
-        qtbl_name_and_index; normalized_eff_names; fv_delta_depths; proof_ns;
-        synth_hook; try_solve_implicits_hook; splice; mpreprocess;
-        postprocess; identifier_info; tc_hooks; dsenv; nbe; strict_args_tab;
-        erasable_types_tab; enable_defer_to_tac; unif_allow_ref_guards;
-        erase_erasable_args;_} -> erase_erasable_args
+        typeof_well_typed_tot_or_gtot_term; subtype_nosmt_force;
+        use_bv_sorts; qtbl_name_and_index; normalized_eff_names;
+        fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
+        splice; mpreprocess; postprocess; identifier_info; tc_hooks; 
+        dsenv; nbe; strict_args_tab; erasable_types_tab; enable_defer_to_tac;
+        unif_allow_ref_guards; erase_erasable_args;_} -> erase_erasable_args
 let (__proj__Mksolver_t__item__init : solver_t -> env -> unit) =
   fun projectee ->
     match projectee with
@@ -1400,6 +1423,7 @@ let (rename_env : FStar_Syntax_Syntax.subst_t -> env -> env) =
         universe_of = (env1.universe_of);
         typeof_well_typed_tot_or_gtot_term =
           (env1.typeof_well_typed_tot_or_gtot_term);
+        subtype_nosmt_force = (env1.subtype_nosmt_force);
         use_bv_sorts = (env1.use_bv_sorts);
         qtbl_name_and_index = (env1.qtbl_name_and_index);
         normalized_eff_names = (env1.normalized_eff_names);
@@ -1457,6 +1481,7 @@ let (set_tc_hooks : env -> tcenv_hooks -> env) =
         universe_of = (env1.universe_of);
         typeof_well_typed_tot_or_gtot_term =
           (env1.typeof_well_typed_tot_or_gtot_term);
+        subtype_nosmt_force = (env1.subtype_nosmt_force);
         use_bv_sorts = (env1.use_bv_sorts);
         qtbl_name_and_index = (env1.qtbl_name_and_index);
         normalized_eff_names = (env1.normalized_eff_names);
@@ -1513,6 +1538,7 @@ let (set_dep_graph : env -> FStar_Parser_Dep.deps -> env) =
         universe_of = (e.universe_of);
         typeof_well_typed_tot_or_gtot_term =
           (e.typeof_well_typed_tot_or_gtot_term);
+        subtype_nosmt_force = (e.subtype_nosmt_force);
         use_bv_sorts = (e.use_bv_sorts);
         qtbl_name_and_index = (e.qtbl_name_and_index);
         normalized_eff_names = (e.normalized_eff_names);
@@ -1578,128 +1604,137 @@ let (initial_env :
           ->
           (env -> FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.universe)
             ->
-            solver_t ->
-              FStar_Ident.lident ->
-                (step Prims.list ->
-                   env ->
-                     FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term)
-                  -> env)
+            (env ->
+               FStar_Syntax_Syntax.term ->
+                 FStar_Syntax_Syntax.term -> Prims.bool)
+              ->
+              solver_t ->
+                FStar_Ident.lident ->
+                  (step Prims.list ->
+                     env ->
+                       FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term)
+                    -> env)
   =
   fun deps ->
     fun tc_term ->
       fun typeof_tot_or_gtot_term ->
         fun typeof_tot_or_gtot_term_fastpath ->
           fun universe_of ->
-            fun solver ->
-              fun module_lid ->
-                fun nbe ->
-                  let uu___ = new_gamma_cache () in
-                  let uu___1 = new_sigtab () in
-                  let uu___2 = new_sigtab () in
-                  let uu___3 =
+            fun subtype_nosmt_force ->
+              fun solver ->
+                fun module_lid ->
+                  fun nbe ->
+                    let uu___ = new_gamma_cache () in
+                    let uu___1 = new_sigtab () in
+                    let uu___2 = new_sigtab () in
+                    let uu___3 =
+                      let uu___4 =
+                        FStar_Compiler_Util.smap_create (Prims.of_int (10)) in
+                      (uu___4, FStar_Pervasives_Native.None) in
                     let uu___4 =
-                      FStar_Compiler_Util.smap_create (Prims.of_int (10)) in
-                    (uu___4, FStar_Pervasives_Native.None) in
-                  let uu___4 =
-                    FStar_Compiler_Util.smap_create (Prims.of_int (20)) in
-                  let uu___5 =
-                    FStar_Compiler_Util.smap_create (Prims.of_int (50)) in
-                  let uu___6 = FStar_Options.using_facts_from () in
-                  let uu___7 =
-                    FStar_Compiler_Util.mk_ref
-                      FStar_TypeChecker_Common.id_info_table_empty in
-                  let uu___8 = FStar_Syntax_DsEnv.empty_env deps in
-                  let uu___9 =
-                    FStar_Compiler_Util.smap_create (Prims.of_int (20)) in
-                  let uu___10 =
-                    FStar_Compiler_Util.smap_create (Prims.of_int (20)) in
-                  {
-                    solver;
-                    range = FStar_Compiler_Range.dummyRange;
-                    curmodule = module_lid;
-                    gamma = [];
-                    gamma_sig = [];
-                    gamma_cache = uu___;
-                    modules = [];
-                    expected_typ = FStar_Pervasives_Native.None;
-                    sigtab = uu___1;
-                    attrtab = uu___2;
-                    instantiate_imp = true;
-                    effects =
-                      {
-                        decls = [];
-                        order = [];
-                        joins = [];
-                        polymonadic_binds = [];
-                        polymonadic_subcomps = []
-                      };
-                    generalize = true;
-                    letrecs = [];
-                    top_level = false;
-                    check_uvars = false;
-                    use_eq_strict = false;
-                    is_iface = false;
-                    admit = false;
-                    lax = false;
-                    lax_universes = false;
-                    phase1 = false;
-                    failhard = false;
-                    nosynth = false;
-                    uvar_subtyping = true;
-                    tc_term;
-                    typeof_tot_or_gtot_term;
-                    universe_of;
-                    typeof_well_typed_tot_or_gtot_term =
-                      (fun env1 ->
-                         fun t ->
-                           fun must_tot1 ->
-                             let uu___11 =
-                               typeof_tot_or_gtot_term_fastpath env1 t
-                                 must_tot1 in
-                             match uu___11 with
-                             | FStar_Pervasives_Native.Some k ->
-                                 (k, FStar_TypeChecker_Common.trivial_guard)
-                             | FStar_Pervasives_Native.None ->
-                                 let uu___12 =
-                                   typeof_tot_or_gtot_term env1 t must_tot1 in
-                                 (match uu___12 with
-                                  | (uu___13, k, g) -> (k, g)));
-                    use_bv_sorts = false;
-                    qtbl_name_and_index = uu___3;
-                    normalized_eff_names = uu___4;
-                    fv_delta_depths = uu___5;
-                    proof_ns = uu___6;
-                    synth_hook =
-                      (fun e ->
-                         fun g ->
-                           fun tau -> failwith "no synthesizer available");
-                    try_solve_implicits_hook =
-                      (fun e ->
-                         fun tau ->
-                           fun imps -> failwith "no implicit hook available");
-                    splice =
-                      (fun e ->
-                         fun rng ->
-                           fun tau -> failwith "no splicer available");
-                    mpreprocess =
-                      (fun e ->
-                         fun tau ->
-                           fun tm -> failwith "no preprocessor available");
-                    postprocess =
-                      (fun e ->
-                         fun tau ->
-                           fun typ ->
-                             fun tm -> failwith "no postprocessor available");
-                    identifier_info = uu___7;
-                    tc_hooks = default_tc_hooks;
-                    dsenv = uu___8;
-                    nbe;
-                    strict_args_tab = uu___9;
-                    erasable_types_tab = uu___10;
-                    enable_defer_to_tac = true;
-                    unif_allow_ref_guards = false;
-                    erase_erasable_args = false
-                  }
+                      FStar_Compiler_Util.smap_create (Prims.of_int (20)) in
+                    let uu___5 =
+                      FStar_Compiler_Util.smap_create (Prims.of_int (50)) in
+                    let uu___6 = FStar_Options.using_facts_from () in
+                    let uu___7 =
+                      FStar_Compiler_Util.mk_ref
+                        FStar_TypeChecker_Common.id_info_table_empty in
+                    let uu___8 = FStar_Syntax_DsEnv.empty_env deps in
+                    let uu___9 =
+                      FStar_Compiler_Util.smap_create (Prims.of_int (20)) in
+                    let uu___10 =
+                      FStar_Compiler_Util.smap_create (Prims.of_int (20)) in
+                    {
+                      solver;
+                      range = FStar_Compiler_Range.dummyRange;
+                      curmodule = module_lid;
+                      gamma = [];
+                      gamma_sig = [];
+                      gamma_cache = uu___;
+                      modules = [];
+                      expected_typ = FStar_Pervasives_Native.None;
+                      sigtab = uu___1;
+                      attrtab = uu___2;
+                      instantiate_imp = true;
+                      effects =
+                        {
+                          decls = [];
+                          order = [];
+                          joins = [];
+                          polymonadic_binds = [];
+                          polymonadic_subcomps = []
+                        };
+                      generalize = true;
+                      letrecs = [];
+                      top_level = false;
+                      check_uvars = false;
+                      use_eq_strict = false;
+                      is_iface = false;
+                      admit = false;
+                      lax = false;
+                      lax_universes = false;
+                      phase1 = false;
+                      failhard = false;
+                      nosynth = false;
+                      uvar_subtyping = true;
+                      tc_term;
+                      typeof_tot_or_gtot_term;
+                      universe_of;
+                      typeof_well_typed_tot_or_gtot_term =
+                        (fun env1 ->
+                           fun t ->
+                             fun must_tot1 ->
+                               let uu___11 =
+                                 typeof_tot_or_gtot_term_fastpath env1 t
+                                   must_tot1 in
+                               match uu___11 with
+                               | FStar_Pervasives_Native.Some k ->
+                                   (k,
+                                     FStar_TypeChecker_Common.trivial_guard)
+                               | FStar_Pervasives_Native.None ->
+                                   let uu___12 =
+                                     typeof_tot_or_gtot_term env1 t must_tot1 in
+                                   (match uu___12 with
+                                    | (uu___13, k, g) -> (k, g)));
+                      subtype_nosmt_force;
+                      use_bv_sorts = false;
+                      qtbl_name_and_index = uu___3;
+                      normalized_eff_names = uu___4;
+                      fv_delta_depths = uu___5;
+                      proof_ns = uu___6;
+                      synth_hook =
+                        (fun e ->
+                           fun g ->
+                             fun tau -> failwith "no synthesizer available");
+                      try_solve_implicits_hook =
+                        (fun e ->
+                           fun tau ->
+                             fun imps ->
+                               failwith "no implicit hook available");
+                      splice =
+                        (fun e ->
+                           fun rng ->
+                             fun tau -> failwith "no splicer available");
+                      mpreprocess =
+                        (fun e ->
+                           fun tau ->
+                             fun tm -> failwith "no preprocessor available");
+                      postprocess =
+                        (fun e ->
+                           fun tau ->
+                             fun typ ->
+                               fun tm ->
+                                 failwith "no postprocessor available");
+                      identifier_info = uu___7;
+                      tc_hooks = default_tc_hooks;
+                      dsenv = uu___8;
+                      nbe;
+                      strict_args_tab = uu___9;
+                      erasable_types_tab = uu___10;
+                      enable_defer_to_tac = true;
+                      unif_allow_ref_guards = false;
+                      erase_erasable_args = false
+                    }
 let (dsenv : env -> FStar_Syntax_DsEnv.env) = fun env1 -> env1.dsenv
 let (sigtab : env -> FStar_Syntax_Syntax.sigelt FStar_Compiler_Util.smap) =
   fun env1 -> env1.sigtab
@@ -1809,6 +1844,7 @@ let (push_stack : env -> env) =
        universe_of = (env1.universe_of);
        typeof_well_typed_tot_or_gtot_term =
          (env1.typeof_well_typed_tot_or_gtot_term);
+       subtype_nosmt_force = (env1.subtype_nosmt_force);
        use_bv_sorts = (env1.use_bv_sorts);
        qtbl_name_and_index = uu___4;
        normalized_eff_names = uu___5;
@@ -1890,6 +1926,8 @@ let (snapshot : env -> Prims.string -> (tcenv_depth_t * env)) =
                                   universe_of = (env2.universe_of);
                                   typeof_well_typed_tot_or_gtot_term =
                                     (env2.typeof_well_typed_tot_or_gtot_term);
+                                  subtype_nosmt_force =
+                                    (env2.subtype_nosmt_force);
                                   use_bv_sorts = (env2.use_bv_sorts);
                                   qtbl_name_and_index =
                                     (env2.qtbl_name_and_index);
@@ -2012,6 +2050,7 @@ let (incr_query_index : env -> env) =
                 universe_of = (env1.universe_of);
                 typeof_well_typed_tot_or_gtot_term =
                   (env1.typeof_well_typed_tot_or_gtot_term);
+                subtype_nosmt_force = (env1.subtype_nosmt_force);
                 use_bv_sorts = (env1.use_bv_sorts);
                 qtbl_name_and_index =
                   (tbl, (FStar_Pervasives_Native.Some (l, next)));
@@ -2069,6 +2108,7 @@ let (incr_query_index : env -> env) =
                 universe_of = (env1.universe_of);
                 typeof_well_typed_tot_or_gtot_term =
                   (env1.typeof_well_typed_tot_or_gtot_term);
+                subtype_nosmt_force = (env1.subtype_nosmt_force);
                 use_bv_sorts = (env1.use_bv_sorts);
                 qtbl_name_and_index =
                   (tbl, (FStar_Pervasives_Native.Some (l, next)));
@@ -2132,6 +2172,7 @@ let (set_range : env -> FStar_Compiler_Range.range -> env) =
           universe_of = (e.universe_of);
           typeof_well_typed_tot_or_gtot_term =
             (e.typeof_well_typed_tot_or_gtot_term);
+          subtype_nosmt_force = (e.subtype_nosmt_force);
           use_bv_sorts = (e.use_bv_sorts);
           qtbl_name_and_index = (e.qtbl_name_and_index);
           normalized_eff_names = (e.normalized_eff_names);
@@ -2223,6 +2264,7 @@ let (set_current_module : env -> FStar_Ident.lident -> env) =
         universe_of = (env1.universe_of);
         typeof_well_typed_tot_or_gtot_term =
           (env1.typeof_well_typed_tot_or_gtot_term);
+        subtype_nosmt_force = (env1.subtype_nosmt_force);
         use_bv_sorts = (env1.use_bv_sorts);
         qtbl_name_and_index = (env1.qtbl_name_and_index);
         normalized_eff_names = (env1.normalized_eff_names);
@@ -4367,6 +4409,7 @@ let (push_sigelt : env -> FStar_Syntax_Syntax.sigelt -> env) =
           universe_of = (env1.universe_of);
           typeof_well_typed_tot_or_gtot_term =
             (env1.typeof_well_typed_tot_or_gtot_term);
+          subtype_nosmt_force = (env1.subtype_nosmt_force);
           use_bv_sorts = (env1.use_bv_sorts);
           qtbl_name_and_index = (env1.qtbl_name_and_index);
           normalized_eff_names = (env1.normalized_eff_names);
@@ -4440,6 +4483,7 @@ let (push_new_effect :
             universe_of = (env1.universe_of);
             typeof_well_typed_tot_or_gtot_term =
               (env1.typeof_well_typed_tot_or_gtot_term);
+            subtype_nosmt_force = (env1.subtype_nosmt_force);
             use_bv_sorts = (env1.use_bv_sorts);
             qtbl_name_and_index = (env1.qtbl_name_and_index);
             normalized_eff_names = (env1.normalized_eff_names);
@@ -4885,6 +4929,7 @@ let (update_effect_lattice :
              universe_of = (env1.universe_of);
              typeof_well_typed_tot_or_gtot_term =
                (env1.typeof_well_typed_tot_or_gtot_term);
+             subtype_nosmt_force = (env1.subtype_nosmt_force);
              use_bv_sorts = (env1.use_bv_sorts);
              qtbl_name_and_index = (env1.qtbl_name_and_index);
              normalized_eff_names = (env1.normalized_eff_names);
@@ -4955,6 +5000,7 @@ let (add_polymonadic_bind :
               universe_of = (env1.universe_of);
               typeof_well_typed_tot_or_gtot_term =
                 (env1.typeof_well_typed_tot_or_gtot_term);
+              subtype_nosmt_force = (env1.subtype_nosmt_force);
               use_bv_sorts = (env1.use_bv_sorts);
               qtbl_name_and_index = (env1.qtbl_name_and_index);
               normalized_eff_names = (env1.normalized_eff_names);
@@ -5024,6 +5070,7 @@ let (add_polymonadic_subcomp :
             universe_of = (env1.universe_of);
             typeof_well_typed_tot_or_gtot_term =
               (env1.typeof_well_typed_tot_or_gtot_term);
+            subtype_nosmt_force = (env1.subtype_nosmt_force);
             use_bv_sorts = (env1.use_bv_sorts);
             qtbl_name_and_index = (env1.qtbl_name_and_index);
             normalized_eff_names = (env1.normalized_eff_names);
@@ -5078,6 +5125,7 @@ let (push_local_binding : env -> FStar_Syntax_Syntax.binding -> env) =
         universe_of = (env1.universe_of);
         typeof_well_typed_tot_or_gtot_term =
           (env1.typeof_well_typed_tot_or_gtot_term);
+        subtype_nosmt_force = (env1.subtype_nosmt_force);
         use_bv_sorts = (env1.use_bv_sorts);
         qtbl_name_and_index = (env1.qtbl_name_and_index);
         normalized_eff_names = (env1.normalized_eff_names);
@@ -5144,6 +5192,7 @@ let (pop_bv :
               universe_of = (env1.universe_of);
               typeof_well_typed_tot_or_gtot_term =
                 (env1.typeof_well_typed_tot_or_gtot_term);
+              subtype_nosmt_force = (env1.subtype_nosmt_force);
               use_bv_sorts = (env1.use_bv_sorts);
               qtbl_name_and_index = (env1.qtbl_name_and_index);
               normalized_eff_names = (env1.normalized_eff_names);
@@ -5254,6 +5303,7 @@ let (set_expected_typ : env -> FStar_Syntax_Syntax.typ -> env) =
         universe_of = (env1.universe_of);
         typeof_well_typed_tot_or_gtot_term =
           (env1.typeof_well_typed_tot_or_gtot_term);
+        subtype_nosmt_force = (env1.subtype_nosmt_force);
         use_bv_sorts = (env1.use_bv_sorts);
         qtbl_name_and_index = (env1.qtbl_name_and_index);
         normalized_eff_names = (env1.normalized_eff_names);
@@ -5310,6 +5360,7 @@ let (set_expected_typ_maybe_eq :
           universe_of = (env1.universe_of);
           typeof_well_typed_tot_or_gtot_term =
             (env1.typeof_well_typed_tot_or_gtot_term);
+          subtype_nosmt_force = (env1.subtype_nosmt_force);
           use_bv_sorts = (env1.use_bv_sorts);
           qtbl_name_and_index = (env1.qtbl_name_and_index);
           normalized_eff_names = (env1.normalized_eff_names);
@@ -5376,6 +5427,7 @@ let (clear_expected_typ :
        universe_of = (env_.universe_of);
        typeof_well_typed_tot_or_gtot_term =
          (env_.typeof_well_typed_tot_or_gtot_term);
+       subtype_nosmt_force = (env_.subtype_nosmt_force);
        use_bv_sorts = (env_.use_bv_sorts);
        qtbl_name_and_index = (env_.qtbl_name_and_index);
        normalized_eff_names = (env_.normalized_eff_names);
@@ -5445,6 +5497,7 @@ let (finish_module : env -> FStar_Syntax_Syntax.modul -> env) =
         universe_of = (env1.universe_of);
         typeof_well_typed_tot_or_gtot_term =
           (env1.typeof_well_typed_tot_or_gtot_term);
+        subtype_nosmt_force = (env1.subtype_nosmt_force);
         use_bv_sorts = (env1.use_bv_sorts);
         qtbl_name_and_index = (env1.qtbl_name_and_index);
         normalized_eff_names = (env1.normalized_eff_names);
@@ -5647,6 +5700,7 @@ let (cons_proof_ns : Prims.bool -> env -> name_prefix -> env) =
           universe_of = (e.universe_of);
           typeof_well_typed_tot_or_gtot_term =
             (e.typeof_well_typed_tot_or_gtot_term);
+          subtype_nosmt_force = (e.subtype_nosmt_force);
           use_bv_sorts = (e.use_bv_sorts);
           qtbl_name_and_index = (e.qtbl_name_and_index);
           normalized_eff_names = (e.normalized_eff_names);
@@ -5706,6 +5760,7 @@ let (set_proof_ns : proof_namespace -> env -> env) =
         universe_of = (e.universe_of);
         typeof_well_typed_tot_or_gtot_term =
           (e.typeof_well_typed_tot_or_gtot_term);
+        subtype_nosmt_force = (e.subtype_nosmt_force);
         use_bv_sorts = (e.use_bv_sorts);
         qtbl_name_and_index = (e.qtbl_name_and_index);
         normalized_eff_names = (e.normalized_eff_names);

--- a/src/ocaml-output/FStar_TypeChecker_Env.ml
+++ b/src/ocaml-output/FStar_TypeChecker_Env.ml
@@ -6265,7 +6265,7 @@ let (uvars_for_binders :
                               | (uu___3, t::uu___4) ->
                                   ((FStar_Pervasives_Native.Some
                                       (FStar_Syntax_Syntax.Ctx_uvar_meta_attr
-                                         t)), true)
+                                         t)), false)
                               | uu___3 ->
                                   (FStar_Pervasives_Native.None, false) in
                             (match uu___2 with

--- a/src/ocaml-output/FStar_TypeChecker_Env.ml
+++ b/src/ocaml-output/FStar_TypeChecker_Env.ml
@@ -6199,7 +6199,6 @@ let (new_implicit_var_aux :
                       FStar_Syntax_Syntax.ctx_uvar_head = uu___2;
                       FStar_Syntax_Syntax.ctx_uvar_gamma = gamma;
                       FStar_Syntax_Syntax.ctx_uvar_binders = binders;
-                      FStar_Syntax_Syntax.ctx_uvar_typ = k;
                       FStar_Syntax_Syntax.ctx_uvar_reason = reason;
                       FStar_Syntax_Syntax.ctx_uvar_range = r;
                       FStar_Syntax_Syntax.ctx_uvar_meta = meta

--- a/src/ocaml-output/FStar_TypeChecker_Generalize.ml
+++ b/src/ocaml-output/FStar_TypeChecker_Generalize.ml
@@ -241,8 +241,9 @@ let (gen :
                                    FStar_Syntax_Print.uvar_to_string
                                      u.FStar_Syntax_Syntax.ctx_uvar_head in
                                  let uu___10 =
-                                   FStar_Syntax_Print.term_to_string
-                                     u.FStar_Syntax_Syntax.ctx_uvar_typ in
+                                   let uu___11 =
+                                     FStar_Syntax_Util.ctx_uvar_typ u in
+                                   FStar_Syntax_Print.term_to_string uu___11 in
                                  FStar_Compiler_Util.format2 "(%s : %s)"
                                    uu___9 uu___10)) in
                        FStar_Compiler_Effect.op_Bar_Greater uu___7
@@ -257,8 +258,8 @@ let (gen :
                        (fun univs2 ->
                           fun uv ->
                             let uu___5 =
-                              FStar_Syntax_Free.univs
-                                uv.FStar_Syntax_Syntax.ctx_uvar_typ in
+                              let uu___6 = FStar_Syntax_Util.ctx_uvar_typ uv in
+                              FStar_Syntax_Free.univs uu___6 in
                             FStar_Compiler_Util.set_union univs2 uu___5)
                        univs uu___4 in
                    let uvs = gen_uvars uvt in
@@ -288,8 +289,10 @@ let (gen :
                                     FStar_Syntax_Print.uvar_to_string
                                       u.FStar_Syntax_Syntax.ctx_uvar_head in
                                   let uu___10 =
+                                    let uu___11 =
+                                      FStar_Syntax_Util.ctx_uvar_typ u in
                                     FStar_TypeChecker_Normalize.term_to_string
-                                      env u.FStar_Syntax_Syntax.ctx_uvar_typ in
+                                      env uu___11 in
                                   FStar_Compiler_Util.format2 "(%s : %s)"
                                     uu___9 uu___10)) in
                         FStar_Compiler_Effect.op_Bar_Greater uu___8
@@ -410,11 +413,11 @@ let (gen :
                                "Unexpected instantiation of mutually recursive uvar"
                          | uu___4 ->
                              let k =
+                               let uu___5 = FStar_Syntax_Util.ctx_uvar_typ u in
                                FStar_TypeChecker_Normalize.normalize
                                  [FStar_TypeChecker_Env.Beta;
                                  FStar_TypeChecker_Env.Exclude
-                                   FStar_TypeChecker_Env.Zeta] env
-                                 u.FStar_Syntax_Syntax.ctx_uvar_typ in
+                                   FStar_TypeChecker_Env.Zeta] env uu___5 in
                              let uu___5 = FStar_Syntax_Util.arrow_formals k in
                              (match uu___5 with
                               | (bs, kres) ->

--- a/src/ocaml-output/FStar_TypeChecker_Normalize.ml
+++ b/src/ocaml-output/FStar_TypeChecker_Normalize.ml
@@ -8066,8 +8066,8 @@ let (eta_expand :
                 | FStar_Syntax_Syntax.Tm_uvar (u, s) ->
                     let uu___3 =
                       let uu___4 =
-                        FStar_Syntax_Subst.subst' s
-                          u.FStar_Syntax_Syntax.ctx_uvar_typ in
+                        let uu___5 = FStar_Syntax_Util.ctx_uvar_typ u in
+                        FStar_Syntax_Subst.subst' s uu___5 in
                       FStar_Syntax_Util.arrow_formals uu___4 in
                     (match uu___3 with
                      | (formals, _tres) ->

--- a/src/ocaml-output/FStar_TypeChecker_Normalize.ml
+++ b/src/ocaml-output/FStar_TypeChecker_Normalize.ml
@@ -8139,6 +8139,8 @@ let (eta_expand :
                                   FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term
                                     =
                                     (env1.FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term);
+                                  FStar_TypeChecker_Env.subtype_nosmt_force =
+                                    (env1.FStar_TypeChecker_Env.subtype_nosmt_force);
                                   FStar_TypeChecker_Env.use_bv_sorts = true;
                                   FStar_TypeChecker_Env.qtbl_name_and_index =
                                     (env1.FStar_TypeChecker_Env.qtbl_name_and_index);
@@ -8245,6 +8247,8 @@ let (eta_expand :
                           FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term
                             =
                             (env1.FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term);
+                          FStar_TypeChecker_Env.subtype_nosmt_force =
+                            (env1.FStar_TypeChecker_Env.subtype_nosmt_force);
                           FStar_TypeChecker_Env.use_bv_sorts = true;
                           FStar_TypeChecker_Env.qtbl_name_and_index =
                             (env1.FStar_TypeChecker_Env.qtbl_name_and_index);

--- a/src/ocaml-output/FStar_TypeChecker_Normalize.ml
+++ b/src/ocaml-output/FStar_TypeChecker_Normalize.ml
@@ -2427,21 +2427,20 @@ let (should_unfold :
                  uu___3 > Prims.int_zero) in
             if uu___2
             then
-              ((let uu___4 =
-                  let uu___5 =
-                    let uu___6 = FStar_Syntax_Print.fv_to_string fv in
-                    FStar_Compiler_Util.format1
-                      "Unfolding name which is marked as a plugin: %s" uu___6 in
-                  (FStar_Errors.Warning_UnfoldPlugin, uu___5) in
-                FStar_Errors.log_issue
-                  (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.p
-                  uu___4);
-               (let uu___4 =
-                  let uu___5 =
+              let msg =
+                let uu___3 = FStar_Syntax_Print.fv_to_string fv in
+                FStar_Compiler_Util.format1
+                  "Unfolding name which is marked as a plugin: %s" uu___3 in
+              (FStar_Compiler_Util.print1 "%s\n" msg;
+               FStar_Errors.log_issue
+                 (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.p
+                 (FStar_Errors.Warning_UnfoldPlugin, msg);
+               (let uu___5 =
+                  let uu___6 =
                     FStar_Compiler_Effect.op_Bang plugin_unfold_warn_ctr in
-                  uu___5 - Prims.int_one in
+                  uu___6 - Prims.int_one in
                 FStar_Compiler_Effect.op_Colon_Equals plugin_unfold_warn_ctr
-                  uu___4))
+                  uu___5))
             else ());
            r)
 let decide_unfolding :

--- a/src/ocaml-output/FStar_TypeChecker_Rel.ml
+++ b/src/ocaml-output/FStar_TypeChecker_Rel.ml
@@ -13493,11 +13493,14 @@ let (try_solve_single_valued_implicits :
                (fun b1 ->
                   fun imp ->
                     let uu___1 =
-                      let uu___2 =
-                        FStar_Syntax_Unionfind.find
-                          (imp.FStar_TypeChecker_Common.imp_uvar).FStar_Syntax_Syntax.ctx_uvar_head in
-                      FStar_Compiler_Effect.op_Bar_Greater uu___2
-                        FStar_Compiler_Util.is_none in
+                      (let uu___2 =
+                         FStar_Syntax_Unionfind.find
+                           (imp.FStar_TypeChecker_Common.imp_uvar).FStar_Syntax_Syntax.ctx_uvar_head in
+                       FStar_Compiler_Effect.op_Bar_Greater uu___2
+                         FStar_Compiler_Util.is_none)
+                        &&
+                        ((imp.FStar_TypeChecker_Common.imp_uvar).FStar_Syntax_Syntax.ctx_uvar_should_check
+                           = FStar_Syntax_Syntax.Strict) in
                     if uu___1
                     then
                       let uu___2 = imp_value imp in

--- a/src/ocaml-output/FStar_TypeChecker_Rel.ml
+++ b/src/ocaml-output/FStar_TypeChecker_Rel.ml
@@ -14432,52 +14432,38 @@ let (resolve_implicits' :
                                                        if uu___15
                                                        then true
                                                        else
-                                                         (let compute t =
-                                                            FStar_TypeChecker_Normalize.normalize
-                                                              [FStar_TypeChecker_Env.UnfoldTac;
-                                                              FStar_TypeChecker_Env.UnfoldUntil
-                                                                FStar_Syntax_Syntax.delta_constant;
-                                                              FStar_TypeChecker_Env.Zeta;
-                                                              FStar_TypeChecker_Env.Iota;
-                                                              FStar_TypeChecker_Env.Primops]
-                                                              env2 t in
-                                                          let tm_t1 =
-                                                            compute tm_t in
-                                                          let uv_t =
-                                                            compute
-                                                              uvar_decoration_typ in
-                                                          let uu___17 =
-                                                            env2.FStar_TypeChecker_Env.subtype_nosmt_force
-                                                              env2 tm_t1 uv_t in
-                                                          if uu___17
-                                                          then true
-                                                          else
-                                                            ((let uu___20 =
-                                                                let uu___21 =
-                                                                  FStar_TypeChecker_Env.get_range
-                                                                    env2 in
-                                                                FStar_Compiler_Range.string_of_range
-                                                                  uu___21 in
-                                                              let uu___21 =
-                                                                FStar_Syntax_Print.uvar_to_string
-                                                                  ctx_u.FStar_Syntax_Syntax.ctx_uvar_head in
-                                                              let uu___22 =
-                                                                FStar_Syntax_Print.term_to_string
-                                                                  uv_t in
-                                                              let uu___23 =
-                                                                FStar_Syntax_Print.term_to_string
-                                                                  tm2 in
-                                                              let uu___24 =
-                                                                FStar_Syntax_Print.term_to_string
-                                                                  tm_t1 in
-                                                              FStar_Compiler_Util.print5
-                                                                "(%s) Uvar solution for %s was not well-typed. Expected %s got %s : %s\n"
-                                                                uu___20
-                                                                uu___21
-                                                                uu___22
-                                                                uu___23
-                                                                uu___24);
-                                                             false)))))
+                                                         ((let uu___18 =
+                                                             FStar_Options.debug_any
+                                                               () in
+                                                           if uu___18
+                                                           then
+                                                             let uu___19 =
+                                                               let uu___20 =
+                                                                 FStar_TypeChecker_Env.get_range
+                                                                   env2 in
+                                                               FStar_Compiler_Range.string_of_range
+                                                                 uu___20 in
+                                                             let uu___20 =
+                                                               FStar_Syntax_Print.uvar_to_string
+                                                                 ctx_u.FStar_Syntax_Syntax.ctx_uvar_head in
+                                                             let uu___21 =
+                                                               FStar_Syntax_Print.term_to_string
+                                                                 uvar_decoration_typ in
+                                                             let uu___22 =
+                                                               FStar_Syntax_Print.term_to_string
+                                                                 tm2 in
+                                                             let uu___23 =
+                                                               FStar_Syntax_Print.term_to_string
+                                                                 tm_t in
+                                                             FStar_Compiler_Util.print5
+                                                               "(%s) Uvar solution for %s was not well-typed. Expected %s got %s : %s\n"
+                                                               uu___19
+                                                               uu___20
+                                                               uu___21
+                                                               uu___22
+                                                               uu___23
+                                                           else ());
+                                                          false))))
                                           else false in
                                         if is_tac
                                         then

--- a/src/ocaml-output/FStar_TypeChecker_Rel.ml
+++ b/src/ocaml-output/FStar_TypeChecker_Rel.ml
@@ -14116,11 +14116,12 @@ let (check_implicit_solution_for_tac :
                         FStar_TypeChecker_Env.Zeta;
                         FStar_TypeChecker_Env.Iota;
                         FStar_TypeChecker_Env.Primops] env1 t in
-                    let tm_t1 = compute tm_t in
-                    let uv_t = compute uvar_ty in
-                    let uu___7 =
+                    let retry uu___7 =
+                      let tm_t1 = compute tm_t in
+                      let uv_t = compute uvar_ty in
                       env1.FStar_TypeChecker_Env.subtype_nosmt_force env1
                         tm_t1 uv_t in
+                    let uu___7 = retry () in
                     if uu___7
                     then true
                     else
@@ -14138,7 +14139,7 @@ let (check_implicit_solution_for_tac :
                             FStar_Syntax_Print.term_to_string uvar_ty in
                           let uu___14 = FStar_Syntax_Print.term_to_string tm in
                           let uu___15 =
-                            FStar_Syntax_Print.term_to_string tm_t1 in
+                            FStar_Syntax_Print.term_to_string tm_t in
                           FStar_Compiler_Util.print5
                             "(%s) Uvar solution for %s was not well-typed. Expected %s got %s : %s\n"
                             uu___11 uu___12 uu___13 uu___14 uu___15

--- a/src/ocaml-output/FStar_TypeChecker_Rel.ml
+++ b/src/ocaml-output/FStar_TypeChecker_Rel.ml
@@ -307,6 +307,8 @@ let (copy_uvar :
                 (uu___.FStar_TypeChecker_Env.universe_of);
               FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term =
                 (uu___.FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term);
+              FStar_TypeChecker_Env.subtype_nosmt_force =
+                (uu___.FStar_TypeChecker_Env.subtype_nosmt_force);
               FStar_TypeChecker_Env.use_bv_sorts =
                 (uu___.FStar_TypeChecker_Env.use_bv_sorts);
               FStar_TypeChecker_Env.qtbl_name_and_index =
@@ -5688,6 +5690,9 @@ and (solve_t_flex_rigid_eq :
                                         FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term
                                           =
                                           (env1.FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term);
+                                        FStar_TypeChecker_Env.subtype_nosmt_force
+                                          =
+                                          (env1.FStar_TypeChecker_Env.subtype_nosmt_force);
                                         FStar_TypeChecker_Env.use_bv_sorts =
                                           true;
                                         FStar_TypeChecker_Env.qtbl_name_and_index
@@ -6045,6 +6050,9 @@ and (solve_t_flex_rigid_eq :
                                                     FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term
                                                       =
                                                       (env1.FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term);
+                                                    FStar_TypeChecker_Env.subtype_nosmt_force
+                                                      =
+                                                      (env1.FStar_TypeChecker_Env.subtype_nosmt_force);
                                                     FStar_TypeChecker_Env.use_bv_sorts
                                                       = true;
                                                     FStar_TypeChecker_Env.qtbl_name_and_index
@@ -13597,6 +13605,8 @@ let (check_implicit_solution :
                     (env.FStar_TypeChecker_Env.universe_of);
                   FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term =
                     (env.FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term);
+                  FStar_TypeChecker_Env.subtype_nosmt_force =
+                    (env.FStar_TypeChecker_Env.subtype_nosmt_force);
                   FStar_TypeChecker_Env.use_bv_sorts = true;
                   FStar_TypeChecker_Env.qtbl_name_and_index =
                     (env.FStar_TypeChecker_Env.qtbl_name_and_index);
@@ -13722,6 +13732,8 @@ let (check_implicit_solution_and_discharge_guard :
                   (env.FStar_TypeChecker_Env.universe_of);
                 FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term =
                   (env.FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term);
+                FStar_TypeChecker_Env.subtype_nosmt_force =
+                  (env.FStar_TypeChecker_Env.subtype_nosmt_force);
                 FStar_TypeChecker_Env.use_bv_sorts =
                   (env.FStar_TypeChecker_Env.use_bv_sorts);
                 FStar_TypeChecker_Env.qtbl_name_and_index =
@@ -14056,6 +14068,9 @@ let (resolve_implicits' :
                                      FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term
                                        =
                                        (env.FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term);
+                                     FStar_TypeChecker_Env.subtype_nosmt_force
+                                       =
+                                       (env.FStar_TypeChecker_Env.subtype_nosmt_force);
                                      FStar_TypeChecker_Env.use_bv_sorts =
                                        (env.FStar_TypeChecker_Env.use_bv_sorts);
                                      FStar_TypeChecker_Env.qtbl_name_and_index
@@ -14146,30 +14161,213 @@ let (resolve_implicits' :
                                        FStar_TypeChecker_Common.imp_range =
                                          (hd.FStar_TypeChecker_Common.imp_range)
                                      } in
-                                   let force_univ_constraints = false in
-                                   let imps_opt =
-                                     check_implicit_solution_and_discharge_guard
-                                       env1 hd1 force_univ_constraints in
-                                   match imps_opt with
-                                   | FStar_Pervasives_Native.None ->
-                                       until_fixpoint
-                                         (((hd1,
-                                             Implicit_checking_defers_univ_constraint)
-                                           :: out), changed) tl
-                                   | FStar_Pervasives_Native.Some imps ->
+                                   let tm_ok_for_tac tm2 =
+                                     let no_unresolved =
                                        let uu___9 =
                                          let uu___10 =
+                                           FStar_Compiler_Effect.op_Bar_Greater
+                                             tm2 FStar_Syntax_Free.uvars in
+                                         FStar_Compiler_Effect.op_Bar_Greater
+                                           uu___10
+                                           FStar_Compiler_Util.set_elements in
+                                       FStar_Compiler_Effect.op_Bar_Greater
+                                         uu___9
+                                         (FStar_Compiler_List.for_all
+                                            (fun uv ->
+                                               uv.FStar_Syntax_Syntax.ctx_uvar_should_check
+                                                 =
+                                                 FStar_Syntax_Syntax.Allow_unresolved)) in
+                                     if no_unresolved
+                                     then
+                                       let env2 =
+                                         {
+                                           FStar_TypeChecker_Env.solver =
+                                             (env1.FStar_TypeChecker_Env.solver);
+                                           FStar_TypeChecker_Env.range =
+                                             (env1.FStar_TypeChecker_Env.range);
+                                           FStar_TypeChecker_Env.curmodule =
+                                             (env1.FStar_TypeChecker_Env.curmodule);
+                                           FStar_TypeChecker_Env.gamma =
+                                             (ctx_u.FStar_Syntax_Syntax.ctx_uvar_gamma);
+                                           FStar_TypeChecker_Env.gamma_sig =
+                                             (env1.FStar_TypeChecker_Env.gamma_sig);
+                                           FStar_TypeChecker_Env.gamma_cache
+                                             =
+                                             (env1.FStar_TypeChecker_Env.gamma_cache);
+                                           FStar_TypeChecker_Env.modules =
+                                             (env1.FStar_TypeChecker_Env.modules);
+                                           FStar_TypeChecker_Env.expected_typ
+                                             =
+                                             (env1.FStar_TypeChecker_Env.expected_typ);
+                                           FStar_TypeChecker_Env.sigtab =
+                                             (env1.FStar_TypeChecker_Env.sigtab);
+                                           FStar_TypeChecker_Env.attrtab =
+                                             (env1.FStar_TypeChecker_Env.attrtab);
+                                           FStar_TypeChecker_Env.instantiate_imp
+                                             =
+                                             (env1.FStar_TypeChecker_Env.instantiate_imp);
+                                           FStar_TypeChecker_Env.effects =
+                                             (env1.FStar_TypeChecker_Env.effects);
+                                           FStar_TypeChecker_Env.generalize =
+                                             (env1.FStar_TypeChecker_Env.generalize);
+                                           FStar_TypeChecker_Env.letrecs =
+                                             (env1.FStar_TypeChecker_Env.letrecs);
+                                           FStar_TypeChecker_Env.top_level =
+                                             (env1.FStar_TypeChecker_Env.top_level);
+                                           FStar_TypeChecker_Env.check_uvars
+                                             =
+                                             (env1.FStar_TypeChecker_Env.check_uvars);
+                                           FStar_TypeChecker_Env.use_eq_strict
+                                             =
+                                             (env1.FStar_TypeChecker_Env.use_eq_strict);
+                                           FStar_TypeChecker_Env.is_iface =
+                                             (env1.FStar_TypeChecker_Env.is_iface);
+                                           FStar_TypeChecker_Env.admit =
+                                             (env1.FStar_TypeChecker_Env.admit);
+                                           FStar_TypeChecker_Env.lax =
+                                             (env1.FStar_TypeChecker_Env.lax);
+                                           FStar_TypeChecker_Env.lax_universes
+                                             =
+                                             (env1.FStar_TypeChecker_Env.lax_universes);
+                                           FStar_TypeChecker_Env.phase1 =
+                                             (env1.FStar_TypeChecker_Env.phase1);
+                                           FStar_TypeChecker_Env.failhard =
+                                             (env1.FStar_TypeChecker_Env.failhard);
+                                           FStar_TypeChecker_Env.nosynth =
+                                             (env1.FStar_TypeChecker_Env.nosynth);
+                                           FStar_TypeChecker_Env.uvar_subtyping
+                                             =
+                                             (env1.FStar_TypeChecker_Env.uvar_subtyping);
+                                           FStar_TypeChecker_Env.tc_term =
+                                             (env1.FStar_TypeChecker_Env.tc_term);
+                                           FStar_TypeChecker_Env.typeof_tot_or_gtot_term
+                                             =
+                                             (env1.FStar_TypeChecker_Env.typeof_tot_or_gtot_term);
+                                           FStar_TypeChecker_Env.universe_of
+                                             =
+                                             (env1.FStar_TypeChecker_Env.universe_of);
+                                           FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term
+                                             =
+                                             (env1.FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term);
+                                           FStar_TypeChecker_Env.subtype_nosmt_force
+                                             =
+                                             (env1.FStar_TypeChecker_Env.subtype_nosmt_force);
+                                           FStar_TypeChecker_Env.use_bv_sorts
+                                             =
+                                             (env1.FStar_TypeChecker_Env.use_bv_sorts);
+                                           FStar_TypeChecker_Env.qtbl_name_and_index
+                                             =
+                                             (env1.FStar_TypeChecker_Env.qtbl_name_and_index);
+                                           FStar_TypeChecker_Env.normalized_eff_names
+                                             =
+                                             (env1.FStar_TypeChecker_Env.normalized_eff_names);
+                                           FStar_TypeChecker_Env.fv_delta_depths
+                                             =
+                                             (env1.FStar_TypeChecker_Env.fv_delta_depths);
+                                           FStar_TypeChecker_Env.proof_ns =
+                                             (env1.FStar_TypeChecker_Env.proof_ns);
+                                           FStar_TypeChecker_Env.synth_hook =
+                                             (env1.FStar_TypeChecker_Env.synth_hook);
+                                           FStar_TypeChecker_Env.try_solve_implicits_hook
+                                             =
+                                             (env1.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                                           FStar_TypeChecker_Env.splice =
+                                             (env1.FStar_TypeChecker_Env.splice);
+                                           FStar_TypeChecker_Env.mpreprocess
+                                             =
+                                             (env1.FStar_TypeChecker_Env.mpreprocess);
+                                           FStar_TypeChecker_Env.postprocess
+                                             =
+                                             (env1.FStar_TypeChecker_Env.postprocess);
+                                           FStar_TypeChecker_Env.identifier_info
+                                             =
+                                             (env1.FStar_TypeChecker_Env.identifier_info);
+                                           FStar_TypeChecker_Env.tc_hooks =
+                                             (env1.FStar_TypeChecker_Env.tc_hooks);
+                                           FStar_TypeChecker_Env.dsenv =
+                                             (env1.FStar_TypeChecker_Env.dsenv);
+                                           FStar_TypeChecker_Env.nbe =
+                                             (env1.FStar_TypeChecker_Env.nbe);
+                                           FStar_TypeChecker_Env.strict_args_tab
+                                             =
+                                             (env1.FStar_TypeChecker_Env.strict_args_tab);
+                                           FStar_TypeChecker_Env.erasable_types_tab
+                                             =
+                                             (env1.FStar_TypeChecker_Env.erasable_types_tab);
+                                           FStar_TypeChecker_Env.enable_defer_to_tac
+                                             =
+                                             (env1.FStar_TypeChecker_Env.enable_defer_to_tac);
+                                           FStar_TypeChecker_Env.unif_allow_ref_guards
+                                             =
+                                             (env1.FStar_TypeChecker_Env.unif_allow_ref_guards);
+                                           FStar_TypeChecker_Env.erase_erasable_args
+                                             =
+                                             (env1.FStar_TypeChecker_Env.erase_erasable_args)
+                                         } in
+                                       let uu___9 =
+                                         env2.FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term
+                                           env2 tm2 false in
+                                       match uu___9 with
+                                       | (tm_t, uu___10) ->
                                            let uu___11 =
-                                             FStar_Compiler_Effect.op_Bar_Greater
-                                               imps
-                                               (FStar_Compiler_List.map
-                                                  (fun imp ->
-                                                     (imp,
-                                                       Implicit_unresolved))) in
-                                           FStar_Compiler_List.op_At uu___11
-                                             out in
-                                         (uu___10, true) in
-                                       until_fixpoint uu___9 tl))))))) in
+                                             env2.FStar_TypeChecker_Env.subtype_nosmt_force
+                                               env2 tm_t
+                                               ctx_u.FStar_Syntax_Syntax.ctx_uvar_typ in
+                                           (if uu___11
+                                            then true
+                                            else
+                                              ((let uu___14 =
+                                                  FStar_Syntax_Print.uvar_to_string
+                                                    ctx_u.FStar_Syntax_Syntax.ctx_uvar_head in
+                                                let uu___15 =
+                                                  FStar_Syntax_Print.term_to_string
+                                                    ctx_u.FStar_Syntax_Syntax.ctx_uvar_typ in
+                                                let uu___16 =
+                                                  FStar_Syntax_Print.term_to_string
+                                                    tm2 in
+                                                let uu___17 =
+                                                  FStar_Syntax_Print.term_to_string
+                                                    tm_t in
+                                                FStar_Compiler_Util.print4
+                                                  "Uvar solution for %s was not well-typed. Expected %s got %s : %s\n"
+                                                  uu___14 uu___15 uu___16
+                                                  uu___17);
+                                               false))
+                                     else false in
+                                   if is_tac
+                                   then
+                                     let uu___9 = tm_ok_for_tac tm1 in
+                                     (if uu___9
+                                      then until_fixpoint (out, true) tl
+                                      else
+                                        until_fixpoint
+                                          (((hd1, Implicit_unresolved) ::
+                                            out), changed) tl)
+                                   else
+                                     (let force_univ_constraints = false in
+                                      let imps_opt =
+                                        check_implicit_solution_and_discharge_guard
+                                          env1 hd1 force_univ_constraints in
+                                      match imps_opt with
+                                      | FStar_Pervasives_Native.None ->
+                                          until_fixpoint
+                                            (((hd1,
+                                                Implicit_checking_defers_univ_constraint)
+                                              :: out), changed) tl
+                                      | FStar_Pervasives_Native.Some imps ->
+                                          let uu___10 =
+                                            let uu___11 =
+                                              let uu___12 =
+                                                FStar_Compiler_Effect.op_Bar_Greater
+                                                  imps
+                                                  (FStar_Compiler_List.map
+                                                     (fun imp ->
+                                                        (imp,
+                                                          Implicit_unresolved))) in
+                                              FStar_Compiler_List.op_At
+                                                uu___12 out in
+                                            (uu___11, true) in
+                                          until_fixpoint uu___10 tl)))))))) in
         let imps =
           FStar_Compiler_Effect.op_Bar_Greater
             g.FStar_TypeChecker_Common.implicits (until_fixpoint ([], false)) in

--- a/src/ocaml-output/FStar_TypeChecker_Rel.ml
+++ b/src/ocaml-output/FStar_TypeChecker_Rel.ml
@@ -1,4 +1,31 @@
 open Prims
+type implicit_checking_status =
+  | Implicit_unresolved 
+  | Implicit_checking_defers_univ_constraint 
+  | Implicit_has_typing_guard of (FStar_Syntax_Syntax.term *
+  FStar_Syntax_Syntax.typ) 
+let (uu___is_Implicit_unresolved : implicit_checking_status -> Prims.bool) =
+  fun projectee ->
+    match projectee with | Implicit_unresolved -> true | uu___ -> false
+let (uu___is_Implicit_checking_defers_univ_constraint :
+  implicit_checking_status -> Prims.bool) =
+  fun projectee ->
+    match projectee with
+    | Implicit_checking_defers_univ_constraint -> true
+    | uu___ -> false
+let (uu___is_Implicit_has_typing_guard :
+  implicit_checking_status -> Prims.bool) =
+  fun projectee ->
+    match projectee with
+    | Implicit_has_typing_guard _0 -> true
+    | uu___ -> false
+let (__proj__Implicit_has_typing_guard__item___0 :
+  implicit_checking_status ->
+    (FStar_Syntax_Syntax.term * FStar_Syntax_Syntax.typ))
+  =
+  fun projectee -> match projectee with | Implicit_has_typing_guard _0 -> _0
+type tagged_implicits =
+  (FStar_TypeChecker_Common.implicit * implicit_checking_status) Prims.list
 let (is_base_type :
   FStar_TypeChecker_Env.env -> FStar_Syntax_Syntax.typ -> Prims.bool) =
   fun env ->
@@ -13909,23 +13936,10 @@ let rec (unresolved : FStar_Syntax_Syntax.ctx_uvar -> Prims.bool) =
                   unresolved ctx_u'
               | uu___3 -> false))
     | FStar_Pervasives_Native.None -> true
-type implicit_checking_status =
-  | Implicit_unresolved 
-  | Implicit_checking_defers_univ_constraint 
-let (uu___is_Implicit_unresolved : implicit_checking_status -> Prims.bool) =
-  fun projectee ->
-    match projectee with | Implicit_unresolved -> true | uu___ -> false
-let (uu___is_Implicit_checking_defers_univ_constraint :
-  implicit_checking_status -> Prims.bool) =
-  fun projectee ->
-    match projectee with
-    | Implicit_checking_defers_univ_constraint -> true
-    | uu___ -> false
 let (pick_a_univ_deffered_implicit :
-  (FStar_TypeChecker_Common.implicit * implicit_checking_status) Prims.list
-    ->
+  tagged_implicits ->
     (FStar_TypeChecker_Env.implicit FStar_Pervasives_Native.option *
-      FStar_TypeChecker_Env.implicits))
+      tagged_implicits))
   =
   fun out ->
     let uu___ =
@@ -13937,11 +13951,7 @@ let (pick_a_univ_deffered_implicit :
     match uu___ with
     | (imps_with_deferred_univs, rest) ->
         (match imps_with_deferred_univs with
-         | [] ->
-             let uu___1 =
-               FStar_Compiler_Effect.op_Bar_Greater out
-                 (FStar_Compiler_List.map FStar_Pervasives_Native.fst) in
-             (FStar_Pervasives_Native.None, uu___1)
+         | [] -> (FStar_Pervasives_Native.None, out)
          | hd::tl ->
              let uu___1 =
                let uu___2 =
@@ -13949,11 +13959,7 @@ let (pick_a_univ_deffered_implicit :
                    FStar_Pervasives_Native.fst in
                FStar_Compiler_Effect.op_Bar_Greater uu___2
                  (fun uu___3 -> FStar_Pervasives_Native.Some uu___3) in
-             let uu___2 =
-               FStar_Compiler_Effect.op_Bar_Greater
-                 (FStar_Compiler_List.op_At tl rest)
-                 (FStar_Compiler_List.map FStar_Pervasives_Native.fst) in
-             (uu___1, uu___2))
+             (uu___1, (FStar_Compiler_List.op_At tl rest)))
 let (is_implicit_resolved :
   FStar_TypeChecker_Env.env ->
     FStar_TypeChecker_Common.implicit -> Prims.bool)
@@ -13973,7 +13979,9 @@ let (is_implicit_resolved :
               uu___1 = FStar_Syntax_Syntax.Allow_unresolved))
 let (check_implicit_solution_for_tac :
   FStar_TypeChecker_Env.env ->
-    FStar_TypeChecker_Common.implicit -> Prims.bool)
+    FStar_TypeChecker_Common.implicit ->
+      (FStar_Syntax_Syntax.term * FStar_Syntax_Syntax.typ)
+        FStar_Pervasives_Native.option)
   =
   fun env ->
     fun i ->
@@ -13990,7 +13998,7 @@ let (check_implicit_solution_for_tac :
             (uvar_should_check = FStar_Syntax_Syntax.Allow_untyped) ||
               (is_base_type env uvar_ty) in
           if uu___1
-          then true
+          then FStar_Pervasives_Native.None
           else
             (let env1 =
                {
@@ -14106,7 +14114,7 @@ let (check_implicit_solution_for_tac :
                           tm_t uvar_ty) FStar_Pervasives_Native.None
                      "subtype_tactic_solution" in
                  if uu___5
-                 then true
+                 then FStar_Pervasives_Native.None
                  else
                    (let compute t =
                       FStar_TypeChecker_Normalize.normalize
@@ -14123,49 +14131,31 @@ let (check_implicit_solution_for_tac :
                         tm_t1 uv_t in
                     let uu___7 = retry () in
                     if uu___7
-                    then true
-                    else
-                      ((let uu___10 = FStar_Options.debug_any () in
-                        if uu___10
-                        then
-                          let uu___11 =
-                            let uu___12 =
-                              FStar_TypeChecker_Env.get_range env1 in
-                            FStar_Compiler_Range.string_of_range uu___12 in
-                          let uu___12 =
-                            FStar_Syntax_Print.uvar_to_string
-                              ctx_u.FStar_Syntax_Syntax.ctx_uvar_head in
-                          let uu___13 =
-                            FStar_Syntax_Print.term_to_string uvar_ty in
-                          let uu___14 = FStar_Syntax_Print.term_to_string tm in
-                          let uu___15 =
-                            FStar_Syntax_Print.term_to_string tm_t in
-                          FStar_Compiler_Util.print5
-                            "(%s) Uvar solution for %s was not well-typed. Expected %s got %s : %s\n"
-                            uu___11 uu___12 uu___13 uu___14 uu___15
-                        else ());
-                       false)))
+                    then FStar_Pervasives_Native.None
+                    else FStar_Pervasives_Native.Some (tm, tm_t)))
 let (resolve_implicits' :
   FStar_TypeChecker_Env.env ->
     Prims.bool ->
-      FStar_TypeChecker_Common.guard_t -> FStar_TypeChecker_Common.guard_t)
+      FStar_TypeChecker_Env.implicits ->
+        (FStar_TypeChecker_Common.implicit * implicit_checking_status)
+          Prims.list)
   =
   fun env ->
     fun is_tac ->
-      fun g ->
-        let rec until_fixpoint acc implicits =
+      fun implicits ->
+        let rec until_fixpoint acc implicits1 =
           let uu___ = acc in
           match uu___ with
           | (out, changed) ->
-              let out_imps =
-                FStar_Compiler_Effect.op_Bar_Greater out
-                  (FStar_Compiler_List.map FStar_Pervasives_Native.fst) in
-              (match implicits with
+              (match implicits1 with
                | [] ->
                    if Prims.op_Negation changed
                    then
                      let uu___1 =
-                       try_solve_single_valued_implicits env is_tac out_imps in
+                       let uu___2 =
+                         FStar_Compiler_List.map FStar_Pervasives_Native.fst
+                           out in
+                       try_solve_single_valued_implicits env is_tac uu___2 in
                      (match uu___1 with
                       | (imps, changed1) ->
                           if changed1
@@ -14184,9 +14174,18 @@ let (resolve_implicits' :
                                             env imp force_univ_constraints in
                                         FStar_Compiler_Effect.op_Bar_Greater
                                           uu___4 FStar_Compiler_Util.must in
-                                      until_fixpoint ([], false)
-                                        (FStar_Compiler_List.op_At imps1 rest))))
-                   else until_fixpoint ([], false) out_imps
+                                      let uu___4 =
+                                        let uu___5 =
+                                          FStar_Compiler_List.map
+                                            FStar_Pervasives_Native.fst rest in
+                                        FStar_Compiler_List.op_At imps1
+                                          uu___5 in
+                                      until_fixpoint ([], false) uu___4)))
+                   else
+                     (let uu___2 =
+                        FStar_Compiler_List.map FStar_Pervasives_Native.fst
+                          out in
+                      until_fixpoint ([], false) uu___2)
                | hd::tl ->
                    let uu___1 = hd in
                    (match uu___1 with
@@ -14238,8 +14237,8 @@ let (resolve_implicits' :
                                         | FStar_Pervasives_Native.None ->
                                             failwith
                                               "resolve_implicits: unifying with an unresolved uvar failed?"
-                                        | FStar_Pervasives_Native.Some g1 ->
-                                            g1.FStar_TypeChecker_Common.implicits in
+                                        | FStar_Pervasives_Native.Some g ->
+                                            g.FStar_TypeChecker_Common.implicits in
                                       until_fixpoint (out, true)
                                         (FStar_Compiler_List.op_At extra tl)
                                     else
@@ -14397,20 +14396,24 @@ let (resolve_implicits' :
                                         then
                                           (if
                                              env1.FStar_TypeChecker_Env.phase1
-                                           then true
+                                           then FStar_Pervasives_Native.None
                                            else
                                              check_implicit_solution_for_tac
                                                env1 hd1)
-                                        else false in
+                                        else FStar_Pervasives_Native.None in
                                       if is_tac
                                       then
                                         let uu___8 = tm_ok_for_tac () in
-                                        (if uu___8
-                                         then until_fixpoint (out, true) tl
-                                         else
-                                           until_fixpoint
-                                             (((hd1, Implicit_unresolved) ::
-                                               out), changed) tl)
+                                        match uu___8 with
+                                        | FStar_Pervasives_Native.None ->
+                                            until_fixpoint (out, true) tl
+                                        | FStar_Pervasives_Native.Some
+                                            (tm2, ty) ->
+                                            until_fixpoint
+                                              (((hd1,
+                                                  (Implicit_has_typing_guard
+                                                     (tm2, ty))) :: out),
+                                                changed) tl
                                       else
                                         (let force_univ_constraints = false in
                                          let imps_opt =
@@ -14430,27 +14433,14 @@ let (resolve_implicits' :
                                                    FStar_Compiler_Effect.op_Bar_Greater
                                                      imps
                                                      (FStar_Compiler_List.map
-                                                        (fun imp ->
-                                                           (imp,
+                                                        (fun i ->
+                                                           (i,
                                                              Implicit_unresolved))) in
                                                  FStar_Compiler_List.op_At
                                                    uu___11 out in
                                                (uu___10, true) in
                                              until_fixpoint uu___9 tl))))))) in
-        let imps =
-          FStar_Compiler_Effect.op_Bar_Greater
-            g.FStar_TypeChecker_Common.implicits (until_fixpoint ([], false)) in
-        {
-          FStar_TypeChecker_Common.guard_f =
-            (g.FStar_TypeChecker_Common.guard_f);
-          FStar_TypeChecker_Common.deferred_to_tac =
-            (g.FStar_TypeChecker_Common.deferred_to_tac);
-          FStar_TypeChecker_Common.deferred =
-            (g.FStar_TypeChecker_Common.deferred);
-          FStar_TypeChecker_Common.univ_ineqs =
-            (g.FStar_TypeChecker_Common.univ_ineqs);
-          FStar_TypeChecker_Common.implicits = imps
-        }
+        until_fixpoint ([], false) implicits
 let (resolve_implicits :
   FStar_TypeChecker_Env.env ->
     FStar_TypeChecker_Common.guard_t -> FStar_TypeChecker_Common.guard_t)
@@ -14467,11 +14457,28 @@ let (resolve_implicits :
            "//////////////////////////ResolveImplicitsHook: resolve_implicits////////////\nguard = %s\n"
            uu___2
        else ());
-      resolve_implicits' env false g
+      (let tagged_implicits1 =
+         resolve_implicits' env false g.FStar_TypeChecker_Common.implicits in
+       let uu___1 =
+         FStar_Compiler_List.map FStar_Pervasives_Native.fst
+           tagged_implicits1 in
+       {
+         FStar_TypeChecker_Common.guard_f =
+           (g.FStar_TypeChecker_Common.guard_f);
+         FStar_TypeChecker_Common.deferred_to_tac =
+           (g.FStar_TypeChecker_Common.deferred_to_tac);
+         FStar_TypeChecker_Common.deferred =
+           (g.FStar_TypeChecker_Common.deferred);
+         FStar_TypeChecker_Common.univ_ineqs =
+           (g.FStar_TypeChecker_Common.univ_ineqs);
+         FStar_TypeChecker_Common.implicits = uu___1
+       })
 let (resolve_implicits_tac :
   FStar_TypeChecker_Env.env ->
-    FStar_TypeChecker_Common.guard_t -> FStar_TypeChecker_Common.guard_t)
-  = fun env -> fun g -> resolve_implicits' env true g
+    FStar_TypeChecker_Common.guard_t -> tagged_implicits)
+  =
+  fun env ->
+    fun g -> resolve_implicits' env true g.FStar_TypeChecker_Common.implicits
 let (force_trivial_guard :
   FStar_TypeChecker_Env.env -> FStar_TypeChecker_Common.guard_t -> unit) =
   fun env ->

--- a/src/ocaml-output/FStar_TypeChecker_Rel.ml
+++ b/src/ocaml-output/FStar_TypeChecker_Rel.ml
@@ -14361,23 +14361,49 @@ let (resolve_implicits' :
                                                   if uu___14
                                                   then true
                                                   else
-                                                    ((let uu___17 =
-                                                        FStar_Syntax_Print.uvar_to_string
-                                                          ctx_u.FStar_Syntax_Syntax.ctx_uvar_head in
-                                                      let uu___18 =
-                                                        FStar_Syntax_Print.term_to_string
-                                                          ctx_u.FStar_Syntax_Syntax.ctx_uvar_typ in
-                                                      let uu___19 =
-                                                        FStar_Syntax_Print.term_to_string
-                                                          tm2 in
-                                                      let uu___20 =
-                                                        FStar_Syntax_Print.term_to_string
-                                                          tm_t in
-                                                      FStar_Compiler_Util.print4
-                                                        "Uvar solution for %s was not well-typed. Expected %s got %s : %s\n"
-                                                        uu___17 uu___18
-                                                        uu___19 uu___20);
-                                                     false))))
+                                                    (let compute t =
+                                                       FStar_TypeChecker_Normalize.normalize
+                                                         [FStar_TypeChecker_Env.UnfoldTac;
+                                                         FStar_TypeChecker_Env.UnfoldUntil
+                                                           FStar_Syntax_Syntax.delta_constant;
+                                                         FStar_TypeChecker_Env.Zeta;
+                                                         FStar_TypeChecker_Env.Iota;
+                                                         FStar_TypeChecker_Env.Primops]
+                                                         env2 t in
+                                                     let tm_t1 = compute tm_t in
+                                                     let uv_t =
+                                                       compute
+                                                         ctx_u.FStar_Syntax_Syntax.ctx_uvar_typ in
+                                                     let uu___16 =
+                                                       env2.FStar_TypeChecker_Env.subtype_nosmt_force
+                                                         env2 tm_t1 uv_t in
+                                                     if uu___16
+                                                     then true
+                                                     else
+                                                       ((let uu___19 =
+                                                           let uu___20 =
+                                                             FStar_TypeChecker_Env.get_range
+                                                               env2 in
+                                                           FStar_Compiler_Range.string_of_range
+                                                             uu___20 in
+                                                         let uu___20 =
+                                                           FStar_Syntax_Print.uvar_to_string
+                                                             ctx_u.FStar_Syntax_Syntax.ctx_uvar_head in
+                                                         let uu___21 =
+                                                           FStar_Syntax_Print.term_to_string
+                                                             ctx_u.FStar_Syntax_Syntax.ctx_uvar_typ in
+                                                         let uu___22 =
+                                                           FStar_Syntax_Print.term_to_string
+                                                             tm2 in
+                                                         let uu___23 =
+                                                           FStar_Syntax_Print.term_to_string
+                                                             tm_t1 in
+                                                         FStar_Compiler_Util.print5
+                                                           "(%s) Uvar solution for %s was not well-typed. Expected %s got %s : %s\n"
+                                                           uu___19 uu___20
+                                                           uu___21 uu___22
+                                                           uu___23);
+                                                        false)))))
                                      else false in
                                    if is_tac
                                    then

--- a/src/ocaml-output/FStar_TypeChecker_Rel.ml
+++ b/src/ocaml-output/FStar_TypeChecker_Rel.ml
@@ -13961,8 +13961,7 @@ let (pick_a_univ_deffered_implicit :
                  (fun uu___3 -> FStar_Pervasives_Native.Some uu___3) in
              (uu___1, (FStar_Compiler_List.op_At tl rest)))
 let (is_implicit_resolved :
-  FStar_TypeChecker_Env.env ->
-    FStar_TypeChecker_Common.implicit -> Prims.bool)
+  FStar_TypeChecker_Env.env -> FStar_TypeChecker_Env.implicit -> Prims.bool)
   =
   fun env ->
     fun i ->
@@ -13979,7 +13978,7 @@ let (is_implicit_resolved :
               uu___1 = FStar_Syntax_Syntax.Allow_unresolved))
 let (check_implicit_solution_for_tac :
   FStar_TypeChecker_Env.env ->
-    FStar_TypeChecker_Common.implicit ->
+    FStar_TypeChecker_Env.implicit ->
       (FStar_Syntax_Syntax.term * FStar_Syntax_Syntax.typ)
         FStar_Pervasives_Native.option)
   =

--- a/src/ocaml-output/FStar_TypeChecker_Rel.ml
+++ b/src/ocaml-output/FStar_TypeChecker_Rel.ml
@@ -14182,160 +14182,178 @@ let (resolve_implicits' :
                                                  FStar_Syntax_Syntax.Allow_unresolved)) in
                                      if no_unresolved
                                      then
-                                       let env2 =
-                                         {
-                                           FStar_TypeChecker_Env.solver =
-                                             (env1.FStar_TypeChecker_Env.solver);
-                                           FStar_TypeChecker_Env.range =
-                                             (env1.FStar_TypeChecker_Env.range);
-                                           FStar_TypeChecker_Env.curmodule =
-                                             (env1.FStar_TypeChecker_Env.curmodule);
-                                           FStar_TypeChecker_Env.gamma =
-                                             (ctx_u.FStar_Syntax_Syntax.ctx_uvar_gamma);
-                                           FStar_TypeChecker_Env.gamma_sig =
-                                             (env1.FStar_TypeChecker_Env.gamma_sig);
-                                           FStar_TypeChecker_Env.gamma_cache
-                                             =
-                                             (env1.FStar_TypeChecker_Env.gamma_cache);
-                                           FStar_TypeChecker_Env.modules =
-                                             (env1.FStar_TypeChecker_Env.modules);
-                                           FStar_TypeChecker_Env.expected_typ
-                                             =
-                                             (env1.FStar_TypeChecker_Env.expected_typ);
-                                           FStar_TypeChecker_Env.sigtab =
-                                             (env1.FStar_TypeChecker_Env.sigtab);
-                                           FStar_TypeChecker_Env.attrtab =
-                                             (env1.FStar_TypeChecker_Env.attrtab);
-                                           FStar_TypeChecker_Env.instantiate_imp
-                                             =
-                                             (env1.FStar_TypeChecker_Env.instantiate_imp);
-                                           FStar_TypeChecker_Env.effects =
-                                             (env1.FStar_TypeChecker_Env.effects);
-                                           FStar_TypeChecker_Env.generalize =
-                                             (env1.FStar_TypeChecker_Env.generalize);
-                                           FStar_TypeChecker_Env.letrecs =
-                                             (env1.FStar_TypeChecker_Env.letrecs);
-                                           FStar_TypeChecker_Env.top_level =
-                                             (env1.FStar_TypeChecker_Env.top_level);
-                                           FStar_TypeChecker_Env.check_uvars
-                                             =
-                                             (env1.FStar_TypeChecker_Env.check_uvars);
-                                           FStar_TypeChecker_Env.use_eq_strict
-                                             =
-                                             (env1.FStar_TypeChecker_Env.use_eq_strict);
-                                           FStar_TypeChecker_Env.is_iface =
-                                             (env1.FStar_TypeChecker_Env.is_iface);
-                                           FStar_TypeChecker_Env.admit =
-                                             (env1.FStar_TypeChecker_Env.admit);
-                                           FStar_TypeChecker_Env.lax =
-                                             (env1.FStar_TypeChecker_Env.lax);
-                                           FStar_TypeChecker_Env.lax_universes
-                                             =
-                                             (env1.FStar_TypeChecker_Env.lax_universes);
-                                           FStar_TypeChecker_Env.phase1 =
-                                             (env1.FStar_TypeChecker_Env.phase1);
-                                           FStar_TypeChecker_Env.failhard =
-                                             (env1.FStar_TypeChecker_Env.failhard);
-                                           FStar_TypeChecker_Env.nosynth =
-                                             (env1.FStar_TypeChecker_Env.nosynth);
-                                           FStar_TypeChecker_Env.uvar_subtyping
-                                             =
-                                             (env1.FStar_TypeChecker_Env.uvar_subtyping);
-                                           FStar_TypeChecker_Env.tc_term =
-                                             (env1.FStar_TypeChecker_Env.tc_term);
-                                           FStar_TypeChecker_Env.typeof_tot_or_gtot_term
-                                             =
-                                             (env1.FStar_TypeChecker_Env.typeof_tot_or_gtot_term);
-                                           FStar_TypeChecker_Env.universe_of
-                                             =
-                                             (env1.FStar_TypeChecker_Env.universe_of);
-                                           FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term
-                                             =
-                                             (env1.FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term);
-                                           FStar_TypeChecker_Env.subtype_nosmt_force
-                                             =
-                                             (env1.FStar_TypeChecker_Env.subtype_nosmt_force);
-                                           FStar_TypeChecker_Env.use_bv_sorts
-                                             =
-                                             (env1.FStar_TypeChecker_Env.use_bv_sorts);
-                                           FStar_TypeChecker_Env.qtbl_name_and_index
-                                             =
-                                             (env1.FStar_TypeChecker_Env.qtbl_name_and_index);
-                                           FStar_TypeChecker_Env.normalized_eff_names
-                                             =
-                                             (env1.FStar_TypeChecker_Env.normalized_eff_names);
-                                           FStar_TypeChecker_Env.fv_delta_depths
-                                             =
-                                             (env1.FStar_TypeChecker_Env.fv_delta_depths);
-                                           FStar_TypeChecker_Env.proof_ns =
-                                             (env1.FStar_TypeChecker_Env.proof_ns);
-                                           FStar_TypeChecker_Env.synth_hook =
-                                             (env1.FStar_TypeChecker_Env.synth_hook);
-                                           FStar_TypeChecker_Env.try_solve_implicits_hook
-                                             =
-                                             (env1.FStar_TypeChecker_Env.try_solve_implicits_hook);
-                                           FStar_TypeChecker_Env.splice =
-                                             (env1.FStar_TypeChecker_Env.splice);
-                                           FStar_TypeChecker_Env.mpreprocess
-                                             =
-                                             (env1.FStar_TypeChecker_Env.mpreprocess);
-                                           FStar_TypeChecker_Env.postprocess
-                                             =
-                                             (env1.FStar_TypeChecker_Env.postprocess);
-                                           FStar_TypeChecker_Env.identifier_info
-                                             =
-                                             (env1.FStar_TypeChecker_Env.identifier_info);
-                                           FStar_TypeChecker_Env.tc_hooks =
-                                             (env1.FStar_TypeChecker_Env.tc_hooks);
-                                           FStar_TypeChecker_Env.dsenv =
-                                             (env1.FStar_TypeChecker_Env.dsenv);
-                                           FStar_TypeChecker_Env.nbe =
-                                             (env1.FStar_TypeChecker_Env.nbe);
-                                           FStar_TypeChecker_Env.strict_args_tab
-                                             =
-                                             (env1.FStar_TypeChecker_Env.strict_args_tab);
-                                           FStar_TypeChecker_Env.erasable_types_tab
-                                             =
-                                             (env1.FStar_TypeChecker_Env.erasable_types_tab);
-                                           FStar_TypeChecker_Env.enable_defer_to_tac
-                                             =
-                                             (env1.FStar_TypeChecker_Env.enable_defer_to_tac);
-                                           FStar_TypeChecker_Env.unif_allow_ref_guards
-                                             =
-                                             (env1.FStar_TypeChecker_Env.unif_allow_ref_guards);
-                                           FStar_TypeChecker_Env.erase_erasable_args
-                                             =
-                                             (env1.FStar_TypeChecker_Env.erase_erasable_args)
-                                         } in
-                                       let uu___9 =
-                                         env2.FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term
-                                           env2 tm2 false in
-                                       match uu___9 with
-                                       | (tm_t, uu___10) ->
-                                           let uu___11 =
-                                             env2.FStar_TypeChecker_Env.subtype_nosmt_force
-                                               env2 tm_t
-                                               ctx_u.FStar_Syntax_Syntax.ctx_uvar_typ in
-                                           (if uu___11
-                                            then true
-                                            else
-                                              ((let uu___14 =
-                                                  FStar_Syntax_Print.uvar_to_string
-                                                    ctx_u.FStar_Syntax_Syntax.ctx_uvar_head in
-                                                let uu___15 =
-                                                  FStar_Syntax_Print.term_to_string
-                                                    ctx_u.FStar_Syntax_Syntax.ctx_uvar_typ in
-                                                let uu___16 =
-                                                  FStar_Syntax_Print.term_to_string
-                                                    tm2 in
-                                                let uu___17 =
-                                                  FStar_Syntax_Print.term_to_string
-                                                    tm_t in
-                                                FStar_Compiler_Util.print4
-                                                  "Uvar solution for %s was not well-typed. Expected %s got %s : %s\n"
-                                                  uu___14 uu___15 uu___16
-                                                  uu___17);
-                                               false))
+                                       (if env1.FStar_TypeChecker_Env.phase1
+                                        then true
+                                        else
+                                          (let env2 =
+                                             {
+                                               FStar_TypeChecker_Env.solver =
+                                                 (env1.FStar_TypeChecker_Env.solver);
+                                               FStar_TypeChecker_Env.range =
+                                                 (env1.FStar_TypeChecker_Env.range);
+                                               FStar_TypeChecker_Env.curmodule
+                                                 =
+                                                 (env1.FStar_TypeChecker_Env.curmodule);
+                                               FStar_TypeChecker_Env.gamma =
+                                                 (ctx_u.FStar_Syntax_Syntax.ctx_uvar_gamma);
+                                               FStar_TypeChecker_Env.gamma_sig
+                                                 =
+                                                 (env1.FStar_TypeChecker_Env.gamma_sig);
+                                               FStar_TypeChecker_Env.gamma_cache
+                                                 =
+                                                 (env1.FStar_TypeChecker_Env.gamma_cache);
+                                               FStar_TypeChecker_Env.modules
+                                                 =
+                                                 (env1.FStar_TypeChecker_Env.modules);
+                                               FStar_TypeChecker_Env.expected_typ
+                                                 =
+                                                 (env1.FStar_TypeChecker_Env.expected_typ);
+                                               FStar_TypeChecker_Env.sigtab =
+                                                 (env1.FStar_TypeChecker_Env.sigtab);
+                                               FStar_TypeChecker_Env.attrtab
+                                                 =
+                                                 (env1.FStar_TypeChecker_Env.attrtab);
+                                               FStar_TypeChecker_Env.instantiate_imp
+                                                 =
+                                                 (env1.FStar_TypeChecker_Env.instantiate_imp);
+                                               FStar_TypeChecker_Env.effects
+                                                 =
+                                                 (env1.FStar_TypeChecker_Env.effects);
+                                               FStar_TypeChecker_Env.generalize
+                                                 =
+                                                 (env1.FStar_TypeChecker_Env.generalize);
+                                               FStar_TypeChecker_Env.letrecs
+                                                 =
+                                                 (env1.FStar_TypeChecker_Env.letrecs);
+                                               FStar_TypeChecker_Env.top_level
+                                                 =
+                                                 (env1.FStar_TypeChecker_Env.top_level);
+                                               FStar_TypeChecker_Env.check_uvars
+                                                 =
+                                                 (env1.FStar_TypeChecker_Env.check_uvars);
+                                               FStar_TypeChecker_Env.use_eq_strict
+                                                 =
+                                                 (env1.FStar_TypeChecker_Env.use_eq_strict);
+                                               FStar_TypeChecker_Env.is_iface
+                                                 =
+                                                 (env1.FStar_TypeChecker_Env.is_iface);
+                                               FStar_TypeChecker_Env.admit =
+                                                 (env1.FStar_TypeChecker_Env.admit);
+                                               FStar_TypeChecker_Env.lax =
+                                                 (env1.FStar_TypeChecker_Env.lax);
+                                               FStar_TypeChecker_Env.lax_universes
+                                                 =
+                                                 (env1.FStar_TypeChecker_Env.lax_universes);
+                                               FStar_TypeChecker_Env.phase1 =
+                                                 (env1.FStar_TypeChecker_Env.phase1);
+                                               FStar_TypeChecker_Env.failhard
+                                                 =
+                                                 (env1.FStar_TypeChecker_Env.failhard);
+                                               FStar_TypeChecker_Env.nosynth
+                                                 =
+                                                 (env1.FStar_TypeChecker_Env.nosynth);
+                                               FStar_TypeChecker_Env.uvar_subtyping
+                                                 =
+                                                 (env1.FStar_TypeChecker_Env.uvar_subtyping);
+                                               FStar_TypeChecker_Env.tc_term
+                                                 =
+                                                 (env1.FStar_TypeChecker_Env.tc_term);
+                                               FStar_TypeChecker_Env.typeof_tot_or_gtot_term
+                                                 =
+                                                 (env1.FStar_TypeChecker_Env.typeof_tot_or_gtot_term);
+                                               FStar_TypeChecker_Env.universe_of
+                                                 =
+                                                 (env1.FStar_TypeChecker_Env.universe_of);
+                                               FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term
+                                                 =
+                                                 (env1.FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term);
+                                               FStar_TypeChecker_Env.subtype_nosmt_force
+                                                 =
+                                                 (env1.FStar_TypeChecker_Env.subtype_nosmt_force);
+                                               FStar_TypeChecker_Env.use_bv_sorts
+                                                 =
+                                                 (env1.FStar_TypeChecker_Env.use_bv_sorts);
+                                               FStar_TypeChecker_Env.qtbl_name_and_index
+                                                 =
+                                                 (env1.FStar_TypeChecker_Env.qtbl_name_and_index);
+                                               FStar_TypeChecker_Env.normalized_eff_names
+                                                 =
+                                                 (env1.FStar_TypeChecker_Env.normalized_eff_names);
+                                               FStar_TypeChecker_Env.fv_delta_depths
+                                                 =
+                                                 (env1.FStar_TypeChecker_Env.fv_delta_depths);
+                                               FStar_TypeChecker_Env.proof_ns
+                                                 =
+                                                 (env1.FStar_TypeChecker_Env.proof_ns);
+                                               FStar_TypeChecker_Env.synth_hook
+                                                 =
+                                                 (env1.FStar_TypeChecker_Env.synth_hook);
+                                               FStar_TypeChecker_Env.try_solve_implicits_hook
+                                                 =
+                                                 (env1.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                                               FStar_TypeChecker_Env.splice =
+                                                 (env1.FStar_TypeChecker_Env.splice);
+                                               FStar_TypeChecker_Env.mpreprocess
+                                                 =
+                                                 (env1.FStar_TypeChecker_Env.mpreprocess);
+                                               FStar_TypeChecker_Env.postprocess
+                                                 =
+                                                 (env1.FStar_TypeChecker_Env.postprocess);
+                                               FStar_TypeChecker_Env.identifier_info
+                                                 =
+                                                 (env1.FStar_TypeChecker_Env.identifier_info);
+                                               FStar_TypeChecker_Env.tc_hooks
+                                                 =
+                                                 (env1.FStar_TypeChecker_Env.tc_hooks);
+                                               FStar_TypeChecker_Env.dsenv =
+                                                 (env1.FStar_TypeChecker_Env.dsenv);
+                                               FStar_TypeChecker_Env.nbe =
+                                                 (env1.FStar_TypeChecker_Env.nbe);
+                                               FStar_TypeChecker_Env.strict_args_tab
+                                                 =
+                                                 (env1.FStar_TypeChecker_Env.strict_args_tab);
+                                               FStar_TypeChecker_Env.erasable_types_tab
+                                                 =
+                                                 (env1.FStar_TypeChecker_Env.erasable_types_tab);
+                                               FStar_TypeChecker_Env.enable_defer_to_tac
+                                                 =
+                                                 (env1.FStar_TypeChecker_Env.enable_defer_to_tac);
+                                               FStar_TypeChecker_Env.unif_allow_ref_guards
+                                                 =
+                                                 (env1.FStar_TypeChecker_Env.unif_allow_ref_guards);
+                                               FStar_TypeChecker_Env.erase_erasable_args
+                                                 =
+                                                 (env1.FStar_TypeChecker_Env.erase_erasable_args)
+                                             } in
+                                           let uu___10 =
+                                             env2.FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term
+                                               env2 tm2 false in
+                                           match uu___10 with
+                                           | (tm_t, uu___11) ->
+                                               let uu___12 =
+                                                 env2.FStar_TypeChecker_Env.subtype_nosmt_force
+                                                   env2 tm_t
+                                                   ctx_u.FStar_Syntax_Syntax.ctx_uvar_typ in
+                                               if uu___12
+                                               then true
+                                               else
+                                                 ((let uu___15 =
+                                                     FStar_Syntax_Print.uvar_to_string
+                                                       ctx_u.FStar_Syntax_Syntax.ctx_uvar_head in
+                                                   let uu___16 =
+                                                     FStar_Syntax_Print.term_to_string
+                                                       ctx_u.FStar_Syntax_Syntax.ctx_uvar_typ in
+                                                   let uu___17 =
+                                                     FStar_Syntax_Print.term_to_string
+                                                       tm2 in
+                                                   let uu___18 =
+                                                     FStar_Syntax_Print.term_to_string
+                                                       tm_t in
+                                                   FStar_Compiler_Util.print4
+                                                     "Uvar solution for %s was not well-typed. Expected %s got %s : %s\n"
+                                                     uu___15 uu___16 uu___17
+                                                     uu___18);
+                                                  false)))
                                      else false in
                                    if is_tac
                                    then

--- a/src/ocaml-output/FStar_TypeChecker_Rel.ml
+++ b/src/ocaml-output/FStar_TypeChecker_Rel.ml
@@ -14463,7 +14463,7 @@ let (resolve_implicits' :
                                                                   ctx_u.FStar_Syntax_Syntax.ctx_uvar_head in
                                                               let uu___22 =
                                                                 FStar_Syntax_Print.term_to_string
-                                                                  uvar_decoration_typ in
+                                                                  uv_t in
                                                               let uu___23 =
                                                                 FStar_Syntax_Print.term_to_string
                                                                   tm2 in

--- a/src/ocaml-output/FStar_TypeChecker_Rel.ml
+++ b/src/ocaml-output/FStar_TypeChecker_Rel.ml
@@ -203,16 +203,20 @@ let (new_uvar :
             fun k ->
               fun should_check ->
                 fun meta ->
+                  let decoration =
+                    {
+                      FStar_Syntax_Syntax.uvar_decoration_typ = k;
+                      FStar_Syntax_Syntax.uvar_decoration_should_check =
+                        should_check
+                    } in
                   let ctx_uvar =
-                    let uu___ = FStar_Syntax_Unionfind.fresh r in
+                    let uu___ = FStar_Syntax_Unionfind.fresh decoration r in
                     {
                       FStar_Syntax_Syntax.ctx_uvar_head = uu___;
                       FStar_Syntax_Syntax.ctx_uvar_gamma = gamma;
                       FStar_Syntax_Syntax.ctx_uvar_binders = binders;
                       FStar_Syntax_Syntax.ctx_uvar_typ = k;
                       FStar_Syntax_Syntax.ctx_uvar_reason = reason;
-                      FStar_Syntax_Syntax.ctx_uvar_should_check =
-                        should_check;
                       FStar_Syntax_Syntax.ctx_uvar_range = r;
                       FStar_Syntax_Syntax.ctx_uvar_meta = meta
                     } in
@@ -367,11 +371,11 @@ let (copy_uvar :
             } in
           let env1 = FStar_TypeChecker_Env.push_binders env bs in
           let uu___ = FStar_TypeChecker_Env.all_binders env1 in
+          let uu___1 = FStar_Syntax_Util.ctx_uvar_should_check u in
           new_uvar
             (Prims.op_Hat "copy:" u.FStar_Syntax_Syntax.ctx_uvar_reason) wl
             u.FStar_Syntax_Syntax.ctx_uvar_range
-            env1.FStar_TypeChecker_Env.gamma uu___ t
-            u.FStar_Syntax_Syntax.ctx_uvar_should_check
+            env1.FStar_TypeChecker_Env.gamma uu___ t uu___1
             u.FStar_Syntax_Syntax.ctx_uvar_meta
 type solution =
   | Success of (FStar_TypeChecker_Common.deferred *
@@ -1808,13 +1812,14 @@ let (ensure_no_uvar_subst :
                                  FStar_Syntax_Syntax.mk_Total
                                    uv.FStar_Syntax_Syntax.ctx_uvar_typ in
                                FStar_Syntax_Util.arrow dom_binders uu___7 in
+                             let uu___7 =
+                               FStar_Syntax_Util.ctx_uvar_should_check uv in
                              new_uvar
                                (Prims.op_Hat
                                   uv.FStar_Syntax_Syntax.ctx_uvar_reason
                                   "; force delayed") wl
                                t0.FStar_Syntax_Syntax.pos new_gamma uu___5
-                               uu___6
-                               uv.FStar_Syntax_Syntax.ctx_uvar_should_check
+                               uu___6 uu___7
                                uv.FStar_Syntax_Syntax.ctx_uvar_meta in
                            (match uu___4 with
                             | (v, t_v, wl1) ->
@@ -2267,9 +2272,9 @@ let (restrict_ctx :
                         FStar_Syntax_Print.uvar_to_string
                           src.FStar_Syntax_Syntax.ctx_uvar_head in
                       Prims.op_Hat "restricted " uu___4 in
+                    let uu___4 = FStar_Syntax_Util.ctx_uvar_should_check src in
                     new_uvar uu___3 wl src.FStar_Syntax_Syntax.ctx_uvar_range
-                      g pfx t src.FStar_Syntax_Syntax.ctx_uvar_should_check
-                      src.FStar_Syntax_Syntax.ctx_uvar_meta in
+                      g pfx t uu___4 src.FStar_Syntax_Syntax.ctx_uvar_meta in
                   match uu___2 with
                   | (uu___3, src', wl1) ->
                       ((let uu___5 = f src' in set_uvar env src uu___5); wl1) in
@@ -3743,50 +3748,49 @@ let (quasi_pattern :
              FStar_Syntax_Syntax.ctx_uvar_binders = ctx;
              FStar_Syntax_Syntax.ctx_uvar_typ = t_hd;
              FStar_Syntax_Syntax.ctx_uvar_reason = uu___4;
-             FStar_Syntax_Syntax.ctx_uvar_should_check = uu___5;
-             FStar_Syntax_Syntax.ctx_uvar_range = uu___6;
-             FStar_Syntax_Syntax.ctx_uvar_meta = uu___7;_},
+             FStar_Syntax_Syntax.ctx_uvar_range = uu___5;
+             FStar_Syntax_Syntax.ctx_uvar_meta = uu___6;_},
            args)
           ->
           let name_exists_in x bs =
             FStar_Compiler_Util.for_some
-              (fun uu___8 ->
-                 match uu___8 with
+              (fun uu___7 ->
+                 match uu___7 with
                  | { FStar_Syntax_Syntax.binder_bv = y;
-                     FStar_Syntax_Syntax.binder_qual = uu___9;
-                     FStar_Syntax_Syntax.binder_attrs = uu___10;_} ->
+                     FStar_Syntax_Syntax.binder_qual = uu___8;
+                     FStar_Syntax_Syntax.binder_attrs = uu___9;_} ->
                      FStar_Syntax_Syntax.bv_eq x y) bs in
           let rec aux pat_binders formals t_res args1 =
             match (formals, args1) with
             | ([], []) ->
+                let uu___7 =
+                  let uu___8 =
+                    let uu___9 = FStar_Syntax_Syntax.mk_Total t_res in
+                    FStar_Syntax_Util.arrow formals uu___9 in
+                  ((FStar_Compiler_List.rev pat_binders), uu___8) in
+                FStar_Pervasives_Native.Some uu___7
+            | (uu___7, []) ->
                 let uu___8 =
                   let uu___9 =
                     let uu___10 = FStar_Syntax_Syntax.mk_Total t_res in
                     FStar_Syntax_Util.arrow formals uu___10 in
                   ((FStar_Compiler_List.rev pat_binders), uu___9) in
                 FStar_Pervasives_Native.Some uu___8
-            | (uu___8, []) ->
-                let uu___9 =
-                  let uu___10 =
-                    let uu___11 = FStar_Syntax_Syntax.mk_Total t_res in
-                    FStar_Syntax_Util.arrow formals uu___11 in
-                  ((FStar_Compiler_List.rev pat_binders), uu___10) in
-                FStar_Pervasives_Native.Some uu___9
             | (fml::formals1, (a, a_imp)::args2) ->
-                let uu___8 =
+                let uu___7 =
                   ((fml.FStar_Syntax_Syntax.binder_bv),
                     (fml.FStar_Syntax_Syntax.binder_qual)) in
-                (match uu___8 with
+                (match uu___7 with
                  | (formal, formal_imp) ->
-                     let uu___9 =
-                       let uu___10 = FStar_Syntax_Subst.compress a in
-                       uu___10.FStar_Syntax_Syntax.n in
-                     (match uu___9 with
+                     let uu___8 =
+                       let uu___9 = FStar_Syntax_Subst.compress a in
+                       uu___9.FStar_Syntax_Syntax.n in
+                     (match uu___8 with
                       | FStar_Syntax_Syntax.Tm_name x ->
-                          let uu___10 =
+                          let uu___9 =
                             (name_exists_in x ctx) ||
                               (name_exists_in x pat_binders) in
-                          if uu___10
+                          if uu___9
                           then aux (fml :: pat_binders) formals1 t_res args2
                           else
                             (let x1 =
@@ -3799,25 +3803,25 @@ let (quasi_pattern :
                                    (formal.FStar_Syntax_Syntax.sort)
                                } in
                              let subst =
-                               let uu___12 =
-                                 let uu___13 =
-                                   let uu___14 =
+                               let uu___11 =
+                                 let uu___12 =
+                                   let uu___13 =
                                      FStar_Syntax_Syntax.bv_to_name x1 in
-                                   (formal, uu___14) in
-                                 FStar_Syntax_Syntax.NT uu___13 in
-                               [uu___12] in
+                                   (formal, uu___13) in
+                                 FStar_Syntax_Syntax.NT uu___12 in
+                               [uu___11] in
                              let formals2 =
                                FStar_Syntax_Subst.subst_binders subst
                                  formals1 in
                              let t_res1 =
                                FStar_Syntax_Subst.subst subst t_res in
-                             let uu___12 =
+                             let uu___11 =
                                FStar_Syntax_Util.bqual_and_attrs_of_aqual
                                  a_imp in
-                             match uu___12 with
-                             | (q, uu___13) ->
-                                 let uu___14 =
-                                   let uu___15 =
+                             match uu___11 with
+                             | (q, uu___12) ->
+                                 let uu___13 =
+                                   let uu___14 =
                                      FStar_Syntax_Syntax.mk_binder_with_attrs
                                        {
                                          FStar_Syntax_Syntax.ppname =
@@ -3828,25 +3832,25 @@ let (quasi_pattern :
                                            (formal.FStar_Syntax_Syntax.sort)
                                        } q
                                        fml.FStar_Syntax_Syntax.binder_attrs in
-                                   uu___15 :: pat_binders in
-                                 aux uu___14 formals2 t_res1 args2)
-                      | uu___10 ->
+                                   uu___14 :: pat_binders in
+                                 aux uu___13 formals2 t_res1 args2)
+                      | uu___9 ->
                           aux (fml :: pat_binders) formals1 t_res args2))
             | ([], args2) ->
-                let uu___8 =
-                  let uu___9 =
+                let uu___7 =
+                  let uu___8 =
                     FStar_TypeChecker_Normalize.unfold_whnf env t_res in
-                  FStar_Syntax_Util.arrow_formals uu___9 in
-                (match uu___8 with
+                  FStar_Syntax_Util.arrow_formals uu___8 in
+                (match uu___7 with
                  | (more_formals, t_res1) ->
                      (match more_formals with
                       | [] -> FStar_Pervasives_Native.None
-                      | uu___9 -> aux pat_binders more_formals t_res1 args2)) in
+                      | uu___8 -> aux pat_binders more_formals t_res1 args2)) in
           (match args with
            | [] -> FStar_Pervasives_Native.Some ([], t_hd)
-           | uu___8 ->
-               let uu___9 = FStar_Syntax_Util.arrow_formals t_hd in
-               (match uu___9 with
+           | uu___7 ->
+               let uu___8 = FStar_Syntax_Util.arrow_formals t_hd in
+               (match uu___8 with
                 | (formals, t_res) -> aux [] formals t_res args))
 let (run_meta_arg_tac :
   FStar_Syntax_Syntax.ctx_uvar -> FStar_Syntax_Syntax.term) =
@@ -5215,7 +5219,15 @@ and (solve_binders :
                  FStar_Compiler_Util.print3 "solve_binders\n\t%s\n%s\n\t%s\n"
                    uu___2 (rel_to_string (p_rel orig)) uu___3
                else ());
-              (let rec aux wl1 scope env1 subst xs ys =
+              (let eq_bqual a1 a2 =
+                 match (a1, a2) with
+                 | (FStar_Pervasives_Native.Some
+                    (FStar_Syntax_Syntax.Implicit b1),
+                    FStar_Pervasives_Native.Some
+                    (FStar_Syntax_Syntax.Implicit b2)) ->
+                     FStar_Syntax_Util.Equal
+                 | uu___1 -> FStar_Syntax_Util.eq_bqual a1 a2 in
+               let rec aux wl1 scope env1 subst xs ys =
                  match (xs, ys) with
                  | ([], []) ->
                      let uu___1 = rhs wl1 scope env1 subst in
@@ -5237,8 +5249,7 @@ and (solve_binders :
                               wl2))))
                  | (x::xs1, y::ys1) when
                      let uu___1 =
-                       FStar_Syntax_Util.eq_bqual
-                         x.FStar_Syntax_Syntax.binder_qual
+                       eq_bqual x.FStar_Syntax_Syntax.binder_qual
                          y.FStar_Syntax_Syntax.binder_qual in
                      uu___1 = FStar_Syntax_Util.Equal ->
                      let uu___1 =
@@ -6609,6 +6620,24 @@ and (solve_t_flex_flex :
                                                         uu___22
                                                     else ());
                                                    (let uu___21 =
+                                                      let uu___22 =
+                                                        let uu___23 =
+                                                          (let uu___24 =
+                                                             FStar_Syntax_Util.ctx_uvar_should_check
+                                                               u_lhs in
+                                                           uu___24 =
+                                                             FStar_Syntax_Syntax.Allow_untyped)
+                                                            &&
+                                                            (let uu___24 =
+                                                               FStar_Syntax_Util.ctx_uvar_should_check
+                                                                 u_rhs in
+                                                             uu___24 =
+                                                               FStar_Syntax_Syntax.Allow_untyped) in
+                                                        if uu___23
+                                                        then
+                                                          FStar_Syntax_Syntax.Allow_untyped
+                                                        else
+                                                          FStar_Syntax_Syntax.Strict in
                                                       new_uvar
                                                         (Prims.op_Hat
                                                            "flex-flex quasi:"
@@ -6621,18 +6650,7 @@ and (solve_t_flex_flex :
                                                                     u_rhs.FStar_Syntax_Syntax.ctx_uvar_reason))))
                                                         wl range gamma_w
                                                         ctx_w new_uvar_typ
-                                                        (if
-                                                           (u_lhs.FStar_Syntax_Syntax.ctx_uvar_should_check
-                                                              =
-                                                              FStar_Syntax_Syntax.Allow_untyped)
-                                                             &&
-                                                             (u_rhs.FStar_Syntax_Syntax.ctx_uvar_should_check
-                                                                =
-                                                                FStar_Syntax_Syntax.Allow_untyped)
-                                                         then
-                                                           FStar_Syntax_Syntax.Allow_untyped
-                                                         else
-                                                           FStar_Syntax_Syntax.Strict)
+                                                        uu___22
                                                         FStar_Pervasives_Native.None in
                                                     match uu___21 with
                                                     | (uu___22, w, wl1) ->
@@ -13517,8 +13535,10 @@ let (try_solve_single_valued_implicits :
                        FStar_Compiler_Effect.op_Bar_Greater uu___2
                          FStar_Compiler_Util.is_none)
                         &&
-                        ((imp.FStar_TypeChecker_Common.imp_uvar).FStar_Syntax_Syntax.ctx_uvar_should_check
-                           = FStar_Syntax_Syntax.Strict) in
+                        (let uu___2 =
+                           FStar_Syntax_Util.ctx_uvar_should_check
+                             imp.FStar_TypeChecker_Common.imp_uvar in
+                         uu___2 = FStar_Syntax_Syntax.Strict) in
                     if uu___1
                     then
                       let uu___2 = imp_value imp in
@@ -13813,12 +13833,14 @@ let (check_implicit_solution_and_discharge_guard :
               else ());
              (let g =
                 let must_tot =
-                  Prims.op_Negation
-                    ((env1.FStar_TypeChecker_Env.phase1 ||
-                        env1.FStar_TypeChecker_Env.lax)
-                       ||
-                       (ctx_u.FStar_Syntax_Syntax.ctx_uvar_should_check =
-                          FStar_Syntax_Syntax.Allow_ghost)) in
+                  let uu___2 =
+                    (env1.FStar_TypeChecker_Env.phase1 ||
+                       env1.FStar_TypeChecker_Env.lax)
+                      ||
+                      (let uu___3 =
+                         FStar_Syntax_Util.ctx_uvar_should_check ctx_u in
+                       uu___3 = FStar_Syntax_Syntax.Allow_ghost) in
+                  Prims.op_Negation uu___2 in
                 let uu___2 =
                   let uu___3 =
                     FStar_Syntax_Print.uvar_to_string
@@ -13981,464 +14003,518 @@ let (resolve_implicits' :
                         FStar_TypeChecker_Common.imp_uvar = ctx_u;
                         FStar_TypeChecker_Common.imp_tm = tm;
                         FStar_TypeChecker_Common.imp_range = r;_} ->
-                        ((let uu___3 =
-                            FStar_Compiler_Effect.op_Less_Bar
-                              (FStar_TypeChecker_Env.debug env)
-                              (FStar_Options.Other "Rel") in
-                          if uu___3
-                          then
-                            let uu___4 = FStar_Syntax_Print.term_to_string tm in
-                            let uu___5 =
-                              FStar_Syntax_Print.ctx_uvar_to_string ctx_u in
-                            let uu___6 =
-                              FStar_Compiler_Util.string_of_bool is_tac in
-                            FStar_Compiler_Util.print3
-                              "resolve_implicits' loop, imp_tm = %s and ctx_u = %s, is_tac: %s\n"
-                              uu___4 uu___5 uu___6
-                          else ());
-                         if
-                           ctx_u.FStar_Syntax_Syntax.ctx_uvar_should_check =
-                             FStar_Syntax_Syntax.Allow_unresolved
-                         then until_fixpoint (out, true) tl
-                         else
-                           (let uu___4 = unresolved ctx_u in
-                            if uu___4
-                            then
-                              (if flex_uvar_has_meta_tac ctx_u
+                        let uu___2 =
+                          FStar_Syntax_Unionfind.find_decoration
+                            ctx_u.FStar_Syntax_Syntax.ctx_uvar_head in
+                        (match uu___2 with
+                         | {
+                             FStar_Syntax_Syntax.uvar_decoration_typ =
+                               uvar_decoration_typ;
+                             FStar_Syntax_Syntax.uvar_decoration_should_check
+                               = uvar_decoration_should_check;_}
+                             ->
+                             ((let uu___4 =
+                                 FStar_Compiler_Effect.op_Less_Bar
+                                   (FStar_TypeChecker_Env.debug env)
+                                   (FStar_Options.Other "Rel") in
+                               if uu___4
                                then
-                                 let t = run_meta_arg_tac ctx_u in
-                                 let extra =
-                                   let uu___5 = teq_nosmt env t tm in
-                                   match uu___5 with
-                                   | FStar_Pervasives_Native.None ->
-                                       failwith
-                                         "resolve_implicits: unifying with an unresolved uvar failed?"
-                                   | FStar_Pervasives_Native.Some g1 ->
-                                       g1.FStar_TypeChecker_Common.implicits in
-                                 until_fixpoint (out, true)
-                                   (FStar_Compiler_List.op_At extra tl)
-                               else
-                                 until_fixpoint
-                                   (((hd, Implicit_unresolved) :: out),
-                                     changed) tl)
-                            else
+                                 let uu___5 =
+                                   FStar_Syntax_Print.term_to_string tm in
+                                 let uu___6 =
+                                   FStar_Syntax_Print.ctx_uvar_to_string
+                                     ctx_u in
+                                 let uu___7 =
+                                   FStar_Compiler_Util.string_of_bool is_tac in
+                                 FStar_Compiler_Util.print3
+                                   "resolve_implicits' loop, imp_tm = %s and ctx_u = %s, is_tac: %s\n"
+                                   uu___5 uu___6 uu___7
+                               else ());
                               if
-                                ctx_u.FStar_Syntax_Syntax.ctx_uvar_should_check
-                                  = FStar_Syntax_Syntax.Allow_untyped
+                                uvar_decoration_should_check =
+                                  FStar_Syntax_Syntax.Allow_unresolved
                               then until_fixpoint (out, true) tl
                               else
-                                (let env1 =
-                                   {
-                                     FStar_TypeChecker_Env.solver =
-                                       (env.FStar_TypeChecker_Env.solver);
-                                     FStar_TypeChecker_Env.range =
-                                       (env.FStar_TypeChecker_Env.range);
-                                     FStar_TypeChecker_Env.curmodule =
-                                       (env.FStar_TypeChecker_Env.curmodule);
-                                     FStar_TypeChecker_Env.gamma =
-                                       (ctx_u.FStar_Syntax_Syntax.ctx_uvar_gamma);
-                                     FStar_TypeChecker_Env.gamma_sig =
-                                       (env.FStar_TypeChecker_Env.gamma_sig);
-                                     FStar_TypeChecker_Env.gamma_cache =
-                                       (env.FStar_TypeChecker_Env.gamma_cache);
-                                     FStar_TypeChecker_Env.modules =
-                                       (env.FStar_TypeChecker_Env.modules);
-                                     FStar_TypeChecker_Env.expected_typ =
-                                       (env.FStar_TypeChecker_Env.expected_typ);
-                                     FStar_TypeChecker_Env.sigtab =
-                                       (env.FStar_TypeChecker_Env.sigtab);
-                                     FStar_TypeChecker_Env.attrtab =
-                                       (env.FStar_TypeChecker_Env.attrtab);
-                                     FStar_TypeChecker_Env.instantiate_imp =
-                                       (env.FStar_TypeChecker_Env.instantiate_imp);
-                                     FStar_TypeChecker_Env.effects =
-                                       (env.FStar_TypeChecker_Env.effects);
-                                     FStar_TypeChecker_Env.generalize =
-                                       (env.FStar_TypeChecker_Env.generalize);
-                                     FStar_TypeChecker_Env.letrecs =
-                                       (env.FStar_TypeChecker_Env.letrecs);
-                                     FStar_TypeChecker_Env.top_level =
-                                       (env.FStar_TypeChecker_Env.top_level);
-                                     FStar_TypeChecker_Env.check_uvars =
-                                       (env.FStar_TypeChecker_Env.check_uvars);
-                                     FStar_TypeChecker_Env.use_eq_strict =
-                                       (env.FStar_TypeChecker_Env.use_eq_strict);
-                                     FStar_TypeChecker_Env.is_iface =
-                                       (env.FStar_TypeChecker_Env.is_iface);
-                                     FStar_TypeChecker_Env.admit =
-                                       (env.FStar_TypeChecker_Env.admit);
-                                     FStar_TypeChecker_Env.lax =
-                                       (env.FStar_TypeChecker_Env.lax);
-                                     FStar_TypeChecker_Env.lax_universes =
-                                       (env.FStar_TypeChecker_Env.lax_universes);
-                                     FStar_TypeChecker_Env.phase1 =
-                                       (env.FStar_TypeChecker_Env.phase1);
-                                     FStar_TypeChecker_Env.failhard =
-                                       (env.FStar_TypeChecker_Env.failhard);
-                                     FStar_TypeChecker_Env.nosynth =
-                                       (env.FStar_TypeChecker_Env.nosynth);
-                                     FStar_TypeChecker_Env.uvar_subtyping =
-                                       (env.FStar_TypeChecker_Env.uvar_subtyping);
-                                     FStar_TypeChecker_Env.tc_term =
-                                       (env.FStar_TypeChecker_Env.tc_term);
-                                     FStar_TypeChecker_Env.typeof_tot_or_gtot_term
-                                       =
-                                       (env.FStar_TypeChecker_Env.typeof_tot_or_gtot_term);
-                                     FStar_TypeChecker_Env.universe_of =
-                                       (env.FStar_TypeChecker_Env.universe_of);
-                                     FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term
-                                       =
-                                       (env.FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term);
-                                     FStar_TypeChecker_Env.subtype_nosmt_force
-                                       =
-                                       (env.FStar_TypeChecker_Env.subtype_nosmt_force);
-                                     FStar_TypeChecker_Env.use_bv_sorts =
-                                       (env.FStar_TypeChecker_Env.use_bv_sorts);
-                                     FStar_TypeChecker_Env.qtbl_name_and_index
-                                       =
-                                       (env.FStar_TypeChecker_Env.qtbl_name_and_index);
-                                     FStar_TypeChecker_Env.normalized_eff_names
-                                       =
-                                       (env.FStar_TypeChecker_Env.normalized_eff_names);
-                                     FStar_TypeChecker_Env.fv_delta_depths =
-                                       (env.FStar_TypeChecker_Env.fv_delta_depths);
-                                     FStar_TypeChecker_Env.proof_ns =
-                                       (env.FStar_TypeChecker_Env.proof_ns);
-                                     FStar_TypeChecker_Env.synth_hook =
-                                       (env.FStar_TypeChecker_Env.synth_hook);
-                                     FStar_TypeChecker_Env.try_solve_implicits_hook
-                                       =
-                                       (env.FStar_TypeChecker_Env.try_solve_implicits_hook);
-                                     FStar_TypeChecker_Env.splice =
-                                       (env.FStar_TypeChecker_Env.splice);
-                                     FStar_TypeChecker_Env.mpreprocess =
-                                       (env.FStar_TypeChecker_Env.mpreprocess);
-                                     FStar_TypeChecker_Env.postprocess =
-                                       (env.FStar_TypeChecker_Env.postprocess);
-                                     FStar_TypeChecker_Env.identifier_info =
-                                       (env.FStar_TypeChecker_Env.identifier_info);
-                                     FStar_TypeChecker_Env.tc_hooks =
-                                       (env.FStar_TypeChecker_Env.tc_hooks);
-                                     FStar_TypeChecker_Env.dsenv =
-                                       (env.FStar_TypeChecker_Env.dsenv);
-                                     FStar_TypeChecker_Env.nbe =
-                                       (env.FStar_TypeChecker_Env.nbe);
-                                     FStar_TypeChecker_Env.strict_args_tab =
-                                       (env.FStar_TypeChecker_Env.strict_args_tab);
-                                     FStar_TypeChecker_Env.erasable_types_tab
-                                       =
-                                       (env.FStar_TypeChecker_Env.erasable_types_tab);
-                                     FStar_TypeChecker_Env.enable_defer_to_tac
-                                       =
-                                       (env.FStar_TypeChecker_Env.enable_defer_to_tac);
-                                     FStar_TypeChecker_Env.unif_allow_ref_guards
-                                       =
-                                       (env.FStar_TypeChecker_Env.unif_allow_ref_guards);
-                                     FStar_TypeChecker_Env.erase_erasable_args
-                                       =
-                                       (env.FStar_TypeChecker_Env.erase_erasable_args)
-                                   } in
-                                 (let uu___8 =
-                                    FStar_Compiler_Effect.op_Less_Bar
-                                      (FStar_TypeChecker_Env.debug env1)
-                                      (FStar_Options.Other "Rel") in
-                                  if uu___8
-                                  then
-                                    let uu___9 =
-                                      FStar_Syntax_Print.term_to_string tm in
-                                    let uu___10 =
-                                      FStar_Syntax_Print.ctx_uvar_to_string
-                                        ctx_u in
-                                    FStar_Compiler_Util.print2
-                                      "resolve_implicits' loop before norm, imp_tm = %s and ctx_u = %s\n"
-                                      uu___9 uu___10
-                                  else ());
-                                 (let tm1 =
-                                    norm_with_steps
-                                      "FStar.TypeChecker.Rel.norm_with_steps.8"
-                                      [FStar_TypeChecker_Env.Beta] env1 tm in
-                                  (let uu___9 =
-                                     FStar_Compiler_Effect.op_Less_Bar
-                                       (FStar_TypeChecker_Env.debug env1)
-                                       (FStar_Options.Other "Rel") in
-                                   if uu___9
-                                   then
-                                     let uu___10 =
-                                       FStar_Syntax_Print.term_to_string tm1 in
-                                     let uu___11 =
-                                       FStar_Syntax_Print.ctx_uvar_to_string
-                                         ctx_u in
-                                     FStar_Compiler_Util.print2
-                                       "resolve_implicits' loop after norm, imp_tm = %s and ctx_u = %s\n"
-                                       uu___10 uu___11
-                                   else ());
-                                  (let hd1 =
-                                     {
-                                       FStar_TypeChecker_Common.imp_reason =
-                                         (hd.FStar_TypeChecker_Common.imp_reason);
-                                       FStar_TypeChecker_Common.imp_uvar =
-                                         (hd.FStar_TypeChecker_Common.imp_uvar);
-                                       FStar_TypeChecker_Common.imp_tm = tm1;
-                                       FStar_TypeChecker_Common.imp_range =
-                                         (hd.FStar_TypeChecker_Common.imp_range)
-                                     } in
-                                   let tm_ok_for_tac tm2 =
-                                     let no_unresolved =
-                                       let uu___9 =
-                                         let uu___10 =
-                                           FStar_Compiler_Effect.op_Bar_Greater
-                                             tm2 FStar_Syntax_Free.uvars in
-                                         FStar_Compiler_Effect.op_Bar_Greater
-                                           uu___10
-                                           FStar_Compiler_Util.set_elements in
-                                       FStar_Compiler_Effect.op_Bar_Greater
-                                         uu___9
-                                         (FStar_Compiler_List.for_all
-                                            (fun uv ->
-                                               uv.FStar_Syntax_Syntax.ctx_uvar_should_check
-                                                 =
-                                                 FStar_Syntax_Syntax.Allow_unresolved)) in
-                                     if no_unresolved
-                                     then
-                                       (if env1.FStar_TypeChecker_Env.phase1
-                                        then true
-                                        else
-                                          (let env2 =
-                                             {
-                                               FStar_TypeChecker_Env.solver =
-                                                 (env1.FStar_TypeChecker_Env.solver);
-                                               FStar_TypeChecker_Env.range =
-                                                 (env1.FStar_TypeChecker_Env.range);
-                                               FStar_TypeChecker_Env.curmodule
-                                                 =
-                                                 (env1.FStar_TypeChecker_Env.curmodule);
-                                               FStar_TypeChecker_Env.gamma =
-                                                 (ctx_u.FStar_Syntax_Syntax.ctx_uvar_gamma);
-                                               FStar_TypeChecker_Env.gamma_sig
-                                                 =
-                                                 (env1.FStar_TypeChecker_Env.gamma_sig);
-                                               FStar_TypeChecker_Env.gamma_cache
-                                                 =
-                                                 (env1.FStar_TypeChecker_Env.gamma_cache);
-                                               FStar_TypeChecker_Env.modules
-                                                 =
-                                                 (env1.FStar_TypeChecker_Env.modules);
-                                               FStar_TypeChecker_Env.expected_typ
-                                                 =
-                                                 (env1.FStar_TypeChecker_Env.expected_typ);
-                                               FStar_TypeChecker_Env.sigtab =
-                                                 (env1.FStar_TypeChecker_Env.sigtab);
-                                               FStar_TypeChecker_Env.attrtab
-                                                 =
-                                                 (env1.FStar_TypeChecker_Env.attrtab);
-                                               FStar_TypeChecker_Env.instantiate_imp
-                                                 =
-                                                 (env1.FStar_TypeChecker_Env.instantiate_imp);
-                                               FStar_TypeChecker_Env.effects
-                                                 =
-                                                 (env1.FStar_TypeChecker_Env.effects);
-                                               FStar_TypeChecker_Env.generalize
-                                                 =
-                                                 (env1.FStar_TypeChecker_Env.generalize);
-                                               FStar_TypeChecker_Env.letrecs
-                                                 =
-                                                 (env1.FStar_TypeChecker_Env.letrecs);
-                                               FStar_TypeChecker_Env.top_level
-                                                 =
-                                                 (env1.FStar_TypeChecker_Env.top_level);
-                                               FStar_TypeChecker_Env.check_uvars
-                                                 =
-                                                 (env1.FStar_TypeChecker_Env.check_uvars);
-                                               FStar_TypeChecker_Env.use_eq_strict
-                                                 =
-                                                 (env1.FStar_TypeChecker_Env.use_eq_strict);
-                                               FStar_TypeChecker_Env.is_iface
-                                                 =
-                                                 (env1.FStar_TypeChecker_Env.is_iface);
-                                               FStar_TypeChecker_Env.admit =
-                                                 (env1.FStar_TypeChecker_Env.admit);
-                                               FStar_TypeChecker_Env.lax =
-                                                 (env1.FStar_TypeChecker_Env.lax);
-                                               FStar_TypeChecker_Env.lax_universes
-                                                 =
-                                                 (env1.FStar_TypeChecker_Env.lax_universes);
-                                               FStar_TypeChecker_Env.phase1 =
-                                                 (env1.FStar_TypeChecker_Env.phase1);
-                                               FStar_TypeChecker_Env.failhard
-                                                 =
-                                                 (env1.FStar_TypeChecker_Env.failhard);
-                                               FStar_TypeChecker_Env.nosynth
-                                                 =
-                                                 (env1.FStar_TypeChecker_Env.nosynth);
-                                               FStar_TypeChecker_Env.uvar_subtyping
-                                                 =
-                                                 (env1.FStar_TypeChecker_Env.uvar_subtyping);
-                                               FStar_TypeChecker_Env.tc_term
-                                                 =
-                                                 (env1.FStar_TypeChecker_Env.tc_term);
-                                               FStar_TypeChecker_Env.typeof_tot_or_gtot_term
-                                                 =
-                                                 (env1.FStar_TypeChecker_Env.typeof_tot_or_gtot_term);
-                                               FStar_TypeChecker_Env.universe_of
-                                                 =
-                                                 (env1.FStar_TypeChecker_Env.universe_of);
-                                               FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term
-                                                 =
-                                                 (env1.FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term);
-                                               FStar_TypeChecker_Env.subtype_nosmt_force
-                                                 =
-                                                 (env1.FStar_TypeChecker_Env.subtype_nosmt_force);
-                                               FStar_TypeChecker_Env.use_bv_sorts
-                                                 =
-                                                 (env1.FStar_TypeChecker_Env.use_bv_sorts);
-                                               FStar_TypeChecker_Env.qtbl_name_and_index
-                                                 =
-                                                 (env1.FStar_TypeChecker_Env.qtbl_name_and_index);
-                                               FStar_TypeChecker_Env.normalized_eff_names
-                                                 =
-                                                 (env1.FStar_TypeChecker_Env.normalized_eff_names);
-                                               FStar_TypeChecker_Env.fv_delta_depths
-                                                 =
-                                                 (env1.FStar_TypeChecker_Env.fv_delta_depths);
-                                               FStar_TypeChecker_Env.proof_ns
-                                                 =
-                                                 (env1.FStar_TypeChecker_Env.proof_ns);
-                                               FStar_TypeChecker_Env.synth_hook
-                                                 =
-                                                 (env1.FStar_TypeChecker_Env.synth_hook);
-                                               FStar_TypeChecker_Env.try_solve_implicits_hook
-                                                 =
-                                                 (env1.FStar_TypeChecker_Env.try_solve_implicits_hook);
-                                               FStar_TypeChecker_Env.splice =
-                                                 (env1.FStar_TypeChecker_Env.splice);
-                                               FStar_TypeChecker_Env.mpreprocess
-                                                 =
-                                                 (env1.FStar_TypeChecker_Env.mpreprocess);
-                                               FStar_TypeChecker_Env.postprocess
-                                                 =
-                                                 (env1.FStar_TypeChecker_Env.postprocess);
-                                               FStar_TypeChecker_Env.identifier_info
-                                                 =
-                                                 (env1.FStar_TypeChecker_Env.identifier_info);
-                                               FStar_TypeChecker_Env.tc_hooks
-                                                 =
-                                                 (env1.FStar_TypeChecker_Env.tc_hooks);
-                                               FStar_TypeChecker_Env.dsenv =
-                                                 (env1.FStar_TypeChecker_Env.dsenv);
-                                               FStar_TypeChecker_Env.nbe =
-                                                 (env1.FStar_TypeChecker_Env.nbe);
-                                               FStar_TypeChecker_Env.strict_args_tab
-                                                 =
-                                                 (env1.FStar_TypeChecker_Env.strict_args_tab);
-                                               FStar_TypeChecker_Env.erasable_types_tab
-                                                 =
-                                                 (env1.FStar_TypeChecker_Env.erasable_types_tab);
-                                               FStar_TypeChecker_Env.enable_defer_to_tac
-                                                 =
-                                                 (env1.FStar_TypeChecker_Env.enable_defer_to_tac);
-                                               FStar_TypeChecker_Env.unif_allow_ref_guards
-                                                 =
-                                                 (env1.FStar_TypeChecker_Env.unif_allow_ref_guards);
-                                               FStar_TypeChecker_Env.erase_erasable_args
-                                                 =
-                                                 (env1.FStar_TypeChecker_Env.erase_erasable_args)
-                                             } in
-                                           let uu___10 =
-                                             is_base_type env2
-                                               ctx_u.FStar_Syntax_Syntax.ctx_uvar_typ in
-                                           if uu___10
-                                           then true
-                                           else
-                                             (let uu___12 =
-                                                env2.FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term
-                                                  env2 tm2 false in
-                                              match uu___12 with
-                                              | (tm_t, uu___13) ->
-                                                  let uu___14 =
-                                                    env2.FStar_TypeChecker_Env.subtype_nosmt_force
-                                                      env2 tm_t
-                                                      ctx_u.FStar_Syntax_Syntax.ctx_uvar_typ in
-                                                  if uu___14
-                                                  then true
-                                                  else
-                                                    (let compute t =
-                                                       FStar_TypeChecker_Normalize.normalize
-                                                         [FStar_TypeChecker_Env.UnfoldTac;
-                                                         FStar_TypeChecker_Env.UnfoldUntil
-                                                           FStar_Syntax_Syntax.delta_constant;
-                                                         FStar_TypeChecker_Env.Zeta;
-                                                         FStar_TypeChecker_Env.Iota;
-                                                         FStar_TypeChecker_Env.Primops]
-                                                         env2 t in
-                                                     let tm_t1 = compute tm_t in
-                                                     let uv_t =
-                                                       compute
-                                                         ctx_u.FStar_Syntax_Syntax.ctx_uvar_typ in
-                                                     let uu___16 =
-                                                       env2.FStar_TypeChecker_Env.subtype_nosmt_force
-                                                         env2 tm_t1 uv_t in
-                                                     if uu___16
-                                                     then true
-                                                     else
-                                                       ((let uu___19 =
-                                                           let uu___20 =
-                                                             FStar_TypeChecker_Env.get_range
-                                                               env2 in
-                                                           FStar_Compiler_Range.string_of_range
-                                                             uu___20 in
-                                                         let uu___20 =
-                                                           FStar_Syntax_Print.uvar_to_string
-                                                             ctx_u.FStar_Syntax_Syntax.ctx_uvar_head in
-                                                         let uu___21 =
-                                                           FStar_Syntax_Print.term_to_string
-                                                             ctx_u.FStar_Syntax_Syntax.ctx_uvar_typ in
-                                                         let uu___22 =
-                                                           FStar_Syntax_Print.term_to_string
-                                                             tm2 in
-                                                         let uu___23 =
-                                                           FStar_Syntax_Print.term_to_string
-                                                             tm_t1 in
-                                                         FStar_Compiler_Util.print5
-                                                           "(%s) Uvar solution for %s was not well-typed. Expected %s got %s : %s\n"
-                                                           uu___19 uu___20
-                                                           uu___21 uu___22
-                                                           uu___23);
-                                                        false)))))
-                                     else false in
-                                   if is_tac
-                                   then
-                                     let uu___9 = tm_ok_for_tac tm1 in
-                                     (if uu___9
-                                      then until_fixpoint (out, true) tl
-                                      else
-                                        until_fixpoint
-                                          (((hd1, Implicit_unresolved) ::
-                                            out), changed) tl)
+                                (let uu___5 = unresolved ctx_u in
+                                 if uu___5
+                                 then
+                                   (if flex_uvar_has_meta_tac ctx_u
+                                    then
+                                      let t = run_meta_arg_tac ctx_u in
+                                      let extra =
+                                        let uu___6 = teq_nosmt env t tm in
+                                        match uu___6 with
+                                        | FStar_Pervasives_Native.None ->
+                                            failwith
+                                              "resolve_implicits: unifying with an unresolved uvar failed?"
+                                        | FStar_Pervasives_Native.Some g1 ->
+                                            g1.FStar_TypeChecker_Common.implicits in
+                                      until_fixpoint (out, true)
+                                        (FStar_Compiler_List.op_At extra tl)
+                                    else
+                                      until_fixpoint
+                                        (((hd, Implicit_unresolved) :: out),
+                                          changed) tl)
+                                 else
+                                   if
+                                     uvar_decoration_should_check =
+                                       FStar_Syntax_Syntax.Allow_untyped
+                                   then until_fixpoint (out, true) tl
                                    else
-                                     (let force_univ_constraints = false in
-                                      let imps_opt =
-                                        check_implicit_solution_and_discharge_guard
-                                          env1 hd1 force_univ_constraints in
-                                      match imps_opt with
-                                      | FStar_Pervasives_Native.None ->
-                                          until_fixpoint
-                                            (((hd1,
-                                                Implicit_checking_defers_univ_constraint)
-                                              :: out), changed) tl
-                                      | FStar_Pervasives_Native.Some imps ->
-                                          let uu___10 =
-                                            let uu___11 =
-                                              let uu___12 =
+                                     (let env1 =
+                                        {
+                                          FStar_TypeChecker_Env.solver =
+                                            (env.FStar_TypeChecker_Env.solver);
+                                          FStar_TypeChecker_Env.range =
+                                            (env.FStar_TypeChecker_Env.range);
+                                          FStar_TypeChecker_Env.curmodule =
+                                            (env.FStar_TypeChecker_Env.curmodule);
+                                          FStar_TypeChecker_Env.gamma =
+                                            (ctx_u.FStar_Syntax_Syntax.ctx_uvar_gamma);
+                                          FStar_TypeChecker_Env.gamma_sig =
+                                            (env.FStar_TypeChecker_Env.gamma_sig);
+                                          FStar_TypeChecker_Env.gamma_cache =
+                                            (env.FStar_TypeChecker_Env.gamma_cache);
+                                          FStar_TypeChecker_Env.modules =
+                                            (env.FStar_TypeChecker_Env.modules);
+                                          FStar_TypeChecker_Env.expected_typ
+                                            =
+                                            (env.FStar_TypeChecker_Env.expected_typ);
+                                          FStar_TypeChecker_Env.sigtab =
+                                            (env.FStar_TypeChecker_Env.sigtab);
+                                          FStar_TypeChecker_Env.attrtab =
+                                            (env.FStar_TypeChecker_Env.attrtab);
+                                          FStar_TypeChecker_Env.instantiate_imp
+                                            =
+                                            (env.FStar_TypeChecker_Env.instantiate_imp);
+                                          FStar_TypeChecker_Env.effects =
+                                            (env.FStar_TypeChecker_Env.effects);
+                                          FStar_TypeChecker_Env.generalize =
+                                            (env.FStar_TypeChecker_Env.generalize);
+                                          FStar_TypeChecker_Env.letrecs =
+                                            (env.FStar_TypeChecker_Env.letrecs);
+                                          FStar_TypeChecker_Env.top_level =
+                                            (env.FStar_TypeChecker_Env.top_level);
+                                          FStar_TypeChecker_Env.check_uvars =
+                                            (env.FStar_TypeChecker_Env.check_uvars);
+                                          FStar_TypeChecker_Env.use_eq_strict
+                                            =
+                                            (env.FStar_TypeChecker_Env.use_eq_strict);
+                                          FStar_TypeChecker_Env.is_iface =
+                                            (env.FStar_TypeChecker_Env.is_iface);
+                                          FStar_TypeChecker_Env.admit =
+                                            (env.FStar_TypeChecker_Env.admit);
+                                          FStar_TypeChecker_Env.lax =
+                                            (env.FStar_TypeChecker_Env.lax);
+                                          FStar_TypeChecker_Env.lax_universes
+                                            =
+                                            (env.FStar_TypeChecker_Env.lax_universes);
+                                          FStar_TypeChecker_Env.phase1 =
+                                            (env.FStar_TypeChecker_Env.phase1);
+                                          FStar_TypeChecker_Env.failhard =
+                                            (env.FStar_TypeChecker_Env.failhard);
+                                          FStar_TypeChecker_Env.nosynth =
+                                            (env.FStar_TypeChecker_Env.nosynth);
+                                          FStar_TypeChecker_Env.uvar_subtyping
+                                            =
+                                            (env.FStar_TypeChecker_Env.uvar_subtyping);
+                                          FStar_TypeChecker_Env.tc_term =
+                                            (env.FStar_TypeChecker_Env.tc_term);
+                                          FStar_TypeChecker_Env.typeof_tot_or_gtot_term
+                                            =
+                                            (env.FStar_TypeChecker_Env.typeof_tot_or_gtot_term);
+                                          FStar_TypeChecker_Env.universe_of =
+                                            (env.FStar_TypeChecker_Env.universe_of);
+                                          FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term
+                                            =
+                                            (env.FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term);
+                                          FStar_TypeChecker_Env.subtype_nosmt_force
+                                            =
+                                            (env.FStar_TypeChecker_Env.subtype_nosmt_force);
+                                          FStar_TypeChecker_Env.use_bv_sorts
+                                            =
+                                            (env.FStar_TypeChecker_Env.use_bv_sorts);
+                                          FStar_TypeChecker_Env.qtbl_name_and_index
+                                            =
+                                            (env.FStar_TypeChecker_Env.qtbl_name_and_index);
+                                          FStar_TypeChecker_Env.normalized_eff_names
+                                            =
+                                            (env.FStar_TypeChecker_Env.normalized_eff_names);
+                                          FStar_TypeChecker_Env.fv_delta_depths
+                                            =
+                                            (env.FStar_TypeChecker_Env.fv_delta_depths);
+                                          FStar_TypeChecker_Env.proof_ns =
+                                            (env.FStar_TypeChecker_Env.proof_ns);
+                                          FStar_TypeChecker_Env.synth_hook =
+                                            (env.FStar_TypeChecker_Env.synth_hook);
+                                          FStar_TypeChecker_Env.try_solve_implicits_hook
+                                            =
+                                            (env.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                                          FStar_TypeChecker_Env.splice =
+                                            (env.FStar_TypeChecker_Env.splice);
+                                          FStar_TypeChecker_Env.mpreprocess =
+                                            (env.FStar_TypeChecker_Env.mpreprocess);
+                                          FStar_TypeChecker_Env.postprocess =
+                                            (env.FStar_TypeChecker_Env.postprocess);
+                                          FStar_TypeChecker_Env.identifier_info
+                                            =
+                                            (env.FStar_TypeChecker_Env.identifier_info);
+                                          FStar_TypeChecker_Env.tc_hooks =
+                                            (env.FStar_TypeChecker_Env.tc_hooks);
+                                          FStar_TypeChecker_Env.dsenv =
+                                            (env.FStar_TypeChecker_Env.dsenv);
+                                          FStar_TypeChecker_Env.nbe =
+                                            (env.FStar_TypeChecker_Env.nbe);
+                                          FStar_TypeChecker_Env.strict_args_tab
+                                            =
+                                            (env.FStar_TypeChecker_Env.strict_args_tab);
+                                          FStar_TypeChecker_Env.erasable_types_tab
+                                            =
+                                            (env.FStar_TypeChecker_Env.erasable_types_tab);
+                                          FStar_TypeChecker_Env.enable_defer_to_tac
+                                            =
+                                            (env.FStar_TypeChecker_Env.enable_defer_to_tac);
+                                          FStar_TypeChecker_Env.unif_allow_ref_guards
+                                            =
+                                            (env.FStar_TypeChecker_Env.unif_allow_ref_guards);
+                                          FStar_TypeChecker_Env.erase_erasable_args
+                                            =
+                                            (env.FStar_TypeChecker_Env.erase_erasable_args)
+                                        } in
+                                      (let uu___9 =
+                                         FStar_Compiler_Effect.op_Less_Bar
+                                           (FStar_TypeChecker_Env.debug env1)
+                                           (FStar_Options.Other "Rel") in
+                                       if uu___9
+                                       then
+                                         let uu___10 =
+                                           FStar_Syntax_Print.term_to_string
+                                             tm in
+                                         let uu___11 =
+                                           FStar_Syntax_Print.ctx_uvar_to_string
+                                             ctx_u in
+                                         FStar_Compiler_Util.print2
+                                           "resolve_implicits' loop before norm, imp_tm = %s and ctx_u = %s\n"
+                                           uu___10 uu___11
+                                       else ());
+                                      (let tm1 =
+                                         norm_with_steps
+                                           "FStar.TypeChecker.Rel.norm_with_steps.8"
+                                           [FStar_TypeChecker_Env.Beta] env1
+                                           tm in
+                                       (let uu___10 =
+                                          FStar_Compiler_Effect.op_Less_Bar
+                                            (FStar_TypeChecker_Env.debug env1)
+                                            (FStar_Options.Other "Rel") in
+                                        if uu___10
+                                        then
+                                          let uu___11 =
+                                            FStar_Syntax_Print.term_to_string
+                                              tm1 in
+                                          let uu___12 =
+                                            FStar_Syntax_Print.ctx_uvar_to_string
+                                              ctx_u in
+                                          FStar_Compiler_Util.print2
+                                            "resolve_implicits' loop after norm, imp_tm = %s and ctx_u = %s\n"
+                                            uu___11 uu___12
+                                        else ());
+                                       (let hd1 =
+                                          {
+                                            FStar_TypeChecker_Common.imp_reason
+                                              =
+                                              (hd.FStar_TypeChecker_Common.imp_reason);
+                                            FStar_TypeChecker_Common.imp_uvar
+                                              =
+                                              (hd.FStar_TypeChecker_Common.imp_uvar);
+                                            FStar_TypeChecker_Common.imp_tm =
+                                              tm1;
+                                            FStar_TypeChecker_Common.imp_range
+                                              =
+                                              (hd.FStar_TypeChecker_Common.imp_range)
+                                          } in
+                                        let tm_ok_for_tac tm2 =
+                                          let no_unresolved =
+                                            let uu___10 =
+                                              let uu___11 =
                                                 FStar_Compiler_Effect.op_Bar_Greater
-                                                  imps
-                                                  (FStar_Compiler_List.map
-                                                     (fun imp ->
-                                                        (imp,
-                                                          Implicit_unresolved))) in
-                                              FStar_Compiler_List.op_At
-                                                uu___12 out in
-                                            (uu___11, true) in
-                                          until_fixpoint uu___10 tl)))))))) in
+                                                  tm2 FStar_Syntax_Free.uvars in
+                                              FStar_Compiler_Effect.op_Bar_Greater
+                                                uu___11
+                                                FStar_Compiler_Util.set_elements in
+                                            FStar_Compiler_Effect.op_Bar_Greater
+                                              uu___10
+                                              (FStar_Compiler_List.for_all
+                                                 (fun uv ->
+                                                    let uu___11 =
+                                                      FStar_Syntax_Util.ctx_uvar_should_check
+                                                        uv in
+                                                    uu___11 =
+                                                      FStar_Syntax_Syntax.Allow_unresolved)) in
+                                          if no_unresolved
+                                          then
+                                            (if
+                                               env1.FStar_TypeChecker_Env.phase1
+                                             then true
+                                             else
+                                               (let env2 =
+                                                  {
+                                                    FStar_TypeChecker_Env.solver
+                                                      =
+                                                      (env1.FStar_TypeChecker_Env.solver);
+                                                    FStar_TypeChecker_Env.range
+                                                      =
+                                                      (env1.FStar_TypeChecker_Env.range);
+                                                    FStar_TypeChecker_Env.curmodule
+                                                      =
+                                                      (env1.FStar_TypeChecker_Env.curmodule);
+                                                    FStar_TypeChecker_Env.gamma
+                                                      =
+                                                      (ctx_u.FStar_Syntax_Syntax.ctx_uvar_gamma);
+                                                    FStar_TypeChecker_Env.gamma_sig
+                                                      =
+                                                      (env1.FStar_TypeChecker_Env.gamma_sig);
+                                                    FStar_TypeChecker_Env.gamma_cache
+                                                      =
+                                                      (env1.FStar_TypeChecker_Env.gamma_cache);
+                                                    FStar_TypeChecker_Env.modules
+                                                      =
+                                                      (env1.FStar_TypeChecker_Env.modules);
+                                                    FStar_TypeChecker_Env.expected_typ
+                                                      =
+                                                      (env1.FStar_TypeChecker_Env.expected_typ);
+                                                    FStar_TypeChecker_Env.sigtab
+                                                      =
+                                                      (env1.FStar_TypeChecker_Env.sigtab);
+                                                    FStar_TypeChecker_Env.attrtab
+                                                      =
+                                                      (env1.FStar_TypeChecker_Env.attrtab);
+                                                    FStar_TypeChecker_Env.instantiate_imp
+                                                      =
+                                                      (env1.FStar_TypeChecker_Env.instantiate_imp);
+                                                    FStar_TypeChecker_Env.effects
+                                                      =
+                                                      (env1.FStar_TypeChecker_Env.effects);
+                                                    FStar_TypeChecker_Env.generalize
+                                                      =
+                                                      (env1.FStar_TypeChecker_Env.generalize);
+                                                    FStar_TypeChecker_Env.letrecs
+                                                      =
+                                                      (env1.FStar_TypeChecker_Env.letrecs);
+                                                    FStar_TypeChecker_Env.top_level
+                                                      =
+                                                      (env1.FStar_TypeChecker_Env.top_level);
+                                                    FStar_TypeChecker_Env.check_uvars
+                                                      =
+                                                      (env1.FStar_TypeChecker_Env.check_uvars);
+                                                    FStar_TypeChecker_Env.use_eq_strict
+                                                      =
+                                                      (env1.FStar_TypeChecker_Env.use_eq_strict);
+                                                    FStar_TypeChecker_Env.is_iface
+                                                      =
+                                                      (env1.FStar_TypeChecker_Env.is_iface);
+                                                    FStar_TypeChecker_Env.admit
+                                                      =
+                                                      (env1.FStar_TypeChecker_Env.admit);
+                                                    FStar_TypeChecker_Env.lax
+                                                      =
+                                                      (env1.FStar_TypeChecker_Env.lax);
+                                                    FStar_TypeChecker_Env.lax_universes
+                                                      =
+                                                      (env1.FStar_TypeChecker_Env.lax_universes);
+                                                    FStar_TypeChecker_Env.phase1
+                                                      =
+                                                      (env1.FStar_TypeChecker_Env.phase1);
+                                                    FStar_TypeChecker_Env.failhard
+                                                      =
+                                                      (env1.FStar_TypeChecker_Env.failhard);
+                                                    FStar_TypeChecker_Env.nosynth
+                                                      =
+                                                      (env1.FStar_TypeChecker_Env.nosynth);
+                                                    FStar_TypeChecker_Env.uvar_subtyping
+                                                      =
+                                                      (env1.FStar_TypeChecker_Env.uvar_subtyping);
+                                                    FStar_TypeChecker_Env.tc_term
+                                                      =
+                                                      (env1.FStar_TypeChecker_Env.tc_term);
+                                                    FStar_TypeChecker_Env.typeof_tot_or_gtot_term
+                                                      =
+                                                      (env1.FStar_TypeChecker_Env.typeof_tot_or_gtot_term);
+                                                    FStar_TypeChecker_Env.universe_of
+                                                      =
+                                                      (env1.FStar_TypeChecker_Env.universe_of);
+                                                    FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term
+                                                      =
+                                                      (env1.FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term);
+                                                    FStar_TypeChecker_Env.subtype_nosmt_force
+                                                      =
+                                                      (env1.FStar_TypeChecker_Env.subtype_nosmt_force);
+                                                    FStar_TypeChecker_Env.use_bv_sorts
+                                                      =
+                                                      (env1.FStar_TypeChecker_Env.use_bv_sorts);
+                                                    FStar_TypeChecker_Env.qtbl_name_and_index
+                                                      =
+                                                      (env1.FStar_TypeChecker_Env.qtbl_name_and_index);
+                                                    FStar_TypeChecker_Env.normalized_eff_names
+                                                      =
+                                                      (env1.FStar_TypeChecker_Env.normalized_eff_names);
+                                                    FStar_TypeChecker_Env.fv_delta_depths
+                                                      =
+                                                      (env1.FStar_TypeChecker_Env.fv_delta_depths);
+                                                    FStar_TypeChecker_Env.proof_ns
+                                                      =
+                                                      (env1.FStar_TypeChecker_Env.proof_ns);
+                                                    FStar_TypeChecker_Env.synth_hook
+                                                      =
+                                                      (env1.FStar_TypeChecker_Env.synth_hook);
+                                                    FStar_TypeChecker_Env.try_solve_implicits_hook
+                                                      =
+                                                      (env1.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                                                    FStar_TypeChecker_Env.splice
+                                                      =
+                                                      (env1.FStar_TypeChecker_Env.splice);
+                                                    FStar_TypeChecker_Env.mpreprocess
+                                                      =
+                                                      (env1.FStar_TypeChecker_Env.mpreprocess);
+                                                    FStar_TypeChecker_Env.postprocess
+                                                      =
+                                                      (env1.FStar_TypeChecker_Env.postprocess);
+                                                    FStar_TypeChecker_Env.identifier_info
+                                                      =
+                                                      (env1.FStar_TypeChecker_Env.identifier_info);
+                                                    FStar_TypeChecker_Env.tc_hooks
+                                                      =
+                                                      (env1.FStar_TypeChecker_Env.tc_hooks);
+                                                    FStar_TypeChecker_Env.dsenv
+                                                      =
+                                                      (env1.FStar_TypeChecker_Env.dsenv);
+                                                    FStar_TypeChecker_Env.nbe
+                                                      =
+                                                      (env1.FStar_TypeChecker_Env.nbe);
+                                                    FStar_TypeChecker_Env.strict_args_tab
+                                                      =
+                                                      (env1.FStar_TypeChecker_Env.strict_args_tab);
+                                                    FStar_TypeChecker_Env.erasable_types_tab
+                                                      =
+                                                      (env1.FStar_TypeChecker_Env.erasable_types_tab);
+                                                    FStar_TypeChecker_Env.enable_defer_to_tac
+                                                      =
+                                                      (env1.FStar_TypeChecker_Env.enable_defer_to_tac);
+                                                    FStar_TypeChecker_Env.unif_allow_ref_guards
+                                                      =
+                                                      (env1.FStar_TypeChecker_Env.unif_allow_ref_guards);
+                                                    FStar_TypeChecker_Env.erase_erasable_args
+                                                      =
+                                                      (env1.FStar_TypeChecker_Env.erase_erasable_args)
+                                                  } in
+                                                let uu___11 =
+                                                  is_base_type env2
+                                                    uvar_decoration_typ in
+                                                if uu___11
+                                                then true
+                                                else
+                                                  (let uu___13 =
+                                                     FStar_Profiling.profile
+                                                       (fun uu___14 ->
+                                                          env2.FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term
+                                                            env2 tm2 false)
+                                                       FStar_Pervasives_Native.None
+                                                       "retype_tactic_solution" in
+                                                   match uu___13 with
+                                                   | (tm_t, uu___14) ->
+                                                       let uu___15 =
+                                                         FStar_Profiling.profile
+                                                           (fun uu___16 ->
+                                                              env2.FStar_TypeChecker_Env.subtype_nosmt_force
+                                                                env2 tm_t
+                                                                uvar_decoration_typ)
+                                                           FStar_Pervasives_Native.None
+                                                           "subtype_tactic_solution" in
+                                                       if uu___15
+                                                       then true
+                                                       else
+                                                         (let compute t =
+                                                            FStar_TypeChecker_Normalize.normalize
+                                                              [FStar_TypeChecker_Env.UnfoldTac;
+                                                              FStar_TypeChecker_Env.UnfoldUntil
+                                                                FStar_Syntax_Syntax.delta_constant;
+                                                              FStar_TypeChecker_Env.Zeta;
+                                                              FStar_TypeChecker_Env.Iota;
+                                                              FStar_TypeChecker_Env.Primops]
+                                                              env2 t in
+                                                          let tm_t1 =
+                                                            compute tm_t in
+                                                          let uv_t =
+                                                            compute
+                                                              uvar_decoration_typ in
+                                                          let uu___17 =
+                                                            env2.FStar_TypeChecker_Env.subtype_nosmt_force
+                                                              env2 tm_t1 uv_t in
+                                                          if uu___17
+                                                          then true
+                                                          else
+                                                            ((let uu___20 =
+                                                                let uu___21 =
+                                                                  FStar_TypeChecker_Env.get_range
+                                                                    env2 in
+                                                                FStar_Compiler_Range.string_of_range
+                                                                  uu___21 in
+                                                              let uu___21 =
+                                                                FStar_Syntax_Print.uvar_to_string
+                                                                  ctx_u.FStar_Syntax_Syntax.ctx_uvar_head in
+                                                              let uu___22 =
+                                                                FStar_Syntax_Print.term_to_string
+                                                                  uvar_decoration_typ in
+                                                              let uu___23 =
+                                                                FStar_Syntax_Print.term_to_string
+                                                                  tm2 in
+                                                              let uu___24 =
+                                                                FStar_Syntax_Print.term_to_string
+                                                                  tm_t1 in
+                                                              FStar_Compiler_Util.print5
+                                                                "(%s) Uvar solution for %s was not well-typed. Expected %s got %s : %s\n"
+                                                                uu___20
+                                                                uu___21
+                                                                uu___22
+                                                                uu___23
+                                                                uu___24);
+                                                             false)))))
+                                          else false in
+                                        if is_tac
+                                        then
+                                          let uu___10 = tm_ok_for_tac tm1 in
+                                          (if uu___10
+                                           then until_fixpoint (out, true) tl
+                                           else
+                                             until_fixpoint
+                                               (((hd1, Implicit_unresolved)
+                                                 :: out), changed) tl)
+                                        else
+                                          (let force_univ_constraints = false in
+                                           let imps_opt =
+                                             check_implicit_solution_and_discharge_guard
+                                               env1 hd1
+                                               force_univ_constraints in
+                                           match imps_opt with
+                                           | FStar_Pervasives_Native.None ->
+                                               until_fixpoint
+                                                 (((hd1,
+                                                     Implicit_checking_defers_univ_constraint)
+                                                   :: out), changed) tl
+                                           | FStar_Pervasives_Native.Some
+                                               imps ->
+                                               let uu___11 =
+                                                 let uu___12 =
+                                                   let uu___13 =
+                                                     FStar_Compiler_Effect.op_Bar_Greater
+                                                       imps
+                                                       (FStar_Compiler_List.map
+                                                          (fun imp ->
+                                                             (imp,
+                                                               Implicit_unresolved))) in
+                                                   FStar_Compiler_List.op_At
+                                                     uu___13 out in
+                                                 (uu___12, true) in
+                                               until_fixpoint uu___11 tl))))))))) in
         let imps =
           FStar_Compiler_Effect.op_Bar_Greater
             g.FStar_TypeChecker_Common.implicits (until_fixpoint ([], false)) in

--- a/src/ocaml-output/FStar_TypeChecker_Rel.ml
+++ b/src/ocaml-output/FStar_TypeChecker_Rel.ml
@@ -1,4 +1,22 @@
 open Prims
+let (is_base_type :
+  FStar_TypeChecker_Env.env -> FStar_Syntax_Syntax.typ -> Prims.bool) =
+  fun env ->
+    fun typ ->
+      let t = FStar_TypeChecker_Normalize.unfold_whnf env typ in
+      let uu___ = FStar_Syntax_Util.head_and_args t in
+      match uu___ with
+      | (head, args) ->
+          let uu___1 =
+            let uu___2 =
+              let uu___3 = FStar_Syntax_Util.un_uinst head in
+              FStar_Syntax_Util.unascribe uu___3 in
+            uu___2.FStar_Syntax_Syntax.n in
+          (match uu___1 with
+           | FStar_Syntax_Syntax.Tm_name uu___2 -> true
+           | FStar_Syntax_Syntax.Tm_fvar uu___2 -> true
+           | FStar_Syntax_Syntax.Tm_type uu___2 -> true
+           | uu___2 -> false)
 let (print_ctx_uvar : FStar_Syntax_Syntax.ctx_uvar -> Prims.string) =
   fun ctx_uvar -> FStar_Syntax_Print.ctx_uvar_to_string ctx_uvar
 let (binders_as_bv_set :
@@ -14326,34 +14344,40 @@ let (resolve_implicits' :
                                                  (env1.FStar_TypeChecker_Env.erase_erasable_args)
                                              } in
                                            let uu___10 =
-                                             env2.FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term
-                                               env2 tm2 false in
-                                           match uu___10 with
-                                           | (tm_t, uu___11) ->
-                                               let uu___12 =
-                                                 env2.FStar_TypeChecker_Env.subtype_nosmt_force
-                                                   env2 tm_t
-                                                   ctx_u.FStar_Syntax_Syntax.ctx_uvar_typ in
-                                               if uu___12
-                                               then true
-                                               else
-                                                 ((let uu___15 =
-                                                     FStar_Syntax_Print.uvar_to_string
-                                                       ctx_u.FStar_Syntax_Syntax.ctx_uvar_head in
-                                                   let uu___16 =
-                                                     FStar_Syntax_Print.term_to_string
-                                                       ctx_u.FStar_Syntax_Syntax.ctx_uvar_typ in
-                                                   let uu___17 =
-                                                     FStar_Syntax_Print.term_to_string
-                                                       tm2 in
-                                                   let uu___18 =
-                                                     FStar_Syntax_Print.term_to_string
-                                                       tm_t in
-                                                   FStar_Compiler_Util.print4
-                                                     "Uvar solution for %s was not well-typed. Expected %s got %s : %s\n"
-                                                     uu___15 uu___16 uu___17
-                                                     uu___18);
-                                                  false)))
+                                             is_base_type env2
+                                               ctx_u.FStar_Syntax_Syntax.ctx_uvar_typ in
+                                           if uu___10
+                                           then true
+                                           else
+                                             (let uu___12 =
+                                                env2.FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term
+                                                  env2 tm2 false in
+                                              match uu___12 with
+                                              | (tm_t, uu___13) ->
+                                                  let uu___14 =
+                                                    env2.FStar_TypeChecker_Env.subtype_nosmt_force
+                                                      env2 tm_t
+                                                      ctx_u.FStar_Syntax_Syntax.ctx_uvar_typ in
+                                                  if uu___14
+                                                  then true
+                                                  else
+                                                    ((let uu___17 =
+                                                        FStar_Syntax_Print.uvar_to_string
+                                                          ctx_u.FStar_Syntax_Syntax.ctx_uvar_head in
+                                                      let uu___18 =
+                                                        FStar_Syntax_Print.term_to_string
+                                                          ctx_u.FStar_Syntax_Syntax.ctx_uvar_typ in
+                                                      let uu___19 =
+                                                        FStar_Syntax_Print.term_to_string
+                                                          tm2 in
+                                                      let uu___20 =
+                                                        FStar_Syntax_Print.term_to_string
+                                                          tm_t in
+                                                      FStar_Compiler_Util.print4
+                                                        "Uvar solution for %s was not well-typed. Expected %s got %s : %s\n"
+                                                        uu___17 uu___18
+                                                        uu___19 uu___20);
+                                                     false))))
                                      else false in
                                    if is_tac
                                    then

--- a/src/ocaml-output/FStar_TypeChecker_Rel.ml
+++ b/src/ocaml-output/FStar_TypeChecker_Rel.ml
@@ -13954,6 +13954,178 @@ let (pick_a_univ_deffered_implicit :
                  (FStar_Compiler_List.op_At tl rest)
                  (FStar_Compiler_List.map FStar_Pervasives_Native.fst) in
              (uu___1, uu___2))
+let (is_implicit_resolved :
+  FStar_TypeChecker_Env.env ->
+    FStar_TypeChecker_Common.implicit -> Prims.bool)
+  =
+  fun env ->
+    fun i ->
+      let uu___ =
+        let uu___1 =
+          FStar_Compiler_Effect.op_Bar_Greater
+            i.FStar_TypeChecker_Common.imp_tm FStar_Syntax_Free.uvars in
+        FStar_Compiler_Effect.op_Bar_Greater uu___1
+          FStar_Compiler_Util.set_elements in
+      FStar_Compiler_Effect.op_Bar_Greater uu___
+        (FStar_Compiler_List.for_all
+           (fun uv ->
+              let uu___1 = FStar_Syntax_Util.ctx_uvar_should_check uv in
+              uu___1 = FStar_Syntax_Syntax.Allow_unresolved))
+let (check_implicit_solution_for_tac :
+  FStar_TypeChecker_Env.env ->
+    FStar_TypeChecker_Common.implicit -> Prims.bool)
+  =
+  fun env ->
+    fun i ->
+      let uu___ = i in
+      match uu___ with
+      | { FStar_TypeChecker_Common.imp_reason = reason;
+          FStar_TypeChecker_Common.imp_uvar = ctx_u;
+          FStar_TypeChecker_Common.imp_tm = tm;
+          FStar_TypeChecker_Common.imp_range = r;_} ->
+          let uvar_ty = FStar_Syntax_Util.ctx_uvar_typ ctx_u in
+          let uvar_should_check =
+            FStar_Syntax_Util.ctx_uvar_should_check ctx_u in
+          let uu___1 =
+            (uvar_should_check = FStar_Syntax_Syntax.Allow_untyped) ||
+              (is_base_type env uvar_ty) in
+          if uu___1
+          then true
+          else
+            (let env1 =
+               {
+                 FStar_TypeChecker_Env.solver =
+                   (env.FStar_TypeChecker_Env.solver);
+                 FStar_TypeChecker_Env.range =
+                   (env.FStar_TypeChecker_Env.range);
+                 FStar_TypeChecker_Env.curmodule =
+                   (env.FStar_TypeChecker_Env.curmodule);
+                 FStar_TypeChecker_Env.gamma =
+                   (ctx_u.FStar_Syntax_Syntax.ctx_uvar_gamma);
+                 FStar_TypeChecker_Env.gamma_sig =
+                   (env.FStar_TypeChecker_Env.gamma_sig);
+                 FStar_TypeChecker_Env.gamma_cache =
+                   (env.FStar_TypeChecker_Env.gamma_cache);
+                 FStar_TypeChecker_Env.modules =
+                   (env.FStar_TypeChecker_Env.modules);
+                 FStar_TypeChecker_Env.expected_typ =
+                   (env.FStar_TypeChecker_Env.expected_typ);
+                 FStar_TypeChecker_Env.sigtab =
+                   (env.FStar_TypeChecker_Env.sigtab);
+                 FStar_TypeChecker_Env.attrtab =
+                   (env.FStar_TypeChecker_Env.attrtab);
+                 FStar_TypeChecker_Env.instantiate_imp =
+                   (env.FStar_TypeChecker_Env.instantiate_imp);
+                 FStar_TypeChecker_Env.effects =
+                   (env.FStar_TypeChecker_Env.effects);
+                 FStar_TypeChecker_Env.generalize =
+                   (env.FStar_TypeChecker_Env.generalize);
+                 FStar_TypeChecker_Env.letrecs =
+                   (env.FStar_TypeChecker_Env.letrecs);
+                 FStar_TypeChecker_Env.top_level =
+                   (env.FStar_TypeChecker_Env.top_level);
+                 FStar_TypeChecker_Env.check_uvars =
+                   (env.FStar_TypeChecker_Env.check_uvars);
+                 FStar_TypeChecker_Env.use_eq_strict =
+                   (env.FStar_TypeChecker_Env.use_eq_strict);
+                 FStar_TypeChecker_Env.is_iface =
+                   (env.FStar_TypeChecker_Env.is_iface);
+                 FStar_TypeChecker_Env.admit =
+                   (env.FStar_TypeChecker_Env.admit);
+                 FStar_TypeChecker_Env.lax = (env.FStar_TypeChecker_Env.lax);
+                 FStar_TypeChecker_Env.lax_universes =
+                   (env.FStar_TypeChecker_Env.lax_universes);
+                 FStar_TypeChecker_Env.phase1 =
+                   (env.FStar_TypeChecker_Env.phase1);
+                 FStar_TypeChecker_Env.failhard =
+                   (env.FStar_TypeChecker_Env.failhard);
+                 FStar_TypeChecker_Env.nosynth =
+                   (env.FStar_TypeChecker_Env.nosynth);
+                 FStar_TypeChecker_Env.uvar_subtyping =
+                   (env.FStar_TypeChecker_Env.uvar_subtyping);
+                 FStar_TypeChecker_Env.tc_term =
+                   (env.FStar_TypeChecker_Env.tc_term);
+                 FStar_TypeChecker_Env.typeof_tot_or_gtot_term =
+                   (env.FStar_TypeChecker_Env.typeof_tot_or_gtot_term);
+                 FStar_TypeChecker_Env.universe_of =
+                   (env.FStar_TypeChecker_Env.universe_of);
+                 FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term =
+                   (env.FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term);
+                 FStar_TypeChecker_Env.subtype_nosmt_force =
+                   (env.FStar_TypeChecker_Env.subtype_nosmt_force);
+                 FStar_TypeChecker_Env.use_bv_sorts =
+                   (env.FStar_TypeChecker_Env.use_bv_sorts);
+                 FStar_TypeChecker_Env.qtbl_name_and_index =
+                   (env.FStar_TypeChecker_Env.qtbl_name_and_index);
+                 FStar_TypeChecker_Env.normalized_eff_names =
+                   (env.FStar_TypeChecker_Env.normalized_eff_names);
+                 FStar_TypeChecker_Env.fv_delta_depths =
+                   (env.FStar_TypeChecker_Env.fv_delta_depths);
+                 FStar_TypeChecker_Env.proof_ns =
+                   (env.FStar_TypeChecker_Env.proof_ns);
+                 FStar_TypeChecker_Env.synth_hook =
+                   (env.FStar_TypeChecker_Env.synth_hook);
+                 FStar_TypeChecker_Env.try_solve_implicits_hook =
+                   (env.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                 FStar_TypeChecker_Env.splice =
+                   (env.FStar_TypeChecker_Env.splice);
+                 FStar_TypeChecker_Env.mpreprocess =
+                   (env.FStar_TypeChecker_Env.mpreprocess);
+                 FStar_TypeChecker_Env.postprocess =
+                   (env.FStar_TypeChecker_Env.postprocess);
+                 FStar_TypeChecker_Env.identifier_info =
+                   (env.FStar_TypeChecker_Env.identifier_info);
+                 FStar_TypeChecker_Env.tc_hooks =
+                   (env.FStar_TypeChecker_Env.tc_hooks);
+                 FStar_TypeChecker_Env.dsenv =
+                   (env.FStar_TypeChecker_Env.dsenv);
+                 FStar_TypeChecker_Env.nbe = (env.FStar_TypeChecker_Env.nbe);
+                 FStar_TypeChecker_Env.strict_args_tab =
+                   (env.FStar_TypeChecker_Env.strict_args_tab);
+                 FStar_TypeChecker_Env.erasable_types_tab =
+                   (env.FStar_TypeChecker_Env.erasable_types_tab);
+                 FStar_TypeChecker_Env.enable_defer_to_tac =
+                   (env.FStar_TypeChecker_Env.enable_defer_to_tac);
+                 FStar_TypeChecker_Env.unif_allow_ref_guards =
+                   (env.FStar_TypeChecker_Env.unif_allow_ref_guards);
+                 FStar_TypeChecker_Env.erase_erasable_args =
+                   (env.FStar_TypeChecker_Env.erase_erasable_args)
+               } in
+             let uu___3 =
+               FStar_Profiling.profile
+                 (fun uu___4 ->
+                    env1.FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term
+                      env1 tm false) FStar_Pervasives_Native.None
+                 "retype_tactic_solution" in
+             match uu___3 with
+             | (tm_t, uu___4) ->
+                 let uu___5 =
+                   FStar_Profiling.profile
+                     (fun uu___6 ->
+                        env1.FStar_TypeChecker_Env.subtype_nosmt_force env1
+                          tm_t uvar_ty) FStar_Pervasives_Native.None
+                     "subtype_tactic_solution" in
+                 if uu___5
+                 then true
+                 else
+                   ((let uu___8 = FStar_Options.debug_any () in
+                     if uu___8
+                     then
+                       let uu___9 =
+                         let uu___10 = FStar_TypeChecker_Env.get_range env1 in
+                         FStar_Compiler_Range.string_of_range uu___10 in
+                       let uu___10 =
+                         FStar_Syntax_Print.uvar_to_string
+                           ctx_u.FStar_Syntax_Syntax.ctx_uvar_head in
+                       let uu___11 =
+                         FStar_Syntax_Print.term_to_string uvar_ty in
+                       let uu___12 = FStar_Syntax_Print.term_to_string tm in
+                       let uu___13 = FStar_Syntax_Print.term_to_string tm_t in
+                       FStar_Compiler_Util.print5
+                         "(%s) Uvar solution for %s was not well-typed. Expected %s got %s : %s\n"
+                         uu___9 uu___10 uu___11 uu___12 uu___13
+                     else ());
+                    false))
 let (resolve_implicits' :
   FStar_TypeChecker_Env.env ->
     Prims.bool ->
@@ -14181,326 +14353,71 @@ let (resolve_implicits' :
                                             =
                                             (env.FStar_TypeChecker_Env.erase_erasable_args)
                                         } in
-                                      (let uu___9 =
-                                         FStar_Compiler_Effect.op_Less_Bar
-                                           (FStar_TypeChecker_Env.debug env1)
-                                           (FStar_Options.Other "Rel") in
-                                       if uu___9
-                                       then
-                                         let uu___10 =
-                                           FStar_Syntax_Print.term_to_string
-                                             tm in
-                                         let uu___11 =
-                                           FStar_Syntax_Print.ctx_uvar_to_string
-                                             ctx_u in
-                                         FStar_Compiler_Util.print2
-                                           "resolve_implicits' loop before norm, imp_tm = %s and ctx_u = %s\n"
-                                           uu___10 uu___11
-                                       else ());
-                                      (let tm1 =
-                                         norm_with_steps
-                                           "FStar.TypeChecker.Rel.norm_with_steps.8"
-                                           [FStar_TypeChecker_Env.Beta] env1
-                                           tm in
-                                       (let uu___10 =
-                                          FStar_Compiler_Effect.op_Less_Bar
-                                            (FStar_TypeChecker_Env.debug env1)
-                                            (FStar_Options.Other "Rel") in
-                                        if uu___10
+                                      let tm1 =
+                                        norm_with_steps
+                                          "FStar.TypeChecker.Rel.norm_with_steps.8"
+                                          [FStar_TypeChecker_Env.Beta] env1
+                                          tm in
+                                      let hd1 =
+                                        {
+                                          FStar_TypeChecker_Common.imp_reason
+                                            =
+                                            (hd.FStar_TypeChecker_Common.imp_reason);
+                                          FStar_TypeChecker_Common.imp_uvar =
+                                            (hd.FStar_TypeChecker_Common.imp_uvar);
+                                          FStar_TypeChecker_Common.imp_tm =
+                                            tm1;
+                                          FStar_TypeChecker_Common.imp_range
+                                            =
+                                            (hd.FStar_TypeChecker_Common.imp_range)
+                                        } in
+                                      let tm_ok_for_tac uu___8 =
+                                        let uu___9 =
+                                          is_implicit_resolved env1 hd1 in
+                                        if uu___9
                                         then
-                                          let uu___11 =
-                                            FStar_Syntax_Print.term_to_string
-                                              tm1 in
-                                          let uu___12 =
-                                            FStar_Syntax_Print.ctx_uvar_to_string
-                                              ctx_u in
-                                          FStar_Compiler_Util.print2
-                                            "resolve_implicits' loop after norm, imp_tm = %s and ctx_u = %s\n"
-                                            uu___11 uu___12
-                                        else ());
-                                       (let hd1 =
-                                          {
-                                            FStar_TypeChecker_Common.imp_reason
-                                              =
-                                              (hd.FStar_TypeChecker_Common.imp_reason);
-                                            FStar_TypeChecker_Common.imp_uvar
-                                              =
-                                              (hd.FStar_TypeChecker_Common.imp_uvar);
-                                            FStar_TypeChecker_Common.imp_tm =
-                                              tm1;
-                                            FStar_TypeChecker_Common.imp_range
-                                              =
-                                              (hd.FStar_TypeChecker_Common.imp_range)
-                                          } in
-                                        let tm_ok_for_tac tm2 =
-                                          let no_unresolved =
-                                            let uu___10 =
-                                              let uu___11 =
-                                                FStar_Compiler_Effect.op_Bar_Greater
-                                                  tm2 FStar_Syntax_Free.uvars in
-                                              FStar_Compiler_Effect.op_Bar_Greater
-                                                uu___11
-                                                FStar_Compiler_Util.set_elements in
-                                            FStar_Compiler_Effect.op_Bar_Greater
-                                              uu___10
-                                              (FStar_Compiler_List.for_all
-                                                 (fun uv ->
-                                                    let uu___11 =
-                                                      FStar_Syntax_Util.ctx_uvar_should_check
-                                                        uv in
-                                                    uu___11 =
-                                                      FStar_Syntax_Syntax.Allow_unresolved)) in
-                                          if no_unresolved
-                                          then
-                                            (if
-                                               env1.FStar_TypeChecker_Env.phase1
-                                             then true
-                                             else
-                                               (let env2 =
-                                                  {
-                                                    FStar_TypeChecker_Env.solver
-                                                      =
-                                                      (env1.FStar_TypeChecker_Env.solver);
-                                                    FStar_TypeChecker_Env.range
-                                                      =
-                                                      (env1.FStar_TypeChecker_Env.range);
-                                                    FStar_TypeChecker_Env.curmodule
-                                                      =
-                                                      (env1.FStar_TypeChecker_Env.curmodule);
-                                                    FStar_TypeChecker_Env.gamma
-                                                      =
-                                                      (ctx_u.FStar_Syntax_Syntax.ctx_uvar_gamma);
-                                                    FStar_TypeChecker_Env.gamma_sig
-                                                      =
-                                                      (env1.FStar_TypeChecker_Env.gamma_sig);
-                                                    FStar_TypeChecker_Env.gamma_cache
-                                                      =
-                                                      (env1.FStar_TypeChecker_Env.gamma_cache);
-                                                    FStar_TypeChecker_Env.modules
-                                                      =
-                                                      (env1.FStar_TypeChecker_Env.modules);
-                                                    FStar_TypeChecker_Env.expected_typ
-                                                      =
-                                                      (env1.FStar_TypeChecker_Env.expected_typ);
-                                                    FStar_TypeChecker_Env.sigtab
-                                                      =
-                                                      (env1.FStar_TypeChecker_Env.sigtab);
-                                                    FStar_TypeChecker_Env.attrtab
-                                                      =
-                                                      (env1.FStar_TypeChecker_Env.attrtab);
-                                                    FStar_TypeChecker_Env.instantiate_imp
-                                                      =
-                                                      (env1.FStar_TypeChecker_Env.instantiate_imp);
-                                                    FStar_TypeChecker_Env.effects
-                                                      =
-                                                      (env1.FStar_TypeChecker_Env.effects);
-                                                    FStar_TypeChecker_Env.generalize
-                                                      =
-                                                      (env1.FStar_TypeChecker_Env.generalize);
-                                                    FStar_TypeChecker_Env.letrecs
-                                                      =
-                                                      (env1.FStar_TypeChecker_Env.letrecs);
-                                                    FStar_TypeChecker_Env.top_level
-                                                      =
-                                                      (env1.FStar_TypeChecker_Env.top_level);
-                                                    FStar_TypeChecker_Env.check_uvars
-                                                      =
-                                                      (env1.FStar_TypeChecker_Env.check_uvars);
-                                                    FStar_TypeChecker_Env.use_eq_strict
-                                                      =
-                                                      (env1.FStar_TypeChecker_Env.use_eq_strict);
-                                                    FStar_TypeChecker_Env.is_iface
-                                                      =
-                                                      (env1.FStar_TypeChecker_Env.is_iface);
-                                                    FStar_TypeChecker_Env.admit
-                                                      =
-                                                      (env1.FStar_TypeChecker_Env.admit);
-                                                    FStar_TypeChecker_Env.lax
-                                                      =
-                                                      (env1.FStar_TypeChecker_Env.lax);
-                                                    FStar_TypeChecker_Env.lax_universes
-                                                      =
-                                                      (env1.FStar_TypeChecker_Env.lax_universes);
-                                                    FStar_TypeChecker_Env.phase1
-                                                      =
-                                                      (env1.FStar_TypeChecker_Env.phase1);
-                                                    FStar_TypeChecker_Env.failhard
-                                                      =
-                                                      (env1.FStar_TypeChecker_Env.failhard);
-                                                    FStar_TypeChecker_Env.nosynth
-                                                      =
-                                                      (env1.FStar_TypeChecker_Env.nosynth);
-                                                    FStar_TypeChecker_Env.uvar_subtyping
-                                                      =
-                                                      (env1.FStar_TypeChecker_Env.uvar_subtyping);
-                                                    FStar_TypeChecker_Env.tc_term
-                                                      =
-                                                      (env1.FStar_TypeChecker_Env.tc_term);
-                                                    FStar_TypeChecker_Env.typeof_tot_or_gtot_term
-                                                      =
-                                                      (env1.FStar_TypeChecker_Env.typeof_tot_or_gtot_term);
-                                                    FStar_TypeChecker_Env.universe_of
-                                                      =
-                                                      (env1.FStar_TypeChecker_Env.universe_of);
-                                                    FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term
-                                                      =
-                                                      (env1.FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term);
-                                                    FStar_TypeChecker_Env.subtype_nosmt_force
-                                                      =
-                                                      (env1.FStar_TypeChecker_Env.subtype_nosmt_force);
-                                                    FStar_TypeChecker_Env.use_bv_sorts
-                                                      =
-                                                      (env1.FStar_TypeChecker_Env.use_bv_sorts);
-                                                    FStar_TypeChecker_Env.qtbl_name_and_index
-                                                      =
-                                                      (env1.FStar_TypeChecker_Env.qtbl_name_and_index);
-                                                    FStar_TypeChecker_Env.normalized_eff_names
-                                                      =
-                                                      (env1.FStar_TypeChecker_Env.normalized_eff_names);
-                                                    FStar_TypeChecker_Env.fv_delta_depths
-                                                      =
-                                                      (env1.FStar_TypeChecker_Env.fv_delta_depths);
-                                                    FStar_TypeChecker_Env.proof_ns
-                                                      =
-                                                      (env1.FStar_TypeChecker_Env.proof_ns);
-                                                    FStar_TypeChecker_Env.synth_hook
-                                                      =
-                                                      (env1.FStar_TypeChecker_Env.synth_hook);
-                                                    FStar_TypeChecker_Env.try_solve_implicits_hook
-                                                      =
-                                                      (env1.FStar_TypeChecker_Env.try_solve_implicits_hook);
-                                                    FStar_TypeChecker_Env.splice
-                                                      =
-                                                      (env1.FStar_TypeChecker_Env.splice);
-                                                    FStar_TypeChecker_Env.mpreprocess
-                                                      =
-                                                      (env1.FStar_TypeChecker_Env.mpreprocess);
-                                                    FStar_TypeChecker_Env.postprocess
-                                                      =
-                                                      (env1.FStar_TypeChecker_Env.postprocess);
-                                                    FStar_TypeChecker_Env.identifier_info
-                                                      =
-                                                      (env1.FStar_TypeChecker_Env.identifier_info);
-                                                    FStar_TypeChecker_Env.tc_hooks
-                                                      =
-                                                      (env1.FStar_TypeChecker_Env.tc_hooks);
-                                                    FStar_TypeChecker_Env.dsenv
-                                                      =
-                                                      (env1.FStar_TypeChecker_Env.dsenv);
-                                                    FStar_TypeChecker_Env.nbe
-                                                      =
-                                                      (env1.FStar_TypeChecker_Env.nbe);
-                                                    FStar_TypeChecker_Env.strict_args_tab
-                                                      =
-                                                      (env1.FStar_TypeChecker_Env.strict_args_tab);
-                                                    FStar_TypeChecker_Env.erasable_types_tab
-                                                      =
-                                                      (env1.FStar_TypeChecker_Env.erasable_types_tab);
-                                                    FStar_TypeChecker_Env.enable_defer_to_tac
-                                                      =
-                                                      (env1.FStar_TypeChecker_Env.enable_defer_to_tac);
-                                                    FStar_TypeChecker_Env.unif_allow_ref_guards
-                                                      =
-                                                      (env1.FStar_TypeChecker_Env.unif_allow_ref_guards);
-                                                    FStar_TypeChecker_Env.erase_erasable_args
-                                                      =
-                                                      (env1.FStar_TypeChecker_Env.erase_erasable_args)
-                                                  } in
-                                                let uu___11 =
-                                                  is_base_type env2
-                                                    uvar_decoration_typ in
-                                                if uu___11
-                                                then true
-                                                else
-                                                  (let uu___13 =
-                                                     FStar_Profiling.profile
-                                                       (fun uu___14 ->
-                                                          env2.FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term
-                                                            env2 tm2 false)
-                                                       FStar_Pervasives_Native.None
-                                                       "retype_tactic_solution" in
-                                                   match uu___13 with
-                                                   | (tm_t, uu___14) ->
-                                                       let uu___15 =
-                                                         FStar_Profiling.profile
-                                                           (fun uu___16 ->
-                                                              env2.FStar_TypeChecker_Env.subtype_nosmt_force
-                                                                env2 tm_t
-                                                                uvar_decoration_typ)
-                                                           FStar_Pervasives_Native.None
-                                                           "subtype_tactic_solution" in
-                                                       if uu___15
-                                                       then true
-                                                       else
-                                                         ((let uu___18 =
-                                                             FStar_Options.debug_any
-                                                               () in
-                                                           if uu___18
-                                                           then
-                                                             let uu___19 =
-                                                               let uu___20 =
-                                                                 FStar_TypeChecker_Env.get_range
-                                                                   env2 in
-                                                               FStar_Compiler_Range.string_of_range
-                                                                 uu___20 in
-                                                             let uu___20 =
-                                                               FStar_Syntax_Print.uvar_to_string
-                                                                 ctx_u.FStar_Syntax_Syntax.ctx_uvar_head in
-                                                             let uu___21 =
-                                                               FStar_Syntax_Print.term_to_string
-                                                                 uvar_decoration_typ in
-                                                             let uu___22 =
-                                                               FStar_Syntax_Print.term_to_string
-                                                                 tm2 in
-                                                             let uu___23 =
-                                                               FStar_Syntax_Print.term_to_string
-                                                                 tm_t in
-                                                             FStar_Compiler_Util.print5
-                                                               "(%s) Uvar solution for %s was not well-typed. Expected %s got %s : %s\n"
-                                                               uu___19
-                                                               uu___20
-                                                               uu___21
-                                                               uu___22
-                                                               uu___23
-                                                           else ());
-                                                          false))))
-                                          else false in
-                                        if is_tac
-                                        then
-                                          let uu___10 = tm_ok_for_tac tm1 in
-                                          (if uu___10
-                                           then until_fixpoint (out, true) tl
+                                          (if
+                                             env1.FStar_TypeChecker_Env.phase1
+                                           then true
                                            else
+                                             check_implicit_solution_for_tac
+                                               env1 hd1)
+                                        else false in
+                                      if is_tac
+                                      then
+                                        let uu___8 = tm_ok_for_tac () in
+                                        (if uu___8
+                                         then until_fixpoint (out, true) tl
+                                         else
+                                           until_fixpoint
+                                             (((hd1, Implicit_unresolved) ::
+                                               out), changed) tl)
+                                      else
+                                        (let force_univ_constraints = false in
+                                         let imps_opt =
+                                           check_implicit_solution_and_discharge_guard
+                                             env1 hd1 force_univ_constraints in
+                                         match imps_opt with
+                                         | FStar_Pervasives_Native.None ->
                                              until_fixpoint
-                                               (((hd1, Implicit_unresolved)
-                                                 :: out), changed) tl)
-                                        else
-                                          (let force_univ_constraints = false in
-                                           let imps_opt =
-                                             check_implicit_solution_and_discharge_guard
-                                               env1 hd1
-                                               force_univ_constraints in
-                                           match imps_opt with
-                                           | FStar_Pervasives_Native.None ->
-                                               until_fixpoint
-                                                 (((hd1,
-                                                     Implicit_checking_defers_univ_constraint)
-                                                   :: out), changed) tl
-                                           | FStar_Pervasives_Native.Some
-                                               imps ->
-                                               let uu___11 =
-                                                 let uu___12 =
-                                                   let uu___13 =
-                                                     FStar_Compiler_Effect.op_Bar_Greater
-                                                       imps
-                                                       (FStar_Compiler_List.map
-                                                          (fun imp ->
-                                                             (imp,
-                                                               Implicit_unresolved))) in
-                                                   FStar_Compiler_List.op_At
-                                                     uu___13 out in
-                                                 (uu___12, true) in
-                                               until_fixpoint uu___11 tl))))))))) in
+                                               (((hd1,
+                                                   Implicit_checking_defers_univ_constraint)
+                                                 :: out), changed) tl
+                                         | FStar_Pervasives_Native.Some imps
+                                             ->
+                                             let uu___9 =
+                                               let uu___10 =
+                                                 let uu___11 =
+                                                   FStar_Compiler_Effect.op_Bar_Greater
+                                                     imps
+                                                     (FStar_Compiler_List.map
+                                                        (fun imp ->
+                                                           (imp,
+                                                             Implicit_unresolved))) in
+                                                 FStar_Compiler_List.op_At
+                                                   uu___11 out in
+                                               (uu___10, true) in
+                                             until_fixpoint uu___9 tl))))))) in
         let imps =
           FStar_Compiler_Effect.op_Bar_Greater
             g.FStar_TypeChecker_Common.implicits (until_fixpoint ([], false)) in

--- a/src/ocaml-output/FStar_TypeChecker_Rel.ml
+++ b/src/ocaml-output/FStar_TypeChecker_Rel.ml
@@ -215,7 +215,6 @@ let (new_uvar :
                       FStar_Syntax_Syntax.ctx_uvar_head = uu___;
                       FStar_Syntax_Syntax.ctx_uvar_gamma = gamma;
                       FStar_Syntax_Syntax.ctx_uvar_binders = binders;
-                      FStar_Syntax_Syntax.ctx_uvar_typ = k;
                       FStar_Syntax_Syntax.ctx_uvar_reason = reason;
                       FStar_Syntax_Syntax.ctx_uvar_range = r;
                       FStar_Syntax_Syntax.ctx_uvar_meta = meta
@@ -1809,8 +1808,9 @@ let (ensure_no_uvar_subst :
                                  new_gamma in
                              let uu___6 =
                                let uu___7 =
-                                 FStar_Syntax_Syntax.mk_Total
-                                   uv.FStar_Syntax_Syntax.ctx_uvar_typ in
+                                 let uu___8 =
+                                   FStar_Syntax_Util.ctx_uvar_typ uv in
+                                 FStar_Syntax_Syntax.mk_Total uu___8 in
                                FStar_Syntax_Util.arrow dom_binders uu___7 in
                              let uu___7 =
                                FStar_Syntax_Util.ctx_uvar_should_check uv in
@@ -2319,20 +2319,20 @@ let (restrict_ctx :
                                  Prims.op_Negation uu___5))) in
                 if (FStar_Compiler_List.length bs1) = Prims.int_zero
                 then
-                  aux src.FStar_Syntax_Syntax.ctx_uvar_typ (fun src' -> src')
+                  let uu___2 = FStar_Syntax_Util.ctx_uvar_typ src in
+                  aux uu___2 (fun src' -> src')
                 else
                   (let uu___3 =
+                     let t = FStar_Syntax_Util.ctx_uvar_typ src in
                      let uu___4 =
                        let uu___5 =
                          let uu___6 =
-                           FStar_Compiler_Effect.op_Bar_Greater
-                             src.FStar_Syntax_Syntax.ctx_uvar_typ
+                           FStar_Compiler_Effect.op_Bar_Greater t
                              (env.FStar_TypeChecker_Env.universe_of env) in
                          FStar_Compiler_Effect.op_Bar_Greater uu___6
                            (fun uu___7 -> FStar_Pervasives_Native.Some uu___7) in
                        FStar_Compiler_Effect.op_Bar_Greater uu___5
-                         (FStar_Syntax_Syntax.mk_Total'
-                            src.FStar_Syntax_Syntax.ctx_uvar_typ) in
+                         (FStar_Syntax_Syntax.mk_Total' t) in
                      FStar_Compiler_Effect.op_Bar_Greater uu___4
                        (FStar_Syntax_Util.arrow bs1) in
                    aux uu___3
@@ -3741,56 +3741,48 @@ let (quasi_pattern :
     fun f ->
       let uu___ = f in
       match uu___ with
-      | Flex
-          (uu___1,
-           { FStar_Syntax_Syntax.ctx_uvar_head = uu___2;
-             FStar_Syntax_Syntax.ctx_uvar_gamma = uu___3;
-             FStar_Syntax_Syntax.ctx_uvar_binders = ctx;
-             FStar_Syntax_Syntax.ctx_uvar_typ = t_hd;
-             FStar_Syntax_Syntax.ctx_uvar_reason = uu___4;
-             FStar_Syntax_Syntax.ctx_uvar_range = uu___5;
-             FStar_Syntax_Syntax.ctx_uvar_meta = uu___6;_},
-           args)
-          ->
+      | Flex (uu___1, ctx_uvar, args) ->
+          let t_hd = FStar_Syntax_Util.ctx_uvar_typ ctx_uvar in
+          let ctx = ctx_uvar.FStar_Syntax_Syntax.ctx_uvar_binders in
           let name_exists_in x bs =
             FStar_Compiler_Util.for_some
-              (fun uu___7 ->
-                 match uu___7 with
+              (fun uu___2 ->
+                 match uu___2 with
                  | { FStar_Syntax_Syntax.binder_bv = y;
-                     FStar_Syntax_Syntax.binder_qual = uu___8;
-                     FStar_Syntax_Syntax.binder_attrs = uu___9;_} ->
+                     FStar_Syntax_Syntax.binder_qual = uu___3;
+                     FStar_Syntax_Syntax.binder_attrs = uu___4;_} ->
                      FStar_Syntax_Syntax.bv_eq x y) bs in
           let rec aux pat_binders formals t_res args1 =
             match (formals, args1) with
             | ([], []) ->
-                let uu___7 =
-                  let uu___8 =
-                    let uu___9 = FStar_Syntax_Syntax.mk_Total t_res in
-                    FStar_Syntax_Util.arrow formals uu___9 in
-                  ((FStar_Compiler_List.rev pat_binders), uu___8) in
-                FStar_Pervasives_Native.Some uu___7
-            | (uu___7, []) ->
-                let uu___8 =
-                  let uu___9 =
-                    let uu___10 = FStar_Syntax_Syntax.mk_Total t_res in
-                    FStar_Syntax_Util.arrow formals uu___10 in
-                  ((FStar_Compiler_List.rev pat_binders), uu___9) in
-                FStar_Pervasives_Native.Some uu___8
+                let uu___2 =
+                  let uu___3 =
+                    let uu___4 = FStar_Syntax_Syntax.mk_Total t_res in
+                    FStar_Syntax_Util.arrow formals uu___4 in
+                  ((FStar_Compiler_List.rev pat_binders), uu___3) in
+                FStar_Pervasives_Native.Some uu___2
+            | (uu___2, []) ->
+                let uu___3 =
+                  let uu___4 =
+                    let uu___5 = FStar_Syntax_Syntax.mk_Total t_res in
+                    FStar_Syntax_Util.arrow formals uu___5 in
+                  ((FStar_Compiler_List.rev pat_binders), uu___4) in
+                FStar_Pervasives_Native.Some uu___3
             | (fml::formals1, (a, a_imp)::args2) ->
-                let uu___7 =
+                let uu___2 =
                   ((fml.FStar_Syntax_Syntax.binder_bv),
                     (fml.FStar_Syntax_Syntax.binder_qual)) in
-                (match uu___7 with
+                (match uu___2 with
                  | (formal, formal_imp) ->
-                     let uu___8 =
-                       let uu___9 = FStar_Syntax_Subst.compress a in
-                       uu___9.FStar_Syntax_Syntax.n in
-                     (match uu___8 with
+                     let uu___3 =
+                       let uu___4 = FStar_Syntax_Subst.compress a in
+                       uu___4.FStar_Syntax_Syntax.n in
+                     (match uu___3 with
                       | FStar_Syntax_Syntax.Tm_name x ->
-                          let uu___9 =
+                          let uu___4 =
                             (name_exists_in x ctx) ||
                               (name_exists_in x pat_binders) in
-                          if uu___9
+                          if uu___4
                           then aux (fml :: pat_binders) formals1 t_res args2
                           else
                             (let x1 =
@@ -3803,25 +3795,25 @@ let (quasi_pattern :
                                    (formal.FStar_Syntax_Syntax.sort)
                                } in
                              let subst =
-                               let uu___11 =
-                                 let uu___12 =
-                                   let uu___13 =
+                               let uu___6 =
+                                 let uu___7 =
+                                   let uu___8 =
                                      FStar_Syntax_Syntax.bv_to_name x1 in
-                                   (formal, uu___13) in
-                                 FStar_Syntax_Syntax.NT uu___12 in
-                               [uu___11] in
+                                   (formal, uu___8) in
+                                 FStar_Syntax_Syntax.NT uu___7 in
+                               [uu___6] in
                              let formals2 =
                                FStar_Syntax_Subst.subst_binders subst
                                  formals1 in
                              let t_res1 =
                                FStar_Syntax_Subst.subst subst t_res in
-                             let uu___11 =
+                             let uu___6 =
                                FStar_Syntax_Util.bqual_and_attrs_of_aqual
                                  a_imp in
-                             match uu___11 with
-                             | (q, uu___12) ->
-                                 let uu___13 =
-                                   let uu___14 =
+                             match uu___6 with
+                             | (q, uu___7) ->
+                                 let uu___8 =
+                                   let uu___9 =
                                      FStar_Syntax_Syntax.mk_binder_with_attrs
                                        {
                                          FStar_Syntax_Syntax.ppname =
@@ -3832,25 +3824,25 @@ let (quasi_pattern :
                                            (formal.FStar_Syntax_Syntax.sort)
                                        } q
                                        fml.FStar_Syntax_Syntax.binder_attrs in
-                                   uu___14 :: pat_binders in
-                                 aux uu___13 formals2 t_res1 args2)
-                      | uu___9 ->
+                                   uu___9 :: pat_binders in
+                                 aux uu___8 formals2 t_res1 args2)
+                      | uu___4 ->
                           aux (fml :: pat_binders) formals1 t_res args2))
             | ([], args2) ->
-                let uu___7 =
-                  let uu___8 =
+                let uu___2 =
+                  let uu___3 =
                     FStar_TypeChecker_Normalize.unfold_whnf env t_res in
-                  FStar_Syntax_Util.arrow_formals uu___8 in
-                (match uu___7 with
+                  FStar_Syntax_Util.arrow_formals uu___3 in
+                (match uu___2 with
                  | (more_formals, t_res1) ->
                      (match more_formals with
                       | [] -> FStar_Pervasives_Native.None
-                      | uu___8 -> aux pat_binders more_formals t_res1 args2)) in
+                      | uu___3 -> aux pat_binders more_formals t_res1 args2)) in
           (match args with
            | [] -> FStar_Pervasives_Native.Some ([], t_hd)
-           | uu___7 ->
-               let uu___8 = FStar_Syntax_Util.arrow_formals t_hd in
-               (match uu___8 with
+           | uu___2 ->
+               let uu___3 = FStar_Syntax_Util.arrow_formals t_hd in
+               (match uu___3 with
                 | (formals, t_res) -> aux [] formals t_res args))
 let (run_meta_arg_tac :
   FStar_Syntax_Syntax.ctx_uvar -> FStar_Syntax_Syntax.term) =
@@ -3869,8 +3861,8 @@ let (run_meta_arg_tac :
           else ());
          FStar_Errors.with_ctx "Running tactic for meta-arg"
            (fun uu___1 ->
-              env.FStar_TypeChecker_Env.synth_hook env
-                ctx_u.FStar_Syntax_Syntax.ctx_uvar_typ tau))
+              let uu___2 = FStar_Syntax_Util.ctx_uvar_typ ctx_u in
+              env.FStar_TypeChecker_Env.synth_hook env uu___2 tau))
     | uu___ ->
         failwith
           "run_meta_arg_tac must have been called with a uvar that has a meta tac"
@@ -5579,9 +5571,10 @@ and (solve_t_flex_rigid_eq :
                              match bs1 with
                              | [] -> rhs2
                              | uu___6 ->
-                                 let uu___7 = sn_binders env1 bs1 in
-                                 u_abs ctx_u.FStar_Syntax_Syntax.ctx_uvar_typ
-                                   uu___7 rhs2 in
+                                 let uu___7 =
+                                   FStar_Syntax_Util.ctx_uvar_typ ctx_u in
+                                 let uu___8 = sn_binders env1 bs1 in
+                                 u_abs uu___7 uu___8 rhs2 in
                            [TERM (ctx_u, sol)]) in
                 let try_quasi_pattern orig1 env1 wl1 lhs1 rhs1 =
                   (let uu___4 =
@@ -6246,9 +6239,11 @@ and (solve_t_flex_rigid_eq :
                                                                    lstring1))) in
                                                   let uu___15 =
                                                     let uu___16 =
+                                                      let uu___17 =
+                                                        FStar_Syntax_Util.ctx_uvar_typ
+                                                          ctx_uv in
                                                       FStar_Syntax_Util.eq_tm
-                                                        t_head
-                                                        ctx_uv.FStar_Syntax_Syntax.ctx_uvar_typ in
+                                                        t_head uu___17 in
                                                     uu___16 =
                                                       FStar_Syntax_Util.Equal in
                                                   if uu___15
@@ -6264,8 +6259,11 @@ and (solve_t_flex_rigid_eq :
                                                       if uu___18
                                                       then
                                                         let uu___19 =
+                                                          let uu___20 =
+                                                            FStar_Syntax_Util.ctx_uvar_typ
+                                                              ctx_uv in
                                                           FStar_Syntax_Print.term_to_string
-                                                            ctx_uv.FStar_Syntax_Syntax.ctx_uvar_typ in
+                                                            uu___20 in
                                                         let uu___20 =
                                                           FStar_Syntax_Print.term_to_string
                                                             t_head in
@@ -6276,9 +6274,11 @@ and (solve_t_flex_rigid_eq :
                                                      (let typ_equality_prob
                                                         wl2 =
                                                         let uu___18 =
+                                                          let uu___19 =
+                                                            FStar_Syntax_Util.ctx_uvar_typ
+                                                              ctx_uv in
                                                           mk_t_problem wl2 []
-                                                            orig1
-                                                            ctx_uv.FStar_Syntax_Syntax.ctx_uvar_typ
+                                                            orig1 uu___19
                                                             FStar_TypeChecker_Common.EQ
                                                             t_head
                                                             FStar_Pervasives_Native.None
@@ -6449,8 +6449,8 @@ and (solve_t_flex_flex :
               let uv = flex_uvar flex in
               (flex_uvar_has_meta_tac uv) &&
                 (let uu___ =
-                   FStar_Syntax_Free.uvars
-                     uv.FStar_Syntax_Syntax.ctx_uvar_typ in
+                   let uu___1 = FStar_Syntax_Util.ctx_uvar_typ uv in
+                   FStar_Syntax_Free.uvars uu___1 in
                  FStar_Compiler_Util.set_is_empty uu___) in
             let run_meta_arg_tac_and_try_again flex =
               let uv = flex_uvar flex in
@@ -13500,9 +13500,9 @@ let (try_solve_single_valued_implicits :
              match uu___1 with
              | (ctx_u, r) ->
                  let t_norm =
+                   let uu___2 = FStar_Syntax_Util.ctx_uvar_typ ctx_u in
                    FStar_TypeChecker_Normalize.normalize
-                     FStar_TypeChecker_Normalize.whnf_steps env
-                     ctx_u.FStar_Syntax_Syntax.ctx_uvar_typ in
+                     FStar_TypeChecker_Normalize.whnf_steps env uu___2 in
                  let uu___2 =
                    let uu___3 = FStar_Syntax_Subst.compress t_norm in
                    uu___3.FStar_Syntax_Syntax.n in
@@ -13824,8 +13824,8 @@ let (check_implicit_solution_and_discharge_guard :
                     ctx_u.FStar_Syntax_Syntax.ctx_uvar_head in
                 let uu___4 = FStar_Syntax_Print.term_to_string tm in
                 let uu___5 =
-                  FStar_Syntax_Print.term_to_string
-                    ctx_u.FStar_Syntax_Syntax.ctx_uvar_typ in
+                  let uu___6 = FStar_Syntax_Util.ctx_uvar_typ ctx_u in
+                  FStar_Syntax_Print.term_to_string uu___6 in
                 let uu___6 = FStar_Compiler_Range.string_of_range r in
                 FStar_Compiler_Util.print5
                   "Checking uvar %s resolved to %s at type %s, introduce for %s at %s\n"
@@ -13848,15 +13848,15 @@ let (check_implicit_solution_and_discharge_guard :
                   let uu___4 =
                     FStar_TypeChecker_Normalize.term_to_string env1 tm in
                   let uu___5 =
-                    FStar_TypeChecker_Normalize.term_to_string env1
-                      ctx_u.FStar_Syntax_Syntax.ctx_uvar_typ in
+                    let uu___6 = FStar_Syntax_Util.ctx_uvar_typ ctx_u in
+                    FStar_TypeChecker_Normalize.term_to_string env1 uu___6 in
                   FStar_Compiler_Util.format3
                     "While checking implicit %s set to %s of expected type %s"
                     uu___3 uu___4 uu___5 in
                 FStar_Errors.with_ctx uu___2
                   (fun uu___3 ->
-                     check_implicit_solution env1 tm
-                       ctx_u.FStar_Syntax_Syntax.ctx_uvar_typ must_tot) in
+                     let uu___4 = FStar_Syntax_Util.ctx_uvar_typ ctx_u in
+                     check_implicit_solution env1 tm uu___4 must_tot) in
               let uu___2 =
                 (Prims.op_Negation force_univ_constraints) &&
                   (FStar_Compiler_List.existsb
@@ -14577,8 +14577,10 @@ let (force_trivial_guard :
                  FStar_Syntax_Print.uvar_to_string
                    (imp.FStar_TypeChecker_Common.imp_uvar).FStar_Syntax_Syntax.ctx_uvar_head in
                let uu___5 =
-                 FStar_TypeChecker_Normalize.term_to_string env
-                   (imp.FStar_TypeChecker_Common.imp_uvar).FStar_Syntax_Syntax.ctx_uvar_typ in
+                 let uu___6 =
+                   FStar_Syntax_Util.ctx_uvar_typ
+                     imp.FStar_TypeChecker_Common.imp_uvar in
+                 FStar_TypeChecker_Normalize.term_to_string env uu___6 in
                FStar_Compiler_Util.format3
                  "Failed to resolve implicit argument %s of type %s introduced for %s"
                  uu___4 uu___5 imp.FStar_TypeChecker_Common.imp_reason in

--- a/src/ocaml-output/FStar_TypeChecker_Rel.ml
+++ b/src/ocaml-output/FStar_TypeChecker_Rel.ml
@@ -14146,55 +14146,30 @@ let (resolve_implicits' :
                                        FStar_TypeChecker_Common.imp_range =
                                          (hd.FStar_TypeChecker_Common.imp_range)
                                      } in
-                                   let tm_ok_for_tac tm2 =
-                                     let uu___9 =
-                                       let uu___10 =
-                                         FStar_Compiler_Effect.op_Bar_Greater
-                                           tm2 FStar_Syntax_Free.uvars in
-                                       FStar_Compiler_Effect.op_Bar_Greater
-                                         uu___10
-                                         FStar_Compiler_Util.set_elements in
-                                     FStar_Compiler_Effect.op_Bar_Greater
-                                       uu___9
-                                       (FStar_Compiler_List.for_all
-                                          (fun uv ->
-                                             uv.FStar_Syntax_Syntax.ctx_uvar_should_check
-                                               =
-                                               FStar_Syntax_Syntax.Allow_unresolved)) in
-                                   if is_tac
-                                   then
-                                     let uu___9 = tm_ok_for_tac tm1 in
-                                     (if uu___9
-                                      then until_fixpoint (out, true) tl
-                                      else
-                                        until_fixpoint
-                                          (((hd1, Implicit_unresolved) ::
-                                            out), changed) tl)
-                                   else
-                                     (let force_univ_constraints = false in
-                                      let imps_opt =
-                                        check_implicit_solution_and_discharge_guard
-                                          env1 hd1 force_univ_constraints in
-                                      match imps_opt with
-                                      | FStar_Pervasives_Native.None ->
-                                          until_fixpoint
-                                            (((hd1,
-                                                Implicit_checking_defers_univ_constraint)
-                                              :: out), changed) tl
-                                      | FStar_Pervasives_Native.Some imps ->
-                                          let uu___10 =
-                                            let uu___11 =
-                                              let uu___12 =
-                                                FStar_Compiler_Effect.op_Bar_Greater
-                                                  imps
-                                                  (FStar_Compiler_List.map
-                                                     (fun imp ->
-                                                        (imp,
-                                                          Implicit_unresolved))) in
-                                              FStar_Compiler_List.op_At
-                                                uu___12 out in
-                                            (uu___11, true) in
-                                          until_fixpoint uu___10 tl)))))))) in
+                                   let force_univ_constraints = false in
+                                   let imps_opt =
+                                     check_implicit_solution_and_discharge_guard
+                                       env1 hd1 force_univ_constraints in
+                                   match imps_opt with
+                                   | FStar_Pervasives_Native.None ->
+                                       until_fixpoint
+                                         (((hd1,
+                                             Implicit_checking_defers_univ_constraint)
+                                           :: out), changed) tl
+                                   | FStar_Pervasives_Native.Some imps ->
+                                       let uu___9 =
+                                         let uu___10 =
+                                           let uu___11 =
+                                             FStar_Compiler_Effect.op_Bar_Greater
+                                               imps
+                                               (FStar_Compiler_List.map
+                                                  (fun imp ->
+                                                     (imp,
+                                                       Implicit_unresolved))) in
+                                           FStar_Compiler_List.op_At uu___11
+                                             out in
+                                         (uu___10, true) in
+                                       until_fixpoint uu___9 tl))))))) in
         let imps =
           FStar_Compiler_Effect.op_Bar_Greater
             g.FStar_TypeChecker_Common.implicits (until_fixpoint ([], false)) in

--- a/src/ocaml-output/FStar_TypeChecker_Rel.ml
+++ b/src/ocaml-output/FStar_TypeChecker_Rel.ml
@@ -14108,24 +14108,42 @@ let (check_implicit_solution_for_tac :
                  if uu___5
                  then true
                  else
-                   ((let uu___8 = FStar_Options.debug_any () in
-                     if uu___8
-                     then
-                       let uu___9 =
-                         let uu___10 = FStar_TypeChecker_Env.get_range env1 in
-                         FStar_Compiler_Range.string_of_range uu___10 in
-                       let uu___10 =
-                         FStar_Syntax_Print.uvar_to_string
-                           ctx_u.FStar_Syntax_Syntax.ctx_uvar_head in
-                       let uu___11 =
-                         FStar_Syntax_Print.term_to_string uvar_ty in
-                       let uu___12 = FStar_Syntax_Print.term_to_string tm in
-                       let uu___13 = FStar_Syntax_Print.term_to_string tm_t in
-                       FStar_Compiler_Util.print5
-                         "(%s) Uvar solution for %s was not well-typed. Expected %s got %s : %s\n"
-                         uu___9 uu___10 uu___11 uu___12 uu___13
-                     else ());
-                    false))
+                   (let compute t =
+                      FStar_TypeChecker_Normalize.normalize
+                        [FStar_TypeChecker_Env.UnfoldTac;
+                        FStar_TypeChecker_Env.UnfoldUntil
+                          FStar_Syntax_Syntax.delta_constant;
+                        FStar_TypeChecker_Env.Zeta;
+                        FStar_TypeChecker_Env.Iota;
+                        FStar_TypeChecker_Env.Primops] env1 t in
+                    let tm_t1 = compute tm_t in
+                    let uv_t = compute uvar_ty in
+                    let uu___7 =
+                      env1.FStar_TypeChecker_Env.subtype_nosmt_force env1
+                        tm_t1 uv_t in
+                    if uu___7
+                    then true
+                    else
+                      ((let uu___10 = FStar_Options.debug_any () in
+                        if uu___10
+                        then
+                          let uu___11 =
+                            let uu___12 =
+                              FStar_TypeChecker_Env.get_range env1 in
+                            FStar_Compiler_Range.string_of_range uu___12 in
+                          let uu___12 =
+                            FStar_Syntax_Print.uvar_to_string
+                              ctx_u.FStar_Syntax_Syntax.ctx_uvar_head in
+                          let uu___13 =
+                            FStar_Syntax_Print.term_to_string uvar_ty in
+                          let uu___14 = FStar_Syntax_Print.term_to_string tm in
+                          let uu___15 =
+                            FStar_Syntax_Print.term_to_string tm_t1 in
+                          FStar_Compiler_Util.print5
+                            "(%s) Uvar solution for %s was not well-typed. Expected %s got %s : %s\n"
+                            uu___11 uu___12 uu___13 uu___14 uu___15
+                        else ());
+                       false)))
 let (resolve_implicits' :
   FStar_TypeChecker_Env.env ->
     Prims.bool ->

--- a/src/ocaml-output/FStar_TypeChecker_Tc.ml
+++ b/src/ocaml-output/FStar_TypeChecker_Tc.ml
@@ -80,6 +80,8 @@ let (set_hint_correlator :
               (env.FStar_TypeChecker_Env.universe_of);
             FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term =
               (env.FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term);
+            FStar_TypeChecker_Env.subtype_nosmt_force =
+              (env.FStar_TypeChecker_Env.subtype_nosmt_force);
             FStar_TypeChecker_Env.use_bv_sorts =
               (env.FStar_TypeChecker_Env.use_bv_sorts);
             FStar_TypeChecker_Env.qtbl_name_and_index = uu___1;
@@ -184,6 +186,8 @@ let (set_hint_correlator :
               (env.FStar_TypeChecker_Env.universe_of);
             FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term =
               (env.FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term);
+            FStar_TypeChecker_Env.subtype_nosmt_force =
+              (env.FStar_TypeChecker_Env.subtype_nosmt_force);
             FStar_TypeChecker_Env.use_bv_sorts =
               (env.FStar_TypeChecker_Env.use_bv_sorts);
             FStar_TypeChecker_Env.qtbl_name_and_index = uu___1;
@@ -1118,6 +1122,8 @@ let (tc_sig_let :
                           FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term
                             =
                             (env1.FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term);
+                          FStar_TypeChecker_Env.subtype_nosmt_force =
+                            (env1.FStar_TypeChecker_Env.subtype_nosmt_force);
                           FStar_TypeChecker_Env.use_bv_sorts =
                             (env1.FStar_TypeChecker_Env.use_bv_sorts);
                           FStar_TypeChecker_Env.qtbl_name_and_index =
@@ -1292,6 +1298,9 @@ let (tc_sig_let :
                                        FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term
                                          =
                                          (env'.FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term);
+                                       FStar_TypeChecker_Env.subtype_nosmt_force
+                                         =
+                                         (env'.FStar_TypeChecker_Env.subtype_nosmt_force);
                                        FStar_TypeChecker_Env.use_bv_sorts =
                                          (env'.FStar_TypeChecker_Env.use_bv_sorts);
                                        FStar_TypeChecker_Env.qtbl_name_and_index
@@ -1645,6 +1654,8 @@ let (tc_decl' :
                      FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term
                        =
                        (env.FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term);
+                     FStar_TypeChecker_Env.subtype_nosmt_force =
+                       (env.FStar_TypeChecker_Env.subtype_nosmt_force);
                      FStar_TypeChecker_Env.use_bv_sorts =
                        (env.FStar_TypeChecker_Env.use_bv_sorts);
                      FStar_TypeChecker_Env.qtbl_name_and_index =
@@ -1847,6 +1858,8 @@ let (tc_decl' :
                                FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term
                                  =
                                  (env1.FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term);
+                               FStar_TypeChecker_Env.subtype_nosmt_force =
+                                 (env1.FStar_TypeChecker_Env.subtype_nosmt_force);
                                FStar_TypeChecker_Env.use_bv_sorts =
                                  (env1.FStar_TypeChecker_Env.use_bv_sorts);
                                FStar_TypeChecker_Env.qtbl_name_and_index =
@@ -2104,6 +2117,8 @@ let (tc_decl' :
                                   FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term
                                     =
                                     (env.FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term);
+                                  FStar_TypeChecker_Env.subtype_nosmt_force =
+                                    (env.FStar_TypeChecker_Env.subtype_nosmt_force);
                                   FStar_TypeChecker_Env.use_bv_sorts =
                                     (env.FStar_TypeChecker_Env.use_bv_sorts);
                                   FStar_TypeChecker_Env.qtbl_name_and_index =
@@ -2300,6 +2315,8 @@ let (tc_decl' :
                              FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term
                                =
                                (env.FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term);
+                             FStar_TypeChecker_Env.subtype_nosmt_force =
+                               (env.FStar_TypeChecker_Env.subtype_nosmt_force);
                              FStar_TypeChecker_Env.use_bv_sorts =
                                (env.FStar_TypeChecker_Env.use_bv_sorts);
                              FStar_TypeChecker_Env.qtbl_name_and_index =
@@ -2492,6 +2509,8 @@ let (tc_decl' :
                            FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term
                              =
                              (env1.FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term);
+                           FStar_TypeChecker_Env.subtype_nosmt_force =
+                             (env1.FStar_TypeChecker_Env.subtype_nosmt_force);
                            FStar_TypeChecker_Env.use_bv_sorts =
                              (env1.FStar_TypeChecker_Env.use_bv_sorts);
                            FStar_TypeChecker_Env.qtbl_name_and_index =
@@ -2644,6 +2663,8 @@ let (tc_decl' :
                            FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term
                              =
                              (env1.FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term);
+                           FStar_TypeChecker_Env.subtype_nosmt_force =
+                             (env1.FStar_TypeChecker_Env.subtype_nosmt_force);
                            FStar_TypeChecker_Env.use_bv_sorts =
                              (env1.FStar_TypeChecker_Env.use_bv_sorts);
                            FStar_TypeChecker_Env.qtbl_name_and_index =
@@ -2838,6 +2859,8 @@ let (tc_decl' :
                             FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term
                               =
                               (env.FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term);
+                            FStar_TypeChecker_Env.subtype_nosmt_force =
+                              (env.FStar_TypeChecker_Env.subtype_nosmt_force);
                             FStar_TypeChecker_Env.use_bv_sorts =
                               (env.FStar_TypeChecker_Env.use_bv_sorts);
                             FStar_TypeChecker_Env.qtbl_name_and_index =
@@ -2968,6 +2991,8 @@ let (tc_decl' :
                                FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term
                                  =
                                  (env.FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term);
+                               FStar_TypeChecker_Env.subtype_nosmt_force =
+                                 (env.FStar_TypeChecker_Env.subtype_nosmt_force);
                                FStar_TypeChecker_Env.use_bv_sorts =
                                  (env.FStar_TypeChecker_Env.use_bv_sorts);
                                FStar_TypeChecker_Env.qtbl_name_and_index =
@@ -3157,6 +3182,8 @@ let (tc_decl' :
                                FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term
                                  =
                                  (env.FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term);
+                               FStar_TypeChecker_Env.subtype_nosmt_force =
+                                 (env.FStar_TypeChecker_Env.subtype_nosmt_force);
                                FStar_TypeChecker_Env.use_bv_sorts =
                                  (env.FStar_TypeChecker_Env.use_bv_sorts);
                                FStar_TypeChecker_Env.qtbl_name_and_index =
@@ -3436,6 +3463,8 @@ let (add_sigelt_to_env :
                        FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term
                          =
                          (env1.FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term);
+                       FStar_TypeChecker_Env.subtype_nosmt_force =
+                         (env1.FStar_TypeChecker_Env.subtype_nosmt_force);
                        FStar_TypeChecker_Env.use_bv_sorts =
                          (env1.FStar_TypeChecker_Env.use_bv_sorts);
                        FStar_TypeChecker_Env.qtbl_name_and_index =
@@ -3540,6 +3569,8 @@ let (add_sigelt_to_env :
                        FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term
                          =
                          (env1.FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term);
+                       FStar_TypeChecker_Env.subtype_nosmt_force =
+                         (env1.FStar_TypeChecker_Env.subtype_nosmt_force);
                        FStar_TypeChecker_Env.use_bv_sorts =
                          (env1.FStar_TypeChecker_Env.use_bv_sorts);
                        FStar_TypeChecker_Env.qtbl_name_and_index =
@@ -3644,6 +3675,8 @@ let (add_sigelt_to_env :
                        FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term
                          =
                          (env1.FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term);
+                       FStar_TypeChecker_Env.subtype_nosmt_force =
+                         (env1.FStar_TypeChecker_Env.subtype_nosmt_force);
                        FStar_TypeChecker_Env.use_bv_sorts =
                          (env1.FStar_TypeChecker_Env.use_bv_sorts);
                        FStar_TypeChecker_Env.qtbl_name_and_index =
@@ -3748,6 +3781,8 @@ let (add_sigelt_to_env :
                        FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term
                          =
                          (env1.FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term);
+                       FStar_TypeChecker_Env.subtype_nosmt_force =
+                         (env1.FStar_TypeChecker_Env.subtype_nosmt_force);
                        FStar_TypeChecker_Env.use_bv_sorts =
                          (env1.FStar_TypeChecker_Env.use_bv_sorts);
                        FStar_TypeChecker_Env.qtbl_name_and_index =
@@ -4108,6 +4143,8 @@ let (tc_partial_modul :
              (env.FStar_TypeChecker_Env.universe_of);
            FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term =
              (env.FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term);
+           FStar_TypeChecker_Env.subtype_nosmt_force =
+             (env.FStar_TypeChecker_Env.subtype_nosmt_force);
            FStar_TypeChecker_Env.use_bv_sorts =
              (env.FStar_TypeChecker_Env.use_bv_sorts);
            FStar_TypeChecker_Env.qtbl_name_and_index =
@@ -4354,6 +4391,8 @@ let (check_module :
                (env.FStar_TypeChecker_Env.universe_of);
              FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term =
                (env.FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term);
+             FStar_TypeChecker_Env.subtype_nosmt_force =
+               (env.FStar_TypeChecker_Env.subtype_nosmt_force);
              FStar_TypeChecker_Env.use_bv_sorts =
                (env.FStar_TypeChecker_Env.use_bv_sorts);
              FStar_TypeChecker_Env.qtbl_name_and_index =

--- a/src/ocaml-output/FStar_TypeChecker_TcEffect.ml
+++ b/src/ocaml-output/FStar_TypeChecker_TcEffect.ml
@@ -212,6 +212,8 @@ let (check_no_subtyping_for_layered_combinator :
                (env.FStar_TypeChecker_Env.universe_of);
              FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term =
                (env.FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term);
+             FStar_TypeChecker_Env.subtype_nosmt_force =
+               (env.FStar_TypeChecker_Env.subtype_nosmt_force);
              FStar_TypeChecker_Env.use_bv_sorts =
                (env.FStar_TypeChecker_Env.use_bv_sorts);
              FStar_TypeChecker_Env.qtbl_name_and_index =
@@ -2508,6 +2510,9 @@ let (tc_layered_eff_decl :
                                         FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term
                                           =
                                           (uu___16.FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term);
+                                        FStar_TypeChecker_Env.subtype_nosmt_force
+                                          =
+                                          (uu___16.FStar_TypeChecker_Env.subtype_nosmt_force);
                                         FStar_TypeChecker_Env.use_bv_sorts =
                                           (uu___16.FStar_TypeChecker_Env.use_bv_sorts);
                                         FStar_TypeChecker_Env.qtbl_name_and_index
@@ -4252,6 +4257,9 @@ let (tc_non_layered_eff_decl :
                                                                     FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term
                                                                     =
                                                                     (env1.FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term);
+                                                                    FStar_TypeChecker_Env.subtype_nosmt_force
+                                                                    =
+                                                                    (env1.FStar_TypeChecker_Env.subtype_nosmt_force);
                                                                     FStar_TypeChecker_Env.use_bv_sorts
                                                                     =
                                                                     (env1.FStar_TypeChecker_Env.use_bv_sorts);
@@ -4524,6 +4532,9 @@ let (tc_non_layered_eff_decl :
                                                                    FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term
                                                                     =
                                                                     (uu___24.FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term);
+                                                                   FStar_TypeChecker_Env.subtype_nosmt_force
+                                                                    =
+                                                                    (uu___24.FStar_TypeChecker_Env.subtype_nosmt_force);
                                                                    FStar_TypeChecker_Env.use_bv_sorts
                                                                     =
                                                                     (uu___24.FStar_TypeChecker_Env.use_bv_sorts);
@@ -5754,6 +5765,8 @@ let (tc_lift :
                                FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term
                                  =
                                  (env.FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term);
+                               FStar_TypeChecker_Env.subtype_nosmt_force =
+                                 (env.FStar_TypeChecker_Env.subtype_nosmt_force);
                                FStar_TypeChecker_Env.use_bv_sorts =
                                  (env.FStar_TypeChecker_Env.use_bv_sorts);
                                FStar_TypeChecker_Env.qtbl_name_and_index =

--- a/src/ocaml-output/FStar_TypeChecker_TcEffect.ml
+++ b/src/ocaml-output/FStar_TypeChecker_TcEffect.ml
@@ -336,24 +336,10 @@ let (validate_layered_effect_binders :
                  "Checking layered effect combinator binders validity, names: %s, binders: %s\n\n"
                  uu___2 uu___3
              else ());
-            (let valid_binder b =
-               (FStar_Compiler_List.existsb
-                  (fun t ->
-                     let uu___1 =
-                       let uu___2 =
-                         FStar_Syntax_Syntax.bv_to_name
-                           b.FStar_Syntax_Syntax.binder_bv in
-                       FStar_Syntax_Util.eq_tm uu___2 t in
-                     uu___1 = FStar_Syntax_Util.Equal) repr_names_args)
-                 ||
-                 (match b.FStar_Syntax_Syntax.binder_attrs with
-                  | uu___1::uu___2 -> true
-                  | uu___1 -> false) in
+            (let valid_binder b = true in
              let invalid_binders =
                FStar_Compiler_List.filter
-                 (fun b ->
-                    let uu___1 = valid_binder b in Prims.op_Negation uu___1)
-                 bs in
+                 (fun b -> Prims.op_Negation (valid_binder b)) bs in
              if
                (FStar_Compiler_List.length invalid_binders) <> Prims.int_zero
              then

--- a/src/ocaml-output/FStar_TypeChecker_TcEffect.ml
+++ b/src/ocaml-output/FStar_TypeChecker_TcEffect.ml
@@ -262,132 +262,45 @@ let (check_no_subtyping_for_layered_combinator :
 let (validate_layered_effect_binders :
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.binders ->
-      FStar_Syntax_Syntax.term Prims.list ->
-        Prims.bool -> FStar_Compiler_Range.range -> unit)
+      Prims.bool -> FStar_Compiler_Range.range -> unit)
   =
   fun env ->
     fun bs ->
-      fun repr_terms ->
-        fun check_non_informatve_binders ->
-          fun r ->
-            let repr_args repr =
-              let uu___ =
-                let uu___1 = FStar_Syntax_Subst.compress repr in
-                uu___1.FStar_Syntax_Syntax.n in
-              match uu___ with
-              | FStar_Syntax_Syntax.Tm_app (uu___1, args) -> args
-              | FStar_Syntax_Syntax.Tm_arrow (uu___1::[], c) ->
-                  FStar_Compiler_Effect.op_Bar_Greater c
-                    FStar_Syntax_Util.comp_effect_args
-              | uu___1 ->
-                  let uu___2 =
-                    let uu___3 =
-                      let uu___4 = FStar_Syntax_Print.term_to_string repr in
-                      FStar_Compiler_Util.format1
-                        "Unexpected repr term %s when validating layered effect combinator binders"
-                        uu___4 in
-                    (FStar_Errors.Fatal_UnexpectedEffect, uu___3) in
-                  FStar_Errors.raise_error uu___2 r in
-            let rec head_names_in_term arg =
-              let uu___ =
-                let uu___1 = FStar_Syntax_Subst.compress arg in
-                uu___1.FStar_Syntax_Syntax.n in
-              match uu___ with
-              | FStar_Syntax_Syntax.Tm_name uu___1 -> [arg]
-              | FStar_Syntax_Syntax.Tm_app (head, uu___1) ->
-                  let uu___2 =
-                    let uu___3 = FStar_Syntax_Subst.compress head in
-                    uu___3.FStar_Syntax_Syntax.n in
-                  (match uu___2 with
-                   | FStar_Syntax_Syntax.Tm_name uu___3 -> [head]
-                   | uu___3 -> [])
-              | FStar_Syntax_Syntax.Tm_abs (uu___1, body, uu___2) ->
-                  head_names_in_term body
-              | uu___1 -> [] in
-            let head_names_in_args args =
-              let uu___ =
-                FStar_Compiler_Effect.op_Bar_Greater args
-                  (FStar_Compiler_List.map FStar_Pervasives_Native.fst) in
-              FStar_Compiler_Effect.op_Bar_Greater uu___
-                (FStar_Compiler_List.collect head_names_in_term) in
-            let repr_names_args =
-              FStar_Compiler_List.collect
-                (fun repr ->
-                   let uu___ =
-                     FStar_Compiler_Effect.op_Bar_Greater repr repr_args in
-                   FStar_Compiler_Effect.op_Bar_Greater uu___
-                     head_names_in_args) repr_terms in
-            (let uu___1 =
-               FStar_Compiler_Effect.op_Less_Bar
-                 (FStar_TypeChecker_Env.debug env)
-                 (FStar_Options.Other "LayeredEffectsTc") in
-             if uu___1
-             then
-               let uu___2 =
-                 FStar_Compiler_List.fold_left
-                   (fun s ->
-                      fun t ->
-                        let uu___3 =
-                          let uu___4 = FStar_Syntax_Print.term_to_string t in
-                          Prims.op_Hat "; " uu___4 in
-                        Prims.op_Hat s uu___3) "" repr_names_args in
-               let uu___3 = FStar_Syntax_Print.binders_to_string "; " bs in
-               FStar_Compiler_Util.print2
-                 "Checking layered effect combinator binders validity, names: %s, binders: %s\n\n"
-                 uu___2 uu___3
-             else ());
-            (let valid_binder b = true in
-             let invalid_binders =
-               FStar_Compiler_List.filter
-                 (fun b -> Prims.op_Negation (valid_binder b)) bs in
-             if
-               (FStar_Compiler_List.length invalid_binders) <> Prims.int_zero
-             then
-               (let uu___2 =
-                  let uu___3 =
-                    let uu___4 =
-                      FStar_Syntax_Print.binders_to_string "; "
-                        invalid_binders in
-                    FStar_Compiler_Util.format1
-                      "Binders %s neither appear as repr indices nor have an associated tactic"
-                      uu___4 in
-                  (FStar_Errors.Fatal_UnexpectedEffect, uu___3) in
-                FStar_Errors.raise_error uu___2 r)
-             else ();
-             if check_non_informatve_binders
-             then
-               (let uu___2 =
-                  FStar_Compiler_List.fold_left
-                    (fun uu___3 ->
-                       fun b ->
-                         match uu___3 with
-                         | (env1, bs1) ->
-                             let env2 =
-                               FStar_TypeChecker_Env.push_binders env1 [b] in
-                             let uu___4 =
-                               FStar_TypeChecker_Normalize.non_info_norm env2
-                                 (b.FStar_Syntax_Syntax.binder_bv).FStar_Syntax_Syntax.sort in
-                             if uu___4
-                             then (env2, bs1)
-                             else (env2, (b :: bs1))) (env, []) bs in
-                match uu___2 with
-                | (uu___3, informative_binders) ->
-                    if
-                      (FStar_Compiler_List.length informative_binders) <>
-                        Prims.int_zero
-                    then
-                      let uu___4 =
-                        let uu___5 =
-                          let uu___6 =
-                            FStar_Syntax_Print.binders_to_string "; "
-                              informative_binders in
-                          FStar_Compiler_Util.format1
-                            "Binders %s are informative while the effect is reifiable"
-                            uu___6 in
-                        (FStar_Errors.Fatal_UnexpectedEffect, uu___5) in
-                      FStar_Errors.raise_error uu___4 r
-                    else ())
-             else ())
+      fun check_non_informatve_binders ->
+        fun r ->
+          if check_non_informatve_binders
+          then
+            let uu___ =
+              FStar_Compiler_List.fold_left
+                (fun uu___1 ->
+                   fun b ->
+                     match uu___1 with
+                     | (env1, bs1) ->
+                         let env2 =
+                           FStar_TypeChecker_Env.push_binders env1 [b] in
+                         let uu___2 =
+                           FStar_TypeChecker_Normalize.non_info_norm env2
+                             (b.FStar_Syntax_Syntax.binder_bv).FStar_Syntax_Syntax.sort in
+                         if uu___2 then (env2, bs1) else (env2, (b :: bs1)))
+                (env, []) bs in
+            match uu___ with
+            | (uu___1, informative_binders) ->
+                (if
+                   (FStar_Compiler_List.length informative_binders) <>
+                     Prims.int_zero
+                 then
+                   let uu___2 =
+                     let uu___3 =
+                       let uu___4 =
+                         FStar_Syntax_Print.binders_to_string "; "
+                           informative_binders in
+                       FStar_Compiler_Util.format1
+                         "Binders %s are informative while the effect is reifiable"
+                         uu___4 in
+                     (FStar_Errors.Fatal_UnexpectedEffect, uu___3) in
+                   FStar_Errors.raise_error uu___2 r
+                 else ())
+          else ()
 let (tc_layered_eff_decl :
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.eff_decl ->
@@ -762,7 +675,7 @@ let (tc_layered_eff_decl :
                                                       FStar_TypeChecker_Env.push_binders
                                                         env [a1; x] in
                                                     validate_layered_effect_binders
-                                                      env1 bs2 [res_t]
+                                                      env1 bs2
                                                       check_non_informative_binders
                                                       r));
                                           (let uu___12 =
@@ -1186,10 +1099,6 @@ let (tc_layered_eff_decl :
                                                                     [a1; b1] in
                                                                     validate_layered_effect_binders
                                                                     env1 bs4
-                                                                    [
-                                                                    (f_b.FStar_Syntax_Syntax.binder_bv).FStar_Syntax_Syntax.sort;
-                                                                    g_sort;
-                                                                    res_t]
                                                                     check_non_informative_binders
                                                                     r)));
                                                                     (
@@ -1544,9 +1453,6 @@ let (tc_layered_eff_decl :
                                                                     [a1] in
                                                                     validate_layered_effect_binders
                                                                     env1 bs3
-                                                                    [
-                                                                    (f_b.FStar_Syntax_Syntax.binder_bv).FStar_Syntax_Syntax.sort;
-                                                                    res_t]
                                                                     check_non_informative_binders
                                                                     r)));
                                                         (let uu___18 =
@@ -1898,10 +1804,6 @@ let (tc_layered_eff_decl :
                                                                     [a1] in
                                                                     validate_layered_effect_binders
                                                                     env1 bs3
-                                                                    [
-                                                                    (f_b.FStar_Syntax_Syntax.binder_bv).FStar_Syntax_Syntax.sort;
-                                                                    (g_b.FStar_Syntax_Syntax.binder_bv).FStar_Syntax_Syntax.sort;
-                                                                    body1]
                                                                     check_non_informative_binders
                                                                     r)));
                                                             (let uu___19 =
@@ -5364,10 +5266,8 @@ let (tc_layered_lift :
                                            FStar_TypeChecker_Env.push_binders
                                              env [a] in
                                          validate_layered_effect_binders env1
-                                           bs2
-                                           [(f_b.FStar_Syntax_Syntax.binder_bv).FStar_Syntax_Syntax.sort;
-                                           res_t]
-                                           check_non_informative_binders r)));
+                                           bs2 check_non_informative_binders
+                                           r)));
                           (let sub1 =
                              let uu___10 =
                                let uu___11 =
@@ -6684,10 +6584,6 @@ let (tc_polymonadic_bind :
                                                                     [a1; b1] in
                                                                     validate_layered_effect_binders
                                                                     env2 bs3
-                                                                    [
-                                                                    (f_b.FStar_Syntax_Syntax.binder_bv).FStar_Syntax_Syntax.sort;
-                                                                    g_sort;
-                                                                    res_t]
                                                                     check_non_informative_binders
                                                                     r)));
                                                        (let uu___13 =
@@ -6995,8 +6891,6 @@ let (tc_polymonadic_subcomp :
                                                                 env [a1] in
                                                             validate_layered_effect_binders
                                                               env1 bs3
-                                                              [(f_b.FStar_Syntax_Syntax.binder_bv).FStar_Syntax_Syntax.sort;
-                                                              res_t]
                                                               check_non_informative_binders
                                                               r)));
                                              (let uu___12 =

--- a/src/ocaml-output/FStar_TypeChecker_TcTerm.ml
+++ b/src/ocaml-output/FStar_TypeChecker_TcTerm.ml
@@ -11853,7 +11853,11 @@ let rec (universe_of_aux :
       | FStar_Syntax_Syntax.Tm_uvar (u, s) ->
           FStar_Syntax_Subst.subst' s u.FStar_Syntax_Syntax.ctx_uvar_typ
       | FStar_Syntax_Syntax.Tm_meta (t, uu___1) -> universe_of_aux env t
-      | FStar_Syntax_Syntax.Tm_name n -> n.FStar_Syntax_Syntax.sort
+      | FStar_Syntax_Syntax.Tm_name n ->
+          let uu___1 = FStar_TypeChecker_Env.try_lookup_bv env n in
+          (match uu___1 with
+           | FStar_Pervasives_Native.Some (t, uu___2) -> t
+           | FStar_Pervasives_Native.None -> n.FStar_Syntax_Syntax.sort)
       | FStar_Syntax_Syntax.Tm_fvar fv ->
           let uu___1 =
             FStar_TypeChecker_Env.lookup_lid env

--- a/src/ocaml-output/FStar_TypeChecker_TcTerm.ml
+++ b/src/ocaml-output/FStar_TypeChecker_TcTerm.ml
@@ -42,6 +42,8 @@ let (instantiate_both :
         (env.FStar_TypeChecker_Env.universe_of);
       FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term =
         (env.FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term);
+      FStar_TypeChecker_Env.subtype_nosmt_force =
+        (env.FStar_TypeChecker_Env.subtype_nosmt_force);
       FStar_TypeChecker_Env.use_bv_sorts =
         (env.FStar_TypeChecker_Env.use_bv_sorts);
       FStar_TypeChecker_Env.qtbl_name_and_index =
@@ -118,6 +120,8 @@ let (no_inst : FStar_TypeChecker_Env.env -> FStar_TypeChecker_Env.env) =
         (env.FStar_TypeChecker_Env.universe_of);
       FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term =
         (env.FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term);
+      FStar_TypeChecker_Env.subtype_nosmt_force =
+        (env.FStar_TypeChecker_Env.subtype_nosmt_force);
       FStar_TypeChecker_Env.use_bv_sorts =
         (env.FStar_TypeChecker_Env.use_bv_sorts);
       FStar_TypeChecker_Env.qtbl_name_and_index =
@@ -1076,6 +1080,8 @@ let (guard_letrecs :
                   (env.FStar_TypeChecker_Env.universe_of);
                 FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term =
                   (env.FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term);
+                FStar_TypeChecker_Env.subtype_nosmt_force =
+                  (env.FStar_TypeChecker_Env.subtype_nosmt_force);
                 FStar_TypeChecker_Env.use_bv_sorts =
                   (env.FStar_TypeChecker_Env.use_bv_sorts);
                 FStar_TypeChecker_Env.qtbl_name_and_index =
@@ -1620,6 +1626,8 @@ let rec (tc_term :
                     (env.FStar_TypeChecker_Env.universe_of);
                   FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term =
                     (env.FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term);
+                  FStar_TypeChecker_Env.subtype_nosmt_force =
+                    (env.FStar_TypeChecker_Env.subtype_nosmt_force);
                   FStar_TypeChecker_Env.use_bv_sorts =
                     (env.FStar_TypeChecker_Env.use_bv_sorts);
                   FStar_TypeChecker_Env.qtbl_name_and_index =
@@ -1910,6 +1918,8 @@ and (tc_maybe_toplevel_term :
                          FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term
                            =
                            (env'.FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term);
+                         FStar_TypeChecker_Env.subtype_nosmt_force =
+                           (env'.FStar_TypeChecker_Env.subtype_nosmt_force);
                          FStar_TypeChecker_Env.use_bv_sorts =
                            (env'.FStar_TypeChecker_Env.use_bv_sorts);
                          FStar_TypeChecker_Env.qtbl_name_and_index =
@@ -3962,6 +3972,8 @@ and (tc_tactic :
                 (env.FStar_TypeChecker_Env.universe_of);
               FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term =
                 (env.FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term);
+              FStar_TypeChecker_Env.subtype_nosmt_force =
+                (env.FStar_TypeChecker_Env.subtype_nosmt_force);
               FStar_TypeChecker_Env.use_bv_sorts =
                 (env.FStar_TypeChecker_Env.use_bv_sorts);
               FStar_TypeChecker_Env.qtbl_name_and_index =
@@ -4634,6 +4646,8 @@ and (tc_comp :
                   (env.FStar_TypeChecker_Env.universe_of);
                 FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term =
                   (env.FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term);
+                FStar_TypeChecker_Env.subtype_nosmt_force =
+                  (env.FStar_TypeChecker_Env.subtype_nosmt_force);
                 FStar_TypeChecker_Env.use_bv_sorts =
                   (env.FStar_TypeChecker_Env.use_bv_sorts);
                 FStar_TypeChecker_Env.qtbl_name_and_index =
@@ -5125,6 +5139,8 @@ and (tc_abs_expected_function_typ :
                                FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term
                                  =
                                  (envbody.FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term);
+                               FStar_TypeChecker_Env.subtype_nosmt_force =
+                                 (envbody.FStar_TypeChecker_Env.subtype_nosmt_force);
                                FStar_TypeChecker_Env.use_bv_sorts =
                                  (envbody.FStar_TypeChecker_Env.use_bv_sorts);
                                FStar_TypeChecker_Env.qtbl_name_and_index =
@@ -5277,6 +5293,8 @@ and (tc_abs_expected_function_typ :
                              FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term
                                =
                                (env.FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term);
+                             FStar_TypeChecker_Env.subtype_nosmt_force =
+                               (env.FStar_TypeChecker_Env.subtype_nosmt_force);
                              FStar_TypeChecker_Env.use_bv_sorts =
                                (env.FStar_TypeChecker_Env.use_bv_sorts);
                              FStar_TypeChecker_Env.qtbl_name_and_index =
@@ -5383,6 +5401,8 @@ and (tc_abs_expected_function_typ :
                                   FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term
                                     =
                                     (envbody1.FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term);
+                                  FStar_TypeChecker_Env.subtype_nosmt_force =
+                                    (envbody1.FStar_TypeChecker_Env.subtype_nosmt_force);
                                   FStar_TypeChecker_Env.use_bv_sorts =
                                     (envbody1.FStar_TypeChecker_Env.use_bv_sorts);
                                   FStar_TypeChecker_Env.qtbl_name_and_index =
@@ -5922,6 +5942,8 @@ and (tc_abs :
                                   FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term
                                     =
                                     (envbody2.FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term);
+                                  FStar_TypeChecker_Env.subtype_nosmt_force =
+                                    (envbody2.FStar_TypeChecker_Env.subtype_nosmt_force);
                                   FStar_TypeChecker_Env.use_bv_sorts =
                                     (envbody2.FStar_TypeChecker_Env.use_bv_sorts);
                                   FStar_TypeChecker_Env.qtbl_name_and_index =
@@ -9149,6 +9171,9 @@ and (tc_eqn :
                                                                     FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term
                                                                     =
                                                                     (uu___16.FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term);
+                                                                    FStar_TypeChecker_Env.subtype_nosmt_force
+                                                                    =
+                                                                    (uu___16.FStar_TypeChecker_Env.subtype_nosmt_force);
                                                                     FStar_TypeChecker_Env.use_bv_sorts
                                                                     =
                                                                     (uu___16.FStar_TypeChecker_Env.use_bv_sorts);
@@ -9799,6 +9824,8 @@ and (check_inner_let :
                 (env1.FStar_TypeChecker_Env.universe_of);
               FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term =
                 (env1.FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term);
+              FStar_TypeChecker_Env.subtype_nosmt_force =
+                (env1.FStar_TypeChecker_Env.subtype_nosmt_force);
               FStar_TypeChecker_Env.use_bv_sorts =
                 (env1.FStar_TypeChecker_Env.use_bv_sorts);
               FStar_TypeChecker_Env.qtbl_name_and_index =
@@ -10538,6 +10565,8 @@ and (build_let_rec_env :
                   (env01.FStar_TypeChecker_Env.universe_of);
                 FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term =
                   (env01.FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term);
+                FStar_TypeChecker_Env.subtype_nosmt_force =
+                  (env01.FStar_TypeChecker_Env.subtype_nosmt_force);
                 FStar_TypeChecker_Env.use_bv_sorts =
                   (env01.FStar_TypeChecker_Env.use_bv_sorts);
                 FStar_TypeChecker_Env.qtbl_name_and_index =
@@ -10722,6 +10751,9 @@ and (build_let_rec_env :
                                            FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term
                                              =
                                              (env2.FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term);
+                                           FStar_TypeChecker_Env.subtype_nosmt_force
+                                             =
+                                             (env2.FStar_TypeChecker_Env.subtype_nosmt_force);
                                            FStar_TypeChecker_Env.use_bv_sorts
                                              =
                                              (env2.FStar_TypeChecker_Env.use_bv_sorts);
@@ -11004,6 +11036,8 @@ and (check_let_bound_def :
                          FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term
                            =
                            (env11.FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term);
+                         FStar_TypeChecker_Env.subtype_nosmt_force =
+                           (env11.FStar_TypeChecker_Env.subtype_nosmt_force);
                          FStar_TypeChecker_Env.use_bv_sorts =
                            (env11.FStar_TypeChecker_Env.use_bv_sorts);
                          FStar_TypeChecker_Env.qtbl_name_and_index =
@@ -11498,6 +11532,8 @@ let (typeof_tot_or_gtot_term :
                (env.FStar_TypeChecker_Env.universe_of);
              FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term =
                (env.FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term);
+             FStar_TypeChecker_Env.subtype_nosmt_force =
+               (env.FStar_TypeChecker_Env.subtype_nosmt_force);
              FStar_TypeChecker_Env.use_bv_sorts =
                (env.FStar_TypeChecker_Env.use_bv_sorts);
              FStar_TypeChecker_Env.qtbl_name_and_index =
@@ -11669,6 +11705,8 @@ let (level_of_type :
                          FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term
                            =
                            (env.FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term);
+                         FStar_TypeChecker_Env.subtype_nosmt_force =
+                           (env.FStar_TypeChecker_Env.subtype_nosmt_force);
                          FStar_TypeChecker_Env.use_bv_sorts =
                            (env.FStar_TypeChecker_Env.use_bv_sorts);
                          FStar_TypeChecker_Env.qtbl_name_and_index =
@@ -12021,6 +12059,8 @@ let rec (universe_of_aux :
                          FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term
                            =
                            (env1.FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term);
+                         FStar_TypeChecker_Env.subtype_nosmt_force =
+                           (env1.FStar_TypeChecker_Env.subtype_nosmt_force);
                          FStar_TypeChecker_Env.use_bv_sorts = true;
                          FStar_TypeChecker_Env.qtbl_name_and_index =
                            (env1.FStar_TypeChecker_Env.qtbl_name_and_index);

--- a/src/ocaml-output/FStar_TypeChecker_TcTerm.ml
+++ b/src/ocaml-output/FStar_TypeChecker_TcTerm.ml
@@ -12418,10 +12418,27 @@ let rec (typeof_tot_or_gtot_term_fastpath :
         | FStar_Syntax_Syntax.Tm_match
             (uu___, uu___1, uu___2, FStar_Pervasives_Native.Some rc) ->
             rc.FStar_Syntax_Syntax.residual_typ
-        | FStar_Syntax_Syntax.Tm_match uu___ -> FStar_Pervasives_Native.None
-        | FStar_Syntax_Syntax.Tm_let uu___ -> FStar_Pervasives_Native.None
-        | FStar_Syntax_Syntax.Tm_unknown -> FStar_Pervasives_Native.None
-        | FStar_Syntax_Syntax.Tm_uinst uu___ -> FStar_Pervasives_Native.None
+        | FStar_Syntax_Syntax.Tm_match uu___ ->
+            let uu___1 =
+              let uu___2 =
+                let uu___3 = FStar_Syntax_Print.tag_of_term t1 in
+                Prims.op_Hat uu___3 ")" in
+              Prims.op_Hat "Impossible! (" uu___2 in
+            failwith uu___1
+        | FStar_Syntax_Syntax.Tm_let uu___ ->
+            let uu___1 =
+              let uu___2 =
+                let uu___3 = FStar_Syntax_Print.tag_of_term t1 in
+                Prims.op_Hat uu___3 ")" in
+              Prims.op_Hat "Impossible! (" uu___2 in
+            failwith uu___1
+        | FStar_Syntax_Syntax.Tm_unknown ->
+            let uu___ =
+              let uu___1 =
+                let uu___2 = FStar_Syntax_Print.tag_of_term t1 in
+                Prims.op_Hat uu___2 ")" in
+              Prims.op_Hat "Impossible! (" uu___1 in
+            failwith uu___
         | uu___ ->
             let uu___1 =
               let uu___2 =

--- a/src/ocaml-output/FStar_TypeChecker_TcTerm.ml
+++ b/src/ocaml-output/FStar_TypeChecker_TcTerm.ml
@@ -4090,7 +4090,8 @@ and (tc_value :
       | FStar_Syntax_Syntax.Tm_uvar (u, s) ->
           let uu___ =
             let uu___1 =
-              FStar_Syntax_Subst.subst' s u.FStar_Syntax_Syntax.ctx_uvar_typ in
+              let uu___2 = FStar_Syntax_Util.ctx_uvar_typ u in
+              FStar_Syntax_Subst.subst' s uu___2 in
             FStar_Pervasives.Inl uu___1 in
           value_check_expected_typ env1 e uu___
             FStar_TypeChecker_Env.trivial_guard
@@ -11851,7 +11852,8 @@ let rec (universe_of_aux :
       | FStar_Syntax_Syntax.Tm_abs (bs, t, uu___1) ->
           level_of_type_fail env e "arrow type"
       | FStar_Syntax_Syntax.Tm_uvar (u, s) ->
-          FStar_Syntax_Subst.subst' s u.FStar_Syntax_Syntax.ctx_uvar_typ
+          let uu___1 = FStar_Syntax_Util.ctx_uvar_typ u in
+          FStar_Syntax_Subst.subst' s uu___1
       | FStar_Syntax_Syntax.Tm_meta (t, uu___1) -> universe_of_aux env t
       | FStar_Syntax_Syntax.Tm_name n ->
           let uu___1 = FStar_TypeChecker_Env.try_lookup_bv env n in
@@ -12405,8 +12407,8 @@ let rec (typeof_tot_or_gtot_term_fastpath :
             if Prims.op_Negation must_tot
             then
               let uu___ =
-                FStar_Syntax_Subst.subst' s
-                  u.FStar_Syntax_Syntax.ctx_uvar_typ in
+                let uu___1 = FStar_Syntax_Util.ctx_uvar_typ u in
+                FStar_Syntax_Subst.subst' s uu___1 in
               FStar_Pervasives_Native.Some uu___
             else FStar_Pervasives_Native.None
         | FStar_Syntax_Syntax.Tm_quoted (tm, qi) ->

--- a/src/ocaml-output/FStar_TypeChecker_Util.ml
+++ b/src/ocaml-output/FStar_TypeChecker_Util.ml
@@ -7049,6 +7049,8 @@ let (update_env_sub_eff :
                 (env.FStar_TypeChecker_Env.universe_of);
               FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term =
                 (env.FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term);
+              FStar_TypeChecker_Env.subtype_nosmt_force =
+                (env.FStar_TypeChecker_Env.subtype_nosmt_force);
               FStar_TypeChecker_Env.use_bv_sorts =
                 (env.FStar_TypeChecker_Env.use_bv_sorts);
               FStar_TypeChecker_Env.qtbl_name_and_index =
@@ -7139,6 +7141,8 @@ let (update_env_sub_eff :
             (env1.FStar_TypeChecker_Env.universe_of);
           FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term =
             (env1.FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term);
+          FStar_TypeChecker_Env.subtype_nosmt_force =
+            (env1.FStar_TypeChecker_Env.subtype_nosmt_force);
           FStar_TypeChecker_Env.use_bv_sorts =
             (env1.FStar_TypeChecker_Env.use_bv_sorts);
           FStar_TypeChecker_Env.qtbl_name_and_index =

--- a/src/ocaml-output/FStar_Universal.ml
+++ b/src/ocaml-output/FStar_Universal.ml
@@ -73,6 +73,8 @@ let with_dsenv_of_tcenv :
                 (tcenv.FStar_TypeChecker_Env.universe_of);
               FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term =
                 (tcenv.FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term);
+              FStar_TypeChecker_Env.subtype_nosmt_force =
+                (tcenv.FStar_TypeChecker_Env.subtype_nosmt_force);
               FStar_TypeChecker_Env.use_bv_sorts =
                 (tcenv.FStar_TypeChecker_Env.use_bv_sorts);
               FStar_TypeChecker_Env.qtbl_name_and_index =
@@ -242,7 +244,8 @@ let (init_env : FStar_Parser_Dep.deps -> FStar_TypeChecker_Env.env) =
       FStar_TypeChecker_Env.initial_env deps FStar_TypeChecker_TcTerm.tc_term
         FStar_TypeChecker_TcTerm.typeof_tot_or_gtot_term
         FStar_TypeChecker_TcTerm.typeof_tot_or_gtot_term_fastpath
-        FStar_TypeChecker_TcTerm.universe_of solver
+        FStar_TypeChecker_TcTerm.universe_of
+        FStar_TypeChecker_Rel.subtype_nosmt_force solver
         FStar_Parser_Const.prims_lid uu___ in
     let env1 =
       {
@@ -289,6 +292,8 @@ let (init_env : FStar_Parser_Dep.deps -> FStar_TypeChecker_Env.env) =
           (env.FStar_TypeChecker_Env.universe_of);
         FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term =
           (env.FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term);
+        FStar_TypeChecker_Env.subtype_nosmt_force =
+          (env.FStar_TypeChecker_Env.subtype_nosmt_force);
         FStar_TypeChecker_Env.use_bv_sorts =
           (env.FStar_TypeChecker_Env.use_bv_sorts);
         FStar_TypeChecker_Env.qtbl_name_and_index =
@@ -369,6 +374,8 @@ let (init_env : FStar_Parser_Dep.deps -> FStar_TypeChecker_Env.env) =
           (env1.FStar_TypeChecker_Env.universe_of);
         FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term =
           (env1.FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term);
+        FStar_TypeChecker_Env.subtype_nosmt_force =
+          (env1.FStar_TypeChecker_Env.subtype_nosmt_force);
         FStar_TypeChecker_Env.use_bv_sorts =
           (env1.FStar_TypeChecker_Env.use_bv_sorts);
         FStar_TypeChecker_Env.qtbl_name_and_index =
@@ -452,6 +459,8 @@ let (init_env : FStar_Parser_Dep.deps -> FStar_TypeChecker_Env.env) =
           (env2.FStar_TypeChecker_Env.universe_of);
         FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term =
           (env2.FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term);
+        FStar_TypeChecker_Env.subtype_nosmt_force =
+          (env2.FStar_TypeChecker_Env.subtype_nosmt_force);
         FStar_TypeChecker_Env.use_bv_sorts =
           (env2.FStar_TypeChecker_Env.use_bv_sorts);
         FStar_TypeChecker_Env.qtbl_name_and_index =
@@ -535,6 +544,8 @@ let (init_env : FStar_Parser_Dep.deps -> FStar_TypeChecker_Env.env) =
           (env3.FStar_TypeChecker_Env.universe_of);
         FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term =
           (env3.FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term);
+        FStar_TypeChecker_Env.subtype_nosmt_force =
+          (env3.FStar_TypeChecker_Env.subtype_nosmt_force);
         FStar_TypeChecker_Env.use_bv_sorts =
           (env3.FStar_TypeChecker_Env.use_bv_sorts);
         FStar_TypeChecker_Env.qtbl_name_and_index =
@@ -617,6 +628,8 @@ let (init_env : FStar_Parser_Dep.deps -> FStar_TypeChecker_Env.env) =
           (env4.FStar_TypeChecker_Env.universe_of);
         FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term =
           (env4.FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term);
+        FStar_TypeChecker_Env.subtype_nosmt_force =
+          (env4.FStar_TypeChecker_Env.subtype_nosmt_force);
         FStar_TypeChecker_Env.use_bv_sorts =
           (env4.FStar_TypeChecker_Env.use_bv_sorts);
         FStar_TypeChecker_Env.qtbl_name_and_index =

--- a/src/smtencoding/FStar.SMTEncoding.EncodeTerm.fst
+++ b/src/smtencoding/FStar.SMTEncoding.EncodeTerm.fst
@@ -898,7 +898,7 @@ and encode_term (t:typ) (env:env_t) : (term         (* encoding of t, expects t 
 
       | Tm_uvar (uv, _) ->
         let ttm = mk_Term_uvar (Unionfind.uvar_id uv.ctx_uvar_head) in
-        let t_has_k, decls = encode_term_pred None uv.ctx_uvar_typ env ttm in //TODO: skip encoding this if it has already been encoded before
+        let t_has_k, decls = encode_term_pred None (U.ctx_uvar_typ uv) env ttm in //TODO: skip encoding this if it has already been encoded before
         let d =
             Util.mkAssume(t_has_k,
                           Some "Uvar typing",

--- a/src/syntax/FStar.Syntax.Free.fst
+++ b/src/syntax/FStar.Syntax.Free.fst
@@ -26,6 +26,8 @@ open FStar.Syntax
 open FStar.Syntax.Syntax
 module Util = FStar.Compiler.Util
 module UF = FStar.Syntax.Unionfind
+let ctx_uvar_typ (u:ctx_uvar) = 
+    (UF.find_decoration u.ctx_uvar_head).uvar_decoration_typ
 
 
 (********************************************************************************)
@@ -94,7 +96,7 @@ let rec free_names_and_uvs' tm (use_cache:use_cache_t) : free_vars_and_fvars =
 
       | Tm_uvar (uv, (s, _)) ->
         union (singleton_uv uv)
-              (if use_cache = Full then free_names_and_uvars uv.ctx_uvar_typ use_cache else no_free_vars)
+              (if use_cache = Full then free_names_and_uvars (ctx_uvar_typ uv) use_cache else no_free_vars)
 
       | Tm_type u ->
         free_univs u

--- a/src/syntax/FStar.Syntax.Print.fst
+++ b/src/syntax/FStar.Syntax.Print.fst
@@ -388,7 +388,7 @@ and ctx_uvar_to_string_aux print_reason ctx_uvar =
             reason_string
             (binders_to_string ", " ctx_uvar.ctx_uvar_binders)
             (uvar_to_string ctx_uvar.ctx_uvar_head)
-            (term_to_string ctx_uvar.ctx_uvar_typ)
+            (term_to_string (SU.ctx_uvar_typ ctx_uvar))
             (match SU.ctx_uvar_should_check ctx_uvar with
              | Allow_unresolved -> "Allow_unresolved"
              | Allow_untyped  -> "Allow_untyped"

--- a/src/syntax/FStar.Syntax.Print.fst
+++ b/src/syntax/FStar.Syntax.Print.fst
@@ -389,7 +389,7 @@ and ctx_uvar_to_string_aux print_reason ctx_uvar =
             (binders_to_string ", " ctx_uvar.ctx_uvar_binders)
             (uvar_to_string ctx_uvar.ctx_uvar_head)
             (term_to_string ctx_uvar.ctx_uvar_typ)
-            (match ctx_uvar.ctx_uvar_should_check with
+            (match SU.ctx_uvar_should_check ctx_uvar with
              | Allow_unresolved -> "Allow_unresolved"
              | Allow_untyped  -> "Allow_untyped"
              | Allow_ghost  -> "Allow_ghost"

--- a/src/syntax/FStar.Syntax.Print.fst
+++ b/src/syntax/FStar.Syntax.Print.fst
@@ -384,11 +384,17 @@ and ctx_uvar_to_string_aux print_reason ctx_uvar =
       else U.format2 "(%s-%s) "
              (Range.string_of_pos (Range.start_of_range ctx_uvar.ctx_uvar_range))
              (Range.string_of_pos (Range.end_of_range ctx_uvar.ctx_uvar_range)) in
-    format4 "%s(%s |- %s : %s)"
+    format5 "%s(%s |- %s : %s) %s"
             reason_string
             (binders_to_string ", " ctx_uvar.ctx_uvar_binders)
             (uvar_to_string ctx_uvar.ctx_uvar_head)
             (term_to_string ctx_uvar.ctx_uvar_typ)
+            (match ctx_uvar.ctx_uvar_should_check with
+             | Allow_unresolved -> "Allow_unresolved"
+             | Allow_untyped  -> "Allow_untyped"
+             | Allow_ghost  -> "Allow_ghost"
+             | Strict   -> "Strict")
+
 
 and subst_elt_to_string = function
    | DB(i, x) -> U.format2 "DB (%s, %s)" (string_of_int i) (bv_to_string x)

--- a/src/syntax/FStar.Syntax.Subst.fst
+++ b/src/syntax/FStar.Syntax.Subst.fst
@@ -298,6 +298,7 @@ let subst_binders' s bs =
         else subst_binder' (shift_subst' i s) b)
 let subst_binders s (bs:binders) = subst_binders' ([s], NoUseRange) bs
 
+
 // NOTE: We don't descend into `imp` here since one cannot *apply* a
 // `Meta t` argument, so this would always be a no-op
 let subst_arg' s (t, imp) = (subst' s t, imp)
@@ -531,6 +532,10 @@ let subst_bqual s imp = subst_bqual' ([s], NoUseRange) imp
 let subst_aqual s imp = subst_aqual' ([s], NoUseRange) imp
 let subst_ascription s (asc:ascription) = subst_ascription' ([s], NoUseRange) asc
 let subst_decreasing_order s dec = subst_dec_order' ([s], NoUseRange) dec
+let subst_residual_comp s rc =
+  match rc.residual_typ with
+  | None -> rc
+  | Some t -> {rc with residual_typ=subst s t |> Some}
 let closing_subst (bs:binders) =
     List.fold_right (fun b (subst, n)  -> (NM(b.binder_bv, n)::subst, n+1)) bs ([], 0) |> fst
 let open_binders' bs =

--- a/src/syntax/FStar.Syntax.Subst.fsti
+++ b/src/syntax/FStar.Syntax.Subst.fsti
@@ -32,6 +32,7 @@ val subst_ascription:   list subst_elt -> ascription -> ascription
 val subst_decreasing_order:
                         list subst_elt -> decreases_order -> decreases_order
 val subst_binders:      list subst_elt -> binders -> binders
+val subst_residual_comp:list subst_elt -> residual_comp -> residual_comp
 val compress:           term -> term
 val compress_univ:      universe -> universe
 

--- a/src/syntax/FStar.Syntax.Syntax.fsti
+++ b/src/syntax/FStar.Syntax.Syntax.fsti
@@ -30,10 +30,6 @@ open FStar.Const
 module O = FStar.Options
 open FStar.VConfig
 
-// JP: all these types are defined twice and every change has to be performed
-// twice (because of the .fs). TODO: move the type definitions into a standalone
-// fs without fsi, and move the helpers into syntaxhelpers.fs / syntaxhelpers.fsi
-
 (* Objects with metadata *)
 // IN F*: [@@ PpxDerivingYoJson; PpxDerivingShow ]
 type withinfo_t 'a = {
@@ -148,7 +144,6 @@ and ctx_uvar = {                                                 (* (G |- ?u : t
     ctx_uvar_binders:binders;                                    (* All the Tm_name bindings in G, a snoc list (most recent at the tail) *)
     ctx_uvar_typ:typ;                                            (* t *)
     ctx_uvar_reason:string;
-    ctx_uvar_should_check:should_check_uvar;
     ctx_uvar_range:Range.range;
     ctx_uvar_meta: option ctx_uvar_meta_t;
 }
@@ -156,7 +151,11 @@ and ctx_uvar_meta_t =
   | Ctx_uvar_meta_tac of dyn * term (* the dyn is an FStar.TypeChecker.Env.env *)
   | Ctx_uvar_meta_attr of term (* An attribute associated with an implicit argument using the #[@@...] notation *)
 and ctx_uvar_and_subst = ctx_uvar * subst_ts
-and uvar = Unionfind.p_uvar (option term) * version * Range.range
+and uvar_decoration = {
+  uvar_decoration_typ:typ;
+  uvar_decoration_should_check:should_check_uvar
+}
+and uvar = Unionfind.p_uvar (option term * uvar_decoration) * version * Range.range
 and uvars = set ctx_uvar
 and match_returns_ascription = binder * ascription               (* as x returns C|t *)
 and branch = pat * option term * term                           (* optional when clause in each branch *)

--- a/src/syntax/FStar.Syntax.Syntax.fsti
+++ b/src/syntax/FStar.Syntax.Syntax.fsti
@@ -142,7 +142,6 @@ and ctx_uvar = {                                                 (* (G |- ?u : t
     ctx_uvar_head:uvar;                                          (* ?u *)
     ctx_uvar_gamma:gamma;                                        (* G: a cons list of bindings (most recent at the head) *)
     ctx_uvar_binders:binders;                                    (* All the Tm_name bindings in G, a snoc list (most recent at the tail) *)
-    ctx_uvar_typ:typ;                                            (* t *)
     ctx_uvar_reason:string;
     ctx_uvar_range:Range.range;
     ctx_uvar_meta: option ctx_uvar_meta_t;

--- a/src/syntax/FStar.Syntax.Unionfind.fsti
+++ b/src/syntax/FStar.Syntax.Unionfind.fsti
@@ -43,10 +43,12 @@ val rollback           : tx -> unit
 val commit             : tx -> unit
 val update_in_tx       : ref 'a -> 'a -> unit
 
-val fresh              : Range.range -> S.uvar
+val fresh              : S.uvar_decoration -> Range.range -> S.uvar
 val uvar_id            : S.uvar -> int
 val find               : S.uvar -> option S.term
+val find_decoration    : S.uvar -> S.uvar_decoration
 val change             : S.uvar -> S.term -> unit
+val change_decoration  : S.uvar -> S.uvar_decoration -> unit
 val equiv              : S.uvar -> S.uvar -> bool
 val union              : S.uvar -> S.uvar -> unit
 

--- a/src/syntax/FStar.Syntax.Util.fst
+++ b/src/syntax/FStar.Syntax.Util.fst
@@ -2396,3 +2396,6 @@ let check_mutual_universes (lbs:list letbinding)
                    "Mutually recursive definitions do not abstract over the same universes")
                   lb.lbpos)
         lbs
+
+let ctx_uvar_should_check (u:ctx_uvar) = 
+    (Unionfind.find_decoration u.ctx_uvar_head).uvar_decoration_should_check

--- a/src/syntax/FStar.Syntax.Util.fst
+++ b/src/syntax/FStar.Syntax.Util.fst
@@ -2399,3 +2399,6 @@ let check_mutual_universes (lbs:list letbinding)
 
 let ctx_uvar_should_check (u:ctx_uvar) = 
     (Unionfind.find_decoration u.ctx_uvar_head).uvar_decoration_should_check
+
+let ctx_uvar_typ (u:ctx_uvar) = 
+    (Unionfind.find_decoration u.ctx_uvar_head).uvar_decoration_typ

--- a/src/tactics/FStar.Tactics.Basic.fst
+++ b/src/tactics/FStar.Tactics.Basic.fst
@@ -91,10 +91,9 @@ let find_and_map_implicit (u:ctx_uvar) (f:TcComm.implicit -> TcComm.implicit)
     let imps =
       List.map
         (fun i -> 
-             if i.imp_uvar.ctx_uvar_should_check <> Allow_untyped
-             && is_ctx_uvar_for_implicit u i
-             then mark_implicit_as_allow_untyped i
-             else f i)
+             if is_ctx_uvar_for_implicit u i
+             then f i
+             else i)
         ps.all_implicits
     in
     set ({ps with all_implicits = imps}))
@@ -907,7 +906,7 @@ let t_apply_lemma (noinst:bool) (noinst_lhs:bool)
             let hd, _ = U.head_and_args term in
             match (SS.compress hd).n with
             | Tm_uvar (ctx_uvar, _) ->
-                bind (bnorm_goal ({ goal with goal_ctx_uvar = ctx_uvar })) (fun _ ->
+                bind (bnorm_goal ({ goal with goal_ctx_uvar = ctx_uvar })) (fun goal ->
                 ret [goal])
             | _ ->
                 mlog (fun () -> BU.print2 "apply_lemma: arg %s unified to (%s)\n"

--- a/src/tactics/FStar.Tactics.Basic.fst
+++ b/src/tactics/FStar.Tactics.Basic.fst
@@ -110,7 +110,7 @@ let debugging () : tac bool =
 let do_dump_ps (msg:string) (ps:proofstate) : unit =
   let psc = ps.psc in
   let subst = Cfg.psc_subst psc in
-  do_dump_proofstate (subst_proof_display_state subst ps) msg
+  do_dump_proofstate ps msg
 
 let dump (msg:string) : tac unit =
   mk_tac (fun ps ->

--- a/src/tactics/FStar.Tactics.Basic.fsti
+++ b/src/tactics/FStar.Tactics.Basic.fsti
@@ -102,8 +102,6 @@ val lset                   : typ -> string -> term -> tac unit
 val curms                  : unit -> tac Z.t
 val set_urgency            : Z.t -> tac unit
 val t_commute_applied_match : unit -> tac unit
-
-val is_implicit_for_goal (g:goal) (i:TcComm.implicit) : bool
-val mark_implicit_as_allow_untyped (i:TcComm.implicit) : TcComm.implicit
-val goal_with_type : goal -> typ -> tac goal
+val goal_with_type : goal -> typ -> goal
+val mark_goal_implicit_allow_untyped : goal -> unit
 

--- a/src/tactics/FStar.Tactics.Basic.fsti
+++ b/src/tactics/FStar.Tactics.Basic.fsti
@@ -81,6 +81,7 @@ val dup                    : unit -> tac unit
 val prune                  : string -> tac unit
 val addns                  : string -> tac unit
 val t_destruct             : term -> tac (list (fv * Z.t))
+val gather_explicit_guards_for_resolved_goals : unit -> tac unit
 val set_options            : string -> tac unit
 val uvar_env               : env -> option typ -> tac term
 val fresh_universe_uvar    : unit -> tac term
@@ -104,4 +105,3 @@ val set_urgency            : Z.t -> tac unit
 val t_commute_applied_match : unit -> tac unit
 val goal_with_type : goal -> typ -> goal
 val mark_goal_implicit_allow_untyped : goal -> unit
-

--- a/src/tactics/FStar.Tactics.Basic.fsti
+++ b/src/tactics/FStar.Tactics.Basic.fsti
@@ -34,6 +34,7 @@ module EMB   = FStar.Syntax.Embeddings
 module O     = FStar.Options
 module Range = FStar.Compiler.Range
 module Z     = FStar.BigInt
+module TcComm = FStar.TypeChecker.Common
 
 (* Internal utilities *)
 
@@ -101,3 +102,8 @@ val lset                   : typ -> string -> term -> tac unit
 val curms                  : unit -> tac Z.t
 val set_urgency            : Z.t -> tac unit
 val t_commute_applied_match : unit -> tac unit
+
+val is_implicit_for_goal (g:goal) (i:TcComm.implicit) : bool
+val mark_implicit_as_allow_untyped (i:TcComm.implicit) : TcComm.implicit
+
+

--- a/src/tactics/FStar.Tactics.Basic.fsti
+++ b/src/tactics/FStar.Tactics.Basic.fsti
@@ -69,7 +69,7 @@ val clear_top              : unit -> tac unit
 val clear                  : binder -> tac unit
 val rewrite                : binder -> tac unit
 val t_exact                : bool -> bool -> term -> tac unit
-val t_apply                : bool -> bool -> term -> tac unit
+val t_apply                : bool -> bool -> bool -> term -> tac unit
 val t_apply_lemma          : bool -> bool -> term -> tac unit
 val print                  : string -> tac unit
 val debugging              : unit -> tac bool

--- a/src/tactics/FStar.Tactics.Basic.fsti
+++ b/src/tactics/FStar.Tactics.Basic.fsti
@@ -105,5 +105,5 @@ val t_commute_applied_match : unit -> tac unit
 
 val is_implicit_for_goal (g:goal) (i:TcComm.implicit) : bool
 val mark_implicit_as_allow_untyped (i:TcComm.implicit) : TcComm.implicit
-
+val goal_with_type : goal -> typ -> tac goal
 

--- a/src/tactics/FStar.Tactics.CtrlRewrite.fst
+++ b/src/tactics/FStar.Tactics.CtrlRewrite.fst
@@ -102,7 +102,7 @@ let __do_rewrite
       ret tm (* SHOULD THIS CHECK BE IN maybe_rewrite INSTEAD? *)
     else
     let typ = lcomp.res_typ in
-    bind (new_uvar "do_rewrite.rhs" env typ (rangeof g0)) (fun (ut, uvar_ut) ->
+    bind (new_uvar "do_rewrite.rhs" env typ None (rangeof g0)) (fun (ut, uvar_ut) ->
     mlog (fun () ->
        BU.print2 "do_rewrite: making equality\n\t%s ==\n\t%s\n"
          (Print.term_to_string tm) (Print.term_to_string ut)) (fun () ->

--- a/src/tactics/FStar.Tactics.CtrlRewrite.fst
+++ b/src/tactics/FStar.Tactics.CtrlRewrite.fst
@@ -223,14 +223,15 @@ let rec ctrl_fold_env
 
 and recurse_option_residual_comp (env:env) (rc_opt:option residual_comp) recurse
   : tac (option residual_comp & ctrl_flag)
-  = match rc_opt with
-    | None -> ret (None, Continue)
-    | Some rc ->
-      match rc.residual_typ with
-      | None -> ret (Some rc, Continue)
-      | Some t ->
-        bind (recurse env t) (fun (t, flag) ->
-        ret (Some ({rc with residual_typ=Some t}), flag))
+  = ret (None, Continue)
+    // match rc_opt with
+    // | None -> ret (None, Continue)
+    // | Some rc ->
+    //   match rc.residual_typ with
+    //   | None -> ret (Some rc, Continue)
+    //   | Some t ->
+    //     bind (recurse env t) (fun (t, flag) ->
+    //     ret (Some ({rc with residual_typ=Some t}), flag))
 
 and on_subterms
     (g0 : goal)

--- a/src/tactics/FStar.Tactics.CtrlRewrite.fst
+++ b/src/tactics/FStar.Tactics.CtrlRewrite.fst
@@ -102,7 +102,7 @@ let __do_rewrite
       ret tm (* SHOULD THIS CHECK BE IN maybe_rewrite INSTEAD? *)
     else
     let typ = lcomp.res_typ in
-    bind (new_uvar "do_rewrite.rhs" env typ (Some Allow_untyped) (rangeof g0)) (fun (ut, uvar_ut) ->
+    bind (new_uvar "do_rewrite.rhs" env typ None (rangeof g0)) (fun (ut, uvar_ut) ->
     mlog (fun () ->
        BU.print2 "do_rewrite: making equality\n\t%s ==\n\t%s\n"
          (Print.term_to_string tm) (Print.term_to_string ut)) (fun () ->

--- a/src/tactics/FStar.Tactics.CtrlRewrite.fst
+++ b/src/tactics/FStar.Tactics.CtrlRewrite.fst
@@ -372,4 +372,5 @@ let ctrl_rewrite
         BU.print1 "ctrl_rewrite seems to have succeded with %s\n" (Print.term_to_string gt'));
 
     bind (push_goals gs) (fun _ ->
-    add_goals [goal_with_type g gt']))))
+    bind (goal_with_type g gt') (fun g ->
+    add_goals [g])))))

--- a/src/tactics/FStar.Tactics.CtrlRewrite.fst
+++ b/src/tactics/FStar.Tactics.CtrlRewrite.fst
@@ -102,7 +102,7 @@ let __do_rewrite
       ret tm (* SHOULD THIS CHECK BE IN maybe_rewrite INSTEAD? *)
     else
     let typ = lcomp.res_typ in
-    bind (new_uvar "do_rewrite.rhs" env typ None (rangeof g0)) (fun (ut, uvar_ut) ->
+    bind (new_uvar "do_rewrite.rhs" env typ (Some Allow_untyped) (rangeof g0)) (fun (ut, uvar_ut) ->
     mlog (fun () ->
        BU.print2 "do_rewrite: making equality\n\t%s ==\n\t%s\n"
          (Print.term_to_string tm) (Print.term_to_string ut)) (fun () ->

--- a/src/tactics/FStar.Tactics.CtrlRewrite.fst
+++ b/src/tactics/FStar.Tactics.CtrlRewrite.fst
@@ -223,15 +223,15 @@ let rec ctrl_fold_env
 
 and recurse_option_residual_comp (env:env) (rc_opt:option residual_comp) recurse
   : tac (option residual_comp & ctrl_flag)
-  = ret (None, Continue)
-    // match rc_opt with
-    // | None -> ret (None, Continue)
-    // | Some rc ->
-    //   match rc.residual_typ with
-    //   | None -> ret (Some rc, Continue)
-    //   | Some t ->
-    //     bind (recurse env t) (fun (t, flag) ->
-    //     ret (Some ({rc with residual_typ=Some t}), flag))
+  = // ret (None, Continue)
+    match rc_opt with
+    | None -> ret (None, Continue)
+    | Some rc ->
+      match rc.residual_typ with
+      | None -> ret (Some rc, Continue)
+      | Some t ->
+        bind (recurse env t) (fun (t, flag) ->
+        ret (Some ({rc with residual_typ=Some t}), flag))
 
 and on_subterms
     (g0 : goal)

--- a/src/tactics/FStar.Tactics.CtrlRewrite.fst
+++ b/src/tactics/FStar.Tactics.CtrlRewrite.fst
@@ -393,5 +393,5 @@ let ctrl_rewrite
         BU.print1 "ctrl_rewrite seems to have succeded with %s\n" (Print.term_to_string gt'));
 
     bind (push_goals gs) (fun _ ->
-    bind (goal_with_type g gt') (fun g ->
-    add_goals [g])))))
+    let g = goal_with_type g gt' in
+    add_goals [g]))))

--- a/src/tactics/FStar.Tactics.Hooks.fst
+++ b/src/tactics/FStar.Tactics.Hooks.fst
@@ -161,8 +161,8 @@ let by_tactic_interp (pol:pol) (e:Env.env) (t:term) : tres =
         in
 
         // abort if the uvar was not solved
-        let g_imp = TcRel.resolve_implicits_tac e g_imp in
-        report_implicits tm.pos g_imp.implicits;
+        let tagged_imps = TcRel.resolve_implicits_tac e g_imp in
+        report_implicits tm.pos tagged_imps;
 
         // If the rewriting succeeded, we return the generated uvar, which is now
         // a synthesized term
@@ -881,8 +881,8 @@ let postprocess (env:Env.env) (tau:term) (typ:term) (tm:term) : term =
         | None ->
             Err.raise_error (Err.Fatal_OpenGoalsInSynthesis, "postprocessing left open goals") typ.pos) gs;
     (* abort if the uvar was not solved *)
-    let g_imp = TcRel.resolve_implicits_tac env g_imp in
-    report_implicits tm.pos g_imp.implicits;
+    let tagged_imps = TcRel.resolve_implicits_tac env g_imp in
+    report_implicits tm.pos tagged_imps;
 
     uvtm
     end

--- a/src/tactics/FStar.Tactics.Interpreter.fst
+++ b/src/tactics/FStar.Tactics.Interpreter.fst
@@ -487,6 +487,10 @@ let () =
         t_commute_applied_match e_unit e_unit
         t_commute_applied_match NBET.e_unit NBET.e_unit;
 
+      mk_tac_step_1 0 "gather_or_solve_explicit_guards_for_resolved_goals"
+        gather_explicit_guards_for_resolved_goals e_unit e_unit
+        gather_explicit_guards_for_resolved_goals NBET.e_unit NBET.e_unit;
+
     ]
 
 let unembed_tactic_1_alt (ea:embedding 'a) (er:embedding 'r) (f:term) (ncb:norm_cb) : option ('a -> tac 'r) =
@@ -520,7 +524,7 @@ let report_implicits rng (is : TcRel.tagged_implicits) : unit =
       | TcRel.Implicit_has_typing_guard (tm, ty) ->
         Errors.log_issue rng
                 (Err.Error_UninstantiatedUnificationVarInTactic,
-                 BU.format4 ("Tactic solved goal %s of type %s to %s : %s, but it has a non-trivial typing guard")
+                 BU.format4 ("Tactic solved goal %s of type %s to %s : %s, but it has a non-trivial typing guard. Use gather_or_solve_explicit_guards_for_resolved_goals to inspect and prove these goals")
                              (Print.uvar_to_string imp.imp_uvar.ctx_uvar_head)
                              (Print.term_to_string (U.ctx_uvar_typ imp.imp_uvar))
                              (Print.term_to_string tm)

--- a/src/tactics/FStar.Tactics.Interpreter.fst
+++ b/src/tactics/FStar.Tactics.Interpreter.fst
@@ -323,9 +323,9 @@ let () =
         t_exact e_bool e_bool RE.e_term e_unit
         t_exact NBET.e_bool NBET.e_bool NRE.e_term NBET.e_unit;
 
-      mk_tac_step_3 0 "t_apply"
-        t_apply e_bool e_bool RE.e_term e_unit
-        t_apply NBET.e_bool NBET.e_bool NRE.e_term NBET.e_unit;
+      mk_tac_step_4 0 "t_apply"
+        t_apply e_bool e_bool e_bool RE.e_term e_unit
+        t_apply NBET.e_bool NBET.e_bool NBET.e_bool NRE.e_term NBET.e_unit;
 
       mk_tac_step_3 0 "t_apply_lemma"
         t_apply_lemma e_bool e_bool RE.e_term e_unit

--- a/src/tactics/FStar.Tactics.Interpreter.fst
+++ b/src/tactics/FStar.Tactics.Interpreter.fst
@@ -512,7 +512,7 @@ let report_implicits rng (is : Env.implicits) : unit =
                 (Err.Error_UninstantiatedUnificationVarInTactic,
                  BU.format3 ("Tactic left uninstantiated unification variable %s of type %s (reason = \"%s\")")
                              (Print.uvar_to_string imp.imp_uvar.ctx_uvar_head)
-                             (Print.term_to_string imp.imp_uvar.ctx_uvar_typ)
+                             (Print.term_to_string (U.ctx_uvar_typ imp.imp_uvar))
                              imp.imp_reason));
   Err.stop_if_err ()
 
@@ -593,11 +593,11 @@ let run_tactic_on_ps'
         // /implicits
 
         if !tacdbg then
-            do_dump_proofstate (subst_proof_state (Cfg.psc_subst ps.psc) ps) "at the finish line";
+            do_dump_proofstate (subst_proof_display_state (Cfg.psc_subst ps.psc) ps) "at the finish line";
         (ps.goals@ps.smt_goals, ret)
 
     | Failed (e, ps) ->
-        do_dump_proofstate (subst_proof_state (Cfg.psc_subst ps.psc) ps) "at the time of failure";
+        do_dump_proofstate (subst_proof_display_state (Cfg.psc_subst ps.psc) ps) "at the time of failure";
         let texn_to_string e =
             match e with
             | TacticFailure s ->

--- a/src/tactics/FStar.Tactics.Interpreter.fst
+++ b/src/tactics/FStar.Tactics.Interpreter.fst
@@ -555,37 +555,26 @@ let run_tactic_on_ps'
         (* if !tacdbg || Options.tactics_info () then *)
         (*     BU.print1 "Tactic generated proofterm %s\n" (Print.term_to_string w); *)
         let remaining_smt_goals = ps.goals@ps.smt_goals in
-        List.iter (fun g -> if is_irrelevant g
-                         then (
-                           if !tacdbg then BU.print1 "Assigning irrelevant goal %s\n" (Print.term_to_string (goal_witness g));
-                           if TcRel.teq_nosmt_force (goal_env g) (goal_witness g) U.exp_unit
-                           then ()
-                           else failwith (BU.format1 "Irrelevant tactic witness does not unify with (): %s"
-                                                    (Print.term_to_string (goal_witness g)))
-                         )
-                         else ())
-                  remaining_smt_goals;
+        List.iter 
+          (fun g -> 
+            FStar.Tactics.Basic.mark_goal_implicit_allow_untyped g;//all of these will be fed to SMT anyway
+            if is_irrelevant g
+            then (
+              if !tacdbg then BU.print1 "Assigning irrelevant goal %s\n" (Print.term_to_string (goal_witness g));
+              if TcRel.teq_nosmt_force (goal_env g) (goal_witness g) U.exp_unit
+              then ()
+              else failwith (BU.format1 "Irrelevant tactic witness does not unify with (): %s"
+                                                           (Print.term_to_string (goal_witness g)))
+            ))
+          remaining_smt_goals;
 
         // Check that all implicits were instantiated
         if !tacdbg then
             BU.print1 "About to check tactic implicits: %s\n" (FStar.Common.string_of_list
                                                                     (fun imp -> Print.ctx_uvar_to_string imp.imp_uvar)
                                                                     ps.all_implicits);
-                      
-        let is_smt_implicit (i:FStar.TypeChecker.Common.implicit) =
-            BU.for_some (fun g -> FStar.Tactics.Basic.is_implicit_for_goal g i)
-                        remaining_smt_goals
-        in
-        let all_implicits = 
-          List.map 
-            (fun i -> 
-              if i.imp_uvar.ctx_uvar_should_check <> Allow_untyped
-              && is_smt_implicit i //SMT goals will be checked separately with an SMT query, Allow_untyped here
-              then mark_implicit_as_allow_untyped i
-              else i)
-            ps.all_implicits
-        in
-        let g = {Env.trivial_guard with TcComm.implicits=all_implicits} in
+
+        let g = {Env.trivial_guard with TcComm.implicits=ps.all_implicits} in
         let g = TcRel.solve_deferred_constraints env g in
         if !tacdbg then
             BU.print2 "Checked %s implicits (1): %s\n"

--- a/src/tactics/FStar.Tactics.Interpreter.fst
+++ b/src/tactics/FStar.Tactics.Interpreter.fst
@@ -593,11 +593,11 @@ let run_tactic_on_ps'
         // /implicits
 
         if !tacdbg then
-            do_dump_proofstate (subst_proof_display_state (Cfg.psc_subst ps.psc) ps) "at the finish line";
+            do_dump_proofstate ps "at the finish line";
         (ps.goals@ps.smt_goals, ret)
 
     | Failed (e, ps) ->
-        do_dump_proofstate (subst_proof_display_state (Cfg.psc_subst ps.psc) ps) "at the time of failure";
+        do_dump_proofstate ps "at the time of failure";
         let texn_to_string e =
             match e with
             | TacticFailure s ->

--- a/src/tactics/FStar.Tactics.Interpreter.fsti
+++ b/src/tactics/FStar.Tactics.Interpreter.fsti
@@ -35,7 +35,7 @@ val run_tactic_on_ps :
 
 val primitive_steps : unit -> list FStar.TypeChecker.Cfg.primitive_step
 
-val report_implicits : range -> Env.implicits -> unit
+val report_implicits : range -> FStar.TypeChecker.Rel.tagged_implicits -> unit
 
 (* For debugging only *)
 val tacdbg : ref bool

--- a/src/tactics/FStar.Tactics.Monad.fst
+++ b/src/tactics/FStar.Tactics.Monad.fst
@@ -239,8 +239,15 @@ let add_implicits (i:implicits) : tac unit =
     set ({ps with all_implicits=i@ps.all_implicits}))
 
 let new_uvar (reason:string) (env:env) (typ:typ) (rng:Range.range) : tac (term * ctx_uvar) =
+    let is_base_typ =
+        let t = FStar.TypeChecker.Normalize.unfold_whnf env typ in
+        let head, args = U.head_and_args t in
+        match (U.un_uinst head).n with
+        | Tm_fvar _ -> true
+        | _ -> false
+    in
     let u, ctx_uvar, g_u =
-        Env.new_implicit_var_aux reason rng env typ Allow_untyped None
+        Env.new_implicit_var_aux reason rng env typ (if is_base_typ then Allow_untyped else Strict) None
     in
     bind (add_implicits g_u.implicits) (fun _ ->
     ret (u, fst (List.hd ctx_uvar)))

--- a/src/tactics/FStar.Tactics.Monad.fst
+++ b/src/tactics/FStar.Tactics.Monad.fst
@@ -243,16 +243,7 @@ let new_uvar (reason:string) (env:env) (typ:typ) (sc_opt:option should_check_uva
       match sc_opt with
       | Some sc -> sc
       | _ -> 
-        let is_base_typ =
-          let t = FStar.TypeChecker.Normalize.unfold_whnf env typ in
-          let head, args = U.head_and_args t in
-          match (U.unascribe (U.un_uinst head)).n with
-          | Tm_name _
-          | Tm_fvar _
-          | Tm_type _ -> true
-          | _ -> false
-        in
-        if is_base_typ
+        if FStar.TypeChecker.Rel.is_base_type env typ
         then Allow_untyped
         else (
           if Env.debug env <| Options.Other "2635"

--- a/src/tactics/FStar.Tactics.Monad.fst
+++ b/src/tactics/FStar.Tactics.Monad.fst
@@ -306,6 +306,6 @@ let compress_implicits : tac unit =
     bind get (fun ps ->
     let imps = ps.all_implicits in
     let g = { Env.trivial_guard with implicits = imps } in
-    let g = Rel.resolve_implicits_tac ps.main_context g in
-    let ps' = { ps with all_implicits = g.implicits } in
+    let imps = Rel.resolve_implicits_tac ps.main_context g in
+    let ps' = { ps with all_implicits = List.map fst imps } in
     set ps')

--- a/src/tactics/FStar.Tactics.Monad.fst
+++ b/src/tactics/FStar.Tactics.Monad.fst
@@ -259,7 +259,8 @@ let new_uvar (reason:string) (env:env) (typ:typ) (sc_opt:option should_check_uva
           then (
             BU.print2 "Tactic introduced a strict uvar for %s\n\%s\n" 
                       (Print.term_to_string typ)
-                      (BU.stack_dump ())
+                      // (BU.stack_dump ())
+                      ""
           );
           Strict
         )

--- a/src/tactics/FStar.Tactics.Monad.fsti
+++ b/src/tactics/FStar.Tactics.Monad.fsti
@@ -103,7 +103,7 @@ val add_implicits : implicits -> tac unit
 
 (* Create a new uvar, and keep track of it in the proofstate to
  * ensure we solve it. *)
-val new_uvar : string -> env -> typ -> Range.range -> tac (term * ctx_uvar)
+val new_uvar : string -> env -> typ -> option should_check_uvar -> Range.range -> tac (term * ctx_uvar)
 
 (* Create a squashed goal from a given formula *)
 val mk_irrelevant_goal : string -> env -> typ -> Range.range -> O.optionstate -> string -> tac goal

--- a/src/tactics/FStar.Tactics.Printing.fst
+++ b/src/tactics/FStar.Tactics.Printing.fst
@@ -33,6 +33,7 @@ module Print   = FStar.Syntax.Print
 module SS      = FStar.Syntax.Subst
 module S       = FStar.Syntax.Syntax
 module Env     = FStar.TypeChecker.Env
+module U       = FStar.Syntax.Util
 
 let term_to_string (e:Env.env) (t:term) : string =
     Print.term_to_string' e.dsenv t
@@ -90,7 +91,7 @@ let goal_to_string (kind : string) (maybe_num : option (int * int)) (ps:proofsta
         | l -> " (" ^ l ^ ")"
     in
     let goal_binders = g.goal_ctx_uvar.ctx_uvar_binders in
-    let goal_ty = g.goal_ctx_uvar.ctx_uvar_typ in
+    let goal_ty = g.goal_display_type in
     let goal_binders, goal_ty = unshadow goal_binders goal_ty in
     let actual_goal =
         if ps.tac_verb_dbg

--- a/src/tactics/FStar.Tactics.Printing.fst
+++ b/src/tactics/FStar.Tactics.Printing.fst
@@ -34,6 +34,7 @@ module SS      = FStar.Syntax.Subst
 module S       = FStar.Syntax.Syntax
 module Env     = FStar.TypeChecker.Env
 module U       = FStar.Syntax.Util
+module Cfg     = FStar.TypeChecker.Cfg
 
 let term_to_string (e:Env.env) (t:term) : string =
     Print.term_to_string' e.dsenv t
@@ -90,8 +91,28 @@ let goal_to_string (kind : string) (maybe_num : option (int * int)) (ps:proofsta
         | "" -> ""
         | l -> " (" ^ l ^ ")"
     in
-    let goal_binders = g.goal_ctx_uvar.ctx_uvar_binders in
-    let goal_ty = g.goal_display_type in
+    let goal_binders, goal_ty =
+      let rename_binders subst bs =
+        bs |> List.map (function b ->
+          let x = b.binder_bv in
+          let y = SS.subst subst (S.bv_to_name x) in
+          match (SS.compress y).n with
+          | Tm_name y ->
+            // We don't want to change the type
+            { b with binder_bv = { b.binder_bv with sort = SS.subst subst x.sort } }
+          | _ -> failwith "Not a renaming")
+      in
+      let goal_binders = g.goal_ctx_uvar.ctx_uvar_binders in
+      let goal_ty = goal_type g in
+      if Options.tactic_raw_binders()
+      then goal_binders, goal_ty
+      else (
+        let subst = Cfg.psc_subst ps.psc in
+        let binders = rename_binders subst goal_binders in
+        let ty = SS.subst subst goal_ty in
+        binders, ty
+      )
+    in
     let goal_binders, goal_ty = unshadow goal_binders goal_ty in
     let actual_goal =
         if ps.tac_verb_dbg

--- a/src/tactics/FStar.Tactics.Types.fst
+++ b/src/tactics/FStar.Tactics.Types.fst
@@ -35,7 +35,7 @@ module UF      = FStar.Syntax.Unionfind
 let goal_env g = g.goal_main_env
 let goal_witness g =
     FStar.Syntax.Syntax.mk (Tm_uvar (g.goal_ctx_uvar, ([], NoUseRange))) Range.dummyRange
-let goal_type g = g.goal_ctx_uvar.ctx_uvar_typ
+let goal_type g = U.ctx_uvar_typ g.goal_ctx_uvar
 
 let goal_with_env g env : goal =
     let c = g.goal_ctx_uvar in
@@ -49,6 +49,7 @@ let goal_of_ctx_uvar (g:goal) (ctx_u : ctx_uvar) : goal =
 let mk_goal env u o b l = {
     goal_main_env=env;
     goal_ctx_uvar=u;
+    goal_display_type=U.ctx_uvar_typ u;
     opts=o;
     is_guard=b;
     label=l;
@@ -82,11 +83,11 @@ let subst_goal subst goal =
     let ctx_uvar = {
         g with ctx_uvar_gamma=Env.rename_gamma subst g.ctx_uvar_gamma;
                ctx_uvar_binders=rename_binders subst g.ctx_uvar_binders;
-               ctx_uvar_typ=SS.subst subst g.ctx_uvar_typ;
     } in
-    { goal with goal_ctx_uvar = ctx_uvar }
+    { goal with goal_ctx_uvar = ctx_uvar;
+                goal_display_type = SS.subst subst goal.goal_display_type }
 
-let subst_proof_state subst ps =
+let subst_proof_display_state subst ps =
     if O.tactic_raw_binders ()
     then ps
     else { ps with goals = List.map (subst_goal subst) ps.goals
@@ -104,14 +105,14 @@ let tracepoint_with_psc psc ps : bool =
     if O.tactic_trace () || (ps.depth <= O.tactic_trace_d ()) then begin
         let ps = set_ps_psc psc ps in
         let subst = Cfg.psc_subst ps.psc in
-        ps.__dump (subst_proof_state subst ps) "TRACE"
+        ps.__dump (subst_proof_display_state subst ps) "TRACE"
     end;
     true
 
 let tracepoint ps : bool =
     if O.tactic_trace () || (ps.depth <= O.tactic_trace_d ()) then begin
         let subst = Cfg.psc_subst ps.psc in
-        ps.__dump (subst_proof_state subst ps) "TRACE"
+        ps.__dump (subst_proof_display_state subst ps) "TRACE"
     end;
     true
 

--- a/src/tactics/FStar.Tactics.Types.fst
+++ b/src/tactics/FStar.Tactics.Types.fst
@@ -30,16 +30,12 @@ module Range   = FStar.Compiler.Range
 module BU      = FStar.Compiler.Util
 module S       = FStar.Syntax.Syntax
 module U       = FStar.Syntax.Util
+module UF      = FStar.Syntax.Unionfind
 
 let goal_env g = g.goal_main_env
 let goal_witness g =
     FStar.Syntax.Syntax.mk (Tm_uvar (g.goal_ctx_uvar, ([], NoUseRange))) Range.dummyRange
 let goal_type g = g.goal_ctx_uvar.ctx_uvar_typ
-
-let goal_with_type_pure g t : goal =
-    let c = g.goal_ctx_uvar in
-    let c' = {c with ctx_uvar_typ = t} in
-    { g with goal_ctx_uvar = c' }
 
 let goal_with_env g env : goal =
     let c = g.goal_ctx_uvar in

--- a/src/tactics/FStar.Tactics.Types.fst
+++ b/src/tactics/FStar.Tactics.Types.fst
@@ -36,7 +36,7 @@ let goal_witness g =
     FStar.Syntax.Syntax.mk (Tm_uvar (g.goal_ctx_uvar, ([], NoUseRange))) Range.dummyRange
 let goal_type g = g.goal_ctx_uvar.ctx_uvar_typ
 
-let goal_with_type g t : goal =
+let goal_with_type_pure g t : goal =
     let c = g.goal_ctx_uvar in
     let c' = {c with ctx_uvar_typ = t} in
     { g with goal_ctx_uvar = c' }

--- a/src/tactics/FStar.Tactics.Types.fsti
+++ b/src/tactics/FStar.Tactics.Types.fsti
@@ -38,6 +38,7 @@ module O = FStar.Options
 type goal = {
     goal_main_env: env;
     goal_ctx_uvar : ctx_uvar;
+    goal_display_type: typ; //just for display
     opts    : FStar.Options.optionstate; // option state for this particular goal
     is_guard : bool; // Marks whether this goal arose from a guard during tactic runtime
                      // We make the distinction to be more user-friendly at times
@@ -83,7 +84,7 @@ val tracepoint_with_psc : Cfg.psc -> proofstate -> bool
 val tracepoint : proofstate -> bool
 val set_proofstate_range : proofstate -> Range.range -> proofstate
 
-val subst_proof_state: subst_t -> proofstate -> proofstate
+val subst_proof_display_state: subst_t -> proofstate -> proofstate
 
 val set_ps_psc : Cfg.psc -> proofstate -> proofstate
 val goal_env: goal -> env

--- a/src/tactics/FStar.Tactics.Types.fsti
+++ b/src/tactics/FStar.Tactics.Types.fsti
@@ -89,7 +89,7 @@ val set_ps_psc : Cfg.psc -> proofstate -> proofstate
 val goal_env: goal -> env
 val goal_witness: goal -> term
 val goal_type: goal -> term
-val goal_with_type: goal -> term -> goal
+val goal_with_type_pure: goal -> term -> goal
 val goal_with_env: goal -> env -> goal
 val is_guard : goal -> bool
 

--- a/src/tactics/FStar.Tactics.Types.fsti
+++ b/src/tactics/FStar.Tactics.Types.fsti
@@ -38,7 +38,6 @@ module O = FStar.Options
 type goal = {
     goal_main_env: env;
     goal_ctx_uvar : ctx_uvar;
-    goal_display_type: typ; //just for display
     opts    : FStar.Options.optionstate; // option state for this particular goal
     is_guard : bool; // Marks whether this goal arose from a guard during tactic runtime
                      // We make the distinction to be more user-friendly at times
@@ -83,8 +82,6 @@ val incr_depth : proofstate -> proofstate
 val tracepoint_with_psc : Cfg.psc -> proofstate -> bool
 val tracepoint : proofstate -> bool
 val set_proofstate_range : proofstate -> Range.range -> proofstate
-
-val subst_proof_display_state: subst_t -> proofstate -> proofstate
 
 val set_ps_psc : Cfg.psc -> proofstate -> proofstate
 val goal_env: goal -> env

--- a/src/tactics/FStar.Tactics.Types.fsti
+++ b/src/tactics/FStar.Tactics.Types.fsti
@@ -89,7 +89,6 @@ val set_ps_psc : Cfg.psc -> proofstate -> proofstate
 val goal_env: goal -> env
 val goal_witness: goal -> term
 val goal_type: goal -> term
-val goal_with_type_pure: goal -> term -> goal
 val goal_with_env: goal -> env -> goal
 val is_guard : goal -> bool
 

--- a/src/tests/FStar.Tests.Pars.fst
+++ b/src/tests/FStar.Tests.Pars.fst
@@ -72,6 +72,7 @@ let init_once () : unit =
                 TcTerm.typeof_tot_or_gtot_term
                 TcTerm.typeof_tot_or_gtot_term_fastpath
                 TcTerm.universe_of
+                Rel.subtype_nosmt_force
                 solver
                 Const.prims_lid
                 NBE.normalize_for_unit_test in

--- a/src/typechecker/FStar.TypeChecker.Env.fst
+++ b/src/typechecker/FStar.TypeChecker.Env.fst
@@ -118,6 +118,7 @@ let initial_env deps
   typeof_tot_or_gtot_term
   typeof_tot_or_gtot_term_fastpath
   universe_of
+  subtype_nosmt_force
   solver module_lid nbe : env =
   { solver=solver;
     range=dummyRange;
@@ -155,7 +156,7 @@ let initial_env deps
          let _, k, g = typeof_tot_or_gtot_term env t must_tot in
          k, g);
     universe_of=universe_of;
-
+    subtype_nosmt_force=subtype_nosmt_force;
     use_bv_sorts=false;
     qtbl_name_and_index=BU.smap_create 10, None;  //10?
     normalized_eff_names=BU.smap_create 20;  //20?

--- a/src/typechecker/FStar.TypeChecker.Env.fst
+++ b/src/typechecker/FStar.TypeChecker.Env.fst
@@ -1827,7 +1827,7 @@ let uvars_for_binders env (bs:S.binders) substs reason r =
       | Some (Meta t), [] ->
         Some (Ctx_uvar_meta_tac (FStar.Compiler.Dyn.mkdyn env, t)), false
       | _, t::_ ->
-        Some (Ctx_uvar_meta_attr t), true
+        Some (Ctx_uvar_meta_attr t), false
       | _ -> None, false in
 
     let t, l_ctx_uvars, g_t = new_implicit_var_aux

--- a/src/typechecker/FStar.TypeChecker.Env.fst
+++ b/src/typechecker/FStar.TypeChecker.Env.fst
@@ -153,7 +153,11 @@ let initial_env deps
        match typeof_tot_or_gtot_term_fastpath env t must_tot with
        | Some k -> k, trivial_guard
        | None ->
-         let _, k, g = typeof_tot_or_gtot_term env t must_tot in
+         let t', k, g = typeof_tot_or_gtot_term env t must_tot in
+         BU.print3 "typeof_well_typed_tot_or_gtot_term took slow path: %s was types as %s at type %s\n"
+           (Print.term_to_string t)
+           (Print.term_to_string t')
+           (Print.term_to_string k);
          k, g);
     universe_of=universe_of;
     subtype_nosmt_force=subtype_nosmt_force;
@@ -1642,7 +1646,7 @@ let guard_form g = g.guard_f
 let is_trivial g = match g with
     | {guard_f=Trivial; deferred=[]; univ_ineqs=([], []); implicits=i} ->
       i |> BU.for_all (fun imp ->
-           (imp.imp_uvar.ctx_uvar_should_check=Allow_unresolved)
+           (U.ctx_uvar_should_check imp.imp_uvar=Allow_unresolved)
            || (match Unionfind.find imp.imp_uvar.ctx_uvar_head with
                | Some _ -> true
                | None -> false))
@@ -1754,13 +1758,17 @@ let new_implicit_var_aux reason r env k should_check meta =
      | _ ->
       let binders = all_binders env in
       let gamma = env.gamma in
+      let decoration = {
+             uvar_decoration_typ = k;
+             uvar_decoration_should_check = should_check
+          }
+      in
       let ctx_uvar = {
-          ctx_uvar_head=FStar.Syntax.Unionfind.fresh r;
+          ctx_uvar_head=FStar.Syntax.Unionfind.fresh decoration r;
           ctx_uvar_gamma=gamma;
           ctx_uvar_binders=binders;
           ctx_uvar_typ=k;
           ctx_uvar_reason=reason;
-          ctx_uvar_should_check=should_check;
           ctx_uvar_range=r;
           ctx_uvar_meta=meta;
       } in

--- a/src/typechecker/FStar.TypeChecker.Env.fst
+++ b/src/typechecker/FStar.TypeChecker.Env.fst
@@ -1767,7 +1767,6 @@ let new_implicit_var_aux reason r env k should_check meta =
           ctx_uvar_head=FStar.Syntax.Unionfind.fresh decoration r;
           ctx_uvar_gamma=gamma;
           ctx_uvar_binders=binders;
-          ctx_uvar_typ=k;
           ctx_uvar_reason=reason;
           ctx_uvar_range=r;
           ctx_uvar_meta=meta;

--- a/src/typechecker/FStar.TypeChecker.Env.fst
+++ b/src/typechecker/FStar.TypeChecker.Env.fst
@@ -154,10 +154,10 @@ let initial_env deps
        | Some k -> k, trivial_guard
        | None ->
          let t', k, g = typeof_tot_or_gtot_term env t must_tot in
-         BU.print3 "typeof_well_typed_tot_or_gtot_term took slow path: %s was types as %s at type %s\n"
-           (Print.term_to_string t)
-           (Print.term_to_string t')
-           (Print.term_to_string k);
+         // BU.print3 "typeof_well_typed_tot_or_gtot_term took slow path: %s was types as %s at type %s\n"
+         //   (Print.term_to_string t)
+         //   (Print.term_to_string t')
+         //   (Print.term_to_string k);
          k, g);
     universe_of=universe_of;
     subtype_nosmt_force=subtype_nosmt_force;

--- a/src/typechecker/FStar.TypeChecker.Env.fst
+++ b/src/typechecker/FStar.TypeChecker.Env.fst
@@ -1897,3 +1897,4 @@ let split_smt_query (e:env) (q:term)
     | None -> None
     | Some p -> Some (p e q)
     
+

--- a/src/typechecker/FStar.TypeChecker.Env.fsti
+++ b/src/typechecker/FStar.TypeChecker.Env.fsti
@@ -177,7 +177,7 @@ and env = {
   typeof_tot_or_gtot_term :env -> term -> must_tot -> term * typ * guard_t; (* typechecker callback; G |- e : (G)Tot t <== g *)
   universe_of :env -> term -> universe; (* typechecker callback; G |- e : Tot (Type u) *)
   typeof_well_typed_tot_or_gtot_term :env -> term -> must_tot -> typ * guard_t; (* typechecker callback, uses fast path, with a fallback on the slow path *)
-
+  subtype_nosmt_force: env -> term -> term -> bool;    (* callback to the unifier *)
   use_bv_sorts   :bool;                           (* use bv.sort for a bound-variable's type rather than consulting gamma *)
   qtbl_name_and_index:BU.smap int * option (lident*int);    (* the top-level term we're currently processing and the nth query for it, in addition we maintain a counter for query index per lid *)
   normalized_eff_names:BU.smap lident;           (* cache for normalized effect name, used to be captured in the function norm_eff_name, which made it harder to roll back etc. *)
@@ -236,6 +236,7 @@ val initial_env : FStar.Parser.Dep.deps ->
                   (env -> term -> must_tot -> term * typ * guard_t) ->
                   (env -> term -> must_tot -> option typ) ->
                   (env -> term -> universe) ->
+                  (env -> term -> term -> bool) ->
                   solver_t -> lident ->
                   (list step -> env -> term -> term) -> env
 

--- a/src/typechecker/FStar.TypeChecker.Generalize.fst
+++ b/src/typechecker/FStar.TypeChecker.Generalize.fst
@@ -123,10 +123,10 @@ let gen env (is_rec:bool) (lecs:list (lbname * term * comp)) : option (list (lbn
                 (BU.set_elements univs |> List.map (fun u -> Print.univ_to_string (U_unif u)) |> String.concat ", ")
                 (BU.set_elements uvt |> List.map (fun u -> BU.format2 "(%s : %s)"
                                                                     (Print.uvar_to_string u.ctx_uvar_head)
-                                                                    (Print.term_to_string u.ctx_uvar_typ)) |> String.concat ", ");
+                                                                    (Print.term_to_string (U.ctx_uvar_typ u))) |> String.concat ", ");
           let univs =
             List.fold_left
-              (fun univs uv -> BU.set_union univs (Free.univs uv.ctx_uvar_typ))
+              (fun univs uv -> BU.set_union univs (Free.univs (U.ctx_uvar_typ uv)))
               univs
              (BU.set_elements uvt) in
           let uvs = gen_uvars uvt in
@@ -135,7 +135,7 @@ let gen env (is_rec:bool) (lecs:list (lbname * term * comp)) : option (list (lbn
                 (BU.set_elements univs |> List.map (fun u -> Print.univ_to_string (U_unif u)) |> String.concat ", ")
                 (uvs |> List.map (fun u -> BU.format2 "(%s : %s)"
                                                         (Print.uvar_to_string u.ctx_uvar_head)
-                                                        (N.term_to_string env u.ctx_uvar_typ)) |> String.concat ", ");
+                                                        (N.term_to_string env (U.ctx_uvar_typ u))) |> String.concat ", ");
 
          univs, uvs, (lbname, e, c)
      in
@@ -195,7 +195,7 @@ let gen env (is_rec:bool) (lecs:list (lbname * term * comp)) : option (list (lbn
          match UF.find u.ctx_uvar_head with
          | Some _ -> failwith "Unexpected instantiation of mutually recursive uvar"
          | _ ->
-           let k = N.normalize [Env.Beta; Env.Exclude Env.Zeta] env u.ctx_uvar_typ in
+           let k = N.normalize [Env.Beta; Env.Exclude Env.Zeta] env (U.ctx_uvar_typ u) in
            let bs, kres = U.arrow_formals k in
            let _ =
              //we only generalize variables at type k = a:Type{phi}

--- a/src/typechecker/FStar.TypeChecker.Normalize.fst
+++ b/src/typechecker/FStar.TypeChecker.Normalize.fst
@@ -999,10 +999,11 @@ let should_unfold cfg should_reify fv qninfo : should_unfold_res =
        && !plugin_unfold_warn_ctr > 0                   // and we haven't raised too many warnings
     then begin
       // then warn about it
+      let msg = BU.format1 "Unfolding name which is marked as a plugin: %s"
+                                    (Print.fv_to_string fv) in
+      BU.print1 "%s\n" msg;
       Errors.log_issue fv.fv_name.p
-                       (Errors.Warning_UnfoldPlugin,
-                        BU.format1 "Unfolding name which is marked as a plugin: %s"
-                                    (Print.fv_to_string fv));
+                       (Errors.Warning_UnfoldPlugin, msg);
       plugin_unfold_warn_ctr := !plugin_unfold_warn_ctr - 1
     end;
     r

--- a/src/typechecker/FStar.TypeChecker.Normalize.fst
+++ b/src/typechecker/FStar.TypeChecker.Normalize.fst
@@ -3111,7 +3111,7 @@ let eta_expand (env:Env.env) (t:term) : term =
       let head, args = U.head_and_args t in
       begin match (SS.compress head).n with
       | Tm_uvar (u,s) ->
-        let formals, _tres = U.arrow_formals (SS.subst' s u.ctx_uvar_typ) in
+        let formals, _tres = U.arrow_formals (SS.subst' s (U.ctx_uvar_typ u)) in
         if List.length formals = List.length args
         then t
         else let _, ty, _ = env.typeof_tot_or_gtot_term ({env with lax=true; use_bv_sorts=true; expected_typ=None}) t true in

--- a/src/typechecker/FStar.TypeChecker.Rel.fst
+++ b/src/typechecker/FStar.TypeChecker.Rel.fst
@@ -5051,7 +5051,7 @@ let resolve_implicits' env is_tac g =
                      BU.print5 "(%s) Uvar solution for %s was not well-typed. Expected %s got %s : %s\n"
                                   (Range.string_of_range (Env.get_range env))
                                   (Print.uvar_to_string ctx_u.ctx_uvar_head)
-                                  (Print.term_to_string uvar_decoration_typ)
+                                  (Print.term_to_string uv_t)
                                   (Print.term_to_string tm)
                                   (Print.term_to_string tm_t);
                      false

--- a/src/typechecker/FStar.TypeChecker.Rel.fst
+++ b/src/typechecker/FStar.TypeChecker.Rel.fst
@@ -5031,35 +5031,48 @@ let resolve_implicits' env is_tac g =
                     None
                     "subtype_tactic_solution"                   
                 then true
-                else // failing at this point is fatal;
-                     // and the check may have failed because we didn't unroll let recs;
-                     // so try once more after normalizing both types 
-                 begin
-                   let compute t = 
-                     N.normalize [Env.UnfoldTac; //we're in is_tac; don't unfold "tac_opaque"
-                                  Env.UnfoldUntil delta_constant;
-                                  Env.Zeta;
-                                  Env.Iota; 
-                                  Env.Primops]
-                                 env t 
-                   in
-                   let tm_t = compute tm_t in
-                   let uv_t = compute uvar_decoration_typ in
-                   if env.subtype_nosmt_force env tm_t uv_t
-                   then true
-                   else
-                   (
+                else (
+                  if Options.debug_any () 
+                  then (
                      BU.print5 "(%s) Uvar solution for %s was not well-typed. Expected %s got %s : %s\n"
                                   (Range.string_of_range (Env.get_range env))
                                   (Print.uvar_to_string ctx_u.ctx_uvar_head)
-                                  (Print.term_to_string uv_t)
+                                  (Print.term_to_string uvar_decoration_typ)
                                   (Print.term_to_string tm)
-                                  (Print.term_to_string tm_t);
-                     false
-                   )
-                 end
+                                  (Print.term_to_string tm_t)
+                  );
+                  false
                 )
+                //   // failing at this point is fatal;
+                //      // and the check may have failed because we didn't unroll let recs;
+                //      // so try once more after normalizing both types 
+                //  begin
+                //    let compute t = 
+                //      N.normalize [Env.UnfoldTac; //we're in is_tac; don't unfold "tac_opaque"
+                //                   Env.UnfoldUntil delta_constant;
+                //                   Env.Zeta;
+                //                   Env.Iota; 
+                //                   Env.Primops]
+                //                  env t 
+                //    in
+                //    let tm_t = compute tm_t in
+                //    let uv_t = compute uvar_decoration_typ in
+                //    if env.subtype_nosmt_force env tm_t uv_t
+                //    then true
+                //    else
+                //    (
+                //      BU.print5 "(%s) Uvar solution for %s was not well-typed. Expected %s got %s : %s\n"
+                //                   (Range.string_of_range (Env.get_range env))
+                //                   (Print.uvar_to_string ctx_u.ctx_uvar_head)
+                //                   (Print.term_to_string uv_t)
+                //                   (Print.term_to_string tm)
+                //                   (Print.term_to_string tm_t);
+                //      false
+                //    )
+                //  end
+                // )
               )
+            )
           end
           else false
         in

--- a/src/typechecker/FStar.TypeChecker.Rel.fst
+++ b/src/typechecker/FStar.TypeChecker.Rel.fst
@@ -4773,7 +4773,8 @@ let try_solve_single_valued_implicits env is_tac (imps:Env.implicits) : Env.impl
      | _ -> None in
 
     let b = List.fold_left (fun b imp ->  //check that the imp is still unsolved
-      if UF.find imp.imp_uvar.ctx_uvar_head |> is_none
+      if UF.find imp.imp_uvar.ctx_uvar_head |> is_none &&
+         imp.imp_uvar.ctx_uvar_should_check = Strict
       then match imp_value imp with
            | Some tm -> commit env ([TERM (imp.imp_uvar, tm)]); true
            | None -> b

--- a/src/typechecker/FStar.TypeChecker.Rel.fst
+++ b/src/typechecker/FStar.TypeChecker.Rel.fst
@@ -123,13 +123,17 @@ let as_wl_deferred wl (d:deferred): list (int * deferred_reason * lstring * prob
 (* <new_uvar> Generating new unification variables/patterns  *)
 (* --------------------------------------------------------- *)
 let new_uvar reason wl r gamma binders k should_check meta : ctx_uvar * term * worklist =
+    let decoration = {
+             uvar_decoration_typ = k;
+             uvar_decoration_should_check = should_check
+        }
+    in
     let ctx_uvar = {
-         ctx_uvar_head=UF.fresh r;
+         ctx_uvar_head=UF.fresh decoration r;
          ctx_uvar_gamma=gamma;
          ctx_uvar_binders=binders;
          ctx_uvar_typ=k;
          ctx_uvar_reason=reason;
-         ctx_uvar_should_check=should_check;
          ctx_uvar_range=r;
          ctx_uvar_meta=meta;
        } in
@@ -148,7 +152,9 @@ let copy_uvar u (bs:binders) t wl =
     let env = {wl.tcenv with gamma = u.ctx_uvar_gamma } in
     let env = Env.push_binders env bs in
     new_uvar ("copy:"^u.ctx_uvar_reason) wl u.ctx_uvar_range env.gamma
-            (Env.all_binders env) t u.ctx_uvar_should_check u.ctx_uvar_meta
+            (Env.all_binders env) t
+            (U.ctx_uvar_should_check u)
+            u.ctx_uvar_meta
 
 (* --------------------------------------------------------- *)
 (* </new_uvar>                                               *)
@@ -815,7 +821,7 @@ let ensure_no_uvar_subst env (t0:term) (wl:worklist)
                          new_gamma
                          (Env.binders_of_bindings new_gamma)
                          (U.arrow dom_binders (S.mk_Total uv.ctx_uvar_typ))
-                         uv.ctx_uvar_should_check
+                         (U.ctx_uvar_should_check uv)
                          uv.ctx_uvar_meta
         in
 
@@ -1050,7 +1056,8 @@ let restrict_ctx env (tgt:ctx_uvar) (bs:binders) (src:ctx_uvar) wl : worklist =
   let aux (t:typ) (f:term -> term) =
     let _, src', wl = new_uvar ("restricted " ^ (Print.uvar_to_string src.ctx_uvar_head)) wl
       src.ctx_uvar_range g pfx t
-      src.ctx_uvar_should_check src.ctx_uvar_meta in
+      (U.ctx_uvar_should_check src)
+      src.ctx_uvar_meta in
     set_uvar env src (f src');
     wl in
 
@@ -2275,6 +2282,14 @@ and solve_binders (env:Env.env) (bs1:binders) (bs2:binders) (orig:prob) (wl:work
                        (rel_to_string (p_rel orig))
                        (Print.binders_to_string ", " bs2);
 
+   let eq_bqual a1 a2 =
+       match a1, a2 with
+       | Some (Implicit b1), Some (Implicit b2) ->
+         U.Equal //we don't care about comparing the dot qualifier in this context
+       | _ ->
+         U.eq_bqual a1 a2
+   in
+
    (*
     * AR: adding env to the return type
     *
@@ -2296,7 +2311,7 @@ and solve_binders (env:Env.env) (bs1:binders) (bs2:binders) (orig:prob) (wl:work
           let formula = p_guard rhs_prob in
           env, Inl ([rhs_prob], formula), wl
 
-        | x::xs, y::ys when (U.eq_bqual x.binder_qual y.binder_qual = U.Equal) ->
+        | x::xs, y::ys when (eq_bqual x.binder_qual y.binder_qual = U.Equal) ->
            let hd1, imp = x.binder_bv, x.binder_qual in
            let hd2, imp' = y.binder_bv, y.binder_qual in
            let hd1 = {hd1 with sort=Subst.subst subst hd1.sort} in //open both binders
@@ -2928,8 +2943,8 @@ and solve_t_flex_flex env orig wl (lhs:flex_t) (rhs:flex_t) : solution =
                                           ^"\tlhs="  ^u_lhs.ctx_uvar_reason
                                           ^ "\trhs=" ^u_rhs.ctx_uvar_reason)
                                          wl range gamma_w ctx_w new_uvar_typ
-                                         (if u_lhs.ctx_uvar_should_check = Allow_untyped &&
-                                             u_rhs.ctx_uvar_should_check = Allow_untyped
+                                         (if U.ctx_uvar_should_check u_lhs = Allow_untyped &&
+                                             U.ctx_uvar_should_check u_rhs = Allow_untyped
                                           then Allow_untyped
                                           else Strict)
                                          None in
@@ -4783,7 +4798,7 @@ let try_solve_single_valued_implicits env is_tac (imps:Env.implicits) : Env.impl
 
     let b = List.fold_left (fun b imp ->  //check that the imp is still unsolved
       if UF.find imp.imp_uvar.ctx_uvar_head |> is_none &&
-         imp.imp_uvar.ctx_uvar_should_check = Strict
+         U.ctx_uvar_should_check imp.imp_uvar = Strict
       then match imp_value imp with
            | Some tm -> commit env ([TERM (imp.imp_uvar, tm)]); true
            | None -> b
@@ -4845,7 +4860,7 @@ let check_implicit_solution_and_discharge_guard env imp force_univ_constraints
   let g =
     let must_tot = not (env.phase1 ||
                         env.lax    ||
-                        ctx_u.ctx_uvar_should_check = Allow_ghost) in
+                        U.ctx_uvar_should_check ctx_u = Allow_ghost) in
 
     Errors.with_ctx
       (BU.format3 "While checking implicit %s set to %s of expected type %s"
@@ -4942,12 +4957,17 @@ let resolve_implicits' env is_tac g =
 
     | hd::tl ->
       let { imp_reason = reason; imp_tm = tm; imp_uvar = ctx_u; imp_range = r } = hd in
+      let { 
+            uvar_decoration_typ;
+            uvar_decoration_should_check 
+          } = UF.find_decoration ctx_u.ctx_uvar_head
+      in
       if Env.debug env <| Options.Other "Rel"
       then BU.print3 "resolve_implicits' loop, imp_tm = %s and ctx_u = %s, is_tac: %s\n"
              (Print.term_to_string tm)
              (Print.ctx_uvar_to_string ctx_u)
              (string_of_bool is_tac);
-      if ctx_u.ctx_uvar_should_check = Allow_unresolved
+      if uvar_decoration_should_check = Allow_unresolved
       then until_fixpoint (out, true) tl
       else if unresolved ctx_u
       then (if flex_uvar_has_meta_tac ctx_u
@@ -4960,7 +4980,7 @@ let resolve_implicits' env is_tac g =
 
                  until_fixpoint (out, true) (extra @ tl)
             else until_fixpoint ((hd, Implicit_unresolved)::out, changed) tl)
-      else if ctx_u.ctx_uvar_should_check = Allow_untyped
+      else if uvar_decoration_should_check = Allow_untyped
       then until_fixpoint (out, true) tl
       else begin
         let env = {env with gamma=ctx_u.ctx_uvar_gamma} in
@@ -4990,7 +5010,7 @@ let resolve_implicits' env is_tac g =
             tm
             |> Free.uvars
             |> BU.set_elements
-            |> List.for_all (fun uv -> uv.ctx_uvar_should_check = Allow_unresolved)
+            |> List.for_all (fun uv -> U.ctx_uvar_should_check uv = Allow_unresolved)
           in
           if no_unresolved
           then begin
@@ -4998,11 +5018,17 @@ let resolve_implicits' env is_tac g =
             then true
             else (
               let env = { env with gamma = ctx_u.ctx_uvar_gamma } in
-              if is_base_type env ctx_u.ctx_uvar_typ
+              if is_base_type env uvar_decoration_typ
               then true
               else (
-                let tm_t, _ = env.typeof_well_typed_tot_or_gtot_term env tm false in
-                if env.subtype_nosmt_force env tm_t ctx_u.ctx_uvar_typ
+                let tm_t, _ = 
+                  Profiling.profile (fun () -> env.typeof_well_typed_tot_or_gtot_term env tm false)
+                    None
+                    "retype_tactic_solution"
+                in
+                if Profiling.profile (fun () -> env.subtype_nosmt_force env tm_t uvar_decoration_typ)
+                    None
+                    "subtype_tactic_solution"                   
                 then true
                 else // failing at this point is fatal;
                      // and the check may have failed because we didn't unroll let recs;
@@ -5017,7 +5043,7 @@ let resolve_implicits' env is_tac g =
                                  env t 
                    in
                    let tm_t = compute tm_t in
-                   let uv_t = compute ctx_u.ctx_uvar_typ in
+                   let uv_t = compute uvar_decoration_typ in
                    if env.subtype_nosmt_force env tm_t uv_t
                    then true
                    else
@@ -5025,7 +5051,7 @@ let resolve_implicits' env is_tac g =
                      BU.print5 "(%s) Uvar solution for %s was not well-typed. Expected %s got %s : %s\n"
                                   (Range.string_of_range (Env.get_range env))
                                   (Print.uvar_to_string ctx_u.ctx_uvar_head)
-                                  (Print.term_to_string ctx_u.ctx_uvar_typ)
+                                  (Print.term_to_string uvar_decoration_typ)
                                   (Print.term_to_string tm)
                                   (Print.term_to_string tm_t);
                      false

--- a/src/typechecker/FStar.TypeChecker.Rel.fst
+++ b/src/typechecker/FStar.TypeChecker.Rel.fst
@@ -4970,20 +4970,21 @@ let resolve_implicits' env is_tac g =
              (Print.term_to_string tm)
              (Print.ctx_uvar_to_string ctx_u);
         let hd = {hd with imp_tm=tm} in
-        (*
-         * AR: We do not retypecheck the solutions solved by a tactic
-         *     However we still check that any uvars remaining in those solutions
-         *       are Allow_unresolved
-         *)
-        let tm_ok_for_tac tm =
-          tm
-          |> Free.uvars
-          |> BU.set_elements
-          |> List.for_all (fun uv -> uv.ctx_uvar_should_check = Allow_unresolved) in
-        if is_tac then if tm_ok_for_tac tm
-                       then until_fixpoint (out, true) tl        //Move on to the next imp
-                       else until_fixpoint ((hd, Implicit_unresolved)::out, changed) tl  //Move hd to out
-        else begin
+        // (*
+        //  * AR: We do not retypecheck the solutions solved by a tactic
+        //  *     However we still check that any uvars remaining in those solutions
+        //  *       are Allow_unresolved
+        //  *)
+        // let tm_ok_for_tac tm =
+        //   tm
+        //   |> Free.uvars
+        //   |> BU.set_elements
+        //   |> List.for_all (fun uv -> uv.ctx_uvar_should_check = Allow_unresolved) in
+        // if false && is_tac then if tm_ok_for_tac tm
+        //                    then until_fixpoint (out, true) tl        //Move on to the next imp
+        //                    else until_fixpoint ((hd, Implicit_unresolved)::out, changed) tl  //Move hd to out
+        // else
+        begin
           //typecheck the solution
           let force_univ_constraints = false in
           let imps_opt =

--- a/src/typechecker/FStar.TypeChecker.Rel.fst
+++ b/src/typechecker/FStar.TypeChecker.Rel.fst
@@ -4965,9 +4965,12 @@ let check_implicit_solution_for_tac (env:env) (i:implicit) : bool =
                          env
                          t
         in
-        let tm_t = compute tm_t in
-        let uv_t = compute uvar_ty in
-        if env.subtype_nosmt_force env tm_t uv_t
+        let retry () = 
+          let tm_t = compute tm_t in
+          let uv_t = compute uvar_ty in
+          env.subtype_nosmt_force env tm_t uv_t
+        in
+        if retry()
         then true
         else (
           if Options.debug_any () 

--- a/src/typechecker/FStar.TypeChecker.Rel.fst
+++ b/src/typechecker/FStar.TypeChecker.Rel.fst
@@ -4984,20 +4984,24 @@ let resolve_implicits' env is_tac g =
             |> List.for_all (fun uv -> uv.ctx_uvar_should_check = Allow_unresolved)
           in
           if no_unresolved
-          then (
-            let env = { env with gamma = ctx_u.ctx_uvar_gamma } in
-            let tm_t, _ = env.typeof_well_typed_tot_or_gtot_term env tm false in
-            if env.subtype_nosmt_force env tm_t ctx_u.ctx_uvar_typ
+          then begin
+            if env.phase1
             then true
             else (
-              BU.print4 "Uvar solution for %s was not well-typed. Expected %s got %s : %s\n"
-                              (Print.uvar_to_string ctx_u.ctx_uvar_head)
-                              (Print.term_to_string ctx_u.ctx_uvar_typ)
-                              (Print.term_to_string tm)
-                              (Print.term_to_string tm_t);
-              false
+              let env = { env with gamma = ctx_u.ctx_uvar_gamma } in
+              let tm_t, _ = env.typeof_well_typed_tot_or_gtot_term env tm false in
+              if env.subtype_nosmt_force env tm_t ctx_u.ctx_uvar_typ
+              then true
+              else (
+                BU.print4 "Uvar solution for %s was not well-typed. Expected %s got %s : %s\n"
+                                (Print.uvar_to_string ctx_u.ctx_uvar_head)
+                                (Print.term_to_string ctx_u.ctx_uvar_typ)
+                                (Print.term_to_string tm)
+                                (Print.term_to_string tm_t);
+                false
+              )
             )
-          )
+          end
           else false
         in
         if is_tac then if tm_ok_for_tac tm

--- a/src/typechecker/FStar.TypeChecker.Rel.fsti
+++ b/src/typechecker/FStar.TypeChecker.Rel.fsti
@@ -28,6 +28,13 @@ open FStar.Syntax.Syntax
 open FStar.TypeChecker.Common
 open FStar.Compiler.Range
 
+type implicit_checking_status =
+  | Implicit_unresolved
+  | Implicit_checking_defers_univ_constraint
+  | Implicit_has_typing_guard of term * typ
+
+type tagged_implicits = list (implicit * implicit_checking_status)
+
 val is_base_type : env -> typ -> bool
 val prob_to_string: env -> prob -> string
 val flex_prob_closing         : env -> binders -> prob -> bool
@@ -52,7 +59,8 @@ val discharge_guard_no_smt    : env -> guard_t -> guard_t
 val discharge_guard           : env -> guard_t -> guard_t
 val force_trivial_guard       : env -> guard_t -> unit
 val resolve_implicits         : env -> guard_t -> guard_t
-val resolve_implicits_tac     : env -> guard_t -> guard_t
+
+val resolve_implicits_tac     : env -> guard_t -> tagged_implicits
 val base_and_refinement_maybe_delta : bool -> env -> term -> term * option (bv * term)
 val base_and_refinement       : env -> term -> term * option (bv * term)
 

--- a/src/typechecker/FStar.TypeChecker.Rel.fsti
+++ b/src/typechecker/FStar.TypeChecker.Rel.fsti
@@ -28,6 +28,7 @@ open FStar.Syntax.Syntax
 open FStar.TypeChecker.Common
 open FStar.Compiler.Range
 
+val is_base_type : env -> typ -> bool
 val prob_to_string: env -> prob -> string
 val flex_prob_closing         : env -> binders -> prob -> bool
 //val close_guard_univs         : universes -> binders -> guard_t -> guard_t

--- a/src/typechecker/FStar.TypeChecker.Rel.fsti
+++ b/src/typechecker/FStar.TypeChecker.Rel.fsti
@@ -58,8 +58,9 @@ val solve_non_tactic_deferred_constraints: maybe_defer_flex_flex:bool -> env -> 
 val discharge_guard_no_smt    : env -> guard_t -> guard_t
 val discharge_guard           : env -> guard_t -> guard_t
 val force_trivial_guard       : env -> guard_t -> unit
+val is_implicit_resolved      : env -> Env.implicit -> bool
+val check_implicit_solution_for_tac : env -> Env.implicit -> option (term * typ)
 val resolve_implicits         : env -> guard_t -> guard_t
-
 val resolve_implicits_tac     : env -> guard_t -> tagged_implicits
 val base_and_refinement_maybe_delta : bool -> env -> term -> term * option (bv * term)
 val base_and_refinement       : env -> term -> term * option (bv * term)

--- a/src/typechecker/FStar.TypeChecker.TcEffect.fst
+++ b/src/typechecker/FStar.TypeChecker.TcEffect.fst
@@ -169,13 +169,13 @@ let validate_layered_effect_binders env (bs:binders) (repr_terms:list term) (che
       (List.fold_left (fun s t -> s ^ "; " ^ (Print.term_to_string t)) "" repr_names_args)
       (Print.binders_to_string "; " bs);
 
-  let valid_binder b =
+  let valid_binder b = true in
     //it appears in a repr index in a head position
-    List.existsb (fun t -> U.eq_tm (S.bv_to_name b.binder_bv) t = U.Equal) repr_names_args
-    ||
-    (match b.binder_attrs with  //or has a tactic associated
-     | _::_ -> true
-     | _ -> false) in
+    // List.existsb (fun t -> U.eq_tm (S.bv_to_name b.binder_bv) t = U.Equal) repr_names_args
+    // ||
+    // (match b.binder_attrs with  //or has a tactic associated
+    //  | _::_ -> true
+    //  | _ -> false) in
 
   let invalid_binders = List.filter (fun b -> not (valid_binder b)) bs in
 

--- a/src/typechecker/FStar.TypeChecker.TcTerm.fst
+++ b/src/typechecker/FStar.TypeChecker.TcTerm.fst
@@ -4601,7 +4601,6 @@ let rec typeof_tot_or_gtot_term_fastpath (env:env) (t:term) (must_tot:bool) : op
   | Tm_match _
   | Tm_let _
   | Tm_unknown
-  | Tm_uinst _ -> None
   | _ -> failwith ("Impossible! (" ^ (Print.tag_of_term t) ^ ")")
 
 (*

--- a/src/typechecker/FStar.TypeChecker.TcTerm.fst
+++ b/src/typechecker/FStar.TypeChecker.TcTerm.fst
@@ -4364,7 +4364,7 @@ let rec universe_of_aux env e =
    | Tm_meta(t, _) -> universe_of_aux env t
    | Tm_name n ->
      //
-     // AR: This is suboptimal,
+     // AR: This is unsatisfactory,
      //     We should always be able to find n in the env
      //
      (match Env.try_lookup_bv env n with

--- a/src/typechecker/FStar.TypeChecker.TcTerm.fst
+++ b/src/typechecker/FStar.TypeChecker.TcTerm.fst
@@ -1576,7 +1576,7 @@ and tc_value env (e:term) : term
 
   | Tm_uvar (u, s) -> //the type of a uvar is given directly with it; we do not recheck the type
     //FIXME: Check context inclusion?
-    value_check_expected_typ env e (Inl (SS.subst' s u.ctx_uvar_typ)) Env.trivial_guard
+    value_check_expected_typ env e (Inl (SS.subst' s (U.ctx_uvar_typ u))) Env.trivial_guard
 
   //only occurs where type annotations are missing in source programs
   //or the program has explicit _ for missing terms
@@ -4360,7 +4360,7 @@ let rec universe_of_aux env e =
    | Tm_abs(bs, t, _) ->
      level_of_type_fail env e "arrow type"
    //these next few cases are easy; we just use the type stored at the node
-   | Tm_uvar (u, s) -> SS.subst' s u.ctx_uvar_typ
+   | Tm_uvar (u, s) -> SS.subst' s (U.ctx_uvar_typ u)
    | Tm_meta(t, _) -> universe_of_aux env t
    | Tm_name n ->
      //
@@ -4591,7 +4591,7 @@ let rec typeof_tot_or_gtot_term_fastpath (env:env) (t:term) (must_tot:bool) : op
     then Some k
     else None
 
-  | Tm_uvar (u, s) -> if not must_tot then Some (SS.subst' s u.ctx_uvar_typ) else None
+  | Tm_uvar (u, s) -> if not must_tot then Some (SS.subst' s (U.ctx_uvar_typ u)) else None
 
   | Tm_quoted (tm, qi) -> if not must_tot then Some (S.t_term) else None
 

--- a/src/typechecker/FStar.TypeChecker.TcTerm.fst
+++ b/src/typechecker/FStar.TypeChecker.TcTerm.fst
@@ -4362,7 +4362,14 @@ let rec universe_of_aux env e =
    //these next few cases are easy; we just use the type stored at the node
    | Tm_uvar (u, s) -> SS.subst' s u.ctx_uvar_typ
    | Tm_meta(t, _) -> universe_of_aux env t
-   | Tm_name n -> n.sort
+   | Tm_name n ->
+     //
+     // AR: This is suboptimal,
+     //     We should always be able to find n in the env
+     //
+     (match Env.try_lookup_bv env n with
+      | Some (t, _) -> t
+      | None -> n.sort)
    | Tm_fvar fv ->
      let (_, t), _ = Env.lookup_lid env fv.fv_name.v in
      t

--- a/tests/bug-reports/Bug2169.fst
+++ b/tests/bug-reports/Bug2169.fst
@@ -156,7 +156,7 @@ let wrap (f:int -> ND unit (as_pure_wp (fun p -> True))) (x':int) : ND unit (as_
 // The test below use to fail while running the tactic, now it leaves a
 // goal that cannot be solved. That's what we check for with the 19.
 
-[@@expect_failure [19]]
+[@@expect_failure [217;217]] //used to fail with [19], but since 2635 fails for a different reason
 let rewrite_inside_reify
   (f : int -> ND unit (as_pure_wp (fun p -> True)))
   (g : int -> Tot (option int))

--- a/tests/bug-reports/Bug2635.fst
+++ b/tests/bug-reports/Bug2635.fst
@@ -8,7 +8,8 @@ let prove_False
   : squash False
   = pf
 
-[@@expect_failure]
+//This fails with error 217, correctly complaining that the solved goal does not have type False
+[@@expect_failure [217]]
 let absurd : squash False
   = _ by (// |- ?pf : squash l_False
           apply (`prove_False);
@@ -16,10 +17,63 @@ let absurd : squash False
           // (pf0 : squash l_False) |- _ : ?pf == ()
           trefl ())
 
+//Using the  gather_explicit_guards_for_resolved_goals primitive
+//you can now see that goal explicitly and work on solving from your tactic
+let admit_absurd (_:unit) : squash False
+  = _ by (// |- ?pf : squash l_False
+          apply (`prove_False);
+          let pf0 = intro () in
+          // (pf0 : squash l_False) |- _ : ?pf == ()
+          trefl ();
+          gather_or_solve_explicit_guards_for_resolved_goals();
+          dump "After";
+          tadmit())
+
+
+
 // Revised version, not depending on False by Aseem
 assume
 val p : Type0
 
+assume
+val q (x:pos) : Type0
+
+//the primitive is perhaps more useful in a context like this
+assume
+val expect_pos (_: squash (exists (x:pos). q x)) : squash p
+
+let intro_exists (#a:Type)  (#p:a -> Type) (x:a) (_:squash (p x)) : squash (exists (x:a). p x) = ()
+
+[@@expect_failure [217]]
+let use_pos (x:nat) (xpos:squash (x > 0)) (hyp:squash (q x)) =
+  assert p by (
+    apply (`expect_pos);
+    apply (`intro_exists);
+    apply (quote hyp)) //the implicit `pos` of intro_exists is solved by unification here to x:nat
+
+let use_pos (x:nat) (xpos:squash (x > 0)) (hyp:squash (q x)) =
+  assert p by (
+    apply (`expect_pos);
+    apply (`intro_exists);
+    apply (quote hyp); //the implicit `pos` of intro_exists is solved by unification here to x:nat
+    //can pick up the goal explicitly to prove that x > 0
+    gather_or_solve_explicit_guards_for_resolved_goals ();
+    let _ = implies_intro () in
+    apply (quote xpos))
+
+let use_one (hyp:squash (q 1)) =
+  assert p by (
+    apply (`expect_pos);
+    apply (`intro_exists);
+    apply (quote hyp); //the implicit `pos` of intro_exists is solved by unification here to 1:nat
+    //and F* does not accept that implicitly
+    //but you can ask F* to solve it by simplification
+    gather_or_solve_explicit_guards_for_resolved_goals ())
+
+
+//////////////////////////////////////////////////////////////
+// Some other variants and test cases
+//////////////////////////////////////////////////////////////
 let test (pr:squash p) (f: (unit -> squash (pr == ()))) : squash p = pr
 
 [@@expect_failure]

--- a/tests/bug-reports/Bug2635.fst
+++ b/tests/bug-reports/Bug2635.fst
@@ -32,3 +32,9 @@ let ugh ()
       trefl ()
     ) 
 
+
+let test2 (x:int) (_:squash (x > 0)) = 
+  assert (x >= 0 /\ x > 0)
+    by (split();
+        smt();
+        smt())

--- a/tests/bug-reports/Bug2635.fst
+++ b/tests/bug-reports/Bug2635.fst
@@ -60,3 +60,14 @@ let test2 (x:int) (_:squash (x > 0)) =
     by (split();
         smt();
         smt())
+
+let rec arrow (args:list Type) (res:Type) = 
+  match args with
+  | [] -> res
+  | hd::tl -> hd -> arrow tl res
+
+let app (arg:Type) (res:Type) (f:arrow [arg] res) (x:arg) : res = f x
+
+let id_int : int -> int = fun x -> x
+
+let some_int : int = _ by (apply (`app); norm [zeta; delta; iota]; apply (`id_int); exact (`0))

--- a/tests/bug-reports/Bug2635.fst
+++ b/tests/bug-reports/Bug2635.fst
@@ -32,6 +32,28 @@ let ugh ()
       trefl ()
     ) 
 
+let reflexivity (#a:Type) (x: a) : Lemma (x == x) = ()
+
+[@@expect_failure]
+let alt ()
+  : squash p
+  = _ by (
+      apply (`test);
+      let _ = intro () in
+      apply_lemma (`reflexivity)
+    )
+
+let test_lemma (pr:squash p) (f: (unit -> squash (pr == ()))) : Lemma p = ()
+
+[@@expect_failure]
+let alt2 ()
+  : squash p
+  = _ by (
+      apply_lemma (`test_lemma);
+      let _ = intro () in
+      apply_lemma (`reflexivity)
+    )
+
 
 let test2 (x:int) (_:squash (x > 0)) = 
   assert (x >= 0 /\ x > 0)

--- a/tests/bug-reports/Bug2635.fst
+++ b/tests/bug-reports/Bug2635.fst
@@ -1,0 +1,34 @@
+module Bug2635
+open FStar.Tactics
+
+//Original report by Benjamin Bonneau
+let prove_False
+      (pf : squash False)
+      (_  : (pf0 : squash False) -> squash (eq2 #(squash False) pf ()))
+  : squash False
+  = pf
+
+[@@expect_failure]
+let absurd : squash False
+  = _ by (// |- ?pf : squash l_False
+          apply (`prove_False);
+          let pf0 = intro () in
+          // (pf0 : squash l_False) |- _ : ?pf == ()
+          trefl ())
+
+// Revised version, not depending on False by Aseem
+assume
+val p : Type0
+
+let test (pr:squash p) (f: (unit -> squash (pr == ()))) : squash p = pr
+
+[@@expect_failure]
+let ugh () 
+  : squash p
+  = _ by (
+      apply (`test);
+      let _ = intro () in
+      dump "A";
+      trefl ()
+    ) 
+

--- a/tests/bug-reports/Bug2636.fst
+++ b/tests/bug-reports/Bug2636.fst
@@ -1,0 +1,43 @@
+module Bug2636
+open FStar.Tactics
+
+
+type prop_with_pre (p : Type0) (pf : squash p) : Type0
+  = | PropWithPre
+
+let lazy_and : Type0
+  = False /\ prop_with_pre False ()
+
+
+type this_type (t : Type) = | ThisType
+
+let and_right (p0 p1 : Type0) (_ : this_type (p0 /\ p1)) : Type0
+  = p1
+
+//let  pwp_False  : Type0 = Bug2636.and_right Prims.l_False (Bug2636.prop_with_pre Prims.l_False ()) (Bug2636.ThisType)
+
+let pwp_False : Type0
+  = _ by (apply (`and_right);
+          dump "A";
+          // [this_type (?p0 /\ ?p1)]
+          exact (`(ThisType #lazy_and)))
+
+
+// Just an utility function
+type display_term (#a : Type) (x : a) = unit
+
+let _ : display_term pwp_False
+  = _ by (norm [delta_only [`%pwp_False; `%and_right]];
+          dump "pwp_False"; // prop_with_pre l_False ()
+          exact (`()))
+
+
+let extract_pre (p : Type0) (pf : squash p) (_ : this_type (prop_with_pre p pf))
+  : squash p
+  = pf
+
+[@@expect_failure]
+let absurd : squash False
+  = _ by (apply (`extract_pre);
+          // [this_type (prop_with_pre l_False ?pf)]
+          exact (`(ThisType #pwp_False)))

--- a/tests/micro-benchmarks/SteelIntroExists.fst
+++ b/tests/micro-benchmarks/SteelIntroExists.fst
@@ -368,7 +368,7 @@ let test_split
   return res
 
 assume
-val pts_to (p:ptr) (v:nat) : vprop
+val pts_to (p:ptr) (v:int) : vprop
 
 assume
 val free (p:ptr) : STT unit (exists_ (fun v -> pts_to p v)) (fun _ -> emp)
@@ -704,3 +704,24 @@ let v2 (#p: Ghost.erased nat) (al: ptr) (err: ptr) : STT unit
   let _ = gen_elim () in
   let _ = join al ar in
   return ()
+
+
+assume
+val expect_pos (p:ptr) : STT unit (exists_ (λ (v:pos) → pts_to p v)) (λ _ → emp)
+
+[@@expect_failure]
+let use_zero_as_pos (p:ptr)
+  : STT unit (pts_to p 0) (λ _ → emp)
+  = let _ = expect_pos p in ()
+
+
+assume
+val expect_nat (p:ptr) : STT unit (exists_ (λ (v:nat) → pts_to p v)) (λ _ → emp)
+
+//this fails although it could succeed
+//wips: [F*] (<input>(723,4-723,30)) Uvar solution for ?2022 was not well-typed. Expected Prims.nat got 0 : Prims.int [2 times]
+//
+[@@expect_failure]
+let use_zero_as_nat (p:ptr)
+  : STT unit (pts_to p 0) (λ _ → emp)
+  = let _ = expect_nat p in ()

--- a/ulib/FStar.Tactics.Builtins.fsti
+++ b/ulib/FStar.Tactics.Builtins.fsti
@@ -145,9 +145,13 @@ with all this. *)
 val t_exact : maybe_refine:bool -> set_expected_typ:bool -> term -> Tac unit
 
 (** Inner primitive for [apply], takes a boolean specifying whether
-to not ask for implicits that appear free in posterior goals, and a
+to not ask for implicits that appear free in posterior goals, a
 boolean specifying whether it's forbidden to instantiate uvars in the
-goal.
+goal, and a boolean specifying whether uvars resolved during unification
+of the goal to the term should be typechecked as part of t_apply
+
+If the third boolean is false, those uvars will be typechecked at the
+end by the tactics engine.
 
 Example: when [uopt] is true, applying transitivity to [|- a = c]
 will give two goals, [|- a = ?u] and [|- ?u = c] without asking to

--- a/ulib/FStar.Tactics.Builtins.fsti
+++ b/ulib/FStar.Tactics.Builtins.fsti
@@ -162,7 +162,7 @@ instantiate [?u]. We use this in typeclass resolution.
 You may want [apply] from FStar.Tactics.Derived, or one of
 the other user facing variants.
 *)
-val t_apply : uopt:bool -> noinst:bool -> term -> Tac unit
+val t_apply : uopt:bool -> noinst:bool -> tc_resolved_uvars:bool -> term -> Tac unit
 
 (** [t_apply_lemma ni nilhs l] will solve a goal of type [squash phi]
 when [l] is a Lemma ensuring [phi]. The arguments to [l] and its

--- a/ulib/FStar.Tactics.Builtins.fsti
+++ b/ulib/FStar.Tactics.Builtins.fsti
@@ -217,6 +217,12 @@ This is particularly useful to rewrite the expression on the left to the
 one on the right when the RHS is actually a unification variable. *)
 val t_commute_applied_match : unit -> Tac unit
 
+(** In case there are goals that are already solved which have
+    non-trivial typing guards, make those guards as explicit proof
+    obligations in the tactic state, solving any trivial ones by simplification.
+    See tests/bug-reports/Bug2635.fst for some examples *)
+val gather_or_solve_explicit_guards_for_resolved_goals : unit -> Tac unit
+
 (** [ctrl_rewrite] will traverse the current goal, and call [ctrl]
  * repeatedly on subterms. When [ctrl t] returns [(true, _)], the
  * tactic will call [rw] with a goal of type [t = ?u], which once

--- a/ulib/FStar.Tactics.Derived.fst
+++ b/ulib/FStar.Tactics.Derived.fst
@@ -151,10 +151,10 @@ of [f] to any amount of arguments (which need to be solved as further goals).
 The amount of arguments introduced is the least such that [f a_i] unifies
 with the goal's type. *)
 let apply (t : term) : Tac unit =
-    t_apply true false t
+    t_apply true false false t
 
 let apply_noinst (t : term) : Tac unit =
-    t_apply true true t
+    t_apply true true false t
 
 (** [apply_lemma l] will solve a goal of type [squash phi] when [l] is a
 Lemma ensuring [phi]. The arguments to [l] and its requires clause are
@@ -187,7 +187,7 @@ let apply_lemma_rw (t : term) : Tac unit =
 regardless of whether they appear free in further goals. See the
 explanation in [t_apply]. *)
 let apply_raw (t : term) : Tac unit =
-    t_apply false false t
+    t_apply false false false t
 
 (** Like [exact], but allows for the term [e] to have a type [t] only
 under some guard [g], adding the guard as a goal. *)

--- a/ulib/experimental/Steel.Effect.Common.fsti
+++ b/ulib/experimental/Steel.Effect.Common.fsti
@@ -462,7 +462,7 @@ let frame_equalities
 /// More lemmas about the abstract can_be_split predicates, to be used as
 /// rewriting rules in the tactic below
 val can_be_split_dep_refl (p:vprop)
-: Lemma (can_be_split_dep True p p)
+: Lemma (can_be_split_dep true_p p p)
 
 val equiv_can_be_split (p1 p2:vprop) : Lemma
   (requires p1 `equiv` p2)

--- a/ulib/experimental/Steel.Effect.M.fst
+++ b/ulib/experimental/Steel.Effect.M.fst
@@ -211,6 +211,7 @@ let lift_ens_x (#a:Type u#a) (#pre:a -> slprop)
 //Some possibilities for restoring this:
 // 1. Patch Rel to retain ascriptions?
 // 2. Maybe using PR 2482 we can do the rewrite at a weaker type and then conclude
+#push-options "--warn_error -296"
 let lift_m (#a:Type u#a) (#pre:pre_t) (#post:post_t u#a a)
   (#req:req_t pre) (#ens:ens_t pre a post)
   (f:repr u#a a pre post req ens)
@@ -227,6 +228,7 @@ let lift_m (#a:Type u#a) (#pre:pre_t) (#post:post_t u#a a)
     Sem.Ret (lift_post post) (U.raise_val x) (lift_ens lpost)
 
   | _ -> admit ()
+#pop-options
 
 let lift_m_x (#a:Type u#a) (#pre:a -> slprop)
   (#b:Type u#b) (#post:post_t b) (#req:(x:a -> req_t (pre x))) (#ens:(x:a -> ens_t (pre x) b post))

--- a/ulib/experimental/Steel.Effect.M.fst
+++ b/ulib/experimental/Steel.Effect.M.fst
@@ -228,6 +228,10 @@ let lift_m (#a:Type u#a) (#pre:pre_t) (#post:post_t u#a a)
 
   | _ -> admit ()
 
+assume val lift_m (#a:Type u#a) (#pre:pre_t) (#post:post_t u#a a)
+  (#req:req_t pre) (#ens:ens_t pre a post)
+  (f:repr u#a a pre post req ens)
+: repr u#(max a b) (FStar.Universe.raise_t a) pre (lift_post post) req (lift_ens ens)
 
 let lift_m_x (#a:Type u#a) (#pre:a -> slprop)
   (#b:Type u#b) (#post:post_t b) (#req:(x:a -> req_t (pre x))) (#ens:(x:a -> ens_t (pre x) b post))

--- a/ulib/experimental/Steel.Effect.M.fst
+++ b/ulib/experimental/Steel.Effect.M.fst
@@ -211,7 +211,6 @@ let lift_ens_x (#a:Type u#a) (#pre:a -> slprop)
 //Some possibilities for restoring this:
 // 1. Patch Rel to retain ascriptions?
 // 2. Maybe using PR 2482 we can do the rewrite at a weaker type and then conclude
-[@@expect_failure] 
 let lift_m (#a:Type u#a) (#pre:pre_t) (#post:post_t u#a a)
   (#req:req_t pre) (#ens:ens_t pre a post)
   (f:repr u#a a pre post req ens)
@@ -221,9 +220,10 @@ let lift_m (#a:Type u#a) (#pre:pre_t) (#post:post_t u#a a)
 
     assert ((Sem.return_lpre #_ #_ #(lift_post post) (U.raise_val u#a u#b x) (lift_ens lpost)) ==
              Sem.return_lpre #_ #_ #post x lpost) by
-      T.(norm [delta_only [`%Sem.return_lpre; `%lift_post; `%lift_ens]];
-         FStar.Tactics.Derived.l_to_r [`U.downgrade_val_raise_val ];
-         trefl());
+      T.(tadmit())             ;
+      // T.(norm [delta_only [`%Sem.return_lpre; `%lift_post; `%lift_ens]];
+      //    FStar.Tactics.Derived.l_to_r [`U.downgrade_val_raise_val ];
+      //    trefl());
     Sem.Ret (lift_post post) (U.raise_val x) (lift_ens lpost)
 
   | _ -> admit ()

--- a/ulib/experimental/Steel.Effect.M.fst
+++ b/ulib/experimental/Steel.Effect.M.fst
@@ -15,7 +15,7 @@
 *)
 
 module Steel.Effect.M
-
+//Note: This file is standalone and not used anywhere else in the Steel codebase
 module Sem = Steel.Semantics.Hoare.MST
 module Mem = Steel.Memory
 
@@ -203,6 +203,15 @@ let lift_ens_x (#a:Type u#a) (#pre:a -> slprop)
 
 /// Lifting `m` terms, implementing only the Ret case
 
+//NS, AR: This is failure since the patch to 2635
+//It fails because:
+// we got the problem ?u:t = e <: t, i.e. ascription on RHS,
+// but when solving we removed the ascription, so we solved ?u = e
+// and then retypechecking e did not succeed
+//Some possibilities for restoring this:
+// 1. Patch Rel to retain ascriptions?
+// 2. Maybe using PR 2482 we can do the rewrite at a weaker type and then conclude
+[@@expect_failure] 
 let lift_m (#a:Type u#a) (#pre:pre_t) (#post:post_t u#a a)
   (#req:req_t pre) (#ens:ens_t pre a post)
   (f:repr u#a a pre post req ens)
@@ -212,11 +221,9 @@ let lift_m (#a:Type u#a) (#pre:pre_t) (#post:post_t u#a a)
 
     assert ((Sem.return_lpre #_ #_ #(lift_post post) (U.raise_val u#a u#b x) (lift_ens lpost)) ==
              Sem.return_lpre #_ #_ #post x lpost) by
-      (T.norm [delta_only [`%Sem.return_lpre; `%lift_post; `%lift_ens]];
-       FStar.Tactics.Derived.l_to_r [
-         `U.downgrade_val_raise_val;
-         `U.raise_val_downgrade_val ]);
-
+      T.(norm [delta_only [`%Sem.return_lpre; `%lift_post; `%lift_ens]];
+         FStar.Tactics.Derived.l_to_r [`U.downgrade_val_raise_val ];
+         trefl());
     Sem.Ret (lift_post post) (U.raise_val x) (lift_ens lpost)
 
   | _ -> admit ()

--- a/ulib/experimental/Steel.Effect.M.fst
+++ b/ulib/experimental/Steel.Effect.M.fst
@@ -228,11 +228,6 @@ let lift_m (#a:Type u#a) (#pre:pre_t) (#post:post_t u#a a)
 
   | _ -> admit ()
 
-assume val lift_m (#a:Type u#a) (#pre:pre_t) (#post:post_t u#a a)
-  (#req:req_t pre) (#ens:ens_t pre a post)
-  (f:repr u#a a pre post req ens)
-: repr u#(max a b) (FStar.Universe.raise_t a) pre (lift_post post) req (lift_ens ens)
-
 let lift_m_x (#a:Type u#a) (#pre:a -> slprop)
   (#b:Type u#b) (#post:post_t b) (#req:(x:a -> req_t (pre x))) (#ens:(x:a -> ens_t (pre x) b post))
   (f:(x:a -> repr u#b b (pre x) post (req x) (ens x)))

--- a/ulib/tactics_ml/FStar_Tactics_Builtins.ml
+++ b/ulib/tactics_ml/FStar_Tactics_Builtins.ml
@@ -156,6 +156,7 @@ let pack                    = from_tac_1 B.pack
 let curms                   = from_tac_1 B.curms
 let set_urgency             = from_tac_1 B.set_urgency
 let t_commute_applied_match = from_tac_1 B.t_commute_applied_match
+let gather_or_solve_explicit_guards_for_resolved_goals = from_tac_1 B.gather_explicit_guards_for_resolved_goals
 
 (* sigh *)
 let fix_either (s : ('a, 'b) either) : ('a, 'b) either =

--- a/ulib/tactics_ml/FStar_Tactics_Builtins.ml
+++ b/ulib/tactics_ml/FStar_Tactics_Builtins.ml
@@ -95,6 +95,15 @@ let from_tac_3 (t: 'a -> 'b -> 'c -> 'd TM.tac): 'a  -> 'b -> 'c -> 'd __tac =
           let m = t x y z in
           interpret_tac m ps
 
+let from_tac_4 (t: 'a -> 'b -> 'c -> 'd -> 'e TM.tac): 'a  -> 'b -> 'c -> 'd -> 'e __tac =
+  fun (x: 'a) ->
+  fun (y: 'b) ->
+  fun (z: 'c) ->
+  fun (w: 'd) ->
+  fun (ps: proofstate) ->
+  let m = t x y z w in
+  interpret_tac m ps
+
 (* Pointing to the internal primitives *)
 let set_goals               = from_tac_1 TM.set_goals
 let set_smt_goals           = from_tac_1 TM.set_smt_goals
@@ -117,7 +126,7 @@ let clear_top               = from_tac_1 B.clear_top
 let clear                   = from_tac_1 B.clear
 let rewrite                 = from_tac_1 B.rewrite
 let t_exact                 = from_tac_3 B.t_exact
-let t_apply                 = from_tac_3 B.t_apply
+let t_apply                 = from_tac_4 B.t_apply
 let t_apply_lemma           = from_tac_3 B.t_apply_lemma
 let print                   = from_tac_1 B.print
 let debugging               = from_tac_1 B.debugging


### PR DESCRIPTION
As #2635 shows, the tactic engine was allowing solutions computed by uvars to refined type to get by without checking them.

This PR, with @aseemr, ensures that the solutions computed for uvars introduced by the tactic engine are either:

1. computed by trusted primitive of the tactic engine (e.g., by t_destruct, or t_apply_lemma etc.)

2. or, are computed implicitly by the unifier, in which case, if the type of the uvar may contain a refinement, then the solution is checked to make sure that the refinement is indeed valid. This check is done by trying to show that the type of the solution is a subtype of (more precise than) the type of the uvar, *without the implicit use of the SMT solver*. In case this check fails, F* reports Error 217 and suggests to use a new tactic primitive `gather_or_solve_explicit_guards_for_resolved_goals`, which will collect, simplify, and present and non-trivial guards remaining, for further processing by a user tactic.
 