### PR TITLE
Encoding the definition of `logical` types to the SMT solver

### DIFF
--- a/src/ocaml-output/FStar_SMTEncoding_Encode.ml
+++ b/src/ocaml-output/FStar_SMTEncoding_Encode.ml
@@ -2852,103 +2852,145 @@ let (encode_top_level_let :
                                                         (vars, uu___16)) in
                                                    (match uu___14 with
                                                     | (vars1, app) ->
-                                                        let uu___15 =
-                                                          let is_logical =
+                                                        let is_logical =
+                                                          let uu___15 =
+                                                            let uu___16 =
+                                                              FStar_Syntax_Subst.compress
+                                                                t_body in
+                                                            uu___16.FStar_Syntax_Syntax.n in
+                                                          match uu___15 with
+                                                          | FStar_Syntax_Syntax.Tm_fvar
+                                                              fv when
+                                                              FStar_Syntax_Syntax.fv_eq_lid
+                                                                fv
+                                                                FStar_Parser_Const.logical_lid
+                                                              -> true
+                                                          | uu___16 -> false in
+                                                        let is_smt_theory_symbol
+                                                          =
+                                                          let fv =
+                                                            FStar_Compiler_Util.right
+                                                              lbn in
+                                                          FStar_TypeChecker_Env.fv_has_attr
+                                                            env2.FStar_SMTEncoding_Env.tcenv
+                                                            fv
+                                                            FStar_Parser_Const.smt_theory_symbol_attr_lid in
+                                                        let should_encode_logical
+                                                          =
+                                                          (Prims.op_Negation
+                                                             is_smt_theory_symbol)
+                                                            &&
+                                                            ((FStar_Compiler_Effect.op_Bar_Greater
+                                                                quals
+                                                                (FStar_Compiler_List.contains
+                                                                   FStar_Syntax_Syntax.Logic))
+                                                               || is_logical) in
+                                                        let make_eqn name pat
+                                                          app1 body1 =
+                                                          let uu___15 =
                                                             let uu___16 =
                                                               let uu___17 =
-                                                                FStar_Syntax_Subst.compress
-                                                                  t_body in
-                                                              uu___17.FStar_Syntax_Syntax.n in
-                                                            match uu___16
-                                                            with
-                                                            | FStar_Syntax_Syntax.Tm_fvar
-                                                                fv when
-                                                                FStar_Syntax_Syntax.fv_eq_lid
-                                                                  fv
-                                                                  FStar_Parser_Const.logical_lid
-                                                                -> true
-                                                            | uu___17 ->
-                                                                false in
-                                                          let is_smt_theory_symbol
-                                                            =
-                                                            let fv =
-                                                              FStar_Compiler_Util.right
-                                                                lbn in
-                                                            FStar_TypeChecker_Env.fv_has_attr
-                                                              env2.FStar_SMTEncoding_Env.tcenv
-                                                              fv
-                                                              FStar_Parser_Const.smt_theory_symbol_attr_lid in
-                                                          let uu___16 =
-                                                            (Prims.op_Negation
-                                                               is_smt_theory_symbol)
-                                                              &&
-                                                              ((FStar_Compiler_Effect.op_Bar_Greater
-                                                                  quals
-                                                                  (FStar_Compiler_List.contains
-                                                                    FStar_Syntax_Syntax.Logic))
-                                                                 ||
-                                                                 is_logical) in
-                                                          if uu___16
-                                                          then
-                                                            let uu___17 =
-                                                              FStar_SMTEncoding_Term.mk_Valid
-                                                                app in
-                                                            let uu___18 =
-                                                              FStar_SMTEncoding_EncodeTerm.encode_formula
-                                                                body env'1 in
-                                                            (app, uu___17,
-                                                              uu___18)
-                                                          else
-                                                            (let uu___18 =
-                                                               FStar_SMTEncoding_EncodeTerm.encode_term
-                                                                 body env'1 in
-                                                             (app, app,
-                                                               uu___18)) in
-                                                        (match uu___15 with
-                                                         | (pat, app1,
-                                                            (body1, decls2))
-                                                             ->
-                                                             let eqn =
-                                                               let uu___16 =
-                                                                 let uu___17
-                                                                   =
-                                                                   let uu___18
-                                                                    =
-                                                                    FStar_Syntax_Util.range_of_lbname
-                                                                    lbn in
-                                                                   let uu___19
-                                                                    =
-                                                                    let uu___20
-                                                                    =
-                                                                    FStar_SMTEncoding_Util.mkEq
+                                                                FStar_Syntax_Util.range_of_lbname
+                                                                  lbn in
+                                                              let uu___18 =
+                                                                let uu___19 =
+                                                                  FStar_SMTEncoding_Util.mkEq
                                                                     (app1,
                                                                     body1) in
-                                                                    ([[pat]],
-                                                                    vars1,
-                                                                    uu___20) in
-                                                                   FStar_SMTEncoding_Term.mkForall
-                                                                    uu___18
-                                                                    uu___19 in
-                                                                 let uu___18
-                                                                   =
-                                                                   let uu___19
-                                                                    =
-                                                                    let uu___20
-                                                                    =
-                                                                    FStar_Ident.string_of_lid
+                                                                ([[pat]],
+                                                                  vars1,
+                                                                  uu___19) in
+                                                              FStar_SMTEncoding_Term.mkForall
+                                                                uu___17
+                                                                uu___18 in
+                                                            let uu___17 =
+                                                              let uu___18 =
+                                                                let uu___19 =
+                                                                  FStar_Ident.string_of_lid
                                                                     flid in
-                                                                    FStar_Compiler_Util.format1
-                                                                    "Equation for %s"
-                                                                    uu___20 in
-                                                                   FStar_Pervasives_Native.Some
-                                                                    uu___19 in
-                                                                 (uu___17,
-                                                                   uu___18,
-                                                                   (Prims.op_Hat
-                                                                    "equation_"
-                                                                    fvb.FStar_SMTEncoding_Env.smt_id)) in
-                                                               FStar_SMTEncoding_Util.mkAssume
-                                                                 uu___16 in
+                                                                FStar_Compiler_Util.format1
+                                                                  "Equation for %s"
+                                                                  uu___19 in
+                                                              FStar_Pervasives_Native.Some
+                                                                uu___18 in
+                                                            (uu___16,
+                                                              uu___17,
+                                                              (Prims.op_Hat
+                                                                 name
+                                                                 (Prims.op_Hat
+                                                                    "_"
+                                                                    fvb.FStar_SMTEncoding_Env.smt_id))) in
+                                                          FStar_SMTEncoding_Util.mkAssume
+                                                            uu___15 in
+                                                        let uu___15 =
+                                                          let basic_eqn_name
+                                                            =
+                                                            if
+                                                              should_encode_logical
+                                                            then
+                                                              "defn_equation"
+                                                            else "equation" in
+                                                          let uu___16 =
+                                                            let uu___17 =
+                                                              let uu___18 =
+                                                                FStar_SMTEncoding_EncodeTerm.encode_term
+                                                                  body env'1 in
+                                                              (app, app,
+                                                                uu___18) in
+                                                            match uu___17
+                                                            with
+                                                            | (pat, app1,
+                                                               (body1,
+                                                                decls2)) ->
+                                                                let uu___18 =
+                                                                  make_eqn
+                                                                    basic_eqn_name
+                                                                    pat app1
+                                                                    body1 in
+                                                                (uu___18,
+                                                                  decls2) in
+                                                          match uu___16 with
+                                                          | (basic_eqn,
+                                                             decls2) ->
+                                                              if
+                                                                should_encode_logical
+                                                              then
+                                                                let uu___17 =
+                                                                  let uu___18
+                                                                    =
+                                                                    FStar_SMTEncoding_Term.mk_Valid
+                                                                    app in
+                                                                  let uu___19
+                                                                    =
+                                                                    FStar_SMTEncoding_EncodeTerm.encode_formula
+                                                                    body
+                                                                    env'1 in
+                                                                  (app,
+                                                                    uu___18,
+                                                                    uu___19) in
+                                                                (match uu___17
+                                                                 with
+                                                                 | (pat,
+                                                                    app1,
+                                                                    (body1,
+                                                                    decls21))
+                                                                    ->
+                                                                    let logical_eqn
+                                                                    =
+                                                                    make_eqn
+                                                                    "equation"
+                                                                    pat app1
+                                                                    body1 in
+                                                                    ([logical_eqn;
+                                                                    basic_eqn],
+                                                                    (FStar_Compiler_List.op_At
+                                                                    decls2
+                                                                    decls21)))
+                                                              else
+                                                                ([basic_eqn],
+                                                                  decls2) in
+                                                        (match uu___15 with
+                                                         | (eqns, decls2) ->
                                                              let uu___16 =
                                                                let uu___17 =
                                                                  let uu___18
@@ -2963,8 +3005,9 @@ let (encode_top_level_let :
                                                                     env2.FStar_SMTEncoding_Env.tcenv
                                                                     flid
                                                                     fvb.FStar_SMTEncoding_Env.smt_id
-                                                                    app1 in
-                                                                    eqn ::
+                                                                    app in
+                                                                    FStar_Compiler_List.op_At
+                                                                    eqns
                                                                     uu___21 in
                                                                     FStar_Compiler_Effect.op_Bar_Greater
                                                                     uu___20

--- a/src/ocaml-output/FStar_SMTEncoding_Encode.ml
+++ b/src/ocaml-output/FStar_SMTEncoding_Encode.ml
@@ -2932,20 +2932,23 @@ let (encode_top_level_let :
                                                             else "equation" in
                                                           let uu___16 =
                                                             let uu___17 =
-                                                              let uu___18 =
-                                                                FStar_SMTEncoding_EncodeTerm.encode_term
-                                                                  body env'1 in
-                                                              (app, app,
-                                                                uu___18) in
+                                                              FStar_SMTEncoding_EncodeTerm.encode_term
+                                                                body env'1 in
                                                             match uu___17
                                                             with
-                                                            | (pat, app1,
-                                                               (body1,
-                                                                decls2)) ->
+                                                            | (body1, decls2)
+                                                                ->
+                                                                let pat =
+                                                                  if
+                                                                    should_encode_logical
+                                                                  then
+                                                                    FStar_SMTEncoding_Term.mk_subtype_of_unit
+                                                                    app
+                                                                  else app in
                                                                 let uu___18 =
                                                                   make_eqn
                                                                     basic_eqn_name
-                                                                    pat app1
+                                                                    pat app
                                                                     body1 in
                                                                 (uu___18,
                                                                   decls2) in

--- a/src/ocaml-output/FStar_SMTEncoding_Term.ml
+++ b/src/ocaml-output/FStar_SMTEncoding_Term.ml
@@ -2141,6 +2141,9 @@ let (mk_Valid : term -> term) =
         let uu___ = unboxBool t1 in
         { tm = (uu___.tm); freevars = (uu___.freevars); rng = (t.rng) }
     | uu___ -> mkApp ("Valid", [t]) t.rng
+let (mk_unit_type : term) = mkApp ("Prims.unit", []) norng
+let (mk_subtype_of_unit : term -> term) =
+  fun v -> mkApp ("Prims.subtype_of", [v; mk_unit_type]) v.rng
 let (mk_HasType : term -> term -> term) =
   fun v -> fun t -> mkApp ("HasType", [v; t]) t.rng
 let (mk_HasTypeZ : term -> term -> term) =

--- a/src/smtencoding/FStar.SMTEncoding.Encode.fst
+++ b/src/smtencoding/FStar.SMTEncoding.Encode.fst
@@ -817,7 +817,12 @@ let encode_top_level_let :
                     else "equation"
                   in
                   let basic_eqn, decls =
-                    let pat, app, (body, decls) = app, app, encode_term body env' in
+                    let body, decls = encode_term body env' in
+                    let pat =
+                      if should_encode_logical
+                      then Term.mk_subtype_of_unit app
+                      else app
+                    in
                     make_eqn basic_eqn_name pat app body, decls
                   in
                   if should_encode_logical

--- a/src/smtencoding/FStar.SMTEncoding.Term.fst
+++ b/src/smtencoding/FStar.SMTEncoding.Term.fst
@@ -1017,6 +1017,8 @@ let mk_Valid t        = match t.tm with
     | App(Var "Prims.b2t", [t1]) -> {unboxBool t1 with rng=t.rng}
     | _ ->
         mkApp("Valid",  [t]) t.rng
+let mk_unit_type = mkApp("Prims.unit", []) norng
+let mk_subtype_of_unit v = mkApp("Prims.subtype_of", [v;mk_unit_type]) v.rng
 let mk_HasType v t    = mkApp("HasType", [v;t]) t.rng
 let mk_HasTypeZ v t   = mkApp("HasTypeZ", [v;t]) t.rng
 let mk_IsTotFun t     = mkApp("IsTotFun", [t]) t.rng

--- a/src/smtencoding/FStar.SMTEncoding.Term.fsti
+++ b/src/smtencoding/FStar.SMTEncoding.Term.fsti
@@ -282,6 +282,7 @@ val mk_Term_unit:    term
 
 val mk_PreType:      term -> term
 val mk_Valid:        term -> term
+val mk_subtype_of_unit: term -> term
 val mk_HasType:      term -> term -> term
 val mk_HasTypeZ:     term -> term -> term
 val mk_IsTotFun:     term -> term

--- a/tests/bug-reports/Makefile
+++ b/tests/bug-reports/Makefile
@@ -47,7 +47,7 @@ SHOULD_VERIFY_CLOSED=Bug022.fst Bug024.fst Bug025.fst Bug026.fst Bug026b.fst Bug
   Bug1418.fst Bug171.fst Bug2496.fst Bug2478.fst Bug2414.fst Bug2515.fst \
   Bug2535.fst Bug2557.fst Bug2572.fst Bug2522.fst Bug2486.fst \
   Bug2552.fst Bug2597.fst Bug2471_B.fst Bug2605.fst Bug2614.fst Bug2622.fst \
-  Bug2637.fst Bug2641.fst Bug1486.fst
+  Bug2637.fst Bug2641.fst Bug1486.fst PropProofs.fst
 
 SHOULD_VERIFY_INTERFACE_CLOSED=Bug771.fsti Bug771b.fsti
 SHOULD_VERIFY_AND_WARN_CLOSED=Bug016.fst

--- a/tests/bug-reports/PropProofs.fst
+++ b/tests/bug-reports/PropProofs.fst
@@ -1,0 +1,4 @@
+module PropProofs
+
+let x = True
+let y : prop = x


### PR DESCRIPTION
Definitions that are inferred to have type `logical` we encoded to the SMT solver just with a shallow embedding of their validity axioms. This meant that using the SMT solver to prove simple properties about their definitions, e.g., that they are `props` did not work directly, and would require intervention from the user, e.g., to use the normalizer first etc.

This PR encodes logical definitions both shallowly (as before) but also deeply. The latter has a pattern that restricts its use to a trigger `Prims.subtype_of <encoded term> unit`, i.e., the `prop` condition. So, this quantifier should only fire when you want to treat the `logical` definition as a `prop`. The restrictive pattern also ensures that this doesn't interfere much with existing proofs---indeed, all the everest proof still go through in the same end-to-end build time with this change.

Further, simple things like this, which used to fail, now work

```
let x = True
let y : prop = x
```

And workarounds like `let y : prop = x /\ True` should no longer be necessary.

This has been a wart for a while, e.g., @arvinda has noticed this several times before.
Thanks to @TWal for reporting it most recently and bumping it to the top of my radar.

Of course, a better long-term solution would be to do away with the `logical` type altogether. But, that's another story.