### PR TITLE
Erasing computation with erasable effects when normalizing for extraction

### DIFF
--- a/src/ocaml-output/FStar_TypeChecker_Normalize.ml
+++ b/src/ocaml-output/FStar_TypeChecker_Normalize.ml
@@ -4113,12 +4113,60 @@ let rec (norm :
                      let uu___4 = FStar_Syntax_Print.metadata_to_string m in
                      FStar_Compiler_Util.print1 ">> metadata = %s\n" uu___4);
                 (match m with
-                 | FStar_Syntax_Syntax.Meta_monadic (m1, t2) ->
-                     reduce_impure_comp cfg env1 stack1 head
-                       (FStar_Pervasives.Inl m1) t2
-                 | FStar_Syntax_Syntax.Meta_monadic_lift (m1, m', t2) ->
-                     reduce_impure_comp cfg env1 stack1 head
-                       (FStar_Pervasives.Inr (m1, m')) t2
+                 | FStar_Syntax_Syntax.Meta_monadic (m_from, ty) ->
+                     if
+                       (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.for_extraction
+                     then
+                       let uu___3 =
+                         (FStar_TypeChecker_Env.is_erasable_effect
+                            cfg.FStar_TypeChecker_Cfg.tcenv m_from)
+                           ||
+                           ((FStar_Syntax_Util.is_pure_effect m_from) &&
+                              (FStar_TypeChecker_Env.non_informative
+                                 cfg.FStar_TypeChecker_Cfg.tcenv ty)) in
+                       (if uu___3
+                        then
+                          let uu___4 =
+                            FStar_Syntax_Syntax.mk
+                              (FStar_Syntax_Syntax.Tm_meta
+                                 (FStar_Syntax_Util.exp_unit, m))
+                              t1.FStar_Syntax_Syntax.pos in
+                          rebuild cfg env1 stack1 uu___4
+                        else
+                          reduce_impure_comp cfg env1 stack1 head
+                            (FStar_Pervasives.Inl m_from) ty)
+                     else
+                       reduce_impure_comp cfg env1 stack1 head
+                         (FStar_Pervasives.Inl m_from) ty
+                 | FStar_Syntax_Syntax.Meta_monadic_lift (m_from, m_to, ty)
+                     ->
+                     if
+                       (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.for_extraction
+                     then
+                       let uu___3 =
+                         ((FStar_TypeChecker_Env.is_erasable_effect
+                             cfg.FStar_TypeChecker_Cfg.tcenv m_from)
+                            ||
+                            (FStar_TypeChecker_Env.is_erasable_effect
+                               cfg.FStar_TypeChecker_Cfg.tcenv m_to))
+                           ||
+                           ((FStar_Syntax_Util.is_pure_effect m_from) &&
+                              (FStar_TypeChecker_Env.non_informative
+                                 cfg.FStar_TypeChecker_Cfg.tcenv ty)) in
+                       (if uu___3
+                        then
+                          let uu___4 =
+                            FStar_Syntax_Syntax.mk
+                              (FStar_Syntax_Syntax.Tm_meta
+                                 (FStar_Syntax_Util.exp_unit, m))
+                              t1.FStar_Syntax_Syntax.pos in
+                          rebuild cfg env1 stack1 uu___4
+                        else
+                          reduce_impure_comp cfg env1 stack1 head
+                            (FStar_Pervasives.Inr (m_from, m_to)) ty)
+                     else
+                       reduce_impure_comp cfg env1 stack1 head
+                         (FStar_Pervasives.Inr (m_from, m_to)) ty
                  | uu___3 ->
                      if
                        (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.unmeta


### PR DESCRIPTION
See discussion #2667 

In Steel, we have ghost effectful functions (STGhost etc.) that can get quite large when reducing terms for extraction. However, these are irrelevant for extraction. So, erasing them during normalization for extraction gives a big boost in performance. In contrast to running out of memory, the example in #2667 now extracts instantly.

Also, generalized the notion of non-informative types, which previously included arrows with Ghost effect, to also include arrows with any erasable effect.