### PR TITLE
Fix `smaller` predicates for reflections

### DIFF
--- a/ulib/FStar.Reflection.Arith.fst
+++ b/ulib/FStar.Reflection.Arith.fst
@@ -120,22 +120,17 @@ private let atom (t:term) : tm expr = fun (n, atoms) ->
 private val fail : (#a:Type) -> string -> tm a
 private let fail #a s = fun i -> Inl s
 
-let refined_list_t (#a:Type) (p:(a -> Type0)) = list (x:a{p x})
-
-val list_unref : #a:Type -> #p:(a -> Type0) -> refined_list_t p -> Tot (l:list a{forall x. List.Tot.Base.memP x l ==> p x})
-let rec list_unref #a #p l =
-    match l with
-    | [] -> []
-    | x::xs -> x :: list_unref xs
-
-let collect_app_ref (t:term) : ((h:term{h == t \/ h << t}) * refined_list_t (fun (a:argv) -> fst a << t)) =
-  collect_app_ref t
-
 val as_arith_expr : term -> tm expr
 #push-options "--initial_fuel 4 --max_fuel 4"
 let rec as_arith_expr (t:term) =
-    let hd, tl = collect_app_ref t in
-    let tl = list_unref tl in //need to be careful to instantiate list_unref at the right type to allow SMT to unfold its recursive definition properly
+    let hd, tl = collect_app t in
+    // Invoke [collect_app_order]: forall (arg, qual) ∈ tl, (arg, qual) << t
+    collect_app_order t;
+    // [precedes_fst_tl]: forall (arg, qual) ∈ tl, arg << t
+    let precedes_fst_tl (arg: term) (q: aqualv)
+      : Lemma (List.Tot.memP (arg, q) tl ==> arg << t)
+      = let _: argv = arg, q in ()
+    in Classical.forall_intro_2 (precedes_fst_tl);
     match inspect_ln hd, tl with
     | Tv_FVar fv, [(e1, Q_Implicit); (e2, Q_Explicit) ; (e3, Q_Explicit)] ->
       let qn = inspect_fv fv in

--- a/ulib/FStar.Reflection.Builtins.fsti
+++ b/ulib/FStar.Reflection.Builtins.fsti
@@ -41,13 +41,13 @@ val pack_sigelt    : sigelt_view -> sigelt
 val inspect_fv     : fv -> name
 val pack_fv        : name -> fv
 
-val inspect_bv     : bv -> bv_view
+val inspect_bv     : v:bv -> vv: bv_view {smaller_bv vv v}
 val pack_bv        : bv_view -> bv
 
-val inspect_lb     : letbinding -> lb_view
+val inspect_lb     : lb:letbinding -> lbv:lb_view {smaller_letbinding lbv lb}
 val pack_lb        : lb_view -> letbinding
 
-val inspect_binder : binder -> bv * (aqualv * list term)
+val inspect_binder : b:binder -> bv:(bv * (aqualv * list term)) {smaller_binder b bv}
 val pack_binder    : bv -> aqualv -> attrs:list term -> binder
 
 val inspect_universe : u:universe -> uv:universe_view{smaller_universe uv u}

--- a/ulib/FStar.Reflection.Builtins.fsti
+++ b/ulib/FStar.Reflection.Builtins.fsti
@@ -35,6 +35,9 @@ val inspect_pack_inv : (tv:term_view) -> Lemma (inspect_ln (pack_ln tv) == tv)
 val inspect_comp   : (c:comp) -> cv:comp_view{smaller_comp cv c}
 val pack_comp      : comp_view -> comp
 
+val pack_inspect_comp_inv : (c:comp) -> Lemma (pack_comp (inspect_comp c) == c)
+val inspect_pack_comp_inv : (cv:comp_view) -> Lemma (inspect_comp (pack_comp cv) == cv)
+
 val inspect_sigelt : sigelt -> sigelt_view
 val pack_sigelt    : sigelt_view -> sigelt
 

--- a/ulib/FStar.Reflection.Data.fsti
+++ b/ulib/FStar.Reflection.Data.fsti
@@ -179,11 +179,6 @@ type exp : Type =
 
 type decls = list sigelt
 
-let rec forall_list (p:'a -> Type) (l:list 'a) : Type =
-    match l with
-    | [] -> True
-    | x::xs -> p x /\ forall_list p xs
-
 (* Comparison of a term_view to term. Allows to recurse while changing the view *)
 [@@ remove_unused_type_parameters [0; 1]]
 let smaller (tv:term_view) (t:term) : Type0 =
@@ -199,22 +194,24 @@ let smaller (tv:term_view) (t:term) : Type0 =
         bv << t /\ t' << t
 
     | Tv_Let r attrs bv t1 t2 ->
-        (forall_list (fun t' -> t' << t) attrs) /\ bv << t /\ t1 << t /\ t2 << t
+        attrs << t /\ bv << t /\ t1 << t /\ t2 << t
 
     | Tv_Match t1 ret_opt brs ->
-        t1 << t /\ ret_opt << t /\ (forall_list (fun (b, t') -> t' << t) brs)
+        t1 << t /\ ret_opt << t /\ brs << t
 
     | Tv_AscribedT e ty tac _use_eq ->
-      e << t /\ ty << t /\ tac << t
+        e << t /\ ty << t /\ tac << t
 
     | Tv_AscribedC e c tac _use_eq ->
-      e << t /\ c << t /\ tac << t
+        e << t /\ c << t /\ tac << t
+
+    | Tv_Var v
+    | Tv_BVar v ->
+        v << t
 
     | Tv_Type _
     | Tv_Const _
     | Tv_Unknown
-    | Tv_Var _
-    | Tv_BVar _
     | Tv_Uvar _ _
     | Tv_FVar _
     | Tv_UInst _ _ -> True
@@ -222,21 +219,24 @@ let smaller (tv:term_view) (t:term) : Type0 =
 [@@ remove_unused_type_parameters [0; 1]]
 let smaller_comp (cv:comp_view) (c:comp) : Type0 =
     match cv with
-    | C_Total t _ md -> t << c /\ md << c
+    | C_Total t _ md
     | C_GTotal t _ md ->
         t << c /\ md << c
     | C_Lemma pre post pats ->
         pre << c /\ post << c /\ pats << c
     | C_Eff _us eff res args ->
-        res << c
+        res << c /\ args << c
 
 [@@ remove_unused_type_parameters [0; 1]]
 let smaller_bv (bvv:bv_view) (bv:bv) : Type0 =
     bvv.bv_sort << bv
 
 [@@ remove_unused_type_parameters [0; 1]]
-let smaller_binder (b:binder) ((bv, _): bv * aqualv) : Type0 =
-    bv << b
+let smaller_binder (b:binder) ((bv, (q, attrs)): bv * (aqualv * list term)) : Type0 =
+      bv << b /\ attrs << b
+    /\ ( match q with
+      | Q_Meta m -> m << b
+      | _ -> True )
 
 [@@ remove_unused_type_parameters [0; 1]]
 let smaller_universe (uv:universe_view) (u:universe) : Type0 =
@@ -248,3 +248,7 @@ let smaller_universe (uv:universe_view) (u:universe) : Type0 =
   | Uv_Name _
   | Uv_Unif _
   | Uv_Unk -> True
+
+[@@ remove_unused_type_parameters [0; 1]]
+let smaller_letbinding (lbv:lb_view) (lb: letbinding) : Type0 =
+    lbv.lb_typ << lb /\ lbv.lb_def << lb

--- a/ulib/FStar.Reflection.Derived.Lemmas.fst
+++ b/ulib/FStar.Reflection.Derived.Lemmas.fst
@@ -19,23 +19,32 @@ open FStar.Reflection.Types
 open FStar.Reflection.Builtins
 open FStar.Reflection.Data
 open FStar.Reflection.Derived
+open FStar.List.Tot
 
+(**** Helpers *)
 val uncurry : ('a -> 'b -> 'c) -> ('a * 'b -> 'c)
 let uncurry f (x, y) = f x y
 
 val curry : ('a * 'b -> 'c) -> ('a -> 'b -> 'c)
 let curry f x y = f (x, y)
 
+let forallP (p: 'a -> Type) (l: list 'a): Type
+  = forall (x: 'a). memP x l ==> p x
+// Precedence relation on the element of a list
+unfold let (<<:) (l: list 'a) (r: 'r)
+  = forallP (fun x -> x << r) l
+
 // A glorified `id`
 val list_ref : (#a:Type) -> (#p:(a -> Type)) -> (l:list a) ->
                     Pure (list (x:a{p x}))
-                         (requires (forall_list p l))
+                         (requires (forallP p l))
                          (ensures (fun _ -> True))
 let rec list_ref #a #p l =
     match l with
     | [] -> []
     | x::xs -> x :: list_ref #a #p xs
 
+(**** [mk_app] and [collect_app] are invertible functions *)
 val mk_app_collect_inv_s : (t:term) -> (args:list argv) ->
                             Lemma (uncurry mk_app (collect_app' args t) == mk_app t args)
 let rec mk_app_collect_inv_s t args =
@@ -48,16 +57,16 @@ let rec mk_app_collect_inv_s t args =
 val mk_app_collect_inv : (t:term) -> Lemma (uncurry mk_app (collect_app t) == t)
 let mk_app_collect_inv t = mk_app_collect_inv_s t []
 
+(**** [collect_app t] is smaller than [t] *)
 (*
  * The way back is not stricly true: the list of arguments could grow.
  * It's annoying to even state
  *)
 val collect_app_order' : (args:list argv) -> (tt:term) -> (t:term) ->
-            Lemma (requires (forall_list (fun a -> fst a << tt) args)
-                             /\ t << tt)
-                  (ensures (forall_list (fun a -> fst a << tt) (snd (collect_app' args t)))
-                           /\ fst (collect_app' args t) << tt)
-                  (decreases t)
+             Lemma (requires args <<: tt /\ t << tt)
+                   (ensures (let fn, args' = collect_app' args t in
+                             args' <<: tt /\ fn << tt))
+                   (decreases t)
 let rec collect_app_order' args tt t =
     match inspect_ln t with
     | Tv_App l r -> collect_app_order' (r::args) tt l
@@ -65,16 +74,80 @@ let rec collect_app_order' args tt t =
 
 val collect_app_order : (t:term) ->
             Lemma (ensures (forall (f:term). forall (s:list argv). (f,s) == collect_app t ==>
-                              (f << t /\ forall_list (fun a -> fst a << t) (snd (collect_app t)))
-                           \/ (f == t /\ s == [])))
+                              (f << t /\ s <<: t)
+                            \/ (f == t /\ s == [])))
 let collect_app_order t =
     match inspect_ln t with
     | Tv_App l r -> collect_app_order' [r] t l
     | _ -> ()
 
-
-val collect_app_ref : (t:term) -> (h:term{h == t \/ h << t}) * list (a:argv{fst a << t})
+val collect_app_ref : (t:term) -> (h:term{h == t \/ h << t}) * list (a:argv{a << t})
 let collect_app_ref t =
     let h, a = collect_app t in
     collect_app_order t;
-    h, list_ref #_ #(fun a -> fst a << t) a
+    h, list_ref a
+
+(**** [collect_abs_ln t] is smaller than [t] *)
+let rec collect_abs_order' (bds: binders) (tt t: term)
+  : Lemma (requires t << tt /\ bds <<: tt)
+          (ensures (let bds', body = collect_abs' bds t in
+                    bds' <<: tt /\ body << tt ))
+          (decreases t)
+  = match inspect_ln t with
+    | Tv_Abs b body -> collect_abs_order' (b::bds) tt body
+    | _ -> ()
+
+val collect_abs_ln_order : (t:term) ->
+            Lemma (ensures forall bds body. 
+                           (bds, body) == collect_abs_ln t ==>
+                                (body << t /\ bds <<: t)
+                              \/ (body == t /\ bds == [])
+                  )
+let collect_abs_ln_order t =
+    match inspect_ln t with
+    | Tv_Abs b body -> collect_abs_order' [b] t body;
+                      let bds, body = collect_abs' [] t in
+                      Classical.forall_intro (rev_memP bds)
+    | _ -> ()
+
+val collect_abs_ln_ref : (t:term) -> list (bd:binder{bd << t}) * (body:term{body == t \/ body << t})
+let collect_abs_ln_ref t =
+    let bds, body = collect_abs_ln t in
+    collect_abs_ln_order t;
+    list_ref bds, body
+
+
+
+(**** [collect_arr_ln_bs t] is smaller than [t] *)
+let rec collect_arr_order' (bds: binders) (tt: term) (c: comp)
+  : Lemma (requires c << tt /\ bds <<: tt)
+          (ensures (let bds', c' = collect_arr' bds c in
+                    bds' <<: tt /\ c' << tt))
+          (decreases c)
+  = match inspect_comp c with
+    | C_Total ret _ _ ->
+        ( match inspect_ln ret with
+        | Tv_Arrow b c -> collect_arr_order' (b::bds) tt c
+        | _ -> ())
+    | _ -> ()
+
+val collect_arr_ln_bs_order : (t:term) ->
+            Lemma (ensures forall bds c. 
+                           (bds, c) == collect_arr_ln_bs t ==>
+                                (c << t /\ bds <<: t)
+                              \/ (c == pack_comp (C_Total t u_unk []) /\ bds == [])
+                  )
+let collect_arr_ln_bs_order t = 
+  match inspect_ln t with
+  | Tv_Arrow b c -> collect_arr_order' [b] t c;
+                   Classical.forall_intro_2 (rev_memP #binder);
+                   inspect_pack_comp_inv (C_Total t u_unk [])
+  | _ -> inspect_pack_comp_inv (C_Total t u_unk [])
+
+val collect_arr_ln_bs_ref : (t:term) -> list (bd:binder{bd << t}) 
+                                     * (c:comp{ c == pack_comp (C_Total t u_unk []) \/ c << t})
+let collect_arr_ln_bs_ref t =
+    let bds, c = collect_arr_ln_bs t in
+    collect_arr_ln_bs_order t;
+    list_ref bds, c
+

--- a/ulib/FStar.Reflection.Derived.fst
+++ b/ulib/FStar.Reflection.Derived.fst
@@ -87,7 +87,6 @@ let rec mk_tot_arr_ln (bs: list binder) (cod : term) : Tot term (decreases bs) =
     | [] -> cod
     | (b::bs) -> pack_ln (Tv_Arrow b (pack_comp (C_Total (mk_tot_arr_ln bs cod) u_unk [])))
 
-private
 let rec collect_arr' (bs : list binder) (c : comp) : Tot (list binder * comp) (decreases c) =
     begin match inspect_comp c with
     | C_Total t _ _ ->
@@ -107,11 +106,9 @@ let collect_arr_ln_bs t =
 
 val collect_arr_ln : typ -> list typ * comp
 let collect_arr_ln t =
-    let (bs, c) = collect_arr' [] (pack_comp (C_Total t u_unk [])) in
-    let ts = List.Tot.Base.map type_of_binder bs in
-    (List.Tot.Base.rev ts, c)
+    let bs, c = collect_arr_ln_bs t in
+    List.Tot.Base.map type_of_binder bs, c
 
-private
 let rec collect_abs' (bs : list binder) (t : term) : Tot (list binder * term) (decreases t) =
     match inspect_ln t with
     | Tv_Abs b t' ->


### PR DESCRIPTION
Hi,

I was using the reflection API in a total context and found some `inspect_*` primitive were lacking refinements, forcing me to add `admit`s about termination of some of my functions.

Hence, this PR adds refinements on the builtins `inspect_bv`, `inspect_lb` and `inspect_binder` to specify that inspecting a bv/lb/binder `x` results in a view that is smaller than `x`.
It also fixes and simplifies some of those `smaller` functions that sometimes missed some `<<` relations.
