### PR TITLE
Fix a perf regression in the normalizer

### DIFF
--- a/src/ocaml-output/FStar_TypeChecker_Normalize.ml
+++ b/src/ocaml-output/FStar_TypeChecker_Normalize.ml
@@ -7514,7 +7514,13 @@ and (rebuild :
                                                   let uu___10 =
                                                     let uu___11 =
                                                       FStar_Compiler_Util.mk_ref
-                                                        FStar_Pervasives_Native.None in
+                                                        (if
+                                                           (cfg1.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.hnf
+                                                         then
+                                                           FStar_Pervasives_Native.None
+                                                         else
+                                                           FStar_Pervasives_Native.Some
+                                                             ([], t2)) in
                                                     ([], t2, uu___11, false) in
                                                   Clos uu___10 in
                                                 (uu___8, uu___9) in


### PR DESCRIPTION
A change that landed with the core typechecker involved not memoizing the sub-terms of a scrutinee matched by a pattern. This leads to a big perf degradation, see #2757. This restores that memoization, guarded by a check to make sure that we're not reducing in head normal form