### PR TITLE
Fixing an admit and adding a new SMT option

### DIFF
--- a/src/basic/FStar.Options.fst
+++ b/src/basic/FStar.Options.fst
@@ -253,6 +253,7 @@ let defaults =
       ("z3rlimit_factor"              , Int 1);
       ("z3seed"                       , Int 0);
       ("z3cliopt"                     , List []);
+      ("z3smtopt"                     , List []);
       ("__no_positivity"              , Bool false);
       ("__tactics_nbe"                , Bool false);
       ("warn_error"                   , List []);
@@ -310,6 +311,7 @@ let set_verification_options o =
     "no_tactics";
     "vcgen.optimize_bind_as_seq";
     "z3cliopt";
+    "z3smtopt";    
     "z3refresh";
     "z3rlimit";
     "z3rlimit_factor";
@@ -426,6 +428,7 @@ let get_verify_module           ()      = lookup_opt "verify_module"            
 let get_version                 ()      = lookup_opt "version"                  as_bool
 let get_warn_default_effects    ()      = lookup_opt "warn_default_effects"     as_bool
 let get_z3cliopt                ()      = lookup_opt "z3cliopt"                 (as_list as_string)
+let get_z3smtopt                ()      = lookup_opt "z3smtopt"                 (as_list as_string)
 let get_z3refresh               ()      = lookup_opt "z3refresh"                as_bool
 let get_z3rlimit                ()      = lookup_opt "z3rlimit"                 as_int
 let get_z3rlimit_factor         ()      = lookup_opt "z3rlimit_factor"          as_int
@@ -1233,6 +1236,11 @@ let rec specs_with_types warn_unsafe : list (char * string * opt_type * string) 
          "Z3 command line options");
 
        ( noshort,
+         "z3smtopt",
+         ReverseAccumulated (SimpleStr "option"),
+         "Z3 options in smt2 format");
+
+       ( noshort,
         "z3refresh",
         Const (Bool true),
         "Restart Z3 after each query; useful for ensuring proof robustness");
@@ -1398,6 +1406,7 @@ let settable = function
     | "vcgen.optimize_bind_as_seq"
     | "warn_error"
     | "z3cliopt"
+    | "z3smtopt"    
     | "z3refresh"
     | "z3rlimit"
     | "z3rlimit_factor"
@@ -1783,6 +1792,7 @@ let z3_exe                       () = match get_smt () with
                                     | None -> Platform.exe "z3"
                                     | Some s -> s
 let z3_cliopt                    () = get_z3cliopt                    ()
+let z3_smtopt                    () = get_z3smtopt                    ()
 let z3_refresh                   () = get_z3refresh                   ()
 let z3_rlimit                    () = get_z3rlimit                    ()
 let z3_rlimit_factor             () = get_z3rlimit_factor             ()
@@ -2039,6 +2049,7 @@ let get_vconfig () =
     no_tactics                                = get_no_tactics ();
     vcgen_optimize_bind_as_seq                = get_vcgen_optimize_bind_as_seq ();
     z3cliopt                                  = get_z3cliopt ();
+    z3smtopt                                  = get_z3smtopt ();    
     z3refresh                                 = get_z3refresh ();
     z3rlimit                                  = get_z3rlimit ();
     z3rlimit_factor                           = get_z3rlimit_factor ();
@@ -2076,6 +2087,7 @@ let set_vconfig (vcfg:vconfig) : unit =
   set_option "no_tactics"                                (Bool vcfg.no_tactics);
   set_option "vcgen.optimize_bind_as_seq"                (option_as String vcfg.vcgen_optimize_bind_as_seq);
   set_option "z3cliopt"                                  (List (List.map String vcfg.z3cliopt));
+  set_option "z3smtopt"                                  (List (List.map String vcfg.z3smtopt));  
   set_option "z3refresh"                                 (Bool vcfg.z3refresh);
   set_option "z3rlimit"                                  (Int vcfg.z3rlimit);
   set_option "z3rlimit_factor"                           (Int vcfg.z3rlimit_factor);

--- a/src/basic/FStar.Options.fsti
+++ b/src/basic/FStar.Options.fsti
@@ -227,6 +227,7 @@ val warn_default_effects        : unit    -> bool
 val with_saved_options          : (unit -> 'a) -> 'a
 val z3_exe                      : unit    -> string
 val z3_cliopt                   : unit    -> list string
+val z3_smtopt                   : unit    -> list string
 val z3_refresh                  : unit    -> bool
 val z3_rlimit                   : unit    -> int
 val z3_rlimit_factor            : unit    -> int

--- a/src/ocaml-output/FStar_Options.ml
+++ b/src/ocaml-output/FStar_Options.ml
@@ -375,6 +375,7 @@ let (defaults : (Prims.string * option_val) Prims.list) =
   ("z3rlimit_factor", (Int Prims.int_one));
   ("z3seed", (Int Prims.int_zero));
   ("z3cliopt", (List []));
+  ("z3smtopt", (List []));
   ("__no_positivity", (Bool false));
   ("__tactics_nbe", (Bool false));
   ("warn_error", (List []));
@@ -429,6 +430,7 @@ let (set_verification_options : optionstate -> unit) =
       "no_tactics";
       "vcgen.optimize_bind_as_seq";
       "z3cliopt";
+      "z3smtopt";
       "z3refresh";
       "z3rlimit";
       "z3rlimit_factor";
@@ -651,6 +653,8 @@ let (get_warn_default_effects : unit -> Prims.bool) =
   fun uu___ -> lookup_opt "warn_default_effects" as_bool
 let (get_z3cliopt : unit -> Prims.string Prims.list) =
   fun uu___ -> lookup_opt "z3cliopt" (as_list as_string)
+let (get_z3smtopt : unit -> Prims.string Prims.list) =
+  fun uu___ -> lookup_opt "z3smtopt" (as_list as_string)
 let (get_z3refresh : unit -> Prims.bool) =
   fun uu___ -> lookup_opt "z3refresh" as_bool
 let (get_z3rlimit : unit -> Prims.int) =
@@ -949,7 +953,7 @@ let (interp_quake_arg : Prims.string -> (Prims.int * Prims.int * Prims.bool))
           let uu___ = ios f1 in let uu___1 = ios f2 in (uu___, uu___1, true)
         else failwith "unexpected value for --quake"
     | uu___ -> failwith "unexpected value for --quake"
-let (uu___406 : (((Prims.string -> unit) -> unit) * (Prims.string -> unit)))
+let (uu___407 : (((Prims.string -> unit) -> unit) * (Prims.string -> unit)))
   =
   let cb = FStar_Compiler_Util.mk_ref FStar_Pervasives_Native.None in
   let set1 f =
@@ -961,11 +965,11 @@ let (uu___406 : (((Prims.string -> unit) -> unit) * (Prims.string -> unit)))
     | FStar_Pervasives_Native.Some f -> f msg in
   (set1, call)
 let (set_option_warning_callback_aux : (Prims.string -> unit) -> unit) =
-  match uu___406 with
+  match uu___407 with
   | (set_option_warning_callback_aux1, option_warning_callback) ->
       set_option_warning_callback_aux1
 let (option_warning_callback : Prims.string -> unit) =
-  match uu___406 with
+  match uu___407 with
   | (set_option_warning_callback_aux1, option_warning_callback1) ->
       option_warning_callback1
 let (set_option_warning_callback : (Prims.string -> unit) -> unit) =
@@ -1296,6 +1300,8 @@ let rec (specs_with_types :
       "Warn when (a -> b) is desugared to (a -> Tot b)");
     (FStar_Getopt.noshort, "z3cliopt",
       (ReverseAccumulated (SimpleStr "option")), "Z3 command line options");
+    (FStar_Getopt.noshort, "z3smtopt",
+      (ReverseAccumulated (SimpleStr "option")), "Z3 options in smt2 format");
     (FStar_Getopt.noshort, "z3refresh", (Const (Bool true)),
       "Restart Z3 after each query; useful for ensuring proof robustness");
     (FStar_Getopt.noshort, "z3rlimit", (IntStr "positive_integer"),
@@ -1436,6 +1442,7 @@ let (settable : Prims.string -> Prims.bool) =
     | "vcgen.optimize_bind_as_seq" -> true
     | "warn_error" -> true
     | "z3cliopt" -> true
+    | "z3smtopt" -> true
     | "z3refresh" -> true
     | "z3rlimit" -> true
     | "z3rlimit_factor" -> true
@@ -1457,7 +1464,7 @@ let (settable_specs :
     (FStar_Compiler_List.filter
        (fun uu___ ->
           match uu___ with | (uu___1, x, uu___2, uu___3) -> settable x))
-let (uu___589 :
+let (uu___591 :
   (((unit -> FStar_Getopt.parse_cmdline_res) -> unit) *
     (unit -> FStar_Getopt.parse_cmdline_res)))
   =
@@ -1474,11 +1481,11 @@ let (uu___589 :
   (set1, call)
 let (set_error_flags_callback_aux :
   (unit -> FStar_Getopt.parse_cmdline_res) -> unit) =
-  match uu___589 with
+  match uu___591 with
   | (set_error_flags_callback_aux1, set_error_flags) ->
       set_error_flags_callback_aux1
 let (set_error_flags : unit -> FStar_Getopt.parse_cmdline_res) =
-  match uu___589 with
+  match uu___591 with
   | (set_error_flags_callback_aux1, set_error_flags1) -> set_error_flags1
 let (set_error_flags_callback :
   (unit -> FStar_Getopt.parse_cmdline_res) -> unit) =
@@ -2023,6 +2030,8 @@ let (z3_exe : unit -> Prims.string) =
     | FStar_Pervasives_Native.Some s -> s
 let (z3_cliopt : unit -> Prims.string Prims.list) =
   fun uu___ -> get_z3cliopt ()
+let (z3_smtopt : unit -> Prims.string Prims.list) =
+  fun uu___ -> get_z3smtopt ()
 let (z3_refresh : unit -> Prims.bool) = fun uu___ -> get_z3refresh ()
 let (z3_rlimit : unit -> Prims.int) = fun uu___ -> get_z3rlimit ()
 let (z3_rlimit_factor : unit -> Prims.int) =
@@ -2387,12 +2396,13 @@ let (get_vconfig : unit -> FStar_VConfig.vconfig) =
       let uu___19 = get_no_tactics () in
       let uu___20 = get_vcgen_optimize_bind_as_seq () in
       let uu___21 = get_z3cliopt () in
-      let uu___22 = get_z3refresh () in
-      let uu___23 = get_z3rlimit () in
-      let uu___24 = get_z3rlimit_factor () in
-      let uu___25 = get_z3seed () in
-      let uu___26 = get_trivial_pre_for_unannotated_effectful_fns () in
-      let uu___27 = get_reuse_hint_for () in
+      let uu___22 = get_z3smtopt () in
+      let uu___23 = get_z3refresh () in
+      let uu___24 = get_z3rlimit () in
+      let uu___25 = get_z3rlimit_factor () in
+      let uu___26 = get_z3seed () in
+      let uu___27 = get_trivial_pre_for_unannotated_effectful_fns () in
+      let uu___28 = get_reuse_hint_for () in
       {
         FStar_VConfig.initial_fuel = uu___1;
         FStar_VConfig.max_fuel = uu___2;
@@ -2415,12 +2425,13 @@ let (get_vconfig : unit -> FStar_VConfig.vconfig) =
         FStar_VConfig.no_tactics = uu___19;
         FStar_VConfig.vcgen_optimize_bind_as_seq = uu___20;
         FStar_VConfig.z3cliopt = uu___21;
-        FStar_VConfig.z3refresh = uu___22;
-        FStar_VConfig.z3rlimit = uu___23;
-        FStar_VConfig.z3rlimit_factor = uu___24;
-        FStar_VConfig.z3seed = uu___25;
-        FStar_VConfig.trivial_pre_for_unannotated_effectful_fns = uu___26;
-        FStar_VConfig.reuse_hint_for = uu___27
+        FStar_VConfig.z3smtopt = uu___22;
+        FStar_VConfig.z3refresh = uu___23;
+        FStar_VConfig.z3rlimit = uu___24;
+        FStar_VConfig.z3rlimit_factor = uu___25;
+        FStar_VConfig.z3seed = uu___26;
+        FStar_VConfig.trivial_pre_for_unannotated_effectful_fns = uu___27;
+        FStar_VConfig.reuse_hint_for = uu___28
       } in
     vcfg
 let (set_vconfig : FStar_VConfig.vconfig -> unit) =
@@ -2464,13 +2475,19 @@ let (set_vconfig : FStar_VConfig.vconfig -> unit) =
            vcfg.FStar_VConfig.z3cliopt in
        List uu___22 in
      set_option "z3cliopt" uu___21);
+    (let uu___22 =
+       let uu___23 =
+         FStar_Compiler_List.map (fun uu___24 -> String uu___24)
+           vcfg.FStar_VConfig.z3smtopt in
+       List uu___23 in
+     set_option "z3smtopt" uu___22);
     set_option "z3refresh" (Bool (vcfg.FStar_VConfig.z3refresh));
     set_option "z3rlimit" (Int (vcfg.FStar_VConfig.z3rlimit));
     set_option "z3rlimit_factor" (Int (vcfg.FStar_VConfig.z3rlimit_factor));
     set_option "z3seed" (Int (vcfg.FStar_VConfig.z3seed));
     set_option "trivial_pre_for_unannotated_effectful_fns"
       (Bool (vcfg.FStar_VConfig.trivial_pre_for_unannotated_effectful_fns));
-    (let uu___27 =
-       option_as (fun uu___28 -> String uu___28)
+    (let uu___28 =
+       option_as (fun uu___29 -> String uu___29)
          vcfg.FStar_VConfig.reuse_hint_for in
-     set_option "reuse_hint_for" uu___27)
+     set_option "reuse_hint_for" uu___28)

--- a/src/ocaml-output/FStar_SMTEncoding_EncodeTerm.ml
+++ b/src/ocaml-output/FStar_SMTEncoding_EncodeTerm.ml
@@ -580,32 +580,35 @@ let is_BitVector_primitive :
       match ((head.FStar_Syntax_Syntax.n), args) with
       | (FStar_Syntax_Syntax.Tm_fvar fv, (sz_arg, uu___)::uu___1::uu___2::[])
           ->
-          (((((((((((FStar_Syntax_Syntax.fv_eq_lid fv
-                       FStar_Parser_Const.bv_and_lid)
+          ((((((((((((FStar_Syntax_Syntax.fv_eq_lid fv
+                        FStar_Parser_Const.bv_and_lid)
+                       ||
+                       (FStar_Syntax_Syntax.fv_eq_lid fv
+                          FStar_Parser_Const.bv_xor_lid))
                       ||
                       (FStar_Syntax_Syntax.fv_eq_lid fv
-                         FStar_Parser_Const.bv_xor_lid))
+                         FStar_Parser_Const.bv_or_lid))
                      ||
                      (FStar_Syntax_Syntax.fv_eq_lid fv
-                        FStar_Parser_Const.bv_or_lid))
+                        FStar_Parser_Const.bv_add_lid))
                     ||
                     (FStar_Syntax_Syntax.fv_eq_lid fv
-                       FStar_Parser_Const.bv_add_lid))
+                       FStar_Parser_Const.bv_sub_lid))
                    ||
                    (FStar_Syntax_Syntax.fv_eq_lid fv
-                      FStar_Parser_Const.bv_sub_lid))
+                      FStar_Parser_Const.bv_shift_left_lid))
                   ||
                   (FStar_Syntax_Syntax.fv_eq_lid fv
-                     FStar_Parser_Const.bv_shift_left_lid))
+                     FStar_Parser_Const.bv_shift_right_lid))
                  ||
                  (FStar_Syntax_Syntax.fv_eq_lid fv
-                    FStar_Parser_Const.bv_shift_right_lid))
+                    FStar_Parser_Const.bv_udiv_lid))
                 ||
                 (FStar_Syntax_Syntax.fv_eq_lid fv
-                   FStar_Parser_Const.bv_udiv_lid))
+                   FStar_Parser_Const.bv_mod_lid))
                ||
                (FStar_Syntax_Syntax.fv_eq_lid fv
-                  FStar_Parser_Const.bv_mod_lid))
+                  FStar_Parser_Const.bv_ult_lid))
               ||
               (FStar_Syntax_Syntax.fv_eq_lid fv
                  FStar_Parser_Const.bv_uext_lid))

