### PR TITLE
Some (memory) optimizations to the normalizer

### DIFF
--- a/src/ocaml-output/FStar_TypeChecker_Normalize.ml
+++ b/src/ocaml-output/FStar_TypeChecker_Normalize.ml
@@ -82,6 +82,7 @@ let (uu___is_Dummy : closure -> Prims.bool) =
 type env =
   (FStar_Syntax_Syntax.binder FStar_Pervasives_Native.option * closure)
     Prims.list
+let (empty_env : env) = []
 let (dummy :
   (FStar_Syntax_Syntax.binder FStar_Pervasives_Native.option * closure)) =
   (FStar_Pervasives_Native.None, Dummy)
@@ -2450,139 +2451,136 @@ let (should_unfold :
 let decide_unfolding :
   'uuuuu .
     FStar_TypeChecker_Cfg.cfg ->
-      env ->
-        stack_elt Prims.list ->
-          'uuuuu ->
-            FStar_Syntax_Syntax.fv ->
-              FStar_TypeChecker_Env.qninfo ->
-                (FStar_TypeChecker_Cfg.cfg * stack_elt Prims.list)
-                  FStar_Pervasives_Native.option
+      stack_elt Prims.list ->
+        'uuuuu ->
+          FStar_Syntax_Syntax.fv ->
+            FStar_TypeChecker_Env.qninfo ->
+              (FStar_TypeChecker_Cfg.cfg * stack_elt Prims.list)
+                FStar_Pervasives_Native.option
   =
   fun cfg ->
-    fun env1 ->
-      fun stack1 ->
-        fun rng ->
-          fun fv ->
-            fun qninfo ->
-              let res =
-                should_unfold cfg (fun cfg1 -> should_reify cfg1 stack1) fv
-                  qninfo in
-              match res with
-              | Should_unfold_no -> FStar_Pervasives_Native.None
-              | Should_unfold_yes ->
-                  FStar_Pervasives_Native.Some (cfg, stack1)
-              | Should_unfold_fully ->
-                  let cfg' =
-                    {
-                      FStar_TypeChecker_Cfg.steps =
-                        (let uu___ = cfg.FStar_TypeChecker_Cfg.steps in
-                         {
-                           FStar_TypeChecker_Cfg.beta =
-                             (uu___.FStar_TypeChecker_Cfg.beta);
-                           FStar_TypeChecker_Cfg.iota =
-                             (uu___.FStar_TypeChecker_Cfg.iota);
-                           FStar_TypeChecker_Cfg.zeta =
-                             (uu___.FStar_TypeChecker_Cfg.zeta);
-                           FStar_TypeChecker_Cfg.zeta_full =
-                             (uu___.FStar_TypeChecker_Cfg.zeta_full);
-                           FStar_TypeChecker_Cfg.weak =
-                             (uu___.FStar_TypeChecker_Cfg.weak);
-                           FStar_TypeChecker_Cfg.hnf =
-                             (uu___.FStar_TypeChecker_Cfg.hnf);
-                           FStar_TypeChecker_Cfg.primops =
-                             (uu___.FStar_TypeChecker_Cfg.primops);
-                           FStar_TypeChecker_Cfg.do_not_unfold_pure_lets =
-                             (uu___.FStar_TypeChecker_Cfg.do_not_unfold_pure_lets);
-                           FStar_TypeChecker_Cfg.unfold_until =
-                             (FStar_Pervasives_Native.Some
-                                FStar_Syntax_Syntax.delta_constant);
-                           FStar_TypeChecker_Cfg.unfold_only =
-                             FStar_Pervasives_Native.None;
-                           FStar_TypeChecker_Cfg.unfold_fully =
-                             FStar_Pervasives_Native.None;
-                           FStar_TypeChecker_Cfg.unfold_attr =
-                             FStar_Pervasives_Native.None;
-                           FStar_TypeChecker_Cfg.unfold_qual =
-                             FStar_Pervasives_Native.None;
-                           FStar_TypeChecker_Cfg.unfold_tac =
-                             (uu___.FStar_TypeChecker_Cfg.unfold_tac);
-                           FStar_TypeChecker_Cfg.pure_subterms_within_computations
-                             =
-                             (uu___.FStar_TypeChecker_Cfg.pure_subterms_within_computations);
-                           FStar_TypeChecker_Cfg.simplify =
-                             (uu___.FStar_TypeChecker_Cfg.simplify);
-                           FStar_TypeChecker_Cfg.erase_universes =
-                             (uu___.FStar_TypeChecker_Cfg.erase_universes);
-                           FStar_TypeChecker_Cfg.allow_unbound_universes =
-                             (uu___.FStar_TypeChecker_Cfg.allow_unbound_universes);
-                           FStar_TypeChecker_Cfg.reify_ =
-                             (uu___.FStar_TypeChecker_Cfg.reify_);
-                           FStar_TypeChecker_Cfg.compress_uvars =
-                             (uu___.FStar_TypeChecker_Cfg.compress_uvars);
-                           FStar_TypeChecker_Cfg.no_full_norm =
-                             (uu___.FStar_TypeChecker_Cfg.no_full_norm);
-                           FStar_TypeChecker_Cfg.check_no_uvars =
-                             (uu___.FStar_TypeChecker_Cfg.check_no_uvars);
-                           FStar_TypeChecker_Cfg.unmeta =
-                             (uu___.FStar_TypeChecker_Cfg.unmeta);
-                           FStar_TypeChecker_Cfg.unascribe =
-                             (uu___.FStar_TypeChecker_Cfg.unascribe);
-                           FStar_TypeChecker_Cfg.in_full_norm_request =
-                             (uu___.FStar_TypeChecker_Cfg.in_full_norm_request);
-                           FStar_TypeChecker_Cfg.weakly_reduce_scrutinee =
-                             (uu___.FStar_TypeChecker_Cfg.weakly_reduce_scrutinee);
-                           FStar_TypeChecker_Cfg.nbe_step =
-                             (uu___.FStar_TypeChecker_Cfg.nbe_step);
-                           FStar_TypeChecker_Cfg.for_extraction =
-                             (uu___.FStar_TypeChecker_Cfg.for_extraction);
-                           FStar_TypeChecker_Cfg.unrefine =
-                             (uu___.FStar_TypeChecker_Cfg.unrefine)
-                         });
-                      FStar_TypeChecker_Cfg.tcenv =
-                        (cfg.FStar_TypeChecker_Cfg.tcenv);
-                      FStar_TypeChecker_Cfg.debug =
-                        (cfg.FStar_TypeChecker_Cfg.debug);
-                      FStar_TypeChecker_Cfg.delta_level =
-                        (cfg.FStar_TypeChecker_Cfg.delta_level);
-                      FStar_TypeChecker_Cfg.primitive_steps =
-                        (cfg.FStar_TypeChecker_Cfg.primitive_steps);
-                      FStar_TypeChecker_Cfg.strong =
-                        (cfg.FStar_TypeChecker_Cfg.strong);
-                      FStar_TypeChecker_Cfg.memoize_lazy =
-                        (cfg.FStar_TypeChecker_Cfg.memoize_lazy);
-                      FStar_TypeChecker_Cfg.normalize_pure_lets =
-                        (cfg.FStar_TypeChecker_Cfg.normalize_pure_lets);
-                      FStar_TypeChecker_Cfg.reifying =
-                        (cfg.FStar_TypeChecker_Cfg.reifying)
-                    } in
-                  let stack' =
-                    match stack1 with
-                    | (UnivArgs (us, r))::stack'1 -> (UnivArgs (us, r)) ::
-                        (Cfg (cfg, FStar_Pervasives_Native.None)) :: stack'1
-                    | stack'1 -> (Cfg (cfg, FStar_Pervasives_Native.None)) ::
-                        stack'1 in
-                  FStar_Pervasives_Native.Some (cfg', stack')
-              | Should_unfold_reify ->
-                  let rec push e s =
-                    match s with
-                    | [] -> [e]
-                    | (UnivArgs (us, r))::t ->
-                        let uu___ = push e t in (UnivArgs (us, r)) :: uu___
-                    | h::t -> e :: h :: t in
-                  let ref =
-                    let uu___ =
-                      let uu___1 =
-                        let uu___2 = FStar_Syntax_Syntax.lid_of_fv fv in
-                        FStar_Const.Const_reflect uu___2 in
-                      FStar_Syntax_Syntax.Tm_constant uu___1 in
-                    FStar_Syntax_Syntax.mk uu___
-                      FStar_Compiler_Range.dummyRange in
-                  let stack2 =
-                    push
-                      (App
-                         (env1, ref, FStar_Pervasives_Native.None,
-                           FStar_Compiler_Range.dummyRange)) stack1 in
-                  FStar_Pervasives_Native.Some (cfg, stack2)
+    fun stack1 ->
+      fun rng ->
+        fun fv ->
+          fun qninfo ->
+            let res =
+              should_unfold cfg (fun cfg1 -> should_reify cfg1 stack1) fv
+                qninfo in
+            match res with
+            | Should_unfold_no -> FStar_Pervasives_Native.None
+            | Should_unfold_yes -> FStar_Pervasives_Native.Some (cfg, stack1)
+            | Should_unfold_fully ->
+                let cfg' =
+                  {
+                    FStar_TypeChecker_Cfg.steps =
+                      (let uu___ = cfg.FStar_TypeChecker_Cfg.steps in
+                       {
+                         FStar_TypeChecker_Cfg.beta =
+                           (uu___.FStar_TypeChecker_Cfg.beta);
+                         FStar_TypeChecker_Cfg.iota =
+                           (uu___.FStar_TypeChecker_Cfg.iota);
+                         FStar_TypeChecker_Cfg.zeta =
+                           (uu___.FStar_TypeChecker_Cfg.zeta);
+                         FStar_TypeChecker_Cfg.zeta_full =
+                           (uu___.FStar_TypeChecker_Cfg.zeta_full);
+                         FStar_TypeChecker_Cfg.weak =
+                           (uu___.FStar_TypeChecker_Cfg.weak);
+                         FStar_TypeChecker_Cfg.hnf =
+                           (uu___.FStar_TypeChecker_Cfg.hnf);
+                         FStar_TypeChecker_Cfg.primops =
+                           (uu___.FStar_TypeChecker_Cfg.primops);
+                         FStar_TypeChecker_Cfg.do_not_unfold_pure_lets =
+                           (uu___.FStar_TypeChecker_Cfg.do_not_unfold_pure_lets);
+                         FStar_TypeChecker_Cfg.unfold_until =
+                           (FStar_Pervasives_Native.Some
+                              FStar_Syntax_Syntax.delta_constant);
+                         FStar_TypeChecker_Cfg.unfold_only =
+                           FStar_Pervasives_Native.None;
+                         FStar_TypeChecker_Cfg.unfold_fully =
+                           FStar_Pervasives_Native.None;
+                         FStar_TypeChecker_Cfg.unfold_attr =
+                           FStar_Pervasives_Native.None;
+                         FStar_TypeChecker_Cfg.unfold_qual =
+                           FStar_Pervasives_Native.None;
+                         FStar_TypeChecker_Cfg.unfold_tac =
+                           (uu___.FStar_TypeChecker_Cfg.unfold_tac);
+                         FStar_TypeChecker_Cfg.pure_subterms_within_computations
+                           =
+                           (uu___.FStar_TypeChecker_Cfg.pure_subterms_within_computations);
+                         FStar_TypeChecker_Cfg.simplify =
+                           (uu___.FStar_TypeChecker_Cfg.simplify);
+                         FStar_TypeChecker_Cfg.erase_universes =
+                           (uu___.FStar_TypeChecker_Cfg.erase_universes);
+                         FStar_TypeChecker_Cfg.allow_unbound_universes =
+                           (uu___.FStar_TypeChecker_Cfg.allow_unbound_universes);
+                         FStar_TypeChecker_Cfg.reify_ =
+                           (uu___.FStar_TypeChecker_Cfg.reify_);
+                         FStar_TypeChecker_Cfg.compress_uvars =
+                           (uu___.FStar_TypeChecker_Cfg.compress_uvars);
+                         FStar_TypeChecker_Cfg.no_full_norm =
+                           (uu___.FStar_TypeChecker_Cfg.no_full_norm);
+                         FStar_TypeChecker_Cfg.check_no_uvars =
+                           (uu___.FStar_TypeChecker_Cfg.check_no_uvars);
+                         FStar_TypeChecker_Cfg.unmeta =
+                           (uu___.FStar_TypeChecker_Cfg.unmeta);
+                         FStar_TypeChecker_Cfg.unascribe =
+                           (uu___.FStar_TypeChecker_Cfg.unascribe);
+                         FStar_TypeChecker_Cfg.in_full_norm_request =
+                           (uu___.FStar_TypeChecker_Cfg.in_full_norm_request);
+                         FStar_TypeChecker_Cfg.weakly_reduce_scrutinee =
+                           (uu___.FStar_TypeChecker_Cfg.weakly_reduce_scrutinee);
+                         FStar_TypeChecker_Cfg.nbe_step =
+                           (uu___.FStar_TypeChecker_Cfg.nbe_step);
+                         FStar_TypeChecker_Cfg.for_extraction =
+                           (uu___.FStar_TypeChecker_Cfg.for_extraction);
+                         FStar_TypeChecker_Cfg.unrefine =
+                           (uu___.FStar_TypeChecker_Cfg.unrefine)
+                       });
+                    FStar_TypeChecker_Cfg.tcenv =
+                      (cfg.FStar_TypeChecker_Cfg.tcenv);
+                    FStar_TypeChecker_Cfg.debug =
+                      (cfg.FStar_TypeChecker_Cfg.debug);
+                    FStar_TypeChecker_Cfg.delta_level =
+                      (cfg.FStar_TypeChecker_Cfg.delta_level);
+                    FStar_TypeChecker_Cfg.primitive_steps =
+                      (cfg.FStar_TypeChecker_Cfg.primitive_steps);
+                    FStar_TypeChecker_Cfg.strong =
+                      (cfg.FStar_TypeChecker_Cfg.strong);
+                    FStar_TypeChecker_Cfg.memoize_lazy =
+                      (cfg.FStar_TypeChecker_Cfg.memoize_lazy);
+                    FStar_TypeChecker_Cfg.normalize_pure_lets =
+                      (cfg.FStar_TypeChecker_Cfg.normalize_pure_lets);
+                    FStar_TypeChecker_Cfg.reifying =
+                      (cfg.FStar_TypeChecker_Cfg.reifying)
+                  } in
+                let stack' =
+                  match stack1 with
+                  | (UnivArgs (us, r))::stack'1 -> (UnivArgs (us, r)) ::
+                      (Cfg (cfg, FStar_Pervasives_Native.None)) :: stack'1
+                  | stack'1 -> (Cfg (cfg, FStar_Pervasives_Native.None)) ::
+                      stack'1 in
+                FStar_Pervasives_Native.Some (cfg', stack')
+            | Should_unfold_reify ->
+                let rec push e s =
+                  match s with
+                  | [] -> [e]
+                  | (UnivArgs (us, r))::t ->
+                      let uu___ = push e t in (UnivArgs (us, r)) :: uu___
+                  | h::t -> e :: h :: t in
+                let ref =
+                  let uu___ =
+                    let uu___1 =
+                      let uu___2 = FStar_Syntax_Syntax.lid_of_fv fv in
+                      FStar_Const.Const_reflect uu___2 in
+                    FStar_Syntax_Syntax.Tm_constant uu___1 in
+                  FStar_Syntax_Syntax.mk uu___
+                    FStar_Compiler_Range.dummyRange in
+                let stack2 =
+                  push
+                    (App
+                       (empty_env, ref, FStar_Pervasives_Native.None,
+                         FStar_Compiler_Range.dummyRange)) stack1 in
+                FStar_Pervasives_Native.Some (cfg, stack2)
 let (on_domain_lids : FStar_Ident.lident Prims.list) =
   let fext_lid s =
     FStar_Ident.lid_of_path ["FStar"; "FunctionalExtensionality"; s]
@@ -2671,6 +2669,16 @@ let rec (norm :
     fun env1 ->
       fun stack1 ->
         fun t ->
+          let rec collapse_metas st =
+            match st with
+            | (Meta
+                (uu___, FStar_Syntax_Syntax.Meta_monadic uu___1, uu___2))::(Meta
+                (e, FStar_Syntax_Syntax.Meta_monadic m, r))::st' ->
+                collapse_metas
+                  ((Meta (e, (FStar_Syntax_Syntax.Meta_monadic m), r)) ::
+                  st')
+            | uu___ -> st in
+          let stack2 = collapse_metas stack1 in
           let t1 =
             if
               (cfg.FStar_TypeChecker_Cfg.debug).FStar_TypeChecker_Cfg.norm_delayed
@@ -2694,12 +2702,12 @@ let rec (norm :
                    (FStar_Compiler_List.length env1) in
                let uu___6 =
                  let uu___7 =
-                   let uu___8 = firstn (Prims.of_int (4)) stack1 in
+                   let uu___8 = firstn (Prims.of_int (4)) stack2 in
                    FStar_Compiler_Effect.op_Less_Bar
                      FStar_Pervasives_Native.fst uu___8 in
                  stack_to_string uu___7 in
                FStar_Compiler_Util.print5
-                 ">>> %s (no_full_norm=%s)\nNorm %s  with with %s env elements top of the stack %s \n"
+                 ">>> %s (no_full_norm=%s)\nNorm %s with %s env elements; top of the stack = %s\n"
                  uu___2 uu___3 uu___4 uu___5 uu___6);
           FStar_TypeChecker_Cfg.log_cfg cfg
             (fun uu___2 ->
@@ -2707,33 +2715,13 @@ let rec (norm :
                FStar_Compiler_Util.print1 ">>> cfg = %s\n" uu___3);
           (match t1.FStar_Syntax_Syntax.n with
            | FStar_Syntax_Syntax.Tm_unknown ->
-               (FStar_TypeChecker_Cfg.log_unfolding cfg
-                  (fun uu___3 ->
-                     let uu___4 = FStar_Syntax_Print.term_to_string t1 in
-                     FStar_Compiler_Util.print1 ">>> Tm_fvar case 0 for %s\n"
-                       uu___4);
-                rebuild cfg env1 stack1 t1)
+               rebuild cfg empty_env stack2 t1
            | FStar_Syntax_Syntax.Tm_constant uu___2 ->
-               (FStar_TypeChecker_Cfg.log_unfolding cfg
-                  (fun uu___4 ->
-                     let uu___5 = FStar_Syntax_Print.term_to_string t1 in
-                     FStar_Compiler_Util.print1 ">>> Tm_fvar case 0 for %s\n"
-                       uu___5);
-                rebuild cfg env1 stack1 t1)
+               rebuild cfg empty_env stack2 t1
            | FStar_Syntax_Syntax.Tm_name uu___2 ->
-               (FStar_TypeChecker_Cfg.log_unfolding cfg
-                  (fun uu___4 ->
-                     let uu___5 = FStar_Syntax_Print.term_to_string t1 in
-                     FStar_Compiler_Util.print1 ">>> Tm_fvar case 0 for %s\n"
-                       uu___5);
-                rebuild cfg env1 stack1 t1)
+               rebuild cfg empty_env stack2 t1
            | FStar_Syntax_Syntax.Tm_lazy uu___2 ->
-               (FStar_TypeChecker_Cfg.log_unfolding cfg
-                  (fun uu___4 ->
-                     let uu___5 = FStar_Syntax_Print.term_to_string t1 in
-                     FStar_Compiler_Util.print1 ">>> Tm_fvar case 0 for %s\n"
-                       uu___5);
-                rebuild cfg env1 stack1 t1)
+               rebuild cfg empty_env stack2 t1
            | FStar_Syntax_Syntax.Tm_fvar
                { FStar_Syntax_Syntax.fv_name = uu___2;
                  FStar_Syntax_Syntax.fv_delta = uu___3;
@@ -2745,7 +2733,7 @@ let rec (norm :
                      let uu___6 = FStar_Syntax_Print.term_to_string t1 in
                      FStar_Compiler_Util.print1 ">>> Tm_fvar case 0 for %s\n"
                        uu___6);
-                rebuild cfg env1 stack1 t1)
+                rebuild cfg empty_env stack2 t1)
            | FStar_Syntax_Syntax.Tm_fvar
                { FStar_Syntax_Syntax.fv_name = uu___2;
                  FStar_Syntax_Syntax.fv_delta = uu___3;
@@ -2757,7 +2745,7 @@ let rec (norm :
                      let uu___7 = FStar_Syntax_Print.term_to_string t1 in
                      FStar_Compiler_Util.print1 ">>> Tm_fvar case 0 for %s\n"
                        uu___7);
-                rebuild cfg env1 stack1 t1)
+                rebuild cfg empty_env stack2 t1)
            | FStar_Syntax_Syntax.Tm_fvar fv ->
                let lid = FStar_Syntax_Syntax.lid_of_fv fv in
                let qninfo =
@@ -2773,17 +2761,17 @@ let rec (norm :
                        (fun uu___5 ->
                           let uu___6 = FStar_Syntax_Print.term_to_string t1 in
                           FStar_Compiler_Util.print1
-                            ">>> Tm_fvar case 0 for %s\n" uu___6);
-                     rebuild cfg env1 stack1 t1)
+                            ">>> Tm_fvar case 1 for %s\n" uu___6);
+                     rebuild cfg empty_env stack2 t1)
                 | uu___3 ->
                     let uu___4 =
-                      decide_unfolding cfg env1 stack1
-                        t1.FStar_Syntax_Syntax.pos fv qninfo in
+                      decide_unfolding cfg stack2 t1.FStar_Syntax_Syntax.pos
+                        fv qninfo in
                     (match uu___4 with
-                     | FStar_Pervasives_Native.Some (cfg1, stack2) ->
-                         do_unfold_fv cfg1 env1 stack2 t1 qninfo fv
+                     | FStar_Pervasives_Native.Some (cfg1, stack3) ->
+                         do_unfold_fv cfg1 stack3 t1 qninfo fv
                      | FStar_Pervasives_Native.None ->
-                         rebuild cfg env1 stack1 t1))
+                         rebuild cfg empty_env stack2 t1))
            | FStar_Syntax_Syntax.Tm_quoted (qt, qi) ->
                let qi1 =
                  FStar_Syntax_Syntax.on_antiquoted (norm cfg env1 []) qi in
