### PR TITLE
Expose definition of arrayref, enable interoperation with Steel.Array

### DIFF
--- a/ulib/experimental/Steel.ArrayRef.fst
+++ b/ulib/experimental/Steel.ArrayRef.fst
@@ -79,7 +79,7 @@ let ptrp r p = hp_of (vptr0 r p)
 
 let ptrp_sel r p = sel_of (vptr0 r p)
 
-let intro_vptrp
+let intro_vptrp'
   (#opened: _)
   (#a: Type0)
   (r: ref a)
@@ -102,6 +102,12 @@ let intro_vptrp
       assert (interp (hp_of (vptrp r p)) m);
       assert_norm (sel_of (vptrp r p) m === sel_of (vptr0 r p) m)
     )
+
+let intro_vptrp r p =
+  let h0 = get () in
+  intro_vptrp' r p;
+  let h1 = get () in
+  assert (Seq.create 1 (selp r p h1) `Seq.equal` A.aselp r p h0)
 
 let elim_vptrp
   (#opened: _)
@@ -128,7 +134,7 @@ let elim_vptrp
 let malloc
   x
 = let r = A.malloc x 1sz in
-  intro_vptrp r full_perm;
+  intro_vptrp' r full_perm;
   return r
 
 let free
@@ -148,14 +154,14 @@ let write
   r x
 = elim_vptrp r full_perm;
   A.upd r 0sz x;
-  intro_vptrp r full_perm
+  intro_vptrp' r full_perm
 
 let share
   #_ #_ #p r
 = elim_vptrp r p;
   A.share r p (half_perm p) (half_perm p);
-  intro_vptrp r (half_perm p);
-  intro_vptrp r (half_perm p)
+  intro_vptrp' r (half_perm p);
+  intro_vptrp' r (half_perm p)
 
 let gather_gen
   r p0 p1
@@ -166,7 +172,7 @@ let gather_gen
   change_equal_slprop
     (A.varrayp r (sum_perm p0 p1))
     (A.varrayp r s);
-  intro_vptrp r s;
+  intro_vptrp' r s;
   s
 
 let gather
@@ -180,4 +186,4 @@ let vptrp_not_null
   r p
 = elim_vptrp r p;
   A.varrayp_not_null r p;
-  intro_vptrp r p
+  intro_vptrp' r p

--- a/ulib/experimental/Steel.ArrayRef.fst
+++ b/ulib/experimental/Steel.ArrayRef.fst
@@ -2,8 +2,6 @@ module Steel.ArrayRef
 
 module A = Steel.Array
 
-let ref a = (r: A.array a { (A.length r == 1 /\ A.is_full_array r) \/ r == A.null })
-
 let null #a = A.null #a
 
 let is_null r = A.is_null r

--- a/ulib/experimental/Steel.ArrayRef.fsti
+++ b/ulib/experimental/Steel.ArrayRef.fsti
@@ -6,13 +6,15 @@ open Steel.Effect.Common
 open Steel.Effect
 open Steel.Effect.Atomic
 
+module A = Steel.Array
+
 (** This module provides the same interface as Steel.Reference, however, it builds on top
     of Steel.Array to enable the interoperation between arrays and references.
     Similarly to C, a reference is defined as an array of length 1 *)
 
 /// An abstract datatype for references
 inline_for_extraction
-val ref ([@@@strictly_positive] a:Type0) : Type0
+let ref (a : Type0) : Type0 = (r: A.array a { A.length r == 1 \/ r == A.null })
 
 /// The null pointer
 [@@ noextract_to "krml"]
@@ -80,7 +82,7 @@ val malloc (#a:Type0) (x:a) : Steel (ref a)
 inline_for_extraction
 val free (#a:Type0) (r:ref a) : Steel unit
   (vptr r) (fun _ -> emp)
-  (requires fun _ -> True)
+  (requires fun _ -> A.is_full_array r)
   (ensures fun _ _ _ -> True)
 
 /// Reads the current value of reference [r]

--- a/ulib/experimental/Steel.ArrayRef.fsti
+++ b/ulib/experimental/Steel.ArrayRef.fsti
@@ -71,6 +71,54 @@ let sel (#a:Type) (#p:vprop) (r:ref a)
   (h:rmem p{FStar.Tactics.with_tactic selector_tactic (can_be_split p (vptr r) /\ True)})
   = h (vptr r)
 
+/// Stateful lemmas to interoperate between Steel arrays and this module
+
+val intro_vptrp
+  (#opened: _)
+  (#a: Type0)
+  (r: ref a)
+  (p: perm)
+: SteelGhost unit opened
+    (A.varrayp r p)
+    (fun _ -> vptrp r p)
+    (fun _ -> True)
+    (fun h0 _ h1 ->
+      Seq.create 1 (selp r p h1) == A.aselp r p h0
+    )
+
+val elim_vptrp
+  (#opened: _)
+  (#a: Type0)
+  (r: ref a)
+  (p: perm)
+: SteelGhost unit opened
+    (vptrp r p)
+    (fun _ -> A.varrayp r p)
+    (fun _ -> True)
+    (fun h0 _ h1 ->
+      A.aselp r p h1 == Seq.create 1 (selp r p h0)
+    )
+
+let intro_vptr (#opened: _)
+  (#a: Type0)
+  (r: ref a)
+: SteelGhost unit opened
+    (A.varray r)
+    (fun _ -> vptr r)
+    (fun _ -> True)
+    (fun h0 _ h1 -> A.asel r h0 == Seq.create 1 (sel r h1))
+  = intro_vptrp r full_perm
+
+let elim_vptr (#opened: _)
+  (#a: Type0)
+  (r: ref a)
+: SteelGhost unit opened
+    (vptr r)
+    (fun _ -> A.varray r)
+    (fun _ -> True)
+    (fun h0 _ h1 -> A.asel r h1 == Seq.create 1 (sel r h0))
+  = elim_vptrp r full_perm
+
 /// Allocates a reference with value [x].
 inline_for_extraction
 val malloc (#a:Type0) (x:a) : Steel (ref a)


### PR DESCRIPTION
This PR exposes the definition of Steel.ArrayRef.ref, as well as vprop elimination and introduction lemmas to enable the interoperation between Steel.ArrayRef and Steel.Array