--- a/src/ocaml-output/FStar_SMTEncoding_Solver.ml
+++ b/src/ocaml-output/FStar_SMTEncoding_Solver.ml
@@ -1642,31 +1642,38 @@ type solver_cfg =
   {
   seed: Prims.int ;
   cliopt: Prims.string Prims.list ;
+  smtopt: Prims.string Prims.list ;
   facts: (Prims.string Prims.list * Prims.bool) Prims.list ;
   valid_intro: Prims.bool ;
   valid_elim: Prims.bool }
 let (__proj__Mksolver_cfg__item__seed : solver_cfg -> Prims.int) =
   fun projectee ->
     match projectee with
-    | { seed; cliopt; facts; valid_intro; valid_elim;_} -> seed
+    | { seed; cliopt; smtopt; facts; valid_intro; valid_elim;_} -> seed
 let (__proj__Mksolver_cfg__item__cliopt :
   solver_cfg -> Prims.string Prims.list) =
   fun projectee ->
     match projectee with
-    | { seed; cliopt; facts; valid_intro; valid_elim;_} -> cliopt
+    | { seed; cliopt; smtopt; facts; valid_intro; valid_elim;_} -> cliopt
+let (__proj__Mksolver_cfg__item__smtopt :
+  solver_cfg -> Prims.string Prims.list) =
+  fun projectee ->
+    match projectee with
+    | { seed; cliopt; smtopt; facts; valid_intro; valid_elim;_} -> smtopt
 let (__proj__Mksolver_cfg__item__facts :
   solver_cfg -> (Prims.string Prims.list * Prims.bool) Prims.list) =
   fun projectee ->
     match projectee with
-    | { seed; cliopt; facts; valid_intro; valid_elim;_} -> facts
+    | { seed; cliopt; smtopt; facts; valid_intro; valid_elim;_} -> facts
 let (__proj__Mksolver_cfg__item__valid_intro : solver_cfg -> Prims.bool) =
   fun projectee ->
     match projectee with
-    | { seed; cliopt; facts; valid_intro; valid_elim;_} -> valid_intro
+    | { seed; cliopt; smtopt; facts; valid_intro; valid_elim;_} ->
+        valid_intro
 let (__proj__Mksolver_cfg__item__valid_elim : solver_cfg -> Prims.bool) =
   fun projectee ->
     match projectee with
-    | { seed; cliopt; facts; valid_intro; valid_elim;_} -> valid_elim
+    | { seed; cliopt; smtopt; facts; valid_intro; valid_elim;_} -> valid_elim
 let (_last_cfg :
   solver_cfg FStar_Pervasives_Native.option FStar_Compiler_Effect.ref) =
   FStar_Compiler_Util.mk_ref FStar_Pervasives_Native.None
@@ -1674,14 +1681,16 @@ let (get_cfg : FStar_TypeChecker_Env.env -> solver_cfg) =
   fun env ->
     let uu___ = FStar_Options.z3_seed () in
     let uu___1 = FStar_Options.z3_cliopt () in
-    let uu___2 = FStar_Options.smtencoding_valid_intro () in
-    let uu___3 = FStar_Options.smtencoding_valid_elim () in
+    let uu___2 = FStar_Options.z3_smtopt () in
+    let uu___3 = FStar_Options.smtencoding_valid_intro () in
+    let uu___4 = FStar_Options.smtencoding_valid_elim () in
     {
       seed = uu___;
       cliopt = uu___1;
+      smtopt = uu___2;
       facts = (env.FStar_TypeChecker_Env.proof_ns);
-      valid_intro = uu___2;
-      valid_elim = uu___3
+      valid_intro = uu___3;
+      valid_elim = uu___4
     }
 let (save_cfg : FStar_TypeChecker_Env.env -> unit) =
   fun env ->

--- a/src/ocaml-output/FStar_SMTEncoding_Z3.ml
+++ b/src/ocaml-output/FStar_SMTEncoding_Z3.ml
@@ -734,21 +734,6 @@ let (z3_options : Prims.string FStar_Compiler_Effect.ref) =
     "(set-option :global-decls false)\n(set-option :smt.mbqi false)\n(set-option :auto_config false)\n(set-option :produce-unsat-cores true)\n(set-option :model true)\n(set-option :smt.case_split 3)\n(set-option :smt.relevancy 2)\n"
 let (set_z3_options : Prims.string -> unit) =
   fun opts -> FStar_Compiler_Effect.op_Colon_Equals z3_options opts
-let (cli_as_options : Prims.string Prims.list -> Prims.string) =
-  fun clis ->
-    let uu___ =
-      FStar_Compiler_List.collect
-        (fun cli ->
-           FStar_Compiler_List.collect
-             (fun opt ->
-                match FStar_Compiler_Util.split opt "=" with
-                | lhs::rhs::[] ->
-                    let uu___1 =
-                      FStar_Compiler_Util.format2 "(set-option :%s %s)" lhs
-                        rhs in
-                    [uu___1]
-                | uu___1 -> []) (FStar_Compiler_Util.split cli " ")) clis in
-    FStar_Compiler_Effect.op_Bar_Greater uu___ (FStar_String.concat "\n")
 let (init : unit -> unit) = fun uu___ -> ()
 let (finish : unit -> unit) = fun uu___ -> ()
 let (fresh_scope : scope_t FStar_Compiler_Effect.ref) =