@@ -2792,7 +2780,7 @@ let rec (norm :
                    (FStar_Syntax_Syntax.Tm_quoted (qt, qi1))
                    t1.FStar_Syntax_Syntax.pos in
                let uu___2 = closure_as_term cfg env1 t2 in
-               rebuild cfg env1 stack1 uu___2
+               rebuild cfg env1 stack2 uu___2
            | FStar_Syntax_Syntax.Tm_app (hd, args) when
                (should_consider_norm_requests cfg) &&
                  (let uu___2 = is_norm_request hd args in
@@ -2805,7 +2793,7 @@ let rec (norm :
                     "Rejigging norm request ... \n"
                 else ();
                 (let uu___3 = rejig_norm_request hd args in
-                 norm cfg env1 stack1 uu___3))
+                 norm cfg env1 stack2 uu___3))
            | FStar_Syntax_Syntax.Tm_app (hd, args) when
                (should_consider_norm_requests cfg) &&
                  (let uu___2 = is_norm_request hd args in
@@ -2911,11 +2899,11 @@ let rec (norm :
                         FStar_Compiler_Util.print_string
                           "Norm request None ... \n"
                       else ();
-                      (let stack2 =
-                         FStar_Compiler_Effect.op_Bar_Greater stack1
+                      (let stack3 =
+                         FStar_Compiler_Effect.op_Bar_Greater stack2
                            (FStar_Compiler_List.fold_right
                               (fun uu___5 ->
-                                 fun stack3 ->
+                                 fun stack4 ->
                                    match uu___5 with
                                    | (a, aq) ->
                                        let uu___6 =
@@ -2930,7 +2918,7 @@ let rec (norm :
                                            (uu___8, aq,
                                              (t1.FStar_Syntax_Syntax.pos)) in
                                          Arg uu___7 in
-                                       uu___6 :: stack3) args) in
+                                       uu___6 :: stack4) args) in
                        FStar_TypeChecker_Cfg.log cfg
                          (fun uu___6 ->
                             let uu___7 =
@@ -2939,7 +2927,7 @@ let rec (norm :
                                 (FStar_Compiler_List.length args) in
                             FStar_Compiler_Util.print1
                               "\tPushed %s arguments\n" uu___7);
-                       norm cfg env1 stack2 hd))
+                       norm cfg env1 stack3 hd))
                  | FStar_Pervasives_Native.Some (s, tm) when is_nbe_request s
                      ->
                      let tm' = closure_as_term cfg env1 tm in
