### PR TITLE
Some revisions to dot patterns

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,9 @@ Guidelines for the changelog:
 # Version 0.9.7.0
 
 ## Tactics & Reflection
+  * Pat_Dot_Term now only has an `option term` as argument, where a `Some e` indicates that
+    the dot pattern has been resolved to `e`.
+
   * Pat_Cons, the case of constructed patterns, now takes an additional argument representing
     the universe instantiation of the constructor.
   

--- a/examples/hello/TestSeq/TestSeq.fst.hints
+++ b/examples/hello/TestSeq/TestSeq.fst.hints
@@ -23,7 +23,7 @@
         "typing_FStar.Seq.Base.length", "unit_typing"
       ],
       0,
-      "9a3ed42f195a73eb244da5a9111417b5"
+      "3edebb46381cb8a44300e4b925d2c924"
     ],
     [
       "TestSeq.main",
@@ -47,7 +47,7 @@
         "typing_Tm_abs_f8b7175ad4f28c0bc3c11371abe1d18d"
       ],
       0,
-      "2395e05218915c5efbc15487b3b783db"
+      "c9a3896879182831b0a8bb3555145b5d"
     ]
   ]
 ]

--- a/src/extraction/FStar.Extraction.ML.Term.fst
+++ b/src/extraction/FStar.Extraction.ML.Term.fst
@@ -955,7 +955,7 @@ let rec extract_one_pat (imp : bool)
                     | _ ->
                       //Otherwise, if it has a dot pattern for matching the type parameters
                       match p.v with
-                      | Pat_dot_term (_, t) ->
+                      | Pat_dot_term (Some t) ->
                         //use the type that the dot patterns is instantiated to
                         term_as_mlty g t
                       | _ ->

--- a/src/fstar/FStar.CheckedFiles.fst
+++ b/src/fstar/FStar.CheckedFiles.fst
@@ -40,7 +40,7 @@ module Dep     = FStar.Parser.Dep
  * detect when loading the cache that the version number is same
  * It needs to be kept in sync with prims.fst
  *)
-let cache_version_number = 43
+let cache_version_number = 44
 
 (*
  * Abbreviation for what we store in the checked files (stages as described below)

--- a/src/ocaml-output/FStar_CheckedFiles.ml
+++ b/src/ocaml-output/FStar_CheckedFiles.ml
@@ -1,5 +1,5 @@
 open Prims
-let (cache_version_number : Prims.int) = (Prims.of_int (43))
+let (cache_version_number : Prims.int) = (Prims.of_int (44))
 type tc_result =
   {
   checked_module: FStar_Syntax_Syntax.modul ;

--- a/src/ocaml-output/FStar_Extraction_ML_Term.ml
+++ b/src/ocaml-output/FStar_Extraction_ML_Term.ml
@@ -1463,8 +1463,8 @@ let rec (extract_one_pat :
                                                (match p1.FStar_Syntax_Syntax.v
                                                 with
                                                 | FStar_Syntax_Syntax.Pat_dot_term
-                                                    (uu___6, t) ->
-                                                    term_as_mlty g t
+                                                    (FStar_Pervasives_Native.Some
+                                                    t) -> term_as_mlty g t
                                                 | uu___6 ->
                                                     FStar_Extraction_ML_Syntax.MLTY_Top)))) in
                             let f_ty1 =

