### PR TITLE
Disable simplification of equalities of quoted terms

### DIFF
--- a/src/ocaml-output/FStar_Syntax_Util.ml
+++ b/src/ocaml-output/FStar_Syntax_Util.ml
@@ -905,20 +905,22 @@ let (injectives : Prims.string Prims.list) =
   "FStar.UInt32.__uint_to_t";
   "FStar.UInt64.__uint_to_t"]
 let (eq_inj : eq_result -> eq_result -> eq_result) =
-  fun f ->
-    fun g ->
-      match (f, g) with
+  fun r ->
+    fun s ->
+      match (r, s) with
       | (Equal, Equal) -> Equal
       | (NotEqual, uu___) -> NotEqual
       | (uu___, NotEqual) -> NotEqual
-      | (Unknown, uu___) -> Unknown
-      | (uu___, Unknown) -> Unknown
+      | (uu___, uu___1) -> Unknown
 let (equal_if : Prims.bool -> eq_result) =
   fun uu___ -> if uu___ then Equal else Unknown
 let (equal_iff : Prims.bool -> eq_result) =
   fun uu___ -> if uu___ then Equal else NotEqual
 let (eq_and : eq_result -> (unit -> eq_result) -> eq_result) =
-  fun f -> fun g -> match f with | Equal -> g () | uu___ -> Unknown
+  fun r ->
+    fun s ->
+      let uu___ = (r = Equal) && (let uu___1 = s () in uu___1 = Equal) in
+      if uu___ then Equal else Unknown
 let rec (eq_tm :
   FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term -> eq_result) =
   fun t1 ->
@@ -1004,9 +1006,11 @@ let rec (eq_tm :
             (fun uu___1 ->
                let uu___2 = eq_univs_list us vs in equal_if uu___2)
       | (FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_range uu___),
-         uu___1) -> Unknown
-      | (uu___, FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_range
-         uu___1)) -> Unknown
+         FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_range uu___1)) ->
+          Unknown
+      | (FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_real r1),
+         FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_real r2)) ->
+          equal_if (r1 = r2)
       | (FStar_Syntax_Syntax.Tm_constant c, FStar_Syntax_Syntax.Tm_constant
          d) -> let uu___ = FStar_Const.eq_const c d in equal_iff uu___
       | (FStar_Syntax_Syntax.Tm_uvar (u1, ([], uu___)),
@@ -1054,9 +1058,7 @@ let rec (eq_tm :
       | (FStar_Syntax_Syntax.Tm_type u, FStar_Syntax_Syntax.Tm_type v) ->
           let uu___ = eq_univs u v in equal_if uu___
       | (FStar_Syntax_Syntax.Tm_quoted (t13, q1),
-         FStar_Syntax_Syntax.Tm_quoted (t23, q2)) ->
-          let uu___ = eq_quoteinfo q1 q2 in
-          eq_and uu___ (fun uu___1 -> eq_tm t13 t23)
+         FStar_Syntax_Syntax.Tm_quoted (t23, q2)) -> Unknown
       | (FStar_Syntax_Syntax.Tm_refine (t13, phi1),
          FStar_Syntax_Syntax.Tm_refine (t23, phi2)) ->
           let uu___ =
@@ -1095,21 +1097,10 @@ let rec (eq_tm :
               Equal bs1 bs2 in
           eq_and uu___ (fun uu___1 -> eq_comp c1 c2)
       | uu___ -> Unknown
-and (eq_quoteinfo :
-  FStar_Syntax_Syntax.quoteinfo -> FStar_Syntax_Syntax.quoteinfo -> eq_result)
-  =
-  fun q1 ->
-    fun q2 ->
-      if q1.FStar_Syntax_Syntax.qkind <> q2.FStar_Syntax_Syntax.qkind
-      then NotEqual
-      else
-        eq_antiquotes q1.FStar_Syntax_Syntax.antiquotes
-          q2.FStar_Syntax_Syntax.antiquotes
 and (eq_antiquotes :
-  (FStar_Syntax_Syntax.bv * FStar_Syntax_Syntax.term'
-    FStar_Syntax_Syntax.syntax) Prims.list ->
-    (FStar_Syntax_Syntax.bv * FStar_Syntax_Syntax.term'
-      FStar_Syntax_Syntax.syntax) Prims.list -> eq_result)
+  (FStar_Syntax_Syntax.bv * FStar_Syntax_Syntax.term) Prims.list ->
+    (FStar_Syntax_Syntax.bv * FStar_Syntax_Syntax.term) Prims.list ->
+      eq_result)
   =
   fun a1 ->
     fun a2 ->
@@ -1220,6 +1211,16 @@ and (eq_comp :
                          eq_args ct1.FStar_Syntax_Syntax.effect_args
                            ct2.FStar_Syntax_Syntax.effect_args)))
       | uu___ -> NotEqual
