### PR TITLE
Make snapshot diff a hard failure

### DIFF
--- a/.docker/build/build_funs.sh
+++ b/.docker/build/build_funs.sh
@@ -232,12 +232,12 @@ function fstar_default_build () {
     $gnutime make -C src -j $threads -k $localTarget && echo true >$status_file
     echo Done building FStar
 
-    # Make it an orange if there's a git diff. Note: FStar_Version.ml is in the
+    # Make it a hard failure if there's a git diff. Note: FStar_Version.ml is in the
     # .gitignore.
     echo "Searching for a diff in src/ocaml-output"
     if ! git diff --exit-code src/ocaml-output; then
         echo "GIT DIFF: the files in the list above have a git diff"
-        { echo " - snapshot-diff (F*)" >>$ORANGE_FILE; }
+        echo false >$status_file
     fi
 
     # We should not generate hints when building on Windows


### PR DESCRIPTION
As a remnant of the old CI system, CI jobs could succeed even if the snapshot was not up-to-date. This was in part due to logs not easily available to external contributors.
That is no longer true today thanks to GitHub Actions. So, this PR makes snapshot diffs a hard failure.

So far this PR does not upgrade the contributing guidelines, in the sense that reviewers, not contributors, are responsible for updating the snapshot:
> We **do not** expect external pull requests to refresh the snapshot. However, reviewers should take it upon themselves to update the snapshot before merging to master when this is needed to obtain a "Success" without breakages from CI (in particular without "snapshot-diff" breakages in the VSTS "Extra logs" = "Build Summary"). The reviewer may (in rare cases, when the change touches extraction) need to bootstrap twice to reach the fixpoint.

**Question:** should that still be the case? (One possible reason why it still should be: a snapshot diff may "clutter" the PR diff)