### PR TITLE
SLDump: print the current vprop

### DIFF
--- a/tests/micro-benchmarks/SteelSLDump.fst
+++ b/tests/micro-benchmarks/SteelSLDump.fst
@@ -1,0 +1,15 @@
+module SteelSLDump
+open Steel.SLDump
+
+assume val p (idx: string) ([@@@smt_fallback] _ : int) : vprop
+
+assume val inc (#n: int) (idx: string) : SteelT unit (p idx n) (fun _ -> p idx (n + 1))
+
+let test () : SteelT unit (p "foo" 0 `star` p "bar" 18) (fun _ -> p "foo" 3 `star` p "bar" 19) =
+  inc "foo";
+  sldump "test 1" ();
+  inc "foo";
+  inc "bar";
+  sldump "test 2" ();
+  inc "foo";
+  return ()

--- a/ulib/Makefile
+++ b/ulib/Makefile
@@ -40,7 +40,7 @@ fstartaclib.mgen: fstarlib.mgen
 	rm -f .depend.extract
 	+OUTPUT_DIRECTORY=tactics_ml/extracted \
 	    CODEGEN=Plugin \
-	    EXTRACT_MODULES="--extract '+FStar.Tactics +FStar.Reflection $(NOEXTRACT_MODULES) +Steel.Effect.Common +Steel.ST.GenElim.Base +FStar.InteractiveHelpers'" \
+	    EXTRACT_MODULES="--extract '+FStar.Tactics +FStar.Reflection $(NOEXTRACT_MODULES) +Steel.Effect.Common +Steel.ST.GenElim.Base +Steel.SLDump.Base +FStar.InteractiveHelpers'" \
 	    $(MAKE) -f Makefile.extract all-ml
 	mkdir -p tactics_ml/fstarlib_leftovers
 	cp $(FSTARLIB_LEFTOVERS) tactics_ml/fstarlib_leftovers

--- a/ulib/Makefile.extract
+++ b/ulib/Makefile.extract
@@ -17,6 +17,7 @@ FSTAR_FILES:=$(filter-out $(NOEXTRACT_FILES), \
 	$(wildcard experimental/*fst experimental/*fsti)) \
         Steel.Effect.Common.fst \
         Steel.ST.GenElim.Base.fst \
+        Steel.SLDump.Base.fst \
         $(wildcard FStar.InteractiveHelpers.*.fst)
 
 CODEGEN ?= OCaml

--- a/ulib/experimental/Steel.SLDump.Base.fst
+++ b/ulib/experimental/Steel.SLDump.Base.fst
@@ -1,0 +1,58 @@
+module Steel.SLDump.Base
+
+include Steel.Effect.Common
+
+[@@noextract_to "Plugin"]
+let sldump_prop
+  (text: string)
+  (p: vprop)
+  (q: vprop)
+: Tot prop
+= p == q
+
+let sldump_prop_intro
+  (text: string)
+  (p: vprop)
+: Lemma
+  (sldump_prop text p p)
+= ()
+
+module T = FStar.Tactics
+
+let solve_sldump_prop
+  ()
+: T.Tac bool
+=
+  let (hd, tl) = T.collect_app (T.cur_goal ()) in
+  if not (hd `T.term_eq` (`squash) || hd `T.term_eq` (`auto_squash))
+  then T.fail "not a squash goal";
+  match tl with
+  | [body1, T.Q_Explicit] ->
+    let (hd1, tl1) = T.collect_app body1 in
+    if not (hd1 `T.term_eq` (`sldump_prop))
+    then T.fail "not a sldump_prop goal";
+    begin match List.Tot.filter (fun (_, x) -> T.Q_Explicit? x) tl1 with
+    | [(text, _); (p, _); (q, _)] ->
+      let msg = match T.inspect text with
+      | T.Tv_Const (T.C_String s) -> s
+      | _ -> T.fail "not a constant string message"
+      in
+      if slterm_nbr_uvars p <> 0
+      then T.fail "pre-resource not solved yet";
+      let q_is_uvar = T.Tv_Uvar? (T.inspect q) in
+      if not (q_is_uvar)
+      then T.fail "sldump_prop is already solved";
+      let p' = T.term_to_string p in
+      T.print (msg ^ ": " ^ p');
+      T.unshelve q;
+      T.exact p;
+      T.apply_lemma (`sldump_prop_intro);
+      true
+    | _ -> T.fail "ill-formed sldump_prop"
+    end
+  | _ -> T.fail "ill-formed squash"
+
+[@@ resolve_implicits; framing_implicit; plugin;
+    override_resolve_implicits_handler framing_implicit [`%Steel.Effect.Common.init_resolve_tac]]
+let init_resolve_tac () = init_resolve_tac'
+  [(`sldump_prop), solve_sldump_prop]

--- a/ulib/experimental/Steel.SLDump.fst
+++ b/ulib/experimental/Steel.SLDump.fst
@@ -1,0 +1,7 @@
+module Steel.SLDump
+
+let sldump' #opened p q text sq () =
+  change_equal_slprop p (guard_vprop q)
+
+let sldump #opened #p #q text #sq () =
+  sldump' #opened p q text sq ()

--- a/ulib/experimental/Steel.SLDump.fsti
+++ b/ulib/experimental/Steel.SLDump.fsti
@@ -1,0 +1,23 @@
+module Steel.SLDump
+
+include Steel.SLDump.Base
+include Steel.Effect
+include Steel.Effect.Atomic
+
+val sldump'
+  (#opened: _)
+  (p: vprop)
+  (q: vprop)
+  (text: string)
+  (sq: squash (sldump_prop text p q))
+  (_: unit)
+: SteelGhost unit opened p (fun _ -> guard_vprop q) (fun _ -> True) (fun h _ h' -> h' p == h p) // TODO: replace with frame_equalities p h h'?
+
+val sldump
+  (#opened: _)
+  (#[@@@framing_implicit] p: vprop)
+  (#[@@@framing_implicit] q: vprop)
+  (text: string)
+  (#[@@@framing_implicit] sq: squash (sldump_prop text p q))
+  (_: unit)
+: SteelGhostF unit opened p (fun _ -> guard_vprop q) (fun _ -> True) (fun h _ h' -> h' p == h p) // TODO: replace with frame_equalities p h h'?


### PR DESCRIPTION
This PR implements a suggestion by @R1kM : provide a SteelGhost function, `sldump`, to print the current vprop at type-checking time.

For instance, the code below (available in this PR at `tests/micro-benchmarks/SteelSLDump.fst`) will behave as follows when type-checking:
```fstar
assume val p (idx: string) ([@@@smt_fallback] _ : int) : vprop
assume val inc (#n: int) (idx: string) : SteelT unit (p idx n) (fun _ -> p idx (n + 1))
let test () : SteelT unit (p "foo" 0 `star` p "bar" 18) (fun _ -> p "foo" 3 `star` p "bar" 19) =
  inc "foo";
  sldump "test 1" (); // this prints out:  test 1: p "bar" 19 `star` p "foo" 1
  inc "foo";
  inc "bar";
  sldump "test 2" (); // this prints out:  test 2: p "foo" 2 `star` p "bar" 20
  inc "foo";
  return ()
```

As Aymeric noted, this PR gathers the whole vprop available at its call site by virtue of being specified in the `SteelGhostF` effect.

The critical takeaway of this PR is that it implements `sldump` **without any change to the Steel tactic.** The secret sauce: follow the same pattern as `gen_elim` (#2553).

Here is the signature of `sldump`:

```fstar
val sldump
  (#opened: _)
  (#[@@@framing_implicit] p: vprop)
  (#[@@@framing_implicit] q: vprop)
  (text: string)
  (#[@@@framing_implicit] sq: squash (sldump_prop text p q))
  (_: unit)
: SteelGhostF unit opened p (fun _ -> guard_vprop q) (fun _ -> True) (fun h _ h' -> h' p == h p)
```
The post-resource is guarded by `guard_vprop`: if any vprop uvar ?r appears in the same goal as `guard_vprop q` (or transitively "depends" on such a vprop uvar), then `q` must be solved before `?r`. Thus, `sldump` is the only place where `guard_vprop q` can be solved.

In practice, `q` is solved by solving the *logical* goal `sldump_prop text p q` introduced when calling `sldump`.

To solve this logical goal, we register a tactic, `solve_sldump_prop`, separate from the Steel tactic, by including it as an entry into the dictionary passed when instantiating the Steel framing tactic:

```fstar
[@@ resolve_implicits; framing_implicit; plugin;
    override_resolve_implicits_handler framing_implicit [`%Steel.Effect.Common.init_resolve_tac]]
let init_resolve_tac () = init_resolve_tac'
  [(`sldump_prop), solve_sldump_prop]
```

(This step wouldn't be necessary if `unquote` were supported by native tactics; if so, then an attribute on `solve_sldump_prop` would be enough.)

Then, I implemented `solve_sldump_prop` in such a way that it makes progress only once `p` is fully resolved (i.e. has no remaining vprop uvars.)

And, most importantly, that tactic is in charge of printing `p`...