@@ -879,7 +864,9 @@ let (mk_input :
       let options = FStar_Compiler_Effect.op_Bang z3_options in
       let options1 =
         let uu___ =
-          let uu___1 = FStar_Options.z3_cliopt () in cli_as_options uu___1 in
+          let uu___1 = FStar_Options.z3_smtopt () in
+          FStar_Compiler_Effect.op_Bar_Greater uu___1
+            (FStar_String.concat "\n") in
         Prims.op_Hat options uu___ in
       (let uu___1 = FStar_Options.print_z3_statistics () in
        if uu___1 then context_profile theory else ());

--- a/src/ocaml-output/FStar_SMTEncoding_Z3.ml
+++ b/src/ocaml-output/FStar_SMTEncoding_Z3.ml
@@ -734,6 +734,21 @@ let (z3_options : Prims.string FStar_Compiler_Effect.ref) =
     "(set-option :global-decls false)\n(set-option :smt.mbqi false)\n(set-option :auto_config false)\n(set-option :produce-unsat-cores true)\n(set-option :model true)\n(set-option :smt.case_split 3)\n(set-option :smt.relevancy 2)\n"
 let (set_z3_options : Prims.string -> unit) =
   fun opts -> FStar_Compiler_Effect.op_Colon_Equals z3_options opts
+let (cli_as_options : Prims.string Prims.list -> Prims.string) =
+  fun clis ->
+    let uu___ =
+      FStar_Compiler_List.collect
+        (fun cli ->
+           FStar_Compiler_List.collect
+             (fun opt ->
+                match FStar_Compiler_Util.split opt "=" with
+                | lhs::rhs::[] ->
+                    let uu___1 =
+                      FStar_Compiler_Util.format2 "(set-option :%s %s)" lhs
+                        rhs in
+                    [uu___1]
+                | uu___1 -> []) (FStar_Compiler_Util.split cli " ")) clis in
+    FStar_Compiler_Effect.op_Bar_Greater uu___ (FStar_String.concat "\n")
 let (init : unit -> unit) = fun uu___ -> ()
 let (finish : unit -> unit) = fun uu___ -> ()
 let (fresh_scope : scope_t FStar_Compiler_Effect.ref) =
@@ -862,6 +877,10 @@ let (mk_input :
   fun fresh ->
     fun theory ->
       let options = FStar_Compiler_Effect.op_Bang z3_options in
+      let options1 =
+        let uu___ =
+          let uu___1 = FStar_Options.z3_cliopt () in cli_as_options uu___1 in
+        Prims.op_Hat options uu___ in
       (let uu___1 = FStar_Options.print_z3_statistics () in
        if uu___1 then context_profile theory else ());
       (let uu___1 =
@@ -885,7 +904,7 @@ let (mk_input :
            | (prefix, check_sat, suffix) ->
                let pp =
                  FStar_Compiler_List.map
-                   (FStar_SMTEncoding_Term.declToSmt options) in
+                   (FStar_SMTEncoding_Term.declToSmt options1) in
                let suffix1 = check_sat :: suffix in
                let ps_lines = pp prefix in
                let ss_lines = pp suffix1 in
@@ -898,7 +917,7 @@ let (mk_input :
                    let uu___5 =
                      FStar_Compiler_Effect.op_Bar_Greater prefix
                        (FStar_Compiler_List.map
-                          (FStar_SMTEncoding_Term.declToSmt_no_caps options)) in
+                          (FStar_SMTEncoding_Term.declToSmt_no_caps options1)) in
                    FStar_Compiler_Effect.op_Bar_Greater uu___5
                      (FStar_String.concat "\n")
                  else ps in
@@ -910,7 +929,7 @@ let (mk_input :
            (let uu___4 =
               let uu___5 =
                 FStar_Compiler_List.map
-                  (FStar_SMTEncoding_Term.declToSmt options) theory in
+                  (FStar_SMTEncoding_Term.declToSmt options1) theory in
               FStar_Compiler_Effect.op_Bar_Greater uu___5
                 (FStar_String.concat "\n") in
             (uu___4, FStar_Pervasives_Native.None)) in

--- a/src/ocaml-output/FStar_Syntax_Embeddings.ml
+++ b/src/ocaml-output/FStar_Syntax_Embeddings.ml
@@ -1790,8 +1790,8 @@ let (e_vconfig : FStar_VConfig.vconfig embedding) =
                                                 let uu___44 =
                                                   let uu___45 =
                                                     let uu___46 =
-                                                      embed e_bool
-                                                        vcfg.FStar_VConfig.z3refresh in
+                                                      embed e_string_list
+                                                        vcfg.FStar_VConfig.z3smtopt in
                                                     uu___46 rng
                                                       FStar_Pervasives_Native.None
                                                       norm in
@@ -1801,8 +1801,8 @@ let (e_vconfig : FStar_VConfig.vconfig embedding) =
                                                   let uu___46 =
                                                     let uu___47 =
                                                       let uu___48 =
-                                                        embed e_fsint
-                                                          vcfg.FStar_VConfig.z3rlimit in
+                                                        embed e_bool
+                                                          vcfg.FStar_VConfig.z3refresh in
                                                       uu___48 rng
                                                         FStar_Pervasives_Native.None
                                                         norm in
@@ -1813,7 +1813,7 @@ let (e_vconfig : FStar_VConfig.vconfig embedding) =
                                                       let uu___49 =
                                                         let uu___50 =
                                                           embed e_fsint
-                                                            vcfg.FStar_VConfig.z3rlimit_factor in
+                                                            vcfg.FStar_VConfig.z3rlimit in
                                                         uu___50 rng
                                                           FStar_Pervasives_Native.None
                                                           norm in
@@ -1824,7 +1824,7 @@ let (e_vconfig : FStar_VConfig.vconfig embedding) =
                                                         let uu___51 =
                                                           let uu___52 =
                                                             embed e_fsint
-                                                              vcfg.FStar_VConfig.z3seed in
+                                                              vcfg.FStar_VConfig.z3rlimit_factor in
                                                           uu___52 rng
                                                             FStar_Pervasives_Native.None
                                                             norm in
@@ -1834,8 +1834,8 @@ let (e_vconfig : FStar_VConfig.vconfig embedding) =
                                                         let uu___52 =
                                                           let uu___53 =
                                                             let uu___54 =
-                                                              embed e_bool
-                                                                vcfg.FStar_VConfig.trivial_pre_for_unannotated_effectful_fns in
+                                                              embed e_fsint
+                                                                vcfg.FStar_VConfig.z3seed in
                                                             uu___54 rng
                                                               FStar_Pervasives_Native.None
                                                               norm in
@@ -1845,17 +1845,31 @@ let (e_vconfig : FStar_VConfig.vconfig embedding) =
                                                           let uu___54 =
                                                             let uu___55 =
                                                               let uu___56 =
-                                                                let uu___57 =
-                                                                  e_option
-                                                                    e_string in
-                                                                embed uu___57
-                                                                  vcfg.FStar_VConfig.reuse_hint_for in
+                                                                embed e_bool
+                                                                  vcfg.FStar_VConfig.trivial_pre_for_unannotated_effectful_fns in
                                                               uu___56 rng
                                                                 FStar_Pervasives_Native.None
                                                                 norm in
                                                             FStar_Syntax_Syntax.as_arg
                                                               uu___55 in
-                                                          [uu___54] in
+                                                          let uu___55 =
+                                                            let uu___56 =
+                                                              let uu___57 =
+                                                                let uu___58 =
+                                                                  let uu___59
+                                                                    =
+                                                                    e_option
+                                                                    e_string in
+                                                                  embed
+                                                                    uu___59
+                                                                    vcfg.FStar_VConfig.reuse_hint_for in
+                                                                uu___58 rng
+                                                                  FStar_Pervasives_Native.None
+                                                                  norm in
+                                                              FStar_Syntax_Syntax.as_arg
+                                                                uu___57 in
+                                                            [uu___56] in
+                                                          uu___54 :: uu___55 in
                                                         uu___52 :: uu___53 in
                                                       uu___50 :: uu___51 in
                                                     uu___48 :: uu___49 in
@@ -1908,114 +1922,98 @@ let (e_vconfig : FStar_VConfig.vconfig embedding) =
                                                              uu___17)::
             (tcnorm, uu___18)::(no_plugins, uu___19)::(no_tactics, uu___20)::
             (vcgen_optimize_bind_as_seq, uu___21)::(z3cliopt, uu___22)::
-            (z3refresh, uu___23)::(z3rlimit, uu___24)::(z3rlimit_factor,
-                                                        uu___25)::(z3seed,
-                                                                   uu___26)::
-            (trivial_pre_for_unannotated_effectful_fns, uu___27)::(reuse_hint_for,
-                                                                   uu___28)::[])
-             when
+            (z3smtopt, uu___23)::(z3refresh, uu___24)::(z3rlimit, uu___25)::
+            (z3rlimit_factor, uu___26)::(z3seed, uu___27)::(trivial_pre_for_unannotated_effectful_fns,
+                                                            uu___28)::
+            (reuse_hint_for, uu___29)::[]) when
              FStar_Syntax_Syntax.fv_eq_lid fv
                FStar_Parser_Const.mkvconfig_lid
              ->
-             let uu___29 =
-               let uu___30 = unembed e_fsint initial_fuel in uu___30 w norm in
-             FStar_Compiler_Util.bind_opt uu___29
+             let uu___30 =
+               let uu___31 = unembed e_fsint initial_fuel in uu___31 w norm in
+             FStar_Compiler_Util.bind_opt uu___30
                (fun initial_fuel1 ->
-                  let uu___30 =
-                    let uu___31 = unembed e_fsint max_fuel in uu___31 w norm in
-                  FStar_Compiler_Util.bind_opt uu___30
+                  let uu___31 =
+                    let uu___32 = unembed e_fsint max_fuel in uu___32 w norm in
+                  FStar_Compiler_Util.bind_opt uu___31
                     (fun max_fuel1 ->
-                       let uu___31 =
-                         let uu___32 = unembed e_fsint initial_ifuel in
-                         uu___32 w norm in
-                       FStar_Compiler_Util.bind_opt uu___31
+                       let uu___32 =
+                         let uu___33 = unembed e_fsint initial_ifuel in
+                         uu___33 w norm in
+                       FStar_Compiler_Util.bind_opt uu___32
                          (fun initial_ifuel1 ->
-                            let uu___32 =
-                              let uu___33 = unembed e_fsint max_ifuel in
-                              uu___33 w norm in
-                            FStar_Compiler_Util.bind_opt uu___32
+                            let uu___33 =
+                              let uu___34 = unembed e_fsint max_ifuel in
+                              uu___34 w norm in
+                            FStar_Compiler_Util.bind_opt uu___33
                               (fun max_ifuel1 ->
-                                 let uu___33 =
-                                   let uu___34 = unembed e_bool detail_errors in
-                                   uu___34 w norm in
-                                 FStar_Compiler_Util.bind_opt uu___33
+                                 let uu___34 =
+                                   let uu___35 = unembed e_bool detail_errors in
+                                   uu___35 w norm in
+                                 FStar_Compiler_Util.bind_opt uu___34
                                    (fun detail_errors1 ->
-                                      let uu___34 =
-                                        let uu___35 =
+                                      let uu___35 =
+                                        let uu___36 =
                                           unembed e_bool detail_hint_replay in
-                                        uu___35 w norm in
-                                      FStar_Compiler_Util.bind_opt uu___34
+                                        uu___36 w norm in
+                                      FStar_Compiler_Util.bind_opt uu___35
                                         (fun detail_hint_replay1 ->
-                                           let uu___35 =
-                                             let uu___36 =
+                                           let uu___36 =
+                                             let uu___37 =
                                                unembed e_bool no_smt in
-                                             uu___36 w norm in
+                                             uu___37 w norm in
                                            FStar_Compiler_Util.bind_opt
-                                             uu___35
+                                             uu___36
                                              (fun no_smt1 ->
-                                                let uu___36 =
-                                                  let uu___37 =
+                                                let uu___37 =
+                                                  let uu___38 =
                                                     unembed e_fsint quake_lo in
-                                                  uu___37 w norm in
+                                                  uu___38 w norm in
                                                 FStar_Compiler_Util.bind_opt
-                                                  uu___36
+                                                  uu___37
                                                   (fun quake_lo1 ->
-                                                     let uu___37 =
-                                                       let uu___38 =
+                                                     let uu___38 =
+                                                       let uu___39 =
                                                          unembed e_fsint
                                                            quake_hi in
-                                                       uu___38 w norm in
+                                                       uu___39 w norm in
                                                      FStar_Compiler_Util.bind_opt
-                                                       uu___37
+                                                       uu___38
                                                        (fun quake_hi1 ->
-                                                          let uu___38 =
-                                                            let uu___39 =
+                                                          let uu___39 =
+                                                            let uu___40 =
                                                               unembed e_bool
                                                                 quake_keep in
-                                                            uu___39 w norm in
+                                                            uu___40 w norm in
                                                           FStar_Compiler_Util.bind_opt
-                                                            uu___38
+                                                            uu___39
                                                             (fun quake_keep1
                                                                ->
-                                                               let uu___39 =
-                                                                 let uu___40
+                                                               let uu___40 =
+                                                                 let uu___41
                                                                    =
                                                                    unembed
                                                                     e_bool
                                                                     retry in
-                                                                 uu___40 w
+                                                                 uu___41 w
                                                                    norm in
                                                                FStar_Compiler_Util.bind_opt
-                                                                 uu___39
+                                                                 uu___40
                                                                  (fun retry1
-                                                                    ->
-                                                                    let uu___40
-                                                                    =
-                                                                    let uu___41
-                                                                    =
-                                                                    unembed
-                                                                    e_bool
-                                                                    smtencoding_elim_box in
-                                                                    uu___41 w
-                                                                    norm in
-                                                                    FStar_Compiler_Util.bind_opt
-                                                                    uu___40
-                                                                    (fun
-                                                                    smtencoding_elim_box1
                                                                     ->
                                                                     let uu___41
                                                                     =
                                                                     let uu___42
                                                                     =
                                                                     unembed
-                                                                    e_string
-                                                                    smtencoding_nl_arith_repr in
+                                                                    e_bool
+                                                                    smtencoding_elim_box in
                                                                     uu___42 w
                                                                     norm in
                                                                     FStar_Compiler_Util.bind_opt
                                                                     uu___41
                                                                     (fun
-                                                                    smtencoding_nl_arith_repr1
+                                                                    smtencoding_elim_box1
                                                                     ->
                                                                     let uu___42
                                                                     =
@@ -2023,27 +2021,27 @@ let (e_vconfig : FStar_VConfig.vconfig embedding) =
                                                                     =
                                                                     unembed
                                                                     e_string
-                                                                    smtencoding_l_arith_repr in
+                                                                    smtencoding_nl_arith_repr in
                                                                     uu___43 w
                                                                     norm in
                                                                     FStar_Compiler_Util.bind_opt
                                                                     uu___42
                                                                     (fun
-                                                                    smtencoding_l_arith_repr1
+                                                                    smtencoding_nl_arith_repr1
                                                                     ->
                                                                     let uu___43
                                                                     =
                                                                     let uu___44
                                                                     =
                                                                     unembed
-                                                                    e_bool
-                                                                    smtencoding_valid_intro in
+                                                                    e_string
+                                                                    smtencoding_l_arith_repr in
                                                                     uu___44 w
                                                                     norm in
                                                                     FStar_Compiler_Util.bind_opt
                                                                     uu___43
                                                                     (fun
-                                                                    smtencoding_valid_intro1
+                                                                    smtencoding_l_arith_repr1
                                                                     ->
                                                                     let uu___44
                                                                     =
@@ -2051,13 +2049,13 @@ let (e_vconfig : FStar_VConfig.vconfig embedding) =
                                                                     =
                                                                     unembed
                                                                     e_bool
-                                                                    smtencoding_valid_elim in
+                                                                    smtencoding_valid_intro in
                                                                     uu___45 w
                                                                     norm in
                                                                     FStar_Compiler_Util.bind_opt
                                                                     uu___44
                                                                     (fun
-                                                                    smtencoding_valid_elim1
+                                                                    smtencoding_valid_intro1
                                                                     ->
                                                                     let uu___45
                                                                     =
@@ -2065,13 +2063,13 @@ let (e_vconfig : FStar_VConfig.vconfig embedding) =
                                                                     =
                                                                     unembed
                                                                     e_bool
-                                                                    tcnorm in
+                                                                    smtencoding_valid_elim in
                                                                     uu___46 w
                                                                     norm in
                                                                     FStar_Compiler_Util.bind_opt
                                                                     uu___45
                                                                     (fun
-                                                                    tcnorm1
+                                                                    smtencoding_valid_elim1
                                                                     ->
                                                                     let uu___46
                                                                     =
@@ -2079,13 +2077,13 @@ let (e_vconfig : FStar_VConfig.vconfig embedding) =
                                                                     =
                                                                     unembed
                                                                     e_bool
-                                                                    no_plugins in
+                                                                    tcnorm in
                                                                     uu___47 w
                                                                     norm in
                                                                     FStar_Compiler_Util.bind_opt
                                                                     uu___46
                                                                     (fun
-                                                                    no_plugins1
+                                                                    tcnorm1
                                                                     ->
                                                                     let uu___47
                                                                     =
@@ -2093,87 +2091,87 @@ let (e_vconfig : FStar_VConfig.vconfig embedding) =
                                                                     =
                                                                     unembed
                                                                     e_bool
-                                                                    no_tactics in
+                                                                    no_plugins in
                                                                     uu___48 w
                                                                     norm in
                                                                     FStar_Compiler_Util.bind_opt
                                                                     uu___47
                                                                     (fun
-                                                                    no_tactics1
+                                                                    no_plugins1
                                                                     ->
                                                                     let uu___48
                                                                     =
                                                                     let uu___49
                                                                     =
-                                                                    let uu___50
-                                                                    =
-                                                                    e_option
-                                                                    e_string in
                                                                     unembed
-                                                                    uu___50
-                                                                    vcgen_optimize_bind_as_seq in
+                                                                    e_bool
+                                                                    no_tactics in
                                                                     uu___49 w
                                                                     norm in
                                                                     FStar_Compiler_Util.bind_opt
                                                                     uu___48
                                                                     (fun
-                                                                    vcgen_optimize_bind_as_seq1
+                                                                    no_tactics1
                                                                     ->
                                                                     let uu___49
                                                                     =
                                                                     let uu___50
                                                                     =
+                                                                    let uu___51
+                                                                    =
+                                                                    e_option
+                                                                    e_string in
                                                                     unembed
-                                                                    e_string_list
-                                                                    z3cliopt in
+                                                                    uu___51
+                                                                    vcgen_optimize_bind_as_seq in
                                                                     uu___50 w
                                                                     norm in
                                                                     FStar_Compiler_Util.bind_opt
                                                                     uu___49
                                                                     (fun
-                                                                    z3cliopt1
+                                                                    vcgen_optimize_bind_as_seq1
                                                                     ->
                                                                     let uu___50
                                                                     =
                                                                     let uu___51
                                                                     =
                                                                     unembed
-                                                                    e_bool
-                                                                    z3refresh in
+                                                                    e_string_list
+                                                                    z3cliopt in
                                                                     uu___51 w
                                                                     norm in
                                                                     FStar_Compiler_Util.bind_opt
                                                                     uu___50
                                                                     (fun
-                                                                    z3refresh1
+                                                                    z3cliopt1
                                                                     ->
                                                                     let uu___51
                                                                     =
                                                                     let uu___52
                                                                     =
                                                                     unembed
-                                                                    e_fsint
-                                                                    z3rlimit in
+                                                                    e_string_list
+                                                                    z3smtopt in
                                                                     uu___52 w
                                                                     norm in
                                                                     FStar_Compiler_Util.bind_opt
                                                                     uu___51
                                                                     (fun
-                                                                    z3rlimit1
+                                                                    z3smtopt1
                                                                     ->
                                                                     let uu___52
                                                                     =
                                                                     let uu___53
                                                                     =
                                                                     unembed
-                                                                    e_fsint
-                                                                    z3rlimit_factor in
+                                                                    e_bool
+                                                                    z3refresh in
                                                                     uu___53 w
                                                                     norm in
                                                                     FStar_Compiler_Util.bind_opt
                                                                     uu___52
                                                                     (fun
-                                                                    z3rlimit_factor1
+                                                                    z3refresh1
                                                                     ->
                                                                     let uu___53
                                                                     =
@@ -2181,43 +2179,71 @@ let (e_vconfig : FStar_VConfig.vconfig embedding) =
                                                                     =
                                                                     unembed
                                                                     e_fsint
-                                                                    z3seed in
+                                                                    z3rlimit in
                                                                     uu___54 w
                                                                     norm in
                                                                     FStar_Compiler_Util.bind_opt
                                                                     uu___53
                                                                     (fun
-                                                                    z3seed1
+                                                                    z3rlimit1
                                                                     ->
                                                                     let uu___54
                                                                     =
                                                                     let uu___55
                                                                     =
                                                                     unembed
-                                                                    e_bool
-                                                                    trivial_pre_for_unannotated_effectful_fns in
+                                                                    e_fsint
+                                                                    z3rlimit_factor in
                                                                     uu___55 w
                                                                     norm in
                                                                     FStar_Compiler_Util.bind_opt
                                                                     uu___54
                                                                     (fun
-                                                                    trivial_pre_for_unannotated_effectful_fns1
+                                                                    z3rlimit_factor1
                                                                     ->
                                                                     let uu___55
                                                                     =
                                                                     let uu___56
                                                                     =
-                                                                    let uu___57
-                                                                    =
-                                                                    e_option
-                                                                    e_string in
                                                                     unembed
-                                                                    uu___57
-                                                                    reuse_hint_for in
+                                                                    e_fsint
+                                                                    z3seed in
                                                                     uu___56 w
                                                                     norm in
                                                                     FStar_Compiler_Util.bind_opt
                                                                     uu___55
+                                                                    (fun
+                                                                    z3seed1
+                                                                    ->
+                                                                    let uu___56
+                                                                    =
+                                                                    let uu___57
+                                                                    =
+                                                                    unembed
+                                                                    e_bool
+                                                                    trivial_pre_for_unannotated_effectful_fns in
+                                                                    uu___57 w
+                                                                    norm in
+                                                                    FStar_Compiler_Util.bind_opt
+                                                                    uu___56
+                                                                    (fun
+                                                                    trivial_pre_for_unannotated_effectful_fns1
+                                                                    ->
+                                                                    let uu___57
+                                                                    =
+                                                                    let uu___58
+                                                                    =
+                                                                    let uu___59
+                                                                    =
+                                                                    e_option
+                                                                    e_string in
+                                                                    unembed
+                                                                    uu___59
+                                                                    reuse_hint_for in
+                                                                    uu___58 w
+                                                                    norm in
+                                                                    FStar_Compiler_Util.bind_opt
+                                                                    uu___57
                                                                     (fun
                                                                     reuse_hint_for1
                                                                     ->
@@ -2283,6 +2309,9 @@ let (e_vconfig : FStar_VConfig.vconfig embedding) =
                                                                     FStar_VConfig.z3cliopt
                                                                     =
                                                                     z3cliopt1;
+                                                                    FStar_VConfig.z3smtopt
+                                                                    =
+                                                                    z3smtopt1;
                                                                     FStar_VConfig.z3refresh
                                                                     =
                                                                     z3refresh1;
@@ -2300,7 +2329,7 @@ let (e_vconfig : FStar_VConfig.vconfig embedding) =
                                                                     FStar_VConfig.reuse_hint_for
                                                                     =
                                                                     reuse_hint_for1
-                                                                    })))))))))))))))))))))))))))
+                                                                    }))))))))))))))))))))))))))))
          | uu___2 ->
              (if w
               then

--- a/src/ocaml-output/FStar_VConfig.ml
+++ b/src/ocaml-output/FStar_VConfig.ml
@@ -22,6 +22,7 @@ type vconfig =
   no_tactics: Prims.bool ;
   vcgen_optimize_bind_as_seq: Prims.string FStar_Pervasives_Native.option ;
   z3cliopt: Prims.string Prims.list ;
+  z3smtopt: Prims.string Prims.list ;
   z3refresh: Prims.bool ;
   z3rlimit: Prims.int ;
   z3rlimit_factor: Prims.int ;
@@ -36,7 +37,7 @@ let (__proj__Mkvconfig__item__initial_fuel : vconfig -> Prims.int) =
         smtencoding_elim_box; smtencoding_nl_arith_repr;
         smtencoding_l_arith_repr; smtencoding_valid_intro;
         smtencoding_valid_elim; tcnorm; no_plugins; no_tactics;
-        vcgen_optimize_bind_as_seq; z3cliopt; z3refresh; z3rlimit;
+        vcgen_optimize_bind_as_seq; z3cliopt; z3smtopt; z3refresh; z3rlimit;
         z3rlimit_factor; z3seed; trivial_pre_for_unannotated_effectful_fns;
         reuse_hint_for;_} -> initial_fuel
 let (__proj__Mkvconfig__item__max_fuel : vconfig -> Prims.int) =
