### PR TITLE
Variant of Steel for_loop with a selector invariant

### DIFF
--- a/ulib/experimental/Steel.Loops.fsti
+++ b/ulib/experimental/Steel.Loops.fsti
@@ -40,6 +40,31 @@ val for_loop (start:U32.t)
       (inv (U32.v start))
       (fun _ -> inv (U32.v finish))
 
+/// for_loop: for (i = start; i < finish; i++) inv { body i }
+val for_loop_full (start:U32.t)
+             (finish:U32.t { U32.v start <= U32.v finish })
+             (inv: nat_at_most finish -> vprop)
+             (inv_sel: (i:nat_at_most finish) -> t_of (inv i) -> prop)
+             (body:
+                    (i:u32_between start finish ->
+                          Steel unit
+                          (inv (U32.v i))
+                          (fun _ -> inv (U32.v i + 1))
+                          (requires fun h -> inv_sel (U32.v i) (h (inv (U32.v i))))
+                          (ensures fun h0 _ h1 ->
+                            inv_sel (U32.v i) (h0 (inv (U32.v i))) /\
+                            inv_sel (U32.v i + 1) (h1 (inv (U32.v i + 1)))
+                          )))
+  : Steel unit
+      (inv (U32.v start))
+      (fun _ -> inv (U32.v finish))
+      (requires fun h -> inv_sel (U32.v start) (h (inv (U32.v start))))
+      (ensures fun h0 _ h1 ->
+        inv_sel (U32.v start) (h0 (inv (U32.v start))) /\
+        inv_sel (U32.v finish) (h1 (inv (U32.v finish)))
+      )
+
+
 /// while_loop: while (cond()) { body () }
 val while_loop (inv: Ghost.erased bool -> vprop)
                (cond: (unit -> SteelT bool


### PR DESCRIPTION
This PR adds a new variant of the Steel `for_loop` combinator called `for_loop_full`, which supports the additional use of a selector invariant on top of the current vprop invariant.
Note, the old `for_loop` combinator can now be implemented simply by calling `for_loop_full'`

This PR should be merged in conjunction with https://github.com/FStarLang/karamel/pull/289 , which adds support in karamel for this new combinator.