--- a/src/ocaml-output/FStar_Reflection_Basic.ml
+++ b/src/ocaml-output/FStar_Reflection_Basic.ml
@@ -267,8 +267,8 @@ let rec (inspect_ln :
               FStar_Reflection_Data.Pat_Var bv
           | FStar_Syntax_Syntax.Pat_wild bv ->
               FStar_Reflection_Data.Pat_Wild bv
-          | FStar_Syntax_Syntax.Pat_dot_term (bv, t4) ->
-              FStar_Reflection_Data.Pat_Dot_Term (bv, t4) in
+          | FStar_Syntax_Syntax.Pat_dot_term eopt ->
+              FStar_Reflection_Data.Pat_Dot_Term eopt in
         let brs1 =
           FStar_Compiler_List.map
             (fun uu___1 ->
@@ -547,9 +547,9 @@ let (pack_ln : FStar_Reflection_Data.term_view -> FStar_Syntax_Syntax.term) =
           | FStar_Reflection_Data.Pat_Wild bv ->
               FStar_Compiler_Effect.op_Less_Bar wrap
                 (FStar_Syntax_Syntax.Pat_wild bv)
-          | FStar_Reflection_Data.Pat_Dot_Term (bv, t1) ->
+          | FStar_Reflection_Data.Pat_Dot_Term eopt ->
               FStar_Compiler_Effect.op_Less_Bar wrap
-                (FStar_Syntax_Syntax.Pat_dot_term (bv, t1)) in
+                (FStar_Syntax_Syntax.Pat_dot_term eopt) in
         let brs1 =
           FStar_Compiler_List.map
             (fun uu___ ->

--- a/src/ocaml-output/FStar_Reflection_Data.ml
+++ b/src/ocaml-output/FStar_Reflection_Data.ml
@@ -45,7 +45,7 @@ type pattern =
   Prims.list) 
   | Pat_Var of FStar_Syntax_Syntax.bv 
   | Pat_Wild of FStar_Syntax_Syntax.bv 
-  | Pat_Dot_Term of (FStar_Syntax_Syntax.bv * FStar_Syntax_Syntax.term) 
+  | Pat_Dot_Term of FStar_Syntax_Syntax.term FStar_Pervasives_Native.option 
 let (uu___is_Pat_Constant : pattern -> Prims.bool) =
   fun projectee ->
     match projectee with | Pat_Constant _0 -> true | uu___ -> false
@@ -72,7 +72,7 @@ let (uu___is_Pat_Dot_Term : pattern -> Prims.bool) =
   fun projectee ->
     match projectee with | Pat_Dot_Term _0 -> true | uu___ -> false
 let (__proj__Pat_Dot_Term__item___0 :
-  pattern -> (FStar_Syntax_Syntax.bv * FStar_Syntax_Syntax.term)) =
+  pattern -> FStar_Syntax_Syntax.term FStar_Pervasives_Native.option) =
   fun projectee -> match projectee with | Pat_Dot_Term _0 -> _0
 type branch = (pattern * FStar_Syntax_Syntax.term)
 type aqualv =

--- a/src/ocaml-output/FStar_Reflection_Embeddings.ml
+++ b/src/ocaml-output/FStar_Reflection_Embeddings.ml
@@ -725,17 +725,14 @@ let rec (e_pattern' :
           FStar_Syntax_Syntax.mk_Tm_app
             FStar_Reflection_Constants.ref_Pat_Wild.FStar_Reflection_Constants.t
             uu___1 rng
-      | FStar_Reflection_Data.Pat_Dot_Term (bv, t) ->
+      | FStar_Reflection_Data.Pat_Dot_Term eopt ->
           let uu___1 =
             let uu___2 =
-              let uu___3 = embed e_bv rng bv in
+              let uu___3 =
+                let uu___4 = FStar_Syntax_Embeddings.e_option e_term in
+                embed uu___4 rng eopt in
               FStar_Syntax_Syntax.as_arg uu___3 in
-            let uu___3 =
-              let uu___4 =
-                let uu___5 = embed e_term rng t in
-                FStar_Syntax_Syntax.as_arg uu___5 in
-              [uu___4] in
-            uu___2 :: uu___3 in
+            [uu___2] in
           FStar_Syntax_Syntax.mk_Tm_app
             FStar_Reflection_Constants.ref_Pat_Dot_Term.FStar_Reflection_Constants.t
             uu___1 rng in
@@ -811,20 +808,18 @@ let rec (e_pattern' :
                     FStar_Compiler_Effect.op_Less_Bar
                       (fun uu___5 -> FStar_Pervasives_Native.Some uu___5)
                       (FStar_Reflection_Data.Pat_Wild bv1))
-           | (FStar_Syntax_Syntax.Tm_fvar fv, (bv, uu___3)::(t2, uu___4)::[])
-               when
+           | (FStar_Syntax_Syntax.Tm_fvar fv, (eopt, uu___3)::[]) when
                FStar_Syntax_Syntax.fv_eq_lid fv
                  FStar_Reflection_Constants.ref_Pat_Dot_Term.FStar_Reflection_Constants.lid
                ->
-               let uu___5 = unembed' w e_bv bv in
-               FStar_Compiler_Util.bind_opt uu___5
-                 (fun bv1 ->
-                    let uu___6 = unembed' w e_term t2 in
-                    FStar_Compiler_Util.bind_opt uu___6
-                      (fun t3 ->
-                         FStar_Compiler_Effect.op_Less_Bar
-                           (fun uu___7 -> FStar_Pervasives_Native.Some uu___7)
-                           (FStar_Reflection_Data.Pat_Dot_Term (bv1, t3))))
+               let uu___4 =
+                 let uu___5 = FStar_Syntax_Embeddings.e_option e_term in
+                 unembed' w uu___5 eopt in
+               FStar_Compiler_Util.bind_opt uu___4
+                 (fun eopt1 ->
+                    FStar_Compiler_Effect.op_Less_Bar
+                      (fun uu___5 -> FStar_Pervasives_Native.Some uu___5)
+                      (FStar_Reflection_Data.Pat_Dot_Term eopt1))
            | uu___3 ->
                (if w
                 then

--- a/src/ocaml-output/FStar_Reflection_NBEEmbeddings.ml
+++ b/src/ocaml-output/FStar_Reflection_NBEEmbeddings.ml
@@ -533,17 +533,14 @@ let rec (e_pattern' :
           mkConstruct
             FStar_Reflection_Constants.ref_Pat_Wild.FStar_Reflection_Constants.fv
             [] uu___1
-      | FStar_Reflection_Data.Pat_Dot_Term (bv, t) ->
+      | FStar_Reflection_Data.Pat_Dot_Term eopt ->
           let uu___1 =
             let uu___2 =
-              let uu___3 = FStar_TypeChecker_NBETerm.embed e_bv cb bv in
+              let uu___3 =
+                let uu___4 = FStar_TypeChecker_NBETerm.e_option e_term in
+                FStar_TypeChecker_NBETerm.embed uu___4 cb eopt in
               FStar_TypeChecker_NBETerm.as_arg uu___3 in
-            let uu___3 =
-              let uu___4 =
-                let uu___5 = FStar_TypeChecker_NBETerm.embed e_term cb t in
-                FStar_TypeChecker_NBETerm.as_arg uu___5 in
-              [uu___4] in
-            uu___2 :: uu___3 in
+            [uu___2] in
           mkConstruct
             FStar_Reflection_Constants.ref_Pat_Dot_Term.FStar_Reflection_Constants.fv
             [] uu___1 in
@@ -607,20 +604,18 @@ let rec (e_pattern' :
                FStar_Compiler_Effect.op_Less_Bar
                  (fun uu___3 -> FStar_Pervasives_Native.Some uu___3)
                  (FStar_Reflection_Data.Pat_Wild bv1))
-      | FStar_TypeChecker_NBETerm.Construct
-          (fv, [], (t1, uu___1)::(bv, uu___2)::[]) when
+      | FStar_TypeChecker_NBETerm.Construct (fv, [], (eopt, uu___1)::[]) when
           FStar_Syntax_Syntax.fv_eq_lid fv
             FStar_Reflection_Constants.ref_Pat_Dot_Term.FStar_Reflection_Constants.lid
           ->
-          let uu___3 = FStar_TypeChecker_NBETerm.unembed e_bv cb bv in
-          FStar_Compiler_Util.bind_opt uu___3
-            (fun bv1 ->
-               let uu___4 = FStar_TypeChecker_NBETerm.unembed e_term cb t1 in
-               FStar_Compiler_Util.bind_opt uu___4
-                 (fun t2 ->
-                    FStar_Compiler_Effect.op_Less_Bar
-                      (fun uu___5 -> FStar_Pervasives_Native.Some uu___5)
-                      (FStar_Reflection_Data.Pat_Dot_Term (bv1, t2))))
+          let uu___2 =
+            let uu___3 = FStar_TypeChecker_NBETerm.e_option e_term in
+            FStar_TypeChecker_NBETerm.unembed uu___3 cb eopt in
+          FStar_Compiler_Util.bind_opt uu___2
+            (fun eopt1 ->
+               FStar_Compiler_Effect.op_Less_Bar
+                 (fun uu___3 -> FStar_Pervasives_Native.Some uu___3)
+                 (FStar_Reflection_Data.Pat_Dot_Term eopt1))
       | uu___1 ->
           ((let uu___3 =
               let uu___4 =

--- a/src/ocaml-output/FStar_SMTEncoding_EncodeTerm.ml
+++ b/src/ocaml-output/FStar_SMTEncoding_EncodeTerm.ml
@@ -3296,8 +3296,7 @@ and (encode_pat :
                         sub_term_guards) in
                 let rec mk_projections pat1 scrutinee =
                   match pat1.FStar_Syntax_Syntax.v with
-                  | FStar_Syntax_Syntax.Pat_dot_term (x, uu___3) ->
-                      [(x, scrutinee)]
+                  | FStar_Syntax_Syntax.Pat_dot_term uu___3 -> []
                   | FStar_Syntax_Syntax.Pat_var x -> [(x, scrutinee)]
                   | FStar_Syntax_Syntax.Pat_wild x -> [(x, scrutinee)]
                   | FStar_Syntax_Syntax.Pat_constant uu___3 -> []

--- a/src/ocaml-output/FStar_Syntax_Print.ml
+++ b/src/ocaml-output/FStar_Syntax_Print.ml
@@ -816,16 +816,20 @@ and (pat_to_string : FStar_Syntax_Syntax.pat -> Prims.string) =
              FStar_Compiler_Effect.op_Bar_Greater uu___5
                (FStar_String.concat " ") in
            FStar_Compiler_Util.format3 "(%s%s%s)" uu___2 uu___3 uu___4
-       | FStar_Syntax_Syntax.Pat_dot_term (x1, uu___2) ->
-           let uu___3 = FStar_Options.print_bound_var_types () in
-           if uu___3
+       | FStar_Syntax_Syntax.Pat_dot_term topt ->
+           let uu___2 = FStar_Options.print_bound_var_types () in
+           if uu___2
            then
-             let uu___4 = bv_to_string x1 in
-             let uu___5 = term_to_string x1.FStar_Syntax_Syntax.sort in
-             FStar_Compiler_Util.format2 ".%s:%s" uu___4 uu___5
-           else
-             (let uu___5 = bv_to_string x1 in
-              FStar_Compiler_Util.format1 ".%s" uu___5)
+             let uu___3 =
+               if topt = FStar_Pervasives_Native.None
+               then "_"
+               else
+                 (let uu___5 =
+                    FStar_Compiler_Effect.op_Bar_Greater topt
+                      FStar_Compiler_Util.must in
+                  FStar_Compiler_Effect.op_Bar_Greater uu___5 term_to_string) in
+             FStar_Compiler_Util.format1 ".%s" uu___3
+           else "._"
        | FStar_Syntax_Syntax.Pat_var x1 ->
            let uu___2 = FStar_Options.print_bound_var_types () in
            if uu___2

--- a/src/ocaml-output/FStar_Syntax_Resugar.ml
+++ b/src/ocaml-output/FStar_Syntax_Resugar.ml
@@ -630,7 +630,9 @@ let rec (resugar_term' :
                            x.FStar_Syntax_Syntax.binder_bv
                            x.FStar_Syntax_Syntax.binder_qual body_bv)) in
                let body2 = resugar_term' env body1 in
-               mk (FStar_Parser_AST.Abs (patterns, body2)))
+               if FStar_Compiler_List.isEmpty patterns
+               then body2
+               else mk (FStar_Parser_AST.Abs (patterns, body2)))
       | FStar_Syntax_Syntax.Tm_arrow uu___1 ->
           let uu___2 =
             let uu___3 =

--- a/src/ocaml-output/FStar_Syntax_Resugar.ml
+++ b/src/ocaml-output/FStar_Syntax_Resugar.ml
@@ -2073,8 +2073,6 @@ and (resugar_pat' :
                           match pattern.FStar_Syntax_Syntax.v with
                           | FStar_Syntax_Syntax.Pat_var bv ->
                               FStar_Compiler_Util.set_mem bv branch_bv
-                          | FStar_Syntax_Syntax.Pat_dot_term (bv, uu___2) ->
-                              FStar_Compiler_Util.set_mem bv branch_bv
                           | FStar_Syntax_Syntax.Pat_wild uu___2 -> false
                           | uu___2 -> true in
                         is_implicit && might_be_used) args in
@@ -2243,10 +2241,11 @@ and (resugar_pat' :
                 let uu___2 = let uu___3 = to_arg_qual imp_opt in (uu___3, []) in
                 FStar_Parser_AST.PatWild uu___2 in
               mk uu___1
-          | FStar_Syntax_Syntax.Pat_dot_term (bv, term) ->
-              resugar_bv_as_pat' env bv
-                (FStar_Pervasives_Native.Some FStar_Parser_AST.Implicit)
-                branch_bv (FStar_Pervasives_Native.Some term) in
+          | FStar_Syntax_Syntax.Pat_dot_term uu___ ->
+              mk
+                (FStar_Parser_AST.PatWild
+                   ((FStar_Pervasives_Native.Some FStar_Parser_AST.Implicit),
+                     [])) in
         aux p FStar_Pervasives_Native.None
 and (resugar_bqual :
   FStar_Syntax_DsEnv.env ->

--- a/src/ocaml-output/FStar_Syntax_Subst.ml
+++ b/src/ocaml-output/FStar_Syntax_Subst.ml
@@ -654,19 +654,12 @@ let (subst_pat' :
                FStar_Syntax_Syntax.v = (FStar_Syntax_Syntax.Pat_wild x1);
                FStar_Syntax_Syntax.p = (p1.FStar_Syntax_Syntax.p)
              }, (n + Prims.int_one))
-        | FStar_Syntax_Syntax.Pat_dot_term (x, t0) ->
+        | FStar_Syntax_Syntax.Pat_dot_term eopt ->
             let s1 = shift_subst' n s in
-            let x1 =
-              let uu___ = subst' s1 x.FStar_Syntax_Syntax.sort in
-              {
-                FStar_Syntax_Syntax.ppname = (x.FStar_Syntax_Syntax.ppname);
-                FStar_Syntax_Syntax.index = (x.FStar_Syntax_Syntax.index);
-                FStar_Syntax_Syntax.sort = uu___
-              } in
-            let t01 = subst' s1 t0 in
+            let eopt1 = FStar_Compiler_Util.map_option (subst' s1) eopt in
             ({
                FStar_Syntax_Syntax.v =
-                 (FStar_Syntax_Syntax.Pat_dot_term (x1, t01));
+                 (FStar_Syntax_Syntax.Pat_dot_term eopt1);
                FStar_Syntax_Syntax.p = (p1.FStar_Syntax_Syntax.p)
              }, n) in
       aux Prims.int_zero p
@@ -1232,18 +1225,10 @@ let (open_pat :
              FStar_Syntax_Syntax.v = (FStar_Syntax_Syntax.Pat_wild x');
              FStar_Syntax_Syntax.p = (p1.FStar_Syntax_Syntax.p)
            }, sub1)
-      | FStar_Syntax_Syntax.Pat_dot_term (x, t0) ->
-          let x1 =
-            let uu___ = subst sub x.FStar_Syntax_Syntax.sort in
-            {
-              FStar_Syntax_Syntax.ppname = (x.FStar_Syntax_Syntax.ppname);
-              FStar_Syntax_Syntax.index = (x.FStar_Syntax_Syntax.index);
-              FStar_Syntax_Syntax.sort = uu___
-            } in
-          let t01 = subst sub t0 in
+      | FStar_Syntax_Syntax.Pat_dot_term eopt ->
+          let eopt1 = FStar_Compiler_Util.map_option (subst sub) eopt in
           ({
-             FStar_Syntax_Syntax.v =
-               (FStar_Syntax_Syntax.Pat_dot_term (x1, t01));
+             FStar_Syntax_Syntax.v = (FStar_Syntax_Syntax.Pat_dot_term eopt1);
              FStar_Syntax_Syntax.p = (p1.FStar_Syntax_Syntax.p)
            }, sub) in
     open_pat_aux [] p
@@ -1370,18 +1355,10 @@ let (close_pat :
              FStar_Syntax_Syntax.v = (FStar_Syntax_Syntax.Pat_wild x1);
              FStar_Syntax_Syntax.p = (p1.FStar_Syntax_Syntax.p)
            }, sub1)
-      | FStar_Syntax_Syntax.Pat_dot_term (x, t0) ->
-          let x1 =
-            let uu___ = subst sub x.FStar_Syntax_Syntax.sort in
-            {
-              FStar_Syntax_Syntax.ppname = (x.FStar_Syntax_Syntax.ppname);
-              FStar_Syntax_Syntax.index = (x.FStar_Syntax_Syntax.index);
-              FStar_Syntax_Syntax.sort = uu___
-            } in
-          let t01 = subst sub t0 in
+      | FStar_Syntax_Syntax.Pat_dot_term eopt ->
+          let eopt1 = FStar_Compiler_Util.map_option (subst sub) eopt in
           ({
-             FStar_Syntax_Syntax.v =
-               (FStar_Syntax_Syntax.Pat_dot_term (x1, t01));
+             FStar_Syntax_Syntax.v = (FStar_Syntax_Syntax.Pat_dot_term eopt1);
              FStar_Syntax_Syntax.p = (p1.FStar_Syntax_Syntax.p)
            }, sub) in
     aux [] p
@@ -1813,11 +1790,10 @@ let rec (deep_compress :
                 FStar_Syntax_Syntax.v = uu___;
                 FStar_Syntax_Syntax.p = (p.FStar_Syntax_Syntax.p)
               }
-          | FStar_Syntax_Syntax.Pat_dot_term (x, t0) ->
+          | FStar_Syntax_Syntax.Pat_dot_term eopt ->
               let uu___ =
                 let uu___1 =
-                  let uu___2 = elim_bv x in
-                  let uu___3 = deep_compress t0 in (uu___2, uu___3) in
+                  FStar_Compiler_Util.map_option deep_compress eopt in
                 FStar_Syntax_Syntax.Pat_dot_term uu___1 in
               {
                 FStar_Syntax_Syntax.v = uu___;

--- a/src/ocaml-output/FStar_Syntax_Syntax.ml
+++ b/src/ocaml-output/FStar_Syntax_Syntax.ml
@@ -234,7 +234,7 @@ and pat' =
   withinfo_t * Prims.bool) Prims.list) 
   | Pat_var of bv 
   | Pat_wild of bv 
-  | Pat_dot_term of (bv * term' syntax) 
+  | Pat_dot_term of term' syntax FStar_Pervasives_Native.option 
 and letbinding =
   {
   lbname: (bv, fv) FStar_Pervasives.either ;
@@ -573,7 +573,8 @@ let (__proj__Pat_wild__item___0 : pat' -> bv) =
 let (uu___is_Pat_dot_term : pat' -> Prims.bool) =
   fun projectee ->
     match projectee with | Pat_dot_term _0 -> true | uu___ -> false
-let (__proj__Pat_dot_term__item___0 : pat' -> (bv * term' syntax)) =
+let (__proj__Pat_dot_term__item___0 :
+  pat' -> term' syntax FStar_Pervasives_Native.option) =
   fun projectee -> match projectee with | Pat_dot_term _0 -> _0
 let (__proj__Mkletbinding__item__lbname :
   letbinding -> (bv, fv) FStar_Pervasives.either) =
@@ -1985,7 +1986,7 @@ let rec (eq_pat : pat -> pat -> Prims.bool) =
           else false
       | (Pat_var uu___, Pat_var uu___1) -> true
       | (Pat_wild uu___, Pat_wild uu___1) -> true
-      | (Pat_dot_term (bv1, t1), Pat_dot_term (bv2, t2)) -> true
+      | (Pat_dot_term uu___, Pat_dot_term uu___1) -> true
       | (uu___, uu___1) -> false
 let (delta_constant : delta_depth) = Delta_constant_at_level Prims.int_zero
 let (delta_equational : delta_depth) =

--- a/src/ocaml-output/FStar_Tactics_Basic.ml
+++ b/src/ocaml-output/FStar_Tactics_Basic.ml
@@ -5379,7 +5379,8 @@ let (t_destruct :
                                                                     ->
                                                                     ((mk_pat
                                                                     (FStar_Syntax_Syntax.Pat_dot_term
-                                                                    (bv, t))),
+                                                                    (FStar_Pervasives_Native.Some
+                                                                    t))),
                                                                     true))
                                                                     d_ps_a_ps in
                                                                     let subpats_2
@@ -6005,8 +6006,8 @@ let rec (inspect :
                      FStar_Reflection_Data.Pat_Var bv
                  | FStar_Syntax_Syntax.Pat_wild bv ->
                      FStar_Reflection_Data.Pat_Wild bv
-                 | FStar_Syntax_Syntax.Pat_dot_term (bv, t4) ->
-                     FStar_Reflection_Data.Pat_Dot_Term (bv, t4) in
+                 | FStar_Syntax_Syntax.Pat_dot_term eopt ->
+                     FStar_Reflection_Data.Pat_Dot_Term eopt in
                let brs1 =
                  FStar_Compiler_List.map FStar_Syntax_Subst.open_branch brs in
                let brs2 =
@@ -6151,9 +6152,9 @@ let (pack' :
             | FStar_Reflection_Data.Pat_Wild bv ->
                 FStar_Compiler_Effect.op_Less_Bar wrap
                   (FStar_Syntax_Syntax.Pat_wild bv)
-            | FStar_Reflection_Data.Pat_Dot_Term (bv, t1) ->
+            | FStar_Reflection_Data.Pat_Dot_Term eopt ->
                 FStar_Compiler_Effect.op_Less_Bar wrap
-                  (FStar_Syntax_Syntax.Pat_dot_term (bv, t1)) in
+                  (FStar_Syntax_Syntax.Pat_dot_term eopt) in
           let brs1 =
             FStar_Compiler_List.map
               (fun uu___ ->

--- a/src/ocaml-output/FStar_TypeChecker_NBE.ml
+++ b/src/ocaml-output/FStar_TypeChecker_NBE.ml
@@ -1009,20 +1009,13 @@ let rec (translate :
                          let uu___5 = FStar_TypeChecker_NBETerm.mkAccuVar x in
                          uu___5 :: bs1 in
                        (uu___4, (FStar_Syntax_Syntax.Pat_wild x))
-                   | FStar_Syntax_Syntax.Pat_dot_term (bvar, tm) ->
-                       let x =
-                         let uu___4 =
-                           let uu___5 =
-                             translate cfg1 bs1 bvar.FStar_Syntax_Syntax.sort in
-                           readback cfg1 uu___5 in
-                         FStar_Syntax_Syntax.new_bv
-                           FStar_Pervasives_Native.None uu___4 in
+                   | FStar_Syntax_Syntax.Pat_dot_term eopt ->
                        let uu___4 =
                          let uu___5 =
-                           let uu___6 =
-                             let uu___7 = translate cfg1 bs1 tm in
-                             readback cfg1 uu___7 in
-                           (x, uu___6) in
+                           FStar_Compiler_Util.map_option
+                             (fun e1 ->
+                                let uu___6 = translate cfg1 bs1 e1 in
+                                readback cfg1 uu___6) eopt in
                          FStar_Syntax_Syntax.Pat_dot_term uu___5 in
                        (bs1, uu___4) in
                  match uu___3 with

--- a/src/ocaml-output/FStar_TypeChecker_Normalize.ml
+++ b/src/ocaml-output/FStar_TypeChecker_Normalize.ml
@@ -931,22 +931,13 @@ and (rebuild_closure :
                               FStar_Syntax_Syntax.p =
                                 (p.FStar_Syntax_Syntax.p)
                             }, (dummy :: env4))
-                       | FStar_Syntax_Syntax.Pat_dot_term (x, t1) ->
-                           let x1 =
-                             let uu___2 =
-                               non_tail_inline_closure_env cfg1 env4
-                                 x.FStar_Syntax_Syntax.sort in
-                             {
-                               FStar_Syntax_Syntax.ppname =
-                                 (x.FStar_Syntax_Syntax.ppname);
-                               FStar_Syntax_Syntax.index =
-                                 (x.FStar_Syntax_Syntax.index);
-                               FStar_Syntax_Syntax.sort = uu___2
-                             } in
-                           let t2 = non_tail_inline_closure_env cfg1 env4 t1 in
+                       | FStar_Syntax_Syntax.Pat_dot_term eopt ->
+                           let eopt1 =
+                             FStar_Compiler_Util.map_option
+                               (non_tail_inline_closure_env cfg1 env4) eopt in
                            ({
                               FStar_Syntax_Syntax.v =
-                                (FStar_Syntax_Syntax.Pat_dot_term (x1, t2));
+                                (FStar_Syntax_Syntax.Pat_dot_term eopt1);
                               FStar_Syntax_Syntax.p =
                                 (p.FStar_Syntax_Syntax.p)
                             }, env4) in
@@ -7137,21 +7128,13 @@ and (rebuild :
                                 FStar_Syntax_Syntax.p =
                                   (p.FStar_Syntax_Syntax.p)
                               }, (dummy :: env3))
-                         | FStar_Syntax_Syntax.Pat_dot_term (x, t2) ->
-                             let x1 =
-                               let uu___6 =
-                                 norm_or_whnf env3 x.FStar_Syntax_Syntax.sort in
-                               {
-                                 FStar_Syntax_Syntax.ppname =
-                                   (x.FStar_Syntax_Syntax.ppname);
-                                 FStar_Syntax_Syntax.index =
-                                   (x.FStar_Syntax_Syntax.index);
-                                 FStar_Syntax_Syntax.sort = uu___6
-                               } in
-                             let t3 = norm_or_whnf env3 t2 in
+                         | FStar_Syntax_Syntax.Pat_dot_term eopt ->
+                             let eopt1 =
+                               FStar_Compiler_Util.map_option
+                                 (norm_or_whnf env3) eopt in
                              ({
                                 FStar_Syntax_Syntax.v =
-                                  (FStar_Syntax_Syntax.Pat_dot_term (x1, t3));
+                                  (FStar_Syntax_Syntax.Pat_dot_term eopt1);
                                 FStar_Syntax_Syntax.p =
                                   (p.FStar_Syntax_Syntax.p)
                               }, env3) in

--- a/src/ocaml-output/FStar_TypeChecker_PatternUtils.ml
+++ b/src/ocaml-output/FStar_TypeChecker_PatternUtils.ml
@@ -12,7 +12,7 @@ let rec (elaborate_pat :
         if inaccessible
         then
           FStar_Syntax_Syntax.withinfo
-            (FStar_Syntax_Syntax.Pat_dot_term (a, FStar_Syntax_Syntax.tun)) r
+            (FStar_Syntax_Syntax.Pat_dot_term FStar_Pervasives_Native.None) r
         else FStar_Syntax_Syntax.withinfo (FStar_Syntax_Syntax.Pat_var a) r in
       match p.FStar_Syntax_Syntax.v with
       | FStar_Syntax_Syntax.Pat_cons
@@ -190,12 +190,12 @@ let (raw_pat_as_exp :
                   FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_constant c)
                     p1.FStar_Syntax_Syntax.p in
             (e, bs)
-        | FStar_Syntax_Syntax.Pat_dot_term (uu___, t) ->
-            let t1 = FStar_Syntax_Subst.compress t in
-            (match t1.FStar_Syntax_Syntax.n with
-             | FStar_Syntax_Syntax.Tm_unknown ->
+        | FStar_Syntax_Syntax.Pat_dot_term eopt ->
+            (match eopt with
+             | FStar_Pervasives_Native.None ->
                  FStar_Compiler_Effect.raise Raw_pat_cannot_be_translated
-             | uu___1 -> (t1, bs))
+             | FStar_Pervasives_Native.Some e ->
+                 let uu___ = FStar_Syntax_Subst.compress e in (uu___, bs))
         | FStar_Syntax_Syntax.Pat_wild x ->
             let uu___ =
               FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_name x)
@@ -300,69 +300,55 @@ let (pat_as_exp :
                         p1.FStar_Syntax_Syntax.p in
                 ([], [], [], env1, e, FStar_TypeChecker_Common.trivial_guard,
                   p1)
-            | FStar_Syntax_Syntax.Pat_dot_term (x, e) ->
-                let uu___ =
-                  let uu___1 = FStar_Syntax_Subst.compress e in
-                  uu___1.FStar_Syntax_Syntax.n in
-                (match uu___ with
-                 | FStar_Syntax_Syntax.Tm_unknown ->
-                     ((let uu___2 =
+            | FStar_Syntax_Syntax.Pat_dot_term eopt ->
+                (match eopt with
+                 | FStar_Pervasives_Native.None ->
+                     ((let uu___1 =
                          FStar_Compiler_Effect.op_Less_Bar
                            (FStar_TypeChecker_Env.debug env1)
                            (FStar_Options.Other "Patterns") in
-                       if uu___2
+                       if uu___1
                        then
                          (if
                             Prims.op_Negation
                               env1.FStar_TypeChecker_Env.phase1
                           then
-                            let uu___3 = FStar_Syntax_Print.pat_to_string p1 in
+                            let uu___2 = FStar_Syntax_Print.pat_to_string p1 in
                             FStar_Compiler_Util.print1
                               "Found a non-instantiated dot pattern in phase2 (%s)\n"
-                              uu___3
+                              uu___2
                           else ())
                        else ());
-                      (let uu___2 = FStar_Syntax_Util.type_u () in
-                       match uu___2 with
-                       | (k, uu___3) ->
-                           let uu___4 =
-                             let uu___5 = FStar_Syntax_Syntax.range_of_bv x in
+                      (let uu___1 = FStar_Syntax_Util.type_u () in
+                       match uu___1 with
+                       | (k, uu___2) ->
+                           let uu___3 =
                              FStar_TypeChecker_Env.new_implicit_var_aux
-                               "pat_dot_term type" uu___5 env1 k
-                               FStar_Syntax_Syntax.Allow_ghost
+                               "pat_dot_term type" p1.FStar_Syntax_Syntax.p
+                               env1 k FStar_Syntax_Syntax.Allow_ghost
                                FStar_Pervasives_Native.None in
-                           (match uu___4 with
-                            | (t, uu___5, g) ->
-                                let x1 =
-                                  {
-                                    FStar_Syntax_Syntax.ppname =
-                                      (x.FStar_Syntax_Syntax.ppname);
-                                    FStar_Syntax_Syntax.index =
-                                      (x.FStar_Syntax_Syntax.index);
-                                    FStar_Syntax_Syntax.sort = t
-                                  } in
-                                let uu___6 =
-                                  let uu___7 =
-                                    FStar_Syntax_Syntax.range_of_bv x1 in
+                           (match uu___3 with
+                            | (t, uu___4, g) ->
+                                let uu___5 =
                                   FStar_TypeChecker_Env.new_implicit_var_aux
-                                    "pat_dot_term" uu___7 env1 t
-                                    FStar_Syntax_Syntax.Allow_ghost
+                                    "pat_dot_term" p1.FStar_Syntax_Syntax.p
+                                    env1 t FStar_Syntax_Syntax.Allow_ghost
                                     FStar_Pervasives_Native.None in
-                                (match uu___6 with
-                                 | (e1, uu___7, g') ->
+                                (match uu___5 with
+                                 | (e, uu___6, g') ->
                                      let p2 =
                                        {
                                          FStar_Syntax_Syntax.v =
                                            (FStar_Syntax_Syntax.Pat_dot_term
-                                              (x1, e1));
+                                              (FStar_Pervasives_Native.Some e));
                                          FStar_Syntax_Syntax.p =
                                            (p1.FStar_Syntax_Syntax.p)
                                        } in
-                                     let uu___8 =
+                                     let uu___7 =
                                        FStar_TypeChecker_Common.conj_guard g
                                          g' in
-                                     ([], [], [], env1, e1, uu___8, p2)))))
-                 | uu___1 ->
+                                     ([], [], [], env1, e, uu___7, p2)))))
+                 | FStar_Pervasives_Native.Some e ->
                      ([], [], [], env1, e,
                        FStar_TypeChecker_Env.trivial_guard, p1))
             | FStar_Syntax_Syntax.Pat_wild x ->

--- a/src/ocaml-output/FStar_TypeChecker_PatternUtils.ml
+++ b/src/ocaml-output/FStar_TypeChecker_PatternUtils.ml
@@ -300,45 +300,71 @@ let (pat_as_exp :
                         p1.FStar_Syntax_Syntax.p in
                 ([], [], [], env1, e, FStar_TypeChecker_Common.trivial_guard,
                   p1)
-            | FStar_Syntax_Syntax.Pat_dot_term (x, uu___) ->
-                let uu___1 = FStar_Syntax_Util.type_u () in
-                (match uu___1 with
-                 | (k, uu___2) ->
-                     let uu___3 =
-                       let uu___4 = FStar_Syntax_Syntax.range_of_bv x in
-                       FStar_TypeChecker_Env.new_implicit_var_aux
-                         "pat_dot_term type" uu___4 env1 k
-                         FStar_Syntax_Syntax.Allow_ghost
-                         FStar_Pervasives_Native.None in
-                     (match uu___3 with
-                      | (t, uu___4, g) ->
-                          let x1 =
-                            {
-                              FStar_Syntax_Syntax.ppname =
-                                (x.FStar_Syntax_Syntax.ppname);
-                              FStar_Syntax_Syntax.index =
-                                (x.FStar_Syntax_Syntax.index);
-                              FStar_Syntax_Syntax.sort = t
-                            } in
-                          let uu___5 =
-                            let uu___6 = FStar_Syntax_Syntax.range_of_bv x1 in
-                            FStar_TypeChecker_Env.new_implicit_var_aux
-                              "pat_dot_term" uu___6 env1 t
-                              FStar_Syntax_Syntax.Allow_ghost
-                              FStar_Pervasives_Native.None in
-                          (match uu___5 with
-                           | (e, uu___6, g') ->
-                               let p2 =
-                                 {
-                                   FStar_Syntax_Syntax.v =
-                                     (FStar_Syntax_Syntax.Pat_dot_term
-                                        (x1, e));
-                                   FStar_Syntax_Syntax.p =
-                                     (p1.FStar_Syntax_Syntax.p)
-                                 } in
-                               let uu___7 =
-                                 FStar_TypeChecker_Common.conj_guard g g' in
-                               ([], [], [], env1, e, uu___7, p2))))
+            | FStar_Syntax_Syntax.Pat_dot_term (x, e) ->
+                let uu___ =
+                  let uu___1 = FStar_Syntax_Subst.compress e in
+                  uu___1.FStar_Syntax_Syntax.n in
+                (match uu___ with
+                 | FStar_Syntax_Syntax.Tm_unknown ->
+                     ((let uu___2 =
+                         FStar_Compiler_Effect.op_Less_Bar
+                           (FStar_TypeChecker_Env.debug env1)
+                           (FStar_Options.Other "Patterns") in
+                       if uu___2
+                       then
+                         (if
+                            Prims.op_Negation
+                              env1.FStar_TypeChecker_Env.phase1
+                          then
+                            let uu___3 = FStar_Syntax_Print.pat_to_string p1 in
+                            FStar_Compiler_Util.print1
+                              "Found a non-instantiated dot pattern in phase2 (%s)\n"
+                              uu___3
+                          else ())
+                       else ());
+                      (let uu___2 = FStar_Syntax_Util.type_u () in
+                       match uu___2 with
+                       | (k, uu___3) ->
+                           let uu___4 =
+                             let uu___5 = FStar_Syntax_Syntax.range_of_bv x in
+                             FStar_TypeChecker_Env.new_implicit_var_aux
+                               "pat_dot_term type" uu___5 env1 k
+                               FStar_Syntax_Syntax.Allow_ghost
+                               FStar_Pervasives_Native.None in
+                           (match uu___4 with
+                            | (t, uu___5, g) ->
+                                let x1 =
+                                  {
+                                    FStar_Syntax_Syntax.ppname =
+                                      (x.FStar_Syntax_Syntax.ppname);
+                                    FStar_Syntax_Syntax.index =
+                                      (x.FStar_Syntax_Syntax.index);
+                                    FStar_Syntax_Syntax.sort = t
+                                  } in
+                                let uu___6 =
+                                  let uu___7 =
+                                    FStar_Syntax_Syntax.range_of_bv x1 in
+                                  FStar_TypeChecker_Env.new_implicit_var_aux
+                                    "pat_dot_term" uu___7 env1 t
+                                    FStar_Syntax_Syntax.Allow_ghost
+                                    FStar_Pervasives_Native.None in
+                                (match uu___6 with
+                                 | (e1, uu___7, g') ->
+                                     let p2 =
+                                       {
+                                         FStar_Syntax_Syntax.v =
+                                           (FStar_Syntax_Syntax.Pat_dot_term
+                                              (x1, e1));
+                                         FStar_Syntax_Syntax.p =
+                                           (p1.FStar_Syntax_Syntax.p)
+                                       } in
+                                     let uu___8 =
+                                       FStar_TypeChecker_Common.conj_guard g
+                                         g' in
+                                     ([], [], [], env1, e1, uu___8, p2)))))
+                 | uu___1 ->
+                     ([], [], [], env1, e,
+                       FStar_TypeChecker_Env.trivial_guard, p1))
             | FStar_Syntax_Syntax.Pat_wild x ->
                 let uu___ = intro_bv env1 x in
                 (match uu___ with

--- a/src/ocaml-output/FStar_TypeChecker_TcInductive.ml
+++ b/src/ocaml-output/FStar_TypeChecker_TcInductive.ml
@@ -2226,22 +2226,9 @@ let (mk_discriminator_and_indexed_projectors :
                                                        if b && (j < ntps)
                                                        then
                                                          let uu___6 =
-                                                           let uu___7 =
-                                                             let uu___8 =
-                                                               let uu___9 =
-                                                                 let uu___10
-                                                                   =
-                                                                   FStar_Ident.string_of_id
-                                                                    x.FStar_Syntax_Syntax.ppname in
-                                                                 FStar_Syntax_Syntax.gen_bv
-                                                                   uu___10
-                                                                   FStar_Pervasives_Native.None
-                                                                   FStar_Syntax_Syntax.tun in
-                                                               (uu___9,
-                                                                 FStar_Syntax_Syntax.tun) in
-                                                             FStar_Syntax_Syntax.Pat_dot_term
-                                                               uu___8 in
-                                                           pos uu___7 in
+                                                           pos
+                                                             (FStar_Syntax_Syntax.Pat_dot_term
+                                                                FStar_Pervasives_Native.None) in
                                                          (uu___6, b)
                                                        else
                                                          (let uu___7 =
@@ -2572,26 +2559,9 @@ let (mk_discriminator_and_indexed_projectors :
                                                                     (
                                                                     let uu___9
                                                                     =
-                                                                    let uu___10
-                                                                    =
-                                                                    let uu___11
-                                                                    =
-                                                                    let uu___12
-                                                                    =
-                                                                    let uu___13
-                                                                    =
-                                                                    FStar_Ident.string_of_id
-                                                                    x1.FStar_Syntax_Syntax.ppname in
-                                                                    FStar_Syntax_Syntax.gen_bv
-                                                                    uu___13
-                                                                    FStar_Pervasives_Native.None
-                                                                    FStar_Syntax_Syntax.tun in
-                                                                    (uu___12,
-                                                                    FStar_Syntax_Syntax.tun) in
-                                                                    FStar_Syntax_Syntax.Pat_dot_term
-                                                                    uu___11 in
                                                                     pos
-                                                                    uu___10 in
+                                                                    (FStar_Syntax_Syntax.Pat_dot_term
+                                                                    FStar_Pervasives_Native.None) in
                                                                     (uu___9,
                                                                     b))
                                                                   else

--- a/src/ocaml-output/FStar_TypeChecker_TcTerm.ml
+++ b/src/ocaml-output/FStar_TypeChecker_TcTerm.ml
@@ -8573,15 +8573,16 @@ and (tc_pat :
                                    | (hd, b)::simple_pats1 ->
                                        (match hd.FStar_Syntax_Syntax.v with
                                         | FStar_Syntax_Syntax.Pat_dot_term
-                                            (x, e) ->
-                                            let e1 =
-                                              FStar_Syntax_Subst.subst subst
-                                                e in
+                                            eopt ->
+                                            let eopt1 =
+                                              FStar_Compiler_Util.map_option
+                                                (FStar_Syntax_Subst.subst
+                                                   subst) eopt in
                                             let hd1 =
                                               {
                                                 FStar_Syntax_Syntax.v =
                                                   (FStar_Syntax_Syntax.Pat_dot_term
-                                                     (x, e1));
+                                                     eopt1);
                                                 FStar_Syntax_Syntax.p =
                                                   (hd.FStar_Syntax_Syntax.p)
                                               } in

--- a/src/ocaml-output/FStar_TypeChecker_TcTerm.ml
+++ b/src/ocaml-output/FStar_TypeChecker_TcTerm.ml
@@ -7922,7 +7922,25 @@ and (tc_pat :
                                                      ((a1, imp_a), subst1,
                                                        bvs, g))
                                             | uu___13 ->
-                                                fail "Not a simple pattern" in
+                                                let a1 =
+                                                  FStar_Syntax_Subst.subst
+                                                    subst a in
+                                                let env2 =
+                                                  FStar_TypeChecker_Env.set_expected_typ
+                                                    env1 t_f1 in
+                                                let uu___14 =
+                                                  tc_tot_or_gtot_term env2 a1 in
+                                                (match uu___14 with
+                                                 | (a2, uu___15, g) ->
+                                                     (FStar_TypeChecker_Rel.force_trivial_guard
+                                                        env2 g;
+                                                      (let subst1 =
+                                                         (FStar_Syntax_Syntax.NT
+                                                            (f, a2))
+                                                         :: subst in
+                                                       ((a2, imp_a), subst1,
+                                                         bvs,
+                                                         FStar_TypeChecker_Env.trivial_guard)))) in
                                           (match uu___11 with
                                            | (a1, subst1, bvs1, g) ->
                                                let uu___12 =
@@ -7935,7 +7953,7 @@ and (tc_pat :
                                                    uu___13) in
                                                aux uu___12 formals2 args2)
                                       | uu___9 ->
-                                          fail "Not a fully applued pattern") in
+                                          fail "Not a fully applied pattern") in
                                aux
                                  ([], [], [],
                                    FStar_TypeChecker_Env.trivial_guard)
@@ -8058,7 +8076,25 @@ and (tc_pat :
                                                      ((a1, imp_a), subst1,
                                                        bvs, g))
                                             | uu___10 ->
-                                                fail "Not a simple pattern" in
+                                                let a1 =
+                                                  FStar_Syntax_Subst.subst
+                                                    subst a in
+                                                let env2 =
+                                                  FStar_TypeChecker_Env.set_expected_typ
+                                                    env1 t_f1 in
+                                                let uu___11 =
+                                                  tc_tot_or_gtot_term env2 a1 in
+                                                (match uu___11 with
+                                                 | (a2, uu___12, g) ->
+                                                     (FStar_TypeChecker_Rel.force_trivial_guard
+                                                        env2 g;
+                                                      (let subst1 =
+                                                         (FStar_Syntax_Syntax.NT
+                                                            (f, a2))
+                                                         :: subst in
+                                                       ((a2, imp_a), subst1,
+                                                         bvs,
+                                                         FStar_TypeChecker_Env.trivial_guard)))) in
                                           (match uu___8 with
                                            | (a1, subst1, bvs1, g) ->
                                                let uu___9 =
@@ -8071,7 +8107,7 @@ and (tc_pat :
                                                    uu___10) in
                                                aux uu___9 formals2 args2)
                                       | uu___6 ->
-                                          fail "Not a fully applued pattern") in
+                                          fail "Not a fully applied pattern") in
                                aux
                                  ([], [], [],
                                    FStar_TypeChecker_Env.trivial_guard)
@@ -8348,9 +8384,9 @@ and (tc_pat :
                  FStar_TypeChecker_PatternUtils.pat_as_exp false false env1
                    simple_pat in
                (match uu___1 with
-                | (simple_bvs, simple_pat_e, g0, simple_pat_elab) ->
+                | (simple_bvs_pat, simple_pat_e, g0, simple_pat_elab) ->
                     (if
-                       (FStar_Compiler_List.length simple_bvs) <>
+                       (FStar_Compiler_List.length simple_bvs_pat) <>
                          (FStar_Compiler_List.length sub_pats1)
                      then
                        (let uu___3 =
@@ -8364,7 +8400,7 @@ and (tc_pat :
                               (FStar_Compiler_List.length sub_pats1) in
                           let uu___7 =
                             FStar_Compiler_Util.string_of_int
-                              (FStar_Compiler_List.length simple_bvs) in
+                              (FStar_Compiler_List.length simple_bvs_pat) in
                           FStar_Compiler_Util.format4
                             "(%s) Impossible: pattern bvar mismatch: %s; expected %s sub pats; got %s"
                             uu___4 uu___5 uu___6 uu___7 in
@@ -8373,7 +8409,7 @@ and (tc_pat :
                      (let uu___3 =
                         let uu___4 = type_of_simple_pat env1 simple_pat_e in
                         match uu___4 with
-                        | (simple_pat_e1, simple_pat_t, simple_bvs1, guard,
+                        | (simple_pat_e1, simple_pat_t, simple_bvs, guard,
                            erasable) ->
                             let g' =
                               let uu___5 =
@@ -8413,17 +8449,28 @@ and (tc_pat :
                                                Prims.op_Hat uu___15 ")" in
                                              Prims.op_Hat " : " uu___14 in
                                            Prims.op_Hat uu___12 uu___13 in
-                                         Prims.op_Hat "(" uu___11)
-                                      simple_bvs1 in
+                                         Prims.op_Hat "(" uu___11) simple_bvs in
                                   FStar_Compiler_Effect.op_Bar_Greater
                                     uu___10 (FStar_String.concat " ") in
                                 FStar_Compiler_Util.print3
                                   "$$$$$$$$$$$$Checked simple pattern %s at type %s with bvs=%s\n"
                                   uu___7 uu___8 uu___9
                               else ());
-                             (simple_pat_e1, simple_bvs1, guard2, erasable)) in
+                             (let uu___6 =
+                                let uu___7 =
+                                  FStar_Compiler_Effect.op_Bar_Greater
+                                    simple_bvs
+                                    (FStar_Compiler_Util.first_N
+                                       ((FStar_Compiler_List.length
+                                           simple_bvs)
+                                          -
+                                          (FStar_Compiler_List.length
+                                             simple_bvs_pat))) in
+                                FStar_Compiler_Effect.op_Bar_Greater uu___7
+                                  FStar_Pervasives_Native.snd in
+                              (simple_pat_e1, uu___6, guard2, erasable))) in
                       match uu___3 with
-                      | (simple_pat_e1, simple_bvs1, g1, erasable) ->
+                      | (simple_pat_e1, simple_bvs, g1, erasable) ->
                           let uu___4 =
                             let uu___5 =
                               let uu___6 =
@@ -8485,7 +8532,7 @@ and (tc_pat :
                                                 uu___9,
                                                 (erasable1 || erasable_p),
                                                 (i + Prims.int_one)))) uu___5
-                              sub_pats1 simple_bvs1 in
+                              sub_pats1 simple_bvs in
                           (match uu___4 with
                            | (_env, bvs, tms, checked_sub_pats, subst, g,
                               erasable1, uu___5) ->
@@ -8551,7 +8598,7 @@ and (tc_pat :
                                  | FStar_Syntax_Syntax.Pat_cons
                                      (fv1, uu___6, simple_pats) ->
                                      let nested_pats =
-                                       aux simple_pats simple_bvs1
+                                       aux simple_pats simple_bvs
                                          checked_sub_pats in
                                      {
                                        FStar_Syntax_Syntax.v =

--- a/src/ocaml-output/FStar_TypeChecker_TcTerm.ml
+++ b/src/ocaml-output/FStar_TypeChecker_TcTerm.ml
@@ -7932,15 +7932,12 @@ and (tc_pat :
                                                   tc_tot_or_gtot_term env2 a1 in
                                                 (match uu___14 with
                                                  | (a2, uu___15, g) ->
-                                                     (FStar_TypeChecker_Rel.force_trivial_guard
-                                                        env2 g;
-                                                      (let subst1 =
-                                                         (FStar_Syntax_Syntax.NT
-                                                            (f, a2))
-                                                         :: subst in
-                                                       ((a2, imp_a), subst1,
-                                                         bvs,
-                                                         FStar_TypeChecker_Env.trivial_guard)))) in
+                                                     let subst1 =
+                                                       (FStar_Syntax_Syntax.NT
+                                                          (f, a2))
+                                                       :: subst in
+                                                     ((a2, imp_a), subst1,
+                                                       bvs, g)) in
                                           (match uu___11 with
                                            | (a1, subst1, bvs1, g) ->
                                                let uu___12 =
@@ -8086,15 +8083,12 @@ and (tc_pat :
                                                   tc_tot_or_gtot_term env2 a1 in
                                                 (match uu___11 with
                                                  | (a2, uu___12, g) ->
-                                                     (FStar_TypeChecker_Rel.force_trivial_guard
-                                                        env2 g;
-                                                      (let subst1 =
-                                                         (FStar_Syntax_Syntax.NT
-                                                            (f, a2))
-                                                         :: subst in
-                                                       ((a2, imp_a), subst1,
-                                                         bvs,
-                                                         FStar_TypeChecker_Env.trivial_guard)))) in
+                                                     let subst1 =
+                                                       (FStar_Syntax_Syntax.NT
+                                                          (f, a2))
+                                                       :: subst in
+                                                     ((a2, imp_a), subst1,
+                                                       bvs, g)) in
                                           (match uu___8 with
                                            | (a1, subst1, bvs1, g) ->
                                                let uu___9 =
@@ -8411,14 +8405,52 @@ and (tc_pat :
                         match uu___4 with
                         | (simple_pat_e1, simple_pat_t, simple_bvs, guard,
                            erasable) ->
+                            let simple_bvs1 =
+                              let uu___5 =
+                                FStar_Compiler_Effect.op_Bar_Greater
+                                  simple_bvs
+                                  (FStar_Compiler_Util.first_N
+                                     ((FStar_Compiler_List.length simple_bvs)
+                                        -
+                                        (FStar_Compiler_List.length
+                                           simple_bvs_pat))) in
+                              FStar_Compiler_Effect.op_Bar_Greater uu___5
+                                FStar_Pervasives_Native.snd in
                             let g' =
                               let uu___5 =
                                 expected_pat_typ env1
                                   p0.FStar_Syntax_Syntax.p t in
                               pat_typ_ok env1 simple_pat_t uu___5 in
                             let guard1 =
-                              FStar_TypeChecker_Rel.discharge_guard_no_smt
-                                env1 guard in
+                              let fml =
+                                FStar_TypeChecker_Env.guard_form guard in
+                              let guard2 =
+                                FStar_TypeChecker_Rel.discharge_guard_no_smt
+                                  env1
+                                  {
+                                    FStar_TypeChecker_Common.guard_f =
+                                      FStar_TypeChecker_Common.Trivial;
+                                    FStar_TypeChecker_Common.deferred_to_tac
+                                      =
+                                      (guard.FStar_TypeChecker_Common.deferred_to_tac);
+                                    FStar_TypeChecker_Common.deferred =
+                                      (guard.FStar_TypeChecker_Common.deferred);
+                                    FStar_TypeChecker_Common.univ_ineqs =
+                                      (guard.FStar_TypeChecker_Common.univ_ineqs);
+                                    FStar_TypeChecker_Common.implicits =
+                                      (guard.FStar_TypeChecker_Common.implicits)
+                                  } in
+                              {
+                                FStar_TypeChecker_Common.guard_f = fml;
+                                FStar_TypeChecker_Common.deferred_to_tac =
+                                  (guard2.FStar_TypeChecker_Common.deferred_to_tac);
+                                FStar_TypeChecker_Common.deferred =
+                                  (guard2.FStar_TypeChecker_Common.deferred);
+                                FStar_TypeChecker_Common.univ_ineqs =
+                                  (guard2.FStar_TypeChecker_Common.univ_ineqs);
+                                FStar_TypeChecker_Common.implicits =
+                                  (guard2.FStar_TypeChecker_Common.implicits)
+                              } in
                             let guard2 =
                               FStar_TypeChecker_Env.conj_guard guard1 g' in
                             ((let uu___6 =
@@ -8449,61 +8481,58 @@ and (tc_pat :
                                                Prims.op_Hat uu___15 ")" in
                                              Prims.op_Hat " : " uu___14 in
                                            Prims.op_Hat uu___12 uu___13 in
-                                         Prims.op_Hat "(" uu___11) simple_bvs in
+                                         Prims.op_Hat "(" uu___11)
+                                      simple_bvs1 in
                                   FStar_Compiler_Effect.op_Bar_Greater
                                     uu___10 (FStar_String.concat " ") in
                                 FStar_Compiler_Util.print3
                                   "$$$$$$$$$$$$Checked simple pattern %s at type %s with bvs=%s\n"
                                   uu___7 uu___8 uu___9
                               else ());
-                             (let uu___6 =
-                                let uu___7 =
-                                  FStar_Compiler_Effect.op_Bar_Greater
-                                    simple_bvs
-                                    (FStar_Compiler_Util.first_N
-                                       ((FStar_Compiler_List.length
-                                           simple_bvs)
-                                          -
-                                          (FStar_Compiler_List.length
-                                             simple_bvs_pat))) in
-                                FStar_Compiler_Effect.op_Bar_Greater uu___7
-                                  FStar_Pervasives_Native.snd in
-                              (simple_pat_e1, uu___6, guard2, erasable))) in
+                             (simple_pat_e1, simple_bvs1, guard2, erasable)) in
                       match uu___3 with
                       | (simple_pat_e1, simple_bvs, g1, erasable) ->
                           let uu___4 =
                             let uu___5 =
                               let uu___6 =
                                 FStar_TypeChecker_Env.conj_guard g0 g1 in
-                              (env1, [], [], [], [], uu___6, erasable,
+                              ([], [], [], [], uu___6, erasable,
                                 Prims.int_zero) in
                             FStar_Compiler_List.fold_left2
                               (fun uu___6 ->
                                  fun uu___7 ->
                                    fun x ->
                                      match (uu___6, uu___7) with
-                                     | ((env2, bvs, tms, pats, subst, g,
-                                         erasable1, i),
+                                     | ((bvs, tms, pats, subst, g, erasable1,
+                                         i),
                                         (p1, b)) ->
                                          let expected_t =
                                            FStar_Syntax_Subst.subst subst
                                              x.FStar_Syntax_Syntax.sort in
+                                         let env2 =
+                                           FStar_TypeChecker_Env.push_bvs
+                                             env1 bvs in
                                          let uu___8 =
                                            check_nested_pattern env2 p1
                                              expected_t in
                                          (match uu___8 with
                                           | (bvs_p, tms_p, e_p, p2, g',
                                              erasable_p) ->
-                                              let env3 =
-                                                FStar_TypeChecker_Env.push_bvs
-                                                  env2 bvs_p in
+                                              let g'1 =
+                                                let uu___9 =
+                                                  FStar_Compiler_Effect.op_Bar_Greater
+                                                    bvs
+                                                    (FStar_Compiler_List.map
+                                                       FStar_Syntax_Syntax.mk_binder) in
+                                                FStar_TypeChecker_Env.close_guard
+                                                  env2 uu___9 g' in
                                               let tms_p1 =
                                                 let disc_tm =
                                                   let uu___9 =
                                                     FStar_Syntax_Syntax.lid_of_fv
                                                       fv in
                                                   FStar_TypeChecker_Util.get_field_projector_name
-                                                    env3 uu___9 i in
+                                                    env2 uu___9 i in
                                                 let uu___9 =
                                                   let uu___10 =
                                                     let uu___11 =
@@ -8519,10 +8548,9 @@ and (tc_pat :
                                                   tms_p uu___9 in
                                               let uu___9 =
                                                 FStar_TypeChecker_Env.conj_guard
-                                                  g g' in
-                                              (env3,
-                                                (FStar_Compiler_List.op_At
-                                                   bvs bvs_p),
+                                                  g g'1 in
+                                              ((FStar_Compiler_List.op_At bvs
+                                                  bvs_p),
                                                 (FStar_Compiler_List.op_At
                                                    tms tms_p1),
                                                 (FStar_Compiler_List.op_At
@@ -8534,7 +8562,7 @@ and (tc_pat :
                                                 (i + Prims.int_one)))) uu___5
                               sub_pats1 simple_bvs in
                           (match uu___4 with
-                           | (_env, bvs, tms, checked_sub_pats, subst, g,
+                           | (bvs, tms, checked_sub_pats, subst, g,
                               erasable1, uu___5) ->
                                let pat_e =
                                  FStar_Syntax_Subst.subst subst simple_pat_e1 in

--- a/src/ocaml-output/FStar_TypeChecker_Util.ml
+++ b/src/ocaml-output/FStar_TypeChecker_Util.ml
@@ -558,7 +558,12 @@ let rec (decorated_pattern_as_term :
                    FStar_Syntax_Syntax.mk_Tm_uinst head us in
              let uu___1 = mk (FStar_Syntax_Syntax.Tm_app (head1, args)) in
              (vars1, uu___1))
-    | FStar_Syntax_Syntax.Pat_dot_term (x, e) -> ([], e)
+    | FStar_Syntax_Syntax.Pat_dot_term eopt ->
+        (match eopt with
+         | FStar_Pervasives_Native.None ->
+             failwith
+               "TcUtil::decorated_pattern_as_term: dot pattern not resolved"
+         | FStar_Pervasives_Native.Some e -> ([], e))
 let (comp_univ_opt :
   FStar_Syntax_Syntax.comp' FStar_Syntax_Syntax.syntax ->
     FStar_Syntax_Syntax.universe FStar_Pervasives_Native.option)

--- a/src/reflection/FStar.Reflection.Basic.fst
+++ b/src/reflection/FStar.Reflection.Basic.fst
@@ -267,7 +267,7 @@ let rec inspect_ln (t:term) : term_view =
             | Pat_cons (fv, us_opt, ps) -> Pat_Cons (fv, us_opt, List.map (fun (p, b) -> inspect_pat p, b) ps)
             | Pat_var bv -> Pat_Var bv
             | Pat_wild bv -> Pat_Wild bv
-            | Pat_dot_term (bv, t) -> Pat_Dot_Term (bv, t)
+            | Pat_dot_term eopt -> Pat_Dot_Term eopt
         in
         let brs = List.map (function (pat, _, t) -> (inspect_pat pat, t)) brs in
         Tv_Match (t, ret_opt, brs)
@@ -431,7 +431,7 @@ let pack_ln (tv:term_view) : term =
             | Pat_Cons (fv, us_opt, ps) -> wrap <| Pat_cons (fv, us_opt, List.map (fun (p, b) -> pack_pat p, b) ps)
             | Pat_Var  bv -> wrap <| Pat_var bv
             | Pat_Wild bv -> wrap <| Pat_wild bv
-            | Pat_Dot_Term (bv, t) -> wrap <| Pat_dot_term (bv, t)
+            | Pat_Dot_Term eopt -> wrap <| Pat_dot_term eopt
         in
         let brs = List.map (function (pat, t) -> (pack_pat pat, None, t)) brs in
         S.mk (Tm_match (t, ret_opt, brs, None)) Range.dummyRange

--- a/src/reflection/FStar.Reflection.Data.fsti
+++ b/src/reflection/FStar.Reflection.Data.fsti
@@ -49,7 +49,7 @@ type pattern =
     | Pat_Cons     of fv * option (list universe) * list (pattern * bool)
     | Pat_Var      of bv
     | Pat_Wild     of bv
-    | Pat_Dot_Term of bv * term
+    | Pat_Dot_Term of option term
 
 type branch = pattern * term
 

--- a/src/reflection/FStar.Reflection.Embeddings.fst
+++ b/src/reflection/FStar.Reflection.Embeddings.fst
@@ -357,9 +357,8 @@ let rec e_pattern' () =
             S.mk_Tm_app ref_Pat_Var.t [S.as_arg (embed e_bv rng bv)] rng
         | Pat_Wild bv ->
             S.mk_Tm_app ref_Pat_Wild.t [S.as_arg (embed e_bv rng bv)] rng
-        | Pat_Dot_Term (bv, t) ->
-            S.mk_Tm_app ref_Pat_Dot_Term.t [S.as_arg (embed e_bv rng bv);
-                                            S.as_arg (embed e_term rng t)]
+        | Pat_Dot_Term eopt ->
+            S.mk_Tm_app ref_Pat_Dot_Term.t [S.as_arg (embed (e_option e_term) rng eopt)]
                         rng
     in
     let rec unembed_pattern w (t : term) : option pattern =
@@ -384,10 +383,9 @@ let rec e_pattern' () =
             BU.bind_opt (unembed' w e_bv bv) (fun bv ->
             Some <| Pat_Wild bv)
 
-        | Tm_fvar fv, [(bv, _); (t, _)] when S.fv_eq_lid fv ref_Pat_Dot_Term.lid ->
-            BU.bind_opt (unembed' w e_bv bv) (fun bv ->
-            BU.bind_opt (unembed' w e_term t) (fun t ->
-            Some <| Pat_Dot_Term (bv, t)))
+        | Tm_fvar fv, [(eopt, _)] when S.fv_eq_lid fv ref_Pat_Dot_Term.lid ->
+            BU.bind_opt (unembed' w (e_option e_term) eopt) (fun eopt ->
+            Some <| Pat_Dot_Term eopt)
 
         | _ ->
             if w then

--- a/src/reflection/FStar.Reflection.NBEEmbeddings.fst
+++ b/src/reflection/FStar.Reflection.NBEEmbeddings.fst
@@ -287,8 +287,8 @@ let rec e_pattern' () =
             mkConstruct ref_Pat_Var.fv [] [as_arg (embed e_bv cb bv)]
         | Pat_Wild bv ->
             mkConstruct ref_Pat_Wild.fv [] [as_arg (embed e_bv cb bv)]
-        | Pat_Dot_Term (bv, t) ->
-            mkConstruct ref_Pat_Dot_Term.fv [] [as_arg (embed e_bv cb bv); as_arg (embed e_term cb t)]
+        | Pat_Dot_Term eopt ->
+            mkConstruct ref_Pat_Dot_Term.fv [] [as_arg (embed (e_option e_term) cb eopt)]
     in
     let unembed_pattern cb (t : t) : option pattern =
         match t.nbe_t with
@@ -310,10 +310,9 @@ let rec e_pattern' () =
             BU.bind_opt (unembed e_bv cb bv) (fun bv ->
             Some <| Pat_Wild bv)
 
-        | Construct (fv, [], [(t, _); (bv, _)]) when S.fv_eq_lid fv ref_Pat_Dot_Term.lid ->
-            BU.bind_opt (unembed e_bv cb bv) (fun bv ->
-            BU.bind_opt (unembed e_term cb t) (fun t ->
-            Some <| Pat_Dot_Term (bv, t)))
+        | Construct (fv, [], [(eopt, _)]) when S.fv_eq_lid fv ref_Pat_Dot_Term.lid ->
+            BU.bind_opt (unembed (e_option e_term) cb eopt) (fun eopt ->
+            Some <| Pat_Dot_Term eopt)
 
         | _ ->
             Err.log_issue Range.dummyRange (Err.Warning_NotEmbedded, (BU.format1 "Not an embedded pattern: %s" (t_to_string t)));

--- a/src/smtencoding/FStar.SMTEncoding.EncodeTerm.fst
+++ b/src/smtencoding/FStar.SMTEncoding.EncodeTerm.fst
@@ -1311,7 +1311,7 @@ and encode_pat (env:env_t) (pat:S.pat) : (env_t * pattern) =
 
     let rec mk_projections pat (scrutinee:term) =
         match pat.v with
-        | Pat_dot_term (x, _)
+        | Pat_dot_term _ -> []
         | Pat_var x
         | Pat_wild x -> [x, scrutinee]
 

--- a/src/syntax/FStar.Syntax.Print.fst
+++ b/src/syntax/FStar.Syntax.Print.fst
@@ -423,10 +423,10 @@ and pat_to_string x =
                    | Some us ->
                      U.format1 " %s " (List.map univ_to_string us |> String.concat " "))
                 (List.map (fun (x, b) -> let p = pat_to_string x in if b then "#"^p else p) pats |> String.concat " ")
-    | Pat_dot_term (x, _) ->
+    | Pat_dot_term topt ->
       if Options.print_bound_var_types()
-      then U.format2 ".%s:%s" (bv_to_string x) (term_to_string x.sort)
-      else U.format1 ".%s" (bv_to_string x)
+      then U.format1 ".%s" (if topt = None then "_" else topt |> U.must |> term_to_string)
+      else "._"
     | Pat_var x ->
       if Options.print_bound_var_types()
       then U.format2 "%s:%s" (bv_to_string x) (term_to_string x.sort)

--- a/src/syntax/FStar.Syntax.Resugar.fst
+++ b/src/syntax/FStar.Syntax.Resugar.fst
@@ -1083,8 +1083,7 @@ and resugar_pat' env (p:S.pat) (branch_bv: set bv) : A.pattern =
     not (List.existsML (fun (pattern, is_implicit) ->
              let might_be_used =
                match pattern.v with
-               | Pat_var bv
-               | Pat_dot_term (bv, _) -> Util.set_mem bv branch_bv
+               | Pat_var bv -> Util.set_mem bv branch_bv
                | Pat_wild _ -> false
                | _ -> true in
              is_implicit && might_be_used) args) in
@@ -1163,9 +1162,7 @@ and resugar_pat' env (p:S.pat) (branch_bv: set bv) : A.pattern =
 
     | Pat_wild _ -> mk (A.PatWild (to_arg_qual imp_opt, []))
 
-    | Pat_dot_term (bv, term) ->
-      (* TODO : this should never be resugared unless in a comment *)
-      resugar_bv_as_pat' env bv (Some A.Implicit) branch_bv (Some term)
+    | Pat_dot_term _ -> mk (A.PatWild (Some A.Implicit, []))
   in
   aux p None
 // FIXME inspect uses of resugar_arg_qual and resugar_imp

--- a/src/syntax/FStar.Syntax.Subst.fst
+++ b/src/syntax/FStar.Syntax.Subst.fst
@@ -331,11 +331,10 @@ let subst_pat' s p : (pat * int) =
         let x = {x with sort=subst' s x.sort} in
         {p with v=Pat_wild x}, n + 1 //these may be in scope in the inferred types of other terms, so shift the index
 
-      | Pat_dot_term(x, t0) ->
+      | Pat_dot_term eopt ->
         let s = shift_subst' n s in
-        let x = {x with sort=subst' s x.sort} in
-        let t0 = subst' s t0 in
-        {p with v=Pat_dot_term(x, t0)}, n //these are not in scope, so don't shift the index
+        let eopt = U.map_option (subst' s) eopt in
+        {p with v=Pat_dot_term eopt}, n
   in aux 0 p
 
 let push_subst_lcomp s lopt = match lopt with
@@ -592,10 +591,9 @@ let open_pat (p:pat) : pat * subst_t =
             let sub = DB(0, x')::shift_subst 1 sub in
             {p with v=Pat_wild x'}, sub
 
-        | Pat_dot_term(x, t0) ->
-            let x = {x with sort=subst sub x.sort} in
-            let t0 = subst sub t0 in
-            {p with v=Pat_dot_term(x, t0)}, sub //these are not in scope, so don't shift the index
+        | Pat_dot_term eopt ->
+            let eopt = U.map_option (subst sub) eopt in
+            {p with v=Pat_dot_term eopt}, sub
     in
     open_pat_aux [] p
 
@@ -647,10 +645,9 @@ let close_pat p =
          let sub = NM(x, 0)::shift_subst 1 sub in
          {p with v=Pat_wild x}, sub
 
-       | Pat_dot_term(x, t0) ->
-         let x = {x with sort=subst sub x.sort} in
-         let t0 = subst sub t0 in
-         {p with v=Pat_dot_term(x, t0)}, sub in //these are not in scope, so don't shift the index
+       | Pat_dot_term eopt ->
+         let eopt = U.map_option (subst sub) eopt in
+         {p with v=Pat_dot_term eopt}, sub in
     aux [] p
 
 let close_branch (p, wopt, e) =
@@ -872,8 +869,8 @@ let rec deep_compress (t:term) : term =
           {p with v=Pat_var (elim_bv x)}
         | Pat_wild x ->
           {p with v=Pat_wild (elim_bv x)}
-        | Pat_dot_term(x, t0) ->
-          {p with v=Pat_dot_term(elim_bv x, deep_compress t0)}
+        | Pat_dot_term eopt ->
+          {p with v=Pat_dot_term (U.map_option deep_compress eopt)}
         | Pat_cons (fv, us_opt, pats) ->
           let us_opt =
             match us_opt with

--- a/src/syntax/FStar.Syntax.Syntax.fst
+++ b/src/syntax/FStar.Syntax.Syntax.fst
@@ -271,7 +271,7 @@ let rec eq_pat (p1 : pat) (p2 : pat) : bool =
         else false
     | Pat_var _, Pat_var _ -> true
     | Pat_wild _, Pat_wild _ -> true
-    | Pat_dot_term (bv1, t1), Pat_dot_term (bv2, t2) -> true //&& term_eq t1 t2
+    | Pat_dot_term _, Pat_dot_term _ -> true
     | _, _ -> false
 
 ///////////////////////////////////////////////////////////////////////

--- a/src/syntax/FStar.Syntax.Syntax.fsti
+++ b/src/syntax/FStar.Syntax.Syntax.fsti
@@ -178,7 +178,8 @@ and pat' =
   | Pat_cons     of fv * option universes * list (pat * bool)    (* flag marks an explicitly provided implicit *)
   | Pat_var      of bv                                           (* a pattern bound variable (linear in a pattern) *)
   | Pat_wild     of bv                                           (* need stable names for even the wild patterns *)
-  | Pat_dot_term of bv * term                                    (* dot patterns: determined by other elements in the pattern and type *)
+  | Pat_dot_term of option term                                  (* dot patterns: determined by other elements in the pattern *)
+                                                                 (* the option term is the optionally resolved pat dot term *)
 and letbinding = {  //let f : forall u1..un. M t = e
     lbname :lbname;          //f
     lbunivs:list univ_name; //u1..un

--- a/src/tactics/FStar.Tactics.Basic.fst
+++ b/src/tactics/FStar.Tactics.Basic.fst
@@ -1592,7 +1592,7 @@ let t_destruct (s_tm : term) : tac (list (fv * Z.t)) = wrap_err "destruct" <|
                         let subst = List.map (fun (({binder_bv=bv}), (t, _)) -> NT (bv, t)) d_ps_a_ps in
                         let bs = SS.subst_binders subst bs in
                         let subpats_1 = List.map (fun (({binder_bv=bv}), (t, _)) ->
-                                                 (mk_pat (Pat_dot_term (bv, t)), true)) d_ps_a_ps in
+                                                 (mk_pat (Pat_dot_term (Some t)), true)) d_ps_a_ps in
                         let subpats_2 = List.map (fun ({binder_bv=bv;binder_qual=bq}) ->
                                                  (mk_pat (Pat_var bv), is_imp bq)) bs in
                         let subpats = subpats_1 @ subpats_2 in
@@ -1777,7 +1777,7 @@ let rec inspect (t:term) : tac term_view = wrap_err "inspect" (
             | Pat_cons (fv, us_opt, ps) -> Pat_Cons (fv, us_opt, List.map (fun (p, b) -> inspect_pat p, b) ps)
             | Pat_var bv -> Pat_Var bv
             | Pat_wild bv -> Pat_Wild bv
-            | Pat_dot_term (bv, t) -> Pat_Dot_Term (bv, t)
+            | Pat_dot_term eopt -> Pat_Dot_Term eopt
         in
         let brs = List.map SS.open_branch brs in
         let brs = List.map (function (pat, _, t) -> (inspect_pat pat, t)) brs in
@@ -1846,7 +1846,7 @@ let pack' (tv:term_view) (leave_curried:bool) : tac term =
             | Pat_Cons (fv, us_opt, ps) -> wrap <| Pat_cons (fv, us_opt, List.map (fun (p, b) -> pack_pat p, b) ps)
             | Pat_Var  bv -> wrap <| Pat_var bv
             | Pat_Wild bv -> wrap <| Pat_wild bv
-            | Pat_Dot_Term (bv, t) -> wrap <| Pat_dot_term (bv, t)
+            | Pat_Dot_Term eopt -> wrap <| Pat_dot_term eopt
         in
         let brs = List.map (function (pat, t) -> (pack_pat pat, None, t)) brs in
         let brs = List.map SS.close_branch brs in

--- a/src/typechecker/FStar.TypeChecker.NBE.fst
+++ b/src/typechecker/FStar.TypeChecker.NBE.fst
@@ -574,10 +574,9 @@ let rec translate (cfg:config) (bs:list t) (e:term) : t =
             | Pat_wild bvar ->
               let x = S.new_bv None (readback cfg (translate cfg bs bvar.sort)) in
               (mkAccuVar x :: bs, Pat_wild x)
-            | Pat_dot_term (bvar, tm) ->
-              let x = S.new_bv None (readback cfg (translate cfg bs bvar.sort)) in
+            | Pat_dot_term eopt ->
               (bs,
-               Pat_dot_term (x, readback cfg (translate cfg bs tm)))
+               Pat_dot_term (BU.map_option (fun e -> readback cfg (translate cfg bs e)) eopt))
           in
           (bs, {p with v = p_new}) (* keep the info and change the pattern *)
         in

--- a/src/typechecker/FStar.TypeChecker.Normalize.fst
+++ b/src/typechecker/FStar.TypeChecker.Normalize.fst
@@ -473,10 +473,9 @@ and rebuild_closure cfg env stack t =
             | Pat_wild x ->
               let x = {x with sort=non_tail_inline_closure_env cfg env x.sort} in
               {p with v=Pat_wild x}, dummy::env
-            | Pat_dot_term(x, t) ->
-              let x = {x with sort=non_tail_inline_closure_env cfg env x.sort} in
-              let t = non_tail_inline_closure_env cfg env t in
-              {p with v=Pat_dot_term(x, t)}, env
+            | Pat_dot_term eopt ->
+              let eopt = BU.map_option (non_tail_inline_closure_env cfg env) eopt in
+              {p with v=Pat_dot_term eopt}, env
           in
           let pat, env = norm_pat env pat in
           let w_opt =
@@ -2750,10 +2749,9 @@ and rebuild (cfg:cfg) (env:env) (stack:stack) (t:term) : term =
             | Pat_wild x ->
               let x = {x with sort=norm_or_whnf env x.sort} in
               {p with v=Pat_wild x}, dummy::env
-            | Pat_dot_term(x, t) ->
-              let x = {x with sort=norm_or_whnf env x.sort} in
-              let t = norm_or_whnf env t in
-              {p with v=Pat_dot_term(x, t)}, env
+            | Pat_dot_term eopt ->
+              let eopt = BU.map_option (norm_or_whnf env) eopt in
+              {p with v=Pat_dot_term eopt}, env
           in
           let norm_branches () =
             match env with

--- a/src/typechecker/FStar.TypeChecker.PatternUtils.fst
+++ b/src/typechecker/FStar.TypeChecker.PatternUtils.fst
@@ -219,9 +219,8 @@ let pat_as_exp (introduce_bv_uvars:bool)
                 let x = {x with sort=t} in
                 let e, _,  g' = new_implicit_var_aux "pat_dot_term" (S.range_of_bv  x) env t Allow_ghost None in
                 let p = {p with v=Pat_dot_term(x, e)} in
-                ([], [], [], env, e, conj_guard g g', p)
-              | _ ->
-                [], [], [], env, e, Env.trivial_guard, p)
+                [], [], [], env, e, conj_guard g g', p
+              | _ -> [], [], [], env, e, Env.trivial_guard, p)
 
            | Pat_wild x ->
              let x, g, env = intro_bv env x in

--- a/src/typechecker/FStar.TypeChecker.TcInductive.fst
+++ b/src/typechecker/FStar.TypeChecker.TcInductive.fst
@@ -918,7 +918,7 @@ let mk_discriminator_and_indexed_projectors iquals                   (* Qualifie
                         let arg_pats = all_params |> List.mapi (fun j ({binder_bv=x;binder_qual=imp}) ->
                             let b = S.is_bqual_implicit imp in
                             if b && j < ntps
-                            then pos (Pat_dot_term (S.gen_bv (string_of_id x.ppname) None tun, tun)), b
+                            then pos (Pat_dot_term None), b
                             else pos (Pat_wild (S.gen_bv (string_of_id x.ppname) None tun)), b)
                         in
                         let pat_true = pos (S.Pat_cons (S.lid_as_fv lid delta_constant (Some fvq), None, arg_pats)), None, U.exp_true_bool in
@@ -1011,7 +1011,7 @@ let mk_discriminator_and_indexed_projectors iquals                   (* Qualifie
                   if i+ntps=j  //this is the one to project
                   then pos (Pat_var projection), b
                   else if b && j < ntps
-                  then pos (Pat_dot_term (S.gen_bv (string_of_id x.ppname) None tun, tun)), b
+                  then pos (Pat_dot_term None), b
                   else pos (Pat_wild (S.gen_bv (string_of_id x.ppname) None tun)), b)
               in
               let pat = pos (S.Pat_cons (S.lid_as_fv lid delta_constant (Some fvq), None, arg_pats)), None, S.bv_to_name projection in

--- a/src/typechecker/FStar.TypeChecker.TcTerm.fst
+++ b/src/typechecker/FStar.TypeChecker.TcTerm.fst
@@ -3270,9 +3270,9 @@ and tc_pat env (pat_t:typ) (p0:pat) :
                 | [] -> []
                 | (hd, b)::simple_pats ->
                   match hd.v with
-                  | Pat_dot_term(x, e) ->
-                    let e = SS.subst subst e in
-                    let hd = {hd with v=Pat_dot_term(x, e)} in
+                  | Pat_dot_term eopt ->
+                    let eopt = BU.map_option (SS.subst subst) eopt in
+                    let hd = {hd with v=Pat_dot_term eopt} in
                     (hd, b) :: aux simple_pats bvs sub_pats
                   | Pat_var x ->
                     begin

--- a/src/typechecker/FStar.TypeChecker.Util.fst
+++ b/src/typechecker/FStar.TypeChecker.Util.fst
@@ -448,8 +448,10 @@ let extract_let_rec_annotation env {lbname=lbname; lbunivs=univ_vars; lbtyp=t; l
         in
         vars,  mk (Tm_app(head, args))
 
-    | Pat_dot_term(x, e) ->
-        [], e
+    | Pat_dot_term eopt ->
+        (match eopt with
+         | None -> failwith "TcUtil::decorated_pattern_as_term: dot pattern not resolved"
+         | Some e -> [], e)
 
 
 (*********************************************************************************************)

--- a/ulib/FStar.Reflection.Data.fsti
+++ b/ulib/FStar.Reflection.Data.fsti
@@ -41,7 +41,7 @@ type pattern =
                                                     // implicit argument
     | Pat_Var      : bv -> pattern                  // Pattern bound variable
     | Pat_Wild     : bv -> pattern                  // Wildcard (GM: why is this not Pat_var too?)
-    | Pat_Dot_Term : bv -> term -> pattern          // Dot pattern: resolved by other elements in the pattern and type
+    | Pat_Dot_Term : option term -> pattern          // Dot pattern: resolved by other elements in the pattern and type
 
 type branch = pattern * term  // | pattern -> term
 

--- a/ulib/FStar.Tactics.Derived.fst
+++ b/ulib/FStar.Tactics.Derived.fst
@@ -911,10 +911,8 @@ and visit_pat (ff : term -> Tac term) (p:pattern) : Tac pattern =
   | Pat_Wild bv ->
       let bv = on_sort_bv (visit_tm ff) bv in
       Pat_Wild bv
-  | Pat_Dot_Term bv term ->
-      let bv = on_sort_bv (visit_tm ff) bv in
-      let term = visit_tm ff term in
-      Pat_Dot_Term bv term
+  | Pat_Dot_Term eopt ->
+      Pat_Dot_Term (map_opt (visit_tm ff) eopt)
 and visit_comp (ff : term -> Tac term) (c : comp) : Tac comp =
   let cv = inspect_comp c in
   let cv' =

--- a/ulib/experimental/FStar.InteractiveHelpers.Base.fst
+++ b/ulib/experimental/FStar.InteractiveHelpers.Base.fst
@@ -567,10 +567,8 @@ and deep_apply_subst_in_pattern e pat subst =
   | Pat_Wild bv ->
     let bv, subst = deep_apply_subst_in_bv e bv subst in
     Pat_Wild bv, subst
-  | Pat_Dot_Term bv t ->
-    let bv, subst = deep_apply_subst_in_bv e bv subst in
-    let t = deep_apply_subst e t subst in
-    Pat_Dot_Term bv t, subst
+  | Pat_Dot_Term eopt ->
+    Pat_Dot_Term (map_opt (fun t -> deep_apply_subst e t subst) eopt), subst
 
 /// The substitution functions actually used in the rest of the meta F* functions.
 /// For now, we use normalization because even though it is sometimes slow it

--- a/ulib/experimental/FStar.InteractiveHelpers.ExploreTerm.fst
+++ b/ulib/experimental/FStar.InteractiveHelpers.ExploreTerm.fst
@@ -568,10 +568,7 @@ and explore_pattern dbg dfs #a f x ge0 pat =
   | Pat_Var bv | Pat_Wild bv ->
     let ge1 = genv_push_bv ge0 bv false None in
     ge1, x, Continue
-  | Pat_Dot_Term bv t ->
-    (* TODO: I'm not sure what this is *)
-    let ge1 = genv_push_bv ge0 bv false None in
-    ge1, x, Continue
+  | Pat_Dot_Term _ -> ge0, x, Continue
 
 (*** Variables in a term *)
 /// Returns the list of free variables contained in a term

--- a/ulib/prims.fst
+++ b/ulib/prims.fst
@@ -726,4 +726,4 @@ let labeled (r: range) (msg: string) (b: Type) : Type = b
 (** THIS IS MEANT TO BE KEPT IN SYNC WITH FStar.CheckedFiles.fs
     Incrementing this forces all .checked files to be invalidated *)
 irreducible
-let __cache_version_number__ = 43
+let __cache_version_number__ = 44


### PR DESCRIPTION
* Reusing the dot pattern solutions inferred in the first phase of the typechecker for phase two.

* Changing the syntax of dot patterns to `Pat_dot_term (option term) `, i.e., the AST node only keeps the optionally resolved dot pattern term. This option is `None` initially, resolved to `Some` in phase 1, and typechecked in phase 2.

* Corresponding changes in the reflection API for dot patterns.

The main subtlety in reusing dot pattern solutions is to handle the logical guards generated when typechecking the solution terms in phase 2. They are folded into the final VC, after appropriately closed with the pattern variables that appear in them (e.g., in the case of nested patterns).

I have a local Everest green and Zeta also builds. I had to remove one type annotation from a mitls function, will debug it more.