@@ -2967,7 +2955,7 @@ let rec (norm :
                            "NBE result timing (%s ms){\nOn term {\n%s\n}\nwith steps {%s}\nresult is{\n\n%s\n}\n}\n"
                            uu___5 uu___6 uu___7 uu___8)
                       else ();
-                      rebuild cfg env1 stack1 tm_norm)
+                      rebuild cfg env1 stack2 tm_norm)
                  | FStar_Pervasives_Native.Some (s, tm) ->
                      let delta_level =
                        let uu___4 =
@@ -3083,18 +3071,18 @@ let rec (norm :
                              (tm, uu___5) in
                            FStar_Pervasives_Native.Some uu___4
                          else FStar_Pervasives_Native.None in
-                       (Cfg (cfg, debug)) :: stack1 in
+                       (Cfg (cfg, debug)) :: stack2 in
                      norm cfg'1 env1 stack' tm))
            | FStar_Syntax_Syntax.Tm_type u ->
                let u1 = norm_universe cfg env1 u in
                let uu___2 =
                  FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_type u1)
                    t1.FStar_Syntax_Syntax.pos in
-               rebuild cfg env1 stack1 uu___2
+               rebuild cfg env1 stack2 uu___2
            | FStar_Syntax_Syntax.Tm_uinst (t', us) ->
                if
                  (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.erase_universes
-               then norm cfg env1 stack1 t'
+               then norm cfg env1 stack2 t'
                else
                  (let us1 =
                     let uu___3 =
@@ -3102,7 +3090,7 @@ let rec (norm :
                         FStar_Compiler_List.map (norm_universe cfg env1) us in
                       (uu___4, (t1.FStar_Syntax_Syntax.pos)) in
                     UnivArgs uu___3 in
-                  let stack2 = us1 :: stack1 in norm cfg env1 stack2 t')
+                  let stack3 = us1 :: stack2 in norm cfg env1 stack3 t')
            | FStar_Syntax_Syntax.Tm_bvar x ->
                let uu___2 = lookup_bvar env1 x in
                (match uu___2 with
@@ -3132,20 +3120,20 @@ let rec (norm :
                             (let uu___5 = maybe_weakly_reduced t' in
                              if uu___5
                              then
-                               match stack1 with
+                               match stack2 with
                                | [] when
                                    (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.weak
                                      ||
                                      (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.compress_uvars
-                                   -> rebuild cfg env3 stack1 t'
-                               | uu___6 -> norm cfg env3 stack1 t'
-                             else rebuild cfg env3 stack1 t'))
+                                   -> rebuild cfg env3 stack2 t'
+                               | uu___6 -> norm cfg env3 stack2 t'
+                             else rebuild cfg env3 stack2 t'))
                        | FStar_Pervasives_Native.None ->
-                           norm cfg env2 ((MemoLazy r) :: stack1) t0)
-                    else norm cfg env2 stack1 t0)
+                           norm cfg env2 ((MemoLazy r) :: stack2) t0)
+                    else norm cfg env2 stack2 t0)
            | FStar_Syntax_Syntax.Tm_abs (bs, body, lopt) ->
-               let rec maybe_strip_meta_divs stack2 =
-                 match stack2 with
+               let rec maybe_strip_meta_divs stack3 =
+                 match stack3 with
                  | [] -> FStar_Pervasives_Native.None
                  | (Meta
                      (uu___2, FStar_Syntax_Syntax.Meta_monadic (m, uu___3),
@@ -3165,14 +3153,14 @@ let rec (norm :
                           FStar_Parser_Const.effect_DIV_lid)
                      -> maybe_strip_meta_divs tl
                  | (Arg uu___2)::uu___3 ->
-                     FStar_Pervasives_Native.Some stack2
+                     FStar_Pervasives_Native.Some stack3
                  | uu___2 -> FStar_Pervasives_Native.None in
                let fallback uu___2 =
                  if
                    (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.weak
                  then
                    let t2 = closure_as_term cfg env1 t1 in
-                   rebuild cfg env1 stack1 t2
+                   rebuild cfg env1 stack2 t2
                  else
                    (let uu___4 = FStar_Syntax_Subst.open_term' bs body in
                     match uu___4 with
@@ -3208,9 +3196,9 @@ let rec (norm :
                                   (FStar_Compiler_List.length bs1) in
                               FStar_Compiler_Util.print1
                                 "\tShifted %s dummies\n" uu___7);
-                         (let stack2 =
+                         (let stack3 =
                             (Cfg (cfg, FStar_Pervasives_Native.None)) ::
-                            stack1 in
+                            stack2 in
                           let cfg1 =
                             {
                               FStar_TypeChecker_Cfg.steps =
@@ -3234,9 +3222,9 @@ let rec (norm :
                           norm cfg1 env'
                             ((Abs
                                 (env1, bs1, env', lopt1,
-                                  (t1.FStar_Syntax_Syntax.pos))) :: stack2)
+                                  (t1.FStar_Syntax_Syntax.pos))) :: stack3)
                             body1))) in
-               (match stack1 with
+               (match stack2 with
                 | (UnivArgs uu___2)::uu___3 ->
                     failwith
                       "Ill-typed term: universes cannot be applied to term abstraction"
@@ -3271,19 +3259,19 @@ let rec (norm :
                                 norm cfg
                                   (((FStar_Pervasives_Native.Some b), c) ::
                                   env1) stack_rest body1))))
-                | (MemoLazy r)::stack2 ->
+                | (MemoLazy r)::stack3 ->
                     (set_memo cfg r (env1, t1);
                      FStar_TypeChecker_Cfg.log cfg
                        (fun uu___4 ->
                           let uu___5 = FStar_Syntax_Print.term_to_string t1 in
                           FStar_Compiler_Util.print1 "\tSet memo %s\n" uu___5);
-                     norm cfg env1 stack2 t1)
+                     norm cfg env1 stack3 t1)
                 | (Meta uu___2)::uu___3 ->
-                    let uu___4 = maybe_strip_meta_divs stack1 in
+                    let uu___4 = maybe_strip_meta_divs stack2 in
                     (match uu___4 with
                      | FStar_Pervasives_Native.None -> fallback ()
-                     | FStar_Pervasives_Native.Some stack2 ->
-                         norm cfg env1 stack2 t1)
+                     | FStar_Pervasives_Native.Some stack3 ->
+                         norm cfg env1 stack3 t1)
                 | (Cfg uu___2)::uu___3 -> fallback ()
                 | (Match uu___2)::uu___3 -> fallback ()
                 | (Let uu___2)::uu___3 -> fallback ()
@@ -3308,10 +3296,10 @@ let rec (norm :
                  | uu___3 -> FStar_Pervasives_Native.None in
                (match strict_args with
                 | FStar_Pervasives_Native.None ->
-                    let stack2 =
+                    let stack3 =
                       FStar_Compiler_List.fold_right
                         (fun uu___2 ->
-                           fun stack3 ->
+                           fun stack4 ->
                              match uu___2 with
                              | (a, aq) ->
                                  let a1 =
@@ -3329,6 +3317,21 @@ let rec (norm :
                                    if uu___3
                                    then FStar_Syntax_Util.exp_unit
                                    else a in
+                                 let env2 =
+                                   let uu___3 =
+                                     let uu___4 =
+                                       FStar_Syntax_Subst.compress a1 in
+                                     uu___4.FStar_Syntax_Syntax.n in
+                                   match uu___3 with
+                                   | FStar_Syntax_Syntax.Tm_name uu___4 ->
+                                       empty_env
+                                   | FStar_Syntax_Syntax.Tm_constant uu___4
+                                       -> empty_env
+                                   | FStar_Syntax_Syntax.Tm_lazy uu___4 ->
+                                       empty_env
+                                   | FStar_Syntax_Syntax.Tm_fvar uu___4 ->
+                                       empty_env
+                                   | uu___4 -> env1 in
                                  let uu___3 =
                                    let uu___4 =
                                      let uu___5 =
@@ -3336,12 +3339,12 @@ let rec (norm :
                                          let uu___7 =
                                            FStar_Compiler_Util.mk_ref
                                              FStar_Pervasives_Native.None in
-                                         (env1, a1, uu___7, false) in
+                                         (env2, a1, uu___7, false) in
                                        Clos uu___6 in
                                      (uu___5, aq,
                                        (t1.FStar_Syntax_Syntax.pos)) in
                                    Arg uu___4 in
-                                 uu___3 :: stack3) args stack1 in
+                                 uu___3 :: stack4) args stack2 in
                     (FStar_TypeChecker_Cfg.log cfg
                        (fun uu___3 ->
                           let uu___4 =
@@ -3350,7 +3353,7 @@ let rec (norm :
                               (FStar_Compiler_List.length args) in
                           FStar_Compiler_Util.print1
                             "\tPushed %s arguments\n" uu___4);
-                     norm cfg env1 stack2 head)
+                     norm cfg env1 stack3 head)
                 | FStar_Pervasives_Native.Some strict_args1 ->
                     let norm_args =
                       FStar_Compiler_Effect.op_Bar_Greater args
@@ -3401,11 +3404,11 @@ let rec (norm :
                                            | uu___9 -> false))))) in
                     if uu___2
                     then
-                      let stack2 =
-                        FStar_Compiler_Effect.op_Bar_Greater stack1
+                      let stack3 =
+                        FStar_Compiler_Effect.op_Bar_Greater stack2
                           (FStar_Compiler_List.fold_right
                              (fun uu___3 ->
-                                fun stack3 ->
+                                fun stack4 ->
                                   match uu___3 with
                                   | (a, aq) ->
                                       let uu___4 =
@@ -3421,7 +3424,7 @@ let rec (norm :
                                           (uu___6, aq,
                                             (t1.FStar_Syntax_Syntax.pos)) in
                                         Arg uu___5 in
-                                      uu___4 :: stack3) norm_args) in
+                                      uu___4 :: stack4) norm_args) in
                       (FStar_TypeChecker_Cfg.log cfg
                          (fun uu___4 ->
                             let uu___5 =
@@ -3430,23 +3433,23 @@ let rec (norm :
                                 (FStar_Compiler_List.length args) in
                             FStar_Compiler_Util.print1
                               "\tPushed %s arguments\n" uu___5);
-                       norm cfg env1 stack2 head)
+                       norm cfg env1 stack3 head)
                     else
                       (let head1 = closure_as_term cfg env1 head in
                        let term =
                          FStar_Syntax_Syntax.mk_Tm_app head1 norm_args
                            t1.FStar_Syntax_Syntax.pos in
-                       rebuild cfg env1 stack1 term))
+                       rebuild cfg env1 stack2 term))
            | FStar_Syntax_Syntax.Tm_refine (x, uu___2) when
                (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.for_extraction
                  ||
                  (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.unrefine
-               -> norm cfg env1 stack1 x.FStar_Syntax_Syntax.sort
+               -> norm cfg env1 stack2 x.FStar_Syntax_Syntax.sort
            | FStar_Syntax_Syntax.Tm_refine (x, f) ->
                if
                  (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.weak
                then
-                 (match (env1, stack1) with
+                 (match (env1, stack2) with
                   | ([], []) ->
                       let t_x = norm cfg env1 [] x.FStar_Syntax_Syntax.sort in
                       let t2 =
@@ -3459,10 +3462,10 @@ let rec (norm :
                                   (x.FStar_Syntax_Syntax.index);
                                 FStar_Syntax_Syntax.sort = t_x
                               }, f)) t1.FStar_Syntax_Syntax.pos in
-                      rebuild cfg env1 stack1 t2
+                      rebuild cfg env1 stack2 t2
                   | uu___2 ->
                       let uu___3 = closure_as_term cfg env1 t1 in
-                      rebuild cfg env1 stack1 uu___3)
+                      rebuild cfg env1 stack2 uu___3)
                else
                  (let t_x = norm cfg env1 [] x.FStar_Syntax_Syntax.sort in
                   let uu___3 =
@@ -3487,13 +3490,13 @@ let rec (norm :
                           FStar_Syntax_Syntax.Tm_refine uu___5 in
                         FStar_Syntax_Syntax.mk uu___4
                           t1.FStar_Syntax_Syntax.pos in
-                      rebuild cfg env1 stack1 t2)
+                      rebuild cfg env1 stack2 t2)
            | FStar_Syntax_Syntax.Tm_arrow (bs, c) ->
                if
                  (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.weak
                then
                  let uu___2 = closure_as_term cfg env1 t1 in
-                 rebuild cfg env1 stack1 uu___2
+                 rebuild cfg env1 stack2 uu___2
                else
                  (let uu___3 = FStar_Syntax_Subst.open_comp bs c in
                   match uu___3 with
@@ -3507,12 +3510,12 @@ let rec (norm :
                       let t2 =
                         let uu___4 = norm_binders cfg env1 bs1 in
                         FStar_Syntax_Util.arrow uu___4 c2 in
-                      rebuild cfg env1 stack1 t2)
+                      rebuild cfg env1 stack2 t2)
            | FStar_Syntax_Syntax.Tm_ascribed (t11, uu___2, l) when
                (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.unascribe
-               -> norm cfg env1 stack1 t11
+               -> norm cfg env1 stack2 t11
            | FStar_Syntax_Syntax.Tm_ascribed (t11, asc, l) ->
-               (match stack1 with
+               (match stack2 with
                 | (Match uu___2)::uu___3 when
                     (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.beta
                     ->
@@ -3520,7 +3523,7 @@ let rec (norm :
                        (fun uu___5 ->
                           FStar_Compiler_Util.print_string
                             "+++ Dropping ascription \n");
-                     norm cfg env1 stack1 t11)
+                     norm cfg env1 stack2 t11)
                 | (Arg uu___2)::uu___3 when
                     (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.beta
                     ->
@@ -3528,7 +3531,7 @@ let rec (norm :
                        (fun uu___5 ->
                           FStar_Compiler_Util.print_string
                             "+++ Dropping ascription \n");
-                     norm cfg env1 stack1 t11)
+                     norm cfg env1 stack2 t11)
                 | (App
                     (uu___2,
                      {
@@ -3545,7 +3548,7 @@ let rec (norm :
                        (fun uu___9 ->
                           FStar_Compiler_Util.print_string
                             "+++ Dropping ascription \n");
-                     norm cfg env1 stack1 t11)
+                     norm cfg env1 stack2 t11)
                 | (MemoLazy uu___2)::uu___3 when
                     (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.beta
                     ->
@@ -3553,7 +3556,7 @@ let rec (norm :
                        (fun uu___5 ->
                           FStar_Compiler_Util.print_string
                             "+++ Dropping ascription \n");
-                     norm cfg env1 stack1 t11)
+                     norm cfg env1 stack2 t11)
                 | uu___2 ->
                     (FStar_TypeChecker_Cfg.log cfg
                        (fun uu___4 ->
@@ -3565,8 +3568,8 @@ let rec (norm :
                            FStar_Compiler_Util.print_string
                              "+++ Normalizing ascription \n");
                       (let asc1 = norm_ascription cfg env1 asc in
-                       match stack1 with
-                       | (Cfg (cfg', dbg))::stack2 ->
+                       match stack2 with
+                       | (Cfg (cfg', dbg))::stack3 ->
                            (maybe_debug cfg t12 dbg;
                             (let t2 =
                                let uu___6 =
@@ -3577,7 +3580,7 @@ let rec (norm :
                                  FStar_Syntax_Syntax.Tm_ascribed uu___7 in
                                FStar_Syntax_Syntax.mk uu___6
                                  t1.FStar_Syntax_Syntax.pos in
-                             norm cfg' env1 stack2 t2))
+                             norm cfg' env1 stack3 t2))
                        | uu___5 ->
                            let uu___6 =
                              let uu___7 =
@@ -3587,15 +3590,15 @@ let rec (norm :
                                FStar_Syntax_Syntax.Tm_ascribed uu___8 in
                              FStar_Syntax_Syntax.mk uu___7
                                t1.FStar_Syntax_Syntax.pos in
-                           rebuild cfg env1 stack1 uu___6))))
+                           rebuild cfg env1 stack2 uu___6))))
            | FStar_Syntax_Syntax.Tm_match (head, asc_opt, branches1, lopt) ->
                let lopt1 =
                  FStar_Compiler_Util.map_option (maybe_drop_rc_typ cfg) lopt in
-               let stack2 =
+               let stack3 =
                  (Match
                     (env1, asc_opt, branches1, lopt1, cfg,
                       (t1.FStar_Syntax_Syntax.pos)))
-                 :: stack1 in
+                 :: stack2 in
                if
                  ((cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.iota
                     &&
@@ -3686,8 +3689,8 @@ let rec (norm :
                        (cfg.FStar_TypeChecker_Cfg.reifying)
                    } in
                  norm cfg' env1 ((Cfg (cfg, FStar_Pervasives_Native.None)) ::
-                   stack2) head
-               else norm cfg env1 stack2 head
+                   stack3) head
+               else norm cfg env1 stack3 head
            | FStar_Syntax_Syntax.Tm_let ((b, lbs), lbody) when
                (FStar_Syntax_Syntax.is_top_level lbs) &&
                  (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.compress_uvars
@@ -3750,7 +3753,7 @@ let rec (norm :
                  FStar_Syntax_Syntax.mk
                    (FStar_Syntax_Syntax.Tm_let ((b, lbs1), lbody))
                    t1.FStar_Syntax_Syntax.pos in
-               rebuild cfg env1 stack1 uu___2
+               rebuild cfg env1 stack2 uu___2
            | FStar_Syntax_Syntax.Tm_let
                ((uu___2,
                  { FStar_Syntax_Syntax.lbname = FStar_Pervasives.Inr uu___3;
@@ -3761,7 +3764,7 @@ let rec (norm :
                    FStar_Syntax_Syntax.lbattrs = uu___8;
                    FStar_Syntax_Syntax.lbpos = uu___9;_}::uu___10),
                 uu___11)
-               -> rebuild cfg env1 stack1 t1
+               -> rebuild cfg env1 stack2 t1
            | FStar_Syntax_Syntax.Tm_let ((false, lb::[]), body) ->
                let uu___2 =
                  FStar_TypeChecker_Cfg.should_reduce_local_let cfg lb in
@@ -3788,7 +3791,7 @@ let rec (norm :
                     (fun uu___4 ->
                        FStar_Compiler_Util.print_string
                          "+++ Reducing Tm_let\n");
-                  norm cfg env2 stack1 body)
+                  norm cfg env2 stack2 body)
                else
                  (let uu___4 =
                     (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.reify_
@@ -3815,16 +3818,16 @@ let rec (norm :
                         FStar_Syntax_Syntax.Tm_abs uu___6 in
                       FStar_Syntax_Syntax.mk uu___5
                         t1.FStar_Syntax_Syntax.pos in
-                    let stack2 =
+                    let stack3 =
                       (CBVApp
                          (env1, ffun, FStar_Pervasives_Native.None,
                            (t1.FStar_Syntax_Syntax.pos)))
-                      :: stack1 in
+                      :: stack2 in
                     (FStar_TypeChecker_Cfg.log cfg
                        (fun uu___6 ->
                           FStar_Compiler_Util.print_string
                             "+++ Evaluating DIV Tm_let\n");
-                     norm cfg env1 stack2 lb.FStar_Syntax_Syntax.lbdef)
+                     norm cfg env1 stack3 lb.FStar_Syntax_Syntax.lbdef)
                   else
                     if
                       (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.weak
@@ -3834,7 +3837,7 @@ let rec (norm :
                             FStar_Compiler_Util.print_string
                               "+++ Not touching Tm_let\n");
                        (let uu___7 = closure_as_term cfg env1 t1 in
-                        rebuild cfg env1 stack1 uu___7))
+                        rebuild cfg env1 stack2 uu___7))
                     else
                       (let uu___7 =
                          let uu___8 =
@@ -3895,9 +3898,9 @@ let rec (norm :
                                   (FStar_Compiler_List.fold_left
                                      (fun env2 ->
                                         fun uu___10 -> dummy :: env2) env1) in
-                              let stack2 =
+                              let stack3 =
                                 (Cfg (cfg, FStar_Pervasives_Native.None)) ::
-                                stack1 in
+                                stack2 in
                               let cfg1 =
                                 {
                                   FStar_TypeChecker_Cfg.steps =
@@ -3926,7 +3929,7 @@ let rec (norm :
                                 ((Let
                                     (env1, bs, lb1,
                                       (t1.FStar_Syntax_Syntax.pos))) ::
-                                stack2) body1)))))
+                                stack3) body1)))))
            | FStar_Syntax_Syntax.Tm_let ((true, lbs), body) when
                (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.compress_uvars
                  ||
@@ -4028,7 +4031,7 @@ let rec (norm :
                              FStar_Syntax_Syntax.vars =
                                (t1.FStar_Syntax_Syntax.vars)
                            } in
-                         rebuild cfg env1 stack1 t2))
+                         rebuild cfg env1 stack2 t2))
            | FStar_Syntax_Syntax.Tm_let (lbs, body) when
                (Prims.op_Negation
                   (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.zeta)
@@ -4037,7 +4040,7 @@ let rec (norm :
                     (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.zeta_full)
                ->
                let uu___2 = closure_as_term cfg env1 t1 in
-               rebuild cfg env1 stack1 uu___2
+               rebuild cfg env1 stack2 uu___2
            | FStar_Syntax_Syntax.Tm_let (lbs, body) ->
                let uu___2 =
                  FStar_Compiler_List.fold_right
@@ -4097,7 +4100,7 @@ let rec (norm :
                                (FStar_Pervasives_Native.None, uu___6) in
                              uu___5 :: env2)
                         (FStar_Pervasives_Native.snd lbs) env1 in
-                    norm cfg body_env stack1 body)
+                    norm cfg body_env stack2 body)
            | FStar_Syntax_Syntax.Tm_meta (head, m) ->
                (FStar_TypeChecker_Cfg.log cfg
                   (fun uu___3 ->
@@ -4122,12 +4125,12 @@ let rec (norm :
                               (FStar_Syntax_Syntax.Tm_meta
                                  (FStar_Syntax_Util.exp_unit, m))
                               t1.FStar_Syntax_Syntax.pos in
-                          rebuild cfg env1 stack1 uu___4
+                          rebuild cfg env1 stack2 uu___4
                         else
-                          reduce_impure_comp cfg env1 stack1 head
+                          reduce_impure_comp cfg env1 stack2 head
                             (FStar_Pervasives.Inl m_from) ty)
                      else
-                       reduce_impure_comp cfg env1 stack1 head
+                       reduce_impure_comp cfg env1 stack2 head
                          (FStar_Pervasives.Inl m_from) ty
                  | FStar_Syntax_Syntax.Meta_monadic_lift (m_from, m_to, ty)
                      ->
@@ -4151,25 +4154,25 @@ let rec (norm :
                               (FStar_Syntax_Syntax.Tm_meta
                                  (FStar_Syntax_Util.exp_unit, m))
                               t1.FStar_Syntax_Syntax.pos in
-                          rebuild cfg env1 stack1 uu___4
+                          rebuild cfg env1 stack2 uu___4
                         else
-                          reduce_impure_comp cfg env1 stack1 head
+                          reduce_impure_comp cfg env1 stack2 head
                             (FStar_Pervasives.Inr (m_from, m_to)) ty)
                      else
-                       reduce_impure_comp cfg env1 stack1 head
+                       reduce_impure_comp cfg env1 stack2 head
                          (FStar_Pervasives.Inr (m_from, m_to)) ty
                  | uu___3 ->
                      if
                        (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.unmeta
-                     then norm cfg env1 stack1 head
+                     then norm cfg env1 stack2 head
                      else
-                       (match stack1 with
+                       (match stack2 with
                         | uu___5::uu___6 ->
                             (match m with
                              | FStar_Syntax_Syntax.Meta_labeled
                                  (l, r, uu___7) ->
                                  norm cfg env1 ((Meta (env1, m, r)) ::
-                                   stack1) head
+                                   stack2) head
                              | FStar_Syntax_Syntax.Meta_pattern (names, args)
                                  ->
                                  let args1 = norm_pattern_args cfg env1 args in
@@ -4183,7 +4186,7 @@ let rec (norm :
                                          (FStar_Syntax_Syntax.Meta_pattern
                                             (names1, args1)),
                                          (t1.FStar_Syntax_Syntax.pos))) ::
-                                   stack1) head
+                                   stack2) head
                              | FStar_Syntax_Syntax.Meta_desugared
                                  (FStar_Syntax_Syntax.Machine_integer
                                  (uu___7, uu___8)) ->
@@ -4191,8 +4194,8 @@ let rec (norm :
                                    ((Meta
                                        (env1, m,
                                          (t1.FStar_Syntax_Syntax.pos))) ::
-                                   stack1) head
-                             | uu___7 -> norm cfg env1 stack1 head)
+                                   stack2) head
+                             | uu___7 -> norm cfg env1 stack2 head)
                         | [] ->
                             let head1 = norm cfg env1 [] head in
                             let m1 =
@@ -4214,7 +4217,7 @@ let rec (norm :
                               FStar_Syntax_Syntax.mk
                                 (FStar_Syntax_Syntax.Tm_meta (head1, m1))
                                 t1.FStar_Syntax_Syntax.pos in
-                            rebuild cfg env1 stack1 t2)))
+                            rebuild cfg env1 stack2 t2)))
            | FStar_Syntax_Syntax.Tm_delayed uu___2 ->
                failwith "impossible: Tm_delayed on norm"
            | FStar_Syntax_Syntax.Tm_uvar uu___2 ->
