### PR TITLE
Add F# implementation of string_of_char

### DIFF
--- a/ulib/fs/FStar_String.fs
+++ b/ulib/fs/FStar_String.fs
@@ -26,3 +26,4 @@ let index = get
 let index_of (s : string) (c : char) = s.IndexOf(c) 
 let list_of_string (s : string) = s |> Seq.toList 
 let string_of_list (l : char list) = string(Array.ofList l)
+let string_of_char (c : char) =  string(c, 1)


### PR DESCRIPTION
Discovered during attempt to run SimplePrintf.fst as F# code