### PR TITLE
Allow record payloads on constructors in variants

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -264,6 +264,14 @@ Guidelines for the changelog:
      provided (using UInt128).
 
 ## Syntax
+   * PR #2812 allows defining variants whose constructors carry
+     records, for example:
+     ```fstar
+     type foo = | A
+                | B { x: int; y: int }
+     ```
+
+     See `examples/misc/VariantsWithRecords.fst` for more examples.
 
    * PR #2727 allows for custom unicode operators. As long as a
      character belongs to the ["Math Symbol" unicode

--- a/examples/misc/VariantsWithRecords.fst
+++ b/examples/misc/VariantsWithRecords.fst
@@ -1,0 +1,65 @@
+module VariantsWithRecords
+
+(**** General usage *)
+
+/// A record type is declared using the following syntax:
+type record = { field1: int; field2: string (* ... *) }
+
+/// A variant type can be of any arity, and can be declared using a
+/// few different syntaxes.
+type foo =
+  (** constructor [A] carries an integer and a string *)
+  | A: int -> string -> foo
+  (** fields can be named *)
+  | B: named:int -> other:string -> foo
+  (** for constructor of arity 1, one cam use OCaml's [of] notation *)
+  | C of int * string
+  (** [D] carries nothing *)
+  | D
+  (** [E] carries a record *)
+  | E { a: int; b: int }
+
+/// Example of a GADT:
+type expr: Type -> Type =
+  (** [ConstInt] constructs an [expr int] *)
+  | ConstInt: int -> expr int
+  (** but [ConstStr] constructs an [expr string] *)
+  | ConstStr: string -> expr string
+  (** [Add] carries a record and constructs a [expr int] *)
+  | Add { x: expr int; y: expr int }: expr int
+  | StringOfInt { value: expr int }: expr string
+
+let rec eval (e: expr 'a): 'a
+  = match e with
+  | ConstInt c -> c
+  | ConstStr s -> s
+  | Add {x; y} -> eval x + eval y
+  | StringOfInt {value} -> string_of_int (eval value)
+
+let e = StringOfInt { value = Add { x = ConstInt 3; y = ConstInt 39} }
+let _ = assert_norm (eval e == "42")
+
+(**** Desugaring of constructor carrying records *)
+/// The type [bar]...
+type bar = | X
+           | Y { x: int; y: int }
+           | Z { z: int; t: int }: bar
+
+/// ...is desugared into the types [bar], [bar__Y__payload] and [bar__Z__payload]:
+/// (note: to avoiding name clashes, [']s were added below)
+type bar' = | X'
+            | Y' of bar'__Y'__payload
+            | Z': bar'__Z'__payload -> bar'
+and bar'__Y'__payload = { x: int; y: int }
+and bar'__Z'__payload = { z: int; t: int }
+
+/// We can actually observe this desugaring by constructing [Y]'s or
+/// [Z]'s payloads directly:
+
+let _: bar__Y__payload = {x = 1; y = 2}
+let _: bar__Z__payload = {z = 3; t = 4}
+
+/// Note that the desugaring of constructor carrying records doesn't
+/// forbid something like [odd] below:
+type odd = | Odd {something: int}: string -> odd
+let _: odd = Odd {something = 3} "wierd"

--- a/src/ocaml-output/FStar_Parser_AST.ml
+++ b/src/ocaml-output/FStar_Parser_AST.ml
@@ -567,17 +567,38 @@ type aqual = arg_qualifier FStar_Pervasives_Native.option
 type knd = term
 type typ = term
 type expr = term
+type tycon_record =
+  (FStar_Ident.ident * aqual * attributes_ * term) Prims.list
+type constructor_payload =
+  | VpOfNotation of typ 
+  | VpArbitrary of typ 
+  | VpRecord of (tycon_record * typ FStar_Pervasives_Native.option) 
+let (uu___is_VpOfNotation : constructor_payload -> Prims.bool) =
+  fun projectee ->
+    match projectee with | VpOfNotation _0 -> true | uu___ -> false
+let (__proj__VpOfNotation__item___0 : constructor_payload -> typ) =
+  fun projectee -> match projectee with | VpOfNotation _0 -> _0
+let (uu___is_VpArbitrary : constructor_payload -> Prims.bool) =
+  fun projectee ->
+    match projectee with | VpArbitrary _0 -> true | uu___ -> false
+let (__proj__VpArbitrary__item___0 : constructor_payload -> typ) =
+  fun projectee -> match projectee with | VpArbitrary _0 -> _0
+let (uu___is_VpRecord : constructor_payload -> Prims.bool) =
+  fun projectee ->
+    match projectee with | VpRecord _0 -> true | uu___ -> false
+let (__proj__VpRecord__item___0 :
+  constructor_payload -> (tycon_record * typ FStar_Pervasives_Native.option))
+  = fun projectee -> match projectee with | VpRecord _0 -> _0
 type tycon =
   | TyconAbstract of (FStar_Ident.ident * binder Prims.list * knd
   FStar_Pervasives_Native.option) 
   | TyconAbbrev of (FStar_Ident.ident * binder Prims.list * knd
   FStar_Pervasives_Native.option * term) 
   | TyconRecord of (FStar_Ident.ident * binder Prims.list * knd
-  FStar_Pervasives_Native.option * attributes_ * (FStar_Ident.ident * aqual *
-  attributes_ * term) Prims.list) 
+  FStar_Pervasives_Native.option * attributes_ * tycon_record) 
   | TyconVariant of (FStar_Ident.ident * binder Prims.list * knd
-  FStar_Pervasives_Native.option * (FStar_Ident.ident * term
-  FStar_Pervasives_Native.option * Prims.bool * attributes_) Prims.list) 
+  FStar_Pervasives_Native.option * (FStar_Ident.ident * constructor_payload
+  FStar_Pervasives_Native.option * attributes_) Prims.list) 
 let (uu___is_TyconAbstract : tycon -> Prims.bool) =
   fun projectee ->
     match projectee with | TyconAbstract _0 -> true | uu___ -> false
@@ -600,8 +621,7 @@ let (uu___is_TyconRecord : tycon -> Prims.bool) =
 let (__proj__TyconRecord__item___0 :
   tycon ->
     (FStar_Ident.ident * binder Prims.list * knd
-      FStar_Pervasives_Native.option * attributes_ * (FStar_Ident.ident *
-      aqual * attributes_ * term) Prims.list))
+      FStar_Pervasives_Native.option * attributes_ * tycon_record))
   = fun projectee -> match projectee with | TyconRecord _0 -> _0
 let (uu___is_TyconVariant : tycon -> Prims.bool) =
   fun projectee ->