@@ -47,7 +48,7 @@ let (__proj__Mkvconfig__item__max_fuel : vconfig -> Prims.int) =
         smtencoding_elim_box; smtencoding_nl_arith_repr;
         smtencoding_l_arith_repr; smtencoding_valid_intro;
         smtencoding_valid_elim; tcnorm; no_plugins; no_tactics;
-        vcgen_optimize_bind_as_seq; z3cliopt; z3refresh; z3rlimit;
+        vcgen_optimize_bind_as_seq; z3cliopt; z3smtopt; z3refresh; z3rlimit;
         z3rlimit_factor; z3seed; trivial_pre_for_unannotated_effectful_fns;
         reuse_hint_for;_} -> max_fuel
 let (__proj__Mkvconfig__item__initial_ifuel : vconfig -> Prims.int) =
@@ -58,7 +59,7 @@ let (__proj__Mkvconfig__item__initial_ifuel : vconfig -> Prims.int) =
         smtencoding_elim_box; smtencoding_nl_arith_repr;
         smtencoding_l_arith_repr; smtencoding_valid_intro;
         smtencoding_valid_elim; tcnorm; no_plugins; no_tactics;
-        vcgen_optimize_bind_as_seq; z3cliopt; z3refresh; z3rlimit;
+        vcgen_optimize_bind_as_seq; z3cliopt; z3smtopt; z3refresh; z3rlimit;
         z3rlimit_factor; z3seed; trivial_pre_for_unannotated_effectful_fns;
         reuse_hint_for;_} -> initial_ifuel
 let (__proj__Mkvconfig__item__max_ifuel : vconfig -> Prims.int) =
