### PR TITLE
Set ppxlib version to 0.27.0 in base Dockerfile

### DIFF
--- a/.docker/base/Dockerfile
+++ b/.docker/base/Dockerfile
@@ -18,7 +18,7 @@ WORKDIR /home/build
 # Prepare and build OPAM and OCaml
 RUN opam init -y --disable-sandboxing
 RUN opam update
-RUN opam install -y ocamlbuild ocamlfind batteries stdint zarith yojson fileutils pprint menhir sedlex ppx_deriving ppx_deriving_yojson process pprint visitors fix wasm ppxlib=0.22.0
+RUN opam install -y ocamlbuild ocamlfind batteries stdint zarith yojson fileutils pprint menhir sedlex ppx_deriving ppx_deriving_yojson process pprint visitors fix wasm ppxlib=0.27.0
 
 # Prepare and build Z3
 ENV z3=z3-4.8.5-x64-debian-8.11


### PR DESCRIPTION
ppxlib versions prior to 0.27.0 (and in particular 0.22.0 which was used previously in the Dockerfile) lack the Ast_500 module which is required to build F*.

Fixes #2788