### PR TITLE
Fixing a bug in the positivity checker for mutually inductive types

### DIFF
--- a/src/fstar/FStar.Interactive.PushHelper.fst
+++ b/src/fstar/FStar.Interactive.PushHelper.fst
@@ -41,7 +41,7 @@ module CTable = FStar.Interactive.CompletionTable
 let repl_stack: ref repl_stack_t = U.mk_ref []
 
 let set_check_kind env check_kind =
-  { env with lax = (check_kind = LaxCheck);
+  { env with lax = (check_kind = LaxCheck || Options.lax());
              dsenv = DsEnv.set_syntax_only env.dsenv (check_kind = SyntaxCheck)}
 
 (** Build a list of dependency loading tasks from a list of dependencies **)

--- a/src/ocaml-output/FStar_Interactive_PushHelper.ml
+++ b/src/ocaml-output/FStar_Interactive_PushHelper.ml
@@ -56,7 +56,8 @@ let (set_check_kind :
   FStar_TypeChecker_Env.env_t -> push_kind -> FStar_TypeChecker_Env.env_t) =
   fun env ->
     fun check_kind ->
-      let uu___ =
+      let uu___ = (check_kind = LaxCheck) || (FStar_Options.lax ()) in
+      let uu___1 =
         FStar_Syntax_DsEnv.set_syntax_only env.FStar_TypeChecker_Env.dsenv
           (check_kind = SyntaxCheck) in
       {
@@ -88,7 +89,7 @@ let (set_check_kind :
           (env.FStar_TypeChecker_Env.use_eq_strict);
         FStar_TypeChecker_Env.is_iface = (env.FStar_TypeChecker_Env.is_iface);
         FStar_TypeChecker_Env.admit = (env.FStar_TypeChecker_Env.admit);
-        FStar_TypeChecker_Env.lax = (check_kind = LaxCheck);
+        FStar_TypeChecker_Env.lax = uu___;
         FStar_TypeChecker_Env.lax_universes =
           (env.FStar_TypeChecker_Env.lax_universes);
         FStar_TypeChecker_Env.phase1 = (env.FStar_TypeChecker_Env.phase1);
@@ -128,7 +129,7 @@ let (set_check_kind :
         FStar_TypeChecker_Env.identifier_info =
           (env.FStar_TypeChecker_Env.identifier_info);
         FStar_TypeChecker_Env.tc_hooks = (env.FStar_TypeChecker_Env.tc_hooks);
-        FStar_TypeChecker_Env.dsenv = uu___;
+        FStar_TypeChecker_Env.dsenv = uu___1;
         FStar_TypeChecker_Env.nbe = (env.FStar_TypeChecker_Env.nbe);
         FStar_TypeChecker_Env.strict_args_tab =
           (env.FStar_TypeChecker_Env.strict_args_tab);

--- a/src/ocaml-output/FStar_TypeChecker_Tc.ml
+++ b/src/ocaml-output/FStar_TypeChecker_Tc.ml
@@ -382,7 +382,8 @@ let (tc_inductive' :
                       FStar_Compiler_List.iter
                         (fun ty ->
                            let b =
-                             FStar_TypeChecker_Util.check_positivity env1 ty in
+                             FStar_TypeChecker_Util.check_positivity env1
+                               lids ty in
                            if Prims.op_Negation b
                            then
                              let uu___6 =

--- a/src/ocaml-output/FStar_TypeChecker_Util.ml
+++ b/src/ocaml-output/FStar_TypeChecker_Util.ml
@@ -9267,36 +9267,43 @@ let (ty_positive_in_datacon :
                    failwith
                      "Unexpected data constructor type when checking positivity")
 let (check_positivity :
-  FStar_TypeChecker_Env.env -> FStar_Syntax_Syntax.sigelt -> Prims.bool) =
+  FStar_TypeChecker_Env.env ->
+    FStar_Ident.lident Prims.list -> FStar_Syntax_Syntax.sigelt -> Prims.bool)
+  =
   fun env ->
-    fun ty ->
-      let unfolded_inductives = FStar_Compiler_Util.mk_ref [] in
-      let uu___ =
-        match ty.FStar_Syntax_Syntax.sigel with
-        | FStar_Syntax_Syntax.Sig_inductive_typ
-            (lid, us, bs, uu___1, uu___2, uu___3) -> (lid, us, bs)
-        | uu___1 -> failwith "Impossible!" in
-      match uu___ with
-      | (ty_lid, ty_us, ty_bs) ->
-          let uu___1 = FStar_Syntax_Subst.univ_var_opening ty_us in
-          (match uu___1 with
-           | (ty_usubst, ty_us1) ->
-               let env1 = FStar_TypeChecker_Env.push_univ_vars env ty_us1 in
-               let env2 = FStar_TypeChecker_Env.push_binders env1 ty_bs in
-               let ty_bs1 = FStar_Syntax_Subst.subst_binders ty_usubst ty_bs in
-               let ty_bs2 = FStar_Syntax_Subst.open_binders ty_bs1 in
-               let uu___2 =
-                 let uu___3 =
-                   FStar_TypeChecker_Env.datacons_of_typ env2 ty_lid in
-                 FStar_Pervasives_Native.snd uu___3 in
-               FStar_Compiler_List.for_all
-                 (fun d1 ->
-                    let uu___3 =
-                      FStar_Compiler_List.map
-                        (fun uu___4 -> FStar_Syntax_Syntax.U_name uu___4)
-                        ty_us1 in
-                    ty_positive_in_datacon env2 ty_lid d1 ty_bs2 uu___3
-                      unfolded_inductives) uu___2)
+    fun mutuals ->
+      fun ty ->
+        let unfolded_inductives = FStar_Compiler_Util.mk_ref [] in
+        let uu___ =
+          match ty.FStar_Syntax_Syntax.sigel with
+          | FStar_Syntax_Syntax.Sig_inductive_typ
+              (lid, us, bs, uu___1, uu___2, uu___3) -> (lid, us, bs)
+          | uu___1 -> failwith "Impossible!" in
+        match uu___ with
+        | (ty_lid, ty_us, ty_bs) ->
+            let ty_lids = ty_lid :: mutuals in
+            let uu___1 = FStar_Syntax_Subst.univ_var_opening ty_us in
+            (match uu___1 with
+             | (ty_usubst, ty_us1) ->
+                 let env1 = FStar_TypeChecker_Env.push_univ_vars env ty_us1 in
+                 let env2 = FStar_TypeChecker_Env.push_binders env1 ty_bs in
+                 let datacons =
+                   let uu___2 =
+                     FStar_TypeChecker_Env.datacons_of_typ env2 ty_lid in
+                   FStar_Pervasives_Native.snd uu___2 in
+                 let ty_bs1 =
+                   FStar_Syntax_Subst.subst_binders ty_usubst ty_bs in
+                 let ty_bs2 = FStar_Syntax_Subst.open_binders ty_bs1 in
+                 FStar_Compiler_List.for_all
+                   (fun d1 ->
+                      FStar_Compiler_List.for_all
+                        (fun ty_lid1 ->
+                           let uu___2 =
+                             FStar_Compiler_List.map
+                               (fun uu___3 ->
+                                  FStar_Syntax_Syntax.U_name uu___3) ty_us1 in
+                           ty_positive_in_datacon env2 ty_lid1 d1 ty_bs2
+                             uu___2 unfolded_inductives) ty_lids) datacons)
 let (check_exn_positivity :
   FStar_TypeChecker_Env.env -> FStar_Ident.lident -> Prims.bool) =
   fun env ->

--- a/src/typechecker/FStar.TypeChecker.Tc.fst
+++ b/src/typechecker/FStar.TypeChecker.Tc.fst
@@ -134,7 +134,7 @@ let tc_inductive' env ses quals attrs lids =
        let env = Env.push_sigelt env sig_bndle in
        (* Check positivity of the inductives within the Sig_bundle *)
        List.iter (fun ty ->
-         let b = TcUtil.check_positivity env ty in
+         let b = TcUtil.check_positivity env lids ty in
          if not b then
            let lid, r =
              match ty.sigel with

--- a/src/typechecker/FStar.TypeChecker.Util.fsti
+++ b/src/typechecker/FStar.TypeChecker.Util.fsti
@@ -194,6 +194,6 @@ val make_record_fields_in_order : env -> unresolved_constructor -> option (eithe
                                 list 'a
 
 
-val check_positivity: env -> sigelt -> bool
+val check_positivity: env -> list lident -> sigelt -> bool
 val name_strictly_positive_in_type: env -> bv -> term -> bool
 val check_exn_positivity: env -> lident -> bool

--- a/tests/bug-reports/Makefile
+++ b/tests/bug-reports/Makefile
@@ -49,7 +49,7 @@ SHOULD_VERIFY_CLOSED=Bug022.fst Bug024.fst Bug025.fst Bug026.fst Bug026b.fst Bug
   Bug2552.fst Bug2597.fst Bug2471_B.fst Bug2605.fst Bug2614.fst Bug2622.fst \
   Bug2635.fst Bug2637.fst Bug2641.fst Bug1486.fst PropProofs.fst \
   Bug2684a.fst Bug2684b.fst Bug2684c.fst Bug2684d.fst Bug2659b.fst\
-  Bug2756.fst
+  Bug2756.fst MutualRecPositivity.fst
 
 SHOULD_VERIFY_INTERFACE_CLOSED=Bug771.fsti Bug771b.fsti
 SHOULD_VERIFY_AND_WARN_CLOSED=Bug016.fst

--- a/tests/bug-reports/MutualRecPositivity.fst
+++ b/tests/bug-reports/MutualRecPositivity.fst
@@ -1,0 +1,8 @@
+module MutualRecPositivity
+
+[@@expect_failure [3]]
+noeq
+type t =
+  | T : s -> t
+and s =
+  | S : (t -> t) -> s


### PR DESCRIPTION
This was mistakenly accepted by F*:

```
noeq
type t =
  | T : s -> t
and s =
  | S : (t -> t) -> s
```

The fix checks for the strict positivity of all type constructors in a mutually inductive group

(Also, on the fly: A fix in the interactive mode for hacking on the compiler itself in lax mode)