### PR TITLE
Adds a ptrdiff primitive

### DIFF
--- a/src/extraction/FStar.Extraction.Krml.fst
+++ b/src/extraction/FStar.Extraction.Krml.fst
@@ -103,6 +103,7 @@ and expr =
   | EBufRead of expr * expr
   | EBufWrite of expr * expr * expr
   | EBufSub of expr * expr
+  | EBufDiff of expr * expr
   | EBufBlit of expr * expr * expr * expr * expr
   | EMatch of expr * branches
   | EOp of op * width
@@ -372,13 +373,6 @@ let generate_is_null
 = let dummy = UInt64 in
   EApp (ETypApp (EOp (Eq, dummy), [TBuf t]), [x; EBufNull t])
 
-let generate_ptrdiff
-  (t: typ)
-  (e0 e1: expr)
-  : Tot expr
-= let dummy = UInt64 in
-  EApp (ETypApp (EOp (Sub, dummy), [TBuf t]), [e0; e1])
-
 let rec translate_type env t: typ =
   match t with
   | MLTY_Tuple []
@@ -565,9 +559,9 @@ and translate_expr env e: expr =
     ->
     translate_expr env e
 
-  | MLE_App ({ expr = MLE_TApp({ expr = MLE_Name p}, [ t ]) }, [ _perm0; _perm1; _seq0; _seq1; e0; _len0; e1; _len1])
+  | MLE_App ({ expr = MLE_TApp({ expr = MLE_Name p}, _) }, [ _perm0; _perm1; _seq0; _seq1; e0; _len0; e1; _len1])
     when string_of_mlpath p = "Steel.ST.HigherArray.ptrdiff_ptr" ->
-    generate_ptrdiff (translate_type env t) (translate_expr env e0) (translate_expr env e1)
+    EBufDiff (translate_expr env e0, translate_expr env e1)
 
   | MLE_App ({ expr = MLE_TApp({ expr = MLE_Name p }, _) }, [ e1; e2 ])
     when string_of_mlpath p = "FStar.Buffer.index" || string_of_mlpath p = "FStar.Buffer.op_Array_Access"

--- a/src/extraction/FStar.Extraction.Krml.fst
+++ b/src/extraction/FStar.Extraction.Krml.fst
@@ -104,7 +104,6 @@ and expr =
   | EBufRead of expr * expr
   | EBufWrite of expr * expr * expr
   | EBufSub of expr * expr
-  | EBufDiff of expr * expr
   | EBufBlit of expr * expr * expr * expr * expr
   | EMatch of expr * branches
   | EOp of op * width
@@ -132,6 +131,7 @@ and expr =
   | EStandaloneComment of string
   | EAddrOf of expr
   | EBufNull of typ
+  | EBufDiff of expr * expr
 
 and op =
   | Add | AddW | Sub | SubW | Div | DivW | Mult | MultW | Mod

--- a/src/extraction/FStar.Extraction.Krml.fst
+++ b/src/extraction/FStar.Extraction.Krml.fst
@@ -39,6 +39,7 @@ module FC = FStar.Const
 - v28: added many things for which the AST wasn't bumped; bumped it for
   TConstBuf which will expect will be used soon
 - v29: added a SizeT and PtrdiffT width to machine integers
+- v30: Added EBufDiff
 *)
 
 (* COPY-PASTED ****************************************************************)

--- a/src/extraction/FStar.Extraction.Krml.fst
+++ b/src/extraction/FStar.Extraction.Krml.fst
@@ -372,6 +372,13 @@ let generate_is_null
 = let dummy = UInt64 in
   EApp (ETypApp (EOp (Eq, dummy), [TBuf t]), [x; EBufNull t])
 
+let generate_ptrdiff
+  (t: typ)
+  (e0 e1: expr)
+  : Tot expr
+= let dummy = UInt64 in
+  EApp (ETypApp (EOp (Sub, dummy), [TBuf t]), [e0; e1])
+
 let rec translate_type env t: typ =
   match t with
   | MLTY_Tuple []
@@ -557,6 +564,10 @@ and translate_expr env e: expr =
          string_of_mlpath p = "LowStar.ToFStarBuffer.old_to_new_st"
     ->
     translate_expr env e
