### PR TITLE
Add implies_intro_as and instantiate_as tactics

### DIFF
--- a/ulib/FStar.Tactics.Logic.fst
+++ b/ulib/FStar.Tactics.Logic.fst
@@ -70,6 +70,10 @@ let implies_intro () : Tac binder =
     apply_lemma (`imp_intro_lem);
     intro ()
 
+let implies_intro_as (s:string) : Tac binder =
+    apply_lemma (`imp_intro_lem);
+    intro_as s
+
 let implies_intros () : Tac binders = repeat1 implies_intro
 
 let l_intro () = forall_intro `or_else` implies_intro
@@ -270,6 +274,10 @@ let instantiate (fa : term) (x : term) : Tac binder =
     try pose (`__forall_inst_sq (`#fa) (`#x)) with | _ ->
     try pose (`__forall_inst (`#fa) (`#x)) with | _ ->
     fail "could not instantiate"
+
+let instantiate_as (fa : term) (x : term) (s : string) : Tac binder =
+    let b = instantiate fa x in
+    rename_to b s
 
 private
 let sklem0 (#a:Type) (#p : a -> Type0) ($v : (exists (x:a). p x)) (phi:Type0) :


### PR DESCRIPTION
These tactics work similar to the forall_intro_as tactic. They also help ensure that the context binders show up with nice names (e.g. h1 instead of uu___). The same effect can be accomplished in two statements (implies_intro, followed by rename_to) but these tactics allow the user to get the same effect in only one statement. For example, the user can write `let h1 = implies_intro_as "h1" in` to introduce the implication into the context with the name `h1`.