### PR TITLE
Add a remainder operation for ptrdiff_t

### DIFF
--- a/ulib/FStar.PtrdiffT.fst
+++ b/ulib/FStar.PtrdiffT.fst
@@ -23,6 +23,7 @@ let ptrdiff_int_to_t_inj x = ()
 let mk x = int_to_t (I16.v x)
 
 let add = I64.add
+let div x y = I64.div x y
 let rem x y = I64.rem x y
 let gt x y = I64.gt x y
 let gte x y = I64.gte x y

--- a/ulib/FStar.PtrdiffT.fst
+++ b/ulib/FStar.PtrdiffT.fst
@@ -7,19 +7,25 @@ let t = I64.t
 
 let fits x = FStar.Int.fits x I64.n == true
 
+let fits_lt x y = ()
+
 let v x =
   I64.v x
-
-let ptrdiff_v_inj (x1 x2: t) = ()
 
 let int_to_t (x: int) : Pure t
   (requires (fits x))
   (ensures (fun y -> v y == x))
   = I64.int_to_t x
 
+let ptrdiff_v_inj x = ()
+let ptrdiff_int_to_t_inj x = ()
+
 let mk x = int_to_t (I16.v x)
 
 let add = I64.add
+
+let rem x y = admit()
+
 let gt x y = I64.gt x y
 let gte x y = I64.gte x y
 let lt x y = I64.lt x y

--- a/ulib/FStar.PtrdiffT.fst
+++ b/ulib/FStar.PtrdiffT.fst
@@ -3,9 +3,26 @@ module FStar.PtrdiffT
 module Cast = FStar.Int.Cast
 module I64 = FStar.Int64
 
-let t = I64.t
+open FStar.Ghost
 
-let fits x = FStar.Int.fits x I64.n == true
+friend FStar.SizeT
+
+(** We assume the existence of lower and upper bounds corresponding to PTRDIFF_MIN
+    and PTRDIFF_MAX, which ensure that a ptrdiff_t has at least width 16 according to
+    the C standard *)
+assume
+val max_bound : x:erased int { x >= pow2 15 - 1 }
+let min_bound : erased int = hide (- (reveal max_bound + 1))
+
+(** We also assume that size_t is wider than ptrdiff_t *)
+assume
+val bounds_lemma (_:unit) : Lemma (SizeT.bound > max_bound)
+
+let t = x:I64.t{I64.v x >= min_bound /\ I64.v x <= max_bound }
+
+let fits x =
+  FStar.Int.fits x I64.n == true /\
+  x <= max_bound /\ x >= min_bound
 
 let fits_lt x y = ()
 
@@ -22,8 +39,20 @@ let ptrdiff_int_to_t_inj x = ()
 
 let mk x = int_to_t (I16.v x)
 
-let add = I64.add
-let div x y = I64.div x y
+let ptrdifft_to_sizet x =
+  bounds_lemma ();
+  Cast.int64_to_uint64 x
+
+let add x y = I64.add x y
+
+let lem (x:nat) (y:pos) : Lemma (x / y <= x) =
+  let open FStar.Mul in
+  FStar.Math.Lemmas.lemma_div_le x (x * y) y
+
+let div x y =
+  lem (v x) (v y);
+  I64.div x y
+
 let rem x y = I64.rem x y
 let gt x y = I64.gt x y
 let gte x y = I64.gte x y

--- a/ulib/FStar.PtrdiffT.fst
+++ b/ulib/FStar.PtrdiffT.fst
@@ -23,9 +23,7 @@ let ptrdiff_int_to_t_inj x = ()
 let mk x = int_to_t (I16.v x)
 
 let add = I64.add
-
-let rem x y = admit()
-
+let rem x y = I64.rem x y
 let gt x y = I64.gt x y
 let gte x y = I64.gte x y
 let lt x y = I64.lt x y

--- a/ulib/FStar.PtrdiffT.fst
+++ b/ulib/FStar.PtrdiffT.fst
@@ -45,12 +45,8 @@ let ptrdifft_to_sizet x =
 
 let add x y = I64.add x y
 
-let lem (x:nat) (y:pos) : Lemma (x / y <= x) =
-  let open FStar.Mul in
-  FStar.Math.Lemmas.lemma_div_le x (x * y) y
-
 let div x y =
-  lem (v x) (v y);
+  FStar.Math.Lib.slash_decr_axiom (v x) (v y);
   I64.div x y
 
 let rem x y = I64.rem x y

--- a/ulib/FStar.PtrdiffT.fsti
+++ b/ulib/FStar.PtrdiffT.fsti
@@ -49,6 +49,14 @@ val add (x y: t) : Pure t
   (requires (fits (v x + v y)))
   (ensures (fun z -> v z == v x + v y))
 