@@ -69,7 +70,7 @@ let (__proj__Mkvconfig__item__max_ifuel : vconfig -> Prims.int) =
         smtencoding_elim_box; smtencoding_nl_arith_repr;
         smtencoding_l_arith_repr; smtencoding_valid_intro;
         smtencoding_valid_elim; tcnorm; no_plugins; no_tactics;
-        vcgen_optimize_bind_as_seq; z3cliopt; z3refresh; z3rlimit;
+        vcgen_optimize_bind_as_seq; z3cliopt; z3smtopt; z3refresh; z3rlimit;
         z3rlimit_factor; z3seed; trivial_pre_for_unannotated_effectful_fns;
         reuse_hint_for;_} -> max_ifuel
 let (__proj__Mkvconfig__item__detail_errors : vconfig -> Prims.bool) =
@@ -80,7 +81,7 @@ let (__proj__Mkvconfig__item__detail_errors : vconfig -> Prims.bool) =
         smtencoding_elim_box; smtencoding_nl_arith_repr;
         smtencoding_l_arith_repr; smtencoding_valid_intro;
         smtencoding_valid_elim; tcnorm; no_plugins; no_tactics;
-        vcgen_optimize_bind_as_seq; z3cliopt; z3refresh; z3rlimit;
+        vcgen_optimize_bind_as_seq; z3cliopt; z3smtopt; z3refresh; z3rlimit;
         z3rlimit_factor; z3seed; trivial_pre_for_unannotated_effectful_fns;
         reuse_hint_for;_} -> detail_errors
 let (__proj__Mkvconfig__item__detail_hint_replay : vconfig -> Prims.bool) =
@@ -91,7 +92,7 @@ let (__proj__Mkvconfig__item__detail_hint_replay : vconfig -> Prims.bool) =
         smtencoding_elim_box; smtencoding_nl_arith_repr;
         smtencoding_l_arith_repr; smtencoding_valid_intro;
         smtencoding_valid_elim; tcnorm; no_plugins; no_tactics;
-        vcgen_optimize_bind_as_seq; z3cliopt; z3refresh; z3rlimit;
+        vcgen_optimize_bind_as_seq; z3cliopt; z3smtopt; z3refresh; z3rlimit;
         z3rlimit_factor; z3seed; trivial_pre_for_unannotated_effectful_fns;
         reuse_hint_for;_} -> detail_hint_replay
 let (__proj__Mkvconfig__item__no_smt : vconfig -> Prims.bool) =
@@ -102,7 +103,7 @@ let (__proj__Mkvconfig__item__no_smt : vconfig -> Prims.bool) =
         smtencoding_elim_box; smtencoding_nl_arith_repr;
         smtencoding_l_arith_repr; smtencoding_valid_intro;
         smtencoding_valid_elim; tcnorm; no_plugins; no_tactics;
-        vcgen_optimize_bind_as_seq; z3cliopt; z3refresh; z3rlimit;
+        vcgen_optimize_bind_as_seq; z3cliopt; z3smtopt; z3refresh; z3rlimit;
         z3rlimit_factor; z3seed; trivial_pre_for_unannotated_effectful_fns;
         reuse_hint_for;_} -> no_smt
 let (__proj__Mkvconfig__item__quake_lo : vconfig -> Prims.int) =
@@ -113,7 +114,7 @@ let (__proj__Mkvconfig__item__quake_lo : vconfig -> Prims.int) =
         smtencoding_elim_box; smtencoding_nl_arith_repr;
         smtencoding_l_arith_repr; smtencoding_valid_intro;
         smtencoding_valid_elim; tcnorm; no_plugins; no_tactics;
-        vcgen_optimize_bind_as_seq; z3cliopt; z3refresh; z3rlimit;
+        vcgen_optimize_bind_as_seq; z3cliopt; z3smtopt; z3refresh; z3rlimit;
         z3rlimit_factor; z3seed; trivial_pre_for_unannotated_effectful_fns;
         reuse_hint_for;_} -> quake_lo
 let (__proj__Mkvconfig__item__quake_hi : vconfig -> Prims.int) =
@@ -124,7 +125,7 @@ let (__proj__Mkvconfig__item__quake_hi : vconfig -> Prims.int) =
         smtencoding_elim_box; smtencoding_nl_arith_repr;
         smtencoding_l_arith_repr; smtencoding_valid_intro;
         smtencoding_valid_elim; tcnorm; no_plugins; no_tactics;
-        vcgen_optimize_bind_as_seq; z3cliopt; z3refresh; z3rlimit;
+        vcgen_optimize_bind_as_seq; z3cliopt; z3smtopt; z3refresh; z3rlimit;
         z3rlimit_factor; z3seed; trivial_pre_for_unannotated_effectful_fns;
         reuse_hint_for;_} -> quake_hi
 let (__proj__Mkvconfig__item__quake_keep : vconfig -> Prims.bool) =
@@ -135,7 +136,7 @@ let (__proj__Mkvconfig__item__quake_keep : vconfig -> Prims.bool) =
         smtencoding_elim_box; smtencoding_nl_arith_repr;
         smtencoding_l_arith_repr; smtencoding_valid_intro;
         smtencoding_valid_elim; tcnorm; no_plugins; no_tactics;
-        vcgen_optimize_bind_as_seq; z3cliopt; z3refresh; z3rlimit;
+        vcgen_optimize_bind_as_seq; z3cliopt; z3smtopt; z3refresh; z3rlimit;
         z3rlimit_factor; z3seed; trivial_pre_for_unannotated_effectful_fns;
         reuse_hint_for;_} -> quake_keep
 let (__proj__Mkvconfig__item__retry : vconfig -> Prims.bool) =
@@ -146,7 +147,7 @@ let (__proj__Mkvconfig__item__retry : vconfig -> Prims.bool) =
         smtencoding_elim_box; smtencoding_nl_arith_repr;
         smtencoding_l_arith_repr; smtencoding_valid_intro;
         smtencoding_valid_elim; tcnorm; no_plugins; no_tactics;
-        vcgen_optimize_bind_as_seq; z3cliopt; z3refresh; z3rlimit;
+        vcgen_optimize_bind_as_seq; z3cliopt; z3smtopt; z3refresh; z3rlimit;
         z3rlimit_factor; z3seed; trivial_pre_for_unannotated_effectful_fns;
         reuse_hint_for;_} -> retry
 let (__proj__Mkvconfig__item__smtencoding_elim_box : vconfig -> Prims.bool) =
@@ -157,7 +158,7 @@ let (__proj__Mkvconfig__item__smtencoding_elim_box : vconfig -> Prims.bool) =
         smtencoding_elim_box; smtencoding_nl_arith_repr;
         smtencoding_l_arith_repr; smtencoding_valid_intro;
         smtencoding_valid_elim; tcnorm; no_plugins; no_tactics;
