### PR TITLE
Extend Steel arrays with null arrays, add a reference model building on arrays.

### DIFF
--- a/.docker/build/config.json
+++ b/.docker/build/config.json
@@ -31,6 +31,6 @@
     "TrackPerformance" : false,
 
     "RepoVersions" : {
-        "karamel_version" : "origin/master",
+        "karamel_version" : "origin/_taramana_is_null",
     }
 }

--- a/.docker/build/config.json
+++ b/.docker/build/config.json
@@ -31,6 +31,6 @@
     "TrackPerformance" : false,
 
     "RepoVersions" : {
-        "karamel_version" : "origin/master"
+        "karamel_version" : "origin/_taramana_is_null"
     }
 }

--- a/.docker/build/config.json
+++ b/.docker/build/config.json
@@ -31,6 +31,6 @@
     "TrackPerformance" : false,
 
     "RepoVersions" : {
-        "karamel_version" : "origin/master",
+        "karamel_version" : "origin/master"
     }
 }

--- a/.docker/build/config.json
+++ b/.docker/build/config.json
@@ -31,6 +31,6 @@
     "TrackPerformance" : false,
 
     "RepoVersions" : {
-        "karamel_version" : "origin/_taramana_is_null",
+        "karamel_version" : "origin/master",
     }
 }

--- a/.docker/build/config.json
+++ b/.docker/build/config.json
@@ -31,6 +31,6 @@
     "TrackPerformance" : false,
 
     "RepoVersions" : {
-        "karamel_version" : "origin/_taramana_is_null"
+        "karamel_version" : "origin/master"
     }
 }

--- a/examples/steel/Makefile
+++ b/examples/steel/Makefile
@@ -2,7 +2,7 @@ EXCLUDED_FSTAR_FILES=ParDivWP.fst Semantics.WP.fst $(wildcard DList*)
 OTHERFLAGS+=--already_cached 'Prims FStar LowStar Steel NMST MST NMSTTotal MSTTotal' --compat_pre_typed_indexed_effects
 FSTAR_FILES = DList1.fst $(filter-out $(EXCLUDED_FSTAR_FILES), $(wildcard *.fst))
 
-all: verify-all counter
+all: verify-all counter llist2
 
 $(CACHE_DIR):
 	mkdir -p $@
@@ -25,4 +25,15 @@ counter:
 
 endif
 
-.PHONY: all verify-all counter
+ifdef KRML_HOME
+
+llist2: verify-all
+	+$(MAKE) -C $@
+
+else
+
+llist2:
+
+endif
+
+.PHONY: all verify-all counter llist2

--- a/examples/steel/Makefile
+++ b/examples/steel/Makefile
@@ -2,7 +2,7 @@ EXCLUDED_FSTAR_FILES=ParDivWP.fst Semantics.WP.fst $(wildcard DList*)
 OTHERFLAGS+=--already_cached 'Prims FStar LowStar Steel NMST MST NMSTTotal MSTTotal' --compat_pre_typed_indexed_effects
 FSTAR_FILES = DList1.fst $(filter-out $(EXCLUDED_FSTAR_FILES), $(wildcard *.fst))
 
-all: verify-all counter llist2
+all: verify-all counter llist2 llist3
 
 $(CACHE_DIR):
 	mkdir -p $@
@@ -30,10 +30,15 @@ ifdef KRML_HOME
 llist2: verify-all
 	+$(MAKE) -C $@
 
+llist3: verify-all
+	+$(MAKE) -C $@
+
 else
 
 llist2:
 
+llist3:
+
 endif
 
-.PHONY: all verify-all counter llist2
+.PHONY: all verify-all counter llist2 llist3