+(** Division primitive
+
+    As for rem below, we only provide division on positive signed
+    integers, to avoid having to reason about possible overflows *)
+val div (a:t{v a >= 0}) (b:t{v b > 0}) : Pure t
+  (requires True)
+  (ensures fun c -> v a / v b == v c)
+
 (** Modulo specification, similar to FStar.Int.mod *)
 
 let mod_spec (a:int{fits a}) (b:int{fits b /\ b <> 0}) : GTot (n:int{fits n}) =

--- a/ulib/FStar.PtrdiffT.fsti
+++ b/ulib/FStar.PtrdiffT.fsti
@@ -60,7 +60,7 @@ let mod_spec (a:int{fits a}) (b:int{fits b /\ b <> 0}) : GTot (n:int{fits n}) =
 (** Euclidean remainder
 
     The result is the modulus of [a] with respect to a non-zero [b] *)
-val rem (a:t) (b:t{v b <> 0}) : Pure t
+val rem (a:t{v a >= 0}) (b:t{v b > 0}) : Pure t
   (requires True)
   (ensures (fun c -> mod_spec (v a) (v b) = v c))
 

--- a/ulib/FStar.PtrdiffT.fsti
+++ b/ulib/FStar.PtrdiffT.fsti
@@ -1,6 +1,7 @@
 module FStar.PtrdiffT
 
 module I16 = FStar.Int16
+module US = FStar.SizeT
 
 val t : eqtype
 
@@ -44,6 +45,12 @@ val mk (x: I16.t) : Pure t
 noextract inline_for_extraction
 let zero : (zero_ptrdiff: t { v zero_ptrdiff == 0 }) =
   mk 0s
+
+(** Cast from ptrdiff_to to size_t.
+    We restrict the cast to positive integers to avoid reasoning about modular arithmetic *)
+val ptrdifft_to_sizet (x:t{v x >= 0}) : Pure US.t
+  (requires True)
+  (ensures fun c -> v x == US.v c)
 
 val add (x y: t) : Pure t
   (requires (fits (v x + v y)))

--- a/ulib/FStar.PtrdiffT.fsti
+++ b/ulib/FStar.PtrdiffT.fsti
@@ -6,8 +6,8 @@ val t : eqtype
 
 val fits (x: int) : Tot prop
 
-val fits_lte (x y: int) : Lemma
-  (requires (abs x <= abs y /\ fits y))
+val fits_lt (x y: int) : Lemma
+  (requires (abs x < abs y /\ fits y))
   (ensures (fits x))
   [SMTPat (fits x); SMTPat (fits y)]
 
@@ -16,21 +16,21 @@ val v (x: t) : Pure int
   (requires True)
   (ensures (fun y -> fits y))
 
-val uint_to_t (x: int) : Pure t
+val int_to_t (x: int) : Pure t
   (requires (fits x))
   (ensures (fun y -> v y == x))
 
 /// v and uint_to_t are inverses
 val ptrdiff_v_inj (x: t)
   : Lemma
-    (ensures uint_to_t (v x) == x)
+    (ensures int_to_t (v x) == x)
     [SMTPat (v x)]
 
-val ptrdiff_uint_to_t_inj (x: int)
+val ptrdiff_int_to_t_inj (x: int)
   : Lemma
     (requires fits x)
-    (ensures v (uint_to_t x) == x)
-    [SMTPat (uint_to_t x)]
+    (ensures v (int_to_t x) == x)
+    [SMTPat (int_to_t x)]
 
 /// According to the C standard, "the bit width of ptrdiff_t is not less than 17 since c99,
 /// 16 since C23"
@@ -49,12 +49,12 @@ val add (x y: t) : Pure t
   (requires (fits (v x + v y)))
   (ensures (fun z -> v z == v x + v y))
 
-(** Modulo specification, similar to FStar.UInt.mod *)
+(** Modulo specification, similar to FStar.Int.mod *)
 
 let mod_spec (a:int{fits a}) (b:int{fits b /\ b <> 0}) : GTot (n:int{fits n}) =
   let open FStar.Mul in
   let res = a - ((a/b) * b) in