@@ -609,8 +629,9 @@ let (uu___is_TyconVariant : tycon -> Prims.bool) =
 let (__proj__TyconVariant__item___0 :
   tycon ->
     (FStar_Ident.ident * binder Prims.list * knd
-      FStar_Pervasives_Native.option * (FStar_Ident.ident * term
-      FStar_Pervasives_Native.option * Prims.bool * attributes_) Prims.list))
+      FStar_Pervasives_Native.option * (FStar_Ident.ident *
+      constructor_payload FStar_Pervasives_Native.option * attributes_)
+      Prims.list))
   = fun projectee -> match projectee with | TyconVariant _0 -> _0
 type qualifier =
   | Private 

--- a/src/ocaml-output/FStar_Parser_Dep.ml
+++ b/src/ocaml-output/FStar_Parser_Dep.ml
@@ -1295,24 +1295,33 @@ let (collect_one :
                  (uu___3, binders, k, uu___4, identterms) ->
                  (collect_binders binders;
                   FStar_Compiler_Util.iter_opt k collect_term;
-                  FStar_Compiler_List.iter
-                    (fun uu___7 ->
-                       match uu___7 with
-                       | (uu___8, aq, attrs, t) ->
-                           (collect_aqual aq;
-                            FStar_Compiler_Effect.op_Bar_Greater attrs
-                              (FStar_Compiler_List.iter collect_term);
-                            collect_term t)) identterms)
+                  collect_tycon_record identterms)
              | FStar_Parser_AST.TyconVariant (uu___3, binders, k, identterms)
                  ->
                  (collect_binders binders;
                   FStar_Compiler_Util.iter_opt k collect_term;
-                  FStar_Compiler_List.iter
-                    (fun uu___6 ->
-                       match uu___6 with
-                       | (uu___7, t, uu___8, uu___9) ->
-                           FStar_Compiler_Util.iter_opt t collect_term)
-                    identterms)
+                  (let uu___6 =
+                     FStar_Compiler_List.filter_map
+                       FStar_Pervasives_Native.__proj__Mktuple3__item___2
+                       identterms in
+                   FStar_Compiler_List.iter
+                     (fun uu___7 ->
+                        match uu___7 with
+                        | FStar_Parser_AST.VpOfNotation t -> collect_term t
+                        | FStar_Parser_AST.VpArbitrary t -> collect_term t
+                        | FStar_Parser_AST.VpRecord (record, t) ->
+                            (collect_tycon_record record;
+                             FStar_Compiler_Util.iter_opt t collect_term))
+                     uu___6))
+           and collect_tycon_record r =
+             FStar_Compiler_List.iter
+               (fun uu___2 ->
+                  match uu___2 with
+                  | (uu___3, aq, attrs, t) ->
+                      (collect_aqual aq;
+                       FStar_Compiler_Effect.op_Bar_Greater attrs
+                         (FStar_Compiler_List.iter collect_term);
+                       collect_term t)) r
            and collect_effect_decl uu___2 =
              match uu___2 with
              | FStar_Parser_AST.DefineEffect (uu___3, binders, t, decls) ->

--- a/src/ocaml-output/FStar_Parser_ToDocument.ml
+++ b/src/ocaml-output/FStar_Parser_ToDocument.ml
@@ -1343,46 +1343,37 @@ and (p_typeDecl :
                (comm, uu___2, doc, jump2))
       | FStar_Parser_AST.TyconRecord
           (lid, bs, typ_opt, attrs, record_field_decls) ->