@@ -4232,98 +4235,95 @@ let rec (norm :
                  failwith uu___3
                else
                  (let uu___4 = inline_closure_env cfg env1 [] t1 in
-                  rebuild cfg env1 stack1 uu___4))
+                  rebuild cfg env1 stack2 uu___4))
 and (do_unfold_fv :
   FStar_TypeChecker_Cfg.cfg ->
-    env ->
-      stack_elt Prims.list ->
-        FStar_Syntax_Syntax.term ->
-          FStar_TypeChecker_Env.qninfo ->
-            FStar_Syntax_Syntax.fv -> FStar_Syntax_Syntax.term)
+    stack_elt Prims.list ->
+      FStar_Syntax_Syntax.term ->
+        FStar_TypeChecker_Env.qninfo ->
+          FStar_Syntax_Syntax.fv -> FStar_Syntax_Syntax.term)
   =
   fun cfg ->
-    fun env1 ->
-      fun stack1 ->
-        fun t0 ->
-          fun qninfo ->
-            fun f ->
-              let uu___ =
-                FStar_TypeChecker_Env.lookup_definition_qninfo
-                  cfg.FStar_TypeChecker_Cfg.delta_level
-                  (f.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
-                  qninfo in
-              match uu___ with
-              | FStar_Pervasives_Native.None ->
-                  (FStar_TypeChecker_Cfg.log_unfolding cfg
-                     (fun uu___2 ->
-                        let uu___3 = FStar_Syntax_Print.fv_to_string f in
-                        FStar_Compiler_Util.print1
-                          " >> Tm_fvar case 2 for %s\n" uu___3);
-                   rebuild cfg env1 stack1 t0)
-              | FStar_Pervasives_Native.Some (us, t) ->
-                  (FStar_TypeChecker_Cfg.log_unfolding cfg
-                     (fun uu___2 ->
-                        let uu___3 = FStar_Syntax_Print.term_to_string t0 in
-                        let uu___4 = FStar_Syntax_Print.term_to_string t in
-                        FStar_Compiler_Util.print2 " >> Unfolded %s to %s\n"
-                          uu___3 uu___4);
-                   (let t1 =
-                      if
-                        (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.unfold_until
-                          =
-                          (FStar_Pervasives_Native.Some
-                             FStar_Syntax_Syntax.delta_constant)
-                      then t
-                      else
-                        FStar_Syntax_Subst.set_use_range
-                          t0.FStar_Syntax_Syntax.pos t in
-                    let n = FStar_Compiler_List.length us in
-                    if n > Prims.int_zero
-                    then
-                      match stack1 with
-                      | (UnivArgs (us', uu___2))::stack2 ->
-                          ((let uu___4 =
-                              FStar_Compiler_Effect.op_Less_Bar
-                                (FStar_TypeChecker_Env.debug
-                                   cfg.FStar_TypeChecker_Cfg.tcenv)
-                                (FStar_Options.Other "univ_norm") in
-                            if uu___4
-                            then
-                              FStar_Compiler_List.iter
-                                (fun x ->
-                                   let uu___5 =
-                                     FStar_Syntax_Print.univ_to_string x in
-                                   FStar_Compiler_Util.print1
-                                     "Univ (normalizer) %s\n" uu___5) us'
-                            else ());
-                           (let env2 =
-                              FStar_Compiler_Effect.op_Bar_Greater us'
-                                (FStar_Compiler_List.fold_left
-                                   (fun env3 ->
-                                      fun u ->
-                                        (FStar_Pervasives_Native.None,
-                                          (Univ u))
-                                        :: env3) env1) in
-                            norm cfg env2 stack2 t1))
-                      | uu___2 when
-                          (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.erase_universes
-                            ||
-                            (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.allow_unbound_universes
-                          -> norm cfg env1 stack1 t1
-                      | uu___2 ->
-                          let uu___3 =
-                            let uu___4 =
-                              FStar_Syntax_Print.lid_to_string
-                                (f.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-                            FStar_Compiler_Util.format1
-                              "Impossible: missing universe instantiation on %s"
-                              uu___4 in
-                          failwith uu___3
-                    else norm cfg env1 stack1 t1))
+    fun stack1 ->
+      fun t0 ->
+        fun qninfo ->
+          fun f ->
+            let uu___ =
+              FStar_TypeChecker_Env.lookup_definition_qninfo
+                cfg.FStar_TypeChecker_Cfg.delta_level
+                (f.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v qninfo in
+            match uu___ with
+            | FStar_Pervasives_Native.None ->
+                (FStar_TypeChecker_Cfg.log_unfolding cfg
+                   (fun uu___2 ->
+                      let uu___3 = FStar_Syntax_Print.fv_to_string f in
+                      FStar_Compiler_Util.print1
+                        " >> Tm_fvar case 2 for %s\n" uu___3);
+                 rebuild cfg empty_env stack1 t0)
+            | FStar_Pervasives_Native.Some (us, t) ->
+                (FStar_TypeChecker_Cfg.log_unfolding cfg
+                   (fun uu___2 ->
+                      let uu___3 = FStar_Syntax_Print.term_to_string t0 in
+                      let uu___4 = FStar_Syntax_Print.term_to_string t in
+                      FStar_Compiler_Util.print2 " >> Unfolded %s to %s\n"
+                        uu___3 uu___4);
+                 (let t1 =
+                    if
+                      (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.unfold_until
+                        =
+                        (FStar_Pervasives_Native.Some
+                           FStar_Syntax_Syntax.delta_constant)
+                    then t
+                    else
+                      FStar_Syntax_Subst.set_use_range
+                        t0.FStar_Syntax_Syntax.pos t in
+                  let n = FStar_Compiler_List.length us in
+                  if n > Prims.int_zero
+                  then
+                    match stack1 with
+                    | (UnivArgs (us', uu___2))::stack2 ->
+                        ((let uu___4 =
+                            FStar_Compiler_Effect.op_Less_Bar
+                              (FStar_TypeChecker_Env.debug
+                                 cfg.FStar_TypeChecker_Cfg.tcenv)
+                              (FStar_Options.Other "univ_norm") in
+                          if uu___4
+                          then
+                            FStar_Compiler_List.iter
+                              (fun x ->
+                                 let uu___5 =
+                                   FStar_Syntax_Print.univ_to_string x in
+                                 FStar_Compiler_Util.print1
+                                   "Univ (normalizer) %s\n" uu___5) us'
+                          else ());
+                         (let env1 =
+                            FStar_Compiler_Effect.op_Bar_Greater us'
+                              (FStar_Compiler_List.fold_left
+                                 (fun env2 ->
+                                    fun u ->
+                                      (FStar_Pervasives_Native.None,
+                                        (Univ u))
+                                      :: env2) empty_env) in
+                          norm cfg env1 stack2 t1))
+                    | uu___2 when
+                        (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.erase_universes
+                          ||
+                          (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.allow_unbound_universes
+                        -> norm cfg empty_env stack1 t1
+                    | uu___2 ->
+                        let uu___3 =
+                          let uu___4 =
+                            FStar_Syntax_Print.lid_to_string
+                              (f.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
+                          FStar_Compiler_Util.format1
+                            "Impossible: missing universe instantiation on %s"
+                            uu___4 in
+                        failwith uu___3
+                  else norm cfg empty_env stack1 t1))
 and (reduce_impure_comp :
   FStar_TypeChecker_Cfg.cfg ->
     env ->
-      stack ->
+      stack_elt Prims.list ->
         FStar_Syntax_Syntax.term ->
           (FStar_Syntax_Syntax.monad_name,
             (FStar_Syntax_Syntax.monad_name * FStar_Syntax_Syntax.monad_name))

--- a/src/typechecker/FStar.TypeChecker.Normalize.fst
+++ b/src/typechecker/FStar.TypeChecker.Normalize.fst
@@ -80,6 +80,8 @@ type closure =
   | Dummy                                          //Dummy is a placeholder for a binder when doing strong reduction
 and env = list (option binder*closure)
 
+let empty_env : env = []
+
 let dummy : option binder * closure = None,Dummy
 
 type branches = list (pat * option term * term)
@@ -1014,7 +1016,7 @@ let should_unfold cfg should_reify fv qninfo : should_unfold_res =
       plugin_unfold_warn_ctr := !plugin_unfold_warn_ctr - 1
     end;
     r
-let decide_unfolding cfg env stack rng fv qninfo (* : option (cfg * stack) *) =
+let decide_unfolding cfg stack rng fv qninfo (* : option (cfg * stack) *) =
     let res =
         should_unfold cfg (fun cfg -> should_reify cfg stack) fv qninfo
     in
@@ -1055,7 +1057,7 @@ let decide_unfolding cfg env stack rng fv qninfo (* : option (cfg * stack) *) =
         in
         let ref = S.mk (Tm_constant (Const_reflect (S.lid_of_fv fv)))
                        Range.dummyRange in
-        let stack = push (App (env, ref, None, Range.dummyRange)) stack in
+        let stack = push (App (empty_env, ref, None, Range.dummyRange)) stack in
         Some (cfg, stack)
 
 (* on_domain_lids are constant, so compute them once *)
@@ -1124,30 +1126,34 @@ let rec norm : cfg -> env -> stack -> term -> term =
                                         (stack_to_string (fst <| firstn 4 stack)));
         log_cfg cfg (fun () -> BU.print1 ">>> cfg = %s\n" (cfg_to_string cfg));
         match t.n with
+          // Values
           | Tm_unknown
           | Tm_constant _
           | Tm_name _
+          | Tm_lazy _ ->
+            rebuild cfg empty_env stack t
 
-          | Tm_lazy _
-
-          //these three are just constructors; no delta steps can apply
+          // These three are just constructors; no delta steps can apply.
+          // Note: we drop the environment, no free indices here
           | Tm_fvar({ fv_qual = Some Data_ctor })
           | Tm_fvar({ fv_qual = Some (Record_ctor _) }) ->
             log_unfolding cfg (fun () -> BU.print1 ">>> Tm_fvar case 0 for %s\n" (Print.term_to_string t));
-            rebuild cfg env stack t
+            rebuild cfg empty_env stack t
 
+          // A top-level name, possibly unfold it.
+          // In either case, also drop the environment, no free indices here.
           | Tm_fvar fv ->
             let lid = S.lid_of_fv fv in
             let qninfo = Env.lookup_qname cfg.tcenv lid in
             begin
             match Env.delta_depth_of_qninfo fv qninfo with
             | Some (Delta_constant_at_level 0) ->
-              log_unfolding cfg (fun () -> BU.print1 ">>> Tm_fvar case 0 for %s\n" (Print.term_to_string t));
-              rebuild cfg env stack t
+              log_unfolding cfg (fun () -> BU.print1 ">>> Tm_fvar case 1 for %s\n" (Print.term_to_string t));
+              rebuild cfg empty_env stack t
             | _ ->
-              match decide_unfolding cfg env stack t.pos fv qninfo with
-              | Some (cfg, stack) -> do_unfold_fv cfg env stack t qninfo fv
-              | None -> rebuild cfg env stack t
+              match decide_unfolding cfg stack t.pos fv qninfo with
+              | Some (cfg, stack) -> do_unfold_fv cfg stack t qninfo fv
+              | None -> rebuild cfg empty_env stack t
             end
 
           | Tm_quoted (qt, qi) ->
@@ -1690,12 +1696,14 @@ let rec norm : cfg -> env -> stack -> term -> term =
           else rebuild cfg env stack (inline_closure_env cfg env [] t)
 
 
-and do_unfold_fv cfg env stack (t0:term) (qninfo : qninfo) (f:fv) : term =
+(* NOTE: we do not need any environment here, since an fv does not
+ * have any free indices. Hence, we use empty_env as environment when needed. *)
+and do_unfold_fv cfg stack (t0:term) (qninfo : qninfo) (f:fv) : term =
     match Env.lookup_definition_qninfo cfg.delta_level f.fv_name.v qninfo with
        | None ->
          log_unfolding cfg (fun () -> // printfn "delta_level = %A, qninfo=%A" cfg.delta_level qninfo;
                                       BU.print1 " >> Tm_fvar case 2 for %s\n" (Print.fv_to_string f));
-         rebuild cfg env stack t0
+         rebuild cfg empty_env stack t0
 
        | Some (us, t) ->
          begin
@@ -1716,12 +1724,12 @@ and do_unfold_fv cfg env stack (t0:term) (qninfo : qninfo) (f:fv) : term =
                   if Env.debug cfg.tcenv <| Options.Other "univ_norm" then
                       List.iter (fun x -> BU.print1 "Univ (normalizer) %s\n" (Print.univ_to_string x)) us'
                   else ();
-                  let env = us' |> List.fold_left (fun env u -> (None, Univ u)::env) env in
+                  let env = us' |> List.fold_left (fun env u -> (None, Univ u)::env) empty_env in
                   norm cfg env stack t
                 | _ when cfg.steps.erase_universes || cfg.steps.allow_unbound_universes ->
-                  norm cfg env stack t
+                  norm cfg empty_env stack t
                 | _ -> failwith (BU.format1 "Impossible: missing universe instantiation on %s" (Print.lid_to_string f.fv_name.v))
-         else norm cfg env stack t
+         else norm cfg empty_env stack t
          end
 
 and reduce_impure_comp cfg env stack (head : term) // monadic term

--- a/src/typechecker/FStar.TypeChecker.Normalize.fst
+++ b/src/typechecker/FStar.TypeChecker.Normalize.fst
@@ -1393,6 +1393,17 @@ let rec norm : cfg -> env -> stack -> term -> term =
                       then U.exp_unit
                       else a
                     in
+                    // !! Optimization: if the argument we are pushing is an obvious
+                    // value/closed term, then drop the environment. This can save
+                    // a ton of memory, particularly when running tactics in tight loop.
+                    let env =
+                      match (Subst.compress a).n with
+                      | Tm_name _
+                      | Tm_constant _
+                      | Tm_lazy _
+                      | Tm_fvar _ -> empty_env
+                      | _ -> env
+                    in
                     Arg (Clos(env, a, BU.mk_ref None, false),aq,t.pos)::stack)
                   args
                   stack

--- a/src/typechecker/FStar.TypeChecker.Normalize.fst
+++ b/src/typechecker/FStar.TypeChecker.Normalize.fst
@@ -1099,6 +1099,14 @@ let maybe_drop_rc_typ cfg (rc:residual_comp) : residual_comp =
  * time. *)
 let rec norm : cfg -> env -> stack -> term -> term =
     fun cfg env stack t ->
+        let rec collapse_metas st =
+          match st with
+          (* Keep only the outermost Meta_monadic *)
+          | Meta (_, Meta_monadic _, _) :: Meta(e, Meta_monadic m, r) :: st' ->
+            collapse_metas (Meta (e, Meta_monadic m, r) :: st')
+          | _ -> st
+        in
+        let stack = collapse_metas stack in
         let t =
             if cfg.debug.norm_delayed
             then (match t.n with

--- a/src/typechecker/FStar.TypeChecker.Normalize.fst
+++ b/src/typechecker/FStar.TypeChecker.Normalize.fst
@@ -1108,7 +1108,7 @@ let rec norm : cfg -> env -> stack -> term -> term =
             compress t
         in
         log cfg (fun () ->
-          BU.print5 ">>> %s (no_full_norm=%s)\nNorm %s  with with %s env elements top of the stack %s \n"
+          BU.print5 ">>> %s (no_full_norm=%s)\nNorm %s with %s env elements; top of the stack = %s\n"
                                         (Print.tag_of_term t)
                                         (BU.string_of_bool (cfg.steps.no_full_norm))
                                         (Print.term_to_string t)


### PR DESCRIPTION
When trying to (locally) merge PRs #2621, #2645, #2730, and a few minor others, I noticed a pretty huge regression in memory usage.

Some files, in particular those under `examples/csl` would take several GBs of memory, up to 15 iirc (I will run a detailed comparison soon). The only thing I could think that changed was that some functions deep down in the Meta-F* library were redefined to call others, so the normalizer would now perform more steps. The following program confirmed it:
```fstar
let rec tau () : Tac unit = tau ()
let _ = assert True by tau ()
```
While this is a tail-recursive recursive function, it would use an unbounded amount of memory. This even happens for a **Tot** function. I've noticed a few causes of this:

 1- When unfolding an `fvar`, we were keeping the KAM's environment. This is unneeded: the `fvar` has no free indices, and similarly for other cases. 
 2- For the loop above, even in `Tot`, when we push the `()` argument to the stack, we save its environment. Then we unfold `tau` (and drop the current env, due to (1)), and shift the argument on the stack to the new environment. Repeating this process creates a long chain of unit-length environments, that uses an unbounded amount of heap. My naive solution here was to detect some particular closed cases, and discard the environment for the argument if so.
 3- In the particular case of `Tac`, we are accumulating Meta nodes on the KAM's stack, when only the outermost one is actually needed.

With these changes, this loop now runs in constant memory. F* CI returned green.

If this looks sane, I can batch it into my merge for the other PRs. (Or just merge one by one....