### PR TITLE
Extract M?.reflect to a failwith instead of hardfailing

### DIFF
--- a/src/extraction/FStar.Extraction.ML.Term.fst
+++ b/src/extraction/FStar.Extraction.ML.Term.fst
@@ -842,7 +842,7 @@ let resugar_pat g q p = match p with
 // match v with
 // | (| true, b |) -> ...
 //
-// In F*, the sort of b is computed to be bool, since the conditional 
+// In F*, the sort of b is computed to be bool, since the conditional
 // can be eliminated
 // But, in OCaml, this should be typed as Obj.t, since the type of v itself is
 // (bool, Obj.t) dtuple2
@@ -884,7 +884,7 @@ let rec extract_one_pat (imp : bool)
         in
         //these may be extracted to bigint, in which case, we need to emit a when clause
         let g, x = UEnv.new_mlident g in
-        let x_exp = 
+        let x_exp =
           let x_exp = with_ty expected_ty <| MLE_Var x in
           let coerce x = with_ty ml_ty <| (MLE_Coerce(x, ml_ty, expected_ty)) in
           match expected_ty with
@@ -945,7 +945,7 @@ let rec extract_one_pat (imp : bool)
         let f_ty =
             let mlty_args =
                 tysVarPats |>
-                List.map 
+                List.map
                   (fun (p, _) ->
                     match expected_ty with
                     | MLTY_Top ->
@@ -971,7 +971,7 @@ let rec extract_one_pat (imp : bool)
                           (Print.fv_to_string f)
                           (let args, t = f_ty in
                            let args =
-                               List.map 
+                               List.map
                                  (Code.string_of_mlty (current_module_of_uenv g))
                                  args
                                |> String.concat " -> "
@@ -982,7 +982,7 @@ let rec extract_one_pat (imp : bool)
         // These should all come out as None, if they are dot patterns
         // Their expected type does not matter
         let g, tyMLPats =
-          BU.fold_map 
+          BU.fold_map
             (fun g (p, imp) ->
               let g, p, _ = extract_one_pat true g p MLTY_Top term_as_mlexpr in
               g, p)
@@ -1011,8 +1011,8 @@ let rec extract_one_pat (imp : bool)
           |> List.collect (function (Some x) -> [x] | _ -> [])
           |> List.split
         in
-        
-        let pat_ty_compat = 
+
+        let pat_ty_compat =
           match f_ty with
           | ([], t) -> ok t
           | _ -> false //arity mismatch, should be impossible
@@ -1471,7 +1471,11 @@ and term_as_mlexpr' (g:uenv) (top:term) : (mlexpr * e_tag * mlty) =
         | Tm_app({n=Tm_constant Const_set_range_of}, [(t, _); (r, _)]) ->
           term_as_mlexpr g t
 
-        | Tm_app({n=Tm_constant (Const_reflect _)}, _) -> failwith "Unreachable? Tm_app Const_reflect"
+        | Tm_app({n=Tm_constant (Const_reflect _)}, _) ->
+            let ({exp_b_expr=fw}) = UEnv.lookup_fv t.pos g (S.lid_as_fv (PC.failwith_lid()) delta_constant None) in
+            with_ty ml_int_ty <| MLE_App(fw, [with_ty ml_string_ty <| MLE_Const (MLC_String "Extraction of reflect is not supported")]),
+            E_PURE,
+            ml_int_ty
 
         | Tm_app (head, args)
           when is_match head &&

--- a/src/ocaml-output/FStar_Extraction_ML_Term.ml
+++ b/src/ocaml-output/FStar_Extraction_ML_Term.ml
@@ -2848,7 +2848,38 @@ and (term_as_mlexpr' :
               FStar_Syntax_Syntax.pos = uu___2;
               FStar_Syntax_Syntax.vars = uu___3;_},
             uu___4)
-           -> failwith "Unreachable? Tm_app Const_reflect"
+           ->
+           let uu___5 =
+             let uu___6 =
+               let uu___7 = FStar_Parser_Const.failwith_lid () in
+               FStar_Syntax_Syntax.lid_as_fv uu___7
+                 FStar_Syntax_Syntax.delta_constant
+                 FStar_Pervasives_Native.None in
+             FStar_Extraction_ML_UEnv.lookup_fv t.FStar_Syntax_Syntax.pos g
+               uu___6 in
+           (match uu___5 with
+            | { FStar_Extraction_ML_UEnv.exp_b_name = uu___6;
+                FStar_Extraction_ML_UEnv.exp_b_expr = fw;
+                FStar_Extraction_ML_UEnv.exp_b_tscheme = uu___7;_} ->
+                let uu___8 =
+                  let uu___9 =
+                    let uu___10 =
+                      let uu___11 =
+                        let uu___12 =
+                          FStar_Compiler_Effect.op_Less_Bar
+                            (FStar_Extraction_ML_Syntax.with_ty
+                               FStar_Extraction_ML_Syntax.ml_string_ty)
+                            (FStar_Extraction_ML_Syntax.MLE_Const
+                               (FStar_Extraction_ML_Syntax.MLC_String
+                                  "Extraction of reflect is not supported")) in
+                        [uu___12] in
+                      (fw, uu___11) in
+                    FStar_Extraction_ML_Syntax.MLE_App uu___10 in
+                  FStar_Compiler_Effect.op_Less_Bar
+                    (FStar_Extraction_ML_Syntax.with_ty
+                       FStar_Extraction_ML_Syntax.ml_int_ty) uu___9 in
+                (uu___8, FStar_Extraction_ML_Syntax.E_PURE,
+                  FStar_Extraction_ML_Syntax.ml_int_ty))
        | FStar_Syntax_Syntax.Tm_app (head, args) when
            (is_match head) &&
              (FStar_Compiler_Effect.op_Bar_Greater args

--- a/src/ocaml-output/FStar_Extraction_ML_Term.ml
+++ b/src/ocaml-output/FStar_Extraction_ML_Term.ml
@@ -2856,7 +2856,38 @@ and (term_as_mlexpr' :
               FStar_Syntax_Syntax.vars = uu___3;
               FStar_Syntax_Syntax.hash_code = uu___4;_},
             uu___5)
-           -> failwith "Unreachable? Tm_app Const_reflect"
+           ->
+           let uu___6 =
+             let uu___7 =
+               let uu___8 = FStar_Parser_Const.failwith_lid () in
+               FStar_Syntax_Syntax.lid_as_fv uu___8
+                 FStar_Syntax_Syntax.delta_constant
+                 FStar_Pervasives_Native.None in
+             FStar_Extraction_ML_UEnv.lookup_fv t.FStar_Syntax_Syntax.pos g
+               uu___7 in
+           (match uu___6 with
+            | { FStar_Extraction_ML_UEnv.exp_b_name = uu___7;
+                FStar_Extraction_ML_UEnv.exp_b_expr = fw;
+                FStar_Extraction_ML_UEnv.exp_b_tscheme = uu___8;_} ->
+                let uu___9 =
+                  let uu___10 =
+                    let uu___11 =
+                      let uu___12 =
+                        let uu___13 =
+                          FStar_Compiler_Effect.op_Less_Bar
+                            (FStar_Extraction_ML_Syntax.with_ty
+                               FStar_Extraction_ML_Syntax.ml_string_ty)
+                            (FStar_Extraction_ML_Syntax.MLE_Const
+                               (FStar_Extraction_ML_Syntax.MLC_String
+                                  "Extraction of reflect is not supported")) in
+                        [uu___13] in
+                      (fw, uu___12) in
+                    FStar_Extraction_ML_Syntax.MLE_App uu___11 in
+                  FStar_Compiler_Effect.op_Less_Bar
+                    (FStar_Extraction_ML_Syntax.with_ty
+                       FStar_Extraction_ML_Syntax.ml_int_ty) uu___10 in
+                (uu___9, FStar_Extraction_ML_Syntax.E_PURE,
+                  FStar_Extraction_ML_Syntax.ml_int_ty))
        | FStar_Syntax_Syntax.Tm_app (head, args) when
            (is_match head) &&
              (FStar_Compiler_Effect.op_Bar_Greater args


### PR DESCRIPTION
At the moment, extraction of a file containing an M?.reflect node will hardfail, with an uncaught failwith.

This PR proposes instead to extract reflect to an ML failwith.