--- a/examples/steel/Selectors.ArrayRef.fst
+++ b/examples/steel/Selectors.ArrayRef.fst
@@ -1,0 +1,185 @@
+module Selectors.ArrayRef
+
+module A = Steel.Array
+
+let ref a = (r: A.array a { (A.length r == 1 /\ A.is_full_array r) \/ r == A.null })
+
+let null #a = A.null #a
+
+let is_null r = A.is_null r
+
+let vptr0_refine
+  (#a: Type0)
+  (r: ref a)
+  (s: Seq.lseq a (A.length r))
+: Tot prop
+= Seq.length s == 1
+
+let vptr0_rewrite
+  (#a: Type)
+  (r: ref a)
+  (p: perm)
+  (s: normal (vrefine_t (A.varrayp r p) (vptr0_refine r)))
+: Tot a
+= Seq.index s 0
+
+[@@__steel_reduce__; __reduce__]
+let vptr1
+  (#a: Type0)
+  (r: ref a)
+  (p: perm)
+: Tot vprop
+= A.varrayp r p `vrefine`
+  vptr0_refine r `vrewrite`
+  vptr0_rewrite r p
+
+[@@__steel_reduce__]
+let vptr0
+  (#a: Type0)
+  (r: ref a)
+  (p: perm)
+: Tot vprop
+= vptr1 r p
+
+let intro_vptr0
+  (#opened: _)
+  (#a: Type0)
+  (r: ref a)
+  (p: perm)
+: SteelGhost unit opened
+    (A.varrayp r p)
+    (fun _ -> vptr0 r p)
+    (fun _ -> True)
+    (fun h _ h' ->
+      let s = A.aselp r p h in
+      Seq.length s == 1 /\
+      h' (vptr0 r p) == Seq.index s 0
+    )
+= A.varrayp_not_null r p;
+  intro_vrefine (A.varrayp r p) (vptr0_refine r);
+  intro_vrewrite (A.varrayp r p `vrefine` vptr0_refine r) (vptr0_rewrite r p);
+  change_equal_slprop (vptr1 r p) (vptr0 r p)
+
+let elim_vptr0
+  (#opened: _)
+  (#a: Type0)
+  (r: ref a)
+  (p: perm)
+: SteelGhost unit opened
+    (vptr0 r p)
+    (fun _ -> A.varrayp r p)
+    (fun _ -> True)
+    (fun h _ h' ->
+      A.aselp r p h' `Seq.equal` Seq.create 1 (h (vptr0 r p))
+    )
+= 
+  change_equal_slprop (vptr0 r p) (vptr1 r p);
+  elim_vrewrite (A.varrayp r p `vrefine` vptr0_refine r) (vptr0_rewrite r p);
+  elim_vrefine (A.varrayp r p) (vptr0_refine r)
+
+let ptrp r p = hp_of (vptr0 r p)
+
+let ptrp_sel r p = sel_of (vptr0 r p)
+
+let intro_vptrp
+  (#opened: _)
+  (#a: Type0)
+  (r: ref a)
+  (p: perm)
+: SteelGhost unit opened
+    (A.varrayp r p)
+    (fun _ -> vptrp r p)
+    (fun _ -> True)
+    (fun h _ h' ->
+      let s = A.aselp r p h in
+      Seq.length s == 1 /\
+      selp r p h' == Seq.index s 0
+    )
+= intro_vptr0 r p;
+  change_slprop_rel
+    (vptr0 r p)
+    (vptrp r p)
+    (fun v1 v2 -> v1 === v2)
+    (fun m ->
+      assert (interp (hp_of (vptrp r p)) m);
+      assert_norm (sel_of (vptrp r p) m === sel_of (vptr0 r p) m)
+    )
+
+let elim_vptrp
+  (#opened: _)
+  (#a: Type0)
+  (r: ref a)
+  (p: perm)
+: SteelGhost unit opened
+    (vptrp r p)
+    (fun _ -> A.varrayp r p)
+    (fun _ -> True)
+    (fun h _ h' ->
+      A.aselp r p h' `Seq.equal` Seq.create 1 (selp r p h)
+    )
+= change_slprop_rel
+    (vptrp r p)
+    (vptr0 r p)
+    (fun v1 v2 -> v1 === v2)
+    (fun m ->
+      assert (interp (hp_of (vptr0 r p)) m);
+      assert_norm (sel_of (vptr0 r p) m === sel_of (vptrp r p) m)
+    );
+  elim_vptr0 r p
+
+let malloc
+  x
+= let r = A.malloc x 1sz in
+  intro_vptrp r full_perm;
+  return r
+
+let free
+  r
+= elim_vptrp r full_perm;
+  A.varrayp_not_null r full_perm;
+  A.free r
+
+let readp
+  r p
+= elim_vptrp r p;
+  let res = A.index r 0sz in
+  intro_vptrp r p;
+  return res
+
+let write
+  r x
+= elim_vptrp r full_perm;
+  A.upd r 0sz x;
+  intro_vptrp r full_perm
+
+let share
+  #_ #_ #p r
+= elim_vptrp r p;
+  A.share r p (half_perm p) (half_perm p);
+  intro_vptrp r (half_perm p);
+  intro_vptrp r (half_perm p)
+
+let gather_gen
+  r p0 p1
+= elim_vptrp r p0;
+  elim_vptrp r p1;
+  A.gather r p0 p1;
+  let s = sum_perm p0 p1 in
+  change_equal_slprop
+    (A.varrayp r (sum_perm p0 p1))
+    (A.varrayp r s);
+  intro_vptrp r s;
+  s
+
+let gather
+  #_ #_ #p r
+= let p' = gather_gen r (half_perm p) (half_perm p) in
+  change_equal_slprop
+    (vptrp r p')
+    (vptrp r p)
+
+let vptrp_not_null
+  r p
+= elim_vptrp r p;
+  A.varrayp_not_null r p;
+  intro_vptrp r p

--- a/examples/steel/Selectors.ArrayRef.fsti
+++ b/examples/steel/Selectors.ArrayRef.fsti
@@ -1,0 +1,162 @@
+module Selectors.ArrayRef
+
+open Steel.FractionalPermission
+open Steel.Memory
+open Steel.Effect.Common
+open Steel.Effect
+open Steel.Effect.Atomic
+
+(** This module provides the same interface as Steel.Reference, however, it builds on top
+    of Steel.Array to enable the interoperation between arrays and references.
+    Similarly to C, a reference is defined as an array of length 1 *)
+
+/// An abstract datatype for references
+inline_for_extraction
+val ref ([@@@strictly_positive] a:Type0) : Type0
+
+/// The null pointer
+[@@ noextract_to "krml"]
+inline_for_extraction
+val null (#a:Type0) : ref a
+
+/// Checking whether a pointer is null can be done in a decidable way
+[@@ noextract_to "krml"]
+inline_for_extraction
+val is_null (#a:Type0) (r:ref a) : (b:bool{b <==> r == null})
+
+/// An abstract separation logic predicate stating that reference [r] is valid in memory.
+
+val ptrp (#a:Type0) (r:ref a) ([@@@smt_fallback] p: perm) : slprop u#1
+
+[@@ __steel_reduce__; __reduce__]
+unfold
+let ptr (#a:Type0) (r:ref a) : slprop u#1 = ptrp r full_perm
+
+/// A selector for references, returning the value of type [a] stored in memory
+
+val ptrp_sel (#a:Type0) (r:ref a) (p: perm) : selector a (ptrp r p)
+
+[@@ __steel_reduce__; __reduce__]
+unfold
+let ptr_sel (#a:Type0) (r:ref a) : selector a (ptr r) = ptrp_sel r full_perm
+
+/// Combining the separation logic predicate and selector into a vprop
+[@@ __steel_reduce__]
+let vptr' #a r p : vprop' =
+  {hp = ptrp r p;
+   t = a;
+   sel = ptrp_sel r p}
+
+[@@ __steel_reduce__]
+unfold
+let vptrp (#a: Type) (r: ref a) ([@@@smt_fallback] p: perm) = VUnit (vptr' r p)
+
+[@@ __steel_reduce__; __reduce__]
+unfold
+let vptr r = vptrp r full_perm
+
+/// A wrapper to access a reference selector more easily.
+/// Ensuring that the corresponding ptr vprop is in the context is done by
+/// calling a variant of the framing tactic, as defined in Steel.Effect.Common
+
+[@@ __steel_reduce__]
+let selp (#a:Type) (#p:vprop) (r:ref a) (pr: perm)
+  (h:rmem p{FStar.Tactics.with_tactic selector_tactic (can_be_split p (vptrp r pr) /\ True)})
+  = h (vptrp r pr)
+
+[@@ __steel_reduce__]
+let sel (#a:Type) (#p:vprop) (r:ref a)
+  (h:rmem p{FStar.Tactics.with_tactic selector_tactic (can_be_split p (vptr r) /\ True)})
+  = h (vptr r)
+
+/// Allocates a reference with value [x].
+inline_for_extraction
+val malloc (#a:Type0) (x:a) : Steel (ref a)
+  emp (fun r -> vptr r)
+  (requires fun _ -> True)
+  (ensures fun _ r h1 -> sel r h1 == x /\ not (is_null r))
+
+/// Frees a reference [r]
+inline_for_extraction
+val free (#a:Type0) (r:ref a) : Steel unit
+  (vptr r) (fun _ -> emp)
+  (requires fun _ -> True)
+  (ensures fun _ _ _ -> True)
+
+/// Reads the current value of reference [r]
+inline_for_extraction
+val readp (#a:Type0) (r:ref a) (p: perm) : Steel a
+  (vptrp r p) (fun _ -> vptrp r p)
+  (requires fun _ -> True)
+  (ensures fun h0 x h1 -> h0 (vptrp r p) == h1 (vptrp r p) /\ x == h1 (vptrp r p))
+
+inline_for_extraction
+let read (#a:Type0) (r:ref a) : Steel a
+  (vptr r) (fun _ -> vptr r)
+  (requires fun _ -> True)
+  (ensures fun h0 x h1 -> sel r h0 == sel r h1 /\ x == sel r h1)
+= readp r full_perm
+
+/// Writes value [x] in reference [r]
+inline_for_extraction
+val write (#a:Type0) (r:ref a) (x:a) : Steel unit
+  (vptr r) (fun _ -> vptr r)
+  (requires fun _ -> True)
+  (ensures fun _ _ h1 -> x == sel r h1)
+
+val share (#a:Type0) (#uses:_) (#p: perm) (r:ref a)
+  : SteelGhost unit uses
+    (vptrp r p)
+    (fun _ -> vptrp r (half_perm p) `star` vptrp r (half_perm p))
+    (fun _ -> True)
+    (fun h _ h' ->
+      h' (vptrp r (half_perm p)) == h (vptrp r p)
+    )
+
+val gather_gen (#a:Type0) (#uses:_) (r:ref a) (p0:perm) (p1:perm)
+  : SteelGhost perm uses
+    (vptrp r p0 `star` vptrp r p1)
+    (fun res -> vptrp r res)
+    (fun _ -> True)
+    (fun h res h' ->
+      res == sum_perm p0 p1 /\
+      h' (vptrp r res) == h (vptrp r p0) /\
+      h' (vptrp r res) == h (vptrp r p1)
+    )
+
+val gather (#a: Type0) (#uses: _) (#p: perm) (r: ref a)
+  : SteelGhost unit uses
+      (vptrp r (half_perm p) `star` vptrp r (half_perm p))
+      (fun _ -> vptrp r p)
+      (fun _ -> True)
+      (fun h _ h' ->
+        h' (vptrp r p) == h (vptrp r (half_perm p))
+      )
+
+/// A stateful lemma variant of the pts_to_not_null lemma above.
+/// This stateful function is computationally irrelevant and does not modify memory
+val vptrp_not_null (#opened: _)
+  (#a: Type)
+  (r: ref a)
+  (p: perm)
+: SteelGhost unit opened
+    (vptrp r p)
+    (fun _ -> vptrp r p)
+    (fun _ -> True)
+    (fun h0 _ h1 ->
+      h0 (vptrp r p) == h1 (vptrp r p) /\
+      is_null r == false
+    )
+
+let vptr_not_null (#opened: _)
+  (#a: Type)
+  (r: ref a)
+: SteelGhost unit opened
+    (vptr r)
+    (fun _ -> vptr r)
+    (fun _ -> True)
+    (fun h0 _ h1 ->
+      sel r h0 == sel r h1 /\
+      is_null r == false
+    )
+= vptrp_not_null r full_perm

--- a/examples/steel/Selectors.LList2.fsti
+++ b/examples/steel/Selectors.LList2.fsti
@@ -15,12 +15,16 @@ module L = FStar.List.Tot
 /// Abstract type of a list cell containing a value of type [a]
 val cell (a:Type0) : Type0
 /// The type of a list: A reference to a cell
+inline_for_extraction
 let t (a:Type0) = ref (cell a)
 
 (* Helpers to manipulate cells while keeping its definition abstract *)
 
+inline_for_extraction
 val next (#a:Type0) (c:cell a) : t a
+inline_for_extraction
 val data (#a:Type0) (c:cell a) : a
+inline_for_extraction
 val mk_cell (#a:Type0) (n: t a) (d:a)
   : Pure (cell a)
     (requires True)
@@ -30,9 +34,11 @@ val mk_cell (#a:Type0) (n: t a) (d:a)
 
 
 /// The null list pointer
+inline_for_extraction
 val null_llist (#a:Type) : t a
 
 /// Lifting the null pointer check to empty lists
+inline_for_extraction
 val is_null (#a:Type) (ptr:t a) : (b:bool{b <==> ptr == null_llist})
 
 
@@ -61,11 +67,12 @@ let v_llist (#a:Type0) (#p:vprop) (r:t a)
 
 (** Stateful lemmas to fold and unfold the llist predicate **)
 
-val intro_llist_nil (a:Type0)
-  : Steel unit emp (fun _ -> llist (null_llist #a))
+val intro_llist_nil (#opened: _) (a:Type0)
+  : SteelGhost unit opened emp (fun _ -> llist (null_llist #a))
           (requires fun _ -> True)
           (ensures fun _ _ h1 -> v_llist #a null_llist h1 == [])
 
+inline_for_extraction
 val is_nil (#a:Type0) (ptr:t a)
   : Steel bool (llist ptr) (fun _ -> llist ptr)
           (requires fun _ -> True)
@@ -74,12 +81,14 @@ val is_nil (#a:Type0) (ptr:t a)
             v_llist ptr h0 == v_llist ptr h1 /\
             res == Nil? (v_llist ptr h1))
 
+inline_for_extraction
 val intro_llist_cons (#a:Type0) (ptr1 ptr2:t a)
   : Steel unit (vptr ptr1 `star` llist ptr2)
                   (fun _ -> llist ptr1)
                   (requires fun h -> next (sel ptr1 h) == ptr2)
                   (ensures fun h0 _ h1 -> v_llist ptr1 h1 == (data (sel ptr1 h0)) :: v_llist ptr2 h0)
 
+inline_for_extraction
 val tail (#a:Type0) (ptr:t a)
   : Steel (t a) (llist ptr)
                    (fun n -> vptr ptr `star` llist n)

--- a/examples/steel/Selectors.LList3.fst
+++ b/examples/steel/Selectors.LList3.fst
@@ -1,0 +1,314 @@
+module Selectors.LList3
+
+open Steel.FractionalPermission
+module Mem = Steel.Memory
+
+#push-options "--__no_positivity"
+noeq
+type cell (a: Type0) = {
+  tail_fuel: Ghost.erased nat;
+  next: ref (cell a);
+  data: a;
+}
+#pop-options
+
+let next #a (c:cell a) : t a = c.next
+let data #a (c:cell a) : a = c.data
+let mk_cell #a (n: t a) (d:a) = {
+  tail_fuel = Ghost.hide 0;
+  next = n;
+  data = d
+}
+
+let null_llist #a = null
+let is_null #a ptr = is_null ptr
+
+let v_null_rewrite
+  (a: Type0)
+  (_: t_of emp)
+: GTot (list a)
+= []
+
+let v_c
+  (n: Ghost.erased nat)
+  (#a: Type0)
+  (r: t a)
+  (c: normal (t_of (vptr r)))
+: GTot prop
+= (Ghost.reveal c.tail_fuel < Ghost.reveal n) == true // to ensure vprop termination
+
+let v_c_dep
+  (n: Ghost.erased nat)
+  (#a: Type0)
+  (r: t a)
+  (nllist: (n': Ghost.erased nat) -> (r: t a  { Ghost.reveal n' < Ghost.reveal n }) -> Pure vprop (requires True) (ensures (fun y -> t_of y == list a)))
+  (c: normal (t_of (vrefine (vptr r) (v_c n r))))
+: Tot vprop
+= nllist c.tail_fuel c.next
+
+let v_c_l_rewrite
+  (n: Ghost.erased nat)
+  (#a: Type0)
+  (r: t a)
+  (nllist: (n': Ghost.erased nat) -> (r: t a { Ghost.reveal n' < Ghost.reveal n }) -> Pure vprop (requires True) (ensures (fun y -> t_of y == list a)))
+  (res: normal (t_of ((vptr r `vrefine` v_c n r) `vdep` v_c_dep n r nllist)))
+: Tot (list a)
+= let (| c, l |) = res in
+  c.data :: l
+
+let rec nllist
+  (a: Type0)
+  (n: Ghost.erased nat)
+  (r: t a)
+: Pure vprop
+  (requires True)
+  (ensures (fun y -> t_of y == list a))
+  (decreases (Ghost.reveal n))
+= if is_null r
+  then emp `vrewrite` v_null_rewrite a
+  else ((vptr r `vrefine` v_c n r) `vdep` v_c_dep n r (nllist a)) `vrewrite` v_c_l_rewrite n r (nllist a)
+
+let nllist_eq_not_null
+  (a: Type0)
+  (n: Ghost.erased nat)
+  (r: t a)
+: Lemma
+  (requires (is_null r == false))
+  (ensures (
+    nllist a n r == ((vptr r `vrefine` v_c n r) `vdep` v_c_dep n r (nllist a)) `vrewrite` v_c_l_rewrite n r (nllist a)
+  ))
+= assert_norm (nllist a n r ==
+    begin if is_null r
+    then emp `vrewrite` v_null_rewrite a
+    else ((vptr r `vrefine` v_c n r) `vdep` v_c_dep n r (nllist a)) `vrewrite` v_c_l_rewrite n r (nllist a)
+    end
+  )
+
+let llist_vdep
+  (#a: Type0)
+  (r: t a)
+  (c: normal (t_of (vptr r)))
+: Tot vprop
+= nllist a c.tail_fuel c.next
+
+let llist_vrewrite
+  (#a: Type0)
+  (r: t a)
+  (cl: normal (t_of (vptr r `vdep` llist_vdep r)))
+: GTot (list a)
+= (dfst cl).data :: dsnd cl
+
+let llist0
+  (#a: Type0)
+  (r: t a)
+: Pure vprop
+  (requires True)
+  (ensures (fun y -> t_of y == list a))
+= if is_null r
+  then emp `vrewrite` v_null_rewrite a
+  else (vptr r `vdep` llist_vdep r) `vrewrite` llist_vrewrite r
+
+let nllist_of_llist0
+  (#opened: _)
+  (#a: Type0)
+  (r: t a)
+: SteelGhost (Ghost.erased nat) opened
+    (llist0 r)
+    (fun res -> nllist a res r)
+    (fun _ -> True)
+    (fun h0 res h1 ->
+      h0 (llist0 r) == h1 (nllist a res r)
+    )
+=
+  if is_null r
+  then begin
+    let res = Ghost.hide 0 in
+    change_equal_slprop
+      (llist0 r)
+      (nllist a res r);
+    res
+  end else begin
+    change_equal_slprop
+      (llist0 r)
+      ((vptr r `vdep` llist_vdep r) `vrewrite` llist_vrewrite r);
+    elim_vrewrite (vptr r `vdep` llist_vdep r) (llist_vrewrite r);
+    let gk : normal (Ghost.erased (t_of (vptr r))) = elim_vdep (vptr r) (llist_vdep r) in
+    let res = Ghost.hide (Ghost.reveal (Ghost.reveal gk).tail_fuel + 1) in
+    intro_vrefine (vptr r) (v_c res r);
+    intro_vdep
+      (vptr r `vrefine` v_c res r)
+      (llist_vdep r (Ghost.reveal gk))
+      (v_c_dep res r (nllist a));
+    intro_vrewrite ((vptr r `vrefine` v_c res r) `vdep` v_c_dep res r (nllist a)) (v_c_l_rewrite res r (nllist a));
+    nllist_eq_not_null a res r;
+    change_equal_slprop
+      (((vptr r `vrefine` v_c res r) `vdep` v_c_dep res r (nllist a)) `vrewrite` v_c_l_rewrite res r (nllist a))
+      (nllist a res r);
+    res
+  end
+
+let llist0_of_nllist
+  (#opened: _)
+  (#a: Type0)
+  (n: Ghost.erased nat)
+  (r: t a)
+: SteelGhost unit opened
+    (nllist a n r)
+    (fun _ -> llist0 r)
+    (fun _ -> True)
+    (fun h0 res h1 ->
+      h1 (llist0 r) == h0 (nllist a n r)
+    )
+=
+  if is_null r
+  then begin
+    change_equal_slprop
+      (nllist a n r)
+      (llist0 r);
+    ()
+  end else begin
+    nllist_eq_not_null a n r;
+    change_equal_slprop
+      (nllist a n r)
+      (((vptr r `vrefine` v_c n r) `vdep` v_c_dep n r (nllist a)) `vrewrite` v_c_l_rewrite n r (nllist a));
+    elim_vrewrite ((vptr r `vrefine` v_c n r) `vdep` v_c_dep n r (nllist a)) (v_c_l_rewrite n r (nllist a));
+    let gk = elim_vdep (vptr r `vrefine` v_c n r) (v_c_dep n r (nllist a)) in
+    elim_vrefine (vptr r) (v_c n r);
+    intro_vdep
+      (vptr r)
+      (v_c_dep n r (nllist a) (Ghost.reveal gk))
+      (llist_vdep r);
+    intro_vrewrite (vptr r `vdep` llist_vdep r) (llist_vrewrite r);
+    change_equal_slprop
+      ((vptr r `vdep` llist_vdep r) `vrewrite` llist_vrewrite r)
+      (llist0 r)
+  end
+
+let llist_sl
+  #a r
+= hp_of (llist0 r)
+
+let llist_sel
+  #a r
+= fun m -> sel_of (llist0 r) m // eta necessary because sel_of is GTot
+
+let llist_of_llist0
+  (#opened: _)
+  (#a: Type)
+  (r: t a)
+: SteelGhost unit opened
+    (llist0 r)
+    (fun _ -> llist r)
+    (fun _ -> True)
+    (fun h0 _ h1 -> h1 (llist r) == h0 (llist0 r))
+=
+  change_slprop_rel
+    (llist0 r)
+    (llist r)
+    (fun x y -> x == y)
+    (fun _ -> ())
+
+let llist0_of_llist
+  (#opened: _)
+  (#a: Type)
+  (r: t a)
+: SteelGhost unit opened
+    (llist r)
+    (fun _ -> llist0 r)
+    (fun _ -> True)
+    (fun h0 _ h1 -> h1 (llist0 r) == h0 (llist r))
+=
+  change_slprop_rel
+    (llist r)
+    (llist0 r)
+    (fun x y -> x == y)
+    (fun _ -> ())
+
+let intro_llist_nil a =
+  intro_vrewrite emp (v_null_rewrite a);
+  change_equal_slprop
+    (emp `vrewrite` v_null_rewrite a)
+    (llist0 (null_llist #a));
+  llist_of_llist0 (null_llist #a)
+
+let is_nil' (#opened: _) (#a:Type0) (ptr:t a)
+  : SteelGhost unit opened (llist ptr) (fun _ -> llist ptr)
+          (requires fun _ -> True)
+          (ensures fun h0 _ h1 ->
+            let res = is_null ptr in
+            (res == true <==> ptr == null_llist #a) /\
+            v_llist ptr h0 == v_llist ptr h1 /\
+            res == Nil? (v_llist ptr h1))
+=
+  let res = is_null ptr in
+  llist0_of_llist ptr;
+  if res
+  then begin
+    change_equal_slprop
+      (llist0 ptr)
+      (emp `vrewrite` v_null_rewrite a);
+    elim_vrewrite emp (v_null_rewrite a);
+    intro_vrewrite emp (v_null_rewrite a);
+    change_equal_slprop
+      (emp `vrewrite` v_null_rewrite a)
+      (llist0 ptr)
+  end else begin
+    change_equal_slprop
+      (llist0 ptr)
+      ((vptr ptr `vdep` llist_vdep ptr) `vrewrite` llist_vrewrite ptr);
+      elim_vrewrite (vptr ptr `vdep` llist_vdep ptr) (llist_vrewrite ptr);
+      intro_vrewrite (vptr ptr `vdep` llist_vdep ptr) (llist_vrewrite ptr);
+    change_equal_slprop
+      ((vptr ptr `vdep` llist_vdep ptr) `vrewrite` llist_vrewrite ptr)
+      (llist0 ptr)
+  end;
+  llist_of_llist0 ptr
+
+let is_nil
+  #a ptr
+= is_nil' ptr;
+  return (is_null ptr)
+
+let intro_llist_cons
+  #a ptr1 ptr2
+=
+  llist0_of_llist ptr2;
+  let n = nllist_of_llist0 ptr2 in
+  (* set the fuel of the new cons cell *)
+  let c = read ptr1 in
+  let c' = {c with tail_fuel = n} in
+  write ptr1 c' ;
+  (* actually cons the cell *)
+  vptr_not_null ptr1;
+  intro_vdep
+    (vptr ptr1)
+    (nllist a n ptr2)
+    (llist_vdep ptr1);
+  intro_vrewrite
+    (vptr ptr1 `vdep` llist_vdep ptr1)
+    (llist_vrewrite ptr1);
+  change_equal_slprop
+    ((vptr ptr1 `vdep` llist_vdep ptr1) `vrewrite` llist_vrewrite ptr1)
+    (llist0 ptr1);
+  llist_of_llist0 ptr1
+
+let tail
+  #a ptr
+=
+  llist0_of_llist ptr;
+  change_equal_slprop
+    (llist0 ptr)
+    ((vptr ptr `vdep` llist_vdep ptr) `vrewrite` llist_vrewrite ptr);
+  elim_vrewrite (vptr ptr `vdep` llist_vdep ptr) (llist_vrewrite ptr);
+  let gc = elim_vdep (vptr ptr) (llist_vdep ptr) in
+  (* reset tail fuel to match mk_cell *)
+  let c = read ptr in
+  let c' = {c with tail_fuel = Ghost.hide 0} in
+  write ptr c' ;
+  (* actually destruct the list *)
+  change_equal_slprop
+    (llist_vdep ptr (Ghost.reveal gc))
+    (nllist a c.tail_fuel c.next);
+  llist0_of_nllist c.tail_fuel c.next;
+  llist_of_llist0 c.next;
+  return c.next

--- a/examples/steel/Selectors.LList3.fsti
+++ b/examples/steel/Selectors.LList3.fsti
@@ -1,0 +1,99 @@
+module Selectors.LList3
+
+open Steel.Memory
+open Steel.Effect.Atomic
+open Steel.Effect
+open Selectors.ArrayRef
+
+module L = FStar.List.Tot
+
+/// This module provides the same interface as Selectors.LList.
+/// The difference is in the implementation, it uses a newer, promising style to handle vprop.
+/// Instead of going down all the way to the underlying slprop representation, it uses different
+/// combinators to define the core list vprop
+
+/// Abstract type of a list cell containing a value of type [a]
+val cell (a:Type0) : Type0
+/// The type of a list: A reference to a cell
+inline_for_extraction
+let t (a:Type0) = ref (cell a)
+
+(* Helpers to manipulate cells while keeping its definition abstract *)
+
+inline_for_extraction
+val next (#a:Type0) (c:cell a) : t a
+inline_for_extraction
+val data (#a:Type0) (c:cell a) : a
+inline_for_extraction
+val mk_cell (#a:Type0) (n: t a) (d:a)
+  : Pure (cell a)
+    (requires True)
+    (ensures fun c ->
+      next c == n /\
+      data c == d)
+
+
+/// The null list pointer
+inline_for_extraction
+val null_llist (#a:Type) : t a
+
+/// Lifting the null pointer check to empty lists
+inline_for_extraction
+val is_null (#a:Type) (ptr:t a) : (b:bool{b <==> ptr == null_llist})
+
+
+/// Separation logic predicate stating that reference [r] points to a valid list in memory
+val llist_sl (#a:Type0) (r:t a) : slprop u#1
+
+/// Selector of a list. Returns an F* list of elements of type [a]
+val llist_sel (#a:Type0) (r:t a) : selector (list a) (llist_sl r)
+
+/// Combining the two above into a linked list vprop
+[@@__steel_reduce__]
+let llist' #a r : vprop' =
+  {hp = llist_sl r;
+   t = list a;
+   sel = llist_sel r}
+unfold
+let llist (#a:Type0) (r:t a) = VUnit (llist' r)
+
+/// A wrapper to access a list selector more easily.
+/// Ensuring that the corresponding llist vprop is in the context is done by
+/// calling a variant of the framing tactic, as defined in Steel.Effect.Common
+[@@ __steel_reduce__]
+let v_llist (#a:Type0) (#p:vprop) (r:t a)
+  (h:rmem p{FStar.Tactics.with_tactic selector_tactic (can_be_split p (llist r) /\ True)}) : GTot (list a)
+  = h (llist r)
+
+(** Stateful lemmas to fold and unfold the llist predicate **)
+
+val intro_llist_nil (#opened: _) (a:Type0)
+  : SteelGhost unit opened emp (fun _ -> llist (null_llist #a))
+          (requires fun _ -> True)
+          (ensures fun _ _ h1 -> v_llist #a null_llist h1 == [])
+
+inline_for_extraction
+val is_nil (#a:Type0) (ptr:t a)
+  : Steel bool (llist ptr) (fun _ -> llist ptr)
+          (requires fun _ -> True)
+          (ensures fun h0 res h1 ->
+            (res == true <==> ptr == null_llist #a) /\
+            v_llist ptr h0 == v_llist ptr h1 /\
+            res == Nil? (v_llist ptr h1))
+
+inline_for_extraction
+val intro_llist_cons (#a:Type0) (ptr1 ptr2:t a)
+  : Steel unit (vptr ptr1 `star` llist ptr2)
+                  (fun _ -> llist ptr1)
+                  (requires fun h -> next (sel ptr1 h) == ptr2)
+                  (ensures fun h0 _ h1 -> v_llist ptr1 h1 == (data (sel ptr1 h0)) :: v_llist ptr2 h0)
+
+inline_for_extraction
+val tail (#a:Type0) (ptr:t a)
+  : Steel (t a) (llist ptr)
+                   (fun n -> vptr ptr `star` llist n)
+                   (requires fun _ -> ptr =!= null_llist)
+                   (ensures fun h0 n h1 ->
+                     Cons? (v_llist ptr h0) /\
+                     sel ptr h1 == mk_cell n (L.hd (v_llist ptr h0)) /\
+                     v_llist n h1 == L.tl (v_llist ptr h0))

--- a/examples/steel/Selectors.LList3.fsti
+++ b/examples/steel/Selectors.LList3.fsti
@@ -3,7 +3,7 @@ module Selectors.LList3
 open Steel.Memory
 open Steel.Effect.Atomic
 open Steel.Effect
-open Selectors.ArrayRef
+open Steel.ArrayRef
 
 module L = FStar.List.Tot
 

--- a/examples/steel/llist2/.gitignore
+++ b/examples/steel/llist2/.gitignore
@@ -1,0 +1,3 @@
+*.c
+*.h
+compile_flags.txt

--- a/examples/steel/llist2/Makefile
+++ b/examples/steel/llist2/Makefile
@@ -1,0 +1,17 @@
+INCLUDE_PATHS += .. ../_cache
+OTHERFLAGS+=--already_cached '*,-SelectorsLList2Example' --compat_pre_typed_indexed_effects
+FSTAR_FILES = SelectorsLList2Example.fst
+
+all: llist2
+
+include ../../Makefile.common
+
+$(OUTPUT_DIRECTORY)/%.krml:
+	$(MY_FSTAR) $(notdir $(subst .checked,,$<)) --codegen krml \
+	  --extract_module $(basename $(notdir $(subst .checked,,$<)))
+	touch -c $@
+
+llist2: $(ALL_KRML_FILES)
+	$(KRML_HOME)/krml -skip-makefiles -skip-linking -bundle 'SelectorsLList2Example=FStar.*,Steel.*,Selectors.*' $(ALL_KRML_FILES)
+
+.PHONY: all llist2

--- a/examples/steel/llist2/SelectorsLList2Example.fst
+++ b/examples/steel/llist2/SelectorsLList2Example.fst
@@ -1,0 +1,58 @@
+module SelectorsLList2Example
+
+open Steel.Memory
+open Steel.Effect.Atomic
+open Steel.Effect
+open Steel.Reference
+
+module L = FStar.List.Tot
+module LL = Selectors.LList2
+module U32 = FStar.UInt32
+
+inline_for_extraction noextract let a = U32.t
+let cell = LL.cell a
+/// The type of a list: A reference to a cell
+let t = LL.t a
+
+let next (c:cell) : t = LL.next c
+let data (c:cell) : a = LL.data c
+let mk_cell (n: t) (d:a)
+  : Pure cell
+    (requires True)
+    (ensures fun c ->
+      next c == n /\
+      data c == d)
+= LL.mk_cell n d
+
+/// The null list pointer
+let null_llist () : t = LL.null_llist
+
+/// Lifting the null pointer check to empty lists
+let is_null (ptr:t) : (b:bool{b <==> ptr == null_llist ()})
+= LL.is_null ptr
+
+let is_nil (ptr:t)
+  : Steel bool (LL.llist ptr) (fun _ -> LL.llist ptr)
+          (requires fun _ -> True)
+          (ensures fun h0 res h1 ->
+            (res == true <==> ptr == null_llist ()) /\
+            LL.v_llist ptr h0 == LL.v_llist ptr h1 /\
+            res == Nil? (LL.v_llist ptr h1))
+= LL.is_nil ptr
+
+let intro_llist_cons (ptr1 ptr2:t)
+  : Steel unit (vptr ptr1 `star` LL.llist ptr2)
+                  (fun _ -> LL.llist ptr1)
+                  (requires fun h -> next (sel ptr1 h) == ptr2)
+                  (ensures fun h0 _ h1 -> LL.v_llist ptr1 h1 == (data (sel ptr1 h0)) :: LL.v_llist ptr2 h0)
+= LL.intro_llist_cons ptr1 ptr2
+
+let tail (ptr:t)
+  : Steel (t) (LL.llist ptr)
+                   (fun n -> vptr ptr `star` LL.llist n)
+                   (requires fun _ -> ptr =!= null_llist ())
+                   (ensures fun h0 n h1 ->
+                     Cons? (LL.v_llist ptr h0) /\
+                     sel ptr h1 == mk_cell n (L.hd (LL.v_llist ptr h0)) /\
+                     LL.v_llist n h1 == L.tl (LL.v_llist ptr h0))
+= LL.tail ptr

--- a/examples/steel/llist3/.gitignore
+++ b/examples/steel/llist3/.gitignore
@@ -1,0 +1,3 @@
+*.c
+*.h
+compile_flags.txt

--- a/examples/steel/llist3/Makefile
+++ b/examples/steel/llist3/Makefile
@@ -1,0 +1,17 @@
+INCLUDE_PATHS += .. ../_cache
+OTHERFLAGS+=--already_cached '*,-SelectorsLList3Example' --compat_pre_typed_indexed_effects --cmi
+FSTAR_FILES = SelectorsLList3Example.fst
+
+all: llist3
+
+include ../../Makefile.common
+
+$(OUTPUT_DIRECTORY)/%.krml:
+	$(MY_FSTAR) $(notdir $(subst .checked,,$<)) --codegen krml \
+	  --extract_module $(basename $(notdir $(subst .checked,,$<)))
+	touch -c $@
+
+llist3: $(ALL_KRML_FILES)
+	$(KRML_HOME)/krml -skip-makefiles -skip-linking -bundle 'SelectorsLList3Example=FStar.*,Steel.*,Selectors.*' $(ALL_KRML_FILES)
+
+.PHONY: all llist3

--- a/examples/steel/llist3/SelectorsLList3Example.fst
+++ b/examples/steel/llist3/SelectorsLList3Example.fst
@@ -1,0 +1,60 @@
+module SelectorsLList3Example
+
+open Steel.Memory
+open Steel.Effect.Atomic
+open Steel.Effect
+open Selectors.ArrayRef
+
+module L = FStar.List.Tot
+module LL = Selectors.LList3
+module U32 = FStar.UInt32
+
+module MB = LowStar.Monotonic.Buffer // for is_null
+
+inline_for_extraction noextract let a = U32.t
+let cell = LL.cell a
+/// The type of a list: A reference to a cell
+let t = LL.t a
+
+let next (c:cell) : t = LL.next c
+let data (c:cell) : a = LL.data c
+let mk_cell (n: t) (d:a)
+  : Pure cell
+    (requires True)
+    (ensures fun c ->
+      next c == n /\
+      data c == d)
+= LL.mk_cell n d
+
+/// The null list pointer
+let null_llist () : t = LL.null_llist
+
+/// Lifting the null pointer check to empty lists
+let is_null (ptr:t) : (b:bool{b <==> ptr == null_llist ()})
+= LL.is_null ptr
+
+let is_nil (ptr:t)
+  : Steel bool (LL.llist ptr) (fun _ -> LL.llist ptr)
+          (requires fun _ -> True)
+          (ensures fun h0 res h1 ->
+            (res == true <==> ptr == null_llist ()) /\
+            LL.v_llist ptr h0 == LL.v_llist ptr h1 /\
+            res == Nil? (LL.v_llist ptr h1))
+= LL.is_nil ptr
+
+let intro_llist_cons (ptr1 ptr2:t)
+  : Steel unit (vptr ptr1 `star` LL.llist ptr2)
+                  (fun _ -> LL.llist ptr1)
+                  (requires fun h -> next (sel ptr1 h) == ptr2)
+                  (ensures fun h0 _ h1 -> LL.v_llist ptr1 h1 == (data (sel ptr1 h0)) :: LL.v_llist ptr2 h0)
+= LL.intro_llist_cons ptr1 ptr2
+
+let tail (ptr:t)
+  : Steel (t) (LL.llist ptr)
+                   (fun n -> vptr ptr `star` LL.llist n)
+                   (requires fun _ -> ptr =!= null_llist ())
+                   (ensures fun h0 n h1 ->
+                     Cons? (LL.v_llist ptr h0) /\
+                     sel ptr h1 == mk_cell n (L.hd (LL.v_llist ptr h0)) /\
+                     LL.v_llist n h1 == L.tl (LL.v_llist ptr h0))
+= LL.tail ptr

--- a/examples/steel/llist3/SelectorsLList3Example.fst
+++ b/examples/steel/llist3/SelectorsLList3Example.fst
@@ -3,7 +3,7 @@ module SelectorsLList3Example
 open Steel.Memory
 open Steel.Effect.Atomic
 open Steel.Effect
-open Selectors.ArrayRef
+open Steel.ArrayRef
 
 module L = FStar.List.Tot
 module LL = Selectors.LList3

--- a/src/ocaml-output/FStar_Extraction_Krml.ml
+++ b/src/ocaml-output/FStar_Extraction_Krml.ml
@@ -80,9 +80,6 @@ and expr =
   | EAbortT of (Prims.string * typ) 
   | EComment of (Prims.string * expr * Prims.string) 
   | EStandaloneComment of Prims.string 
-  | EAddrOf of expr 
-  | EBufNull of typ 
-  | EIsNull of (typ * expr) 
 and op =
   | Add 
   | AddW 
@@ -431,19 +428,6 @@ let (uu___is_EStandaloneComment : expr -> Prims.bool) =
     match projectee with | EStandaloneComment _0 -> true | uu___ -> false
 let (__proj__EStandaloneComment__item___0 : expr -> Prims.string) =
   fun projectee -> match projectee with | EStandaloneComment _0 -> _0
-let (uu___is_EAddrOf : expr -> Prims.bool) =
-  fun projectee -> match projectee with | EAddrOf _0 -> true | uu___ -> false
-let (__proj__EAddrOf__item___0 : expr -> expr) =
-  fun projectee -> match projectee with | EAddrOf _0 -> _0
-let (uu___is_EBufNull : expr -> Prims.bool) =
-  fun projectee ->
-    match projectee with | EBufNull _0 -> true | uu___ -> false
-let (__proj__EBufNull__item___0 : expr -> typ) =
-  fun projectee -> match projectee with | EBufNull _0 -> _0
-let (uu___is_EIsNull : expr -> Prims.bool) =
-  fun projectee -> match projectee with | EIsNull _0 -> true | uu___ -> false
-let (__proj__EIsNull__item___0 : expr -> (typ * expr)) =
-  fun projectee -> match projectee with | EIsNull _0 -> _0
 let (uu___is_Add : op -> Prims.bool) =
   fun projectee -> match projectee with | Add -> true | uu___ -> false
 let (uu___is_AddW : op -> Prims.bool) =
@@ -1083,43 +1067,6 @@ and (translate_expr : env -> FStar_Extraction_ML_Syntax.mlexpr -> expr) =
             let uu___2 = translate_branches env1 branches1 in
             (uu___1, uu___2) in
           EMatch uu___
-      | FStar_Extraction_ML_Syntax.MLE_App
-          ({
-             FStar_Extraction_ML_Syntax.expr =
-               FStar_Extraction_ML_Syntax.MLE_TApp
-               ({
-                  FStar_Extraction_ML_Syntax.expr =
-                    FStar_Extraction_ML_Syntax.MLE_Name p;
-                  FStar_Extraction_ML_Syntax.mlty = uu___;
-                  FStar_Extraction_ML_Syntax.loc = uu___1;_},
-                t::[]);
-             FStar_Extraction_ML_Syntax.mlty = uu___2;
-             FStar_Extraction_ML_Syntax.loc = uu___3;_},
-           uu___4)
-          when
-          let uu___5 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
-          uu___5 = "Steel.ST.HigherArray.null_ptr" ->
-          let uu___5 = translate_type env1 t in EBufNull uu___5
-      | FStar_Extraction_ML_Syntax.MLE_App
-          ({
-             FStar_Extraction_ML_Syntax.expr =
-               FStar_Extraction_ML_Syntax.MLE_TApp
-               ({
-                  FStar_Extraction_ML_Syntax.expr =
-                    FStar_Extraction_ML_Syntax.MLE_Name p;
-                  FStar_Extraction_ML_Syntax.mlty = uu___;
-                  FStar_Extraction_ML_Syntax.loc = uu___1;_},
-                t::[]);
-             FStar_Extraction_ML_Syntax.mlty = uu___2;
-             FStar_Extraction_ML_Syntax.loc = uu___3;_},
-           arg::[])
-          when
-          let uu___4 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
-          uu___4 = "Steel.ST.HigherArray.is_null_ptr" ->
-          let uu___4 =
-            let uu___5 = translate_type env1 t in
-            let uu___6 = translate_expr env1 arg in (uu___5, uu___6) in
-          EIsNull uu___4
       | FStar_Extraction_ML_Syntax.MLE_App
           ({
              FStar_Extraction_ML_Syntax.expr =

--- a/src/ocaml-output/FStar_Extraction_Krml.ml
+++ b/src/ocaml-output/FStar_Extraction_Krml.ml
@@ -80,6 +80,9 @@ and expr =
   | EAbortT of (Prims.string * typ) 
   | EComment of (Prims.string * expr * Prims.string) 
   | EStandaloneComment of Prims.string 
+  | EAddrOf of expr 
+  | EBufNull of typ 
+  | EIsNull of (typ * expr) 
 and op =
   | Add 
   | AddW 
@@ -428,6 +431,19 @@ let (uu___is_EStandaloneComment : expr -> Prims.bool) =
     match projectee with | EStandaloneComment _0 -> true | uu___ -> false
 let (__proj__EStandaloneComment__item___0 : expr -> Prims.string) =
   fun projectee -> match projectee with | EStandaloneComment _0 -> _0
+let (uu___is_EAddrOf : expr -> Prims.bool) =
+  fun projectee -> match projectee with | EAddrOf _0 -> true | uu___ -> false
+let (__proj__EAddrOf__item___0 : expr -> expr) =
+  fun projectee -> match projectee with | EAddrOf _0 -> _0
+let (uu___is_EBufNull : expr -> Prims.bool) =
+  fun projectee ->
+    match projectee with | EBufNull _0 -> true | uu___ -> false
+let (__proj__EBufNull__item___0 : expr -> typ) =
+  fun projectee -> match projectee with | EBufNull _0 -> _0
+let (uu___is_EIsNull : expr -> Prims.bool) =
+  fun projectee -> match projectee with | EIsNull _0 -> true | uu___ -> false
+let (__proj__EIsNull__item___0 : expr -> (typ * expr)) =
+  fun projectee -> match projectee with | EIsNull _0 -> _0
 let (uu___is_Add : op -> Prims.bool) =
   fun projectee -> match projectee with | Add -> true | uu___ -> false
 let (uu___is_AddW : op -> Prims.bool) =
@@ -1067,6 +1083,43 @@ and (translate_expr : env -> FStar_Extraction_ML_Syntax.mlexpr -> expr) =
             let uu___2 = translate_branches env1 branches1 in
             (uu___1, uu___2) in
           EMatch uu___
+      | FStar_Extraction_ML_Syntax.MLE_App
+          ({
+             FStar_Extraction_ML_Syntax.expr =
+               FStar_Extraction_ML_Syntax.MLE_TApp
+               ({
+                  FStar_Extraction_ML_Syntax.expr =
+                    FStar_Extraction_ML_Syntax.MLE_Name p;
+                  FStar_Extraction_ML_Syntax.mlty = uu___;
+                  FStar_Extraction_ML_Syntax.loc = uu___1;_},
+                t::[]);
+             FStar_Extraction_ML_Syntax.mlty = uu___2;
+             FStar_Extraction_ML_Syntax.loc = uu___3;_},
+           uu___4)
+          when
+          let uu___5 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+          uu___5 = "Steel.ST.HigherArray.null_ptr" ->
+          let uu___5 = translate_type env1 t in EBufNull uu___5
+      | FStar_Extraction_ML_Syntax.MLE_App
+          ({
+             FStar_Extraction_ML_Syntax.expr =
+               FStar_Extraction_ML_Syntax.MLE_TApp
+               ({
+                  FStar_Extraction_ML_Syntax.expr =
+                    FStar_Extraction_ML_Syntax.MLE_Name p;
+                  FStar_Extraction_ML_Syntax.mlty = uu___;
+                  FStar_Extraction_ML_Syntax.loc = uu___1;_},
+                t::[]);
+             FStar_Extraction_ML_Syntax.mlty = uu___2;
+             FStar_Extraction_ML_Syntax.loc = uu___3;_},
+           arg::[])
+          when
+          let uu___4 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+          uu___4 = "Steel.ST.HigherArray.is_null_ptr" ->
+          let uu___4 =
+            let uu___5 = translate_type env1 t in
+            let uu___6 = translate_expr env1 arg in (uu___5, uu___6) in
+          EIsNull uu___4
       | FStar_Extraction_ML_Syntax.MLE_App
           ({
              FStar_Extraction_ML_Syntax.expr =

--- a/ulib/experimental/Steel.Array.fsti
+++ b/ulib/experimental/Steel.Array.fsti
@@ -122,6 +122,20 @@ let elim_varray
     )
 = elim_varrayp _ _
 
+let varrayp_not_null
+  (#opened: _) (#elt: Type) (a: array elt) (p: P.perm)
+: SteelGhost unit opened
+    (varrayp a p)
+    (fun _ -> varrayp a p)
+    (fun _ -> True)
+    (fun h _ h' ->
+      aselp a p h' == aselp a p h /\
+      a =!= null
+    )
+= let _ = elim_varrayp a p in
+  pts_to_not_null a _;
+  intro_varrayp a p _
+
 /// Allocating a new array of size n, where each cell is initialized
 /// with value x. We define the non-selector version of this operation
 /// (and others) with a _pt suffix in the name.

--- a/ulib/experimental/Steel.ArrayRef.fst
+++ b/ulib/experimental/Steel.ArrayRef.fst
@@ -1,4 +1,4 @@
-module Selectors.ArrayRef
+module Steel.ArrayRef
 
 module A = Steel.Array
 
@@ -72,7 +72,7 @@ let elim_vptr0
     (fun h _ h' ->
       A.aselp r p h' `Seq.equal` Seq.create 1 (h (vptr0 r p))
     )
-= 
+=
   change_equal_slprop (vptr0 r p) (vptr1 r p);
   elim_vrewrite (A.varrayp r p `vrefine` vptr0_refine r) (vptr0_rewrite r p);
   elim_vrefine (A.varrayp r p) (vptr0_refine r)

--- a/ulib/experimental/Steel.ArrayRef.fsti
+++ b/ulib/experimental/Steel.ArrayRef.fsti
@@ -1,4 +1,4 @@
-module Selectors.ArrayRef
+module Steel.ArrayRef
 
 open Steel.FractionalPermission
 open Steel.Memory

--- a/ulib/experimental/Steel.ST.Array.fst
+++ b/ulib/experimental/Steel.ST.Array.fst
@@ -85,13 +85,13 @@ let base_t elt = H.base_t (raise_t elt)
 let base_len b = H.base_len b
 
 let ptr elt = H.ptr (raise_t elt)
+let null_ptr elt = H.null_ptr (raise_t elt)
+let is_null_ptr p = H.is_null_ptr p
 let base p = H.base p
 let offset p = H.offset p
 let ptr_base_offset_inj p1 p2 = H.ptr_base_offset_inj p1 p2
 
-let null' #a : ptr a = H.null_ptr (raise_t a)
-let null #a = (| null' #a, Ghost.hide 0 |)
-
+let base_len_null_ptr elt = H.base_len_null_ptr (raise_t elt)
 let length_fits a = H.length_fits a
 
 let pts_to a p s = H.pts_to a p (seq_map raise s)

--- a/ulib/experimental/Steel.ST.Array.fst
+++ b/ulib/experimental/Steel.ST.Array.fst
@@ -99,6 +99,25 @@ let pts_to a p s = H.pts_to a p (seq_map raise s)
 let pts_to_length a s =
   H.pts_to_length a _
 
+let h_array_eq'
+  (#t: Type u#1)
+  (a1 a2: H.array t)
+: Lemma
+  (requires (
+    dfst a1 == dfst a2 /\
+    (Ghost.reveal (dsnd a1) <: nat) == Ghost.reveal (dsnd a2)
+  ))
+  (ensures (
+    a1 == a2
+  ))
+= ()
+
+let pts_to_not_null #_ #t #p a s =
+  let _ = H.pts_to_not_null #_ #_ #p a (seq_map raise s) in
+  assert (a =!= H.null #(raise_t t));
+  Classical.move_requires (h_array_eq' a) (H.null #(raise_t t));
+  noop ()
+
 let pts_to_inj a p1 s1 p2 s2 =
   H.pts_to_inj a p1 (seq_map raise s1) p2 (seq_map raise s2)
 

--- a/ulib/experimental/Steel.ST.Array.fst
+++ b/ulib/experimental/Steel.ST.Array.fst
@@ -88,6 +88,10 @@ let ptr elt = H.ptr (raise_t elt)
 let base p = H.base p
 let offset p = H.offset p
 let ptr_base_offset_inj p1 p2 = H.ptr_base_offset_inj p1 p2
+
+let null' #a : ptr a = H.null_ptr (raise_t a)
+let null #a = (| null' #a, Ghost.hide 0 |)
+
 let length_fits a = H.length_fits a
 
 let pts_to a p s = H.pts_to a p (seq_map raise s)

--- a/ulib/experimental/Steel.ST.Array.fsti
+++ b/ulib/experimental/Steel.ST.Array.fsti
@@ -40,7 +40,7 @@ val base_len (#elt: Type) (b: base_t elt) : GTot nat
 /// into its base
 inline_for_extraction
 [@@noextract_to "krml"]
-val ptr (elt: Type0) : Type0
+val ptr ([@@@strictly_positive] elt: Type0) : Type0
 val base (#elt: Type) (p: ptr elt) : Tot (base_t elt)
 val offset (#elt: Type) (p: ptr elt) : Ghost nat (requires True) (ensures (fun offset -> offset <= base_len (base p)))
 val ptr_base_offset_inj (#elt: Type) (p1 p2: ptr elt) : Lemma
@@ -59,7 +59,7 @@ val ptr_base_offset_inj (#elt: Type) (p1 p2: ptr elt) : Lemma
 /// record type.
 inline_for_extraction
 [@@noextract_to "krml"]
-let array (elt: Type0) : Tot Type0 =
+let array ([@@@strictly_positive] elt: Type0) : Tot Type0 =
   (p: ptr elt & (length: Ghost.erased nat {offset p + length <= base_len (base p)}))
 
 /// This will extract to "let p = a"

--- a/ulib/experimental/Steel.ST.Array.fsti
+++ b/ulib/experimental/Steel.ST.Array.fsti
@@ -62,6 +62,10 @@ inline_for_extraction
 let array ([@@@strictly_positive] elt: Type0) : Tot Type0 =
   (p: ptr elt & (length: Ghost.erased nat {offset p + length <= base_len (base p)}))
 
+inline_for_extraction
+[@@noextract_to "krml"]
+val null (#a: Type0) : array a
+
 /// This will extract to "let p = a"
 inline_for_extraction
 [@@noextract_to "krml"]

--- a/ulib/experimental/Steel.ST.Array.fsti
+++ b/ulib/experimental/Steel.ST.Array.fsti
@@ -146,6 +146,18 @@ val pts_to_length
     (True)
     (fun _ -> Seq.length s == length a)
 
+val pts_to_not_null
+  (#opened: _)
+  (#elt: Type0)
+  (#p: P.perm)
+  (a: array elt)
+  (s: Seq.seq elt)
+: STGhost unit opened
+    (pts_to a p s)
+    (fun _ -> pts_to a p s)
+    (True)
+    (fun _ -> a =!= null)
+
 /// An injectivity property, needed only to define a selector.  Such a
 /// selector can be only defined in universe 0, and universes are not
 /// cumulative, so we need to define a separate module for arrays of

--- a/ulib/experimental/Steel.ST.HigherArray.fst
+++ b/ulib/experimental/Steel.ST.HigherArray.fst
@@ -84,10 +84,11 @@ noeq
 type ptr (elt: Type u#a) : Type0 = {
   base_len: Ghost.erased US.t;
                    // U32.t to prove that A.read, A.write offset computation does not overflow. TODO: replace U32.t with size_t
-  base: ref _ (pcm elt (US.v base_len));
+  base: (r: ref _ (pcm elt (US.v base_len)) { is_null r ==> US.v base_len == 0 });
   offset: (offset: nat { offset <= US.v base_len });
 }
 let null_ptr a = { base_len = 0sz; base = null #_ #(pcm a 0) ; offset = 0 }
+let is_null_ptr p = is_null p.base
 let base (#elt: Type) (p: ptr elt) : Tot (base_t elt) = (| Ghost.reveal p.base_len, p.base |)
 let offset (#elt: Type) (p: ptr elt) : Ghost nat (requires True) (ensures (fun offset -> offset <= base_len (base p))) = p.offset
 
@@ -265,6 +266,7 @@ let malloc0
 =
   let c : carrier elt (US.v n) = mk_carrier (US.v n) 0 (Seq.create (US.v n) x) P.full_perm in
   let base : ref (carrier elt (US.v n)) (pcm elt (US.v n)) = R.alloc c in
+  R.pts_to_not_null base _;
   let p = {
     base_len = n;
     base = base;

--- a/ulib/experimental/Steel.ST.HigherArray.fst
+++ b/ulib/experimental/Steel.ST.HigherArray.fst
@@ -637,8 +637,6 @@ let memcpy0
                            (pts_to a1 _ e0);
     return ()
 
-#pop-options
-
 let blit0 (#t:_) (#p0:perm) (#s0 #s1:Ghost.erased (Seq.seq t))
            (src:array t)
            (idx_src: US.t)
@@ -671,6 +669,8 @@ let blit0 (#t:_) (#p0:perm) (#s0 #s1:Ghost.erased (Seq.seq t))
   vpattern_rewrite #_ #_ #(merge _ _) (fun a -> pts_to a _ _) src;
   vpattern_rewrite (pts_to src _) (Ghost.reveal s0);
   noop ()
+
+#pop-options
 
 let blit_ptr
   src len_src idx_src dst len_dst idx_dst len

--- a/ulib/experimental/Steel.ST.HigherArray.fst
+++ b/ulib/experimental/Steel.ST.HigherArray.fst
@@ -87,6 +87,7 @@ type ptr (elt: Type u#a) : Type0 = {
   base: ref _ (pcm elt (US.v base_len));
   offset: (offset: nat { offset <= US.v base_len });
 }
+let null_ptr a = { base_len = 0sz; base = null #_ #(pcm a 0) ; offset = 0 }
 let base (#elt: Type) (p: ptr elt) : Tot (base_t elt) = (| Ghost.reveal p.base_len, p.base |)
 let offset (#elt: Type) (p: ptr elt) : Ghost nat (requires True) (ensures (fun offset -> offset <= base_len (base p))) = p.offset
 
@@ -99,6 +100,8 @@ let ptr_base_offset_inj (#elt: Type) (p1 p2: ptr elt) : Lemma
     p1 == p2
   ))
 = ()
+
+let null #a = (| null_ptr a, Ghost.hide 0 |)
 
 let length_fits #elt a = ()
 

--- a/ulib/experimental/Steel.ST.HigherArray.fst
+++ b/ulib/experimental/Steel.ST.HigherArray.fst
@@ -102,7 +102,7 @@ let ptr_base_offset_inj (#elt: Type) (p1 p2: ptr elt) : Lemma
   ))
 = ()
 
-let null #a = (| null_ptr a, Ghost.hide 0 |)
+let base_len_null_ptr _ = ()
 
 let length_fits #elt a = ()
 

--- a/ulib/experimental/Steel.ST.HigherArray.fst
+++ b/ulib/experimental/Steel.ST.HigherArray.fst
@@ -183,6 +183,12 @@ let pts_to_length
   elim_pts_to a _ s;
   intro_pts_to a _ s
 
+let pts_to_not_null
+  a s
+= elim_pts_to a _ s;
+  R.pts_to_not_null _ _;
+  intro_pts_to a _ s
+
 let mk_carrier_joinable
   (#elt: Type)
   (len: nat)

--- a/ulib/experimental/Steel.ST.HigherArray.fst
+++ b/ulib/experimental/Steel.ST.HigherArray.fst
@@ -392,9 +392,10 @@ let gather
   a #x1 p1 #x2 p2
 = elim_pts_to a p1 x1;
   elim_pts_to a p2 x2;
-  R.gather (ptr_of a).base
+  let _ = R.gather (ptr_of a).base
     (mk_carrier (US.v (ptr_of a).base_len) ((ptr_of a).offset) x1 p1)
-    (mk_carrier (US.v (ptr_of a).base_len) ((ptr_of a).offset) x2 p2);
+    (mk_carrier (US.v (ptr_of a).base_len) ((ptr_of a).offset) x2 p2)
+  in
   mk_carrier_gather (US.v (ptr_of a).base_len) ((ptr_of a).offset) x1 x2 p1 p2;
   mk_carrier_valid_sum_perm (US.v (ptr_of a).base_len) ((ptr_of a).offset) x1 p1 p2;
   intro_pts_to a (p1 `P.sum_perm` p2) x1
@@ -607,8 +608,8 @@ let memcpy0
     in
     assert (prefix_copied e0 e1 0 `Seq.equal` e1);
     rewrite (pts_to a1 full_perm e1)
-                           (pts_to a1 full_perm (prefix_copied e0 e1 (US.v 0sz)));
-    rewrite (pts_to a0 _ e0 `star` pts_to a1 full_perm (prefix_copied e0 e1 (US.v 0sz)))
+                           (pts_to a1 full_perm (prefix_copied e0 e1 0));
+    rewrite (pts_to a0 _ e0 `star` pts_to a1 full_perm (prefix_copied e0 e1 0))
                            (inv (US.v 0sz));
     let body (j:Steel.ST.Loops.u32_between 0sz i)
       : STT unit
@@ -657,10 +658,10 @@ let blit0 (#t:_) (#p0:perm) (#s0 #s1:Ghost.erased (Seq.seq t))
     (fun _ -> True)
 = pts_to_length src s0;
   pts_to_length dst s1;
-  ghost_split src idx_src;
-  ghost_split (split_r src idx_src) len;
-  ghost_split dst idx_dst;
-  ghost_split (split_r dst idx_dst) len;
+  let _ = ghost_split src idx_src in
+  let _ = ghost_split (split_r src idx_src) len in
+  let _ = ghost_split dst idx_dst in
+  let _ = ghost_split (split_r dst idx_dst) len in
   memcpy0 (split_l (split_r src idx_src) len) (split_l (split_r dst idx_dst) len) len;
   ghost_join (split_l (split_r dst _) _) (split_r (split_r dst _) _) ();
   ghost_join (split_l dst _) (merge _ _) ();

--- a/ulib/experimental/Steel.ST.HigherArray.fsti
+++ b/ulib/experimental/Steel.ST.HigherArray.fsti
@@ -40,7 +40,7 @@ val base_len (#elt: Type) (b: base_t elt) : GTot nat
 /// An abstract type to represent a C pointer, as a base and an offset
 /// into its base
 [@@noextract_to "krml"] // primitive
-val ptr (elt: Type u#a) : Type0
+val ptr ([@@@strictly_positive] elt: Type u#a) : Type0
 val base (#elt: Type) (p: ptr elt) : Tot (base_t elt)
 val offset (#elt: Type) (p: ptr elt) : Ghost nat (requires True) (ensures (fun offset -> offset <= base_len (base p)))
 val ptr_base_offset_inj (#elt: Type) (p1 p2: ptr elt) : Lemma
@@ -59,7 +59,7 @@ val ptr_base_offset_inj (#elt: Type) (p1 p2: ptr elt) : Lemma
 /// record type.
 inline_for_extraction
 [@@noextract_to "krml"]
-let array (elt: Type u#a) : Tot Type0 =
+let array ([@@@strictly_positive] elt: Type u#a) : Tot Type0 =
   (p: ptr elt & (length: Ghost.erased nat {offset p + length <= base_len (base p)}))
 
 /// This will extract to "let p = a"
@@ -189,7 +189,7 @@ let free
   let s = elim_exists () in
   rewrite (pts_to _ _ _)
           (pts_to (| p, Ghost.hide (base_len (base p)) |) full_perm s);
-  free_ptr p            
+  free_ptr p
 
 /// Sharing and gathering permissions on an array. Those only
 /// manipulate permissions, so they are nothing more than stateful

--- a/ulib/experimental/Steel.ST.HigherArray.fsti
+++ b/ulib/experimental/Steel.ST.HigherArray.fsti
@@ -41,6 +41,8 @@ val base_len (#elt: Type) (b: base_t elt) : GTot nat
 /// into its base
 [@@noextract_to "krml"] // primitive
 val ptr ([@@@strictly_positive] elt: Type u#a) : Type0
+[@@noextract_to "krml"]
+val null_ptr (elt: Type u#a) : ptr elt
 val base (#elt: Type) (p: ptr elt) : Tot (base_t elt)
 val offset (#elt: Type) (p: ptr elt) : Ghost nat (requires True) (ensures (fun offset -> offset <= base_len (base p)))
 val ptr_base_offset_inj (#elt: Type) (p1 p2: ptr elt) : Lemma
@@ -61,6 +63,10 @@ inline_for_extraction
 [@@noextract_to "krml"]
 let array ([@@@strictly_positive] elt: Type u#a) : Tot Type0 =
   (p: ptr elt & (length: Ghost.erased nat {offset p + length <= base_len (base p)}))
+
+inline_for_extraction
+[@@noextract_to "krml"]
+val null (#a: Type0) : array a
 
 /// This will extract to "let p = a"
 inline_for_extraction

--- a/ulib/experimental/Steel.ST.HigherArray.fsti
+++ b/ulib/experimental/Steel.ST.HigherArray.fsti
@@ -43,8 +43,8 @@ val base_len (#elt: Type) (b: base_t elt) : GTot nat
 val ptr ([@@@strictly_positive] elt: Type u#a) : Type0
 [@@noextract_to "krml"]
 val null_ptr (elt: Type u#a) : ptr elt
-
 // TODO: turn into a stateful operation to avoid comparing dangling pointers
+[@@noextract_to "krml"]
 val is_null_ptr (#elt: Type u#a) (p: ptr elt) : Pure bool
   (requires True)
   (ensures (fun res -> res == true <==> p == null_ptr elt))

--- a/ulib/experimental/Steel.ST.HigherArray.fsti
+++ b/ulib/experimental/Steel.ST.HigherArray.fsti
@@ -124,6 +124,18 @@ val pts_to_length
     (True)
     (fun _ -> Seq.length s == length a)
 
+val pts_to_not_null
+  (#opened: _)
+  (#elt: Type u#1)
+  (#p: P.perm)
+  (a: array elt)
+  (s: Seq.seq elt)
+: STGhost unit opened
+    (pts_to a p s)
+    (fun _ -> pts_to a p s)
+    (True)
+    (fun _ -> a =!= null)
+
 /// An injectivity property, needed only to define a selector.  Such a
 /// selector can be only defined in universe 0, and universes are not
 /// cumulative, so we need to define a separate module for arrays of

--- a/ulib/experimental/Steel.ST.HigherArray.fsti
+++ b/ulib/experimental/Steel.ST.HigherArray.fsti
@@ -43,6 +43,10 @@ val base_len (#elt: Type) (b: base_t elt) : GTot nat
 val ptr ([@@@strictly_positive] elt: Type u#a) : Type0
 [@@noextract_to "krml"]
 val null_ptr (elt: Type u#a) : ptr elt
+// TODO: turn into a stateful operation to avoid comparing dangling pointers
+val is_null_ptr (#elt: Type u#a) (p: ptr elt) : Pure bool
+  (requires True)
+  (ensures (fun res -> res == true <==> p == null_ptr elt))
 val base (#elt: Type) (p: ptr elt) : Tot (base_t elt)
 val offset (#elt: Type) (p: ptr elt) : Ghost nat (requires True) (ensures (fun offset -> offset <= base_len (base p)))
 val ptr_base_offset_inj (#elt: Type) (p1 p2: ptr elt) : Lemma

--- a/ulib/experimental/Steel.ST.PCMReference.fsti
+++ b/ulib/experimental/Steel.ST.PCMReference.fsti
@@ -32,6 +32,22 @@ open Steel.ST.Util
 unfold
 let pts_to (#a:Type) (#pcm:pcm a) (r:ref a pcm) (v:a) = to_vprop (pts_to r v)
 
+let pts_to_not_null
+  (#opened: _)
+  (#t: Type)
+  (#p: pcm t)
+  (r: ref t p)
+  (v: t)
+: STGhost unit opened
+    (pts_to r v)
+    (fun _ -> pts_to r v)
+    True
+    (fun _ -> r =!= null)
+= extract_fact
+    (pts_to r v)
+    (r =!= null)
+    (fun m -> pts_to_not_null r v m)
+
 /// Reading the contents of reference [r] in memory.
 /// The returned value [v] is ensured to be compatible with respect
 /// to the PCM [pcm] with our current knowledge [v0]


### PR DESCRIPTION
This PR, with work almost entirely from @tahina-pro , does the following:
* It adds null to the Steel arrays, with primitive extraction for karamel. It also adds an `is_null` primitive, extracted to `a == NULL`, and a lemma indicating that permission on an array implies it is not null.
* It adds an abstraction, called ArrayRef, which provides the same interface as Steel.Reference, but builds on top of Steel.Array and is defined as an array of length 1, in order to enable interoperation between references and arrays.
* It ports the linked list example in examples/steel to use ArrayRef, and demonstrates its extraction with karamel (in examples/steel/llist3).