+let (eq_quoteinfo :
+  FStar_Syntax_Syntax.quoteinfo -> FStar_Syntax_Syntax.quoteinfo -> eq_result)
+  =
+  fun q1 ->
+    fun q2 ->
+      if q1.FStar_Syntax_Syntax.qkind <> q2.FStar_Syntax_Syntax.qkind
+      then NotEqual
+      else
+        eq_antiquotes q1.FStar_Syntax_Syntax.antiquotes
+          q2.FStar_Syntax_Syntax.antiquotes
 let (eq_bqual :
   FStar_Syntax_Syntax.binder_qualifier FStar_Pervasives_Native.option ->
     FStar_Syntax_Syntax.binder_qualifier FStar_Pervasives_Native.option ->

--- a/src/ocaml-output/FStar_TypeChecker_TcTerm.ml
+++ b/src/ocaml-output/FStar_TypeChecker_TcTerm.ml
@@ -1298,7 +1298,7 @@ let (guard_letrecs :
                              let uu___12 =
                                FStar_Syntax_Print.term_to_string t2 in
                              FStar_Compiler_Util.format6
-                               "SMT may not be able to prove the types of %s at %s (%s) and %s at %s (%s) to be equal, if the proof fails, try annotating these with the same type\n"
+                               "SMT may not be able to prove the types of %s at %s (%s) and %s at %s (%s) to be equal, if the proof fails, try annotating these with the same type"
                                uu___7 uu___8 uu___9 uu___10 uu___11 uu___12 in
                            (FStar_Errors.Warning_Defensive, uu___6) in
                          FStar_Errors.log_issue e1.FStar_Syntax_Syntax.pos

--- a/src/typechecker/FStar.TypeChecker.TcTerm.fst
+++ b/src/typechecker/FStar.TypeChecker.TcTerm.fst
@@ -532,7 +532,7 @@ let guard_letrecs env actuals expected_c : list (lbname*typ*univ_names) =
                  | Tm_name _, Tm_name _ -> ()
                  | _, _ ->
                    Errors.log_issue e1.pos (Errors.Warning_Defensive,
-                     BU.format6 "SMT may not be able to prove the types of %s at %s (%s) and %s at %s (%s) to be equal, if the proof fails, try annotating these with the same type\n"
+                     BU.format6 "SMT may not be able to prove the types of %s at %s (%s) and %s at %s (%s) to be equal, if the proof fails, try annotating these with the same type"
                        (Print.term_to_string e1)
                        (Range.string_of_range e1.pos)
                        (Print.term_to_string t1)

--- a/tests/bug-reports/Bug2806a.fst
+++ b/tests/bug-reports/Bug2806a.fst
@@ -1,0 +1,11 @@
+module Bug2806a
+
+open FStar.Real
+open FStar.Tactics
+
+let one = 1.0R
+let oone = 01.0R
+
+[@@expect_failure]
+let bad () : Lemma False =
+  assert (~(one == oone)) by (compute ())

--- a/tests/bug-reports/Bug2806b.fst
+++ b/tests/bug-reports/Bug2806b.fst
@@ -1,0 +1,17 @@
+module Bug2806b
+
+open FStar.Reflection
+
+let non_fun #a #b (f : a -> b) (x y : a) (fx fy : b) :
+  Lemma (requires f x == fx /\ f y == fy /\ x == y)
+        (ensures fx == fy) = ()
+
+[@@expect_failure]
+let test () : Lemma False =
+    let t1 = (`(2 <: int)) in
+    let t2 = (`2) in
+    assert (t1 == t2);
+    let tv1 = inspect_ln t1 in
+    let tv2 = inspect_ln t2 in
+    assert (tv1 =!= tv2);
+    non_fun inspect_ln t1 t2 tv1 tv2 // nudge SMT

--- a/tests/bug-reports/Bug2806c.fst
+++ b/tests/bug-reports/Bug2806c.fst
@@ -1,0 +1,21 @@
+module Bug2806c
+
+open FStar.Tactics
+
+let dom (t:term{exists b c. inspect_ln t == Tv_Arrow b c}) =
+  match inspect_ln t with
+  | Tv_Arrow b _ -> bv_of_binder b
+
+let name (t:term{Tv_Arrow? (inspect_ln t)}) : string =
+  assert (Tv_Arrow? (inspect_ln t));
+  let b : bv = dom t in
+  let bv : bv_view = inspect_bv b in
+  bv.bv_ppname
+
+let t1 : (t:term{Tv_Arrow? (inspect_ln t)}) = (`(x:int -> int))
+let t2 : (t:term{Tv_Arrow? (inspect_ln t)}) = (`(y:int -> int))
+
+[@@expect_failure]
+let falso () : Lemma False =
+  assert (t1 == t2) by (compute ());
+  assert_norm (name t1 =!= name t2)

--- a/tests/bug-reports/Bug2806d.fst
+++ b/tests/bug-reports/Bug2806d.fst
@@ -1,0 +1,21 @@
+module Bug2806d
+
+open FStar.Tactics
+
+let dom (t:term{exists b c. inspect_ln t == Tv_Arrow b c}) =
+  match inspect_ln t with
+  | Tv_Arrow b _ -> bv_of_binder b
+
+let idx (t:term{Tv_Arrow? (inspect_ln t)}) : int =
+  assert (Tv_Arrow? (inspect_ln t));
+  let b : bv = dom t in
+  let bv : bv_view = inspect_bv b in
+  bv.bv_index
+
+let t1 : (t:term{Tv_Arrow? (inspect_ln t)}) = (`(x:int -> int))
+let t2 : (t:term{Tv_Arrow? (inspect_ln t)}) = (`(x:int -> int))
+
+[@@expect_failure]
+let falso () : Lemma False =
+  assert (t1 == t2) by (compute ());
+  assert_norm (idx t1 =!= idx t2)

--- a/tests/bug-reports/Makefile
+++ b/tests/bug-reports/Makefile
@@ -49,7 +49,7 @@ SHOULD_VERIFY_CLOSED=Bug022.fst Bug024.fst Bug025.fst Bug026.fst Bug026b.fst Bug
   Bug2552.fst Bug2597.fst Bug2471_B.fst Bug2605.fst Bug2614.fst Bug2622.fst \
   Bug2635.fst Bug2637.fst Bug2641.fst Bug1486.fst PropProofs.fst \
   Bug2684a.fst Bug2684b.fst Bug2684c.fst Bug2684d.fst Bug2659b.fst\
-  Bug2756.fst MutualRecPositivity.fst
+  Bug2756.fst MutualRecPositivity.fst Bug2806a.fst Bug2806b.fst Bug2806c.fst Bug2806d.fst
 
 SHOULD_VERIFY_INTERFACE_CLOSED=Bug771.fsti Bug771b.fsti
 SHOULD_VERIFY_AND_WARN_CLOSED=Bug016.fst


### PR DESCRIPTION
(and also fix the problem with `Const_real`)

This is a first step in tidying this problem up, but enough to prevent the inconsistency. It disallows, for instance, to prove:
```fstar
`(x:int -> int) == `(x:int -> int)
```
since the two "x"s got a different unique id :-). This is not so bad, since we don't seem to be relying on it anywhere, but we agreed with @nikswamy to try to remove these indices in binders, as they are not meaningful in any way. While at it, we will also attempt to remove sorts on bv occurrences.

Fixes #2806.