### PR TITLE
Revert "Add a malloca_of_list to Steel"

### DIFF
--- a/src/extraction/FStar.Extraction.Krml.fst
+++ b/src/extraction/FStar.Extraction.Krml.fst
@@ -588,7 +588,6 @@ and translate_expr env e: expr =
 
   | MLE_App ({ expr = MLE_TApp({ expr = MLE_Name p }, _) }, [ e2 ])
     when (string_of_mlpath p = "FStar.Buffer.createL" ||
-          string_of_mlpath p = "Steel.ST.HigherArray.malloca_of_list_ptr" ||
           string_of_mlpath p = "LowStar.Monotonic.Buffer.malloca_of_list" ||
           string_of_mlpath p = "LowStar.ImmutableBuffer.ialloca_of_list") ->
       EBufCreateL (Stack, List.map (translate_expr env) (list_elements e2))

--- a/src/ocaml-output/FStar_Extraction_Krml.ml
+++ b/src/ocaml-output/FStar_Extraction_Krml.ml
@@ -1389,11 +1389,8 @@ and (translate_expr : env -> FStar_Extraction_ML_Syntax.mlexpr -> expr) =
              FStar_Extraction_ML_Syntax.loc = uu___4;_},
            e2::[])
           when
-          (((let uu___5 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
-             uu___5 = "FStar.Buffer.createL") ||
-              (let uu___5 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
-               uu___5 = "Steel.ST.HigherArray.malloca_of_list_ptr"))
-             ||
+          ((let uu___5 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+            uu___5 = "FStar.Buffer.createL") ||
              (let uu___5 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
               uu___5 = "LowStar.Monotonic.Buffer.malloca_of_list"))
             ||

--- a/ulib/experimental/Steel.Array.fsti
+++ b/ulib/experimental/Steel.Array.fsti
@@ -144,33 +144,7 @@ let malloc
   intro_varray res _;
   return res
 
-/// Allocating a new array, whose initial values are specified by the
-/// ```init``` list, which must be nonempty, and of length representable as
-/// a machine integer
-
-unfold let alloca_of_list_pre (#elt:Type) (init:list elt) =
-  normalize (0 < FStar.List.Tot.length init) /\
-  normalize (FStar.List.Tot.length init <= UInt.max_int 32)
-
-inline_for_extraction
-[@@noextract_to "krml"]
-let malloca_of_list
-  (#elt: Type)
-  (init: list elt)
-  : Steel (array elt)
-       emp
-       (fun a -> varray a)
-       (fun _ -> alloca_of_list_pre init)
-       (fun _ a h' ->
-         length a == normalize_term (List.Tot.length init) /\
-         is_full_array a /\
-         asel a h' == Seq.seq_of_list init
-       )
-= let res = A.malloca_of_list init in
-  intro_varray res _;
-  return res
-
-/// Freeing a full array.
+/// Freeing a full array. 
 inline_for_extraction
 [@@ noextract_to "krml";
     warn_on_use "Steel.Array.free is currently unsound in the presence of zero-size subarrays, have you collected them all?"]

--- a/ulib/experimental/Steel.ST.Array.fst
+++ b/ulib/experimental/Steel.ST.Array.fst
@@ -31,10 +31,6 @@ inline_for_extraction
 let raise (#t: Type) (x: t) : Tot (raise_t t) =
   FStar.Universe.raise_val x
 
-[@@noextract_to "krml"]
-let raise_list (#t: Type) (l: list t) : Tot (list (raise_t t)) =
-  List.Tot.map raise l
-
 inline_for_extraction
 [@@noextract_to "krml"]
 let lower (#t: Type) (x: raise_t t) : Tot t =
@@ -42,7 +38,8 @@ let lower (#t: Type) (x: raise_t t) : Tot t =
 
 /// A map operation on sequences. Here we only need Ghost versions,
 /// because such sequences are only used in vprops or with their
-///
+/// selectors.
+
 let rec seq_map
   (#t: Type u#a)
   (#t' : Type u#b)
@@ -78,18 +75,6 @@ let seq_map_raise_inj
 = assert (seq_map lower (seq_map raise s1) `Seq.equal` s1);
   assert (seq_map lower (seq_map raise s2) `Seq.equal` s2)
 
-let rec seq_map_map_list
-  (#elt:Type0)
-  (l:list elt)
-  : Lemma (Seq.seq_of_list (List.Tot.map raise l) `Seq.equal` seq_map raise (Seq.seq_of_list l))
-  = match l with
-    | [] -> ()
-    | hd::tl ->
-      let s = Seq.seq_of_list l in
-      Seq.lemma_seq_of_list_induction l;
-      Seq.lemma_seq_of_list_induction (List.Tot.map raise l);
-      seq_map_map_list tl
-
 /// Implementation of the interface
 
 /// base, ptr, array, pts_to
@@ -120,14 +105,6 @@ let malloc x n =
   rewrite
     (H.pts_to res _ _)
     (pts_to res _ _);
-  return res
-
-let malloca_of_list init =
-  let res = H.malloca_of_list (normalize_term (raise_list init)) in
-  seq_map_map_list init;
-  rewrite
-    (H.pts_to res _ (Seq.seq_of_list (raise_list init)))
-    (pts_to res _ (Seq.seq_of_list init));
   return res
 
 let free #_ x =

--- a/ulib/experimental/Steel.ST.Array.fsti
+++ b/ulib/experimental/Steel.ST.Array.fsti
@@ -167,30 +167,7 @@ inline_for_extraction
 [@@noextract_to "krml"]
 let alloc #elt = malloc #elt
 
-/// Allocating a new array, whose initial values are specified by the
-/// ```init``` list, which must be nonempty, and of length representable as
-/// a machine integer
-
-unfold let alloca_of_list_pre (#elt:Type) (init:list elt) =
-  normalize (0 < FStar.List.Tot.length init) /\
-  normalize (FStar.List.Tot.length init <= UInt.max_int 32)
-
-inline_for_extraction
-[@@noextract_to "krml"]
-val malloca_of_list
-  (#elt: Type)
-  (init: list elt)
-  : ST (array elt)
-       emp
-       (fun a -> pts_to a P.full_perm (Seq.seq_of_list init))
-       (alloca_of_list_pre init)
-       (fun a ->
-         length a == normalize_term (List.Tot.length init) /\
-         is_full_array a
-       )
-
-
-/// Freeing a full array.
+/// Freeing a full array. 
 inline_for_extraction
 [@@ noextract_to "krml";
     warn_on_use "Steel.Array.free_pt is currently unsound in the presence of zero-size subarrays, have you collected them all?"]

--- a/ulib/experimental/Steel.ST.HigherArray.fst
+++ b/ulib/experimental/Steel.ST.HigherArray.fst
@@ -284,46 +284,6 @@ let malloc_ptr
   return p
 
 [@@noextract_to "krml"]
-let malloca_of_list'
-  (#elt: Type)
-  (init: list elt)
-  (n: U32.t)
-  : ST (array elt)
-       emp
-       (fun a -> pts_to a P.full_perm (Seq.seq_of_list init))
-       (alloca_of_list_pre init /\ U32.v n == List.Tot.length init)
-       (fun a ->
-         length a == U32.v n /\
-         base_len (base (ptr_of a)) == U32.v n
-       )
-=
-  let c : carrier elt (U32.v n) = mk_carrier (U32.v n) 0 (Seq.seq_of_list init) P.full_perm in
-  let base : ref (carrier elt (U32.v n)) (pcm elt (U32.v n)) = R.alloc c in
-  let p = {
-    base_len = Ghost.hide n;
-    base = base;
-    offset = 0;
-  }
-  in
-  let a = (| p, Ghost.hide (U32.v n) |) in
-  change_r_pts_to
-    base c
-    (ptr_of a).base c;
-  intro_pts_to a P.full_perm (Seq.seq_of_list init);
-  return a
-
-#set-options "--ide_id_info_off"
-
-let malloca_of_list_ptr init =
-  let n:U32.t = U32.uint_to_t (List.Tot.length init) in
-  let a = malloca_of_list' init n in
-  let (| p, _ |) = a in
-  rewrite
-    (pts_to _ _ _)
-    (pts_to (| p, Ghost.hide (List.Tot.length init) |) _ _);
-  return p
-
-[@@noextract_to "krml"]
 let free0
   (#elt: Type)
   (#s: Ghost.erased (Seq.seq elt))
@@ -582,7 +542,7 @@ let ptr_shift
 
 let ghost_split
   #_ #_ #x #p a i
-=
+= 
   elim_pts_to a p x;
   mk_carrier_split
     (U32.v (ptr_of a).base_len)

--- a/ulib/experimental/Steel.ST.HigherArray.fsti
+++ b/ulib/experimental/Steel.ST.HigherArray.fsti
@@ -17,7 +17,7 @@
 module Steel.ST.HigherArray
 
 /// C arrays of universe 1 elements.
-///
+/// 
 /// - Due to a limitation on the universe for selectors, no selector
 ///   version can be defined for universe 1.
 /// - Due to F* universes not being cumulative, arrays of universe 0
@@ -131,25 +131,6 @@ val malloc_ptr
     emp
     (fun a -> pts_to (| a, Ghost.hide (U32.v n) |) P.full_perm (Seq.create (U32.v n) x))
 
-/// Allocating a new array, whose initial values are specified by the
-/// ```init``` list, which must be nonempty, and of length representable as
-/// a machine integer
-
-unfold let alloca_of_list_pre (#elt:Type) (init:list elt) =
-  normalize (0 < FStar.List.Tot.length init) /\
-  normalize (FStar.List.Tot.length init <= UInt.max_int 32)
-
-[@@noextract_to "krml"]
-val malloca_of_list_ptr
-  (#elt: Type)
-  (init: list elt)
-  : ST (a: ptr elt {base_len (base a) == normalize_term (List.Tot.length init) /\ offset a == 0})
-       emp
-       (fun a -> pts_to (| a, Ghost.hide (normalize_term (List.Tot.length init)) |)
-         P.full_perm (Seq.seq_of_list init))
-       (alloca_of_list_pre init)
-       (fun _ -> True)
-
 /// Allocating a new array of size n, where each cell is initialized
 /// with value x
 
@@ -176,28 +157,6 @@ let malloc
     (pts_to _ _ _)
     (pts_to a _ _);
   return a
-
-#set-options "--ide_id_info_off"
-
-inline_for_extraction
-[@@noextract_to "krml"]
-let malloca_of_list
-  (#elt: Type)
-  (init: list elt)
-  : ST (array elt)
-       emp
-       (fun a -> pts_to a P.full_perm (Seq.seq_of_list init))
-       (0 < List.Tot.length init /\ List.Tot.length init <= UInt.max_int 32)
-       (fun a ->
-         length a == normalize_term (List.Tot.length init) /\
-         is_full_array a
-       )
-  = let p = malloca_of_list_ptr init in
-    let a : array elt = (| p, Ghost.hide (normalize_term (List.Tot.length init)) |) in
-    rewrite
-      (pts_to _ _ _)
-      (pts_to a _ _);
-    return a
 
 /// Freeing a full array. Same here, we expose a ptr version for extraction purposes only
 [@@ noextract_to "krml"; // primitive


### PR DESCRIPTION
Reverts FStarLang/FStar#2696

This PR introduced a new feature called malloca_of_list which allocates an array with a statically-known list of values, similarly to what exists in Low*.
However, this array is stack-allocated, which is not well supported in the current Steel memory model.
Doing this properly would require exposing a combinator similar to `Steel.ST.Reference.with_local`, in delimit the scope of the array. This however does not interact well with inferring the indices of the body function when it contains non-trivial requires/ensures clauses.