-  fits_lte res b;
+  fits_lt res b;
   res
 
 (** Euclidean remainder

--- a/ulib/FStar.PtrdiffT.fsti
+++ b/ulib/FStar.PtrdiffT.fsti
@@ -20,7 +20,7 @@ val int_to_t (x: int) : Pure t
   (requires (fits x))
   (ensures (fun y -> v y == x))
 
-/// v and uint_to_t are inverses
+/// v and int_to_t are inverses
 val ptrdiff_v_inj (x: t)
   : Lemma
     (ensures int_to_t (v x) == x)
@@ -59,7 +59,12 @@ let mod_spec (a:int{fits a}) (b:int{fits b /\ b <> 0}) : GTot (n:int{fits n}) =
 
 (** Euclidean remainder
 
-    The result is the modulus of [a] with respect to a non-zero [b] *)
+    The result is the modulus of [a] with respect to a non-zero [b].
+    Note, according to the C standard, this operation is only defined
+    if a/b is representable.
+    To avoid requiring the precondition `fits (v a / v b)`, we instead
+    restrict this primitive to positive integers only.
+    *)
 val rem (a:t{v a >= 0}) (b:t{v b > 0}) : Pure t
   (requires True)
   (ensures (fun c -> mod_spec (v a) (v b) = v c))

--- a/ulib/FStar.SizeT.fst
+++ b/ulib/FStar.SizeT.fst
@@ -5,7 +5,7 @@ module I64 = FStar.Int64
 (* This is only intended as a model, but will be extracted natively by Krml
    with the correct C semantics *)
 
-(* We assume the existence of some lower bound on the size, 
+(* We assume the existence of some lower bound on the size,
    where the bound is at least 2^16 *)
 assume
 val bound : x:erased nat { x >= pow2 16 }
@@ -61,13 +61,14 @@ let of_u64 (x: U64.t)
 let uint16_to_sizet x = uint_to_t (U16.v x)
 let uint32_to_sizet x = uint_to_t (U32.v x)
 let uint64_to_sizet x = uint_to_t (U64.v x)
+let sizet_to_uint32 x = FStar.Int.Cast.uint64_to_uint32 x
 
 let fits_lte x y = ()
 
 let add x y = U64.add x y
 let sub x y = U64.sub x y
 let mul x y = U64.mul x y
-let div x y = 
+let div x y =
   let res = U64.div x y in
   fits_lte (U64.v res) (U64.v x);
   FStar.Math.Lib.slash_decr_axiom (U64.v x) (U64.v y);

--- a/ulib/FStar.SizeT.fst
+++ b/ulib/FStar.SizeT.fst
@@ -65,6 +65,7 @@ let sizet_to_uint32 x = FStar.Int.Cast.uint64_to_uint32 x
 
 let fits_lte x y = ()
 
+#push-options "--z3rlimit 20"
 let add x y = U64.add x y
 let sub x y = U64.sub x y
 let mul x y = U64.mul x y

--- a/ulib/FStar.SizeT.fsti
+++ b/ulib/FStar.SizeT.fsti
@@ -11,10 +11,10 @@ val t : eqtype
 val fits (x: nat) : Tot prop
 
 /// According to the C standard, "the bit width of t is not less than 16 since c99"
-/// (https://en.cppreference.com/w/c/types/t)
+/// (https://en.cppreference.com/w/c/types/size_t)
 
 val fits_at_least_16 (x:nat)
-  : Lemma 
+  : Lemma
     (requires x < pow2 16)
     (ensures fits x)
     [SMTPat (fits x)]
@@ -96,6 +96,7 @@ val fits_lte (x y: nat) : Lemma
   (requires (x <= y /\ fits y))
   (ensures (fits x))
   [SMTPat (fits x); SMTPat (fits y)]
+
 (** Non-overflowing arithmetic operations *)
 
 val add (x y: t) : Pure t
@@ -122,7 +123,6 @@ let mod_spec (a:nat{fits a}) (b:nat{fits b /\ b <> 0}) : GTot (n:nat{fits n}) =
   let res = a - ((a/b) * b) in
   fits_lte res a;
   res
-
 
 (** Euclidean remainder
 

--- a/ulib/FStar.SizeT.fsti
+++ b/ulib/FStar.SizeT.fsti
@@ -92,6 +92,10 @@ val uint64_to_sizet (x:U64.t) : Pure t
   (requires fits_u64)
   (ensures fun y -> v y == U64.v x)
 
+val sizet_to_uint32 (x:t) : Pure U32.t
+  (requires True)
+  (ensures fun y -> U32.v y == v x % pow2 32)
+
 val fits_lte (x y: nat) : Lemma
   (requires (x <= y /\ fits y))
   (ensures (fits x))


### PR DESCRIPTION
This PR adds `div` and `rem` primitive for ptrdiff_t, similar to the implementation of the same signed integers' operations.
The main difference is that we only define these operation for positive integers: When defining a%b, the C standard requires a/b to be representable, which can be hard to prove with the abstract `fits` predicate, same for a/b which can lead to overflows for negative integers.

This PR also adds a cast from positive ptrdiff_t to size_t, as well as a cast from size_t to uint32_t using modular arithmetic.

Additionally, this PR also adds a `fits_lt` lemma for ptrdiff_t, and refactors some basic lemmas about its mathematical representation to adopt the same approach as size_t