### PR TITLE
FiniteMap and Sequence: Avoiding pattern-less type quantification 

### DIFF
--- a/ulib/FStar.FiniteMap.Ambient.fst
+++ b/ulib/FStar.FiniteMap.Ambient.fst
@@ -39,6 +39,6 @@ module FStar.FiniteMap.Ambient
 
 open FStar.FiniteMap.Base
 
-let all_finite_map_facts_ambient : squash (all_finite_map_facts) =
-  all_finite_map_facts_lemma ()
+let all_finite_map_facts_ambient : squash (all_finite_map_facts u#b) =
+  all_finite_map_facts_lemma u#b ()
 

--- a/ulib/FStar.FiniteMap.Base.fst
+++ b/ulib/FStar.FiniteMap.Base.fst
@@ -155,24 +155,24 @@ let choose (#a: eqtype) (#b: Type u#b) (m: map a b{exists key. mem key m}) : GTo
 /// We now prove each of the facts that comprise `all_finite_map_facts`.
 /// For fact `xxx_fact`, we prove it with `xxx_lemma`.
 
-let cardinality_zero_iff_empty_lemma (b:Type u#b)
-: Lemma (cardinality_zero_iff_empty_fact b) =
-  introduce forall (a: eqtype) (m: map a b). cardinality m = 0 <==> m == emptymap
+let cardinality_zero_iff_empty_lemma ()
+: Lemma (cardinality_zero_iff_empty_fact u#b) =
+  introduce forall (a: eqtype) (b:Type u#b) (m: map a b). cardinality m = 0 <==> m == emptymap
   with (
     introduce cardinality m = 0 ==> m == emptymap
     with _. assert (feq (elements m) (elements emptymap))
   )
 
 
-let empty_or_domain_occupied_lemma (b:Type u#b)
-  : Lemma (empty_or_domain_occupied_fact b)
-  = introduce forall (a: eqtype) (m: map a b). m == emptymap \/ (exists k. mem k m)
+let empty_or_domain_occupied_lemma ()
+  : Lemma (empty_or_domain_occupied_fact u#b)
+  = introduce forall (a: eqtype) (b:Type u#b) (m: map a b). m == emptymap \/ (exists k. mem k m)
     with (  
     if FSet.cardinality (domain m) = 0 then
       introduce m == emptymap \/ (exists k. mem k m)
       with Left (
         assert (cardinality m = 0);
-        cardinality_zero_iff_empty_lemma b
+        cardinality_zero_iff_empty_lemma ()
       )
     else
       introduce m == emptymap \/ (exists k. mem k m)
@@ -180,15 +180,15 @@ let empty_or_domain_occupied_lemma (b:Type u#b)
     )
     
 
-let empty_or_values_occupied_lemma (b:Type u#b)
-: Lemma (empty_or_values_occupied_fact b) =
-  introduce forall (a: eqtype) (m: map a b). m == emptymap \/ (exists v. (values m) v)
+let empty_or_values_occupied_lemma ()
+: Lemma (empty_or_values_occupied_fact u#b) =
+  introduce forall (a: eqtype) (b:Type u#b) (m: map a b). m == emptymap \/ (exists v. (values m) v)
   with
     if FSet.cardinality (domain m) = 0 then
       introduce m == emptymap \/ (exists v. (values m) v)
       with Left (
         assert (cardinality m = 0);
-        cardinality_zero_iff_empty_lemma b
+        cardinality_zero_iff_empty_lemma u#b ()
       )
     else
       introduce m == emptymap \/ (exists v. (values m) v)
@@ -198,15 +198,15 @@ let empty_or_values_occupied_lemma (b:Type u#b)
         assert ((values m) v)
       )
 
-let empty_or_items_occupied_lemma (b:Type u#b)
-: Lemma (empty_or_items_occupied_fact b) =
-  introduce forall (a: eqtype) (b: Type0) (m: map a b). m == emptymap \/ (exists item. (items m) item)
+let empty_or_items_occupied_lemma ()
+: Lemma (empty_or_items_occupied_fact u#b) =
+  introduce forall (a: eqtype) (b: Type u#b) (m: map a b). m == emptymap \/ (exists item. (items m) item)
   with
     if FSet.cardinality (domain m) = 0 then
       introduce m == emptymap \/ (exists v. (values m) v)
       with Left (
         assert (cardinality m = 0);
-        cardinality_zero_iff_empty_lemma b
+        cardinality_zero_iff_empty_lemma u#b ()
       )
     else
       introduce m == emptymap \/ (exists item. (items m) item)
@@ -216,74 +216,75 @@ let empty_or_items_occupied_lemma (b:Type u#b)
         assert ((items m) (k, v))
       )
 
-let map_cardinality_matches_domain_lemma (b:Type u#b)
-: Lemma (map_cardinality_matches_domain_fact b) =
+let map_cardinality_matches_domain_lemma ()
+: Lemma (map_cardinality_matches_domain_fact u#b) =
   ()
 
-let values_contains_lemma (b:Type u#b)
-: Lemma (values_contains_fact b) =
+let values_contains_lemma ()
+: Lemma (values_contains_fact u#b) =
   ()
 
-let items_contains_lemma (b:Type u#b)
-: Lemma (items_contains_fact b) =
+let items_contains_lemma ()
+: Lemma (items_contains_fact u#b) =
   ()
 
-let empty_domain_empty_lemma (b:Type u#b)
-: Lemma (empty_domain_empty_fact b) =
+let empty_domain_empty_lemma ()
+: Lemma (empty_domain_empty_fact u#b) =
   ()
 
-let glue_domain_lemma (b:Type u#b)
-: Lemma (glue_domain_fact b) =
+let glue_domain_lemma ()
+: Lemma (glue_domain_fact u#b) =
   ()
 
-let glue_elements_lemma (b:Type u#b)
-: Lemma (glue_elements_fact b) =
+let glue_elements_lemma ()
+: Lemma (glue_elements_fact u#b) =
   ()
 
-let insert_elements_lemma (b:Type u#b)
-: Lemma (insert_elements_fact b) =
+let insert_elements_lemma ()
+: Lemma (insert_elements_fact u#b) =
   ()
 
-let insert_member_cardinality_lemma (b:Type u#b)
-: Lemma (insert_member_cardinality_fact b) =
+let insert_member_cardinality_lemma ()
+: Lemma (insert_member_cardinality_fact u#b) =
   ()
 
-let insert_nonmember_cardinality_lemma (b:Type u#b)
-: Lemma (insert_nonmember_cardinality_fact b) =
+let insert_nonmember_cardinality_lemma ()
+: Lemma (insert_nonmember_cardinality_fact u#b) =
   ()
 
-let merge_domain_is_union_lemma (b:Type u#b)
-: Lemma (merge_domain_is_union_fact b) =
+let merge_domain_is_union_lemma ()
+: Lemma (merge_domain_is_union_fact u#b) =
   ()
 
-let merge_element_lemma (b:Type u#b)
-: Lemma (merge_element_fact b) =
+let merge_element_lemma ()
+: Lemma (merge_element_fact u#b) =
   ()
 
-let subtract_domain_lemma (b:Type u#b)
-: Lemma (subtract_domain_fact b) =
+let subtract_domain_lemma ()
+: Lemma (subtract_domain_fact u#b) =
   ()
 
-let subtract_element_lemma (b:Type u#b)
-: Lemma (subtract_element_fact b) =
+let subtract_element_lemma ()
+: Lemma (subtract_element_fact u#b) =
   ()
 
 
-let map_equal_lemma (b:Type u#b)
-: Lemma (map_equal_fact b) //Surprising; needed to split this goal into two
-= assert (map_equal_fact b)
+let map_equal_lemma ()
+: Lemma (map_equal_fact u#b) //Surprising; needed to split this goal into two
+= assert (map_equal_fact u#b)
     by (T.norm [delta_only [`%map_equal_fact]];
         let _ = T.forall_intro () in
         let _ = T.forall_intro () in
         let _ = T.forall_intro () in         
+        let _ = T.forall_intro () in                 
         T.split ();
         T.smt();
         T.smt())
 
 
-let map_extensionality_lemma (b: Type u#b)
-: Lemma (map_extensionality_fact b) =
-  introduce forall (a: eqtype) (m1: map a b) (m2: map a b). equal m1 m2 ==> m1 == m2
+let map_extensionality_lemma ()
+: Lemma (map_extensionality_fact u#b) =
+  introduce forall (a: eqtype) (b:Type u#b) (m1: map a b) (m2: map a b). equal m1 m2 ==> m1 == m2
   with (
     introduce equal m1 m2 ==> m1 == m2
     with _. (
@@ -292,60 +293,29 @@ let map_extensionality_lemma (b: Type u#b)
     )
   )
 
-let disjoint_lemma (b:Type u#b)
-: Lemma (disjoint_fact b) =
+let disjoint_lemma ()
+: Lemma (disjoint_fact u#b) =
   ()
-
-let all_finite_map_facts_b (b:Type u#b) =
-    cardinality_zero_iff_empty_fact b
-  /\ empty_or_domain_occupied_fact b
-  /\ empty_or_values_occupied_fact b
-  /\ empty_or_items_occupied_fact b
-  /\ map_cardinality_matches_domain_fact b
-  /\ values_contains_fact b
-  /\ items_contains_fact b
-  /\ empty_domain_empty_fact b
-  /\ glue_domain_fact b
-  /\ glue_elements_fact b
-  /\ insert_elements_fact b
-  /\ insert_member_cardinality_fact b
-  /\ insert_nonmember_cardinality_fact b
-  /\ merge_domain_is_union_fact b
-  /\ merge_element_fact b
-  /\ subtract_domain_fact b
-  /\ subtract_element_fact b
-  /\ map_equal_fact b 
-  /\ map_extensionality_fact b
-  /\ disjoint_fact b
-
-let all_finite_map_facts_lemma' ()
-: squash (all_finite_map_facts u#b) =
-  introduce forall (b:Type u#b). all_finite_map_facts_b b
-  with ( 
-    cardinality_zero_iff_empty_lemma b;
-    empty_or_domain_occupied_lemma b;
-    empty_or_values_occupied_lemma b;
-    empty_or_items_occupied_lemma b;
-    map_cardinality_matches_domain_lemma b;
-    values_contains_lemma b;
-    items_contains_lemma b;
-    empty_domain_empty_lemma b;
-    glue_domain_lemma b;
-    glue_elements_lemma b;
-    insert_elements_lemma b;
-    insert_member_cardinality_lemma b;
-    insert_nonmember_cardinality_lemma b;
-    merge_domain_is_union_lemma b;
-    merge_element_lemma b;
-    subtract_domain_lemma b;
-    subtract_element_lemma b;
-    map_equal_lemma b;
-    map_extensionality_lemma b;
-    disjoint_lemma b
-  )
 
 let all_finite_map_facts_lemma (_:unit)
   : Lemma (all_finite_map_facts u#b)
-  = all_finite_map_facts_lemma' ()
-
-  
+  = cardinality_zero_iff_empty_lemma u#b ();
+    empty_or_domain_occupied_lemma u#b ();
+    empty_or_values_occupied_lemma u#b ();
+    empty_or_items_occupied_lemma u#b ();
+    map_cardinality_matches_domain_lemma u#b ();
+    values_contains_lemma u#b ();
+    items_contains_lemma u#b ();
+    empty_domain_empty_lemma u#b ();
+    glue_domain_lemma u#b ();
+    glue_elements_lemma u#b ();
+    insert_elements_lemma u#b ();
+    insert_member_cardinality_lemma u#b ();
+    insert_nonmember_cardinality_lemma u#b ();
+    merge_domain_is_union_lemma u#b ();
+    merge_element_lemma u#b ();
+    subtract_domain_lemma u#b ();
+    subtract_element_lemma u#b ();
+    map_equal_lemma u#b ();
+    map_extensionality_lemma u#b ();
+    disjoint_lemma u#b ()

--- a/ulib/FStar.FiniteMap.Base.fsti
+++ b/ulib/FStar.FiniteMap.Base.fsti
@@ -192,8 +192,8 @@ let notin (#a: eqtype) (#b: Type u#b) (key: a) (m: map a b)
 ///  { Map#Card(m) }
 ///  Map#Card(m) == 0 <==> m == Map#Empty());
 
-let cardinality_zero_iff_empty_fact (b:Type u#b) =
-  forall (a: eqtype) (m: map a b).{:pattern cardinality m}
+let cardinality_zero_iff_empty_fact =
+  forall (a: eqtype) (b:Type u#b) (m: map a b).{:pattern cardinality m}
     cardinality m = 0 <==> m == emptymap
 
 /// We represent the following Dafny axiom with `empty_or_domain_occupied_fact`:
@@ -202,8 +202,8 @@ let cardinality_zero_iff_empty_fact (b:Type u#b) =
 ///  { Map#Domain(m) }
 ///  m == Map#Empty() || (exists k: U :: Map#Domain(m)[k]));
 
-let empty_or_domain_occupied_fact (b: Type u#b) =
-  forall (a: eqtype) (m: map a b).{:pattern domain m}
+let empty_or_domain_occupied_fact =
+  forall (a: eqtype) (b: Type u#b) (m: map a b).{:pattern domain m}
     m == emptymap \/ (exists k.{:pattern mem k m} mem k m)
 
 /// We represent the following Dafny axiom with `empty_or_values_occupied_fact`:
@@ -212,8 +212,8 @@ let empty_or_domain_occupied_fact (b: Type u#b) =
 ///  { Map#Values(m) }
 ///  m == Map#Empty() || (exists v: V :: Map#Values(m)[v]));
 
-let empty_or_values_occupied_fact (b: Type u#b) =
-  forall (a: eqtype) (m: map a b).{:pattern values m}
+let empty_or_values_occupied_fact =
+  forall (a: eqtype) (b: Type u#b) (m: map a b).{:pattern values m}
     m == emptymap \/ (exists v. {:pattern values m v } (values m) v)
 
 /// We represent the following Dafny axiom with `empty_or_items_occupied_fact`:
@@ -222,8 +222,8 @@ let empty_or_values_occupied_fact (b: Type u#b) =
 ///  { Map#Items(m) }
 ///  m == Map#Empty() || (exists k, v: Box :: Map#Items(m)[$Box(#_System._tuple#2._#Make2(k, v))]));
 
-let empty_or_items_occupied_fact (b:Type u#b) =
-  forall (a: eqtype) (m: map a b).{:pattern items m}
+let empty_or_items_occupied_fact =
+  forall (a: eqtype) (b:Type u#b) (m: map a b).{:pattern items m}
     m == emptymap \/ (exists item. {:pattern items m item } (items m) item)
 
 /// We represent the following Dafny axiom with `map_cardinality_matches_domain_fact`:
@@ -232,8 +232,8 @@ let empty_or_items_occupied_fact (b:Type u#b) =
 ///  { Set#Card(Map#Domain(m)) }
 ///  Set#Card(Map#Domain(m)) == Map#Card(m));
 
-let map_cardinality_matches_domain_fact (b: Type u#b) =
-  forall (a: eqtype) (m: map a b).{:pattern FSet.cardinality (domain m)}
+let map_cardinality_matches_domain_fact =
+  forall (a: eqtype) (b: Type u#b) (m: map a b).{:pattern FSet.cardinality (domain m)}
     FSet.cardinality (domain m) = cardinality m
     
 /// We don't use the following Dafny axioms, which would require
@@ -255,8 +255,8 @@ let map_cardinality_matches_domain_fact (b: Type u#b) =
 ///          Map#Domain(m)[u] &&
 ///          v == Map#Elements(m)[u]));
 
-let values_contains_fact (b: Type u#b) =
-  forall (a: eqtype) (m: map a b) (v: b).{:pattern (values m) v}
+let values_contains_fact =
+  forall (a: eqtype) (b: Type u#b) (m: map a b) (v: b).{:pattern (values m) v}
     (values m) v <==>
        (exists (u: a).{:pattern FSet.mem u (domain m) \/ ((elements m) u)}
           FSet.mem u (domain m) /\ (elements m) u == Some v)
@@ -268,8 +268,8 @@ let values_contains_fact (b: Type u#b) =
 ///    Map#Domain(m)[_System.Tuple2._0($Unbox(item))] &&
 ///    Map#Elements(m)[_System.Tuple2._0($Unbox(item))] == _System.Tuple2._1($Unbox(item)));
 
-let items_contains_fact (b: Type u#b) =
-  forall (a: eqtype) (m: map a b) (item: a * b).{:pattern (items m) item}
+let items_contains_fact =
+  forall (a: eqtype) (b: Type u#b) (m: map a b) (item: a * b).{:pattern (items m) item}
     (items m) item <==>
         FSet.mem (fst item) (domain m)
       /\ (elements m) (fst item) == Some (snd item)
@@ -280,8 +280,8 @@ let items_contains_fact (b: Type u#b) =
 ///        { Map#Domain(Map#Empty(): Map U V)[u] }
 ///        !Map#Domain(Map#Empty(): Map U V)[u]);
 
-let empty_domain_empty_fact (b: Type u#b) =
-  forall (a: eqtype) (u: a).{:pattern FSet.mem u (domain (emptymap #a #b))}
+let empty_domain_empty_fact =
+  forall (a: eqtype) (b: Type u#b) (u: a).{:pattern FSet.mem u (domain (emptymap #a #b))}
     not (FSet.mem u (domain (emptymap #a #b)))
 
 /// We represent the following Dafny axiom with `glue_domain_fact`:
@@ -290,8 +290,8 @@ let empty_domain_empty_fact (b: Type u#b) =
 ///  { Map#Domain(Map#Glue(a, b, t)) }
 ///  Map#Domain(Map#Glue(a, b, t)) == a);
 
-let glue_domain_fact (b: Type u#b) =
-  forall (a: eqtype) (keys: FSet.set a) (f: setfun_t a b keys).{:pattern domain (glue keys f)}
+let glue_domain_fact =
+  forall (a: eqtype) (b: Type u#b) (keys: FSet.set a) (f: setfun_t a b keys).{:pattern domain (glue keys f)}
     domain (glue keys f) == keys
 
 /// We represent the following Dafny axiom with `glue_elements_fact`.
@@ -302,8 +302,8 @@ let glue_domain_fact (b: Type u#b) =
 ///  { Map#Elements(Map#Glue(a, b, t)) }
 ///  Map#Elements(Map#Glue(a, b, t)) == b);
 
-let glue_elements_fact (b: Type u#b) =
-  forall (a: eqtype) (keys: FSet.set a) (f: setfun_t a b keys).{:pattern elements (glue keys f)}
+let glue_elements_fact =
+  forall (a: eqtype) (b: Type u#b) (keys: FSet.set a) (f: setfun_t a b keys).{:pattern elements (glue keys f)}
       domain (glue keys f) == keys
     /\ elements (glue keys f) == f
 
@@ -325,8 +325,8 @@ let glue_elements_fact (b: Type u#b) =
 ///  (u' != u ==> Map#Domain(Map#Build(m, u, v))[u'] == Map#Domain(m)[u'] &&
 ///               Map#Elements(Map#Build(m, u, v))[u'] == Map#Elements(m)[u']));
 
-let insert_elements_fact (b: Type u#b) =
-  forall (a: eqtype) (m: map a b) (key: a) (key': a) (value: b).
+let insert_elements_fact =
+  forall (a: eqtype) (b: Type u#b) (m: map a b) (key: a) (key': a) (value: b).
     {:pattern FSet.mem key' (domain (insert key value m)) \/ ((elements (insert key value m)) key')}
       (key' = key ==>   FSet.mem key' (domain (insert key value m))
                      /\ (elements (insert key value m)) key' == Some value)
@@ -338,8 +338,8 @@ let insert_elements_fact (b: Type u#b) =
 /// axiom (forall<U, V> m: Map U V, u: U, v: V :: { Map#Card(Map#Build(m, u, v)) }
 ///  Map#Domain(m)[u] ==> Map#Card(Map#Build(m, u, v)) == Map#Card(m));
 
-let insert_member_cardinality_fact (b: Type u#b) =
-  forall (a: eqtype) (m: map a b) (key: a) (value: b).{:pattern cardinality (insert key value m)}
+let insert_member_cardinality_fact =
+  forall (a: eqtype) (b: Type u#b) (m: map a b) (key: a) (value: b).{:pattern cardinality (insert key value m)}
     FSet.mem key (domain m) ==> cardinality (insert key value m) = cardinality m
 
 /// We represent the following Dafny axiom with `insert_nonmember_cardinality_fact`:
@@ -347,8 +347,8 @@ let insert_member_cardinality_fact (b: Type u#b) =
 /// axiom (forall<U, V> m: Map U V, u: U, v: V :: { Map#Card(Map#Build(m, u, v)) }
 ///  !Map#Domain(m)[u] ==> Map#Card(Map#Build(m, u, v)) == Map#Card(m) + 1);
 
-let insert_nonmember_cardinality_fact (b: Type u#b) =
-  forall (a: eqtype) (m: map a b) (key: a) (value: b).{:pattern cardinality (insert key value m)}
+let insert_nonmember_cardinality_fact =
+  forall (a: eqtype) (b: Type u#b) (m: map a b) (key: a) (value: b).{:pattern cardinality (insert key value m)}
     not (FSet.mem key (domain m)) ==> cardinality (insert key value m) = cardinality m + 1
 
 /// We represent the following Dafny axiom with `merge_domain_is_union_fact`:
@@ -357,8 +357,8 @@ let insert_nonmember_cardinality_fact (b: Type u#b) =
 ///  { Map#Domain(Map#Merge(m, n)) }
 ///  Map#Domain(Map#Merge(m, n)) == Set#Union(Map#Domain(m), Map#Domain(n)));
 
-let merge_domain_is_union_fact (b: Type u#b) =
-  forall (a: eqtype) (m1: map a b) (m2: map a b).{:pattern domain (merge m1 m2)}
+let merge_domain_is_union_fact =
+  forall (a: eqtype) (b: Type u#b) (m1: map a b) (m2: map a b).{:pattern domain (merge m1 m2)}
     domain (merge m1 m2) == FSet.union (domain m1) (domain m2)
 
 /// We represent the following Dafny axiom with `merge_element_fact`:
@@ -369,8 +369,8 @@ let merge_domain_is_union_fact (b: Type u#b) =
 ///    (!Map#Domain(n)[u] ==> Map#Elements(Map#Merge(m, n))[u] == Map#Elements(m)[u]) &&
 ///    (Map#Domain(n)[u] ==> Map#Elements(Map#Merge(m, n))[u] == Map#Elements(n)[u]));
 
-let merge_element_fact (b: Type u#b) =
-  forall (a: eqtype) (m1: map a b) (m2: map a b) (key: a).{:pattern (elements (merge m1 m2)) key}
+let merge_element_fact =
+  forall (a: eqtype) (b: Type u#b) (m1: map a b) (m2: map a b) (key: a).{:pattern (elements (merge m1 m2)) key}
     FSet.mem key (domain (merge m1 m2)) ==>
         (not (FSet.mem key (domain m2)) ==> FSet.mem key (domain m1) /\ (elements (merge m1 m2)) key == (elements m1) key)
       /\ (FSet.mem key (domain m2) ==> (elements (merge m1 m2)) key == (elements m2) key)
@@ -381,8 +381,8 @@ let merge_element_fact (b: Type u#b) =
 ///  { Map#Domain(Map#Subtract(m, s)) }
 ///  Map#Domain(Map#Subtract(m, s)) == Set#Difference(Map#Domain(m), s));
 
-let subtract_domain_fact (b: Type u#b) =
-  forall (a: eqtype) (m: map a b) (s: FSet.set a).{:pattern domain (subtract m s)}
+let subtract_domain_fact =
+  forall (a: eqtype) (b: Type u#b) (m: map a b) (s: FSet.set a).{:pattern domain (subtract m s)}
     domain (subtract m s) == FSet.difference (domain m) s
 
 /// We represent the following Dafny axiom with `subtract_element_fact`:
@@ -392,8 +392,8 @@ let subtract_domain_fact (b: Type u#b) =
 ///  Map#Domain(Map#Subtract(m, s))[u] ==>
 ///    Map#Elements(Map#Subtract(m, s))[u] == Map#Elements(m)[u]);
 
-let subtract_element_fact (b: Type u#b) =
-  forall (a: eqtype) (m: map a b) (s: FSet.set a) (key: a).{:pattern (elements (subtract m s)) key}
+let subtract_element_fact =
+  forall (a: eqtype) (b: Type u#b) (m: map a b) (s: FSet.set a) (key: a).{:pattern (elements (subtract m s)) key}
     FSet.mem key (domain (subtract m s)) ==> FSet.mem key (domain m) /\ (elements (subtract m s)) key == (elements m) key
 
 /// We represent the following Dafny axiom with `map_equal_fact`:
@@ -403,8 +403,8 @@ let subtract_element_fact (b: Type u#b) =
 ///    Map#Equal(m, m') <==> (forall u : U :: Map#Domain(m)[u] == Map#Domain(m')[u]) &&
 ///                          (forall u : U :: Map#Domain(m)[u] ==> Map#Elements(m)[u] == Map#Elements(m')[u]));
 
-let map_equal_fact (b: Type u#b) =
-  forall (a: eqtype) (m1: map a b) (m2: map a b).{:pattern equal m1 m2}
+let map_equal_fact =
+  forall (a: eqtype) (b: Type u#b) (m1: map a b) (m2: map a b).{:pattern equal m1 m2}
     equal m1 m2 <==>   (forall key. FSet.mem key (domain m1) = FSet.mem key (domain m2))
                    /\ (forall key. FSet.mem key (domain m1) ==> (elements m1) key == (elements m2) key)
 
@@ -414,8 +414,8 @@ let map_equal_fact (b: Type u#b) =
 ///  { Map#Equal(m, m') }
 ///    Map#Equal(m, m') ==> m == m');
 
-let map_extensionality_fact (b: Type u#b) =
-  forall (a: eqtype) (m1: map a b) (m2: map a b).{:pattern equal m1 m2}
+let map_extensionality_fact =
+  forall (a: eqtype) (b: Type u#b) (m1: map a b) (m2: map a b).{:pattern equal m1 m2}
     equal m1 m2 ==> m1 == m2
 
 /// We represent the following Dafny axiom with `disjoint_fact`:
@@ -424,8 +424,8 @@ let map_extensionality_fact (b: Type u#b) =
 ///  { Map#Disjoint(m, m') }
 ///    Map#Disjoint(m, m') <==> (forall o: U :: {Map#Domain(m)[o]} {Map#Domain(m')[o]} !Map#Domain(m)[o] || !Map#Domain(m')[o]));
 
-let disjoint_fact (b: Type u#b) =
-  forall (a: eqtype) (m1: map a b) (m2: map a b).{:pattern disjoint m1 m2}
+let disjoint_fact =
+  forall (a: eqtype) (b: Type u#b) (m1: map a b) (m2: map a b).{:pattern disjoint m1 m2}
     disjoint m1 m2 <==> (forall key.{:pattern FSet.mem key (domain m1) \/ FSet.mem key (domain m2)}
                           not (FSet.mem key (domain m1)) || not (FSet.mem key (domain m2)))
 
@@ -435,26 +435,26 @@ let disjoint_fact (b: Type u#b) =
 **)
 
 let all_finite_map_facts =
-  forall (b:Type u#b).
-    cardinality_zero_iff_empty_fact b
-  /\ empty_or_domain_occupied_fact b
-  /\ empty_or_values_occupied_fact b
-  /\ empty_or_items_occupied_fact b
-  /\ map_cardinality_matches_domain_fact b
-  /\ values_contains_fact b
-  /\ items_contains_fact b
-  /\ empty_domain_empty_fact b
-  /\ glue_domain_fact b
-  /\ glue_elements_fact b
-  /\ insert_elements_fact b
-  /\ insert_member_cardinality_fact b
-  /\ insert_nonmember_cardinality_fact b
-  /\ merge_domain_is_union_fact b
-  /\ merge_element_fact b
-  /\ subtract_domain_fact b
-  /\ subtract_element_fact b
-  /\ map_equal_fact b 
-  /\ map_extensionality_fact b
-  /\ disjoint_fact b
-
-val all_finite_map_facts_lemma (_:unit) : Lemma (all_finite_map_facts)
+    cardinality_zero_iff_empty_fact u#b
+  /\ empty_or_domain_occupied_fact u#b
+  /\ empty_or_values_occupied_fact u#b
+  /\ empty_or_items_occupied_fact u#b
+  /\ map_cardinality_matches_domain_fact u#b
+  /\ values_contains_fact u#b
+  /\ items_contains_fact u#b
+  /\ empty_domain_empty_fact u#b
+  /\ glue_domain_fact u#b
+  /\ glue_elements_fact u#b
+  /\ insert_elements_fact u#b
+  /\ insert_member_cardinality_fact u#b
+  /\ insert_nonmember_cardinality_fact u#b
+  /\ merge_domain_is_union_fact u#b
+  /\ merge_element_fact u#b
+  /\ subtract_domain_fact u#b
+  /\ subtract_element_fact u#b
+  /\ map_equal_fact u#b
+  /\ map_extensionality_fact u#b
+  /\ disjoint_fact u#b
+  
+val all_finite_map_facts_lemma (_:unit)
+  : Lemma (all_finite_map_facts u#b)

--- a/ulib/experimental/FStar.Sequence.Base.fsti
+++ b/ulib/experimental/FStar.Sequence.Base.fsti
@@ -154,7 +154,7 @@ val rank: #ty: Type -> ty -> ty
 /// axiom (forall<T> :: { Seq#Empty(): Seq T } Seq#Length(Seq#Empty(): Seq T) == 0);
 
 private let length_of_empty_is_zero_fact =
-  forall (ty: Type).{:pattern empty #ty} length (empty #ty) = 0
+  forall (ty: Type u#a).{:pattern empty #ty} length (empty #ty) = 0
 
 /// We represent the following Dafny axiom with `length_zero_implies_empty_fact`:
 ///
@@ -162,14 +162,14 @@ private let length_of_empty_is_zero_fact =
 ///   (Seq#Length(s) == 0 ==> s == Seq#Empty())
 
 private let length_zero_implies_empty_fact =
-  forall (ty: Type) (s: seq ty).{:pattern length s} length s = 0 ==> s == empty
+  forall (ty: Type u#a) (s: seq ty).{:pattern length s} length s = 0 ==> s == empty
 
 /// We represent the following Dafny axiom with `singleton_length_one_fact`:
 /// 
 /// axiom (forall<T> t: T :: { Seq#Length(Seq#Singleton(t)) } Seq#Length(Seq#Singleton(t)) == 1);
 
 private let singleton_length_one_fact =
-  forall (ty: Type) (v: ty).{:pattern length (singleton v)} length (singleton v) = 1
+  forall (ty: Type u#a) (v: ty).{:pattern length (singleton v)} length (singleton v) = 1
 
 /// We represent the following Dafny axiom with `build_increments_length_fact`:
 ///
@@ -178,7 +178,7 @@ private let singleton_length_one_fact =
 ///   Seq#Length(Seq#Build(s,v)) == 1 + Seq#Length(s));
 
 private let build_increments_length_fact =
-  forall (ty: Type) (s: seq ty) (v: ty).{:pattern build s v}
+  forall (ty: Type u#a) (s: seq ty) (v: ty).{:pattern build s v}
     length (build s v) = 1 + length s
 
 /// We represent the following Dafny axiom with `index_into_build_fact`:
@@ -187,8 +187,8 @@ private let build_increments_length_fact =
 ///   (i == Seq#Length(s) ==> Seq#Index(Seq#Build(s,v), i) == v) &&
 ///   (i != Seq#Length(s) ==> Seq#Index(Seq#Build(s,v), i) == Seq#Index(s, i)));
 
-private let index_into_build_fact (_: squash build_increments_length_fact) =
-  forall (ty: Type) (s: seq ty) (v: ty) (i: nat{i < length (build s v)})
+private let index_into_build_fact (_: squash (build_increments_length_fact u#a)) =
+  forall (ty: Type u#a) (s: seq ty) (v: ty) (i: nat{i < length (build s v)})
     .{:pattern index (build s v) i}
       (i = length s ==> index (build s v) i == v)
     /\ (i <> length s ==> index (build s v) i == index s i)
@@ -199,15 +199,15 @@ private let index_into_build_fact (_: squash build_increments_length_fact) =
 ///   Seq#Length(Seq#Append(s0,s1)) == Seq#Length(s0) + Seq#Length(s1));
 
 private let append_sums_lengths_fact =
-  forall (ty: Type) (s0: seq ty) (s1: seq ty).{:pattern length (append s0 s1)}
+  forall (ty: Type u#a) (s0: seq ty) (s1: seq ty).{:pattern length (append s0 s1)}
     length (append s0 s1) = length s0 + length s1
 
 /// We represent the following Dafny axiom with `index_into_singleton_fact`:
 ///
 /// axiom (forall<T> t: T :: { Seq#Index(Seq#Singleton(t), 0) } Seq#Index(Seq#Singleton(t), 0) == t);
 
-private let index_into_singleton_fact (_: squash singleton_length_one_fact) =
-  forall (ty: Type) (v: ty).{:pattern index (singleton v) 0}
+private let index_into_singleton_fact (_: squash (singleton_length_one_fact u#a)) =
+  forall (ty: Type u#a) (v: ty).{:pattern index (singleton v) 0}
      index (singleton v) 0 == v
 
 /// We represent the following axiom with `index_after_append_fact`:
@@ -216,8 +216,8 @@ private let index_into_singleton_fact (_: squash singleton_length_one_fact) =
 ///   (n < Seq#Length(s0) ==> Seq#Index(Seq#Append(s0,s1), n) == Seq#Index(s0, n)) &&
 ///   (Seq#Length(s0) <= n ==> Seq#Index(Seq#Append(s0,s1), n) == Seq#Index(s1, n - Seq#Length(s0))));
 
-private let index_after_append_fact (_: squash append_sums_lengths_fact) =
-  forall (ty: Type) (s0: seq ty) (s1: seq ty) (n: nat{n < length (append s0 s1)})
+private let index_after_append_fact (_: squash (append_sums_lengths_fact u#a)) =
+  forall (ty: Type u#a) (s0: seq ty) (s1: seq ty) (n: nat{n < length (append s0 s1)})
     .{:pattern index (append s0 s1) n}
       (n < length s0 ==> index (append s0 s1) n == index s0 n)
     /\ (length s0 <= n ==> index (append s0 s1) n == index s1 (n - length s0))
@@ -228,7 +228,7 @@ private let index_after_append_fact (_: squash append_sums_lengths_fact) =
 ///   0 <= i && i < Seq#Length(s) ==> Seq#Length(Seq#Update(s,i,v)) == Seq#Length(s));
 
 private let update_maintains_length_fact =
-  forall (ty: Type) (s: seq ty) (i: nat{i < length s}) (v: ty).{:pattern length (update s i v)}
+  forall (ty: Type u#a) (s: seq ty) (i: nat{i < length s}) (v: ty).{:pattern length (update s i v)}
     length (update s i v) = length s
 
 /// We represent the following Dafny axiom with `update_then_index_fact`:
@@ -239,7 +239,7 @@ private let update_maintains_length_fact =
 ///     (i != n ==> Seq#Index(Seq#Update(s,i,v),n) == Seq#Index(s,n)));
 
 private let update_then_index_fact =
-  forall (ty: Type) (s: seq ty) (i: nat{i < length s}) (v: ty) (n: nat{n < length (update s i v)})
+  forall (ty: Type u#a) (s: seq ty) (i: nat{i < length s}) (v: ty) (n: nat{n < length (update s i v)})
       .{:pattern index (update s i v) n}
       n < length s ==>
           (i = n ==> index (update s i v) n == v)
@@ -252,7 +252,7 @@ private let update_then_index_fact =
 ///     (exists i: int :: { Seq#Index(s,i) } 0 <= i && i < Seq#Length(s) && Seq#Index(s,i) == x));
 
 private let contains_iff_exists_index_fact =
-  forall (ty: Type) (s: seq ty) (x: ty).{:pattern contains s x}
+  forall (ty: Type u#a) (s: seq ty) (x: ty).{:pattern contains s x}
     contains s x <==> (exists (i: nat).{:pattern index s i} i < length s /\ index s i == x)
 
 /// We represent the following Dafny axiom with `empty_doesnt_contain_fact`:
@@ -262,7 +262,7 @@ private let contains_iff_exists_index_fact =
 ///   !Seq#Contains(Seq#Empty(), x));
 
 private let empty_doesnt_contain_anything_fact =
-  forall (ty: Type) (x: ty).{:pattern contains empty x} ~(contains empty x)
+  forall (ty: Type u#a) (x: ty).{:pattern contains empty x} ~(contains empty x)
 
 /// We represent the following Dafny axiom with `build_contains_equiv_fact`:
 ///
@@ -271,7 +271,7 @@ private let empty_doesnt_contain_anything_fact =
 ///     Seq#Contains(Seq#Build(s, v), x) <==> (v == x || Seq#Contains(s, x)));
 
 private let build_contains_equiv_fact =
-  forall (ty: Type) (s: seq ty) (v: ty) (x: ty).{:pattern contains (build s v) x}
+  forall (ty: Type u#a) (s: seq ty) (v: ty) (x: ty).{:pattern contains (build s v) x}
     contains (build s v) x <==> (v == x \/ contains s x)
 
 /// We represent the following Dafny axiom with `take_contains_equiv_exists_fact`:
@@ -283,7 +283,7 @@ private let build_contains_equiv_fact =
 ///       0 <= i && i < n && i < Seq#Length(s) && Seq#Index(s, i) == x));
 
 private let take_contains_equiv_exists_fact =
-  forall (ty: Type) (s: seq ty) (n: nat{n <= length s}) (x: ty).{:pattern contains (take s n) x}
+  forall (ty: Type u#a) (s: seq ty) (n: nat{n <= length s}) (x: ty).{:pattern contains (take s n) x}
     contains (take s n) x <==>
     (exists (i: nat).{:pattern index s i} i < n /\ i < length s /\ index s i == x)
 
@@ -296,7 +296,7 @@ private let take_contains_equiv_exists_fact =
 ///       0 <= n && n <= i && i < Seq#Length(s) && Seq#Index(s, i) == x));
 
 private let drop_contains_equiv_exists_fact =
-  forall (ty: Type) (s: seq ty) (n: nat{n <= length s}) (x: ty).{:pattern contains (drop s n) x}
+  forall (ty: Type u#a) (s: seq ty) (n: nat{n <= length s}) (x: ty).{:pattern contains (drop s n) x}
     contains (drop s n) x <==>
     (exists (i: nat).{:pattern index s i} n <= i && i < length s /\ index s i == x)
 
@@ -309,7 +309,7 @@ private let drop_contains_equiv_exists_fact =
 ///         0 <= j && j < Seq#Length(s0) ==> Seq#Index(s0,j) == Seq#Index(s1,j)));
 
 private let equal_def_fact =
-  forall (ty: Type) (s0: seq ty) (s1: seq ty).{:pattern equal s0 s1}
+  forall (ty: Type u#a) (s0: seq ty) (s1: seq ty).{:pattern equal s0 s1}
     equal s0 s1 <==>
     length s0 == length s1 /\
       (forall j.{:pattern index s0 j \/ index s1 j}
@@ -321,7 +321,7 @@ private let equal_def_fact =
 ///   Seq#Equal(a,b) ==> a == b);
 
 private let extensionality_fact =
-  forall (ty: Type) (a: seq ty) (b: seq ty).{:pattern equal a b}
+  forall (ty: Type u#a) (a: seq ty) (b: seq ty).{:pattern equal a b}
     equal a b ==> a == b
 
 /// We represent an analog of the following Dafny axiom with
@@ -334,7 +334,7 @@ private let extensionality_fact =
 ///         0 <= j && j < n ==> Seq#Index(s0,j) == Seq#Index(s1,j)));
 
 private let is_prefix_def_fact =
-  forall (ty: Type) (s0: seq ty) (s1: seq ty).{:pattern is_prefix s0 s1}
+  forall (ty: Type u#a) (s0: seq ty) (s1: seq ty).{:pattern is_prefix s0 s1}
     is_prefix s0 s1 <==>
       length s0 <= length s1
     /\ (forall (j: nat).{:pattern index s0 j \/ index s1 j}
@@ -346,7 +346,7 @@ private let is_prefix_def_fact =
 ///   0 <= n && n <= Seq#Length(s) ==> Seq#Length(Seq#Take(s,n)) == n);
 
 private let take_length_fact =
-  forall (ty: Type) (s: seq ty) (n: nat).{:pattern length (take s n)}
+  forall (ty: Type u#a) (s: seq ty) (n: nat).{:pattern length (take s n)}
     n <= length s ==> length (take s n) = n
 
 /// We represent the following Dafny axiom with `index_into_take_fact`.
@@ -358,8 +358,8 @@ private let take_length_fact =
 ///   0 <= j && j < n && j < Seq#Length(s) ==>
 ///     Seq#Index(Seq#Take(s,n), j) == Seq#Index(s, j));
 
-private let index_into_take_fact (_ : squash take_length_fact) =
-  forall (ty: Type) (s: seq ty) (n: nat) (j: nat).
+private let index_into_take_fact (_ : squash (take_length_fact u#a)) =
+  forall (ty: Type u#a) (s: seq ty) (n: nat) (j: nat).
     {:pattern index (take s n) j \/ index s j ; take s n}
     j < n && n <= length s ==> index (take s n) j == index s j
 
@@ -369,7 +369,7 @@ private let index_into_take_fact (_ : squash take_length_fact) =
 ///   0 <= n && n <= Seq#Length(s) ==> Seq#Length(Seq#Drop(s,n)) == Seq#Length(s) - n);
 
 private let drop_length_fact =
-  forall (ty: Type) (s: seq ty) (n: nat).
+  forall (ty: Type u#a) (s: seq ty) (n: nat).
     {:pattern length (drop s n)}
     n <= length s ==> length (drop s n) = length s - n
 
@@ -381,8 +381,8 @@ private let drop_length_fact =
 ///   0 <= n && 0 <= j && j < Seq#Length(s)-n ==>
 ///     Seq#Index(Seq#Drop(s,n), j) == Seq#Index(s, j+n));
 
-private let index_into_drop_fact (_ : squash drop_length_fact) =
-  forall (ty: Type) (s: seq ty) (n: nat) (j: nat).
+private let index_into_drop_fact (_ : squash (drop_length_fact u#a)) =
+  forall (ty: Type u#a) (s: seq ty) (n: nat) (j: nat).
     {:pattern index (drop s n) j}
     j < length s - n ==> index (drop s n) j == index s (j + n)
 
@@ -394,8 +394,8 @@ private let index_into_drop_fact (_ : squash drop_length_fact) =
 ///   0 <= n && n <= k && k < Seq#Length(s) ==>
 ///     Seq#Index(Seq#Drop(s,n), k-n) == Seq#Index(s, k));
 
-private let drop_index_offset_fact (_ : squash drop_length_fact) =
-  forall (ty: Type) (s: seq ty) (n: nat) (k: nat).
+private let drop_index_offset_fact (_ : squash (drop_length_fact u#a)) =
+  forall (ty: Type u#a) (s: seq ty) (n: nat) (k: nat).
     {:pattern index s k; drop s n}
     n <= k && k < length s ==> index (drop s n) (k - n) == index s k
 
@@ -409,8 +409,8 @@ private let drop_index_offset_fact (_ : squash drop_length_fact) =
 ///   Seq#Take(Seq#Append(s, t), n) == s &&
 ///   Seq#Drop(Seq#Append(s, t), n) == t);
 
-private let append_then_take_or_drop_fact (_ : squash append_sums_lengths_fact) =
-  forall (ty: Type) (s: seq ty) (t: seq ty) (n: nat).
+private let append_then_take_or_drop_fact (_ : squash (append_sums_lengths_fact u#a)) =
+  forall (ty: Type u#a) (s: seq ty) (t: seq ty) (n: nat).
     {:pattern take (append s t) n \/ drop (append s t) n}
     n = length s ==> take (append s t) n == s /\ drop (append s t) n == t
 
@@ -422,8 +422,8 @@ private let append_then_take_or_drop_fact (_ : squash append_sums_lengths_fact) 
 ///         Seq#Take(Seq#Update(s, i, v), n) == Seq#Update(Seq#Take(s, n), i, v) );
 
 private let take_commutes_with_in_range_update_fact
-  (_ : squash (update_maintains_length_fact /\ take_length_fact)) =
-  forall (ty: Type) (s: seq ty) (i: nat) (v: ty) (n: nat).{:pattern take (update s i v) n}
+  (_ : squash (update_maintains_length_fact u#a /\ take_length_fact u#a)) =
+  forall (ty: Type u#a) (s: seq ty) (i: nat) (v: ty) (n: nat).{:pattern take (update s i v) n}
     i < n && n <= length s ==>
     take (update s i v) n == update (take s n) i v
 
@@ -433,8 +433,8 @@ private let take_commutes_with_in_range_update_fact
 ///         { Seq#Take(Seq#Update(s, i, v), n) }
 ///         n <= i && i < Seq#Length(s) ==> Seq#Take(Seq#Update(s, i, v), n) == Seq#Take(s, n));
 
-private let take_ignores_out_of_range_update_fact (_ : squash update_maintains_length_fact) =
-  forall (ty: Type) (s: seq ty) (i: nat) (v: ty) (n: nat).{:pattern take (update s i v) n}
+private let take_ignores_out_of_range_update_fact (_ : squash (update_maintains_length_fact u#a)) =
+  forall (ty: Type u#a) (s: seq ty) (i: nat) (v: ty) (n: nat).{:pattern take (update s i v) n}
     n <= i && i < length s ==>
     take (update s i v) n == take s n
 
@@ -446,8 +446,8 @@ private let take_ignores_out_of_range_update_fact (_ : squash update_maintains_l
 ///         Seq#Drop(Seq#Update(s, i, v), n) == Seq#Update(Seq#Drop(s, n), i-n, v) );
 
 private let drop_commutes_with_in_range_update_fact
-  (_ : squash (update_maintains_length_fact /\ drop_length_fact)) =
-  forall (ty: Type) (s: seq ty) (i: nat) (v: ty) (n: nat).{:pattern drop (update s i v) n}
+  (_ : squash (update_maintains_length_fact u#a /\ drop_length_fact u#a)) =
+  forall (ty: Type u#a) (s: seq ty) (i: nat) (v: ty) (n: nat).{:pattern drop (update s i v) n}
     n <= i && i < length s ==>
     drop (update s i v) n == update (drop s n) (i - n) v
 
@@ -459,8 +459,8 @@ private let drop_commutes_with_in_range_update_fact
 ///         { Seq#Drop(Seq#Update(s, i, v), n) }
 ///         0 <= i && i < n && n < Seq#Length(s) ==> Seq#Drop(Seq#Update(s, i, v), n) == Seq#Drop(s, n));
 
-private let drop_ignores_out_of_range_update_fact (_ : squash update_maintains_length_fact) =
-  forall (ty: Type) (s: seq ty) (i: nat) (v: ty) (n: nat).{:pattern drop (update s i v) n}
+private let drop_ignores_out_of_range_update_fact (_ : squash (update_maintains_length_fact u#a)) =
+  forall (ty: Type u#a) (s: seq ty) (i: nat) (v: ty) (n: nat).{:pattern drop (update s i v) n}
     i < n && n <= length s ==>
     drop (update s i v) n == drop s n
 
@@ -471,14 +471,14 @@ private let drop_ignores_out_of_range_update_fact (_ : squash update_maintains_l
 ///         0 <= n && n <= Seq#Length(s) ==>
 ///         Seq#Drop(Seq#Build(s, v), n) == Seq#Build(Seq#Drop(s, n), v) );
 
-private let drop_commutes_with_build_fact (_ : squash build_increments_length_fact) =
-  forall (ty: Type) (s: seq ty) (v: ty) (n: nat).{:pattern drop (build s v) n}
+private let drop_commutes_with_build_fact (_ : squash (build_increments_length_fact u#a)) =
+  forall (ty: Type u#a) (s: seq ty) (v: ty) (n: nat).{:pattern drop (build s v) n}
     n <= length s ==> drop (build s v) n == build (drop s n) v
 
 /// We include the definition of `rank` among our facts.
 
 private let rank_def_fact =
-  forall (ty: Type) (v: ty).{:pattern rank v} rank v == v
+  forall (ty: Type u#a) (v: ty).{:pattern rank v} rank v == v
 
 /// We represent the following Dafny axiom with `element_ranks_less_fact`.
 ///
@@ -487,7 +487,7 @@ private let rank_def_fact =
 ///         0 <= i && i < Seq#Length(s) ==> DtRank($Unbox(Seq#Index(s, i)): DatatypeType) < Seq#Rank(s) );
 
 private let element_ranks_less_fact =
-  forall (ty: Type) (s: seq ty) (i: nat).{:pattern rank (index s i)}
+  forall (ty: Type u#a) (s: seq ty) (i: nat).{:pattern rank (index s i)}
     i < length s ==> rank (index s i) << rank s
 
 /// We represent the following Dafny axiom with `drop_ranks_less_fact`.
@@ -497,7 +497,7 @@ private let element_ranks_less_fact =
 ///         0 < i && i <= Seq#Length(s) ==> Seq#Rank(Seq#Drop(s, i)) < Seq#Rank(s) );
 
 private let drop_ranks_less_fact =
-  forall (ty: Type) (s: seq ty) (i: nat).{:pattern rank (drop s i)}
+  forall (ty: Type u#a) (s: seq ty) (i: nat).{:pattern rank (drop s i)}
     0 < i && i <= length s ==> rank (drop s i) << rank s
 
 /// We represent the following Dafny axiom with
@@ -510,7 +510,7 @@ private let drop_ranks_less_fact =
 ///         0 <= i && i < Seq#Length(s) ==> Seq#Rank(Seq#Take(s, i)) < Seq#Rank(s) );
 
 private let take_ranks_less_fact =
-  forall (ty: Type) (s: seq ty) (i: nat).{:pattern length (take s i)}
+  forall (ty: Type u#a) (s: seq ty) (i: nat).{:pattern length (take s i)}
     i < length s ==> length (take s i) << length s
 
 /// We represent the following Dafny axiom with
@@ -525,7 +525,7 @@ private let take_ranks_less_fact =
 ///         Seq#Rank(Seq#Append(Seq#Take(s, i), Seq#Drop(s, j))) < Seq#Rank(s) );
 
 private let append_take_drop_ranks_less_fact =
-  forall (ty: Type) (s: seq ty) (i: nat) (j: nat).{:pattern length (append (take s i) (drop s j))}
+  forall (ty: Type u#a) (s: seq ty) (i: nat) (j: nat).{:pattern length (append (take s i) (drop s j))}
     i < j && j <= length s ==> length (append (take s i) (drop s j)) << length s
 
 /// We represent the following Dafny axiom with `drop_zero_fact`.
@@ -534,7 +534,7 @@ private let append_take_drop_ranks_less_fact =
 ///         n == 0 ==> Seq#Drop(s, n) == s);
 
 private let drop_zero_fact =
-  forall (ty: Type) (s: seq ty) (n: nat).{:pattern drop s n}
+  forall (ty: Type u#a) (s: seq ty) (n: nat).{:pattern drop s n}
     n = 0 ==> drop s n == s
 
 /// We represent the following Dafny axiom with `take_zero_fact`.
@@ -543,7 +543,7 @@ private let drop_zero_fact =
 ///         n == 0 ==> Seq#Take(s, n) == Seq#Empty());
 
 private let take_zero_fact =
-  forall (ty: Type) (s: seq ty) (n: nat).{:pattern take s n}
+  forall (ty: Type u#a) (s: seq ty) (n: nat).{:pattern take s n}
     n = 0 ==> take s n == empty
 
 /// We represent the following Dafny axiom with `drop_then_drop_fact`.
@@ -552,8 +552,8 @@ private let take_zero_fact =
 ///         0 <= m && 0 <= n && m+n <= Seq#Length(s) ==>
 ///         Seq#Drop(Seq#Drop(s, m), n) == Seq#Drop(s, m+n));
 
-private let drop_then_drop_fact (_: squash drop_length_fact) =
-  forall (ty: Type) (s: seq ty) (m: nat) (n: nat).{:pattern drop (drop s m) n}
+private let drop_then_drop_fact (_: squash (drop_length_fact u#a)) =
+  forall (ty: Type u#a) (s: seq ty) (m: nat) (n: nat).{:pattern drop (drop s m) n}
     m + n <= length s ==> drop (drop s m) n == drop s (m + n)
 
 (**
@@ -562,42 +562,42 @@ private let drop_then_drop_fact (_: squash drop_length_fact) =
 **)
 
 let all_seq_facts =
-    length_of_empty_is_zero_fact
-  /\ length_zero_implies_empty_fact
-  /\ singleton_length_one_fact
-  /\ build_increments_length_fact
-  /\ index_into_build_fact ()
-  /\ append_sums_lengths_fact
-  /\ index_into_singleton_fact ()
-  /\ index_after_append_fact ()
-  /\ update_maintains_length_fact
-  /\ update_then_index_fact
-  /\ contains_iff_exists_index_fact
-  /\ empty_doesnt_contain_anything_fact
-  /\ build_contains_equiv_fact
-  /\ take_contains_equiv_exists_fact
-  /\ drop_contains_equiv_exists_fact
-  /\ equal_def_fact
-  /\ extensionality_fact
-  /\ is_prefix_def_fact
-  /\ take_length_fact
-  /\ index_into_take_fact ()
-  /\ drop_length_fact
-  /\ index_into_drop_fact ()
-  /\ drop_index_offset_fact ()
-  /\ append_then_take_or_drop_fact ()
-  /\ take_commutes_with_in_range_update_fact ()
-  /\ take_ignores_out_of_range_update_fact ()
-  /\ drop_commutes_with_in_range_update_fact ()
-  /\ drop_ignores_out_of_range_update_fact ()
-  /\ drop_commutes_with_build_fact ()
-  /\ rank_def_fact
-  /\ element_ranks_less_fact
-  /\ drop_ranks_less_fact
-  /\ take_ranks_less_fact
-  /\ append_take_drop_ranks_less_fact
-  /\ drop_zero_fact
-  /\ take_zero_fact
-  /\ drop_then_drop_fact ()
+    length_of_empty_is_zero_fact u#a
+  /\ length_zero_implies_empty_fact u#a
+  /\ singleton_length_one_fact u#a
+  /\ build_increments_length_fact u#a
+  /\ index_into_build_fact u#a ()
+  /\ append_sums_lengths_fact u#a
+  /\ index_into_singleton_fact u#a ()
+  /\ index_after_append_fact u#a ()
+  /\ update_maintains_length_fact u#a
+  /\ update_then_index_fact u#a
+  /\ contains_iff_exists_index_fact u#a
+  /\ empty_doesnt_contain_anything_fact u#a
+  /\ build_contains_equiv_fact u#a
+  /\ take_contains_equiv_exists_fact u#a
+  /\ drop_contains_equiv_exists_fact u#a
+  /\ equal_def_fact u#a
+  /\ extensionality_fact u#a
+  /\ is_prefix_def_fact u#a
+  /\ take_length_fact u#a
+  /\ index_into_take_fact u#a ()
+  /\ drop_length_fact u#a
+  /\ index_into_drop_fact u#a ()
+  /\ drop_index_offset_fact u#a ()
+  /\ append_then_take_or_drop_fact u#a ()
+  /\ take_commutes_with_in_range_update_fact u#a ()
+  /\ take_ignores_out_of_range_update_fact u#a ()
+  /\ drop_commutes_with_in_range_update_fact u#a ()
+  /\ drop_ignores_out_of_range_update_fact u#a ()
+  /\ drop_commutes_with_build_fact u#a ()
+  /\ rank_def_fact u#a
+  /\ element_ranks_less_fact u#a
+  /\ drop_ranks_less_fact u#a
+  /\ take_ranks_less_fact u#a
+  /\ append_take_drop_ranks_less_fact u#a
+  /\ drop_zero_fact u#a
+  /\ take_zero_fact u#a
+  /\ drop_then_drop_fact u#a ()
 
-val all_seq_facts_lemma : unit -> Lemma (all_seq_facts)
+val all_seq_facts_lemma : unit -> Lemma (all_seq_facts u#a)


### PR DESCRIPTION
Addressing #2755, by avoiding quantifying over types without patterns in the main lemmas of FiniteMap.

I also updated Sequence to use the same style (as an aside, I needed to adjust some brittle proofs there)