### PR TITLE
Shorten command line when computing ulib extraction dependencies

### DIFF
--- a/ulib/.gitignore
+++ b/ulib/.gitignore
@@ -8,6 +8,7 @@ tactics_ml/fstarlib_leftovers
 tactics_ml/fstartaclib.mllib
 .depend.extract
 .depend.extract.fsharp
+.depend.extract.rsp
 fs/extracted
 [Bb]in/
 [Oo]bj/

--- a/ulib/Makefile
+++ b/ulib/Makefile
@@ -161,6 +161,7 @@ clean_checked:
 
 clean: clean_checked clean_ocaml
 	@echo "[CLEAN     ulib/]"
+	$(Q)rm -f .depend.extract.rsp
 	$(Q)rm -f .depend.extract
 	$(Q)rm -f *.mgen
 	$(Q)rm -f *.checked.lax .cache/*.checked.lax

--- a/ulib/Makefile.extract
+++ b/ulib/Makefile.extract
@@ -35,7 +35,8 @@ $(OUTPUT_DIRECTORY)/%.ml:
 
 .depend.extract:
 	$(Q)mkdir -p .cache.lax
-	$(Q)$(MY_FSTAR) --dep full $(EXTRACT_MODULES) $(addprefix --include , $(INCLUDE_PATHS)) $(FSTAR_FILES) > .depend.extract
+	@true $(shell rm -f .depend.extract.rsp) $(foreach f,--dep full $(EXTRACT_MODULES) $(addprefix --include , $(INCLUDE_PATHS)) $(FSTAR_FILES),$(shell echo $(f) >> .depend.extract.rsp))
+	$(Q)$(MY_FSTAR) @.depend.extract.rsp > .depend.extract
 	@echo "[DEPEND]"
 
 depend.extract: .depend.extract

--- a/ulib/Makefile.extract
+++ b/ulib/Makefile.extract
@@ -35,8 +35,8 @@ $(OUTPUT_DIRECTORY)/%.ml:
 
 .depend.extract:
 	$(Q)mkdir -p .cache.lax
-	@true $(shell rm -f .depend.extract.rsp) $(foreach f,--dep full $(EXTRACT_MODULES) $(addprefix --include , $(INCLUDE_PATHS)) $(FSTAR_FILES),$(shell echo $(f) >> .depend.extract.rsp))
-	$(Q)$(MY_FSTAR) @.depend.extract.rsp > .depend.extract
+	@true $(shell rm -f .depend.extract.rsp) $(foreach f,$(FSTAR_FILES),$(shell echo $(f) >> .depend.extract.rsp))
+	$(Q)$(MY_FSTAR) --dep full $(EXTRACT_MODULES) $(addprefix --include , $(INCLUDE_PATHS)) @.depend.extract.rsp > .depend.extract
 	@echo "[DEPEND]"
 
 depend.extract: .depend.extract


### PR DESCRIPTION
When calling `fstar.exe --dep` to extract `ulib`, listing all `.fst` and `.fsti` files makes the command line longer than the 8192-byte limit imposed by Windows, so building F* fails with an error message of the following form:
```
(Error 129) File experimental/FStar.N could not be found
gmake[5]: *** [Makefile.extract:38: .depend.extract] Error 1
```
indicating that the `fstar.exe --dep` command was actually truncated.

This PR solves this issue by listing all files in a response file, `.depend.extract.rsp`, and calling `fstar.exe --dep` with `@.depend.extract.rsp`, following the same pattern as #2442 (which was dealing with the same issue for ulib verification.)
