### PR TITLE
View patterns

### DIFF
--- a/examples/misc/ViewPatterns.fst
+++ b/examples/misc/ViewPatterns.fst
@@ -1,0 +1,42 @@
+module ViewPatterns
+
+(*** Matching over terms *)
+open FStar.Tactics
+
+/// Sadly, seems like [term] to [term_view] automatic coercion kicks
+/// wrongly in pattern views, for now I just wrap terms into [t] to
+/// disable the coercion (since there's no subtyping on inductives)
+type t 'a = | T of 'a
+let inspect_ln': term -> t term_view = fun x -> T (inspect_ln x)
+
+/// Small helper
+let string_of_fv (f: fv): string = implode_qn (inspect_fv f)
+
+/// [extract_foo_int_payload] expects a term [foo n] with [n] a
+/// constant integer, and returns that [n]
+let foo (x: int) = x
+let extract_foo_int_payload t 
+  = match inspect_ln t with
+  | Tv_App ((T (Tv_FVar (`%foo <- string_of_fv))) <- inspect_ln')
+           ((T (Tv_Const (C_Int n))) <- inspect_ln', _)
+      -> Some n
+  | _ -> None
+
+/// Works as expected
+let _ = assert_norm (extract_foo_int_payload (`(foo 123)) == Some 123)
+
+
+(*** matching integers, modulo *)
+let mod6 (n:int) = n % 4
+let plus1 (n:int) = match n with
+                | 5 <- mod6 -> 0
+                | n <- mod6 -> n + 1
+
+let _ = assert_norm (plus1 12 == 1)
+
+(*** [as] patterns *)
+open FStar.List.Tot
+let y = match [[1;2];[3]] with
+  | ((1::_) as hello) :: _ -> 0::hello
+  | ((2::_) as hello) :: _ -> 1::hello
+  | _ -> []

--- a/src/parser/FStar.Parser.AST.fst
+++ b/src/parser/FStar.Parser.AST.fst
@@ -132,6 +132,7 @@ and pattern' =
   | PatAscribed of pattern * (term * option term)
   | PatOr       of list pattern
   | PatOp       of ident
+  | PatView     of pattern * term
   | PatVQuote   of term (* [`%foo], transformed into "X.Y.Z.foo" by the desugarer *)
 and pattern = {pat:pattern'; prange:range}
 
@@ -895,6 +896,7 @@ and pat_to_string x = match x.pat with
   | PatOp op ->  Util.format1 "(%s)" (Ident.string_of_id op)
   | PatAscribed(p,(t, None)) -> Util.format2 "(%s:%s)" (p |> pat_to_string) (t |> term_to_string)
   | PatAscribed(p,(t, Some tac)) -> Util.format3 "(%s:%s by %s)" (p |> pat_to_string) (t |> term_to_string) (tac |> term_to_string)
+  | PatView (subpat, view) -> Util.format2 "(%s <@ %s)" (pat_to_string subpat) (term_to_string view)
 
 and attrs_opt_to_string = function
   | None -> ""

--- a/src/parser/FStar.Parser.Dep.fst
+++ b/src/parser/FStar.Parser.Dep.fst
@@ -1114,6 +1114,9 @@ let collect_one
             collect_pattern p;
             collect_term t;
             collect_term tac
+        | PatView (subpat, view) ->
+            collect_term view;
+            collect_pattern subpat
 
 
       and collect_branches bs =

--- a/src/parser/FStar.Parser.ToDocument.fst
+++ b/src/parser/FStar.Parser.ToDocument.fst
@@ -1042,6 +1042,7 @@ and p_atomicPattern p = match p.pat with
   | PatApp ({pat = PatName _}, _)
   | PatTuple (_, false) ->
       soft_parens_with_nesting (p_tuplePattern p)
+  | PatView (subpat, view) -> group (p_atomicPattern subpat ^^ space ^^ str "<@" ^^ space ^^ p_term false false view)
   | _ -> failwith (Util.format1 "Invalid pattern %s" (pat_to_string p))
 
 (* Skipping patternOrMultibinder since it would need retro-engineering the flattening of binders *)

--- a/src/parser/parse.mly
+++ b/src/parser/parse.mly
@@ -516,7 +516,44 @@ constructorPattern:
       { pat }
 
 atomicPattern:
-  | pat=atomicPattern SUBKIND t=atomicTerm { mk_pattern (PatView (pat, t)) (rhs2 parseState 1 3) }
+  | pat=atomicPattern IF LPAREN t=term RPAREN {
+      let r = rhs2 parseState 1 3 in
+      let mk_pair_abs =
+        let r = rhs parseState 3 in
+        let var = id_of_text "x" in
+        let var_pat = mk_pattern (PatVar (var, None, [])) r in
+        let none = mk_term (Name none_lid) r Expr in
+        let some = mk_term (Name some_lid) r Expr in
+        let var_term = mk_term (Var (lid_of_ns_and_id [] var)) r Expr in
+        let some_var = mk_term (App(some, var_term, Nothing)) r Expr in
+        let branches = [
+            pat, None, mk_term (If(t, None, None, some_var, none)) r Expr
+          ] in
+        let body = mk_term (Match(var_term, None, None, branches)) r Expr in
+        mk_term (Abs ([var_pat], body)) r Expr
+      in
+      let some_pat = mk_pattern (PatApp (mk_pattern (PatName some_lid) r, [pat])) r in
+      let pat = mk_pattern (PatView (some_pat, mk_pair_abs)) r in
+      print_endline ("PAT IS NOW: " ^ pat_to_string pat);
+      pat
+    }
+  | pat=atomicPattern AS n=lident {
+      let r = rhs2 parseState 1 3 in
+      let mk_pair_abs =
+        let r = rhs parseState 3 in
+        let mk_tuple_2 = mk_term (Name (mk_tuple_data_lid (Z.of_int 2) r)) r Expr in
+        let var = id_of_text "x" in
+        let var_pat = mk_pattern (PatVar (var, None, [])) r in
+        let var_arg = mk_term (Var (lid_of_ns_and_id [] var)) r Expr, Nothing in
+        let tup_term = mkApp mk_tuple_2 [var_arg; var_arg] r in
+        mk_term (Abs ([var_pat], tup_term)) r Expr
+      in
+      let var_pat = mk_pattern (PatVar (n, None, [])) (rhs parseState 3) in
+      let tup_pat = mk_pattern (PatTuple ([pat; var_pat], false)) r in
+      let pat = mk_pattern (PatView (tup_pat, mk_pair_abs)) r in
+      pat
+    }
+  | pat=atomicPattern LARROW t=atomicTerm { mk_pattern (PatView (pat, t)) (rhs2 parseState 1 3) }
   | LPAREN pat=tuplePattern COLON t=simpleArrow phi_opt=refineOpt RPAREN
       {
         let pos_t = rhs2 parseState 2 4 in

--- a/src/parser/parse.mly
+++ b/src/parser/parse.mly
@@ -516,6 +516,7 @@ constructorPattern:
       { pat }
 
 atomicPattern:
+  | pat=atomicPattern SUBKIND t=atomicTerm { mk_pattern (PatView (pat, t)) (rhs2 parseState 1 3) }
   | LPAREN pat=tuplePattern COLON t=simpleArrow phi_opt=refineOpt RPAREN
       {
         let pos_t = rhs2 parseState 2 4 in

--- a/src/reflection/FStar.Reflection.Basic.fst
+++ b/src/reflection/FStar.Reflection.Basic.fst
@@ -270,6 +270,7 @@ let rec inspect_ln (t:term) : term_view =
             match p.v with
             | Pat_constant c -> Pat_Constant (inspect_const c)
             | Pat_cons (fv, us_opt, ps) -> Pat_Cons (fv, us_opt, List.map (fun (p, b) -> inspect_pat p, b) ps)
+            | Pat_view _ -> failwith "todo: reflection for pat view"
             | Pat_var bv -> Pat_Var bv
             | Pat_wild bv -> Pat_Wild bv
             | Pat_dot_term eopt -> Pat_Dot_Term eopt

--- a/src/syntax/FStar.Syntax.Hash.fst
+++ b/src/syntax/FStar.Syntax.Hash.fst
@@ -183,6 +183,7 @@ and hash_pat p =
   | Pat_var bv -> mix (of_int 101) (hash_bv bv)
   | Pat_wild bv -> mix (of_int 103) (hash_bv bv)
   | Pat_dot_term t -> mix_list_lit [of_int 107; hash_option hash_term t]
+  | Pat_view (sub, t) -> mix_list_lit [of_int 109; hash_pat sub; hash_term t]
 
 
 and hash_bv b = hash_term b.sort
@@ -530,6 +531,8 @@ and equal_pat p1 p2 =
     equal_bv bv1 bv2
   | Pat_dot_term t1, Pat_dot_term t2 ->
     equal_opt equal_term t1 t2
+  | Pat_view (subpat1, view1), Pat_view (subpat2, view2) ->
+    equal_pat subpat1 subpat2 && equal_term view1 view2
   | _ -> false
 
 and equal_meta m1 m2 =

--- a/src/syntax/FStar.Syntax.Print.fst
+++ b/src/syntax/FStar.Syntax.Print.fst
@@ -428,6 +428,8 @@ and pat_to_string x =
       if Options.print_bound_var_types()
       then U.format1 ".%s" (if topt = None then "_" else topt |> U.must |> term_to_string)
       else "._"
+    | Pat_view (pat, view) ->
+      U.format2 "%s <@ %s" (pat_to_string pat) (term_to_string view)
     | Pat_var x ->
       if Options.print_bound_var_types()
       then U.format2 "%s:%s" (bv_to_string x) (term_to_string x.sort)

--- a/src/syntax/FStar.Syntax.Resugar.fst
+++ b/src/syntax/FStar.Syntax.Resugar.fst
@@ -1084,6 +1084,11 @@ and resugar_pat' env (p:S.pat) (branch_bv: set bv) : A.pattern =
     match p.v with
     | Pat_constant c -> mk (A.PatConst c)
 
+    | Pat_view (subpat, view) -> 
+      let subpat = aux subpat imp_opt in
+      let view = resugar_term' env view in
+      mk (A.PatView (subpat, view))
+
     | Pat_cons (fv, _, []) ->
       mk (A.PatName fv.fv_name.v)
 

--- a/src/syntax/FStar.Syntax.Syntax.fst
+++ b/src/syntax/FStar.Syntax.Syntax.fst
@@ -215,7 +215,7 @@ let pat_bvs (p:pat) : list bv =
         | Pat_constant _ -> b
         | Pat_wild x
         | Pat_var x -> x::b
-        | Pat_cons(_, _, pats) -> List.fold_left (fun b (p, _) -> aux b p) b pats
+        | Pat_view (pat,_) -> aux b pat
     in
   List.rev <| aux [] p
 
@@ -270,6 +270,7 @@ let rec eq_pat (p1 : pat) (p2 : pat) : bool =
     | Pat_var _, Pat_var _ -> true
     | Pat_wild _, Pat_wild _ -> true
     | Pat_dot_term _, Pat_dot_term _ -> true
+    | Pat_view _, Pat_view _ -> true
     | _, _ -> false
 
 ///////////////////////////////////////////////////////////////////////

--- a/src/syntax/FStar.Syntax.Syntax.fst
+++ b/src/syntax/FStar.Syntax.Syntax.fst
@@ -215,6 +215,7 @@ let pat_bvs (p:pat) : list bv =
         | Pat_constant _ -> b
         | Pat_wild x
         | Pat_var x -> x::b
+        | Pat_cons (*TODO*)(_, _, pats) -> List.fold_left (fun b (p, _) -> aux b p) b pats
         | Pat_view (pat,_) -> aux b pat
     in
   List.rev <| aux [] p

--- a/src/syntax/FStar.Syntax.Syntax.fsti
+++ b/src/syntax/FStar.Syntax.Syntax.fsti
@@ -171,6 +171,8 @@ and pat' =
   | Pat_wild     of bv                                           (* need stable names for even the wild patterns *)
   | Pat_dot_term of option term                                  (* dot patterns: determined by other elements in the pattern *)
                                                                  (* the option term is the optionally resolved pat dot term *)
+  | Pat_view     of pat * term
+
 and letbinding = {  //let f : forall u1..un. M t = e
     lbname :lbname;          //f
     lbunivs:list univ_name; //u1..un

--- a/src/tactics/FStar.Tactics.Basic.fst
+++ b/src/tactics/FStar.Tactics.Basic.fst
@@ -2016,6 +2016,7 @@ let rec inspect (t:term) : tac term_view = wrap_err "inspect" (
             match p.v with
             | Pat_constant c -> Pat_Constant (inspect_const c)
             | Pat_cons (fv, us_opt, ps) -> Pat_Cons (fv, us_opt, List.map (fun (p, b) -> inspect_pat p, b) ps)
+            | Pat_view _ -> failwith "TODO tactic view"
             | Pat_var bv -> Pat_Var bv
             | Pat_wild bv -> Pat_Wild bv
             | Pat_dot_term eopt -> Pat_Dot_Term eopt

--- a/src/tosyntax/FStar.ToSyntax.ToSyntax.fst
+++ b/src/tosyntax/FStar.ToSyntax.ToSyntax.fst
@@ -711,8 +711,8 @@ let check_linear_pattern_variables pats r =
     | Pat_wild _
     | Pat_constant _ -> S.no_names
     | Pat_var x -> BU.set_add x S.no_names
-    | Pat_cons(_, _, pats) ->
     | Pat_view (pat, _) -> pat_vars pat
+    | Pat_cons (_, _, pats) ->
       let aux out (p, _) =
           let p_vars = pat_vars p in
           let intersection = BU.set_intersect p_vars out in
@@ -1084,6 +1084,14 @@ and desugar_machine_integer env repr (signedness, width) range =
   let app = S.mk (Tm_app (lid, [repr', S.as_aqual_implicit false])) range in
   S.mk (Tm_meta (app, Meta_desugared
                  (Machine_integer (signedness, width)))) range
+
+// and desugar_view_patterns
+//   (env:env_t)
+//   (scrut: term)
+//   (ret_annot: option match_returns_annotation)
+//   (branches: list branch)
+//   : term * option match_returns_annotation * list branch
+//   = 
 
 and desugar_term_maybe_top (top_level:bool) (env:env_t) (top:term) : S.term * antiquotations =
   let mk e = S.mk e top.range in

--- a/src/typechecker/FStar.TypeChecker.NBE.fst
+++ b/src/typechecker/FStar.TypeChecker.NBE.fst
@@ -232,6 +232,8 @@ let pickBranch (cfg:config) (scrut : t) (branches : list branch) : option (term 
             in
             if matches_const scrutinee s then Inl [] else Inr false
 
+        | Pat_view _ -> failwith "TODO: pat view nbe"
+
         | Pat_cons(fv, _us_opt, arg_pats) ->
             let rec matches_args out (a:list (t * aqual)) (p:list (pat * bool))
                 : either (list t) bool =
@@ -556,6 +558,7 @@ let rec translate (cfg:config) (bs:list t) (e:term) : t =
           let (bs, p_new) =
             match p.v with
             | Pat_constant c -> (bs, Pat_constant c)
+            | Pat_view _ -> failwith "TODO: NBE pat view"
             | Pat_cons (fvar, us_opt, args) ->
               let (bs', args') =
                   List.fold_left (fun (bs, args) (arg, b) ->

--- a/src/typechecker/FStar.TypeChecker.Normalize.fst
+++ b/src/typechecker/FStar.TypeChecker.Normalize.fst
@@ -2909,22 +2909,44 @@ and rebuild (cfg:cfg) (env:env) (stack:stack) (t:term) : term =
               
               print1 ">> applied_view: %s" (Print.term_to_string applied_view);
               let applied_view =
-                if cfg.steps.iota
-                && (not cfg.steps.weak)
-                && (not cfg.steps.compress_uvars)
-                && cfg.steps.weakly_reduce_scrutinee
-                && maybe_weakly_reduced applied_view
-                then norm ({cfg with steps={cfg.steps //@ [UnfoldUntil (Delta_equational_at_level 4)]
-                                                      with weakly_reduce_scrutinee=false; unfold_until = Some (Delta_equational_at_level 4)
-                                                      }
-                                                      })
+                if //cfg.steps.iota
+                // && (not cfg.steps.weak)
+                // && (not cfg.steps.compress_uvars)
+                // && cfg.steps.weakly_reduce_scrutinee
+                // && maybe_weakly_reduced applied_view
+                true
+                then norm
+                          // (config' [] [Primops; Iota; Zeta] env)
+                          ({cfg with steps=
+                                     { cfg.steps //@ [UnfoldUntil (Delta_equational_at_level 4)]
+                                       with weakly_reduce_scrutinee=false; 
+                                            unfold_until = None;
+                                            zeta = true;
+                                            zeta_full = true;
+                                            weak = false;
+                                            beta = true;
+                                            primops = true;
+                                            no_full_norm = false;
+                                     }
+                           })
                           env
                           []
                           applied_view
                 else applied_view
               in
-              print1 ">> applied_view(normalzied): %s" (Print.term_to_string applied_view);
-              matches_pat applied_view x
+              // primops; iota; delta; zeta
+              // let applied_view = norm {(config' [] [Primops; Iota; Zeta] env) with delta_level = InliningDelta} env applied_view in
+              print1 "¶¶¶ applied_view(normalzied): %s" (Print.term_to_string applied_view);
+              // let view = norm_or_whnf env applied_view in
+              print2 ">> Does expr [%s] matches pat [%s]?" (Print.term_to_string scrutinee) (Print.pat_to_string p);
+              print2 "    (in other words, does [%s] matches [%s])" (Print.term_to_string applied_view) (Print.pat_to_string x);
+              let result: either (list (bv * term)) bool = matches_pat applied_view x in
+              print1 "%s" ( match result with
+              | Inl l -> "Matches with [" ^ String.concat "; " (List.map (fun (bv, t) -> Print.bv_to_string bv ^ "→" ^ Print.term_to_string t) l) ^ "]"
+              | Inr false -> "Pattern doesn't match scrutinee"
+              | Inr true -> "Pattern may match but we don't know"
+              );
+              result
               
             | Pat_cons(fv, _, arg_pats) -> begin
               match (U.un_uinst head).n with

--- a/src/typechecker/FStar.TypeChecker.PatternUtils.fst
+++ b/src/typechecker/FStar.TypeChecker.PatternUtils.fst
@@ -144,6 +144,8 @@ let raw_pat_as_exp (env:Env.env) (p:pat)
         | Pat_var x ->
           mk (Tm_name x) p.p, x::bs
 
+        | Pat_view _ -> raise Raw_pat_cannot_be_translated
+
         | Pat_cons(fv, us_opt, pats) ->
           let args, bs = 
             List.fold_right
@@ -229,6 +231,10 @@ let pat_as_exp (introduce_bv_uvars:bool)
              let x, g, env = intro_bv env x in
              let e = mk (Tm_name x) p.p in
              ([x], [x], [], env, e, g, p)
+
+           | Pat_view (x, view) ->
+             let (b, a, w, env, te, guard, x) = pat_as_arg_with_env env x in
+             (b, a, w, env, te, guard, {p with v = Pat_view (x, view)})
 
            | Pat_cons(fv, us_opt, pats) -> 
              let (b, a, w, env, args, guard, pats) =

--- a/src/typechecker/FStar.TypeChecker.TcTerm.fst
+++ b/src/typechecker/FStar.TypeChecker.TcTerm.fst
@@ -3160,6 +3160,25 @@ and tc_pat env (pat_t:typ) (p0:pat) :
           Env.trivial_guard,
           false
 
+        | Pat_view (subpat, view) ->
+          let fake_scrutinee = 
+            mk_Tm_app
+              (S.fvar Const.magic_lid (S.Delta_constant_at_level 1) None)
+              [S.iarg t; S.as_arg S.unit_const]
+              Range.dummyRange
+          in
+          let applied_view = mk (Tm_app (view, [fake_scrutinee, None])) Range.dummyRange in
+          let applied_view_tc, {res_typ = t_target}, g = tc_tot_or_gtot_term (fst (clear_expected_typ env)) applied_view in
+          print1 ">> applied_view_tc=%s" (PP.term_to_string applied_view_tc);
+          print1 ">> applied_view_tc.type=%s" (PP.term_to_string t_target);
+          let bvs, tms, e, p, g', erasable = check_nested_pattern env subpat t_target in
+          let tms = tms |> List.map (mk_disc_t view) in
+          let g = Env.conj_guard g g' in
+          let _, e_subpat, _, _ = PatternUtils.pat_as_exp false false env subpat in
+          let e = mk (Tm_app (view, [e_subpat, None])) Range.dummyRange in
+          let p = {p with v = Pat_view (p, view)} in
+          (bvs, tms, e, p, g, erasable)
+
         | Pat_constant c ->
           (*
            * AR: enforcing decidable equality, since the branch guards are in boolean now
@@ -3532,6 +3551,13 @@ and tc_eqn scrutinee env ret_opt branch
                 env.typeof_tot_or_gtot_term env pat_exp true
               in
               [U.mk_decidable_eq t (force_scrutinee ()) pat_exp]
+
+            | Pat_view (subpat, view), _ -> 
+                let _, subpat_exp, _, _ = PatternUtils.pat_as_exp false false env subpat in
+                build_branch_guard
+                  (map_opt scrutinee_tm (fun s -> mk (Tm_app (view, [s, None])) Range.dummyRange))
+                  subpat
+                  subpat_exp
 
             | Pat_cons (_, _, []), Tm_uinst _
             | Pat_cons (_, _, []), Tm_fvar _ ->

--- a/src/typechecker/FStar.TypeChecker.TcTerm.fst
+++ b/src/typechecker/FStar.TypeChecker.TcTerm.fst
@@ -3167,13 +3167,23 @@ and tc_pat env (pat_t:typ) (p0:pat) :
               [S.iarg t; S.as_arg S.unit_const]
               Range.dummyRange
           in
+          // print1 "»» e_subpat=%s" (PP.term_to_string e_subpat);
+          let view, _, g0 = tc_tot_or_gtot_term (fst (clear_expected_typ env)) view in
           let applied_view = mk (Tm_app (view, [fake_scrutinee, None])) Range.dummyRange in
-          let applied_view_tc, {res_typ = t_target}, g = tc_tot_or_gtot_term (fst (clear_expected_typ env)) applied_view in
-          print1 ">> applied_view_tc=%s" (PP.term_to_string applied_view_tc);
-          print1 ">> applied_view_tc.type=%s" (PP.term_to_string t_target);
-          let bvs, tms, e, p, g', erasable = check_nested_pattern env subpat t_target in
+          print1 "»» applied_view=%s" (PP.term_to_string applied_view);
+          let applied_view_tc, {res_typ = t_target}, g1 = tc_tot_or_gtot_term (fst (clear_expected_typ env)) applied_view in
+          print1 "»» applied_view_tc=%s" (PP.term_to_string applied_view_tc);
+          print1 "»» applied_view_tc.type=%s" (PP.term_to_string t_target);
+          let bvs, tms, e, p, g2, erasable = check_nested_pattern env subpat t_target in
           let tms = tms |> List.map (mk_disc_t view) in
-          let g = Env.conj_guard g g' in
+          let g = g0 `Env.conj_guard` g1 `Env.conj_guard` g2 in
+          print1 "»» DONE %s" "!!";
+          print1 "::::::: bvs=%s" (List.map PP.bv_to_string bvs |> String.concat ";");
+          print1 "::::::: tms=%s" (List.map PP.term_to_string tms |> String.concat ";");
+          print1 "::::::: e=%s" (PP.term_to_string e);
+          print1 "::::::: p=%s" (PP.pat_to_string p);
+          print1 "::::::: g=%s" (guard_to_string env g);
+          print1 "::::::: erasbale=%s" (string_of_bool erasable);
           let _, e_subpat, _, _ = PatternUtils.pat_as_exp false false env subpat in
           let e = mk (Tm_app (view, [e_subpat, None])) Range.dummyRange in
           let p = {p with v = Pat_view (p, view)} in

--- a/src/typechecker/FStar.TypeChecker.Util.fst
+++ b/src/typechecker/FStar.TypeChecker.Util.fst
@@ -437,6 +437,10 @@ let extract_let_rec_annotation env {lbname=lbname; lbunivs=univ_vars; lbtyp=t; l
     | Pat_var x  ->
         [x], mk (Tm_name x)
 
+    | Pat_view (x, view) ->
+        let bvs, x = decorated_pattern_as_term x in
+        bvs, mk (Tm_app(view, [x, None]))
+
     | Pat_cons(fv, us_opt, pats) ->
         let vars, args = pats |> List.map pat_as_arg |> List.unzip in
         let vars = List.flatten vars in


### PR DESCRIPTION
Hi,

Chatting with @theolaurent a while back, he had a nice idea: implementing view patterns in F*.

It's a pretty nice feature, that could especially be useful for meta-programming (so that we can pattern-match deeply a term via term_views). But it also gives us for free:
 1. as-patterns (i.e. `x@hd::tl` in Haskell or `hd::tl as x`), and
 2.  `if`/`when` clauses (since F* `when` clauses are basically disabled)

This PR is still quite draft, I just wrote it quickly during this week-end, some part are really ugly. The SMT encoding I wrote for those view patterns is fairly broken (in interactive mode it yields errors, but retrying a code block make it pass). 
There's a lot of room for improvement, but I wanted to get some feedback anyway, before spending more time on it.

Example of pattern matching deeply in terms:
```fstar
// this code is a bit of a lie, there are some issues with term/term_view coercions currently
let string_of_fv (f: fv): string = implode_qn (inspect_fv f)
let foo (x: int) = x
let extract_foo_int_payload t 
  = match inspect_ln t with
  | Tv_App ((Tv_FVar (`%foo <- string_of_fv)) <- inspect_ln')
           ((Tv_Const (C_Int n))) <- inspect_ln', _) -> Some n
  | _ -> None
```

Example of as-patterns:
```fstar
let y = match [[1;2];[3]] with
  | ((1::_) as hello) :: _ -> 0::hello
  | ((2::_) as hello) :: _ -> 1::hello
  | _ -> []
```

Example of `if` clauses (this is a bit silly to have both `when` and `if`, it's just for demo purposes):
```fstar
let y = match [[1;2];[3]] with
  | ((1::_) as hello) :: _ -> 0::hello
  | ((2::_) as hello) :: _ -> 1::hello
  | _ -> []
```

There are more examples in `examples/misc/ViewPatterns.fst`.

What do you think about adding that to F*?