+
+  | MLE_App ({ expr = MLE_TApp({ expr = MLE_Name p}, [ t ]) }, [ _perm0; _perm1; _seq0; _seq1; e0; _len0; e1; _len1])
+    when string_of_mlpath p = "Steel.ST.HigherArray.ptrdiff_ptr" ->
+    generate_ptrdiff (translate_type env t) (translate_expr env e0) (translate_expr env e1)
 
   | MLE_App ({ expr = MLE_TApp({ expr = MLE_Name p }, _) }, [ e1; e2 ])
     when string_of_mlpath p = "FStar.Buffer.index" || string_of_mlpath p = "FStar.Buffer.op_Array_Access"

--- a/src/ocaml-output/FStar_Extraction_Krml.ml
+++ b/src/ocaml-output/FStar_Extraction_Krml.ml
@@ -841,6 +841,12 @@ let (generate_is_null : typ -> expr -> expr) =
     fun x ->
       let dummy = UInt64 in
       EApp ((ETypApp ((EOp (Eq, dummy)), [TBuf t])), [x; EBufNull t])
+let (generate_ptrdiff : typ -> expr -> expr -> expr) =
+  fun t ->
+    fun e0 ->
+      fun e1 ->
+        let dummy = UInt64 in
+        EApp ((ETypApp ((EOp (Sub, dummy)), [TBuf t])), [e0; e1])
 let rec (translate_type : env -> FStar_Extraction_ML_Syntax.mlty -> typ) =
   fun env1 ->
     fun t ->
@@ -1237,6 +1243,26 @@ and (translate_expr : env -> FStar_Extraction_ML_Syntax.mlexpr -> expr) =
             (let uu___5 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
              uu___5 = "LowStar.ToFStarBuffer.old_to_new_st")
           -> translate_expr env1 e1
+      | FStar_Extraction_ML_Syntax.MLE_App
+          ({
+             FStar_Extraction_ML_Syntax.expr =
+               FStar_Extraction_ML_Syntax.MLE_TApp
+               ({
+                  FStar_Extraction_ML_Syntax.expr =
+                    FStar_Extraction_ML_Syntax.MLE_Name p;
+                  FStar_Extraction_ML_Syntax.mlty = uu___;
+                  FStar_Extraction_ML_Syntax.loc = uu___1;_},
+                t::[]);
+             FStar_Extraction_ML_Syntax.mlty = uu___2;
+             FStar_Extraction_ML_Syntax.loc = uu___3;_},
+           _perm0::_perm1::_seq0::_seq1::e0::_len0::e1::_len1::[])
+          when
+          let uu___4 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+          uu___4 = "Steel.ST.HigherArray.ptrdiff_ptr" ->
+          let uu___4 = translate_type env1 t in
+          let uu___5 = translate_expr env1 e0 in
+          let uu___6 = translate_expr env1 e1 in
+          generate_ptrdiff uu___4 uu___5 uu___6
       | FStar_Extraction_ML_Syntax.MLE_App
           ({
              FStar_Extraction_ML_Syntax.expr =

--- a/src/ocaml-output/FStar_Extraction_Krml.ml
+++ b/src/ocaml-output/FStar_Extraction_Krml.ml
@@ -55,6 +55,7 @@ and expr =
   | EBufRead of (expr * expr) 
   | EBufWrite of (expr * expr * expr) 
   | EBufSub of (expr * expr) 
+  | EBufDiff of (expr * expr) 
   | EBufBlit of (expr * expr * expr * expr * expr) 
   | EMatch of (expr * (pattern * expr) Prims.list) 
   | EOp of (op * width) 
@@ -328,6 +329,11 @@ let (uu___is_EBufSub : expr -> Prims.bool) =
   fun projectee -> match projectee with | EBufSub _0 -> true | uu___ -> false
 let (__proj__EBufSub__item___0 : expr -> (expr * expr)) =
   fun projectee -> match projectee with | EBufSub _0 -> _0
+let (uu___is_EBufDiff : expr -> Prims.bool) =
+  fun projectee ->
+    match projectee with | EBufDiff _0 -> true | uu___ -> false
+let (__proj__EBufDiff__item___0 : expr -> (expr * expr)) =
+  fun projectee -> match projectee with | EBufDiff _0 -> _0
 let (uu___is_EBufBlit : expr -> Prims.bool) =
   fun projectee ->
     match projectee with | EBufBlit _0 -> true | uu___ -> false
@@ -841,12 +847,6 @@ let (generate_is_null : typ -> expr -> expr) =
     fun x ->
       let dummy = UInt64 in
       EApp ((ETypApp ((EOp (Eq, dummy)), [TBuf t])), [x; EBufNull t])
-let (generate_ptrdiff : typ -> expr -> expr -> expr) =
-  fun t ->
-    fun e0 ->
-      fun e1 ->
-        let dummy = UInt64 in
-        EApp ((ETypApp ((EOp (Sub, dummy)), [TBuf t])), [e0; e1])
 let rec (translate_type : env -> FStar_Extraction_ML_Syntax.mlty -> typ) =
   fun env1 ->
     fun t ->
@@ -1252,17 +1252,17 @@ and (translate_expr : env -> FStar_Extraction_ML_Syntax.mlexpr -> expr) =
                     FStar_Extraction_ML_Syntax.MLE_Name p;
                   FStar_Extraction_ML_Syntax.mlty = uu___;
                   FStar_Extraction_ML_Syntax.loc = uu___1;_},
-                t::[]);
-             FStar_Extraction_ML_Syntax.mlty = uu___2;
-             FStar_Extraction_ML_Syntax.loc = uu___3;_},
+                uu___2);
+             FStar_Extraction_ML_Syntax.mlty = uu___3;
+             FStar_Extraction_ML_Syntax.loc = uu___4;_},
            _perm0::_perm1::_seq0::_seq1::e0::_len0::e1::_len1::[])
           when
