### PR TITLE
Fix minor typos and rephrasings

### DIFF
--- a/doc/book/under_the_hood/uth_smt.rst
+++ b/doc/book/under_the_hood/uth_smt.rst
@@ -426,7 +426,7 @@ and ``m``. Additionally, the option ``--fuel n`` sets both the initial
 fuel and max fuel to ``n``.
 
 This single value of ``MaxFuel`` controls the number of unfoldings of
-`all` recursive functions in scope. Of coure, the patterns are
+`all` recursive functions in scope. Of course, the patterns are
 arranged so that if you have a query involving, say, ``List.map``,
 quantified assumptions about an unrelated recursive function like
 ``factorial`` should never trigger. Neverthless, large values of
@@ -544,7 +544,7 @@ term, peeling off one application of the ``S`` constructor.  If we
 were to use ``(HasTypeFuel @u0 @x1 SMTEncoding.unat)`` as the pattern,
 this would lead to an infinite quantifier instantiation loop, since
 every each instantiation would lead a new, larger active term that
-could instantiate the quantifier again.  Note, using the introdution
+could instantiate the quantifier again.  Note, using the introduction
 form does not vary the fuel parameter, since the the number of
 applications of the constructor ``S`` decreases at each instantiation
 anyway.
@@ -641,7 +641,7 @@ Logical Connectives
 ....................
 
 The :ref:`logical connectives <Part2_connectives>` that F* offers, all
-derived forms. Given the encodings of datatypes and functions (and
+have derived forms. Given the encodings of datatypes and functions (and
 arrow types, which we haven't shown), the encodings of all these
 connectives just fall out naturally. However, all these connectives
 also have built-in support in the SMT solver as part of its
@@ -934,7 +934,7 @@ almost like a new built-in type, with proof automation to reason about
 its operations. However, making this work well requires some careful
 design of the patterns.
 
-Consider ``mem_union``: the pattern chosen here allows the solver to
+Consider ``mem_union``: the pattern chosen above allows the solver to
 decompose an active term ``mem x (union s1 s2)`` into ``mem x s1`` and
 ``mem x s2``, where both terms are smaller than the term we started
 with. Suppose instead that we had written:
@@ -1012,7 +1012,7 @@ Profiling Z3 and Solving Proof Performance Issues
 -------------------------------------------------
 
 At some point, you will write F* programs where proofs start to take
-much longer than xyou'd like, simple proofs fail to go through, or
+much longer than you'd like: simple proofs fail to go through, or
 proofs that were once working start to fail as you make small changes
 to your program. Hopefully, you notice this early in your project and
 can try to figure out how to make it better before slogging through
@@ -1406,7 +1406,7 @@ instantiation.
 .. literalinclude:: ../code/Alex.fst
    :language: fstar
 
-The hypothesis that ``unbounded f`` has exactly the same problem as
+The hypothesis is that ``unbounded f`` has exactly the same problem as
 the our unbounded hypothesis on factorial---the ``forall/exists``
 quantifier contains a matching loop. 
 
@@ -1472,8 +1472,8 @@ instantiation problem. There are a few elements to the solution.
 2. Selectively revealing the definition within a scope
 
      Of course, we still want to reason about the unbounded
-     predicate. So, we provide a lemma, ``instantiate_unbounded`` that
-     given allows the caller to explicity instantiate the assumption
+     predicate. So, we provide a lemma, ``instantiate_unbounded``, that
+     allows the caller to explicity instantiate the assumption
      that ``f`` is unbounded on some lower bound ``m``.
 
      To prove the lemma, we use ``FStar.Pervasives.reveal_opaque``:
@@ -1502,7 +1502,7 @@ instantiation problem. There are a few elements to the solution.
      instantiate the existential quantifier in the ``returns``
      clause. We'll look at that in more detail shortly.
 
-     But, by making the problematic definition opaque an instantiating
+     But, by making the problematic definition opaque and instantiating
      it explicitly, our performance problem is gone---here's what
      query-stats shows now.
 
@@ -1587,7 +1587,7 @@ likely change in the future.
 
 Of course, rather than relying on implicitly chosen triggers for the
 existentials, one can be explicit about it and provide the instance
-directly, as shown below, where the ``introdude exists ...`` in each
+directly, as shown below, where the ``introduce exists ...`` in each
 branch directly provides the witness rather than relying on Z3 to find
 it.
 


### PR DESCRIPTION
Fixes a few typos and suggests a few rephrasings in the new docs chapter on "Understanding how F* uses Z3".

The only semantically different rewording I suggest is replacing `here` with `above` when describing the `mem_union` pattern. This is because the sentence refers to the code block that appears several paragraphs before, but the word `here` made me initially look at the closest code block (which is after this sentence) which uses a different pattern. The word `above` instead makes me look at the previous code blocks for the pattern.