### PR TITLE
Restore --timing

### DIFF
--- a/src/ocaml-output/FStar_Options.ml
+++ b/src/ocaml-output/FStar_Options.ml
@@ -1275,7 +1275,7 @@ let rec (specs_with_types :
     (FStar_Getopt.noshort, "tcnorm", BoolStr,
       "Attempt to normalize definitions marked as tcnorm (default 'true')");
     (FStar_Getopt.noshort, "timing", (Const (Bool true)),
-      "Print the time it takes to verify each top-level definition");
+      "Print the time it takes to verify each top-level definition.\n\t\tThis is just an alias for an invocation of the profiler, so it may not work well if combined with --profile.\n\t\tIn particular, it implies --profile_group_by_decls.");
     (FStar_Getopt.noshort, "trace_error", (Const (Bool true)),
       "Don't print an error message; show an exception trace instead");
     (FStar_Getopt.noshort, "ugly", (Const (Bool true)),
@@ -2385,10 +2385,14 @@ let (profile_enabled :
           let uu___ = get_profile_component () in
           matches_namespace_filter_opt phase uu___
       | FStar_Pervasives_Native.Some modul ->
-          (let uu___ = get_profile () in
-           matches_namespace_filter_opt modul uu___) &&
-            (let uu___ = get_profile_component () in
-             matches_namespace_filter_opt phase uu___)
+          ((let uu___ = get_profile () in
+            matches_namespace_filter_opt modul uu___) &&
+             (let uu___ = get_profile_component () in
+              matches_namespace_filter_opt phase uu___))
+            ||
+            (((timing ()) &&
+                (phase = "FStar.TypeChecker.Tc.process_one_decl"))
+               && (should_check modul))
 exception File_argument of Prims.string 
 let (uu___is_File_argument : Prims.exn -> Prims.bool) =
   fun projectee ->

--- a/src/ocaml-output/FStar_TypeChecker_Tc.ml
+++ b/src/ocaml-output/FStar_TypeChecker_Tc.ml
@@ -4544,7 +4544,9 @@ let (tc_decls :
                FStar_Profiling.profile
                  (fun uu___4 -> process_one_decl acc se) uu___3
                  "FStar.TypeChecker.Tc.process_one_decl" in
-             ((let uu___4 = FStar_Options.profile_group_by_decls () in
+             ((let uu___4 =
+                 (FStar_Options.profile_group_by_decls ()) ||
+                   (FStar_Options.timing ()) in
                if uu___4
                then
                  let tag =

--- a/src/typechecker/FStar.TypeChecker.Tc.fst
+++ b/src/typechecker/FStar.TypeChecker.Tc.fst
@@ -1027,8 +1027,11 @@ let tc_decls env ses =
                  (fun () -> process_one_decl acc se)
                  (Some (Ident.string_of_lid (Env.current_module env)))
                  "FStar.TypeChecker.Tc.process_one_decl"
+      // ^ See a special case for this phase in FStar.Options. --timing
+      // enables it.
     in
     if Options.profile_group_by_decls()
+    || Options.timing () // --timing implies --profile_group_by_decls
     then begin
          let tag =
           match lids_of_sigelt se with


### PR DESCRIPTION
From the commit message:
```
options/typechecker: restore --timing by aliasing it to the profiler

This simply makes the option enable the profiler as needed.

Fixes #2768
```
The solution is slightly hackish, but does the trick.