-        vcgen_optimize_bind_as_seq; z3cliopt; z3refresh; z3rlimit;
+        vcgen_optimize_bind_as_seq; z3cliopt; z3smtopt; z3refresh; z3rlimit;
         z3rlimit_factor; z3seed; trivial_pre_for_unannotated_effectful_fns;
         reuse_hint_for;_} -> smtencoding_elim_box
 let (__proj__Mkvconfig__item__smtencoding_nl_arith_repr :
@@ -169,7 +170,7 @@ let (__proj__Mkvconfig__item__smtencoding_nl_arith_repr :
         smtencoding_elim_box; smtencoding_nl_arith_repr;
         smtencoding_l_arith_repr; smtencoding_valid_intro;
         smtencoding_valid_elim; tcnorm; no_plugins; no_tactics;
-        vcgen_optimize_bind_as_seq; z3cliopt; z3refresh; z3rlimit;
+        vcgen_optimize_bind_as_seq; z3cliopt; z3smtopt; z3refresh; z3rlimit;
         z3rlimit_factor; z3seed; trivial_pre_for_unannotated_effectful_fns;
         reuse_hint_for;_} -> smtencoding_nl_arith_repr
 let (__proj__Mkvconfig__item__smtencoding_l_arith_repr :
@@ -181,7 +182,7 @@ let (__proj__Mkvconfig__item__smtencoding_l_arith_repr :
         smtencoding_elim_box; smtencoding_nl_arith_repr;
         smtencoding_l_arith_repr; smtencoding_valid_intro;
         smtencoding_valid_elim; tcnorm; no_plugins; no_tactics;
-        vcgen_optimize_bind_as_seq; z3cliopt; z3refresh; z3rlimit;
+        vcgen_optimize_bind_as_seq; z3cliopt; z3smtopt; z3refresh; z3rlimit;
         z3rlimit_factor; z3seed; trivial_pre_for_unannotated_effectful_fns;
         reuse_hint_for;_} -> smtencoding_l_arith_repr
 let (__proj__Mkvconfig__item__smtencoding_valid_intro :
@@ -193,7 +194,7 @@ let (__proj__Mkvconfig__item__smtencoding_valid_intro :
         smtencoding_elim_box; smtencoding_nl_arith_repr;
         smtencoding_l_arith_repr; smtencoding_valid_intro;
         smtencoding_valid_elim; tcnorm; no_plugins; no_tactics;
-        vcgen_optimize_bind_as_seq; z3cliopt; z3refresh; z3rlimit;
+        vcgen_optimize_bind_as_seq; z3cliopt; z3smtopt; z3refresh; z3rlimit;
         z3rlimit_factor; z3seed; trivial_pre_for_unannotated_effectful_fns;
         reuse_hint_for;_} -> smtencoding_valid_intro
 let (__proj__Mkvconfig__item__smtencoding_valid_elim : vconfig -> Prims.bool)
@@ -205,7 +206,7 @@ let (__proj__Mkvconfig__item__smtencoding_valid_elim : vconfig -> Prims.bool)
         smtencoding_elim_box; smtencoding_nl_arith_repr;
         smtencoding_l_arith_repr; smtencoding_valid_intro;
         smtencoding_valid_elim; tcnorm; no_plugins; no_tactics;
-        vcgen_optimize_bind_as_seq; z3cliopt; z3refresh; z3rlimit;
+        vcgen_optimize_bind_as_seq; z3cliopt; z3smtopt; z3refresh; z3rlimit;
         z3rlimit_factor; z3seed; trivial_pre_for_unannotated_effectful_fns;
         reuse_hint_for;_} -> smtencoding_valid_elim
 let (__proj__Mkvconfig__item__tcnorm : vconfig -> Prims.bool) =
@@ -216,7 +217,7 @@ let (__proj__Mkvconfig__item__tcnorm : vconfig -> Prims.bool) =
         smtencoding_elim_box; smtencoding_nl_arith_repr;
         smtencoding_l_arith_repr; smtencoding_valid_intro;
         smtencoding_valid_elim; tcnorm; no_plugins; no_tactics;
-        vcgen_optimize_bind_as_seq; z3cliopt; z3refresh; z3rlimit;
+        vcgen_optimize_bind_as_seq; z3cliopt; z3smtopt; z3refresh; z3rlimit;
         z3rlimit_factor; z3seed; trivial_pre_for_unannotated_effectful_fns;
         reuse_hint_for;_} -> tcnorm
 let (__proj__Mkvconfig__item__no_plugins : vconfig -> Prims.bool) =
@@ -227,7 +228,7 @@ let (__proj__Mkvconfig__item__no_plugins : vconfig -> Prims.bool) =
         smtencoding_elim_box; smtencoding_nl_arith_repr;
         smtencoding_l_arith_repr; smtencoding_valid_intro;
         smtencoding_valid_elim; tcnorm; no_plugins; no_tactics;
-        vcgen_optimize_bind_as_seq; z3cliopt; z3refresh; z3rlimit;
+        vcgen_optimize_bind_as_seq; z3cliopt; z3smtopt; z3refresh; z3rlimit;
         z3rlimit_factor; z3seed; trivial_pre_for_unannotated_effectful_fns;
         reuse_hint_for;_} -> no_plugins
 let (__proj__Mkvconfig__item__no_tactics : vconfig -> Prims.bool) =
@@ -238,7 +239,7 @@ let (__proj__Mkvconfig__item__no_tactics : vconfig -> Prims.bool) =
         smtencoding_elim_box; smtencoding_nl_arith_repr;
         smtencoding_l_arith_repr; smtencoding_valid_intro;
         smtencoding_valid_elim; tcnorm; no_plugins; no_tactics;
-        vcgen_optimize_bind_as_seq; z3cliopt; z3refresh; z3rlimit;
+        vcgen_optimize_bind_as_seq; z3cliopt; z3smtopt; z3refresh; z3rlimit;
         z3rlimit_factor; z3seed; trivial_pre_for_unannotated_effectful_fns;
         reuse_hint_for;_} -> no_tactics
 let (__proj__Mkvconfig__item__vcgen_optimize_bind_as_seq :
@@ -250,7 +251,7 @@ let (__proj__Mkvconfig__item__vcgen_optimize_bind_as_seq :
         smtencoding_elim_box; smtencoding_nl_arith_repr;
         smtencoding_l_arith_repr; smtencoding_valid_intro;
         smtencoding_valid_elim; tcnorm; no_plugins; no_tactics;
-        vcgen_optimize_bind_as_seq; z3cliopt; z3refresh; z3rlimit;
+        vcgen_optimize_bind_as_seq; z3cliopt; z3smtopt; z3refresh; z3rlimit;
         z3rlimit_factor; z3seed; trivial_pre_for_unannotated_effectful_fns;
         reuse_hint_for;_} -> vcgen_optimize_bind_as_seq
 let (__proj__Mkvconfig__item__z3cliopt : vconfig -> Prims.string Prims.list)
@@ -262,9 +263,21 @@ let (__proj__Mkvconfig__item__z3cliopt : vconfig -> Prims.string Prims.list)
         smtencoding_elim_box; smtencoding_nl_arith_repr;
         smtencoding_l_arith_repr; smtencoding_valid_intro;
         smtencoding_valid_elim; tcnorm; no_plugins; no_tactics;
-        vcgen_optimize_bind_as_seq; z3cliopt; z3refresh; z3rlimit;
+        vcgen_optimize_bind_as_seq; z3cliopt; z3smtopt; z3refresh; z3rlimit;
         z3rlimit_factor; z3seed; trivial_pre_for_unannotated_effectful_fns;
         reuse_hint_for;_} -> z3cliopt
+let (__proj__Mkvconfig__item__z3smtopt : vconfig -> Prims.string Prims.list)
+  =
+  fun projectee ->
+    match projectee with
+    | { initial_fuel; max_fuel; initial_ifuel; max_ifuel; detail_errors;
+        detail_hint_replay; no_smt; quake_lo; quake_hi; quake_keep; retry;
+        smtencoding_elim_box; smtencoding_nl_arith_repr;
+        smtencoding_l_arith_repr; smtencoding_valid_intro;
+        smtencoding_valid_elim; tcnorm; no_plugins; no_tactics;
+        vcgen_optimize_bind_as_seq; z3cliopt; z3smtopt; z3refresh; z3rlimit;
+        z3rlimit_factor; z3seed; trivial_pre_for_unannotated_effectful_fns;
+        reuse_hint_for;_} -> z3smtopt
 let (__proj__Mkvconfig__item__z3refresh : vconfig -> Prims.bool) =
   fun projectee ->
     match projectee with
@@ -273,7 +286,7 @@ let (__proj__Mkvconfig__item__z3refresh : vconfig -> Prims.bool) =
         smtencoding_elim_box; smtencoding_nl_arith_repr;
         smtencoding_l_arith_repr; smtencoding_valid_intro;
         smtencoding_valid_elim; tcnorm; no_plugins; no_tactics;
-        vcgen_optimize_bind_as_seq; z3cliopt; z3refresh; z3rlimit;
+        vcgen_optimize_bind_as_seq; z3cliopt; z3smtopt; z3refresh; z3rlimit;
         z3rlimit_factor; z3seed; trivial_pre_for_unannotated_effectful_fns;
         reuse_hint_for;_} -> z3refresh
 let (__proj__Mkvconfig__item__z3rlimit : vconfig -> Prims.int) =
@@ -284,7 +297,7 @@ let (__proj__Mkvconfig__item__z3rlimit : vconfig -> Prims.int) =
         smtencoding_elim_box; smtencoding_nl_arith_repr;
         smtencoding_l_arith_repr; smtencoding_valid_intro;
         smtencoding_valid_elim; tcnorm; no_plugins; no_tactics;
-        vcgen_optimize_bind_as_seq; z3cliopt; z3refresh; z3rlimit;
+        vcgen_optimize_bind_as_seq; z3cliopt; z3smtopt; z3refresh; z3rlimit;
         z3rlimit_factor; z3seed; trivial_pre_for_unannotated_effectful_fns;
         reuse_hint_for;_} -> z3rlimit
 let (__proj__Mkvconfig__item__z3rlimit_factor : vconfig -> Prims.int) =
@@ -295,7 +308,7 @@ let (__proj__Mkvconfig__item__z3rlimit_factor : vconfig -> Prims.int) =
         smtencoding_elim_box; smtencoding_nl_arith_repr;
         smtencoding_l_arith_repr; smtencoding_valid_intro;
         smtencoding_valid_elim; tcnorm; no_plugins; no_tactics;
-        vcgen_optimize_bind_as_seq; z3cliopt; z3refresh; z3rlimit;
+        vcgen_optimize_bind_as_seq; z3cliopt; z3smtopt; z3refresh; z3rlimit;
         z3rlimit_factor; z3seed; trivial_pre_for_unannotated_effectful_fns;
         reuse_hint_for;_} -> z3rlimit_factor
 let (__proj__Mkvconfig__item__z3seed : vconfig -> Prims.int) =
@@ -306,7 +319,7 @@ let (__proj__Mkvconfig__item__z3seed : vconfig -> Prims.int) =
         smtencoding_elim_box; smtencoding_nl_arith_repr;
         smtencoding_l_arith_repr; smtencoding_valid_intro;
         smtencoding_valid_elim; tcnorm; no_plugins; no_tactics;
