### PR TITLE
Fix unsoundness reported in #2641

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -60,6 +60,11 @@ Guidelines for the changelog:
   * Friend modules (https://github.com/FStarLang/FStar/wiki/Friend-modules)
 
 ## Core typechecker
+  * Cf. #2641, F* now supports only type-based reasoning of reification of indexed
+    effects. See https://github.com/FStarLang/FStar/issues/2641 for more discussions
+    and associated pull request. This may be a breaking change for clients relying on
+    extraction/smt reasoning of indexed effects via reification.
+
   * F* now supports accessibility predicates based termination proofs. When writing a recursive function
 
     ```

--- a/examples/layeredeffects/AlgForAll.fst
+++ b/examples/layeredeffects/AlgForAll.fst
@@ -234,9 +234,12 @@ let rec interp_sem #a (t : rwtree a) (s0:state)
 let extract #a #w (c:repr a w)
   : Lemma (w `stronger` interp_as_wp c)
   = ()
-  
+
+let soundness_aux #a #wp (t:repr a wp)
+  : s0:state -> ID5.ID (a & state) (as_pure_wp (wp s0))
+  = interp_sem t
+
 let soundness #a #wp (t : unit -> AlgWP a wp)
   : Tot (s0:state -> ID5.ID (a & state) (as_pure_wp (wp s0)))
-  = let c = reify (t ()) in
-    extract c; //this became necessary after a fix to #2635, though it seems unrelated
-    interp_sem c
+  = soundness_aux (reify (t ()))
+

--- a/examples/layeredeffects/AlgHeap.fst
+++ b/examples/layeredeffects/AlgHeap.fst
@@ -462,12 +462,14 @@ let extract #a #w (c:repr a w)
   : Lemma (w `stronger` interp_as_wp c)
   = ()
 
+let soundness_aux #a #wp (t:repr a wp)
+  : Tot (s0:state -> ID5.ID (a & state) (as_pure_wp (wp s0)))
+  = extract t;
+    interp_sem t
+
 let soundness #a #wp (t : unit -> AlgWP a wp)
   : Tot (s0:state -> ID5.ID (a & state) (as_pure_wp (wp s0)))
-  = let c = reify (t ()) in
-    extract c;
-    interp_sem c
-
+  = soundness_aux (reify (t ()))
 
 (* Same as above, but one doesn't have to think about WPs *)
 let soundnessPP #a #pre #post (t : unit -> AlgPP a pre post)

--- a/examples/layeredeffects/AlgWP.fst
+++ b/examples/layeredeffects/AlgWP.fst
@@ -308,10 +308,9 @@ let st_soundness #a #wp (t : unit -> AlgWP a [Read; Write] wp)
 
 (* This guarantees the final state is unchanged, but see below
 for an alternative statement. *)
-let ro_soundness #a #wp (t : unit -> AlgWP a [Read] wp)
+let ro_soundness #a #wp ($t : unit -> AlgWP a [Read] wp)
   : Tot (s0:state -> ID5.ID (a & state) (as_pure_wp (quotient_ro wp s0)))
   = let c = reify (t ()) in interp_ro c
-
 
 
 (****** Internalizing the relation between the labels
@@ -325,11 +324,16 @@ let quotient_lemma #a (wp : st_wp a) (s0 : state) :
   = assume (is_mono wp);
     ()
 
+let ro_soundness_wrapper #a #wp (t : unit -> AlgWP a [Read] wp)
+  (s0:state) ()
+  : ID5.ID (a & state) (as_pure_wp (quotient_ro wp s0))
+  = ro_soundness t s0
+
 let ro_soundness_pre_post #a #wp (t : unit -> AlgWP a [Read] wp)
   (s0:state)
   : ID5.Id (a & state) (requires (wp s0 (fun _ -> True)))
                        (ensures (fun (r, s1) -> s0 == s1))
-  = let reified = reify (ro_soundness #a #wp t s0) in
+  = let reified = reify (ro_soundness_wrapper #a #wp t s0 ()) in
     quotient_lemma wp s0;
     let r = reified (fun (r, s1) -> s1 == s0) () in
     r

--- a/examples/layeredeffects/Lattice.fst
+++ b/examples/layeredeffects/Lattice.fst
@@ -176,6 +176,8 @@ let sublist_at_self (l1 : list eff_label)
 let labpoly #labs (f g : unit -> EFF int labs) : EFF int labs =
   f () + g ()
 
+#set-options "--log_queries --fuel 2 --ifuel 2"
+#restart-solver
 (* no rollback *)
 let catch #a #labs
   (f : unit -> EFF a (EXN::labs))

--- a/examples/layeredeffects/Locals.Effect.fst
+++ b/examples/layeredeffects/Locals.Effect.fst
@@ -156,14 +156,17 @@ let emp_locals = {
   m = Map.restrict Set.empty (Map.const (| unit, () |))
 }
 
+let run_with_locals_aux (#a:Type) (#wp:wp_t a) (f:repr a wp)
+  : PURE a (as_pure_wp (fun post -> wp (fun r _ -> post r) emp_locals))
+  = fst (f emp_locals)
+
 let run_with_locals (#a:Type)
   (#pre:locals_t -> Type0) (#post:locals_t -> a -> locals_t -> Type0)
   ($f:unit -> LV a pre post)
 : Pure a
   (requires pre emp_locals)
   (ensures fun r -> exists m. post emp_locals r m)
-= fst (reify (f ()) emp_locals)
-
+= run_with_locals_aux (reify (f ()))
 
 /// Testing some termination
 

--- a/examples/layeredeffects/LowParseWriters.NoHoare.fst
+++ b/examples/layeredeffects/LowParseWriters.NoHoare.fst
@@ -531,6 +531,19 @@ let bind_spec'
     | Error e -> Error e
     | Correct (x, v2) -> destr_repr_spec (g x) v2
 
+let bind_spec2_aux
+  (inv: memory_invariant)
+  (p1 p2 p3: parser)
+  (a b: Type)
+  ($f: repr a p1 p2 inv)
+  ($g: a -> repr b p2 p3 inv)
+  (v1: Parser?.t p1)
+: GTot (result (b & Parser?.t p3))
+=
+   match Repr?.spec f v1 with
+    | Error e -> Error e
+    | Correct (x, v2) -> Repr?.spec (g x) v2
+
 let bind_spec2
   (inv: memory_invariant)
   (p1 p2 p3: parser)
@@ -539,10 +552,7 @@ let bind_spec2
   (g: (a -> unit -> TWrite b p2 p3 inv))
   (v1: Parser?.t p1)
 : GTot (result (b & Parser?.t p3))
-=
-   match Repr?.spec (reify (f ())) v1 with
-    | Error e -> Error e
-    | Correct (x, v2) -> Repr?.spec (reify (g x ())) v2
+= bind_spec2_aux _ _ _ _ _ _ (reify (f ())) (fun x -> reify (g x ())) v1
 
 let bind_impl'
   (inv: memory_invariant)

--- a/src/ocaml-output/FStar_Parser_Const.ml
+++ b/src/ocaml-output/FStar_Parser_Const.ml
@@ -542,3 +542,18 @@ let (or_elim_lid : FStar_Ident.lid) = classical_sugar_lid "or_elim"
 let (and_elim_lid : FStar_Ident.lid) = classical_sugar_lid "and_elim"
 let (match_returns_def_name : Prims.string) =
   FStar_String.op_Hat FStar_Ident.reserved_prefix "_ret_"
+let (layered_effect_reify_val_lid :
+  FStar_Ident.lident -> FStar_Compiler_Range.range -> FStar_Ident.lident) =
+  fun eff_name ->
+    fun r ->
+      let ns = FStar_Ident.ns_of_lid eff_name in
+      let reify_fn_name =
+        let uu___ =
+          let uu___1 =
+            FStar_Compiler_Effect.op_Bar_Greater eff_name
+              FStar_Ident.ident_of_lid in
+          FStar_Compiler_Effect.op_Bar_Greater uu___1
+            FStar_Ident.string_of_id in
+        FStar_String.op_Hat "reify___" uu___ in
+      let uu___ = FStar_Ident.mk_ident (reify_fn_name, r) in
+      FStar_Ident.lid_of_ns_and_id ns uu___

--- a/src/ocaml-output/FStar_TypeChecker_Tc.ml
+++ b/src/ocaml-output/FStar_TypeChecker_Tc.ml
@@ -2307,116 +2307,124 @@ let (tc_decl' :
                         let uu___4 =
                           let uu___5 =
                             let uu___6 =
-                              FStar_TypeChecker_TcEffect.tc_eff_decl
-                                {
-                                  FStar_TypeChecker_Env.solver =
-                                    (env.FStar_TypeChecker_Env.solver);
-                                  FStar_TypeChecker_Env.range =
-                                    (env.FStar_TypeChecker_Env.range);
-                                  FStar_TypeChecker_Env.curmodule =
-                                    (env.FStar_TypeChecker_Env.curmodule);
-                                  FStar_TypeChecker_Env.gamma =
-                                    (env.FStar_TypeChecker_Env.gamma);
-                                  FStar_TypeChecker_Env.gamma_sig =
-                                    (env.FStar_TypeChecker_Env.gamma_sig);
-                                  FStar_TypeChecker_Env.gamma_cache =
-                                    (env.FStar_TypeChecker_Env.gamma_cache);
-                                  FStar_TypeChecker_Env.modules =
-                                    (env.FStar_TypeChecker_Env.modules);
-                                  FStar_TypeChecker_Env.expected_typ =
-                                    (env.FStar_TypeChecker_Env.expected_typ);
-                                  FStar_TypeChecker_Env.sigtab =
-                                    (env.FStar_TypeChecker_Env.sigtab);
-                                  FStar_TypeChecker_Env.attrtab =
-                                    (env.FStar_TypeChecker_Env.attrtab);
-                                  FStar_TypeChecker_Env.instantiate_imp =
-                                    (env.FStar_TypeChecker_Env.instantiate_imp);
-                                  FStar_TypeChecker_Env.effects =
-                                    (env.FStar_TypeChecker_Env.effects);
-                                  FStar_TypeChecker_Env.generalize =
-                                    (env.FStar_TypeChecker_Env.generalize);
-                                  FStar_TypeChecker_Env.letrecs =
-                                    (env.FStar_TypeChecker_Env.letrecs);
-                                  FStar_TypeChecker_Env.top_level =
-                                    (env.FStar_TypeChecker_Env.top_level);
-                                  FStar_TypeChecker_Env.check_uvars =
-                                    (env.FStar_TypeChecker_Env.check_uvars);
-                                  FStar_TypeChecker_Env.use_eq_strict =
-                                    (env.FStar_TypeChecker_Env.use_eq_strict);
-                                  FStar_TypeChecker_Env.is_iface =
-                                    (env.FStar_TypeChecker_Env.is_iface);
-                                  FStar_TypeChecker_Env.admit =
-                                    (env.FStar_TypeChecker_Env.admit);
-                                  FStar_TypeChecker_Env.lax = true;
-                                  FStar_TypeChecker_Env.lax_universes =
-                                    (env.FStar_TypeChecker_Env.lax_universes);
-                                  FStar_TypeChecker_Env.phase1 = true;
-                                  FStar_TypeChecker_Env.failhard =
-                                    (env.FStar_TypeChecker_Env.failhard);
-                                  FStar_TypeChecker_Env.nosynth =
-                                    (env.FStar_TypeChecker_Env.nosynth);
-                                  FStar_TypeChecker_Env.uvar_subtyping =
-                                    (env.FStar_TypeChecker_Env.uvar_subtyping);
-                                  FStar_TypeChecker_Env.tc_term =
-                                    (env.FStar_TypeChecker_Env.tc_term);
-                                  FStar_TypeChecker_Env.typeof_tot_or_gtot_term
-                                    =
-                                    (env.FStar_TypeChecker_Env.typeof_tot_or_gtot_term);
-                                  FStar_TypeChecker_Env.universe_of =
-                                    (env.FStar_TypeChecker_Env.universe_of);
-                                  FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term
-                                    =
-                                    (env.FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term);
-                                  FStar_TypeChecker_Env.teq_nosmt_force =
-                                    (env.FStar_TypeChecker_Env.teq_nosmt_force);
-                                  FStar_TypeChecker_Env.subtype_nosmt_force =
-                                    (env.FStar_TypeChecker_Env.subtype_nosmt_force);
-                                  FStar_TypeChecker_Env.use_bv_sorts =
-                                    (env.FStar_TypeChecker_Env.use_bv_sorts);
-                                  FStar_TypeChecker_Env.qtbl_name_and_index =
-                                    (env.FStar_TypeChecker_Env.qtbl_name_and_index);
-                                  FStar_TypeChecker_Env.normalized_eff_names
-                                    =
-                                    (env.FStar_TypeChecker_Env.normalized_eff_names);
-                                  FStar_TypeChecker_Env.fv_delta_depths =
-                                    (env.FStar_TypeChecker_Env.fv_delta_depths);
-                                  FStar_TypeChecker_Env.proof_ns =
-                                    (env.FStar_TypeChecker_Env.proof_ns);
-                                  FStar_TypeChecker_Env.synth_hook =
-                                    (env.FStar_TypeChecker_Env.synth_hook);
-                                  FStar_TypeChecker_Env.try_solve_implicits_hook
-                                    =
-                                    (env.FStar_TypeChecker_Env.try_solve_implicits_hook);
-                                  FStar_TypeChecker_Env.splice =
-                                    (env.FStar_TypeChecker_Env.splice);
-                                  FStar_TypeChecker_Env.mpreprocess =
-                                    (env.FStar_TypeChecker_Env.mpreprocess);
-                                  FStar_TypeChecker_Env.postprocess =
-                                    (env.FStar_TypeChecker_Env.postprocess);
-                                  FStar_TypeChecker_Env.identifier_info =
-                                    (env.FStar_TypeChecker_Env.identifier_info);
-                                  FStar_TypeChecker_Env.tc_hooks =
-                                    (env.FStar_TypeChecker_Env.tc_hooks);
-                                  FStar_TypeChecker_Env.dsenv =
-                                    (env.FStar_TypeChecker_Env.dsenv);
-                                  FStar_TypeChecker_Env.nbe =
-                                    (env.FStar_TypeChecker_Env.nbe);
-                                  FStar_TypeChecker_Env.strict_args_tab =
-                                    (env.FStar_TypeChecker_Env.strict_args_tab);
-                                  FStar_TypeChecker_Env.erasable_types_tab =
-                                    (env.FStar_TypeChecker_Env.erasable_types_tab);
-                                  FStar_TypeChecker_Env.enable_defer_to_tac =
-                                    (env.FStar_TypeChecker_Env.enable_defer_to_tac);
-                                  FStar_TypeChecker_Env.unif_allow_ref_guards
-                                    =
-                                    (env.FStar_TypeChecker_Env.unif_allow_ref_guards);
-                                  FStar_TypeChecker_Env.erase_erasable_args =
-                                    (env.FStar_TypeChecker_Env.erase_erasable_args);
-                                  FStar_TypeChecker_Env.rel_query_for_apply_tac_uvar
-                                    =
-                                    (env.FStar_TypeChecker_Env.rel_query_for_apply_tac_uvar)
-                                } ne se1.FStar_Syntax_Syntax.sigquals
-                                se1.FStar_Syntax_Syntax.sigattrs in
+                              let uu___7 =
+                                FStar_TypeChecker_TcEffect.tc_eff_decl
+                                  {
+                                    FStar_TypeChecker_Env.solver =
+                                      (env.FStar_TypeChecker_Env.solver);
+                                    FStar_TypeChecker_Env.range =
+                                      (env.FStar_TypeChecker_Env.range);
+                                    FStar_TypeChecker_Env.curmodule =
+                                      (env.FStar_TypeChecker_Env.curmodule);
+                                    FStar_TypeChecker_Env.gamma =
+                                      (env.FStar_TypeChecker_Env.gamma);
+                                    FStar_TypeChecker_Env.gamma_sig =
+                                      (env.FStar_TypeChecker_Env.gamma_sig);
+                                    FStar_TypeChecker_Env.gamma_cache =
+                                      (env.FStar_TypeChecker_Env.gamma_cache);
+                                    FStar_TypeChecker_Env.modules =
+                                      (env.FStar_TypeChecker_Env.modules);
+                                    FStar_TypeChecker_Env.expected_typ =
+                                      (env.FStar_TypeChecker_Env.expected_typ);
+                                    FStar_TypeChecker_Env.sigtab =
+                                      (env.FStar_TypeChecker_Env.sigtab);
+                                    FStar_TypeChecker_Env.attrtab =
+                                      (env.FStar_TypeChecker_Env.attrtab);
+                                    FStar_TypeChecker_Env.instantiate_imp =
+                                      (env.FStar_TypeChecker_Env.instantiate_imp);
+                                    FStar_TypeChecker_Env.effects =
+                                      (env.FStar_TypeChecker_Env.effects);
+                                    FStar_TypeChecker_Env.generalize =
+                                      (env.FStar_TypeChecker_Env.generalize);
+                                    FStar_TypeChecker_Env.letrecs =
+                                      (env.FStar_TypeChecker_Env.letrecs);
+                                    FStar_TypeChecker_Env.top_level =
+                                      (env.FStar_TypeChecker_Env.top_level);
+                                    FStar_TypeChecker_Env.check_uvars =
+                                      (env.FStar_TypeChecker_Env.check_uvars);
+                                    FStar_TypeChecker_Env.use_eq_strict =
+                                      (env.FStar_TypeChecker_Env.use_eq_strict);
+                                    FStar_TypeChecker_Env.is_iface =
+                                      (env.FStar_TypeChecker_Env.is_iface);
+                                    FStar_TypeChecker_Env.admit =
+                                      (env.FStar_TypeChecker_Env.admit);
+                                    FStar_TypeChecker_Env.lax = true;
+                                    FStar_TypeChecker_Env.lax_universes =
+                                      (env.FStar_TypeChecker_Env.lax_universes);
+                                    FStar_TypeChecker_Env.phase1 = true;
+                                    FStar_TypeChecker_Env.failhard =
+                                      (env.FStar_TypeChecker_Env.failhard);
+                                    FStar_TypeChecker_Env.nosynth =
+                                      (env.FStar_TypeChecker_Env.nosynth);
+                                    FStar_TypeChecker_Env.uvar_subtyping =
+                                      (env.FStar_TypeChecker_Env.uvar_subtyping);
+                                    FStar_TypeChecker_Env.tc_term =
+                                      (env.FStar_TypeChecker_Env.tc_term);
+                                    FStar_TypeChecker_Env.typeof_tot_or_gtot_term
+                                      =
+                                      (env.FStar_TypeChecker_Env.typeof_tot_or_gtot_term);
+                                    FStar_TypeChecker_Env.universe_of =
+                                      (env.FStar_TypeChecker_Env.universe_of);
+                                    FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term
+                                      =
+                                      (env.FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term);
+                                    FStar_TypeChecker_Env.teq_nosmt_force =
+                                      (env.FStar_TypeChecker_Env.teq_nosmt_force);
+                                    FStar_TypeChecker_Env.subtype_nosmt_force
+                                      =
+                                      (env.FStar_TypeChecker_Env.subtype_nosmt_force);
+                                    FStar_TypeChecker_Env.use_bv_sorts =
+                                      (env.FStar_TypeChecker_Env.use_bv_sorts);
+                                    FStar_TypeChecker_Env.qtbl_name_and_index
+                                      =
+                                      (env.FStar_TypeChecker_Env.qtbl_name_and_index);
+                                    FStar_TypeChecker_Env.normalized_eff_names
+                                      =
+                                      (env.FStar_TypeChecker_Env.normalized_eff_names);
+                                    FStar_TypeChecker_Env.fv_delta_depths =
+                                      (env.FStar_TypeChecker_Env.fv_delta_depths);
+                                    FStar_TypeChecker_Env.proof_ns =
+                                      (env.FStar_TypeChecker_Env.proof_ns);
+                                    FStar_TypeChecker_Env.synth_hook =
+                                      (env.FStar_TypeChecker_Env.synth_hook);
+                                    FStar_TypeChecker_Env.try_solve_implicits_hook
+                                      =
+                                      (env.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                                    FStar_TypeChecker_Env.splice =
+                                      (env.FStar_TypeChecker_Env.splice);
+                                    FStar_TypeChecker_Env.mpreprocess =
+                                      (env.FStar_TypeChecker_Env.mpreprocess);
+                                    FStar_TypeChecker_Env.postprocess =
+                                      (env.FStar_TypeChecker_Env.postprocess);
+                                    FStar_TypeChecker_Env.identifier_info =
+                                      (env.FStar_TypeChecker_Env.identifier_info);
+                                    FStar_TypeChecker_Env.tc_hooks =
+                                      (env.FStar_TypeChecker_Env.tc_hooks);
+                                    FStar_TypeChecker_Env.dsenv =
+                                      (env.FStar_TypeChecker_Env.dsenv);
+                                    FStar_TypeChecker_Env.nbe =
+                                      (env.FStar_TypeChecker_Env.nbe);
+                                    FStar_TypeChecker_Env.strict_args_tab =
+                                      (env.FStar_TypeChecker_Env.strict_args_tab);
+                                    FStar_TypeChecker_Env.erasable_types_tab
+                                      =
+                                      (env.FStar_TypeChecker_Env.erasable_types_tab);
+                                    FStar_TypeChecker_Env.enable_defer_to_tac
+                                      =
+                                      (env.FStar_TypeChecker_Env.enable_defer_to_tac);
+                                    FStar_TypeChecker_Env.unif_allow_ref_guards
+                                      =
+                                      (env.FStar_TypeChecker_Env.unif_allow_ref_guards);
+                                    FStar_TypeChecker_Env.erase_erasable_args
+                                      =
+                                      (env.FStar_TypeChecker_Env.erase_erasable_args);
+                                    FStar_TypeChecker_Env.rel_query_for_apply_tac_uvar
+                                      =
+                                      (env.FStar_TypeChecker_Env.rel_query_for_apply_tac_uvar)
+                                  } ne se1.FStar_Syntax_Syntax.sigquals
+                                  se1.FStar_Syntax_Syntax.sigattrs in
+                              FStar_Compiler_Effect.op_Bar_Greater uu___7
+                                FStar_Pervasives_Native.fst in
                             FStar_Compiler_Effect.op_Bar_Greater uu___6
                               (fun ne3 ->
                                  {
@@ -2464,26 +2472,28 @@ let (tc_decl' :
                         else ());
                        ne2)
                     else ne in
-                  let ne2 =
+                  let uu___3 =
                     FStar_TypeChecker_TcEffect.tc_eff_decl env ne1
                       se1.FStar_Syntax_Syntax.sigquals
                       se1.FStar_Syntax_Syntax.sigattrs in
-                  let se2 =
-                    {
-                      FStar_Syntax_Syntax.sigel =
-                        (FStar_Syntax_Syntax.Sig_new_effect ne2);
-                      FStar_Syntax_Syntax.sigrng =
-                        (se1.FStar_Syntax_Syntax.sigrng);
-                      FStar_Syntax_Syntax.sigquals =
-                        (se1.FStar_Syntax_Syntax.sigquals);
-                      FStar_Syntax_Syntax.sigmeta =
-                        (se1.FStar_Syntax_Syntax.sigmeta);
-                      FStar_Syntax_Syntax.sigattrs =
-                        (se1.FStar_Syntax_Syntax.sigattrs);
-                      FStar_Syntax_Syntax.sigopts =
-                        (se1.FStar_Syntax_Syntax.sigopts)
-                    } in
-                  ([se2], [], env0))
+                  match uu___3 with
+                  | (ne2, ses) ->
+                      let se2 =
+                        {
+                          FStar_Syntax_Syntax.sigel =
+                            (FStar_Syntax_Syntax.Sig_new_effect ne2);
+                          FStar_Syntax_Syntax.sigrng =
+                            (se1.FStar_Syntax_Syntax.sigrng);
+                          FStar_Syntax_Syntax.sigquals =
+                            (se1.FStar_Syntax_Syntax.sigquals);
+                          FStar_Syntax_Syntax.sigmeta =
+                            (se1.FStar_Syntax_Syntax.sigmeta);
+                          FStar_Syntax_Syntax.sigattrs =
+                            (se1.FStar_Syntax_Syntax.sigattrs);
+                          FStar_Syntax_Syntax.sigopts =
+                            (se1.FStar_Syntax_Syntax.sigopts)
+                        } in
+                      ([se2], ses, env0))
            | FStar_Syntax_Syntax.Sig_sub_effect sub ->
                let sub1 = FStar_TypeChecker_TcEffect.tc_lift env sub r in
                let se2 =
@@ -4324,7 +4334,7 @@ let (tc_decls :
                ([], env) ses) in
       match uu___ with
       | (ses1, env1) -> ((FStar_Compiler_List.rev_append ses1 []), env1)
-let (uu___903 : unit) =
+let (uu___905 : unit) =
   FStar_Compiler_Effect.op_Colon_Equals tc_decls_knot
     (FStar_Pervasives_Native.Some tc_decls)
 let (snapshot_context :

--- a/src/ocaml-output/FStar_TypeChecker_TcEffect.ml
+++ b/src/ocaml-output/FStar_TypeChecker_TcEffect.ml
@@ -2829,7 +2829,7 @@ let (tc_layered_eff_decl :
                                                              FStar_Errors.raise_error
                                                                uu___26 r)) in
                                                  act2))))))))) in
-                      let reify_sig =
+                      let reify_sigelt =
                         if
                           FStar_Compiler_List.contains
                             FStar_Syntax_Syntax.Reifiable quals
@@ -3019,7 +3019,7 @@ let (tc_layered_eff_decl :
                           FStar_Syntax_Syntax.eff_attrs =
                             (ed.FStar_Syntax_Syntax.eff_attrs)
                         } in
-                      (uu___10, reify_sig)))))))))
+                      (uu___10, reify_sigelt)))))))))
 let (tc_non_layered_eff_decl :
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.eff_decl ->

--- a/src/ocaml-output/FStar_TypeChecker_TcEffect.ml
+++ b/src/ocaml-output/FStar_TypeChecker_TcEffect.ml
@@ -2978,7 +2978,18 @@ let (tc_layered_eff_decl :
                                        FStar_Syntax_Syntax.sigopts =
                                          FStar_Pervasives_Native.None
                                      } in
-                                   [sig_assume_reify])
+                                   ((let uu___13 =
+                                       let uu___14 =
+                                         let uu___15 =
+                                           FStar_Ident.string_of_lid
+                                             ed.FStar_Syntax_Syntax.mname in
+                                         FStar_Compiler_Util.format1
+                                           "Reification of indexed effects (%s here) is supported only as a type coercion to the underlying representation type (no support for smt-based reasoning or extraction)"
+                                           uu___15 in
+                                       (FStar_Errors.Warning_BleedingEdge_Feature,
+                                         uu___14) in
+                                     FStar_Errors.log_issue r uu___13);
+                                    [sig_assume_reify]))
                         else [] in
                       let tschemes_of uu___10 =
                         match uu___10 with

--- a/src/ocaml-output/FStar_TypeChecker_TcEffect.ml
+++ b/src/ocaml-output/FStar_TypeChecker_TcEffect.ml
@@ -310,7 +310,8 @@ let (tc_layered_eff_decl :
     FStar_Syntax_Syntax.eff_decl ->
       FStar_Syntax_Syntax.qualifier Prims.list ->
         FStar_Syntax_Syntax.attribute Prims.list ->
-          FStar_Syntax_Syntax.eff_decl)
+          (FStar_Syntax_Syntax.eff_decl * FStar_Syntax_Syntax.sigelt
+            Prims.list))
   =
   fun env0 ->
     fun ed ->
@@ -2828,6 +2829,157 @@ let (tc_layered_eff_decl :
                                                              FStar_Errors.raise_error
                                                                uu___26 r)) in
                                                  act2))))))))) in
+                      let reify_sig =
+                        if
+                          FStar_Compiler_List.contains
+                            FStar_Syntax_Syntax.Reifiable quals
+                        then
+                          let env = env0 in
+                          let r =
+                            FStar_Ident.range_of_lid
+                              ed.FStar_Syntax_Syntax.mname in
+                          let uu___10 = fresh_a_and_u_a "a" in
+                          match uu___10 with
+                          | (a, u_a) ->
+                              let rest_bs =
+                                let signature_ts =
+                                  let uu___11 = signature in
+                                  match uu___11 with
+                                  | (us, t, uu___12) -> (us, t) in
+                                let uu___11 =
+                                  FStar_Compiler_Effect.op_Bar_Greater
+                                    a.FStar_Syntax_Syntax.binder_bv
+                                    FStar_Syntax_Syntax.bv_to_name in
+                                FStar_TypeChecker_Util.layered_effect_indices_as_binders
+                                  env r ed.FStar_Syntax_Syntax.mname
+                                  signature_ts u_a uu___11 in
+                              let f_binder =
+                                let thunked_t =
+                                  let uu___11 =
+                                    let uu___12 =
+                                      let uu___13 =
+                                        FStar_Syntax_Syntax.null_bv
+                                          FStar_Syntax_Syntax.t_unit in
+                                      FStar_Compiler_Effect.op_Bar_Greater
+                                        uu___13 FStar_Syntax_Syntax.mk_binder in
+                                    [uu___12] in
+                                  let uu___12 =
+                                    let uu___13 =
+                                      let uu___14 =
+                                        FStar_Syntax_Syntax.bv_to_name
+                                          a.FStar_Syntax_Syntax.binder_bv in
+                                      let uu___15 =
+                                        FStar_Compiler_Effect.op_Bar_Greater
+                                          rest_bs
+                                          (FStar_Compiler_List.map
+                                             (fun b ->
+                                                let uu___16 =
+                                                  FStar_Syntax_Syntax.bv_to_name
+                                                    b.FStar_Syntax_Syntax.binder_bv in
+                                                FStar_Syntax_Syntax.as_arg
+                                                  uu___16)) in
+                                      {
+                                        FStar_Syntax_Syntax.comp_univs = [];
+                                        FStar_Syntax_Syntax.effect_name =
+                                          (ed.FStar_Syntax_Syntax.mname);
+                                        FStar_Syntax_Syntax.result_typ =
+                                          uu___14;
+                                        FStar_Syntax_Syntax.effect_args =
+                                          uu___15;
+                                        FStar_Syntax_Syntax.flags = []
+                                      } in
+                                    FStar_Compiler_Effect.op_Bar_Greater
+                                      uu___13 FStar_Syntax_Syntax.mk_Comp in
+                                  FStar_Syntax_Util.arrow uu___11 uu___12 in
+                                let uu___11 =
+                                  FStar_Syntax_Syntax.null_bv thunked_t in
+                                FStar_Syntax_Syntax.mk_binder_with_attrs
+                                  uu___11
+                                  (FStar_Pervasives_Native.Some
+                                     FStar_Syntax_Syntax.Equality) [] in
+                              let bs = a :: rest_bs in
+                              let applied_repr =
+                                let repr_ts =
+                                  let uu___11 = repr in
+                                  match uu___11 with
+                                  | (us, t, uu___12) -> (us, t) in
+                                let repr1 =
+                                  let uu___11 =
+                                    FStar_TypeChecker_Env.inst_tscheme_with
+                                      repr_ts [u_a] in
+                                  FStar_Compiler_Effect.op_Bar_Greater
+                                    uu___11 FStar_Pervasives_Native.snd in
+                                let uu___11 =
+                                  FStar_Compiler_Effect.op_Bar_Greater bs
+                                    (FStar_Compiler_List.map
+                                       (fun b ->
+                                          let uu___12 =
+                                            FStar_Syntax_Syntax.bv_to_name
+                                              b.FStar_Syntax_Syntax.binder_bv in
+                                          let uu___13 =
+                                            FStar_Syntax_Util.aqual_of_binder
+                                              b in
+                                          (uu___12, uu___13))) in
+                                FStar_Syntax_Syntax.mk_Tm_app repr1 uu___11 r in
+                              let reify_val_t =
+                                let bs1 =
+                                  FStar_Compiler_Effect.op_Bar_Greater bs
+                                    (FStar_Compiler_List.map
+                                       (fun b ->
+                                          {
+                                            FStar_Syntax_Syntax.binder_bv =
+                                              (b.FStar_Syntax_Syntax.binder_bv);
+                                            FStar_Syntax_Syntax.binder_qual =
+                                              (FStar_Pervasives_Native.Some
+                                                 (FStar_Syntax_Syntax.Implicit
+                                                    false));
+                                            FStar_Syntax_Syntax.binder_attrs
+                                              = []
+                                          })) in
+                                let uu___11 =
+                                  if
+                                    FStar_Compiler_List.contains
+                                      FStar_Syntax_Syntax.TotalEffect quals
+                                  then
+                                    FStar_Syntax_Syntax.mk_Total applied_repr
+                                  else
+                                    FStar_Compiler_Effect.op_Bar_Greater
+                                      {
+                                        FStar_Syntax_Syntax.comp_univs = [];
+                                        FStar_Syntax_Syntax.effect_name =
+                                          FStar_Parser_Const.effect_Dv_lid;
+                                        FStar_Syntax_Syntax.result_typ =
+                                          applied_repr;
+                                        FStar_Syntax_Syntax.effect_args = [];
+                                        FStar_Syntax_Syntax.flags = []
+                                      } FStar_Syntax_Syntax.mk_Comp in
+                                FStar_Syntax_Util.arrow
+                                  (FStar_Compiler_List.op_At bs1 [f_binder])
+                                  uu___11 in
+                              let uu___11 =
+                                FStar_TypeChecker_Generalize.generalize_universes
+                                  env reify_val_t in
+                              (match uu___11 with
+                               | (us, reify_val_t1) ->
+                                   let sig_assume_reify =
+                                     let lid =
+                                       FStar_Parser_Const.layered_effect_reify_val_lid
+                                         ed.FStar_Syntax_Syntax.mname r in
+                                     {
+                                       FStar_Syntax_Syntax.sigel =
+                                         (FStar_Syntax_Syntax.Sig_declare_typ
+                                            (lid, us, reify_val_t1));
+                                       FStar_Syntax_Syntax.sigrng = r;
+                                       FStar_Syntax_Syntax.sigquals =
+                                         [FStar_Syntax_Syntax.Assumption];
+                                       FStar_Syntax_Syntax.sigmeta =
+                                         FStar_Syntax_Syntax.default_sigmeta;
+                                       FStar_Syntax_Syntax.sigattrs = [];
+                                       FStar_Syntax_Syntax.sigopts =
+                                         FStar_Pervasives_Native.None
+                                     } in
+                                   [sig_assume_reify])
+                        else [] in
                       let tschemes_of uu___10 =
                         match uu___10 with
                         | (us, t, ty) -> ((us, t), (us, ty)) in
@@ -2847,25 +2999,27 @@ let (tc_layered_eff_decl :
                           } in
                         FStar_Syntax_Syntax.Layered_eff uu___10 in
                       let uu___10 =
-                        FStar_Compiler_List.map (tc_action env0)
-                          ed.FStar_Syntax_Syntax.actions in
-                      {
-                        FStar_Syntax_Syntax.mname =
-                          (ed.FStar_Syntax_Syntax.mname);
-                        FStar_Syntax_Syntax.cattributes =
-                          (ed.FStar_Syntax_Syntax.cattributes);
-                        FStar_Syntax_Syntax.univs =
-                          (ed.FStar_Syntax_Syntax.univs);
-                        FStar_Syntax_Syntax.binders =
-                          (ed.FStar_Syntax_Syntax.binders);
-                        FStar_Syntax_Syntax.signature =
-                          (let uu___11 = signature in
-                           match uu___11 with | (us, t, uu___12) -> (us, t));
-                        FStar_Syntax_Syntax.combinators = combinators;
-                        FStar_Syntax_Syntax.actions = uu___10;
-                        FStar_Syntax_Syntax.eff_attrs =
-                          (ed.FStar_Syntax_Syntax.eff_attrs)
-                      }))))))))
+                        let uu___11 =
+                          FStar_Compiler_List.map (tc_action env0)
+                            ed.FStar_Syntax_Syntax.actions in
+                        {
+                          FStar_Syntax_Syntax.mname =
+                            (ed.FStar_Syntax_Syntax.mname);
+                          FStar_Syntax_Syntax.cattributes =
+                            (ed.FStar_Syntax_Syntax.cattributes);
+                          FStar_Syntax_Syntax.univs =
+                            (ed.FStar_Syntax_Syntax.univs);
+                          FStar_Syntax_Syntax.binders =
+                            (ed.FStar_Syntax_Syntax.binders);
+                          FStar_Syntax_Syntax.signature =
+                            (let uu___12 = signature in
+                             match uu___12 with | (us, t, uu___13) -> (us, t));
+                          FStar_Syntax_Syntax.combinators = combinators;
+                          FStar_Syntax_Syntax.actions = uu___11;
+                          FStar_Syntax_Syntax.eff_attrs =
+                            (ed.FStar_Syntax_Syntax.eff_attrs)
+                        } in
+                      (uu___10, reify_sig)))))))))
 let (tc_non_layered_eff_decl :
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.eff_decl ->
@@ -4927,18 +5081,21 @@ let (tc_eff_decl :
     FStar_Syntax_Syntax.eff_decl ->
       FStar_Syntax_Syntax.qualifier Prims.list ->
         FStar_Syntax_Syntax.attribute Prims.list ->
-          FStar_Syntax_Syntax.eff_decl)
+          (FStar_Syntax_Syntax.eff_decl * FStar_Syntax_Syntax.sigelt
+            Prims.list))
   =
   fun env ->
     fun ed ->
       fun quals ->
         fun attrs ->
           let uu___ =
-            let uu___1 =
-              FStar_Compiler_Effect.op_Bar_Greater ed
-                FStar_Syntax_Util.is_layered in
-            if uu___1 then tc_layered_eff_decl else tc_non_layered_eff_decl in
-          uu___ env ed quals attrs
+            FStar_Compiler_Effect.op_Bar_Greater ed
+              FStar_Syntax_Util.is_layered in
+          if uu___
+          then tc_layered_eff_decl env ed quals attrs
+          else
+            (let uu___2 = tc_non_layered_eff_decl env ed quals attrs in
+             (uu___2, []))
 let (monad_signature :
   FStar_TypeChecker_Env.env ->
     FStar_Ident.lident ->

--- a/src/ocaml-output/FStar_TypeChecker_TcTerm.ml
+++ b/src/ocaml-output/FStar_TypeChecker_TcTerm.ml
@@ -2724,75 +2724,29 @@ and (tc_maybe_toplevel_term :
                                       let thunked_e =
                                         let uu___12 =
                                           let uu___13 =
-                                            FStar_Compiler_Effect.op_Bar_Greater
-                                              e2 FStar_Syntax_Util.unmeta in
-                                          FStar_Compiler_Effect.op_Bar_Greater
-                                            uu___13
-                                            FStar_Syntax_Util.head_and_args in
-                                        match uu___12 with
-                                        | (head, args) ->
-                                            let uu___13 =
-                                              ((FStar_Compiler_List.length
-                                                  args)
-                                                 > Prims.int_zero)
-                                                &&
-                                                (let uu___14 =
-                                                   let uu___15 =
-                                                     let uu___16 =
-                                                       FStar_Compiler_Effect.op_Bar_Greater
-                                                         args
-                                                         FStar_Compiler_List.last in
-                                                     FStar_Compiler_Effect.op_Bar_Greater
-                                                       uu___16
-                                                       FStar_Pervasives_Native.fst in
-                                                   FStar_Syntax_Util.eq_tm
-                                                     uu___15
-                                                     FStar_Syntax_Syntax.unit_const in
-                                                 uu___14 =
-                                                   FStar_Syntax_Util.Equal) in
-                                            if uu___13
-                                            then
-                                              let uu___14 =
-                                                let uu___15 =
-                                                  FStar_Compiler_Effect.op_Bar_Greater
-                                                    args
-                                                    (FStar_Compiler_List.splitAt
-                                                       ((FStar_Compiler_List.length
-                                                           args)
-                                                          - Prims.int_one)) in
-                                                FStar_Compiler_Effect.op_Bar_Greater
-                                                  uu___15
-                                                  FStar_Pervasives_Native.fst in
-                                              FStar_Syntax_Syntax.mk_Tm_app
-                                                head uu___14
-                                                head.FStar_Syntax_Syntax.pos
-                                            else
-                                              (let uu___15 =
-                                                 let uu___16 =
-                                                   let uu___17 =
-                                                     let uu___18 =
-                                                       let uu___19 =
-                                                         FStar_Syntax_Syntax.null_bv
-                                                           FStar_Syntax_Syntax.t_unit in
-                                                       FStar_Syntax_Syntax.mk_binder
-                                                         uu___19 in
-                                                     [uu___18] in
-                                                   (uu___17, e2,
-                                                     (FStar_Pervasives_Native.Some
-                                                        {
-                                                          FStar_Syntax_Syntax.residual_effect
-                                                            =
-                                                            (c1.FStar_Syntax_Syntax.effect_name);
-                                                          FStar_Syntax_Syntax.residual_typ
-                                                            =
-                                                            FStar_Pervasives_Native.None;
-                                                          FStar_Syntax_Syntax.residual_flags
-                                                            = []
-                                                        })) in
-                                                 FStar_Syntax_Syntax.Tm_abs
-                                                   uu___16 in
-                                               FStar_Syntax_Syntax.mk uu___15
-                                                 e2.FStar_Syntax_Syntax.pos) in
+                                            let uu___14 =
+                                              let uu___15 =
+                                                let uu___16 =
+                                                  FStar_Syntax_Syntax.null_bv
+                                                    FStar_Syntax_Syntax.t_unit in
+                                                FStar_Syntax_Syntax.mk_binder
+                                                  uu___16 in
+                                              [uu___15] in
+                                            (uu___14, e2,
+                                              (FStar_Pervasives_Native.Some
+                                                 {
+                                                   FStar_Syntax_Syntax.residual_effect
+                                                     =
+                                                     (c1.FStar_Syntax_Syntax.effect_name);
+                                                   FStar_Syntax_Syntax.residual_typ
+                                                     =
+                                                     FStar_Pervasives_Native.None;
+                                                   FStar_Syntax_Syntax.residual_flags
+                                                     = []
+                                                 })) in
+                                          FStar_Syntax_Syntax.Tm_abs uu___13 in
+                                        FStar_Syntax_Syntax.mk uu___12
+                                          e2.FStar_Syntax_Syntax.pos in
                                       let implicit_args =
                                         let a_arg =
                                           FStar_Syntax_Syntax.iarg c_res_typ in

--- a/src/ocaml-output/FStar_TypeChecker_TcTerm.ml
+++ b/src/ocaml-output/FStar_TypeChecker_TcTerm.ml
@@ -2708,9 +2708,7 @@ and (tc_maybe_toplevel_term :
                                            env1.FStar_TypeChecker_Env.phase1) in
                                     if uu___11
                                     then
-                                      let c_res_typ =
-                                        c1.FStar_Syntax_Syntax.result_typ in
-                                      let reify_tm =
+                                      let reify_val_tm =
                                         let uu___12 =
                                           let uu___13 =
                                             FStar_Parser_Const.layered_effect_reify_val_lid
@@ -2749,7 +2747,8 @@ and (tc_maybe_toplevel_term :
                                           e2.FStar_Syntax_Syntax.pos in
                                       let implicit_args =
                                         let a_arg =
-                                          FStar_Syntax_Syntax.iarg c_res_typ in
+                                          FStar_Syntax_Syntax.iarg
+                                            c1.FStar_Syntax_Syntax.result_typ in
                                         let indices_args =
                                           FStar_Compiler_Effect.op_Bar_Greater
                                             c1.FStar_Syntax_Syntax.effect_args
@@ -2768,8 +2767,9 @@ and (tc_maybe_toplevel_term :
                                           [uu___14] in
                                         FStar_Compiler_List.op_At
                                           implicit_args uu___13 in
-                                      FStar_Syntax_Syntax.mk_Tm_app reify_tm
-                                        uu___12 e2.FStar_Syntax_Syntax.pos
+                                      FStar_Syntax_Syntax.mk_Tm_app
+                                        reify_val_tm uu___12
+                                        e2.FStar_Syntax_Syntax.pos
                                     else
                                       FStar_Syntax_Syntax.mk
                                         (FStar_Syntax_Syntax.Tm_app

--- a/src/ocaml-output/FStar_TypeChecker_TcTerm.ml
+++ b/src/ocaml-output/FStar_TypeChecker_TcTerm.ml
@@ -2663,25 +2663,30 @@ and (tc_maybe_toplevel_term :
                       let uu___7 = FStar_Syntax_Util.head_and_args top in
                       (match uu___7 with
                        | (reify_op, uu___8) ->
-                           let u_c =
-                             env1.FStar_TypeChecker_Env.universe_of env1
-                               c.FStar_TypeChecker_Common.res_typ in
-                           let uu___9 = FStar_TypeChecker_Common.lcomp_comp c in
+                           let uu___9 =
+                             let uu___10 =
+                               FStar_TypeChecker_Common.lcomp_comp c in
+                             match uu___10 with
+                             | (c1, g_c) ->
+                                 let uu___11 =
+                                   FStar_TypeChecker_Env.unfold_effect_abbrev
+                                     env1 c1 in
+                                 (uu___11, g_c) in
                            (match uu___9 with
                             | (c1, g_c) ->
-                                let ef =
-                                  FStar_Syntax_Util.comp_effect_name c1 in
                                 ((let uu___11 =
                                     let uu___12 =
                                       FStar_TypeChecker_Env.is_user_reifiable_effect
-                                        env1 ef in
+                                        env1
+                                        c1.FStar_Syntax_Syntax.effect_name in
                                     Prims.op_Negation uu___12 in
                                   if uu___11
                                   then
                                     let uu___12 =
                                       let uu___13 =
                                         let uu___14 =
-                                          FStar_Ident.string_of_lid ef in
+                                          FStar_Ident.string_of_lid
+                                            c1.FStar_Syntax_Syntax.effect_name in
                                         FStar_Compiler_Util.format1
                                           "Effect %s cannot be reified"
                                           uu___14 in
@@ -2690,18 +2695,96 @@ and (tc_maybe_toplevel_term :
                                     FStar_Errors.raise_error uu___12
                                       e2.FStar_Syntax_Syntax.pos
                                   else ());
-                                 (let repr =
-                                    FStar_TypeChecker_Env.reify_comp env1 c1
-                                      u_c in
+                                 (let u_c =
+                                    FStar_Compiler_List.hd
+                                      c1.FStar_Syntax_Syntax.comp_univs in
                                   let e3 =
-                                    FStar_Syntax_Syntax.mk
-                                      (FStar_Syntax_Syntax.Tm_app
-                                         (reify_op, [(e2, aqual)]))
-                                      top.FStar_Syntax_Syntax.pos in
+                                    let uu___11 =
+                                      (FStar_TypeChecker_Env.is_layered_effect
+                                         env1
+                                         c1.FStar_Syntax_Syntax.effect_name)
+                                        &&
+                                        (Prims.op_Negation
+                                           env1.FStar_TypeChecker_Env.phase1) in
+                                    if uu___11
+                                    then
+                                      let c_res_typ =
+                                        c1.FStar_Syntax_Syntax.result_typ in
+                                      let reify_tm =
+                                        let uu___12 =
+                                          let uu___13 =
+                                            FStar_Parser_Const.layered_effect_reify_val_lid
+                                              c1.FStar_Syntax_Syntax.effect_name
+                                              e2.FStar_Syntax_Syntax.pos in
+                                          FStar_Compiler_Effect.op_Bar_Greater
+                                            uu___13
+                                            FStar_Syntax_Syntax.tconst in
+                                        FStar_Syntax_Syntax.mk_Tm_uinst
+                                          uu___12 [u_c] in
+                                      let thunked_e =
+                                        let uu___12 =
+                                          let uu___13 =
+                                            let uu___14 =
+                                              let uu___15 =
+                                                let uu___16 =
+                                                  FStar_Syntax_Syntax.null_bv
+                                                    FStar_Syntax_Syntax.t_unit in
+                                                FStar_Syntax_Syntax.mk_binder
+                                                  uu___16 in
+                                              [uu___15] in
+                                            (uu___14, e2,
+                                              (FStar_Pervasives_Native.Some
+                                                 {
+                                                   FStar_Syntax_Syntax.residual_effect
+                                                     =
+                                                     (c1.FStar_Syntax_Syntax.effect_name);
+                                                   FStar_Syntax_Syntax.residual_typ
+                                                     =
+                                                     FStar_Pervasives_Native.None;
+                                                   FStar_Syntax_Syntax.residual_flags
+                                                     = []
+                                                 })) in
+                                          FStar_Syntax_Syntax.Tm_abs uu___13 in
+                                        FStar_Syntax_Syntax.mk uu___12
+                                          e2.FStar_Syntax_Syntax.pos in
+                                      let implicit_args =
+                                        let a_arg =
+                                          FStar_Syntax_Syntax.iarg c_res_typ in
+                                        let indices_args =
+                                          FStar_Compiler_Effect.op_Bar_Greater
+                                            c1.FStar_Syntax_Syntax.effect_args
+                                            (FStar_Compiler_List.map
+                                               (fun uu___12 ->
+                                                  match uu___12 with
+                                                  | (t, uu___13) ->
+                                                      FStar_Syntax_Syntax.iarg
+                                                        t)) in
+                                        a_arg :: indices_args in
+                                      let uu___12 =
+                                        let uu___13 =
+                                          let uu___14 =
+                                            FStar_Syntax_Syntax.as_arg
+                                              thunked_e in
+                                          [uu___14] in
+                                        FStar_Compiler_List.op_At
+                                          implicit_args uu___13 in
+                                      FStar_Syntax_Syntax.mk_Tm_app reify_tm
+                                        uu___12 e2.FStar_Syntax_Syntax.pos
+                                    else
+                                      FStar_Syntax_Syntax.mk
+                                        (FStar_Syntax_Syntax.Tm_app
+                                           (reify_op, [(e2, aqual)]))
+                                        top.FStar_Syntax_Syntax.pos in
+                                  let repr =
+                                    let uu___11 =
+                                      FStar_Syntax_Syntax.mk_Comp c1 in
+                                    FStar_TypeChecker_Env.reify_comp env1
+                                      uu___11 u_c in
                                   let c2 =
                                     let uu___11 =
                                       FStar_TypeChecker_Env.is_total_effect
-                                        env1 ef in
+                                        env1
+                                        c1.FStar_Syntax_Syntax.effect_name in
                                     if uu___11
                                     then
                                       let uu___12 =

--- a/src/ocaml-output/FStar_TypeChecker_TcTerm.ml
+++ b/src/ocaml-output/FStar_TypeChecker_TcTerm.ml
@@ -2724,29 +2724,75 @@ and (tc_maybe_toplevel_term :
                                       let thunked_e =
                                         let uu___12 =
                                           let uu___13 =
-                                            let uu___14 =
-                                              let uu___15 =
-                                                let uu___16 =
-                                                  FStar_Syntax_Syntax.null_bv
-                                                    FStar_Syntax_Syntax.t_unit in
-                                                FStar_Syntax_Syntax.mk_binder
-                                                  uu___16 in
-                                              [uu___15] in
-                                            (uu___14, e2,
-                                              (FStar_Pervasives_Native.Some
-                                                 {
-                                                   FStar_Syntax_Syntax.residual_effect
-                                                     =
-                                                     (c1.FStar_Syntax_Syntax.effect_name);
-                                                   FStar_Syntax_Syntax.residual_typ
-                                                     =
-                                                     FStar_Pervasives_Native.None;
-                                                   FStar_Syntax_Syntax.residual_flags
-                                                     = []
-                                                 })) in
-                                          FStar_Syntax_Syntax.Tm_abs uu___13 in
-                                        FStar_Syntax_Syntax.mk uu___12
-                                          e2.FStar_Syntax_Syntax.pos in
+                                            FStar_Compiler_Effect.op_Bar_Greater
+                                              e2 FStar_Syntax_Util.unmeta in
+                                          FStar_Compiler_Effect.op_Bar_Greater
+                                            uu___13
+                                            FStar_Syntax_Util.head_and_args in
+                                        match uu___12 with
+                                        | (head, args) ->
+                                            let uu___13 =
+                                              ((FStar_Compiler_List.length
+                                                  args)
+                                                 > Prims.int_zero)
+                                                &&
+                                                (let uu___14 =
+                                                   let uu___15 =
+                                                     let uu___16 =
+                                                       FStar_Compiler_Effect.op_Bar_Greater
+                                                         args
+                                                         FStar_Compiler_List.last in
+                                                     FStar_Compiler_Effect.op_Bar_Greater
+                                                       uu___16
+                                                       FStar_Pervasives_Native.fst in
+                                                   FStar_Syntax_Util.eq_tm
+                                                     uu___15
+                                                     FStar_Syntax_Syntax.unit_const in
+                                                 uu___14 =
+                                                   FStar_Syntax_Util.Equal) in
+                                            if uu___13
+                                            then
+                                              let uu___14 =
+                                                let uu___15 =
+                                                  FStar_Compiler_Effect.op_Bar_Greater
+                                                    args
+                                                    (FStar_Compiler_List.splitAt
+                                                       ((FStar_Compiler_List.length
+                                                           args)
+                                                          - Prims.int_one)) in
+                                                FStar_Compiler_Effect.op_Bar_Greater
+                                                  uu___15
+                                                  FStar_Pervasives_Native.fst in
+                                              FStar_Syntax_Syntax.mk_Tm_app
+                                                head uu___14
+                                                head.FStar_Syntax_Syntax.pos
+                                            else
+                                              (let uu___15 =
+                                                 let uu___16 =
+                                                   let uu___17 =
+                                                     let uu___18 =
+                                                       let uu___19 =
+                                                         FStar_Syntax_Syntax.null_bv
+                                                           FStar_Syntax_Syntax.t_unit in
+                                                       FStar_Syntax_Syntax.mk_binder
+                                                         uu___19 in
+                                                     [uu___18] in
+                                                   (uu___17, e2,
+                                                     (FStar_Pervasives_Native.Some
+                                                        {
+                                                          FStar_Syntax_Syntax.residual_effect
+                                                            =
+                                                            (c1.FStar_Syntax_Syntax.effect_name);
+                                                          FStar_Syntax_Syntax.residual_typ
+                                                            =
+                                                            FStar_Pervasives_Native.None;
+                                                          FStar_Syntax_Syntax.residual_flags
+                                                            = []
+                                                        })) in
+                                                 FStar_Syntax_Syntax.Tm_abs
+                                                   uu___16 in
+                                               FStar_Syntax_Syntax.mk uu___15
+                                                 e2.FStar_Syntax_Syntax.pos) in
                                       let implicit_args =
                                         let a_arg =
                                           FStar_Syntax_Syntax.iarg c_res_typ in

--- a/src/parser/FStar.Parser.Const.fst
+++ b/src/parser/FStar.Parser.Const.fst
@@ -514,3 +514,8 @@ let and_elim_lid = classical_sugar_lid "and_elim"
 
 
 let match_returns_def_name = reserved_prefix ^ "_ret_"
+
+let layered_effect_reify_val_lid (eff_name:lident) (r:range) : lident =
+  let ns = Ident.ns_of_lid eff_name in
+  let reify_fn_name = "reify___" ^ (eff_name |> ident_of_lid |> string_of_id) in
+  lid_of_ns_and_id ns (mk_ident (reify_fn_name, r))

--- a/src/parser/FStar.Parser.Const.fst
+++ b/src/parser/FStar.Parser.Const.fst
@@ -515,6 +515,9 @@ let and_elim_lid = classical_sugar_lid "and_elim"
 
 let match_returns_def_name = reserved_prefix ^ "_ret_"
 
+//
+// lid for the reify function assume val for an indexed effect
+//
 let layered_effect_reify_val_lid (eff_name:lident) (r:range) : lident =
   let ns = Ident.ns_of_lid eff_name in
   let reify_fn_name = "reify___" ^ (eff_name |> ident_of_lid |> string_of_id) in

--- a/src/typechecker/FStar.TypeChecker.Tc.fst
+++ b/src/typechecker/FStar.TypeChecker.Tc.fst
@@ -733,6 +733,7 @@ let tc_decl' env0 se: list sigelt * list sigelt * Env.env =
         if do_two_phases env then begin
           let ne =
             TcEff.tc_eff_decl ({ env with phase1 = true; lax = true }) ne se.sigquals se.sigattrs
+            |> fst
             |> (fun ne -> { se with sigel = Sig_new_effect ne })
             |> N.elim_uvars env |> U.eff_decl_of_new_effect in
           if Env.debug env <| Options.Other "TwoPhases"
@@ -741,9 +742,9 @@ let tc_decl' env0 se: list sigelt * list sigelt * Env.env =
           ne
         end
         else ne in
-      let ne = TcEff.tc_eff_decl env ne se.sigquals se.sigattrs in
+      let ne, ses = TcEff.tc_eff_decl env ne se.sigquals se.sigattrs in
       let se = { se with sigel = Sig_new_effect(ne) } in
-      [se], [], env0
+      [se], ses, env0
 
   | Sig_sub_effect(sub) ->  //no need to two-phase here, since lifts are already lax checked
     let sub = TcEff.tc_lift env sub r in

--- a/src/typechecker/FStar.TypeChecker.TcEffect.fst
+++ b/src/typechecker/FStar.TypeChecker.TcEffect.fst
@@ -939,6 +939,10 @@ Errors.with_ctx (BU.format1 "While checking layered effect definition `%s`" (str
           sigmeta = default_sigmeta;
           sigattrs = [];
           sigopts = None } in
+      log_issue r (Errors.Warning_BleedingEdge_Feature,
+                   BU.format1 "Reification of indexed effects (%s here) is supported only as a type coercion \
+                     to the underlying representation type (no support for smt-based reasoning or extraction)"
+                     (string_of_lid ed.mname));
       [sig_assume_reify]
     else [] in
 

--- a/src/typechecker/FStar.TypeChecker.TcEffect.fst
+++ b/src/typechecker/FStar.TypeChecker.TcEffect.fst
@@ -884,6 +884,60 @@ Errors.with_ctx (BU.format1 "While checking layered effect definition `%s`" (str
 
     act in
 
+  //
+  // If the effect is reifiable, create an
+  //   assume val reify_M (a:Type) ... ($f:unit -> M a is) : M.repr a is
+  //
+  let reify_sig =
+    if List.contains Reifiable quals
+    then
+      let env = env0 in
+      let r = range_of_lid ed.mname in
+      let a, u_a = fresh_a_and_u_a "a" in
+      let rest_bs =
+        let signature_ts = let us, t, _ = signature in us, t in
+        TcUtil.layered_effect_indices_as_binders env r ed.mname signature_ts u_a (a.binder_bv |> S.bv_to_name) in
+      let f_binder =
+        let thunked_t = U.arrow [S.null_bv S.t_unit |> S.mk_binder]
+          ({comp_univs = [];
+            effect_name = ed.mname;
+            result_typ = S.bv_to_name a.binder_bv;
+            effect_args = rest_bs |> List.map (fun b -> as_arg (S.bv_to_name b.binder_bv));
+            flags=[]} |> S.mk_Comp) in
+        S.mk_binder_with_attrs
+          (S.null_bv thunked_t)
+          (Some Equality)
+          [] in
+      let bs = a::rest_bs in
+      let applied_repr : term =
+        let repr_ts = let us, t, _ = repr in us, t in
+        let repr = Env.inst_tscheme_with repr_ts [u_a] |> snd in
+        mk_Tm_app repr
+          (bs |> List.map (fun b -> S.bv_to_name b.binder_bv, U.aqual_of_binder b))
+          r in
+      let reify_val_t =
+        let bs =
+          bs |> List.map (fun b -> {b with binder_qual = Some (Implicit false); binder_attrs = []}) in
+        U.arrow (bs@[f_binder])
+        (if List.contains S.TotalEffect quals
+         then S.mk_Total applied_repr
+         else { comp_univs = [];
+                effect_name = PC.effect_Dv_lid;
+                result_typ = applied_repr;
+                effect_args = [];
+                flags = [] } |> S.mk_Comp) in
+      let us, reify_val_t = Gen.generalize_universes env reify_val_t in
+      let sig_assume_reify =
+        let lid = PC.layered_effect_reify_val_lid ed.mname r in
+        { sigel = Sig_declare_typ (lid, us, reify_val_t);
+          sigrng = r;
+          sigquals = [Assumption];
+          sigmeta = default_sigmeta;
+          sigattrs = [];
+          sigopts = None } in
+      [sig_assume_reify]
+    else [] in
+
   let tschemes_of (us, t, ty) : tscheme * tscheme = (us, t), (us, ty) in
 
   let combinators = Layered_eff ({
@@ -897,7 +951,8 @@ Errors.with_ctx (BU.format1 "While checking layered effect definition `%s`" (str
   { ed with
     signature     = (let us, t, _ = signature in (us, t));
     combinators   = combinators;
-    actions       = List.map (tc_action env0) ed.actions }
+    actions       = List.map (tc_action env0) ed.actions },
+  reify_sig
 )
 
 let tc_non_layered_eff_decl env0 (ed:S.eff_decl) (_quals : list qualifier) (_attrs : list S.attribute) : S.eff_decl =
@@ -1319,7 +1374,9 @@ Errors.with_ctx (BU.format1 "While checking effect definition `%s`" (string_of_l
 )
 
 let tc_eff_decl env ed quals attrs =
-  (if ed |> U.is_layered then tc_layered_eff_decl else tc_non_layered_eff_decl) env ed quals attrs
+  if ed |> U.is_layered
+  then tc_layered_eff_decl env ed quals attrs
+  else tc_non_layered_eff_decl env ed quals attrs, []
 
 let monad_signature env m s =
  let fail () = raise_error (Err.unexpected_signature_for_monad env m s) (range_of_lid m) in

--- a/src/typechecker/FStar.TypeChecker.TcEffect.fst
+++ b/src/typechecker/FStar.TypeChecker.TcEffect.fst
@@ -148,6 +148,8 @@ let validate_layered_effect_binders env (bs:binders) (check_non_informatve_binde
 
 (*
  * Typechecking of layered effects
+ *
+ * If the effect is reifiable, returns reify__M sigelt also
  *)
 let tc_layered_eff_decl env0 (ed : S.eff_decl) (quals : list qualifier) (attrs : list S.attribute) =
 Errors.with_ctx (BU.format1 "While checking layered effect definition `%s`" (string_of_lid ed.mname)) (fun () ->
@@ -886,9 +888,11 @@ Errors.with_ctx (BU.format1 "While checking layered effect definition `%s`" (str
 
   //
   // If the effect is reifiable, create an
-  //   assume val reify_M (a:Type) ... ($f:unit -> M a is) : M.repr a is
+  //   assume val reify_M (#a:Type) ... ($f:unit -> M a is) : M.repr a is
   //
-  let reify_sig =
+  // The toplevel tc loop will typecheck reify_sigelt
+  //
+  let reify_sigelt =
     if List.contains Reifiable quals
     then
       let env = env0 in
@@ -952,7 +956,7 @@ Errors.with_ctx (BU.format1 "While checking layered effect definition `%s`" (str
     signature     = (let us, t, _ = signature in (us, t));
     combinators   = combinators;
     actions       = List.map (tc_action env0) ed.actions },
-  reify_sig
+  reify_sigelt
 )
 
 let tc_non_layered_eff_decl env0 (ed:S.eff_decl) (_quals : list qualifier) (_attrs : list S.attribute) : S.eff_decl =

--- a/src/typechecker/FStar.TypeChecker.TcEffect.fsti
+++ b/src/typechecker/FStar.TypeChecker.TcEffect.fsti
@@ -27,7 +27,7 @@ module Env = FStar.TypeChecker.Env
 
 val dmff_cps_and_elaborate : Env.env -> S.eff_decl -> (list S.sigelt * S.eff_decl * option S.sigelt)
 
-val tc_eff_decl : Env.env -> S.eff_decl -> list S.qualifier -> list S.attribute -> S.eff_decl
+val tc_eff_decl : Env.env -> S.eff_decl -> list S.qualifier -> list S.attribute -> S.eff_decl & list S.sigelt 
 
 val tc_lift : Env.env -> S.sub_eff -> Range.range -> S.sub_eff
 

--- a/src/typechecker/FStar.TypeChecker.TcTerm.fst
+++ b/src/typechecker/FStar.TypeChecker.TcTerm.fst
@@ -980,23 +980,12 @@ and tc_maybe_toplevel_term env (e:term) : term                  (* type-checked 
                (Const.layered_effect_reify_val_lid c.effect_name e.pos |> S.tconst)
                [u_c] in
            let thunked_e =
-             //
-             // TODO: this optimization is sound only if head has the
-             //   right type, FIX IT
-             //
-             let head, args = e |> U.unmeta |> U.head_and_args in
-             if List.length args > 0 &&
-                U.eq_tm (args |> List.last
-                              |> fst)
-                        S.unit_const = U.Equal
-             then mk_Tm_app head (args |> List.splitAt (List.length args - 1) |> fst) head.pos
-             else
-               S.mk (Tm_abs (
-                       [S.mk_binder (S.null_bv S.t_unit)],
-                       e,
-                       Some ({residual_effect=c.effect_name;
-                              residual_typ=None;
-                              residual_flags=[]}))) e.pos in
+             S.mk (Tm_abs (
+                     [S.mk_binder (S.null_bv S.t_unit)],
+                     e,
+                     Some ({residual_effect=c.effect_name;
+                            residual_typ=None;
+                            residual_flags=[]}))) e.pos in
            let implicit_args =
              let a_arg = S.iarg c_res_typ in
              let indices_args =

--- a/tests/bug-reports/Bug2169.fst
+++ b/tests/bug-reports/Bug2169.fst
@@ -153,10 +153,7 @@ let wrap (f:int -> ND unit (as_pure_wp (fun p -> True))) (x':int) : ND unit (as_
   | Some x -> f x
   | None -> f 4
 
-// The test below use to fail while running the tactic, now it leaves a
-// goal that cannot be solved. That's what we check for with the 19.
-
-[@@expect_failure [19]]
+[@@expect_failure [217]]
 let rewrite_inside_reify
   (f : int -> ND unit (as_pure_wp (fun p -> True)))
   (g : int -> Tot (option int))

--- a/tests/bug-reports/Bug2641.fst
+++ b/tests/bug-reports/Bug2641.fst
@@ -1,0 +1,173 @@
+module Bug2641
+
+open FStar.List.Tot
+open FStar.Tactics.Typeclasses
+
+//
+// Original report by Cezar and Theo
+//
+
+noeq
+type free (a:Type u#a) : Type u#(max a 1) =
+| Return : a -> free a
+| PartialCall : (pre:pure_pre) -> cont:((squash pre) -> free u#a a) -> free a
+
+let rec free_bind (#a:Type u#a) (#b:Type u#b) (l:free a) (k: a -> free b) : free b =
+  match l with
+  | Return x -> k x
+  | PartialCall pre fnc ->
+    PartialCall pre (fun _ -> free_bind (fnc ()) k)
+
+(** *** Spec **)
+(** monotonicity seems relevant **)
+let hist a = wp:(pure_wp' a){pure_wp_monotonic0 a wp}
+
+val hist_ord (#a : Type) : hist a -> hist a -> Type0
+let hist_ord wp1 wp2 = forall p. wp1 p ==> wp2 p
+
+let hist_return (x:'a) : hist 'a =
+  fun p -> p x
+
+let hist_bind (#a #b:Type) (w : hist a) (kw : a -> hist b) : hist b =
+  fun p -> w (fun r -> kw r p)
+
+let wp_lift_pure_hist (w : pure_wp 'a) : hist 'a =
+  FStar.Monotonic.Pure.elim_pure_wp_monotonicity_forall ();
+  w
+
+let partial_call_wp (pre:pure_pre) : hist (squash pre) = 
+  let wp' : pure_wp' (squash pre) = fun p -> pre /\ p () in
+  wp'
+
+
+(** *** Dijkstra Monad **)
+val theta : #a:Type -> free a -> hist a
+let rec theta m =
+  match m with
+  | Return x -> hist_return x
+  | PartialCall pre k -> 
+    hist_bind (partial_call_wp pre) (fun r -> theta (k r))
+
+let dm_free (a:Type) (wp:hist a) =
+  tree:(free a){wp `hist_ord` theta tree} 
+
+val dm_free_return : (a:Type) -> (x:a) -> dm_free a (hist_return x)
+let dm_free_return a x = Return x
+
+val lemma_monad_morphism  : 
+  a: Type ->
+  b: Type ->
+  v: free a ->
+  f: (x: a -> free b) ->
+  Lemma (hist_bind (theta v) (fun x -> theta (f x)) `hist_ord` theta (free_bind v f))
+let rec lemma_monad_morphism a b v f =
+  match v with
+  | Return _ -> ()
+  | PartialCall pre k -> 
+    calc (hist_ord) {
+      hist_bind (theta (PartialCall pre k)) (fun x -> theta (f x));
+      == { _ by (FStar.Tactics.compute ()) }
+      hist_bind (hist_bind (partial_call_wp pre) (fun r -> theta (k r))) (fun x -> theta (f x));
+      == { _ by (FStar.Tactics.compute ()) }
+      hist_bind (partial_call_wp pre) (fun r -> hist_bind (theta (k r)) (fun x -> theta (f x)));
+      `hist_ord` {         
+        let rhs1 : squash pre -> hist b = fun r -> hist_bind (theta (k r)) (fun x -> theta (f x)) in
+        let rhs2 : squash pre -> hist b = fun r -> theta (free_bind (k r) f) in
+        introduce forall (r:squash pre). (rhs1 r) `hist_ord` (rhs2 r) with begin
+          lemma_monad_morphism _ _ (k r) f
+        end
+      }
+      theta (PartialCall pre (fun r -> free_bind (k r) f));
+      `hist_ord` { _ by (FStar.Tactics.compute ()) }
+      theta (free_bind (PartialCall pre k) f);
+    }
+  
+val dm_free_bind  : 
+  a: Type ->
+  b: Type ->
+  wp_v: hist a ->
+  wp_f: (_: a -> Tot (hist b)) ->
+  v: dm_free a wp_v ->
+  f: (x: a -> Tot (dm_free b (wp_f x))) ->
+  Tot (dm_free b (hist_bind wp_v wp_f))
+let dm_free_bind a b wp_v wp_f v f =
+  lemma_monad_morphism a b v f;
+  free_bind v f
+
+val dm_free_subcomp : 
+  a: Type ->
+  wp1: hist a ->
+  wp2: hist a ->
+  f: dm_free a wp1 ->
+  Pure (dm_free a wp2) (hist_ord wp2 wp1) (fun _ -> True)
+let dm_free_subcomp a wp1 wp2 f = f
+
+val lift_pure_dm_free :
+  a: Type ->
+  w: pure_wp a ->
+  f: (_: eqtype_as_type unit -> PURE a w) ->
+  Tot (dm_free a (wp_lift_pure_hist w))
+let lift_pure_dm_free a w f =
+  FStar.Monotonic.Pure.elim_pure_wp_monotonicity_forall ();
+  PartialCall (as_requires w) (fun proof -> Return (f proof))
+
+total
+reifiable
+reflectable
+effect {
+  FREEwp (a:Type) (wp : hist a) 
+  with {
+       repr       = dm_free
+     ; return     = dm_free_return
+     ; bind       = dm_free_bind 
+     ; subcomp    = dm_free_subcomp
+     }
+}
+
+sub_effect PURE ~> FREEwp = lift_pure_dm_free
+
+class compilable (t:Type) = {
+  comp_type : Type;
+  compile: t -> comp_type
+}
+
+instance compile_option (t:Type) {| d1:compilable t |} : compilable (option t) = {
+  comp_type = option (d1.comp_type);
+  compile = (fun x ->
+    match x with
+    | Some r -> Some (compile r)
+    | None -> None)
+}
+
+[@@ expect_failure [19]]
+let test_assert_false
+  (t1:Type)
+  (t2:Type)
+  {| d2:compilable t2 |} 
+  (f:(t1 -> FREEwp (option t2) (fun p -> (forall r. p r)))) 
+  (x:t1) : 
+  Lemma False =
+  let _ : dm_free (option d2.comp_type) (hist_bind (fun p -> forall r . p r)
+                                                   (fun (r:option t2) -> hist_return (compile #(option t2) #(compile_option t2 #d2) r))) =
+       reify (compile #(option t2) #(compile_option t2 #d2) (f x)) in
+  assert (False)
+
+
+//
+// A repro without using typeclasses etc.
+//
+
+let compile_option2 : (option int -> option int) =
+  fun x -> match x with
+        | None -> None
+        | Some r -> Some r
+
+[@@ expect_failure [19]]
+let test_assert_false
+  (f:(unit -> FREEwp (option int) (fun p -> (forall r. p r)))) : 
+  Lemma False =
+  let _ : dm_free (option int) (hist_bind (fun p -> forall r . p r)
+                                        (fun (r:option int) -> hist_return ((compile_option2 r)))) =
+       reify (let eff_val = f () in
+              compile_option2 eff_val) in
+  assert False

--- a/tests/bug-reports/Makefile
+++ b/tests/bug-reports/Makefile
@@ -47,7 +47,7 @@ SHOULD_VERIFY_CLOSED=Bug022.fst Bug024.fst Bug025.fst Bug026.fst Bug026b.fst Bug
   Bug1418.fst Bug171.fst Bug2496.fst Bug2478.fst Bug2414.fst Bug2515.fst \
   Bug2535.fst Bug2557.fst Bug2572.fst Bug2522.fst Bug2486.fst \
   Bug2552.fst Bug2597.fst Bug2471_B.fst Bug2605.fst Bug2614.fst Bug2622.fst \
-  Bug2637.fst
+  Bug2637.fst Bug2641.fst
 
 SHOULD_VERIFY_INTERFACE_CLOSED=Bug771.fsti Bug771b.fsti
 SHOULD_VERIFY_AND_WARN_CLOSED=Bug016.fst


### PR DESCRIPTION
In #2641, @andricicezar and @TheoWinterhalter reported an unsoundness related to the reification of indexed effects. Reification of indexed effects is a long known limitation in F*---the current implementation is not well-equipped to support it in its full generality. We have been trying to support it in some restricted forms, but, as #2641 shows, it only leads to subtle bugs and more confusion.

As a result, we have decided to remove the support for extraction and smt-based reasoning with reification of indexed effects. Until we build internal support for general reification of indexed effects,  F* will support only type-based reasoning for `reify e`.

More concretely, for `reify e`, if `e : M a is`, where `M` is an indexed effect, `a` is the return type`, and `is` are the effect indices, F* will only allow reasoning that `reify e : M.repr a is`. In other words, `reify` acts as a coercion from the effectful computation type to its underlying representation type, and only that.

In the implementation, when an indexed effect is annotated as `reifiable`, F* generates the following function for it:

```
assume val reify___M (#a:Type) (#is:_) ($f:unit -> M a is) : M.repr a is
```

And then rewrites the `reify e` in the program to `reify___M (fun _ -> e)`.

This means, one has to be a little careful when doing proofs (in whatever limited capacity) using such terms. E.g., `fun _ -> e` is an effectful term that does not encoded to the solver. So if the proof reasons with equality of these things, it won't work.

The style that I have found working well, is to use `repr` signature to the proofs, and then write a wrapper over it that calls these functions with `reify`, e.g.

```
let some_lemma_aux (...) (f:M.repr a is) : <... provide some property ...> = ...

let some_lemma (...) (f:unit -> M a is) : < ... provide same property ...> = some_lemma_aux ... (reify (f ()))
```

See fixes in the  `examples/layeredeffects/` directory in this PR.