-          let uu___4 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
-          uu___4 = "Steel.ST.HigherArray.ptrdiff_ptr" ->
-          let uu___4 = translate_type env1 t in
-          let uu___5 = translate_expr env1 e0 in
-          let uu___6 = translate_expr env1 e1 in
-          generate_ptrdiff uu___4 uu___5 uu___6
+          let uu___5 = FStar_Extraction_ML_Syntax.string_of_mlpath p in
+          uu___5 = "Steel.ST.HigherArray.ptrdiff_ptr" ->
+          let uu___5 =
+            let uu___6 = translate_expr env1 e0 in
+            let uu___7 = translate_expr env1 e1 in (uu___6, uu___7) in
+          EBufDiff uu___5
       | FStar_Extraction_ML_Syntax.MLE_App
           ({
              FStar_Extraction_ML_Syntax.expr =

--- a/src/ocaml-output/FStar_Extraction_Krml.ml
+++ b/src/ocaml-output/FStar_Extraction_Krml.ml
@@ -55,7 +55,6 @@ and expr =
   | EBufRead of (expr * expr) 
   | EBufWrite of (expr * expr * expr) 
   | EBufSub of (expr * expr) 
-  | EBufDiff of (expr * expr) 
   | EBufBlit of (expr * expr * expr * expr * expr) 
   | EMatch of (expr * (pattern * expr) Prims.list) 
   | EOp of (op * width) 
@@ -83,6 +82,7 @@ and expr =
   | EStandaloneComment of Prims.string 
   | EAddrOf of expr 
   | EBufNull of typ 
+  | EBufDiff of (expr * expr) 
 and op =
   | Add 
   | AddW 
@@ -329,11 +329,6 @@ let (uu___is_EBufSub : expr -> Prims.bool) =
   fun projectee -> match projectee with | EBufSub _0 -> true | uu___ -> false
 let (__proj__EBufSub__item___0 : expr -> (expr * expr)) =
   fun projectee -> match projectee with | EBufSub _0 -> _0
-let (uu___is_EBufDiff : expr -> Prims.bool) =
-  fun projectee ->
-    match projectee with | EBufDiff _0 -> true | uu___ -> false
-let (__proj__EBufDiff__item___0 : expr -> (expr * expr)) =
-  fun projectee -> match projectee with | EBufDiff _0 -> _0
 let (uu___is_EBufBlit : expr -> Prims.bool) =
   fun projectee ->
     match projectee with | EBufBlit _0 -> true | uu___ -> false
@@ -445,6 +440,11 @@ let (uu___is_EBufNull : expr -> Prims.bool) =
     match projectee with | EBufNull _0 -> true | uu___ -> false
 let (__proj__EBufNull__item___0 : expr -> typ) =
   fun projectee -> match projectee with | EBufNull _0 -> _0
+let (uu___is_EBufDiff : expr -> Prims.bool) =
+  fun projectee ->
+    match projectee with | EBufDiff _0 -> true | uu___ -> false
+let (__proj__EBufDiff__item___0 : expr -> (expr * expr)) =
+  fun projectee -> match projectee with | EBufDiff _0 -> _0
 let (uu___is_Add : op -> Prims.bool) =
   fun projectee -> match projectee with | Add -> true | uu___ -> false
 let (uu___is_AddW : op -> Prims.bool) =

--- a/ulib/experimental/Steel.Array.fsti
+++ b/ulib/experimental/Steel.Array.fsti
@@ -410,7 +410,9 @@ let ptrdiff (#a: Type) (#p1 #p2:P.perm) (arr1 arr2: array a)
   : Steel UP.t
   (varrayp arr1 p1 `star` varrayp arr2 p2)
   (fun _ -> varrayp arr1 p1 `star` varrayp arr2 p2)
-  (requires fun _ -> base (ptr_of arr1) == base (ptr_of arr2))
+  (requires fun _ ->
+    base (ptr_of arr1) == base (ptr_of arr2) /\
+    UP.fits (offset (ptr_of arr1) - offset (ptr_of arr2)))
   (ensures fun h0 r h1 ->
     aselp arr1 p1 h1 == aselp arr1 p1 h0 /\
     aselp arr2 p2 h1 == aselp arr2 p2 h0 /\

--- a/ulib/experimental/Steel.ST.Array.fst
+++ b/ulib/experimental/Steel.ST.Array.fst
@@ -535,3 +535,19 @@ let compare
 
 let intro_fits_u32 () = H.intro_fits_u32 ()
 let intro_fits_u64 () = H.intro_fits_u64 ()
+
+let ptrdiff #_ #p0 #p1 #s0 #s1 a0 a1 =
+  rewrite
+    (pts_to a0 _ _)
+    (H.pts_to a0 p0 (seq_map raise s0));
+  rewrite
+    (pts_to a1 _ _)
+    (H.pts_to a1 p1 (seq_map raise s1));
+  let res = H.ptrdiff a0 a1 in
+  rewrite
+    (H.pts_to a1 _ _)
+    (pts_to a1 _ _);
+  rewrite
+    (H.pts_to a0 _ _)
+    (pts_to a0 _ _);
+  return res

--- a/ulib/experimental/Steel.ST.Array.fsti
+++ b/ulib/experimental/Steel.ST.Array.fsti
@@ -20,6 +20,7 @@ module Steel.ST.Array
 
 module P = Steel.FractionalPermission
 module US = FStar.SizeT
+module UP = FStar.PtrdiffT
 
 open Steel.ST.Util
 
@@ -471,3 +472,14 @@ inline_for_extraction
 val intro_fits_u64 (_:unit)
   : STT (squash (US.fits_u64))
         emp (fun _ -> emp)
+
+inline_for_extraction
+[@@noextract_to "krml"]
+val ptrdiff (#t:_) (#p0 #p1:perm) (#s0 #s1:Ghost.erased (Seq.seq t))
+           (a0:array t)
+           (a1:array t)
+  : ST UP.t
+    (pts_to a0 p0 s0 `star` pts_to a1 p1 s1)
+    (fun _ -> pts_to a0 p0 s0 `star` pts_to a1 p1 s1)
+    (base (ptr_of a0) == base (ptr_of a1))
+    (fun r -> UP.v r == offset (ptr_of a0) - offset (ptr_of a1))

--- a/ulib/experimental/Steel.ST.Array.fsti
+++ b/ulib/experimental/Steel.ST.Array.fsti
@@ -481,5 +481,5 @@ val ptrdiff (#t:_) (#p0 #p1:perm) (#s0 #s1:Ghost.erased (Seq.seq t))
   : ST UP.t
     (pts_to a0 p0 s0 `star` pts_to a1 p1 s1)
     (fun _ -> pts_to a0 p0 s0 `star` pts_to a1 p1 s1)
-    (base (ptr_of a0) == base (ptr_of a1))
+    (base (ptr_of a0) == base (ptr_of a1) /\ UP.fits (offset (ptr_of a0) - offset (ptr_of a1)))
     (fun r -> UP.v r == offset (ptr_of a0) - offset (ptr_of a1))

--- a/ulib/experimental/Steel.ST.HigherArray.fst
+++ b/ulib/experimental/Steel.ST.HigherArray.fst
@@ -690,6 +690,4 @@ let intro_fits_u64 () = admit_ ()
 
 let ptrdiff_ptr a0 len0 a1 len1 =
   let res = a0.offset - a1.offset in
-  /// This assume is justified by the C memory model
-  assume (UP.fits res);
   return (UP.int_to_t res)

--- a/ulib/experimental/Steel.ST.HigherArray.fst
+++ b/ulib/experimental/Steel.ST.HigherArray.fst
@@ -594,7 +594,7 @@ let prefix_copied #t
    : Seq.seq t
    = (Seq.append (Seq.slice e0 0 i) (Seq.slice e1 i (Seq.length e1)))
 
-#push-options "--z3rlimit 16"
+#push-options "--z3rlimit 32"
 
 val memcpy0 (#t:_) (#p0:perm)
            (a0 a1:array t)
@@ -687,3 +687,9 @@ let blit_ptr
 /// These two functions will be natively extracted, we can simply admit them
 let intro_fits_u32 () = admit_ ()
 let intro_fits_u64 () = admit_ ()
+
+let ptrdiff_ptr a0 len0 a1 len1 =
+  let res = a0.offset - a1.offset in
+  /// This assume is justified by the C memory model
+  assume (UP.fits res);
+  return (UP.int_to_t res)

--- a/ulib/experimental/Steel.ST.HigherArray.fsti
+++ b/ulib/experimental/Steel.ST.HigherArray.fsti
@@ -581,7 +581,9 @@ val intro_fits_u64 (_:unit)
 /// The pointer substraction, returning a ptrdiff_t.
 /// Note, this operation is only defined according to the C standard when
 /// both pointers belong to the same allocation unit, which is captured
-/// by the `base a0 == base a1` precondition
+/// by the `base a0 == base a1` precondition, and when the difference between
+/// the two pointers is representable as a ptrdiff_t, captured by the `fits`
+/// precondition.
 [@@noextract_to "krml"] // primitive
 val ptrdiff_ptr (#t:_) (#p0 #p1:perm) (#s0 #s1:Ghost.erased (Seq.seq t))
            (a0:ptr t)
@@ -591,7 +593,7 @@ val ptrdiff_ptr (#t:_) (#p0 #p1:perm) (#s0 #s1:Ghost.erased (Seq.seq t))
   : ST UP.t
     (pts_to (| a0, len0 |) p0 s0 `star` pts_to (| a1, len1 |) p1 s1)
     (fun _ -> pts_to (| a0, len0 |) p0 s0 `star` pts_to (| a1, len1 |) p1 s1)
-    (base a0 == base a1)
+    (base a0 == base a1 /\ UP.fits (offset a0 - offset a1))
     (fun r -> UP.v r == offset a0 - offset a1)
 
 inline_for_extraction
@@ -602,7 +604,7 @@ let ptrdiff (#t:_) (#p0 #p1:perm) (#s0 #s1:Ghost.erased (Seq.seq t))
   : ST UP.t
     (pts_to a0 p0 s0 `star` pts_to a1 p1 s1)
     (fun _ -> pts_to a0 p0 s0 `star` pts_to a1 p1 s1)
-    (base (ptr_of a0) == base (ptr_of a1))
+    (base (ptr_of a0) == base (ptr_of a1) /\ UP.fits (offset (ptr_of a0) - offset (ptr_of a1)))
     (fun r -> UP.v r == offset (ptr_of a0) - offset (ptr_of a1))
   = let (| pt0, len0 |) = a0 in
     let (| pt1, len1 |) = a1 in


### PR DESCRIPTION
This PR adds a primitive called `ptrdiff` to Steel arrays to perform pointer substraction.
According to the C standard, this operation is only defined when the two arrays are live, part of the same allocation unit, and when the difference is representable in a ptrdiff_t.

Note, the primitive extraction of `ptrdiff` relies on a new node in the krml AST, added in a companion krml PR.