-          let p_recordField ps uu___1 =
-            match uu___1 with
-            | (lid1, aq, attrs1, t) ->
-                let uu___2 =
-                  let uu___3 =
-                    FStar_Compiler_Range.extend_to_end_of_line
-                      t.FStar_Parser_AST.range in
-                  with_comment_sep (p_recordFieldDecl ps)
-                    (lid1, aq, attrs1, t) uu___3 in
-                (match uu___2 with
-                 | (comm, field) ->
-                     let sep =
-                       if ps then FStar_Pprint.semi else FStar_Pprint.empty in
-                     inline_comment_or_above comm field sep) in
-          let p_fields =
-            let uu___1 = p_attributes false attrs in
-            let uu___2 =
-              let uu___3 =
-                separate_map_last FStar_Pprint.hardline p_recordField
-                  record_field_decls in
-              braces_with_nesting uu___3 in
-            FStar_Pprint.op_Hat_Hat uu___1 uu___2 in
           let uu___1 = p_typeDeclPrefix pre true lid bs typ_opt in
-          (FStar_Pprint.empty, uu___1, p_fields,
+          let uu___2 =
+            let uu___3 = p_attributes false attrs in
+            let uu___4 = p_typeDeclRecord record_field_decls in
+            FStar_Pprint.op_Hat_Hat uu___3 uu___4 in
+          (FStar_Pprint.empty, uu___1, uu___2,
             ((fun d -> FStar_Pprint.op_Hat_Hat FStar_Pprint.space d)))
       | FStar_Parser_AST.TyconVariant (lid, bs, typ_opt, ct_decls) ->
           let p_constructorBranchAndComments uu___1 =
             match uu___1 with
-            | (uid, t_opt, use_of, attrs) ->
+            | (uid, payload, attrs) ->
                 let range =
                   let uu___2 =
                     let uu___3 = FStar_Ident.range_of_id uid in
                     let uu___4 =
-                      FStar_Compiler_Util.map_opt t_opt
-                        (fun t -> t.FStar_Parser_AST.range) in
+                      FStar_Compiler_Util.bind_opt payload
+                        (fun uu___5 ->
+                           match uu___5 with
+                           | FStar_Parser_AST.VpOfNotation t ->
+                               FStar_Pervasives_Native.Some
+                                 (t.FStar_Parser_AST.range)
+                           | FStar_Parser_AST.VpArbitrary t ->
+                               FStar_Pervasives_Native.Some
+                                 (t.FStar_Parser_AST.range)
+                           | FStar_Parser_AST.VpRecord (record, uu___6) ->
+                               FStar_Pervasives_Native.None) in
                     FStar_Compiler_Util.dflt uu___3 uu___4 in
                   FStar_Compiler_Range.extend_to_end_of_line uu___2 in
                 let uu___2 =
-                  with_comment_sep p_constructorBranch
-                    (uid, t_opt, use_of, attrs) range in
+                  with_comment_sep p_constructorBranch (uid, payload, attrs)
+                    range in
                 (match uu___2 with
                  | (comm, ctor) ->
                      inline_comment_or_above comm ctor FStar_Pprint.empty) in
@@ -1391,6 +1382,24 @@ and (p_typeDecl :
               p_constructorBranchAndComments ct_decls in
           let uu___1 = p_typeDeclPrefix pre true lid bs typ_opt in
           (FStar_Pprint.empty, uu___1, datacon_doc, jump2)
+and (p_typeDeclRecord :
+  FStar_Parser_AST.tycon_record -> FStar_Pprint.document) =
+  fun fields ->
+    let p_recordField ps uu___ =
+      match uu___ with
+      | (lid, aq, attrs, t) ->
+          let uu___1 =
+            let uu___2 =
+              FStar_Compiler_Range.extend_to_end_of_line
+                t.FStar_Parser_AST.range in
+            with_comment_sep (p_recordFieldDecl ps) (lid, aq, attrs, t)
+              uu___2 in
+          (match uu___1 with
+           | (comm, field) ->
+               let sep = if ps then FStar_Pprint.semi else FStar_Pprint.empty in
+               inline_comment_or_above comm field sep) in
+    let uu___ = separate_map_last FStar_Pprint.hardline p_recordField fields in
+    FStar_Compiler_Effect.op_Bar_Greater uu___ braces_with_nesting
 and (p_typeDeclPrefix :
   FStar_Pprint.document ->
     Prims.bool ->
@@ -1456,35 +1465,45 @@ and (p_recordFieldDecl :
             FStar_Pprint.op_Hat_Hat uu___2 uu___3 in
           FStar_Pprint.group uu___1
 and (p_constructorBranch :
-  (FStar_Ident.ident * FStar_Parser_AST.term FStar_Pervasives_Native.option *
-    Prims.bool * FStar_Parser_AST.attributes_) -> FStar_Pprint.document)
+  (FStar_Ident.ident * FStar_Parser_AST.constructor_payload
+    FStar_Pervasives_Native.option * FStar_Parser_AST.attributes_) ->
+    FStar_Pprint.document)
   =
   fun uu___ ->
     match uu___ with
-    | (uid, t_opt, use_of, attrs) ->
-        let sep = if use_of then str "of" else FStar_Pprint.colon in
-        let uid_doc =
-          let uu___1 =
-            let uu___2 =
-              let uu___3 =
-                let uu___4 = p_attributes false attrs in
-                let uu___5 = p_uident uid in
-                FStar_Pprint.op_Hat_Hat uu___4 uu___5 in
-              FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu___3 in
-            FStar_Pprint.op_Hat_Hat FStar_Pprint.bar uu___2 in
-          FStar_Pprint.group uu___1 in
-        default_or_map uid_doc
-          (fun t ->
-             let uu___1 =
-               let uu___2 =
-                 let uu___3 =
-                   let uu___4 =
-                     let uu___5 = p_typ false false t in
-                     FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu___5 in
-                   FStar_Pprint.op_Hat_Hat sep uu___4 in
-                 FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu___3 in
-               FStar_Pprint.op_Hat_Hat uid_doc uu___2 in
-             FStar_Pprint.group uu___1) t_opt
+    | (uid, variant, attrs) ->
+        let h isOf t =
+          let uu___1 = if isOf then str "of" else FStar_Pprint.colon in
+          let uu___2 =
+            let uu___3 = p_typ false false t in
+            FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu___3 in
+          FStar_Pprint.op_Hat_Hat uu___1 uu___2 in
+        let uu___1 =
+          let uu___2 =
+            let uu___3 =
+              let uu___4 =
+                let uu___5 = p_attributes false attrs in
+                let uu___6 = p_uident uid in
+                FStar_Pprint.op_Hat_Hat uu___5 uu___6 in
+              FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu___4 in
+            FStar_Pprint.op_Hat_Hat FStar_Pprint.bar uu___3 in
+          FStar_Pprint.group uu___2 in
+        let uu___2 =
+          default_or_map FStar_Pprint.empty
+            (fun payload ->
+               let uu___3 =
+                 let uu___4 =
+                   match payload with
+                   | FStar_Parser_AST.VpOfNotation t -> h true t
+                   | FStar_Parser_AST.VpArbitrary t -> h false t
+                   | FStar_Parser_AST.VpRecord (r, t) ->
+                       let uu___5 = p_typeDeclRecord r in
+                       let uu___6 =
+                         default_or_map FStar_Pprint.empty (h false) t in
+                       FStar_Pprint.op_Hat_Hat uu___5 uu___6 in
+                 FStar_Pprint.group uu___4 in
+               FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu___3) variant in
+        FStar_Pprint.op_Hat_Hat uu___1 uu___2
 and (p_letlhs :
   FStar_Pprint.document ->
     (FStar_Parser_AST.pattern * FStar_Parser_AST.term) ->

--- a/src/ocaml-output/FStar_Syntax_Resugar.ml
+++ b/src/ocaml-output/FStar_Syntax_Resugar.ml
@@ -2367,12 +2367,14 @@ let (resugar_typ :
                             let c =
                               let uu___7 = FStar_Ident.ident_of_lid l in
                               let uu___8 =
-                                let uu___9 = resugar_term' env term in
+                                let uu___9 =
+                                  let uu___10 = resugar_term' env term in
+                                  FStar_Parser_AST.VpArbitrary uu___10 in
                                 FStar_Pervasives_Native.Some uu___9 in
                               let uu___9 =
                                 FStar_Compiler_List.map (resugar_term' env)
                                   se1.FStar_Syntax_Syntax.sigattrs in
-                              (uu___7, uu___8, false, uu___9) in
+                              (uu___7, uu___8, uu___9) in
                             c :: constructors
                         | uu___5 -> failwith "unexpected" in
                       let constructors =

--- a/src/ocaml-output/FStar_ToSyntax_ToSyntax.ml
+++ b/src/ocaml-output/FStar_ToSyntax_ToSyntax.ml
@@ -6106,6 +6106,129 @@ let rec (desugar_tycon :
                 FStar_Parser_AST.mk_term (FStar_Parser_AST.Tvar a) uu___
                   FStar_Parser_AST.Type_level
             | FStar_Parser_AST.NoName t -> t in
+          let desugar_tycon_variant_record uu___ =
+            match uu___ with
+            | FStar_Parser_AST.TyconVariant (id, bds, k, variants) ->
+                let uu___1 =
+                  let uu___2 =
+                    Obj.magic
+                      (FStar_Compiler_List.map
+                         (fun uu___3 ->
+                            match uu___3 with
+                            | (cid, payload, attrs) ->
+                                (match payload with
+                                 | FStar_Pervasives_Native.Some
+                                     (FStar_Parser_AST.VpRecord (r, k1)) ->
+                                     let record_id =
+                                       let uu___4 =
+                                         let uu___5 =
+                                           let uu___6 =
+                                             FStar_Ident.string_of_id id in
+                                           let uu___7 =
+                                             let uu___8 =
+                                               let uu___9 =
+                                                 FStar_Ident.string_of_id
+                                                   (Obj.magic cid) in
+                                               Prims.op_Hat uu___9
+                                                 "__payload" in
+                                             Prims.op_Hat "__" uu___8 in
+                                           Prims.op_Hat uu___6 uu___7 in
+                                         (uu___5,
+                                           (cid.FStar_Parser_AST.range)) in
+                                       FStar_Ident.mk_ident uu___4 in
+                                     let record_id_t =
+                                       let uu___4 =
+                                         let uu___5 =
+                                           FStar_Ident.lid_of_ns_and_id []
+                                             record_id in
+                                         FStar_Compiler_Effect.op_Bar_Greater
+                                           uu___5
+                                           (fun uu___6 ->
+                                              FStar_Parser_AST.Var uu___6) in
+                                       {
+                                         FStar_Parser_AST.tm = uu___4;
+                                         FStar_Parser_AST.range =
+                                           (cid.FStar_Parser_AST.range);
+                                         FStar_Parser_AST.level =
+                                           FStar_Parser_AST.Type_level
+                                       } in
+                                     let payload_typ =
+                                       let uu___4 =
+                                         FStar_Compiler_List.map
+                                           (fun bd ->
+                                              let uu___5 = binder_to_term bd in
+                                              (uu___5,
+                                                FStar_Parser_AST.Nothing))
+                                           bds in
+                                       let uu___5 =
+                                         FStar_Ident.range_of_id record_id in
+                                       FStar_Parser_AST.mkApp record_id_t
+                                         uu___4 uu___5 in
+                                     let uu___4 =
+                                       FStar_Compiler_Effect.op_Bar_Greater
+                                         (FStar_Parser_AST.TyconRecord
+                                            (record_id, bds,
+                                              FStar_Pervasives_Native.None,
+                                              attrs, r))
+                                         (fun uu___5 ->
+                                            FStar_Pervasives_Native.Some
+                                              uu___5) in
+                                     let uu___5 =
+                                       let uu___6 =
+                                         let uu___7 =
+                                           match k1 with
+                                           | FStar_Pervasives_Native.None ->
+                                               FStar_Parser_AST.VpOfNotation
+                                                 payload_typ
+                                           | FStar_Pervasives_Native.Some k2
+                                               ->
+                                               let uu___8 =
+                                                 let uu___9 =
+                                                   let uu___10 =
+                                                     let uu___11 =
+                                                       let uu___12 =
+                                                         let uu___13 =
+                                                           FStar_Ident.range_of_id
+                                                             record_id in
+                                                         FStar_Parser_AST.mk_binder
+                                                           (FStar_Parser_AST.NoName
+                                                              payload_typ)
+                                                           uu___13
+                                                           FStar_Parser_AST.Type_level
+                                                           FStar_Pervasives_Native.None in
+                                                       [uu___12] in
+                                                     (uu___11, k2) in
+                                                   FStar_Parser_AST.Product
+                                                     uu___10 in
+                                                 {
+                                                   FStar_Parser_AST.tm =
+                                                     uu___9;
+                                                   FStar_Parser_AST.range =
+                                                     (payload_typ.FStar_Parser_AST.range);
+                                                   FStar_Parser_AST.level =
+                                                     FStar_Parser_AST.Type_level
+                                                 } in
+                                               FStar_Parser_AST.VpArbitrary
+                                                 uu___8 in
+                                         FStar_Pervasives_Native.Some uu___7 in
+                                       (cid, uu___6, attrs) in
+                                     (uu___4, uu___5)
+                                 | uu___4 ->
+                                     (FStar_Pervasives_Native.None,
+                                       (cid, payload, attrs))))
+                         (Obj.magic variants)) in
+                  FStar_Compiler_Effect.op_Bar_Greater uu___2
+                    FStar_Compiler_List.unzip in
+                (match uu___1 with
+                 | (additional_records, variants1) ->
+                     let concat_options =
+                       FStar_Compiler_List.filter_map (fun r -> r) in
+                     let uu___2 = concat_options additional_records in
+                     FStar_Compiler_List.op_At uu___2
+                       [FStar_Parser_AST.TyconVariant (id, bds, k, variants1)])
+            | tycon -> [tycon] in
+          let tcs1 =
+            FStar_Compiler_List.concatMap desugar_tycon_variant_record tcs in
           let tot =
             FStar_Parser_AST.mk_term
               (FStar_Parser_AST.Name FStar_Parser_Const.effect_Tot_lid) rng
@@ -6197,7 +6320,8 @@ let rec (desugar_tycon :
                   ((FStar_Parser_AST.TyconVariant
                       (id, parms, kopt,
                         [(constrName,
-                           (FStar_Pervasives_Native.Some constrTyp), false,
+                           (FStar_Pervasives_Native.Some
+                              (FStar_Parser_AST.VpArbitrary constrTyp)),
                            attrs)])), uu___2)))
             | uu___1 -> failwith "impossible" in
           let desugar_abstract_tc quals1 _env mutuals uu___ =
@@ -6269,7 +6393,7 @@ let rec (desugar_tycon :
                               (env3, uu___3))) (env1, []) bs in
             match uu___ with
             | (env2, bs1) -> (env2, (FStar_Compiler_List.rev bs1)) in
-          match tcs with
+          match tcs1 with
           | (FStar_Parser_AST.TyconAbstract (id, bs, kopt))::[] ->
               let kopt1 =
                 match kopt with
@@ -6453,7 +6577,7 @@ let rec (desugar_tycon :
                    let env1 = FStar_Syntax_DsEnv.push_sigelt env se in
                    (env1, [se]))
           | (FStar_Parser_AST.TyconRecord uu___)::[] ->
-              let trec = FStar_Compiler_List.hd tcs in
+              let trec = FStar_Compiler_List.hd tcs1 in
               let uu___1 = tycon_record_as_variant trec in
               (match uu___1 with
                | (t, fs) ->
@@ -6473,11 +6597,11 @@ let rec (desugar_tycon :
                 FStar_Compiler_List.map
                   (fun x ->
                      FStar_Compiler_Effect.op_Less_Bar
-                       (FStar_Syntax_DsEnv.qualify env) (tycon_id x)) tcs in
+                       (FStar_Syntax_DsEnv.qualify env) (tycon_id x)) tcs1 in
               let rec collect_tcs quals1 et tc =
                 let uu___2 = et in
                 match uu___2 with
-                | (env1, tcs1) ->
+                | (env1, tcs2) ->
                     (match tc with
                      | FStar_Parser_AST.TyconRecord uu___3 ->
                          let trec = tc in
@@ -6495,7 +6619,7 @@ let rec (desugar_tycon :
                                     (uu___8, fs) in
                                   FStar_Syntax_Syntax.RecordType uu___7 in
                                 uu___6 :: quals1 in
-                              collect_tcs uu___5 (env1, tcs1) t)
+                              collect_tcs uu___5 (env1, tcs2) t)
                      | FStar_Parser_AST.TyconVariant
                          (id, binders, kopt, constructors) ->
                          let uu___3 =
@@ -6507,7 +6631,7 @@ let rec (desugar_tycon :
                               (env2,
                                 ((FStar_Pervasives.Inl
                                     (se, constructors, tconstr, quals1)) ::
-                                tcs1)))
+                                tcs2)))
                      | FStar_Parser_AST.TyconAbbrev (id, binders, kopt, t) ->
                          let uu___3 =
                            desugar_abstract_tc quals1 env1 mutuals
@@ -6517,7 +6641,7 @@ let rec (desugar_tycon :
                           | (env2, uu___4, se, tconstr) ->
                               (env2,
                                 ((FStar_Pervasives.Inr
-                                    (se, binders, t, quals1)) :: tcs1)))
+                                    (se, binders, t, quals1)) :: tcs2)))
                      | uu___3 ->
                          FStar_Errors.raise_error
                            (FStar_Errors.Fatal_NonInductiveInMutuallyDefinedType,
@@ -6525,12 +6649,12 @@ let rec (desugar_tycon :
                            rng) in
               let uu___2 =
                 FStar_Compiler_List.fold_left (collect_tcs quals) (env, [])
-                  tcs in
+                  tcs1 in
               (match uu___2 with
-               | (env1, tcs1) ->
-                   let tcs2 = FStar_Compiler_List.rev tcs1 in
+               | (env1, tcs2) ->
+                   let tcs3 = FStar_Compiler_List.rev tcs2 in
                    let tps_sigelts =
-                     FStar_Compiler_Effect.op_Bar_Greater tcs2
+                     FStar_Compiler_Effect.op_Bar_Greater tcs3
                        (FStar_Compiler_List.collect
                           (fun uu___3 ->
                              match uu___3 with
@@ -6631,36 +6755,34 @@ let rec (desugar_tycon :
                                             (FStar_Compiler_List.map
                                                (fun uu___12 ->
                                                   match uu___12 with
-                                                  | (id, topt, of_notation,
-                                                     cons_attrs) ->
+                                                  | (id, payload, cons_attrs)
+                                                      ->
                                                       let t =
-                                                        if of_notation
-                                                        then
-                                                          match topt with
-                                                          | FStar_Pervasives_Native.Some
-                                                              t1 ->
-                                                              FStar_Parser_AST.mk_term
-                                                                (FStar_Parser_AST.Product
-                                                                   ([
-                                                                    FStar_Parser_AST.mk_binder
+                                                        match payload with
+                                                        | FStar_Pervasives_Native.Some
+                                                            (FStar_Parser_AST.VpArbitrary
+                                                            t1) -> t1
+                                                        | FStar_Pervasives_Native.Some
+                                                            (FStar_Parser_AST.VpOfNotation
+                                                            t1) ->
+                                                            FStar_Parser_AST.mk_term
+                                                              (FStar_Parser_AST.Product
+                                                                 ([FStar_Parser_AST.mk_binder
                                                                     (FStar_Parser_AST.NoName
                                                                     t1)
                                                                     t1.FStar_Parser_AST.range
                                                                     t1.FStar_Parser_AST.level
                                                                     FStar_Pervasives_Native.None],
-                                                                    tot_tconstr))
-                                                                t1.FStar_Parser_AST.range
-                                                                t1.FStar_Parser_AST.level
-                                                          | FStar_Pervasives_Native.None
-                                                              -> tconstr
-                                                        else
-                                                          (match topt with
-                                                           | FStar_Pervasives_Native.None
-                                                               ->
-                                                               failwith
-                                                                 "Impossible"
-                                                           | FStar_Pervasives_Native.Some
-                                                               t1 -> t1) in
+                                                                   tot_tconstr))
+                                                              t1.FStar_Parser_AST.range
+                                                              t1.FStar_Parser_AST.level
+                                                        | FStar_Pervasives_Native.Some
+                                                            (FStar_Parser_AST.VpRecord
+                                                            uu___13) ->
+                                                            failwith
+                                                              "Impossible: [VpRecord _] should have disappeared after [desugar_tycon_variant_record]"
+                                                        | FStar_Pervasives_Native.None
+                                                            -> tconstr in
                                                       let t1 =
                                                         let uu___13 =
                                                           close env_tps t in

--- a/src/parser/FStar.Parser.AST.fst
+++ b/src/parser/FStar.Parser.AST.fst
@@ -153,12 +153,23 @@ type knd = term
 type typ = term
 type expr = term
 
+type tycon_record = list (ident * aqual * attributes_ * term)
+
+(** The different kinds of payload a constructor can carry *)
+type constructor_payload
+  = (** constructor of arity 1 for a type of kind [Type] (e.g. [C of int]) *)
+    | VpOfNotation of typ
+    (** constructor of any arity & kind (e.g. [C:int->ind] or [C:'a->'b->ind 'c]) *)
+    | VpArbitrary of typ
+    (** constructor whose payload is a record (e.g. [C {a: int}] or [C {x: Type} -> ind x]) *)
+    | VpRecord of (tycon_record * opt_kind:option typ)
+
 (* TODO (KM) : it would be useful for the printer to have range information for those *)
 type tycon =
   | TyconAbstract of ident * list binder * option knd
   | TyconAbbrev   of ident * list binder * option knd * term
-  | TyconRecord   of ident * list binder * option knd * attributes_ * list (ident * aqual * attributes_ * term)
-  | TyconVariant  of ident * list binder * option knd * list (ident * option term * bool * attributes_) (* bool is whether it's using 'of' notation *)
+  | TyconRecord   of ident * list binder * option knd * attributes_ * tycon_record
+  | TyconVariant  of ident * list binder * option knd * list (ident * option constructor_payload * attributes_)
 
 type qualifier =
   | Private

--- a/src/parser/FStar.Parser.Dep.fst
+++ b/src/parser/FStar.Parser.Dep.fst
@@ -825,14 +825,21 @@ let collect_one
         | TyconRecord (_, binders, k, _, identterms) ->
             collect_binders binders;
             iter_opt k collect_term;
-            List.iter (fun (_, aq, attrs, t) ->
-                collect_aqual aq;
-                attrs |> List.iter collect_term;
-                collect_term t) identterms
+            collect_tycon_record identterms
         | TyconVariant (_, binders, k, identterms) ->
             collect_binders binders;
             iter_opt k collect_term;
-            List.iter (fun (_, t, _, _) -> iter_opt t collect_term) identterms
+            List.iter ( function
+                      | VpOfNotation t | VpArbitrary t -> collect_term t
+                      | VpRecord (record, t) -> collect_tycon_record record;
+                                               iter_opt t collect_term
+                      ) (List.filter_map Mktuple3?._2 identterms)
+
+      and collect_tycon_record r = 
+        List.iter (fun (_, aq, attrs, t) ->
+                collect_aqual aq;
+                attrs |> List.iter collect_term;
+                collect_term t) r
 
       and collect_effect_decl = function
         | DefineEffect (_, binders, t, decls) ->

--- a/src/parser/FStar.Parser.ToDocument.fst
+++ b/src/parser/FStar.Parser.ToDocument.fst
@@ -778,21 +778,18 @@ and p_typeDecl pre = function
     let comm, doc = p_typ_sep false false t in
     comm, p_typeDeclPrefix pre true lid bs typ_opt, doc, jump2
   | TyconRecord (lid, bs, typ_opt, attrs, record_field_decls) ->
-    let p_recordField (ps: bool) (lid, aq, attrs, t) =
-      let comm, field =
-        with_comment_sep (p_recordFieldDecl ps) (lid, aq, attrs, t)
-                         (extend_to_end_of_line t.range) in
-      let sep = if ps then semi else empty in
-      inline_comment_or_above comm field sep
-    in
-    let p_fields = p_attributes false attrs ^^ braces_with_nesting (
-        separate_map_last hardline p_recordField record_field_decls)
-    in
-    empty, p_typeDeclPrefix pre true lid bs typ_opt, p_fields, (fun d -> space ^^ d)
+      empty
+    , p_typeDeclPrefix pre true lid bs typ_opt
+    , p_attributes false attrs ^^ p_typeDeclRecord record_field_decls
+    , (fun d -> space ^^ d)
   | TyconVariant (lid, bs, typ_opt, ct_decls) ->
-    let p_constructorBranchAndComments (uid, t_opt, use_of, attrs) =
-        let range = extend_to_end_of_line (dflt (range_of_id uid) (map_opt t_opt (fun t -> t.range))) in
-        let comm, ctor = with_comment_sep p_constructorBranch (uid, t_opt, use_of, attrs) range in
+    let p_constructorBranchAndComments (uid, payload, attrs) =
+        let range = extend_to_end_of_line (
+          dflt (range_of_id uid) 
+               (bind_opt payload 
+                   (function | VpOfNotation t | VpArbitrary t -> Some t.range
+                             | VpRecord (record, _)           -> None))) in
+        let comm, ctor = with_comment_sep p_constructorBranch (uid, payload, attrs) range in
         inline_comment_or_above comm ctor empty
     in
     (* Beware of side effects with comments printing *)
@@ -800,6 +797,15 @@ and p_typeDecl pre = function
         separate_map hardline p_constructorBranchAndComments ct_decls
     in
     empty, p_typeDeclPrefix pre true lid bs typ_opt, datacon_doc, jump2
+and p_typeDeclRecord (fields: tycon_record): document =
+    let p_recordField (ps: bool) (lid, aq, attrs, t) =
+      let comm, field =
+        with_comment_sep (p_recordFieldDecl ps) (lid, aq, attrs, t)
+                         (extend_to_end_of_line t.range) in
+      let sep = if ps then semi else empty in
+      inline_comment_or_above comm field sep
+    in
+    separate_map_last hardline p_recordField fields |> braces_with_nesting
 
 and p_typeDeclPrefix kw eq lid bs typ_opt =
   let with_kw cont =
@@ -823,11 +829,15 @@ and p_typeDeclPrefix kw eq lid bs typ_opt =
 and p_recordFieldDecl ps (lid, aq, attrs, t) =
   group (optional p_aqual aq ^^ p_attributes false attrs ^^ p_lident lid ^^ colon ^^ p_typ ps false t)
 
-and p_constructorBranch (uid, t_opt, use_of, attrs) =
-  let sep = if use_of then str "of" else colon in
-  let uid_doc = group (bar ^^ space ^^ p_attributes false attrs ^^ p_uident uid) in
-  default_or_map uid_doc (fun t -> (group (uid_doc ^^ space ^^ sep ^^ space ^^ p_typ false false t))) t_opt
-
+and p_constructorBranch (uid, variant, attrs) =
+  let h isOf t = (if isOf then str "of" else colon) ^^ space ^^ p_typ false false t
+  in group (bar ^^ space ^^ p_attributes false attrs ^^ p_uident uid)
+  ^^ default_or_map empty
+        (fun payload -> space ^^ group
+           ( match payload with
+           | VpOfNotation t -> h true t | VpArbitrary t -> h false t
+           | VpRecord (r, t) -> p_typeDeclRecord r ^^ default_or_map empty (h false) t
+           )) variant
 and p_letlhs kw (pat, _) inner_let =
   (* TODO : this should be refined when head is an applicative pattern (function definition) *)
   let pat, ascr =

--- a/src/parser/parse.mly
+++ b/src/parser/parse.mly
@@ -288,14 +288,16 @@ tvarinsts:
   | TYP_APP_LESS tvs=separated_nonempty_list(COMMA, tvar) TYP_APP_GREATER
       { map (fun tv -> mk_binder (TVariable(tv)) (range_of_id tv) Kind None) tvs }
 
+%inline recordDefinition:
+  | LBRACE record_field_decls=right_flexible_nonempty_list(SEMICOLON, recordFieldDecl) RBRACE
+    { record_field_decls }
+
 typeDefinition:
   |   { (fun id binders kopt -> check_id id; TyconAbstract(id, binders, kopt)) }
   | EQUALS t=typ
       { (fun id binders kopt ->  check_id id; TyconAbbrev(id, binders, kopt, t)) }
   /* A documentation on the first branch creates a conflict with { x with a = ... }/{ a = ... } */
-  | EQUALS attrs_opt=ioption(binderAttributes) LBRACE
-      record_field_decls=right_flexible_nonempty_list(SEMICOLON, recordFieldDecl)
-   RBRACE
+  | EQUALS attrs_opt=ioption(binderAttributes) record_field_decls=recordDefinition
       { (fun id binders kopt -> check_id id; TyconRecord(id, binders, kopt, none_to_empty_list attrs_opt, record_field_decls)) }
   (* having the first BAR optional using left-flexible list creates a s/r on FSDOC since any decl can be preceded by a FSDOC *)
   | EQUALS ct_decls=list(constructorDecl)
@@ -308,9 +310,16 @@ recordFieldDecl:
         (lid, qual, attrs, t)
       }
 
+constructorPayload:
+  | COLON t=typ                                         {VpArbitrary  t}
+  |    OF t=typ                                         {VpOfNotation t}
+  | fields=recordDefinition opt=option(COLON t=typ {t}) {VpRecord(fields, opt)}
+
 constructorDecl:
-  | BAR attrs_opt=ioption(binderAttributes) uid=uident COLON t=typ                { (uid, Some t, false, none_to_empty_list attrs_opt) }
-  | BAR attrs_opt=ioption(binderAttributes) uid=uident t_opt=option(OF t=typ {t}) { (uid, t_opt, true, none_to_empty_list attrs_opt) }
+  | BAR attrs_opt=ioption(binderAttributes)
+        uid=uident
+        payload=option(constructorPayload)
+    { uid, payload, none_to_empty_list attrs_opt }
 
 attr_letbinding:
   | attr=ioption(attribute) AND lb=letbinding

--- a/src/syntax/FStar.Syntax.Resugar.fst
+++ b/src/syntax/FStar.Syntax.Resugar.fst
@@ -1247,7 +1247,7 @@ let resugar_typ env datacon_ses se : sigelts * A.tycon =
           let resugar_datacon constructors se = match se.sigel with
             | Sig_datacon (l, univs, term, _, num, _) ->
               (* Todo: resugar univs *)
-              let c = (ident_of_lid l, Some (resugar_term' env term), false, map (resugar_term' env) se.sigattrs)  in
+              let c = (ident_of_lid l, Some (VpArbitrary (resugar_term' env term)), map (resugar_term' env) se.sigattrs)  in
               c::constructors
             | _ -> failwith "unexpected"
           in


### PR DESCRIPTION
Hi,

This PR introduces the following syntax:
```fstar
type foo = | A
           | B { x: int; y: int }
           | C { z: int; t: int }: foo (* optional, useful for GADTs *)
```

This is desugared into:
```fstar
type foo = | A
           | B of foo__B__payload
           | C: foo__C__payload -> foo
and foo__B__payload = { x: int; y: int }
and foo__C__payload = { z: int; t: int }
```

This PR also adds the example file `examples/misc/VariantsWithRecords.fst`.

Note: since this record-on-constructors thing desugars into mutual inductives, things turn nasty quickly when universes are involved, and everything needs to be annotated by universes.