-        vcgen_optimize_bind_as_seq; z3cliopt; z3refresh; z3rlimit;
+        vcgen_optimize_bind_as_seq; z3cliopt; z3smtopt; z3refresh; z3rlimit;
         z3rlimit_factor; z3seed; trivial_pre_for_unannotated_effectful_fns;
         reuse_hint_for;_} -> z3seed
 let (__proj__Mkvconfig__item__trivial_pre_for_unannotated_effectful_fns :
@@ -318,7 +331,7 @@ let (__proj__Mkvconfig__item__trivial_pre_for_unannotated_effectful_fns :
         smtencoding_elim_box; smtencoding_nl_arith_repr;
         smtencoding_l_arith_repr; smtencoding_valid_intro;
         smtencoding_valid_elim; tcnorm; no_plugins; no_tactics;
-        vcgen_optimize_bind_as_seq; z3cliopt; z3refresh; z3rlimit;
+        vcgen_optimize_bind_as_seq; z3cliopt; z3smtopt; z3refresh; z3rlimit;
         z3rlimit_factor; z3seed; trivial_pre_for_unannotated_effectful_fns;
         reuse_hint_for;_} -> trivial_pre_for_unannotated_effectful_fns
 let (__proj__Mkvconfig__item__reuse_hint_for :
@@ -330,6 +343,6 @@ let (__proj__Mkvconfig__item__reuse_hint_for :
         smtencoding_elim_box; smtencoding_nl_arith_repr;
         smtencoding_l_arith_repr; smtencoding_valid_intro;
         smtencoding_valid_elim; tcnorm; no_plugins; no_tactics;
-        vcgen_optimize_bind_as_seq; z3cliopt; z3refresh; z3rlimit;
+        vcgen_optimize_bind_as_seq; z3cliopt; z3smtopt; z3refresh; z3rlimit;
         z3rlimit_factor; z3seed; trivial_pre_for_unannotated_effectful_fns;
         reuse_hint_for;_} -> reuse_hint_for

--- a/src/smtencoding/FStar.SMTEncoding.EncodeTerm.fst
+++ b/src/smtencoding/FStar.SMTEncoding.EncodeTerm.fst
@@ -331,7 +331,7 @@ let is_BitVector_primitive head args =
       || S.fv_eq_lid fv Const.bv_shift_right_lid
       || S.fv_eq_lid fv Const.bv_udiv_lid
       || S.fv_eq_lid fv Const.bv_mod_lid
-    //  || S.fv_eq_lid fv Const.bv_ult_lid
+      || S.fv_eq_lid fv Const.bv_ult_lid
       || S.fv_eq_lid fv Const.bv_uext_lid
       || S.fv_eq_lid fv Const.bv_mul_lid) &&
       (isInteger sz_arg.n)

--- a/src/smtencoding/FStar.SMTEncoding.Solver.fst
+++ b/src/smtencoding/FStar.SMTEncoding.Solver.fst
@@ -934,6 +934,7 @@ let ask_and_report_errors is_being_retried env all_labels prefix query query_ter
 type solver_cfg = {
   seed             : int;
   cliopt           : list string;
+  smtopt           : list string;  
   facts            : list (list string * bool);
   valid_intro      : bool;
   valid_elim       : bool;
@@ -944,6 +945,7 @@ let _last_cfg : ref (option solver_cfg) = BU.mk_ref None
 let get_cfg env : solver_cfg =
     { seed             = Options.z3_seed ()
     ; cliopt           = Options.z3_cliopt ()
+    ; smtopt           = Options.z3_smtopt ()    
     ; facts            = env.proof_ns
     ; valid_intro      = Options.smtencoding_valid_intro ()
     ; valid_elim       = Options.smtencoding_valid_elim ()

--- a/src/smtencoding/FStar.SMTEncoding.Z3.fst
+++ b/src/smtencoding/FStar.SMTEncoding.Z3.fst
@@ -429,6 +429,18 @@ let z3_options = BU.mk_ref
 let set_z3_options opts =
     z3_options := opts
 
+let cli_as_options clis =
+  List.collect
+    (fun cli ->
+      List.collect
+        (fun opt ->
+          match BU.split opt "=" with
+          | [lhs;rhs] -> [BU.format2 "(set-option :%s %s)" lhs rhs]
+          | _ -> [])
+        (BU.split cli " "))
+    clis
+  |> String.concat "\n"
+
 let init () =
     (* A no-op now that there's no concurrency *)
     ()
@@ -436,6 +448,7 @@ let init () =
 let finish () =
     (* A no-op now that there's no concurrency *)
     ()
+
 
 // bg_scope is a global, mutable variable that keeps a list of the declarations
 // that we have given to z3 so far. In order to allow rollback of history,
@@ -514,6 +527,7 @@ let context_profile (theory:list decl) =
 
 let mk_input fresh theory =
     let options = !z3_options in
+    let options = options ^ (cli_as_options (Options.z3_cliopt())) in
     if Options.print_z3_statistics() then context_profile theory;
     let r, hash =
         if Options.record_hints()

--- a/src/smtencoding/FStar.SMTEncoding.Z3.fst
+++ b/src/smtencoding/FStar.SMTEncoding.Z3.fst
@@ -429,18 +429,6 @@ let z3_options = BU.mk_ref
 let set_z3_options opts =
     z3_options := opts
 
-let cli_as_options clis =
-  List.collect
-    (fun cli ->
-      List.collect
-        (fun opt ->
-          match BU.split opt "=" with
-          | [lhs;rhs] -> [BU.format2 "(set-option :%s %s)" lhs rhs]
-          | _ -> [])
-        (BU.split cli " "))
-    clis
-  |> String.concat "\n"
-
 let init () =
     (* A no-op now that there's no concurrency *)
     ()
@@ -527,7 +515,7 @@ let context_profile (theory:list decl) =
 
 let mk_input fresh theory =
     let options = !z3_options in
-    let options = options ^ (cli_as_options (Options.z3_cliopt())) in
+    let options = options ^ (Options.z3_smtopt() |> String.concat "\n") in
     if Options.print_z3_statistics() then context_profile theory;
     let r, hash =
         if Options.record_hints()

--- a/src/syntax/FStar.Syntax.Embeddings.fst
+++ b/src/syntax/FStar.Syntax.Embeddings.fst
@@ -852,6 +852,7 @@ let e_vconfig =
                    S.as_arg (embed e_bool              vcfg.no_tactics                                rng None norm);
                    S.as_arg (embed (e_option e_string) vcfg.vcgen_optimize_bind_as_seq                rng None norm);
                    S.as_arg (embed e_string_list       vcfg.z3cliopt                                  rng None norm);
+                   S.as_arg (embed e_string_list       vcfg.z3smtopt                                  rng None norm);                   
                    S.as_arg (embed e_bool              vcfg.z3refresh                                 rng None norm);
                    S.as_arg (embed e_fsint             vcfg.z3rlimit                                  rng None norm);
                    S.as_arg (embed e_fsint             vcfg.z3rlimit_factor                           rng None norm);
@@ -888,6 +889,7 @@ let e_vconfig =
             (no_tactics, _);
             (vcgen_optimize_bind_as_seq, _);
             (z3cliopt, _);
+            (z3smtopt, _);            
             (z3refresh, _);
             (z3rlimit, _);
             (z3rlimit_factor, _);
@@ -916,6 +918,7 @@ let e_vconfig =
                   BU.bind_opt (unembed e_bool              no_tactics w norm) (fun no_tactics ->
                   BU.bind_opt (unembed (e_option e_string) vcgen_optimize_bind_as_seq w norm) (fun vcgen_optimize_bind_as_seq ->
                   BU.bind_opt (unembed e_string_list       z3cliopt w norm) (fun z3cliopt ->
+                  BU.bind_opt (unembed e_string_list       z3smtopt w norm) (fun z3smtopt ->                  
                   BU.bind_opt (unembed e_bool              z3refresh w norm) (fun z3refresh ->
                   BU.bind_opt (unembed e_fsint             z3rlimit w norm) (fun z3rlimit ->
                   BU.bind_opt (unembed e_fsint             z3rlimit_factor w norm) (fun z3rlimit_factor ->
@@ -944,13 +947,14 @@ let e_vconfig =
                     no_tactics = no_tactics;
                     vcgen_optimize_bind_as_seq = vcgen_optimize_bind_as_seq;
                     z3cliopt = z3cliopt;
+                    z3smtopt = z3smtopt;
                     z3refresh = z3refresh;
                     z3rlimit = z3rlimit;
                     z3rlimit_factor = z3rlimit_factor;
                     z3seed = z3seed;
                     trivial_pre_for_unannotated_effectful_fns = trivial_pre_for_unannotated_effectful_fns;
                     reuse_hint_for = reuse_hint_for;
-                  }))))))))))))))))))))))))))))
+                  })))))))))))))))))))))))))))))
         | _ ->
           if w then
             Err.log_issue t0.pos (Err.Warning_NotEmbedded, (BU.format1 "Not an embedded vconfig: %s" (Print.term_to_string t0)));

--- a/ulib/FStar.ModifiesGen.fst
+++ b/ulib/FStar.ModifiesGen.fst
@@ -646,18 +646,6 @@ let dummy #a (c: cls a) (r: HS.rid) : Tot unit =
 
 #push-options "--z3rlimit 128"
 
-let loc_includes_disjoint_elim
-  #al (c: cls al)
-  (l l1 l2: loc c)
-: Lemma
-  (requires ((l1 `loc_union` l2) `loc_includes` l /\ l1 `loc_disjoint` l /\ l1 `loc_disjoint` l2)
-//    (forall r . r `Set.mem` Ghost.reveal (Loc?.regions l) ==> (exists (a: nat) (x: al r a) . ALoc r a (Some x) `GSet.mem` Ghost.reveal (Loc?.aux l)))
-  )
-  (ensures (l2 `loc_includes'` l))
-= assume (Set.subset (Ghost.reveal (Loc?.regions l)) (Ghost.reveal (Loc?.regions l2)));
-  assume (forall r . GSet.subset (addrs_of_loc l r) (addrs_of_loc l2 r));
-  admit()
-
 (** Liveness-insensitive memory locations *)
 
 let address_liveness_insensitive_locs #al c =
@@ -1533,15 +1521,6 @@ let loc_unused_in_not_unused_in_disjoint #al c h =
   assert (Ghost.reveal (Loc?.aux (loc_unused_in c h)) `loc_aux_disjoint` Ghost.reveal (Loc?.aux (loc_not_unused_in c h)));
   assert (loc_disjoint #al #c (loc_unused_in #al c h)
                               (loc_not_unused_in #al c h))
-
-let loc_unused_in_not_unused_in_union
-  #al
-  (#c: cls al)
-  (l: loc c)
-  h
-: Lemma
-  ((loc_not_unused_in c h `loc_union` loc_unused_in c h) `loc_includes` l)
-= admit()
 
 
 #push-options "--initial_fuel 2 --max_fuel 2 --initial_ifuel 1 --max_ifuel 1"

--- a/ulib/FStar.Tactics.BV.fst
+++ b/ulib/FStar.Tactics.BV.fst
@@ -103,7 +103,7 @@ val trans_lt: #n:pos -> (#x:bv_t n) -> (#y:bv_t n) -> (#z:bv_t n) -> (#w:bv_t n)
 let trans_lt #n #x #y #z #w pf1 pf2 pf3 = ()
 
 val trans_lt2: #n:pos -> (#x:uint_t n) -> (#y:uint_t n) -> (#z:bv_t n) -> (#w:bv_t n) ->
-          squash (int2bv #n x == z) -> squash (int2bv #n y == w) -> (b2t (bvult #n z w)) ->
+          squash (int2bv #n x == z) -> squash (int2bv #n y == w) -> squash (bvult #n z w) ->
           Lemma (x < y)
 let trans_lt2 #n #x #y #z #w pf1 pf2 pf3 = int2bv_lemma_ult_2 x y
 

--- a/ulib/FStar.UInt128.fst
+++ b/ulib/FStar.UInt128.fst
@@ -26,8 +26,77 @@ module U64 = FStar.UInt64
 
 module Math = FStar.Math.Lemmas
 
+open FStar.BV
+open FStar.Tactics
+module T = FStar.Tactics
+module TBV = FStar.Tactics.BV
+
+let carry_uint64 (a b: uint_t 64) : Tot (uint_t 64) =
+  let ( ^^ ) = UInt.logxor in
+  let ( |^ ) = UInt.logor in
+  let ( -%^ ) = UInt.sub_mod in
+  let ( >>^ ) = UInt.shift_right in
+  a ^^ ((a ^^ b) |^ ((a -%^ b) ^^ b)) >>^ 63
+
+let carry_bv (a b: uint_t 64) =
+    bvshr (bvxor (int2bv a)
+                 (bvor (bvxor (int2bv a) (int2bv b)) (bvxor (bvsub (int2bv a) (int2bv b)) (int2bv b))))
+          63
+
+let carry_uint64_ok (a b:uint_t 64)
+  : squash (int2bv (carry_uint64 a b) == carry_bv a b)
+  = _ by (T.norm [delta_only [`%carry_uint64]; unascribe];
+          let open FStar.Tactics.BV in
+          mapply (`trans);
+          arith_to_bv_tac ();
+          arith_to_bv_tac ();
+          T.norm [delta_only [`%carry_bv]];
+          trefl())
+
+let fact1 (a b: uint_t 64) = carry_bv a b == int2bv 1
+let fact0 (a b: uint_t 64) = carry_bv a b == int2bv 0
+
+let lem_ult_1 (a b: uint_t 64)
+  : squash (bvult (int2bv a) (int2bv b) ==> fact1 a b)
+  = assert (bvult (int2bv a) (int2bv b) ==> fact1 a b)
+       by (T.norm [delta_only [`%fact1;`%carry_bv]];
+           set_options "--smtencoding.elim_box true --using_facts_from '__Nothing__' --z3cliopt 'smt.case_split=1'";
+           smt())
+
+let lem_ult_2 (a b:uint_t 64)
+  : squash (not (bvult (int2bv a) (int2bv b)) ==> fact0 a b)
+  = assert (not (bvult (int2bv a) (int2bv b)) ==> fact0 a b)
+       by (T.norm [delta_only [`%fact0;`%carry_bv]];
+           set_options "--smtencoding.elim_box true --using_facts_from '__Nothing__' --z3cliopt 'smt.case_split=1'")
+
+let int2bv_ult (#n: pos) (a b: uint_t n)
+  : Lemma (ensures a < b <==> bvult #n (int2bv #n a) (int2bv #n b))
+  = introduce (a < b) ==> (bvult #n (int2bv #n a) (int2bv #n b))
+    with _ . FStar.BV.int2bv_lemma_ult_1 a b;
+    introduce (bvult #n (int2bv #n a) (int2bv #n b)) ==> (a < b)
+    with _ . FStar.BV.int2bv_lemma_ult_2 a b
+
+let lem_ult (a b:uint_t 64)
+  : Lemma (if a < b
+           then fact1 a b
+           else fact0 a b)
+  = int2bv_ult a b;
+    lem_ult_1 a b;
+    lem_ult_2 a b
+
 #reset-options "--max_fuel 0 --max_ifuel 0 --smtencoding.elim_box true --smtencoding.nl_arith_repr wrapped --smtencoding.l_arith_repr native"
 #set-options "--normalize_pure_terms_for_extraction"
+
+let constant_time_carry (a b: U64.t) : Tot U64.t =
+  let open U64 in
+  // CONSTANT_TIME_CARRY macro
+  // ((a ^ ((a ^ b) | ((a - b) ^ b))) >> (sizeof(a) * 8 - 1))
+  // 63 = sizeof(a) * 8 - 1
+  a ^^ ((a ^^ b) |^ ((a -%^ b) ^^ b)) >>^ 63ul
+
+let carry_uint64_equiv (a b:UInt64.t)
+  : Lemma (U64.v (constant_time_carry a b) == carry_uint64 (U64.v a) (U64.v b))
+  = ()
 
 // This type gets a special treatment in KaRaMeL and its definition is never
 // printed in the resulting C file.
@@ -55,17 +124,22 @@ let v_inj (x1 x2: t): Lemma (requires (v x1 == v x2))
  assert (uint_to_t (v x2) == x2);
  ()
 
-let constant_time_carry (a b: U64.t) : Tot U64.t =
-  let open U64 in
-  // CONSTANT_TIME_CARRY macro
-  // ((a ^ ((a ^ b) | ((a - b) ^ b))) >> (sizeof(a) * 8 - 1))
-  // 63 = sizeof(a) * 8 - 1
-  a ^^ ((a ^^ b) |^ ((a -%^ b) ^^ b)) >>^ U32.uint_to_t 63
-
-// TODO: eventually we should prove this equivalence
-assume val constant_time_carry_ok (a b:U64.t) :
-    Lemma (constant_time_carry a b ==
+let constant_time_carry_ok (a b:U64.t)
+  : Lemma (constant_time_carry a b ==
            (if U64.lt a b then U64.uint_to_t 1 else U64.uint_to_t 0))
+  = calc (==) {
+      U64.v (constant_time_carry a b);
+    (==) {     carry_uint64_equiv a b }
+      carry_uint64 (U64.v a) (U64.v b);
+    (==) { carry_uint64_ok (U64.v a) (U64.v b) }
+      bv2int (carry_bv (U64.v a) (U64.v b));
+    (==) { lem_ult (U64.v a) (U64.v b) }
+      bv2int
+        (if U64.v a < U64.v b
+         then int2bv 1
+         else int2bv 0);
+    }
+
 
 let carry (a b: U64.t) : Pure U64.t
   (requires True)
@@ -633,7 +707,7 @@ let add_u64_shift_right (hi lo: U64.t) (s: U32.t{U32.v s < 64}) : Pure U64.t
   assert (low_n < pow2 (64 - s));
   mod_mul_pow2 (U64.v hi) s (64 - s);
   U64.add low high
-  
+
 #set-options "--z3rlimit 10"
 val mul_pow2_diff: a:nat -> n1:nat -> n2:nat{n2 <= n1} ->
   Lemma (a * pow2 (n1 - n2) == a * pow2 n1 / pow2 n2)

--- a/ulib/FStar.UInt128.fst
+++ b/ulib/FStar.UInt128.fst
@@ -64,14 +64,14 @@ let lem_ult_1 (a b: uint_t 64)
   : squash (bvult (int2bv a) (int2bv b) ==> fact1 a b)
   = assert (bvult (int2bv a) (int2bv b) ==> fact1 a b)
        by (T.norm [delta_only [`%fact1;`%carry_bv]];
-           set_options "--smtencoding.elim_box true --using_facts_from '__Nothing__' --z3cliopt 'smt.case_split=1'";
+           set_options "--smtencoding.elim_box true --using_facts_from '__Nothing__' --z3smtopt '(set-option :smt.case_split 1)'";
            smt())
 
 let lem_ult_2 (a b:uint_t 64)
   : squash (not (bvult (int2bv a) (int2bv b)) ==> fact0 a b)
   = assert (not (bvult (int2bv a) (int2bv b)) ==> fact0 a b)
        by (T.norm [delta_only [`%fact0;`%carry_bv]];
-           set_options "--smtencoding.elim_box true --using_facts_from '__Nothing__' --z3cliopt 'smt.case_split=1'")
+           set_options "--smtencoding.elim_box true --using_facts_from '__Nothing__' --z3smtopt '(set-option :smt.case_split 1)'")
 
 let int2bv_ult (#n: pos) (a b: uint_t n)
   : Lemma (ensures a < b <==> bvult #n (int2bv #n a) (int2bv #n b))

--- a/ulib/FStar.UInt128.fst
+++ b/ulib/FStar.UInt128.fst
@@ -31,6 +31,8 @@ open FStar.Tactics
 module T = FStar.Tactics
 module TBV = FStar.Tactics.BV
 
+[@@ noextract_to "krml"]
+noextract
 let carry_uint64 (a b: uint_t 64) : Tot (uint_t 64) =
   let ( ^^ ) = UInt.logxor in
   let ( |^ ) = UInt.logor in
@@ -38,6 +40,8 @@ let carry_uint64 (a b: uint_t 64) : Tot (uint_t 64) =
   let ( >>^ ) = UInt.shift_right in
   a ^^ ((a ^^ b) |^ ((a -%^ b) ^^ b)) >>^ 63
 
+[@@ noextract_to "krml"]
+noextract
 let carry_bv (a b: uint_t 64) =
     bvshr (bvxor (int2bv a)
                  (bvor (bvxor (int2bv a) (int2bv b)) (bvxor (bvsub (int2bv a) (int2bv b)) (int2bv b))))
@@ -1163,6 +1167,7 @@ let sum_rounded_mod_exact n m k =
 
 val div_sum_combine : n:nat -> m:nat -> k:pos ->
   Lemma (n / k + m / k == (n + (m - n % k) - m % k) / k)
+#push-options "--z3rlimit 60"
 let div_sum_combine n m k =
   sum_rounded_mod_exact n m k;
   div_sum_combine1 n m k;

--- a/ulib/FStar.VConfig.fsti
+++ b/ulib/FStar.VConfig.fsti
@@ -43,6 +43,7 @@ type vconfig = {
   no_tactics                                : bool;
   vcgen_optimize_bind_as_seq                : option string;
   z3cliopt                                  : list string;
+  z3smtopt                                  : list string;  
   z3refresh                                 : bool;
   z3rlimit                                  : int;
   z3rlimit_factor                           : int;


### PR DESCRIPTION
This PR fixes an admit in FStar.UInt128

* The admit involves some bitvector reasoning, which Z3 can prove, but only if smt.case_split=1. By default, F* uses smt.case_split=3, which is recorded in the .smt2 file that F* generates. It's not possible to override this option using z3cliopt, so this PR adds a new option --z3smtopt to allow the user to inject new (set-option ...) style directives in the header of the SMT2 file. You can see a usage in FStar.UInt128. 

* Additionally, the admit involves reasoning about bvult, the unsigned less-than bitvector operation, and somehow this had been excluded from the bitvector encoding. I re-enabled it.

* Also, along the way, I removed two admitted but unused lemmas in FStar.ModifiesGen

The main thing worth checking in this PR is that I handled the new option correctly, in terms of the logic around embedding them, checking if the config changed etc. Basically, I handled the new option identically to z3cliopt.