### PR TITLE
Changing the SteelCore semantics and the Steel libraries to use tokens for invariants

### DIFF
--- a/.docker/build/config.json
+++ b/.docker/build/config.json
@@ -31,6 +31,6 @@
     "TrackPerformance" : false,
 
     "RepoVersions" : {
-        "karamel_version" : "origin/nik_steel_witnessed"
+        "karamel_version" : "origin/master"
     }
 }

--- a/.docker/build/config.json
+++ b/.docker/build/config.json
@@ -31,6 +31,6 @@
     "TrackPerformance" : false,
 
     "RepoVersions" : {
-        "karamel_version" : "origin/master"
+        "karamel_version" : "origin/nik_steel_witnessed"
     }
 }

--- a/src/ocaml-output/FStar_Extraction_ML_Term.ml
+++ b/src/ocaml-output/FStar_Extraction_ML_Term.ml
@@ -324,6 +324,67 @@ let (is_type :
                FStar_Compiler_Util.print2 "not a type %s (%s)\n" uu___4
                  uu___5));
        b)
+let (is_steel_with_invariant_g : FStar_Syntax_Syntax.term -> Prims.bool) =
+  fun t ->
+    let uu___ = FStar_Syntax_Util.head_and_args t in
+    match uu___ with
+    | (head, args) ->
+        let uu___1 =
+          let uu___2 =
+            let uu___3 = FStar_Syntax_Util.un_uinst head in
+            uu___3.FStar_Syntax_Syntax.n in
+          (uu___2, args) in
+        (match uu___1 with
+         | (FStar_Syntax_Syntax.Tm_fvar fv,
+            _a::_fp::_fp'::_o::_p::_i::_body::[]) ->
+             (FStar_Syntax_Syntax.fv_eq_lid fv
+                FStar_Parser_Const.steel_with_invariant_g_lid)
+               ||
+               (FStar_Syntax_Syntax.fv_eq_lid fv
+                  FStar_Parser_Const.steel_st_with_invariant_g_lid)
+         | uu___2 -> false)
+let (is_steel_with_invariant :
+  FStar_Syntax_Syntax.term ->
+    FStar_Syntax_Syntax.term FStar_Pervasives_Native.option)
+  =
+  fun t ->
+    let uu___ = FStar_Syntax_Util.head_and_args t in
+    match uu___ with
+    | (head, args) ->
+        let uu___1 =
+          let uu___2 =
+            let uu___3 = FStar_Syntax_Util.un_uinst head in
+            uu___3.FStar_Syntax_Syntax.n in
+          (uu___2, args) in
+        (match uu___1 with
+         | (FStar_Syntax_Syntax.Tm_fvar fv,
+            _a::_fp::_fp'::_o::_obs::_p::_i::body::[]) when
+             (FStar_Syntax_Syntax.fv_eq_lid fv
+                FStar_Parser_Const.steel_with_invariant_lid)
+               ||
+               (FStar_Syntax_Syntax.fv_eq_lid fv
+                  FStar_Parser_Const.steel_st_with_invariant_lid)
+             ->
+             FStar_Pervasives_Native.Some (FStar_Pervasives_Native.fst body)
+         | uu___2 -> FStar_Pervasives_Native.None)
+let (is_steel_new_invariant : FStar_Syntax_Syntax.term -> Prims.bool) =
+  fun t ->
+    let uu___ = FStar_Syntax_Util.head_and_args t in
+    match uu___ with
+    | (head, args) ->
+        let uu___1 =
+          let uu___2 =
+            let uu___3 = FStar_Syntax_Util.un_uinst head in
+            uu___3.FStar_Syntax_Syntax.n in
+          (uu___2, args) in
+        (match uu___1 with
+         | (FStar_Syntax_Syntax.Tm_fvar fv, _o::_p::[]) ->
+             (FStar_Syntax_Syntax.fv_eq_lid fv
+                FStar_Parser_Const.steel_new_invariant_lid)
+               ||
+               (FStar_Syntax_Syntax.fv_eq_lid fv
+                  FStar_Parser_Const.steel_st_new_invariant_lid)
+         | uu___2 -> false)
 let (is_type_binder :
   FStar_Extraction_ML_UEnv.uenv -> FStar_Syntax_Syntax.binder -> Prims.bool)
   =
@@ -1063,18 +1124,25 @@ let rec (translate_term_to_mlty :
         | FStar_Syntax_Syntax.Tm_app (head, args) ->
             let res =
               let uu___ =
-                let uu___1 = FStar_Syntax_Util.un_uinst head in
-                uu___1.FStar_Syntax_Syntax.n in
+                let uu___1 =
+                  let uu___2 = FStar_Syntax_Util.un_uinst head in
+                  uu___2.FStar_Syntax_Syntax.n in
+                (uu___1, args) in
               match uu___ with
-              | FStar_Syntax_Syntax.Tm_name bv -> bv_as_mlty env bv
-              | FStar_Syntax_Syntax.Tm_fvar fv -> fv_app_as_mlty env fv args
-              | FStar_Syntax_Syntax.Tm_app (head1, args') ->
-                  let uu___1 =
+              | (FStar_Syntax_Syntax.Tm_name bv, uu___1) -> bv_as_mlty env bv
+              | (FStar_Syntax_Syntax.Tm_fvar fv, uu___1::[]) when
+                  FStar_Syntax_Syntax.fv_eq_lid fv
+                    FStar_Parser_Const.steel_memory_inv_lid
+                  -> translate_term_to_mlty env FStar_Syntax_Syntax.t_unit
+              | (FStar_Syntax_Syntax.Tm_fvar fv, uu___1) ->
+                  fv_app_as_mlty env fv args
+              | (FStar_Syntax_Syntax.Tm_app (head1, args'), uu___1) ->
+                  let uu___2 =
                     FStar_Syntax_Syntax.mk
                       (FStar_Syntax_Syntax.Tm_app
                          (head1, (FStar_Compiler_List.op_At args' args)))
                       t1.FStar_Syntax_Syntax.pos in
-                  translate_term_to_mlty env uu___1
+                  translate_term_to_mlty env uu___2
               | uu___1 -> FStar_Extraction_ML_Syntax.MLTY_Top in
             res
         | FStar_Syntax_Syntax.Tm_abs (bs, ty, uu___) ->
@@ -2888,6 +2956,29 @@ and (term_as_mlexpr' :
                        FStar_Extraction_ML_Syntax.ml_int_ty) uu___10 in
                 (uu___9, FStar_Extraction_ML_Syntax.E_PURE,
                   FStar_Extraction_ML_Syntax.ml_int_ty))
+       | FStar_Syntax_Syntax.Tm_app uu___1 when is_steel_with_invariant_g t
+           ->
+           (FStar_Extraction_ML_Syntax.ml_unit,
+             FStar_Extraction_ML_Syntax.E_PURE,
+             FStar_Extraction_ML_Syntax.MLTY_Erased)
+       | FStar_Syntax_Syntax.Tm_app uu___1 when
+           let uu___2 = is_steel_with_invariant t in
+           FStar_Pervasives_Native.uu___is_Some uu___2 ->
+           let body =
+             let uu___2 = is_steel_with_invariant t in
+             FStar_Pervasives_Native.__proj__Some__item__v uu___2 in
+           let tm =
+             let uu___2 =
+               let uu___3 =
+                 FStar_Syntax_Syntax.as_arg FStar_Syntax_Syntax.unit_const in
+               [uu___3] in
+             FStar_Syntax_Syntax.mk_Tm_app body uu___2
+               body.FStar_Syntax_Syntax.pos in
+           term_as_mlexpr g tm
+       | FStar_Syntax_Syntax.Tm_app uu___1 when is_steel_new_invariant t ->
+           (FStar_Extraction_ML_Syntax.ml_unit,
+             FStar_Extraction_ML_Syntax.E_PURE,
+             FStar_Extraction_ML_Syntax.ml_unit_ty)
        | FStar_Syntax_Syntax.Tm_app (head, args) when
            (is_match head) &&
              (FStar_Compiler_Effect.op_Bar_Greater args

--- a/src/ocaml-output/FStar_Parser_Const.ml
+++ b/src/ocaml-output/FStar_Parser_Const.ml
@@ -570,3 +570,24 @@ let (layered_effect_reify_val_lid :
         FStar_String.op_Hat "reify___" uu___ in
       let uu___ = FStar_Ident.mk_ident (reify_fn_name, r) in
       FStar_Ident.lid_of_ns_and_id ns uu___
+let (steel_memory_inv_lid : FStar_Ident.lident) =
+  FStar_Ident.lid_of_path ["Steel"; "Memory"; "inv"]
+    FStar_Compiler_Range.dummyRange
+let (steel_new_invariant_lid : FStar_Ident.lident) =
+  FStar_Ident.lid_of_path ["Steel"; "Effect"; "Atomic"; "new_invariant"]
+    FStar_Compiler_Range.dummyRange
+let (steel_st_new_invariant_lid : FStar_Ident.lident) =
+  FStar_Ident.lid_of_path ["Steel"; "ST"; "Util"; "new_invariant"]
+    FStar_Compiler_Range.dummyRange
+let (steel_with_invariant_g_lid : FStar_Ident.lident) =
+  FStar_Ident.lid_of_path ["Steel"; "Effect"; "Atomic"; "with_invariant_g"]
+    FStar_Compiler_Range.dummyRange
+let (steel_st_with_invariant_g_lid : FStar_Ident.lident) =
+  FStar_Ident.lid_of_path ["Steel"; "ST"; "Util"; "with_invariant_g"]
+    FStar_Compiler_Range.dummyRange
+let (steel_with_invariant_lid : FStar_Ident.lident) =
+  FStar_Ident.lid_of_path ["Steel"; "Effect"; "Atomic"; "with_invariant"]
+    FStar_Compiler_Range.dummyRange
+let (steel_st_with_invariant_lid : FStar_Ident.lident) =
+  FStar_Ident.lid_of_path ["Steel"; "ST"; "Util"; "with_invariant"]
+    FStar_Compiler_Range.dummyRange

--- a/src/parser/FStar.Parser.Const.fst
+++ b/src/parser/FStar.Parser.Const.fst
@@ -530,3 +530,17 @@ let layered_effect_reify_val_lid (eff_name:lident) (r:range) : lident =
   let ns = Ident.ns_of_lid eff_name in
   let reify_fn_name = "reify___" ^ (eff_name |> ident_of_lid |> string_of_id) in
   lid_of_ns_and_id ns (mk_ident (reify_fn_name, r))
+
+
+let steel_memory_inv_lid = FStar.Ident.lid_of_path ["Steel"; "Memory"; "inv"] FStar.Compiler.Range.dummyRange
+
+let steel_new_invariant_lid = FStar.Ident.lid_of_path ["Steel"; "Effect"; "Atomic"; "new_invariant"] FStar.Compiler.Range.dummyRange
+let steel_st_new_invariant_lid = FStar.Ident.lid_of_path ["Steel"; "ST"; "Util"; "new_invariant"] FStar.Compiler.Range.dummyRange
+
+let steel_with_invariant_g_lid = FStar.Ident.lid_of_path ["Steel"; "Effect"; "Atomic"; "with_invariant_g"] FStar.Compiler.Range.dummyRange
+let steel_st_with_invariant_g_lid = FStar.Ident.lid_of_path ["Steel"; "ST"; "Util"; "with_invariant_g"] FStar.Compiler.Range.dummyRange
+
+let steel_with_invariant_lid = FStar.Ident.lid_of_path ["Steel"; "Effect"; "Atomic"; "with_invariant"] FStar.Compiler.Range.dummyRange
+let steel_st_with_invariant_lid = FStar.Ident.lid_of_path ["Steel"; "ST"; "Util"; "with_invariant"] FStar.Compiler.Range.dummyRange
+
+

--- a/ulib/experimental/FStar.MST.fst
+++ b/ulib/experimental/FStar.MST.fst
@@ -17,7 +17,7 @@
 module FStar.MST
 
 module P = FStar.Preorder
-
+module W = FStar.Witnessed.Core
 open FStar.Monotonic.Pure
 
 type pre_t (state:Type u#2) = state -> Type0
@@ -126,21 +126,21 @@ let put (#state:Type u#2) (#rel:P.preorder state) (s:state)
     =
   MSTATE?.reflect (fun _ -> (), s)
 
-type s_predicate (state:Type u#2) = state -> Type0
+assume
+val witness (state:Type u#2)
+            (rel:P.preorder state)
+            (p:W.s_predicate state)
+    : MSTATE (W.witnessed state rel p) state rel
+      (fun s0 -> p s0 /\ W.stable state rel p)
+      (fun s0 _ s1 -> s0 == s1)
 
-let stable (state:Type u#2) (rel:P.preorder state) (p:s_predicate state) =
-  forall s0 s1. (p s0 /\ rel s0 s1) ==> p s1
-
-assume val witnessed (state:Type u#2) (rel:P.preorder state) (p:s_predicate state) : prop
-
-assume val witness (state:Type u#2) (rel:P.preorder state) (p:s_predicate state)
+assume
+val recall (state:Type u#2)
+           (rel:P.preorder state)
+           (p:W.s_predicate state)
+           (w:W.witnessed state rel p)
     : MSTATE unit state rel
-      (fun s0 -> p s0 /\ stable state rel p)
-      (fun s0 _ s1 -> s0 == s1 /\ witnessed state rel p)
-
-assume val recall (state:Type u#2) (rel:P.preorder state) (p:s_predicate state)
-    : MSTATE unit state rel
-      (fun _ -> witnessed state rel p)
+      (fun _ -> True)
       (fun s0 _ s1 -> s0 == s1 /\ p s1)
 
 

--- a/ulib/experimental/FStar.MSTTotal.fst
+++ b/ulib/experimental/FStar.MSTTotal.fst
@@ -15,7 +15,7 @@
 *)
 
 module FStar.MSTTotal
-
+module W = FStar.Witnessed.Core
 module P = FStar.Preorder
 
 open FStar.Monotonic.Pure
@@ -127,21 +127,21 @@ let put (#state:Type u#2) (#rel:P.preorder state) (s:state)
     =
   MSTATETOT?.reflect (fun _ -> (), s)
 
-type s_predicate (state:Type u#2) = state -> Type0
+assume
+val witness (state:Type u#2)
+            (rel:P.preorder state)
+            (p:W.s_predicate state)
+    : MSTATETOT (W.witnessed state rel p) state rel
+      (fun s0 -> p s0 /\ W.stable state rel p)
+      (fun s0 _ s1 -> s0 == s1)
 
-let stable (state:Type u#2) (rel:P.preorder state) (p:s_predicate state) =
-  forall s0 s1. (p s0 /\ rel s0 s1) ==> p s1
-
-assume val witnessed (state:Type u#2) (rel:P.preorder state) (p:s_predicate state) : prop
-
-assume val witness (state:Type u#2) (rel:P.preorder state) (p:s_predicate state)
+assume
+val recall (state:Type u#2)
+           (rel:P.preorder state)
+           (p:W.s_predicate state)
+           (w:W.witnessed state rel p)
     : MSTATETOT unit state rel
-      (fun s0 -> p s0 /\ stable state rel p)
-      (fun s0 _ s1 -> s0 == s1 /\ witnessed state rel p)
-
-assume val recall (state:Type u#2) (rel:P.preorder state) (p:s_predicate state)
-    : MSTATETOT unit state rel
-      (fun _ -> witnessed state rel p)
+      (fun _ -> True)
       (fun s0 _ s1 -> s0 == s1 /\ p s1)
 
 

--- a/ulib/experimental/FStar.NMST.fst
+++ b/ulib/experimental/FStar.NMST.fst
@@ -16,6 +16,7 @@
 
 module FStar.NMST
 
+module W = FStar.Witnessed.Core
 module P = FStar.Preorder
 
 module M = FStar.MST
@@ -119,29 +120,25 @@ let put (#state:Type u#2) (#rel:P.preorder state) (s:state)
     =
   NMSTATE?.reflect (fun (_, n) -> MST.put s, n)
 
-type s_predicate (state:Type u#2) = state -> Type0
-
-let stable (state:Type u#2) (rel:P.preorder state) (p:s_predicate state) =
-  forall s0 s1. (p s0 /\ rel s0 s1) ==> p s1
-
-let witnessed (state:Type u#2) (rel:P.preorder state) (p:s_predicate state) =
-  M.witnessed state rel p
 
 [@@ noextract_to "krml"]
-let witness (state:Type u#2) (rel:P.preorder state) (p:s_predicate state)
-    : NMSTATE unit state rel
-      (fun s0 -> p s0 /\ stable state rel p)
-      (fun s0 _ s1 -> s0 == s1 /\ witnessed state rel p)
+let witness (state:Type u#2) (rel:P.preorder state) (p:W.s_predicate state)
+    : NMSTATE (W.witnessed state rel p) state rel
+      (fun s0 -> p s0 /\ W.stable state rel p)
+      (fun s0 _ s1 -> s0 == s1)
     =
   NMSTATE?.reflect (fun (_, n) -> M.witness state rel p, n)
 
 [@@ noextract_to "krml"]
-let recall (state:Type u#2) (rel:P.preorder state) (p:s_predicate state)
+let recall (state:Type u#2)
+           (rel:P.preorder state) 
+           (p:W.s_predicate state)
+           (w:W.witnessed state rel p)
     : NMSTATE unit state rel
-      (fun _ -> witnessed state rel p)
+      (fun _ -> True)
       (fun s0 _ s1 -> s0 == s1 /\ p s1)
     =
-  NMSTATE?.reflect (fun (_, n) -> M.recall state rel p, n)
+  NMSTATE?.reflect (fun (_, n) -> M.recall state rel p w, n)
 
 [@@ noextract_to "krml"]
 let sample (#state:Type u#2) (#rel:P.preorder state) ()

--- a/ulib/experimental/FStar.NMSTTotal.fst
+++ b/ulib/experimental/FStar.NMSTTotal.fst
@@ -16,6 +16,7 @@
 
 module FStar.NMSTTotal
 
+module W = FStar.Witnessed.Core
 module P = FStar.Preorder
 
 module M = FStar.MSTTotal
@@ -120,29 +121,25 @@ let put (#state:Type u#2) (#rel:P.preorder state) (s:state)
     =
   NMSTATETOT?.reflect (fun (_, n) -> MSTTotal.put s, n)
 
-type s_predicate (state:Type u#2) = state -> Type0
-
-let stable (state:Type u#2) (rel:P.preorder state) (p:s_predicate state) =
-  forall s0 s1. (p s0 /\ rel s0 s1) ==> p s1
-
-let witnessed (state:Type u#2) (rel:P.preorder state) (p:s_predicate state) =
-  M.witnessed state rel p
 
 [@@ noextract_to "krml"]
-let witness (state:Type u#2) (rel:P.preorder state) (p:s_predicate state)
-    : NMSTATETOT unit state rel
-      (fun s0 -> p s0 /\ stable state rel p)
-      (fun s0 _ s1 -> s0 == s1 /\ witnessed state rel p)
+let witness (state:Type u#2) (rel:P.preorder state) (p:W.s_predicate state)
+    : NMSTATETOT (W.witnessed state rel p) state rel
+      (fun s0 -> p s0 /\ W.stable state rel p)
+      (fun s0 _ s1 -> s0 == s1)
     =
   NMSTATETOT?.reflect (fun (_, n) -> M.witness state rel p, n)
 
 [@@ noextract_to "krml"]
-let recall (state:Type u#2) (rel:P.preorder state) (p:s_predicate state)
+let recall (state:Type u#2)
+           (rel:P.preorder state)
+           (p:W.s_predicate state)
+           (w:W.witnessed state rel p)
     : NMSTATETOT unit state rel
-      (fun _ -> witnessed state rel p)
+      (fun _ -> True)
       (fun s0 _ s1 -> s0 == s1 /\ p s1)
     =
-  NMSTATETOT?.reflect (fun (_, n) -> M.recall state rel p, n)
+  NMSTATETOT?.reflect (fun (_, n) -> M.recall state rel p w, n)
 
 [@@ noextract_to "krml"]
 let sample (#state:Type u#2) (#rel:P.preorder state) ()

--- a/ulib/experimental/FStar.Witnessed.Core.fst
+++ b/ulib/experimental/FStar.Witnessed.Core.fst
@@ -4,14 +4,14 @@ module P = FStar.Preorder
 (* This is just to give definitions to the witnessed type for extraction.
    It is NOT a semantic model of the witnessed modality *)
    
-let witnessed (state:Type u#2)
+let witnessed (state:Type u#a)
               (rel:P.preorder state)
               (p:s_predicate state)
   : Type0
   = unit
   
 let witnessed_proof_irrelevant 
-      (state:Type u#2)
+      (state:Type u#a)
       (rel:P.preorder state)
       (p:s_predicate state)
       (w0 w1:witnessed state rel p)

--- a/ulib/experimental/FStar.Witnessed.Core.fst
+++ b/ulib/experimental/FStar.Witnessed.Core.fst
@@ -1,0 +1,19 @@
+module FStar.Witnessed.Core
+module P = FStar.Preorder
+
+(* This is just to give definitions to the witnessed type for extraction.
+   It is NOT a semantic model of the witnessed modality *)
+   
+let witnessed (state:Type u#2)
+              (rel:P.preorder state)
+              (p:s_predicate state)
+  : Type0
+  = unit
+  
+let witnessed_proof_irrelevant 
+      (state:Type u#2)
+      (rel:P.preorder state)
+      (p:s_predicate state)
+      (w0 w1:witnessed state rel p)
+  : Lemma (w0 == w1)
+  = ()

--- a/ulib/experimental/FStar.Witnessed.Core.fsti
+++ b/ulib/experimental/FStar.Witnessed.Core.fsti
@@ -1,0 +1,22 @@
+module FStar.Witnessed.Core
+module P = FStar.Preorder
+
+let s_predicate (state:Type u#a) = state -> Type0
+
+let stable (state:Type u#a)
+           (rel:P.preorder state)
+           (p:s_predicate state) =
+  forall s0 s1. (p s0 /\ rel s0 s1) ==> p s1
+
+val witnessed (state:Type u#2)
+              (rel:P.preorder state)
+              (p:s_predicate state)
+  : Type0
+
+val witnessed_proof_irrelevant 
+      (state:Type u#2)
+      (rel:P.preorder state)
+      (p:s_predicate state)
+      (w0 w1:witnessed state rel p)
+  : Lemma (w0 == w1)
+

--- a/ulib/experimental/FStar.Witnessed.Core.fsti
+++ b/ulib/experimental/FStar.Witnessed.Core.fsti
@@ -8,13 +8,13 @@ let stable (state:Type u#a)
            (p:s_predicate state) =
   forall s0 s1. (p s0 /\ rel s0 s1) ==> p s1
 
-val witnessed (state:Type u#2)
+val witnessed (state:Type u#a)
               (rel:P.preorder state)
               (p:s_predicate state)
   : Type0
 
 val witnessed_proof_irrelevant 
-      (state:Type u#2)
+      (state:Type u#a)
       (rel:P.preorder state)
       (p:s_predicate state)
       (w0 w1:witnessed state rel p)

--- a/ulib/experimental/Steel.DisposableInvariant.fst
+++ b/ulib/experimental/Steel.DisposableInvariant.fst
@@ -35,9 +35,9 @@ let conditional_inv (r:ghost_ref bool) (p:vprop) =
 let ex_conditional_inv (r:ghost_ref bool) (p:vprop) =
     h_exists (conditional_inv r p)
 
-let inv (p:vprop) = erased (r:ghost_ref bool & inv (ex_conditional_inv r p))
+let inv (p:vprop) = r:ghost_ref bool & inv (ex_conditional_inv r p)
 
-let name (#p:_) (i:inv p) = dsnd i
+let name (#p:_) (i:inv p) = name_of_inv (dsnd i)
 let gref (#p:_) (i:inv p) = dfst i
 
 [@@__reduce__]
@@ -53,7 +53,7 @@ let new_inv #u p =
     (ghost_pts_to r (half_perm full_perm) true)
     (ghost_pts_to (gref (hide (| r, i |))) (half_perm full_perm) true)
     (fun _ -> ());
-  (| r, i |)
+  return (| r, i |)
 
 let share #p #f #u i = ghost_share_pt #_ #_ #_ #(hide true) (gref i)
 
@@ -65,7 +65,7 @@ let gather #p #f0 #f1 #u i =
     (fun _ -> assert (FStar.Real.two == 2.0R); assert (sum_perm (half_perm f0) (half_perm f1) == (half_perm (sum_perm f0 f1))))
 
 let dispose #p #u i
-  : SteelGhostT unit u
+  : SteelAtomicUT unit u
     (active full_perm i)
     (fun _ -> p)
   = let dispose_aux (r:ghost_ref bool) (_:unit)
@@ -86,13 +86,14 @@ let dispose #p #u i
       intro_exists false (conditional_inv r p);
       drop (ghost_pts_to r (half_perm full_perm) false)
     in
-    with_invariant_g (name i)
-                     (dispose_aux (gref i))
+    let x = with_invariant_g (dsnd i)
+                             (dispose_aux (gref i)) in
+    ()
 
-let with_invariant #a #fp #fp' #u #p #perm i f
+let with_invariant #a #fp #fp' #u #obs #p #perm i f
   = let with_invariant_aux (r:ghost_ref bool)
                            (_:unit)
-      : SteelAtomicT a (add_inv u i)
+      : SteelAtomicBaseT a (add_inv u i) obs
           (ex_conditional_inv r p `star`
             (ghost_pts_to r (half_perm perm) true `star`
           fp))
@@ -107,7 +108,7 @@ let with_invariant #a #fp #fp' #u #p #perm i f
       intro_exists true (conditional_inv r p);
       return x
     in
-    with_invariant (name i)
+    with_invariant (dsnd i)
                    (with_invariant_aux (gref i))
 
 let with_invariant_g #a #fp #fp' #u #p #perm i f
@@ -128,5 +129,6 @@ let with_invariant_g #a #fp #fp' #u #p #perm i f
       intro_exists true (conditional_inv r p);
       x
     in
-    with_invariant_g (name i)
-                     (with_invariant_aux (gref i))
+    let x = with_invariant_g (dsnd i)
+                             (with_invariant_aux (gref i)) in
+    x

--- a/ulib/experimental/Steel.Effect.Atomic.fsti
+++ b/ulib/experimental/Steel.Effect.Atomic.fsti
@@ -331,6 +331,22 @@ effect SteelAtomicF (a:Type)
   (ens:ens_t pre a post)
   = SteelAtomicBase a true opened Observable pre post req ens
 
+effect SteelAtomicU (a:Type)
+  (opened:inames)
+  (pre:pre_t)
+  (post:post_t a)
+  (req:req_t pre)
+  (ens:ens_t pre a post)
+  = SteelAtomicBase a false opened Unobservable pre post req ens
+
+effect SteelAtomicUF (a:Type)
+  (opened:inames)
+  (pre:pre_t)
+  (post:post_t a)
+  (req:req_t pre)
+  (ens:ens_t pre a post)
+  = SteelAtomicBase a true opened Unobservable pre post req ens
+
 (* Composing SteelAtomic and Pure computations *)
 
 /// Logical precondition of a Pure and a SteelAtomic computation composition.
@@ -374,8 +390,15 @@ val bind_pure_steela_ (a:Type) (b:Type)
 polymonadic_bind (PURE, SteelAtomicBase) |> SteelAtomicBase = bind_pure_steela_
 
 /// A version of the SteelAtomic effect with trivial requires and ensures clauses
+///
+effect SteelAtomicBaseT (a:Type) (opened:inames) (obs:observability) (pre:pre_t) (post:post_t a) =
+  SteelAtomicBase a false opened obs pre post (fun _ -> True) (fun _ _ _ -> True)
+
 effect SteelAtomicT (a:Type) (opened:inames) (pre:pre_t) (post:post_t a) =
   SteelAtomic a opened pre post (fun _ -> True) (fun _ _ _ -> True)
+
+effect SteelAtomicUT (a:Type) (opened:inames) (pre:pre_t) (post:post_t a) =
+  SteelAtomicU a opened pre post (fun _ -> True) (fun _ _ _ -> True)
 
 (*** SteelGhost effect ***)
 
@@ -471,6 +494,16 @@ val as_atomic_action_ghost (#a:Type u#a)
                            (#fp': a -> slprop)
                            (f:action_except a opened_invariants fp fp')
   : SteelGhostT a opened_invariants (to_vprop fp) (fun x -> to_vprop (fp' x))
+
+
+[@@warn_on_use "as_unobservable_atomic_action is a trusted primitive"]
+val as_atomic_unobservable_action
+                           (#a:Type u#a)
+                           (#opened_invariants:inames)
+                           (#fp:slprop)
+                           (#fp': a -> slprop)
+                           (f:action_except a opened_invariants fp fp')
+  : SteelAtomicUT a opened_invariants (to_vprop fp) (fun x -> to_vprop (fp' x))
 
 (*** Some helper functions ***)
 
@@ -681,7 +714,7 @@ val exists_cong (#a:_) (#u:_) (p:a -> vprop) (q:a -> vprop {forall x. equiv (p x
 /// Creation of a new invariant associated to vprop [p].
 /// After execution of this function, [p] is consumed and not available in the context anymore
 val new_invariant (#opened_invariants:inames) (p:vprop)
-  : SteelGhostT (inv p) opened_invariants p (fun _ -> emp)
+  : SteelAtomicUT (inv p) opened_invariants p (fun _ -> emp)
 
 /// Atomically executing function [f] which relies on the predicate [p] stored in invariant [i]
 /// as long as it maintains the validity of [p]
@@ -689,13 +722,14 @@ val new_invariant (#opened_invariants:inames) (p:vprop)
 val with_invariant (#a:Type)
                    (#fp:vprop)
                    (#fp':a -> vprop)
+                   (#obs:_)
                    (#opened_invariants:inames)
                    (#p:vprop)
                    (i:inv p{not (mem_inv opened_invariants i)})
-                   ($f:unit -> SteelAtomicT a (add_inv opened_invariants i)
-                                         (p `star` fp)
-                                         (fun x -> p `star` fp' x))
-  : SteelAtomicT a opened_invariants fp fp'
+                   ($f:unit -> SteelAtomicBaseT a (add_inv opened_invariants i) obs
+                                             (p `star` fp)
+                                             (fun x -> p `star` fp' x))
+  : SteelAtomicBaseT a opened_invariants obs fp fp'
 
 /// Variant of the above combinator for ghost computations
 val with_invariant_g (#a:Type)
@@ -705,9 +739,9 @@ val with_invariant_g (#a:Type)
                      (#p:vprop)
                      (i:inv p{not (mem_inv opened_invariants i)})
                      ($f:unit -> SteelGhostT a (add_inv opened_invariants i)
-                                         (p `star` fp)
-                                         (fun x -> p `star` fp' x))
-  : SteelGhostT a opened_invariants fp fp'
+                                              (p `star` fp)
+                                              (fun x -> p `star` fp' x))
+  : SteelAtomicUT (erased a) opened_invariants fp (fun x -> fp' x)
 
 (* Introduction and elimination principles for vprop combinators *)
 

--- a/ulib/experimental/Steel.Effect.Common.fsti
+++ b/ulib/experimental/Steel.Effect.Common.fsti
@@ -3197,21 +3197,19 @@ let join_obs (o1:observability) (o2:observability) =
 
 (* Lifting invariants to vprops *)
 
-///  This operator asserts that the logical content of invariant [i] is the separation logic
-///  predicate [p]
-noextract
-let ( >--> ) (i:iname) (p:vprop) : prop = i >--> (hp_of p)
-
 /// [i : inv p] is an invariant whose content is [p]
-let inv (p:vprop) = i:Ghost.erased iname{reveal i >--> p}
+inline_for_extraction
+let inv (p:vprop) : Type0 = Mem.inv (hp_of p)
+
+let name_of_inv (#p:vprop) (i:inv p) : GTot iname = Mem.name_of_inv i
 
 /// Ghost check to determing whether invariant [i] belongs to the set of opened invariants [e]
-let mem_inv (#p:vprop) (e:inames) (i:inv p) : erased bool = elift2 (fun e i -> Set.mem i e) e i
+let mem_inv (#p:vprop) (e:inames) (i:inv p) : erased bool = elift2 (fun e i -> Set.mem i e) e (name_of_inv i)
 
 /// Adding invariant [i] to the set of opened invariants [e]
 noextract
 let add_inv (#p:vprop) (e:inames) (i:inv p) : inames =
-  Set.union (Set.singleton (reveal i)) (reveal e)
+  Set.union (Set.singleton (name_of_inv i)) (reveal e)
 
 noextract
 let set_add i o : inames = Set.union (Set.singleton i) o

--- a/ulib/experimental/Steel.GhostMonotonicHigherReference.fsti
+++ b/ulib/experimental/Steel.GhostMonotonicHigherReference.fsti
@@ -63,7 +63,7 @@ let property (a:Type)
 /// A wrapper around a property [fact] that has been witnessed to be true and stable
 /// with respect to preorder [p]
 val witnessed (#a:Type u#1) (#p:Preorder.preorder a) (r:ref a p) (fact:property a)
-  : prop
+  : Type0
 
 /// The type of properties depending on values of type [a], and that
 /// are stable with respect to the preorder [p]
@@ -74,21 +74,24 @@ let stable_property (#a:Type) (p:Preorder.preorder a)
 /// it holds for the current value [v] of the reference, then we can witness it
 val witness (#inames: _) (#a:Type) (#q:perm) (#p:Preorder.preorder a) (r:ref a p)
             (fact:stable_property p)
-            (v:a)
+            (v:erased a)
             (_:squash (fact v))
-  : SteelGhost unit inames (pts_to r q v)
-               (fun _ -> pts_to r q v)
-               (requires fun _ -> True)
-               (ensures fun _ _ _ -> witnessed r fact)
+  : SteelAtomicUT (witnessed r fact) inames
+                  (pts_to r q v)
+                  (fun _ -> pts_to r q v)
+
 
 /// If we previously witnessed the validity of [fact], we can recall its validity
 val recall (#inames: _) (#a:Type u#1) (#q:perm) (#p:Preorder.preorder a)
            (fact:property a)
-           (r:ref a p) (v:a)
-  : SteelGhost unit inames (pts_to r q v)
-               (fun _ -> pts_to r q v)
-               (requires fun _ -> witnessed r fact)
-               (ensures fun _ _ _ -> fact v)
+           (r:ref a p)
+           (v:erased a)
+           (w:witnessed r fact)
+  : SteelAtomicU unit inames
+                 (pts_to r q v)
+                 (fun _ -> pts_to r q v)
+                 (requires fun _ -> True)
+                 (ensures fun _ _ _ -> fact v)
 
 /// Monotonic references are also equipped with the usual fractional permission discipline
 /// So, you can split a reference into two read-only shares

--- a/ulib/experimental/Steel.GhostMonotonicReference.fst
+++ b/ulib/experimental/Steel.GhostMonotonicReference.fst
@@ -85,14 +85,13 @@ let witness (#inames: _)
            (#p:Preorder.preorder a)
            (r:ref a p)
            (fact:stable_property p)
-           (v:a)
+           (v:erased a)
            (_:squash (fact v))
-  : SteelGhost unit inames
-               (pts_to r q v)
-               (fun _ -> pts_to r q v)
-               (requires fun _ -> True)
-               (ensures fun _ _ _ -> witnessed r fact)
-  = MHR.witness r (lift_property fact) (U.raise_val (v)) ()
+  : SteelAtomicUT (witnessed r fact) inames
+                  (pts_to r q v)
+                  (fun _ -> pts_to r q v)
+  = let w = MHR.witness r (lift_property fact) (U.raise_val (reveal v)) () in
+    return w
 
 /// If we previously witnessed the validity of [fact], we can recall its validity
 let recall (#inames: _)
@@ -101,12 +100,13 @@ let recall (#inames: _)
            (#p:Preorder.preorder a)
            (fact:property a)
            (r:ref a p)
-           (v:a)
-  : SteelGhost unit inames (pts_to r q v)
+           (v:erased a)
+           (w:witnessed r fact)
+  : SteelAtomicU unit inames (pts_to r q v)
                (fun _ -> pts_to r q v)
-               (requires fun _ -> witnessed r fact)
+               (requires fun _ -> True)
                (ensures fun _ _ _ -> fact v)
-  = MHR.recall (lift_property fact) r (U.raise_val v)
+  = MHR.recall (lift_property fact) r (U.raise_val (reveal v)) w
 
 /// Monotonic references are also equipped with the usual fractional permission discipline
 /// So, you can split a reference into two read-only shares

--- a/ulib/experimental/Steel.GhostMonotonicReference.fsti
+++ b/ulib/experimental/Steel.GhostMonotonicReference.fsti
@@ -73,7 +73,7 @@ let property (a:Type)
 /// A wrapper around a property [fact] that has been witnessed to be true and stable
 /// with respect to preorder [p]
 val witnessed (#a:Type u#0) (#p:Preorder.preorder a) (r:ref a p) (fact:property a)
-  : prop
+  : Type0
 
 /// The type of properties depending on values of type [a], and that
 /// are stable with respect to the preorder [p]
@@ -84,20 +84,21 @@ let stable_property (#a:Type) (p:Preorder.preorder a)
 /// it holds for the current value [v] of the reference, then we can witness it
 val witness (#inames: _) (#a:Type) (#q:perm) (#p:Preorder.preorder a) (r:ref a p)
             (fact:stable_property p)
-            (v:a)
+            (v:erased a)
             (_:squash (fact v))
-  : SteelGhost unit inames (pts_to r q v)
+  : SteelAtomicUT (witnessed r fact) inames (pts_to r q v)
                (fun _ -> pts_to r q v)
-               (requires fun _ -> True)
-               (ensures fun _ _ _ -> witnessed r fact)
+
 
 /// If we previously witnessed the validity of [fact], we can recall its validity
 val recall (#inames: _) (#a:Type u#0) (#q:perm) (#p:Preorder.preorder a)
            (fact:property a)
-           (r:ref a p) (v:a)
-  : SteelGhost unit inames (pts_to r q v)
+           (r:ref a p) 
+           (v:erased a)
+           (w:witnessed r fact)
+  : SteelAtomicU unit inames (pts_to r q v)
                (fun _ -> pts_to r q v)
-               (requires fun _ -> witnessed r fact)
+               (requires fun _ -> True)
                (ensures fun _ _ _ -> fact v)
 
 /// Monotonic references are also equipped with the usual fractional permission discipline

--- a/ulib/experimental/Steel.GhostPCMReference.fst
+++ b/ulib/experimental/Steel.GhostPCMReference.fst
@@ -111,7 +111,7 @@ let gather (#o:inames)
   = P.gather r v0 v1
 
 let witnessed (#a:Type) (#p:pcm a) (r:ref a p) (fact:property a)
-  : prop
+  : Type0
   = Steel.Memory.witnessed r fact
 
 let witness (#o:inames)
@@ -119,13 +119,8 @@ let witness (#o:inames)
             (#pcm:pcm a)
             (r:ref a pcm)
             (fact:Steel.Preorder.stable_property pcm)
-            (v:a)
+            (v:erased a)
             (_:squash (Steel.Preorder.fact_valid_compat fact v))
-  : SteelGhost unit o
-      (pts_to r v)
-      (fun _ -> pts_to r v)
-      (requires fun _ -> True)
-      (ensures fun _ _ _ -> witnessed r fact)
   = P.witness r fact v ()
 
 let recall (#o: _)
@@ -134,10 +129,6 @@ let recall (#o: _)
            (fact:property a)
            (r:ref a pcm)
            (v:erased a)
-  : SteelGhost a o
-          (pts_to r v)
-          (fun v1 -> pts_to r v)
-          (requires fun _ -> witnessed r fact)
-          (ensures fun _ v1 _ -> fact v1 /\ compatible pcm v v1)
-  = let x = P.recall fact r v in
-    reveal x
+           (w:witnessed r fact)
+  = P.recall fact r v w
+

--- a/ulib/experimental/Steel.GhostPCMReference.fsti
+++ b/ulib/experimental/Steel.GhostPCMReference.fsti
@@ -123,7 +123,7 @@ val gather (#o:inames)
 // API for witness/recall of monotonic facts
 ////////////////////////////////////////////////////////////////////////////////
 val witnessed (#a:Type u#1) (#p:pcm a) (r:ref a p) (fact:property a)
-  : prop
+  : Type0
   
 /// If property [fact] is stable with respect to the governing PCM,
 /// and if it is currently valid for any value that is compatible with
@@ -133,13 +133,12 @@ val witness (#o:inames)
             (#pcm:pcm a)
             (r:ref a pcm)
             (fact:Steel.Preorder.stable_property pcm)
-            (v:a)
+            (v:erased a)
             (_:squash (Steel.Preorder.fact_valid_compat fact v))
-  : SteelGhost unit o
+  : SteelAtomicUT (witnessed r fact) o
       (pts_to r v)
       (fun _ -> pts_to r v)
-      (requires fun _ -> True)
-      (ensures fun _ _ _ -> witnessed r fact)
+
 
 /// If we previously witnessed the validity of a predicate [fact],
 /// then we can recall this validity on the current value [v1], which
@@ -150,8 +149,9 @@ val recall (#o: _)
            (fact:property a)
            (r:ref a pcm)
            (v:erased a)
-  : SteelGhost a o
+           (w:witnessed r fact)
+  : SteelAtomicU (erased a) o
           (pts_to r v)
           (fun v1 -> pts_to r v)
-          (requires fun _ -> witnessed r fact)
+          (requires fun _ -> True)
           (ensures fun _ v1 _ -> fact v1 /\ compatible pcm v v1)

--- a/ulib/experimental/Steel.Heap.fst
+++ b/ulib/experimental/Steel.Heap.fst
@@ -707,7 +707,7 @@ let sel_lemma (#a:_) (#pcm:_) (r:ref a pcm) (m:full_hheap (ptr r))
   = let Ref _ _ _ v = select_addr m (Addr?._0 r) in
     assert (sel r m == v);
     compatible_refl pcm v
-
+  
 let witnessed_ref_stability #a #pcm (r:ref a pcm) (fact:a -> prop)
   = let fact_h = witnessed_ref r fact in
     let aux (h0 h1:full_heap)

--- a/ulib/experimental/Steel.LockCoupling.fsti
+++ b/ulib/experimental/Steel.LockCoupling.fsti
@@ -24,21 +24,24 @@ open Steel.FractionalPermission
 
 /// An invariant for lists, where each list node stores a lock to the rest of the list.
 
-#push-options "--__no_positivity"
+val h_exists (#[@@@strictly_positive] a:Type)
+             ([@@@strictly_positive] p:(a -> vprop))
+   : vprop
+
+val pts_to (#[@@@strictly_positive] a:Type)
+           (// [@@@strictly_positive]
+    r:ref a)
+           (// [@@@strictly_positive]
+    v:a) : vprop 
+
+val lock ([@@@strictly_positive] p:vprop) : Type0
+
+
 noeq
-type llist (a:Type0) : Type0 = {
-  v : a;
-  next : ref (llist a);
-  lock : lock_t
-}
-#pop-options
-
-
-let rec llist_inv (#a:Type) (repr:list (a -> vprop)) (n:ref (llist a))
-  = match repr with
-    | [] -> emp
-    | p::tl ->
-      h_exists (fun (cell:llist a) ->
-         p cell.v `star`
-         pts_to n full_perm cell `star`
-         pure (cell.lock `protects` llist_inv tl cell.next))
+type llist (a:Type0) : Type0 = 
+  | Nil : llist a
+  | Cons :
+           v : a ->
+           next : ref (llist a) ->
+           tl_repr: lock (h_exists (pts_to next)) ->
+           llist a

--- a/ulib/experimental/Steel.LockCoupling.fsti
+++ b/ulib/experimental/Steel.LockCoupling.fsti
@@ -22,26 +22,53 @@ open Steel.SpinLock
 open Steel.Reference
 open Steel.FractionalPermission
 
-/// An invariant for lists, where each list node stores a lock to the rest of the list.
+(*
+   This example sketches how an invariant for lock-coupling list
+     (a list that stores a lock at each cell protecting its tail pointer)
+   might work.
 
+   It relies on strictly positive version of the exists and pts_to
+   separation logic predicates, although the libraries are not
+   currently annotated with such positivity annotations.=
+*)
+
+(* It is relatively easy to show that h_exists is strictly positive *)
 val h_exists (#[@@@strictly_positive] a:Type)
              ([@@@strictly_positive] p:(a -> vprop))
    : vprop
 
+(* the pts_to predicate is a bit more subtle. It is an instance
+   of a more general form that involves assertions about a PCM,
+   and it is possible to construct PCMs that are not strictly
+   positive. However, the basic pts_to predicate that this refers to,
+   for the fractional permission PCM, is strictly positive.
+   Revising the library to enable decorating pts_to predicates derived
+   from positive PCMs remains to be done. *)
 val pts_to (#[@@@strictly_positive] a:Type)
-           (// [@@@strictly_positive]
-    r:ref a)
-           (// [@@@strictly_positive]
-    v:a) : vprop 
+           (r:ref a)
+           (f:perm)
+           (v:a) : vprop 
 
 val lock ([@@@strictly_positive] p:vprop) : Type0
 
+let half = half_perm full_perm
 
+(* The lock at each cell holds half permission to the next pointer *)
 noeq
-type llist (a:Type0) : Type0 = 
-  | Nil : llist a
-  | Cons :
-           v : a ->
-           next : ref (llist a) ->
-           tl_repr: lock (h_exists (pts_to next)) ->
-           llist a
+type llist_cell (a:Type0) : Type = {
+  v : a;
+  next : ref (llist_cell a);
+  lock : lock (h_exists (pts_to next half))
+}
+
+(* A separation list_inv holds the other half permission *)
+let rec list_inv (#a:Type) (p:ref (llist_cell a)) (repr:list a) 
+  : Tot vprop (decreases repr) 
+  = match repr with
+    | [] -> pure (p == null)
+    | hd::tl ->
+      h_exists (fun cell ->
+        pts_to p half cell `star`
+        pure (cell.v == hd) `star`
+        list_inv cell.next tl)
+  

--- a/ulib/experimental/Steel.Memory.fst
+++ b/ulib/experimental/Steel.Memory.fst
@@ -252,6 +252,8 @@ let affine_star (p q:slprop) (m:mem) =
 let iname = nat
 module S = FStar.Set
 module L = FStar.List.Tot
+module W = FStar.Witnessed.Core
+
 let rec lock_store_invariant (e:inames) (l:lock_store u#a) : slprop u#a =
   let current_addr = L.length l - 1 in
   match l with
@@ -266,7 +268,7 @@ let lock_i (i:iname) (l:lock_store { i < L.length l }) =
   let ix = L.length l - i - 1 in
   L.index l ix
 
-let iname_for_p (i:iname) (p:slprop) : NMSTTotal.s_predicate lock_store =
+let iname_for_p (i:iname) (p:slprop) : W.s_predicate lock_store =
   fun l ->
     i < L.length l /\
     (lock_i i l).inv == p
@@ -960,7 +962,7 @@ let witnessed (#a:Type u#1)
               (#pcm:pcm a)
               (r:ref a pcm)
               (fact:property a)
-  = NMSTTotal.witnessed _ mem_evolves (witnessed_ref r fact)
+  = W.witnessed _ mem_evolves (witnessed_ref r fact)
 
 let rearrange_pqr_prq (p q r:slprop)
       : Lemma (((p `star` q) `star` r) `equiv`
@@ -1044,102 +1046,73 @@ let preserves_frame_star_pure (e:inames) (p q:slprop) (r s:prop) (m:mem)
     in
     ()
 
+
 let witness (#a:Type) (#pcm:pcm a)
             (e:inames)
-            (r:ref a pcm)
+            (r:erased (ref a pcm))
             (fact:stable_property pcm)
             (v:Ghost.erased a)
             (_:squash (forall z. compatible pcm v z ==> fact z))
             (frame:slprop)
-  : MstTot unit e
+  : MstTot (witnessed r fact) e
            (pts_to r v)
-           (fun _ -> pts_to r v `star` pure (witnessed r fact)) frame
+           (fun _ -> pts_to r v) frame
            (fun _ -> True)
            (fun _ _ _ -> True)
   = let m0 = NMSTTotal.get () in
-    let hr : H.ref a pcm = r in
-    let v' = H.sel_v hr v (heap_of_mem m0) in
-    assert (interp (H.ptr hr) m0 /\ H.sel #a #pcm hr (heap_of_mem m0) == v');
-    assert (compatible pcm v v');
-    assert (fact v');
-    assert (witnessed_ref r fact m0);
-    witnessed_ref_stability r fact;
-    assert (FStar.Preorder.stable (witnessed_ref r fact) mem_evolves);
-    NMSTTotal.witness _ mem_evolves (witnessed_ref r fact);
-    assert (witnessed r fact);
-    emp_unit (pts_to r v `star` locks_invariant e m0);
-    pure_star_interp (pts_to r v `star` locks_invariant e m0) (witnessed r fact) m0;
-    ac_reasoning_for_m_frame_preserving (pts_to r v) frame (locks_invariant e m0) m0;
-    assert (interp (pts_to r v `star` locks_invariant e m0) m0);
-    assert (interp ((pts_to r v `star` locks_invariant e m0) `star` pure (witnessed r fact)) m0);
-    rearrange_pqr_prq (pts_to r v) (locks_invariant e m0) (pure (witnessed r fact));
-    assert (interp ((pts_to r v `star` pure (witnessed r fact)) `star` locks_invariant e m0) m0);
-    assert (preserves_frame e (pts_to r v) (pts_to r v) m0 m0);
-    preserves_frame_star_pure e (pts_to r v) (pts_to r v) True (witnessed r fact) m0;
-    pure_true_equiv (pts_to r v);
-    assert (preserves_frame e (pts_to r v `star` pure True)
-                              (pts_to r v `star` pure (witnessed r fact))
-                              m0 m0);
-    preserves_frame_cong e (pts_to r v `star` pure True) (pts_to r v `star` pure (witnessed r fact))
-                           (pts_to r v) (pts_to r v `star` pure (witnessed r fact))
-                           m0 m0;
-    assert (preserves_frame e (pts_to r v) (pts_to r v `star` pure (witnessed r fact)) m0 m0)
+    let _ : unit = 
+      let hr : H.ref a pcm = r in
+      let v' = H.sel_v hr v (heap_of_mem m0) in
+      assert (interp (H.ptr hr) m0 /\ H.sel #a #pcm hr (heap_of_mem m0) == v');
+      assert (compatible pcm v v');
+      assert (fact v');
+      assert (witnessed_ref r fact m0);
+      witnessed_ref_stability r fact;
+      assert (FStar.Preorder.stable (witnessed_ref r fact) mem_evolves)
+    in
+    let w = NMSTTotal.witness _ mem_evolves (witnessed_ref r fact) in
+    w
 
 let recall (#a:Type u#1) (#pcm:pcm a) (#fact:property a)
            (e:inames)
-           (r:ref a pcm)
+           (r:erased (ref a pcm))
            (v:Ghost.erased a)
+           (w:witnessed r fact)
            (frame:slprop)
   = let m0 = NMSTTotal.get () in
+    NMSTTotal.recall _ mem_evolves (witnessed_ref r fact) w;
     let hr : H.ref a pcm = r in
-    pure_star_interp (pts_to r v) (witnessed r fact) m0;
-    assert (witnessed r fact);
-    NMSTTotal.recall _ mem_evolves (witnessed_ref r fact);
     assert (witnessed_ref r fact m0);
-    affine_star (pts_to r v) (pure (witnessed r fact)) m0;
     let v1 = H.sel_v hr v (heap_of_mem m0) in
     assert (compatible pcm v v1);
     assert (H.sel hr (heap_of_mem m0) == v1);
     assert (fact v1);
-    rearrange_pqr_prq (pts_to r v) (pure (witnessed r fact)) (locks_invariant e m0);
-    affine_star (pts_to r v `star` locks_invariant e m0) (pure (witnessed r fact)) m0;
-    ac_reasoning_for_m_frame_preserving
-      (pts_to r v `star` pure (witnessed r fact))
-      frame
-      (locks_invariant e m0)
-      m0;
-    assert (interp (pts_to r v `star` pure (witnessed r fact) `star` locks_invariant e m0) m0);
-    ac_reasoning_for_m_frame_preserving
-      (pts_to r v)
-      (pure (witnessed r fact))
-      (locks_invariant e m0)
-      m0;
-    assert (interp (pts_to r v `star` locks_invariant e m0) m0);
-    emp_unit (pts_to r v `star` locks_invariant e m0);
-    pure_star_interp (pts_to r v `star` locks_invariant e m0) (fact v1) m0;
-    rearrange_pqr_prq (pts_to r v) (locks_invariant e m0) (pure (fact v1));
-    assert (interp ((pts_to r v `star` pure (fact v1)) `star` locks_invariant e m0) m0);
-    assert (preserves_frame e (pts_to r v `star` pure (witnessed r fact))
-                              (pts_to r v `star` pure (witnessed r fact)) m0 m0);
-    pure_equiv (witnessed r fact) True;
-    star_congruence (pts_to r v) (pure (witnessed r fact)) (pts_to r v) (pure True);
-    pure_true_equiv (pts_to r v);
-    preserves_frame_cong e (pts_to r v `star` pure (witnessed r fact)) (pts_to r v `star` pure (witnessed r fact))
-                           (pts_to r v) (pts_to r v) m0 m0;
-    assert (preserves_frame e (pts_to r v)
-                              (pts_to r v) m0 m0);
-    preserves_frame_star_pure e (pts_to r v) (pts_to r v) (witnessed r fact) (fact v1) m0;
-    assert (preserves_frame e (pts_to r v `star` pure (witnessed r fact)) (pts_to r v `star` pure (fact v1)) m0 m0);
+    assert (interp ((pts_to r v `star` frame) `star` locks_invariant e m0) m0);
+    emp_unit ((pts_to r v `star` frame) `star` locks_invariant e m0);
+    pure_star_interp ((pts_to r v `star` frame) `star` locks_invariant e m0) (fact v1) m0;
+    assert (interp (((pts_to r v `star` frame)
+                     `star` locks_invariant e m0)
+                     `star` pure (fact v1)) m0);
+    rearrange_pqr_prq (pts_to r v `star` frame)
+                      (locks_invariant e m0)
+                      (pure (fact v1));
+    assert (interp (((pts_to r v `star` frame) `star` pure (fact v1)) 
+                   `star` locks_invariant e m0) m0);
+    rearrange_pqr_prq (pts_to r v) frame (pure (fact v1));
+    star_congruence ((pts_to r v `star` frame) `star` pure (fact v1))
+                    (locks_invariant e m0)
+                    ((pts_to r v `star` pure (fact v1)) `star` frame)
+                    (locks_invariant e m0);                    
     Ghost.hide v1
 
-let iname_for_p_mem (i:iname) (p:slprop) : NMSTTotal.s_predicate mem =
+let iname_for_p_mem (i:iname) (p:slprop) : W.s_predicate mem =
   fun m -> iname_for_p i p m.locks
 
 let iname_for_p_stable (i:iname) (p:slprop)
-  : Lemma (NMSTTotal.stable full_mem mem_evolves (iname_for_p_mem i p))
+  : Lemma (W.stable full_mem mem_evolves (iname_for_p_mem i p))
   = ()
 
-let ( >--> ) i p : prop = NMSTTotal.witnessed full_mem mem_evolves (iname_for_p_mem i p)
+let ( >--> ) (i:iname) (p:slprop) : Type0 = W.witnessed full_mem mem_evolves (iname_for_p_mem i p)
 
 let hmem_with_inv_equiv e (m:mem) (p:slprop)
   : Lemma (interp (p `star` linv e m) m <==>
@@ -1231,6 +1204,9 @@ let new_invariant_tot_action (e:inames) (p:slprop) (m0:hmem_with_inv_except e p{
     assert (frame_related_mems p emp e m0 m1);
     ( i, m1 )
 
+let inv (p:slprop u#1) = i:erased iname & (i >--> p)
+let name_of_inv #p (i:inv p) = dfst i
+
 let new_invariant (e:inames) (p:slprop) (frame:slprop)
   : MstTot (inv p) e p (fun _ -> emp) frame (fun _ -> True) (fun _ _ _ -> True)
   = let m0 = NMSTTotal.get () in
@@ -1241,8 +1217,8 @@ let new_invariant (e:inames) (p:slprop) (frame:slprop)
     assert (mem_evolves m0 m1);
     NMSTTotal.put #full_mem #mem_evolves m1;
     iname_for_p_stable i p;
-    NMSTTotal.witness full_mem mem_evolves (iname_for_p_mem i p);
-    i
+    let w  = NMSTTotal.witness full_mem mem_evolves (iname_for_p_mem i p) in
+    (| hide i, w |)
 
 let rearrange_invariant (p q r : slprop) (q0 q1:slprop)
   : Lemma
@@ -1287,13 +1263,13 @@ let preserves_frame_invariant (fp fp':slprop)
                               (m0:hmem_with_inv_except (add_inv opened_invariants i) (p `star` fp))
                               (m1:mem)
     : Lemma
-      (requires preserves_frame (set_add i opened_invariants) (p `star` fp) (p `star` fp') m0 m1 /\
+      (requires preserves_frame (set_add (name_of_inv i) opened_invariants) (p `star` fp) (p `star` fp') m0 m1 /\
                 interp (fp' `star` linv opened_invariants m1) m1 /\
                 inames_ok opened_invariants m1 /\
                 (lock_store_invariant opened_invariants m0.locks `equiv`
-                   (p `star` lock_store_invariant (set_add i opened_invariants) m0.locks)) /\
+                   (p `star` lock_store_invariant (set_add (name_of_inv i) opened_invariants) m0.locks)) /\
                 (lock_store_invariant opened_invariants m1.locks `equiv`
-                 (p `star` lock_store_invariant (set_add i opened_invariants) m1.locks)))
+                 (p `star` lock_store_invariant (set_add (name_of_inv i) opened_invariants) m1.locks)))
       (ensures  preserves_frame opened_invariants fp fp' m0 m1)
     =
       let aux (frame:slprop)
@@ -1305,19 +1281,19 @@ let preserves_frame_invariant (fp fp':slprop)
              (forall (f_frame:mprop frame). f_frame (core_mem m0) == f_frame (core_mem m1)))
            [SMTPat()]
         = rearrange_invariant (fp `star` frame) (lock_store_invariant opened_invariants m0.locks) (ctr_validity m0.ctr (heap_of_mem m0))
-                                                p (lock_store_invariant (set_add i opened_invariants) m0.locks);
-          assert (interp ((p `star` (fp `star` frame)) `star` linv (set_add i opened_invariants) m0) m0);
+                                                p (lock_store_invariant (set_add (name_of_inv i) opened_invariants) m0.locks);
+          assert (interp ((p `star` (fp `star` frame)) `star` linv (set_add (name_of_inv i) opened_invariants) m0) m0);
           star_associative p fp frame;
-          star_congruence (p `star` (fp `star` frame)) (linv (set_add i opened_invariants) m0)
-                          ((p `star` fp) `star` frame)  (linv (set_add i opened_invariants) m0);
-          assert (interp (((p `star` fp) `star` frame) `star` linv (set_add i opened_invariants) m0) m0);
-          assert (interp (((p `star` fp') `star` frame) `star` linv (set_add i opened_invariants) m1) m1);
+          star_congruence (p `star` (fp `star` frame)) (linv (set_add (name_of_inv i) opened_invariants) m0)
+                          ((p `star` fp) `star` frame)  (linv (set_add (name_of_inv i) opened_invariants) m0);
+          assert (interp (((p `star` fp) `star` frame) `star` linv (set_add (name_of_inv i) opened_invariants) m0) m0);
+          assert (interp (((p `star` fp') `star` frame) `star` linv (set_add (name_of_inv i) opened_invariants) m1) m1);
           star_associative p fp' frame;
-          star_congruence ((p `star` fp') `star` frame) (linv (set_add i opened_invariants) m1)
-                          (p `star` (fp' `star` frame)) (linv (set_add i opened_invariants) m1);
-          assert (interp ((p `star` (fp' `star` frame)) `star` linv (set_add i opened_invariants) m1) m1);
+          star_congruence ((p `star` fp') `star` frame) (linv (set_add (name_of_inv i) opened_invariants) m1)
+                          (p `star` (fp' `star` frame)) (linv (set_add (name_of_inv i) opened_invariants) m1);
+          assert (interp ((p `star` (fp' `star` frame)) `star` linv (set_add (name_of_inv i) opened_invariants) m1) m1);
           rearrange_invariant (fp' `star` frame) (lock_store_invariant opened_invariants m1.locks) (ctr_validity m1.ctr (heap_of_mem m1))
-                                                 p (lock_store_invariant (set_add i opened_invariants) m1.locks);
+                                                 p (lock_store_invariant (set_add (name_of_inv i) opened_invariants) m1.locks);
           assert (interp ((fp' `star` frame) `star` linv opened_invariants m1) m1);
           ()
       in
@@ -1390,17 +1366,17 @@ let with_invariant (#a:Type)
                    (frame:slprop)
   : MstTot a opened_invariants fp fp' frame (fun _ -> True) (fun _ _ _ -> True)
   = let m0 = NMSTTotal.get () in
-    NMSTTotal.recall _ mem_evolves (iname_for_p_mem i p);
-    assert (iname_for_p i p m0.locks);
+    NMSTTotal.recall _ mem_evolves (iname_for_p_mem (name_of_inv i) p) (dsnd i);
+    assert (iname_for_p (name_of_inv i) p m0.locks);
 
     assert (interp (fp `star` frame `star` locks_invariant opened_invariants m0) m0);
     assert (interp (fp `star` frame `star`
       (lock_store_invariant opened_invariants m0.locks `star`
        ctr_validity m0.ctr (heap_of_mem m0))) m0);
 
-    move_invariant opened_invariants m0.locks p i;
+    move_invariant opened_invariants m0.locks p (name_of_inv i);
     assert (lock_store_invariant opened_invariants m0.locks `equiv`
-            (p `star` lock_store_invariant (set_add i opened_invariants) m0.locks));
+            (p `star` lock_store_invariant (set_add (name_of_inv i) opened_invariants) m0.locks));
 
     with_inv_helper
       fp
@@ -1408,23 +1384,23 @@ let with_invariant (#a:Type)
       (lock_store_invariant opened_invariants m0.locks)
       (ctr_validity m0.ctr (heap_of_mem m0))
       p
-      (lock_store_invariant (set_add i opened_invariants) m0.locks);
+      (lock_store_invariant (set_add (name_of_inv i) opened_invariants) m0.locks);
 
-    assert (interp (p `star` fp `star` frame `star` locks_invariant (set_add i opened_invariants) m0) m0);
+    assert (interp (p `star` fp `star` frame `star` locks_invariant (set_add (name_of_inv i) opened_invariants) m0) m0);
 
     let r = f frame in
     let m1 : full_mem = NMSTTotal.get () in
 
-    assert (interp (p `star` fp' r `star` frame `star` locks_invariant (set_add i opened_invariants) m1) m1);
+    assert (interp (p `star` fp' r `star` frame `star` locks_invariant (set_add (name_of_inv i) opened_invariants) m1) m1);
     assert (interp (p `star` fp' r `star` frame `star`
-      (lock_store_invariant (set_add i opened_invariants) m1.locks `star`
+      (lock_store_invariant (set_add (name_of_inv i) opened_invariants) m1.locks `star`
        ctr_validity m1.ctr (heap_of_mem m1))) m1);
 
-    NMSTTotal.recall _ mem_evolves (iname_for_p_mem i p);
+    NMSTTotal.recall _ mem_evolves (iname_for_p_mem (name_of_inv i) p) (dsnd i);
 
-    move_invariant opened_invariants m1.locks p i;
+    move_invariant opened_invariants m1.locks p (name_of_inv i);
     assert (lock_store_invariant opened_invariants m1.locks `equiv`
-            (p `star` lock_store_invariant (set_add i opened_invariants) m1.locks));
+            (p `star` lock_store_invariant (set_add (name_of_inv i) opened_invariants) m1.locks));
 
     with_inv_helper
       (fp' r)
@@ -1432,7 +1408,7 @@ let with_invariant (#a:Type)
       (lock_store_invariant opened_invariants m1.locks)
       (ctr_validity m1.ctr (heap_of_mem m1))
       p
-      (lock_store_invariant (set_add i opened_invariants) m1.locks);
+      (lock_store_invariant (set_add (name_of_inv i) opened_invariants) m1.locks);
 
     assert (interp (fp' r `star` frame `star` locks_invariant opened_invariants m1) m1);
 

--- a/ulib/experimental/Steel.Memory.fsti
+++ b/ulib/experimental/Steel.Memory.fsti
@@ -468,7 +468,7 @@ val witnessed (#a:Type u#1)
               (#pcm:pcm a)
               (r:ref a pcm)
               (fact:property a)
-  : prop
+  : Type0
 
 let stable_property (#a:Type) (pcm:pcm a)
   = fact:property a {
@@ -477,35 +477,32 @@ let stable_property (#a:Type) (pcm:pcm a)
 
 val witness (#a:Type) (#pcm:pcm a)
             (e:inames)
-            (r:ref a pcm)
+            (r:erased (ref a pcm))
             (fact:stable_property pcm)
             (v:Ghost.erased a)
             (_:squash (forall z. compatible pcm v z ==> fact z))
-  : action_except unit e (pts_to r v) (fun _ -> pts_to r v `star` pure (witnessed r fact))
+  : action_except (witnessed r fact) e (pts_to r v) (fun _ -> pts_to r v)
 
 val recall (#a:Type u#1) (#pcm:pcm a) (#fact:property a)
            (e:inames)
-           (r:ref a pcm)
+           (r:erased (ref a pcm))
            (v:Ghost.erased a)
+           (w:witnessed r fact)
   : action_except (v1:Ghost.erased a{compatible pcm v v1}) e
-                  (pts_to r v `star` pure (witnessed r fact))
+                  (pts_to r v)
                   (fun v1 -> pts_to r v `star` pure (fact v1))
 
 (**** Invariants *)
 
-(**
-  This operator asserts that the logical content of invariant [i] is the separation logic
-  predicate [p]
-*)
-val ( >--> ) (i:iname) (p:slprop u#1) : prop
-
 (**[i : inv p] is an invariant whose content is [p] *)
-let inv (p:slprop) = i:(erased iname){reveal i >--> p}
+val inv (p:slprop u#1) : Type0
 
-let mem_inv (#p:slprop) (e:inames) (i:inv p) : erased bool = elift2 (fun e i -> Set.mem i e) e i
+val name_of_inv (#p:slprop) (i:inv p) : GTot iname
+
+let mem_inv (#p:slprop) (e:inames) (i:inv p) : erased bool = elift2 (fun e i -> Set.mem i e) e (name_of_inv i)
 
 let add_inv (#p:slprop) (e:inames) (i:inv p) : inames =
-  Set.union (Set.singleton (reveal i)) (reveal e)
+  Set.union (Set.singleton (name_of_inv i)) (reveal e)
 
 (** Creates a new invariant from a separation logic predicate [p] owned at the time of the call *)
 val new_invariant (e:inames) (p:slprop)

--- a/ulib/experimental/Steel.MonotonicHigherReference.fst
+++ b/ulib/experimental/Steel.MonotonicHigherReference.fst
@@ -162,51 +162,49 @@ let witnessed #a #p r fact =
 let get_squash (#p:prop) (_:unit{p}) : squash p = ()
 
 let witness_thunk (#inames: _) (#a:Type) (#pcm:FStar.PCM.pcm a)
-                  (r:M.ref a pcm)
+                  (r:Ghost.erased (M.ref a pcm))
                   (fact:M.stable_property pcm)
                   (v:Ghost.erased a)
                   (_:squash (fact_valid_compat #_ #pcm fact v))
                   (_:unit)
-  : SteelGhost unit inames (PR.pts_to r v)
-               (fun _ -> PR.pts_to r v)
-               (requires fun _ -> True)
-               (ensures fun _ _ _ -> M.witnessed r fact)
+  : SteelAtomicUT (M.witnessed r fact) inames (PR.pts_to r v)
+                (fun _ -> PR.pts_to r v)
   = witness r fact v ()
 
 #push-options "--print_implicits"
 
-let witness (#inames: _) (#a:Type) (#q:perm) (#p:Preorder.preorder a) (r:ref a p)
+let witness (#inames: _) (#a:Type) (#q:perm) (#p:Preorder.preorder a)
+            (r:Ghost.erased (ref a p))
             (fact:stable_property p)
             (v:erased a)
             (_:squash (fact v))
-  : SteelGhost unit inames (pts_to r q v)
+  : SteelAtomicUT (witnessed r fact) inames (pts_to r q v)
                (fun _ -> pts_to r q v)
-               (requires fun _ -> True)
-               (ensures fun _ _ _ -> witnessed r fact)
   = let h = witness_exists #_ #_ #(pts_to_body r q v) () in
     let _ = elim_pure #_ #_ #_ #q r v h in
 
     assert (forall h'. compatible pcm_history h h' ==> lift_fact fact h');
     lift_fact_is_stable #a #p fact;
 
-    witness_thunk #_ #_ #(pcm_history #a #p)  r (lift_fact fact) h () _;
+    let w = witness_thunk #_ #_ #(pcm_history #a #p)  r (lift_fact fact) h () _ in
 
     rewrite_slprop (PR.pts_to r h) (pts_to_body r q v h) (fun m ->
       emp_unit (M.pts_to r h);
       pure_star_interp (M.pts_to r h) (history_val h v q) m);
 
-    intro_exists_erased h (pts_to_body r q v)
+    intro_exists_erased h (pts_to_body r q v);
+    return w
 
 let recall (#inames: _) (#a:Type u#1) (#q:perm) (#p:Preorder.preorder a) (fact:property a)
-           (r:ref a p) (v:erased a)
-  : SteelGhost unit inames (pts_to r q v)
+           (r:Ghost.erased (ref a p)) (v:erased a) (w:witnessed r fact)
+  : SteelAtomicU unit inames (pts_to r q v)
                (fun _ -> pts_to r q v)
-               (requires fun _ -> witnessed r fact)
+               (requires fun _ -> True)
                (ensures fun _ _ _ -> fact v)
   = let h = witness_exists #_ #_ #(pts_to_body r q v) () in
     let _ = elim_pure #_ #_ #_ #q r v h in
 
-    let h1 = recall (lift_fact fact) r h in
+    let h1 = recall (lift_fact fact) r h w in
 
     rewrite_slprop (PR.pts_to r h) (pts_to_body r q v h) (fun m ->
       emp_unit (M.pts_to r h);
@@ -252,6 +250,7 @@ let share #o (#a:Type) (#p:Preorder.preorder a) (r:ref a p) (f:perm) (v:Ghost.er
     intro_exists #(history a p) sh (pts_to_body r (half_perm f) v);
     intro_pts_to r (half_perm f) v
 
+#push-options "--compat_pre_core 1"
 let gather #o (#a:Type) (#p:Preorder.preorder a) (r:ref a p) (f g:perm) (v:Ghost.erased a)
   : SteelGhostT unit o
     (pts_to r f v `star` pts_to r g v)
@@ -267,3 +266,4 @@ let gather #o (#a:Type) (#p:Preorder.preorder a) (r:ref a p) (f g:perm) (v:Ghost
     intro_pure (history_val (op pcm_history hf hg) v (sum_perm f g));
     intro_exists (op pcm_history hf hg) (pts_to_body r (sum_perm f g) v);
     intro_pts_to r (sum_perm f g) v
+#pop-options

--- a/ulib/experimental/Steel.MonotonicHigherReference.fsti
+++ b/ulib/experimental/Steel.MonotonicHigherReference.fsti
@@ -69,7 +69,7 @@ let property (a:Type)
 /// A wrapper around a property [fact] that has been witnessed to be true and stable
 /// with respect to preorder [p]
 val witnessed (#a:Type u#1) (#p:Preorder.preorder a) (r:ref a p) (fact:property a)
-  : prop
+  : Type0
 
 /// The type of properties depending on values of type [a], and that
 /// are stable with respect to the preorder [p]
@@ -78,22 +78,23 @@ let stable_property (#a:Type) (p:Preorder.preorder a)
 
 /// If [fact] is a stable property for the reference preorder [p], and if
 /// it holds for the current value [v] of the reference, then we can witness it
-val witness (#inames: _) (#a:Type) (#q:perm) (#p:Preorder.preorder a) (r:ref a p)
+val witness (#inames: _) (#a:Type) (#q:perm) (#p:Preorder.preorder a)
+            (r:erased (ref a p))
             (fact:stable_property p)
             (v:erased a)
             (_:squash (fact v))
-  : SteelGhost unit inames (pts_to r q v)
-               (fun _ -> pts_to r q v)
-               (requires fun _ -> True)
-               (ensures fun _ _ _ -> witnessed r fact)
+  : SteelAtomicUT (witnessed r fact) inames (pts_to r q v)
+                  (fun _ -> pts_to r q v)
 
 /// If we previously witnessed the validity of [fact], we can recall its validity
 val recall (#inames: _) (#a:Type u#1) (#q:perm) (#p:Preorder.preorder a)
            (fact:property a)
-           (r:ref a p) (v:erased a)
-  : SteelGhost unit inames (pts_to r q v)
+           (r:erased (ref a p))
+           (v:erased a)
+           (w:witnessed r fact)
+  : SteelAtomicU unit inames (pts_to r q v)
                (fun _ -> pts_to r q v)
-               (requires fun _ -> witnessed r fact)
+               (requires fun _ -> True)
                (ensures fun _ _ _ -> fact v)
 
 /// Monotonic references are also equipped with the usual fractional permission discipline

--- a/ulib/experimental/Steel.MonotonicReference.fst
+++ b/ulib/experimental/Steel.MonotonicReference.fst
@@ -83,15 +83,10 @@ let witness (#inames: _)
            (#a:Type)
            (#q:perm)
            (#p:Preorder.preorder a)
-           (r:ref a p)
+           (r:erased (ref a p))
            (fact:stable_property p)
            (v:erased a)
            (_:squash (fact v))
-  : SteelGhost unit inames
-               (pts_to r q v)
-               (fun _ -> pts_to r q v)
-               (requires fun _ -> True)
-               (ensures fun _ _ _ -> witnessed r fact)
   = MHR.witness r (lift_property fact) (hide (U.raise_val (reveal v))) ()
 
 /// If we previously witnessed the validity of [fact], we can recall its validity
@@ -100,13 +95,10 @@ let recall (#inames: _)
            (#q:perm)
            (#p:Preorder.preorder a)
            (fact:property a)
-           (r:ref a p)
+           (r:erased (ref a p))
            (v:erased a)
-  : SteelGhost unit inames (pts_to r q v)
-               (fun _ -> pts_to r q v)
-               (requires fun _ -> witnessed r fact)
-               (ensures fun _ _ _ -> fact v)
-  = MHR.recall (lift_property fact) r (hide (U.raise_val (reveal v)))
+           (w:witnessed r fact)
+  = MHR.recall (lift_property fact) r (hide (U.raise_val (reveal v))) w
 
 /// Monotonic references are also equipped with the usual fractional permission discipline
 /// So, you can split a reference into two read-only shares

--- a/ulib/experimental/Steel.MonotonicReference.fsti
+++ b/ulib/experimental/Steel.MonotonicReference.fsti
@@ -72,7 +72,7 @@ let property (a:Type)
 /// A wrapper around a property [fact] that has been witnessed to be true and stable
 /// with respect to preorder [p]
 val witnessed (#a:Type u#0) (#p:Preorder.preorder a) (r:ref a p) (fact:property a)
-  : prop
+  : Type0
 
 /// The type of properties depending on values of type [a], and that
 /// are stable with respect to the preorder [p]
@@ -81,22 +81,25 @@ let stable_property (#a:Type) (p:Preorder.preorder a)
 
 /// If [fact] is a stable property for the reference preorder [p], and if
 /// it holds for the current value [v] of the reference, then we can witness it
-val witness (#inames: _) (#a:Type) (#q:perm) (#p:Preorder.preorder a) (r:ref a p)
+val witness (#inames: _) (#a:Type) (#q:perm) (#p:Preorder.preorder a)
+            (r:erased (ref a p))
             (fact:stable_property p)
             (v:erased a)
             (_:squash (fact v))
-  : SteelGhost unit inames (pts_to r q v)
-               (fun _ -> pts_to r q v)
-               (requires fun _ -> True)
-               (ensures fun _ _ _ -> witnessed r fact)
+  : SteelAtomicUT (witnessed r fact) inames
+                  (pts_to r q v)
+                  (fun _ -> pts_to r q v)
+
 
 /// If we previously witnessed the validity of [fact], we can recall its validity
 val recall (#inames: _) (#a:Type u#0) (#q:perm) (#p:Preorder.preorder a)
            (fact:property a)
-           (r:ref a p) (v:erased a)
-  : SteelGhost unit inames (pts_to r q v)
+           (r:erased (ref a p))
+           (v:erased a)
+           (w:witnessed r fact)
+  : SteelAtomicU unit inames (pts_to r q v)
                (fun _ -> pts_to r q v)
-               (requires fun _ -> witnessed r fact)
+               (requires fun _ -> True)
                (ensures fun _ _ _ -> fact v)
 
 /// Monotonic references are also equipped with the usual fractional permission discipline

--- a/ulib/experimental/Steel.PCMReference.fst
+++ b/ulib/experimental/Steel.PCMReference.fst
@@ -19,7 +19,7 @@ module Steel.PCMReference
 
 module Mem = Steel.Memory
 
-let read r v0 = as_action (sel_action FStar.Set.empty r v0)
+let read r v0 = let v = as_action (sel_action FStar.Set.empty r v0) in v
 let write r v0 v1 = as_action (upd_action FStar.Set.empty r v0 v1)
 
 val alloc' (#a:Type)
@@ -79,37 +79,31 @@ let gather r v0 v1 =
   gather' r v0 v1
 
 val witness' (#inames: _) (#a:Type) (#pcm:pcm a)
-            (r:ref a pcm)
+            (r:erased (ref a pcm))
             (fact:stable_property pcm)
             (v:erased a)
             (_:fact_valid_compat fact v)
-  : SteelGhostT unit inames (pts_to r v)
-                (fun _ -> to_vprop Mem.(pts_to r v `star` pure (witnessed r fact)))
+  : SteelAtomicUT (witnessed r fact) inames (pts_to r v)
+                  (fun _ -> to_vprop Mem.(pts_to r v))
 
-let witness' #inames r fact v _ = as_atomic_action_ghost (Steel.Memory.witness inames r fact v ())
+let witness' #inames r fact v _ = as_atomic_unobservable_action (Steel.Memory.witness inames r fact v ())
 
 let witness r fact v s =
-  witness' r fact v s;
-  rewrite_slprop (to_vprop Mem.(pts_to r v `star` pure (witnessed r fact)))
-                 (pts_to r v `star` pure (witnessed r fact))
-                 (fun _ -> ());
-  elim_pure (witnessed r fact)
-
+  let w = witness' r fact v s in
+  w
+  
 val recall' (#inames: _) (#a:Type u#1) (#pcm:pcm a) (fact:property a)
-           (r:ref a pcm)
+           (r:erased (ref a pcm))
            (v:erased a)
-  : SteelGhostT (v1:erased a{compatible pcm v v1}) inames
-           (to_vprop Mem.(pts_to r v `star` pure (witnessed r fact)))
+           (w:witnessed r fact)
+  : SteelAtomicUT (v1:erased a{compatible pcm v v1}) inames
+           (to_vprop Mem.(pts_to r v))
            (fun v1 -> to_vprop Mem.(pts_to r v `star` pure (fact v1)))
 
-let recall' #inames #a #pcm fact r v = as_atomic_action_ghost (Steel.Memory.recall #a #pcm #fact inames r v)
+let recall' #inames #a #pcm fact r v w = as_atomic_unobservable_action (Steel.Memory.recall #a #pcm #fact inames r v w)
 
-let recall #inames #a #pcm fact r v =
-  intro_pure (witnessed r fact);
-  rewrite_slprop (pts_to r v `star` pure (witnessed r fact))
-                 (to_vprop Mem.(pts_to r v `star` pure (witnessed r fact)))
-                 (fun _ -> ());
-  let v1 = recall' fact r v in
+let recall #inames #a #pcm fact r v w =
+  let v1 = recall' fact r v w in
   rewrite_slprop (to_vprop Mem.(pts_to r v `star` pure (fact v1)))
                  (pts_to r v `star` pure (fact v1))
                  (fun _ -> ());
@@ -120,5 +114,5 @@ let select_refine #a #p r x f = as_action (Steel.Memory.select_refine Set.empty 
 
 let upd_gen #a #p r x y f = as_action (Steel.Memory.upd_gen Set.empty r x y f)
 
-let atomic_read #opened #_ #_ r v0 = as_atomic_action (sel_action opened r v0)
+let atomic_read #opened #_ #_ r v0 = let v = as_atomic_action (sel_action opened r v0) in v
 let atomic_write #opened #_ #_ r v0 v1 = as_atomic_action (upd_action opened r v0 v1)

--- a/ulib/experimental/Steel.PCMReference.fsti
+++ b/ulib/experimental/Steel.PCMReference.fsti
@@ -117,26 +117,27 @@ let fact_valid_compat (#a:Type) (#pcm:pcm a)
 /// and if it is currently valid for any value that is compatible with
 /// our current knowledge [v], then we can witness the property
 val witness (#inames: _) (#a:Type) (#pcm:pcm a)
-            (r:ref a pcm)
+            (r:erased (ref a pcm))
             (fact:stable_property pcm)
             (v:erased a)
             (_:fact_valid_compat fact v)
-  : SteelGhost unit inames (pts_to r v)
-               (fun _ -> pts_to r v)
-               (requires fun _ -> True)
-               (ensures fun _ _ _ -> witnessed r fact)
+  : SteelAtomicUT (witnessed r fact) inames
+                  (pts_to r v)
+                  (fun _ -> pts_to r v)
+
 
 /// If we previously witnessed the validity of a predicate [fact],
 /// then we can recall this validity on the current value [v1], which
 /// is compatible with our previous knowledge [v]
 val recall (#inames: _) (#a:Type u#1) (#pcm:pcm a)
            (fact:property a)
-           (r:ref a pcm)
+           (r:erased (ref a pcm))
            (v:erased a)
-  : SteelGhost (erased a) inames
+           (w:witnessed r fact)
+  : SteelAtomicU (erased a) inames
           (pts_to r v)
           (fun v1 -> pts_to r v)
-          (requires fun _ -> witnessed r fact)
+          (requires fun _ -> True)
           (ensures fun _ v1 _ -> fact v1 /\ compatible pcm v v1)
 
 /// Refines our current knowledge [x] about reference [r] by applying function [f]

--- a/ulib/experimental/Steel.ST.Effect.Atomic.fst
+++ b/ulib/experimental/Steel.ST.Effect.Atomic.fst
@@ -29,3 +29,13 @@ let as_atomic_action (#a:Type u#a)
   : STAtomicT a opened_invariants (to_vprop fp) (fun x -> to_vprop (fp' x))
   = let ff = SEA.reify_steel_atomic_comp (fun _ -> SEA.as_atomic_action f) in
     STAtomicBase?.reflect ff
+
+
+let as_atomic_unobservable_action (#a:Type u#a)
+                                  (#opened_invariants:inames)
+                                  (#fp:slprop)
+                                  (#fp': a -> slprop)
+                                  (f:action_except a opened_invariants fp fp')
+  : STAtomicUT a opened_invariants (to_vprop fp) (fun x -> to_vprop (fp' x))
+  = let ff = SEA.reify_steel_atomic_comp (fun _ -> SEA.as_atomic_unobservable_action f) in
+    STAtomicBase?.reflect ff

--- a/ulib/experimental/Steel.ST.GhostMonotonicReference.fst
+++ b/ulib/experimental/Steel.ST.GhostMonotonicReference.fst
@@ -51,7 +51,7 @@ let witnessed (#a:Type u#0)
               (#p:Preorder.preorder a)
               (r:ref a p)
               (fact:property a)
-  : prop
+  : Type0
   = MR.witnessed r fact
 
 let witness' (#inames: _)
@@ -60,14 +60,12 @@ let witness' (#inames: _)
             (#p:Preorder.preorder a)
             (r:ref a p)
             (fact:stable_property p)
-            (v:a)
+            (v:erased a)
             (pf:squash (fact v))
             (_:unit)
-  : Steel.Effect.Atomic.SteelGhost unit inames
+  : Steel.Effect.Atomic.SteelAtomicUT (witnessed r fact) inames
       (pts_to r q v)
       (fun _ -> pts_to r q v)
-      (requires fun _ -> True)
-      (ensures fun _ _ _ -> witnessed r fact)
   = MR.witness #inames #a #q #p r fact v pf
 
 let witness (#inames: _)
@@ -76,14 +74,9 @@ let witness (#inames: _)
             (#p:Preorder.preorder a)
             (r:ref a p)
             (fact:stable_property p)
-            (v:a)
+            (v:erased a)
             (pf:squash (fact v))
-  : STGhost unit inames
-      (pts_to r q v)
-      (fun _ -> pts_to r q v)
-      (requires True)
-      (ensures fun _ -> witnessed r fact)
-  = coerce_ghost (witness' r fact v pf); ()
+  = coerce_atomic (witness' r fact v pf)
 
 let recall (#inames: _)
            (#a:Type u#0)
@@ -91,13 +84,9 @@ let recall (#inames: _)
            (#p:Preorder.preorder a)
            (fact:property a)
            (r:ref a p)
-           (v:a)
-  : STGhost unit inames
-      (pts_to r q v)
-      (fun _ -> pts_to r q v)
-      (requires witnessed r fact)
-      (ensures fun _ -> fact v)
-  = coerce_ghost (fun _ -> MR.recall #inames #a #q #p fact r v)
+           (v:erased a)
+           (w:witnessed r fact)
+  = coerce_atomic (fun _ -> MR.recall #inames #a #q #p fact r v w)
 
 let share (#inames:_)
           (#a:Type)

--- a/ulib/experimental/Steel.ST.GhostMonotonicReference.fsti
+++ b/ulib/experimental/Steel.ST.GhostMonotonicReference.fsti
@@ -67,7 +67,7 @@ let property (a:Type)
 /// A wrapper around a property [fact] that has been witnessed to be true and stable
 /// with respect to preorder [p]
 val witnessed (#a:Type u#0) (#p:Preorder.preorder a) (r:ref a p) (fact:property a)
-  : prop
+  : Type0
 
 /// The type of properties depending on values of type [a], and that
 /// are stable with respect to the preorder [p]
@@ -86,13 +86,12 @@ val witness (#inames: _)
             (#p:Preorder.preorder a)
             (r:ref a p)
             (fact:stable_property p)
-            (v:a)
+            (v:erased a)
             (_:squash (fact v))
-  : STGhost unit inames
+  : STAtomicUT (witnessed r fact) inames
       (pts_to r q v)
       (fun _ -> pts_to r q v)
-      (requires True)
-      (ensures fun _ -> witnessed r fact)
+
 
 /// If we previously witnessed the validity of [fact], we can recall its validity
 val recall (#inames: _)
@@ -101,11 +100,12 @@ val recall (#inames: _)
            (#p:Preorder.preorder a)
            (fact:property a)
            (r:ref a p)
-           (v:a)
-  : STGhost unit inames
+           (v:erased a)
+           (w:witnessed r fact)
+  : STAtomicU unit inames
       (pts_to r q v)
       (fun _ -> pts_to r q v)
-      (requires witnessed r fact)
+      (requires True)
       (ensures fun _ -> fact v)
 
 /// Monotonic references are also equipped with the usual fractional

--- a/ulib/experimental/Steel.ST.MonotonicReference.fst
+++ b/ulib/experimental/Steel.ST.MonotonicReference.fst
@@ -51,53 +51,42 @@ let witnessed (#a:Type u#0)
               (#p:Preorder.preorder a)
               (r:ref a p)
               (fact:property a)
-  : prop
+  : Type0
   = MR.witnessed r fact
 
 let witness' (#inames: _)
             (#a:Type)
             (#q:perm)
             (#p:Preorder.preorder a)
-            (r:ref a p)
+            (r:erased (ref a p))
             (fact:stable_property p)
             (v:erased a)
             (pf:squash (fact v))
             (_:unit)
-  : Steel.Effect.Atomic.SteelGhost unit inames
+  : Steel.Effect.Atomic.SteelAtomicUT (witnessed r fact) inames
       (pts_to r q v)
       (fun _ -> pts_to r q v)
-      (requires fun _ -> True)
-      (ensures fun _ _ _ -> witnessed r fact)
   = MR.witness #inames #a #q #p r fact v pf
 
 let witness (#inames: _)
             (#a:Type)
             (#q:perm)
             (#p:Preorder.preorder a)
-            (r:ref a p)
+            (r:erased (ref a p))
             (fact:stable_property p)
             (v:erased a)
             (pf:squash (fact v))
-  : STGhost unit inames
-      (pts_to r q v)
-      (fun _ -> pts_to r q v)
-      (requires True)
-      (ensures fun _ -> witnessed r fact)
-  = coerce_ghost (witness' r fact v pf); ()
+  = coerce_atomic (witness' r fact v pf)
 
 let recall (#inames: _)
            (#a:Type u#0)
            (#q:perm)
            (#p:Preorder.preorder a)
            (fact:property a)
-           (r:ref a p)
+           (r:erased (ref a p))
            (v:erased a)
-  : STGhost unit inames
-      (pts_to r q v)
-      (fun _ -> pts_to r q v)
-      (requires witnessed r fact)
-      (ensures fun _ -> fact v)
-  = coerce_ghost (fun _ -> MR.recall #inames #a #q #p fact r v)
+           (w:witnessed r fact)
+  = coerce_atomic (fun _ -> MR.recall #inames #a #q #p fact r v w)
 
 let share (#inames:_)
           (#a:Type)

--- a/ulib/experimental/Steel.ST.MonotonicReference.fsti
+++ b/ulib/experimental/Steel.ST.MonotonicReference.fsti
@@ -66,7 +66,7 @@ let property (a:Type)
 /// A wrapper around a property [fact] that has been witnessed to be true and stable
 /// with respect to preorder [p]
 val witnessed (#a:Type u#0) (#p:Preorder.preorder a) (r:ref a p) (fact:property a)
-  : prop
+  : Type0
 
 /// The type of properties depending on values of type [a], and that
 /// are stable with respect to the preorder [p]
@@ -83,15 +83,13 @@ val witness (#inames: _)
             (#a:Type)
             (#q:perm)
             (#p:Preorder.preorder a)
-            (r:ref a p)
+            (r:erased (ref a p))
             (fact:stable_property p)
             (v:erased a)
             (_:squash (fact v))
-  : STGhost unit inames
+  : STAtomicUT (witnessed r fact) inames
       (pts_to r q v)
       (fun _ -> pts_to r q v)
-      (requires True)
-      (ensures fun _ -> witnessed r fact)
 
 /// If we previously witnessed the validity of [fact], we can recall its validity
 val recall (#inames: _)
@@ -99,12 +97,13 @@ val recall (#inames: _)
            (#q:perm)
            (#p:Preorder.preorder a)
            (fact:property a)
-           (r:ref a p)
+           (r:erased (ref a p))
            (v:erased a)
-  : STGhost unit inames
+           (w:witnessed r fact)
+  : STAtomicU unit inames
       (pts_to r q v)
       (fun _ -> pts_to r q v)
-      (requires witnessed r fact)
+      (requires True)
       (ensures fun _ -> fact v)
 
 /// Monotonic references are also equipped with the usual fractional

--- a/ulib/experimental/Steel.ST.PCMReference.fst
+++ b/ulib/experimental/Steel.ST.PCMReference.fst
@@ -21,15 +21,13 @@ let witness' (#inames: _) (#a:Type) (#pcm:pcm a)
             (v:erased a)
             (_:fact_valid_compat fact v)
             ()
-  : Steel.Effect.Atomic.SteelGhost unit inames (pts_to r v)
+  : Steel.Effect.Atomic.SteelAtomicUT (witnessed r fact) inames (pts_to r v)
                (fun _ -> pts_to r v)
-               (requires fun _ -> True)
-               (ensures fun _ _ _ -> witnessed r fact)
 = P.witness r fact v ()
 
-let witness r fact v vc = C.coerce_ghost (witness' r fact v vc)
+let witness r fact v vc = C.coerce_atomic (witness' r fact v vc)
 
-let recall fact r v = C.coerce_ghost (fun _ -> P.recall fact r v)
+let recall fact r v w = C.coerce_atomic (fun _ -> P.recall fact r v w)
 
 let select_refine r x f = C.coerce_steel (fun _ -> P.select_refine r x f)
 

--- a/ulib/experimental/Steel.ST.PCMReference.fsti
+++ b/ulib/experimental/Steel.ST.PCMReference.fsti
@@ -135,10 +135,9 @@ val witness (#inames: _) (#a:Type) (#pcm:pcm a)
             (fact:stable_property pcm)
             (v:erased a)
             (_:fact_valid_compat fact v)
-  : STGhost unit inames (pts_to r v)
+  : STAtomicUT (witnessed r fact) inames (pts_to r v)
                (fun _ -> pts_to r v)
-               (requires True)
-               (ensures fun _ -> witnessed r fact)
+
 
 /// If we previously witnessed the validity of a predicate [fact],
 /// then we can recall this validity on the current value [v1], which
@@ -147,10 +146,11 @@ val recall (#inames: _) (#a:Type u#1) (#pcm:pcm a)
            (fact:property a)
            (r:ref a pcm)
            (v:erased a)
-  : STGhost (erased a) inames
+           (w:witnessed r fact)
+  : STAtomicU (erased a) inames
           (pts_to r v)
           (fun v1 -> pts_to r v)
-          (requires witnessed r fact)
+          (requires True)
           (ensures fun v1 -> fact v1 /\ compatible pcm v v1)
 
 /// Refines our current knowledge [x] about reference [r] by applying function [f]

--- a/ulib/experimental/Steel.ST.SpinLock.fsti
+++ b/ulib/experimental/Steel.ST.SpinLock.fsti
@@ -22,13 +22,7 @@ open Steel.ST.Util
 
 /// The type of a lock.  This is implemented as a pair of a boolean
 /// reference, and an invariant name
-val lock_t : Type u#0
-
-/// A predicate relating a lock to a vprop.
-val protects (l:lock_t) (p:vprop) : prop
-
-/// The type of locks associated to a given vprop [p]
-let lock (p:vprop) = l:lock_t{l `protects` p}
+val lock (p:vprop): Type u#0
 
 /// If we have vprop [p] in the context, we can create a new lock
 /// associated to [p]. [p] is then removed from the context, and only

--- a/ulib/experimental/Steel.ST.Util.fst
+++ b/ulib/experimental/Steel.ST.Util.fst
@@ -133,21 +133,22 @@ let exists_cong #a #u p q
   = coerce_ghost (fun _ -> SEA.exists_cong #a #u p q)
 
 let new_invariant #u p
-  = coerce_ghost (fun _ -> SEA.new_invariant #u p)
+  = coerce_atomic (fun _ -> SEA.new_invariant #u p)
 
 let with_invariant (#a:Type)
                    (#fp:vprop)
                    (#fp':a -> vprop)
                    (#opened_invariants:inames)
+                   (#obs:observability)
                    (#p:vprop)
                    (i:inv p{not (mem_inv opened_invariants i)})
-                   ($f:unit -> STAtomicT a (add_inv opened_invariants i)
-                                          (p `star` fp)
-                                          (fun x -> p `star` fp' x))
+                   ($f:unit -> STAtomicBaseT a (add_inv opened_invariants i) obs
+                                              (p `star` fp)
+                                              (fun x -> p `star` fp' x))
   = let f (x:unit)
-      : SEA.SteelAtomicT a (add_inv opened_invariants i)
-                           (p `star` fp)
-                           (fun x -> p `star` fp' x) 
+      : SEA.SteelAtomicBaseT a (add_inv opened_invariants i) obs
+                               (p `star` fp)
+                               (fun x -> p `star` fp' x) 
       = f () in
     coerce_atomic (fun _ -> SEA.with_invariant i f)
 
@@ -165,7 +166,7 @@ let with_invariant_g (#a:Type)
                           (p `star` fp)
                           (fun x -> p `star` fp' x) 
       = f () in
-    coerce_ghost (fun _ -> SEA.with_invariant_g i f)
+    coerce_atomic (fun _ -> SEA.with_invariant_g i f)
 
 let par #aL #aR #preL #postL #preR #postR f g =
   let f : unit -> SE.SteelT aL preL postL = fun _ -> f () in

--- a/ulib/experimental/Steel.ST.Util.fsti
+++ b/ulib/experimental/Steel.ST.Util.fsti
@@ -203,7 +203,7 @@ val exists_cong (#a:_)
 /// Creation of a new invariant associated to vprop [p].
 /// After execution of this function, [p] is consumed and not available in the context anymore
 val new_invariant (#opened_invariants:inames) (p:vprop)
-  : STGhostT (inv p) opened_invariants p (fun _ -> emp)
+  : STAtomicUT (inv p) opened_invariants p (fun _ -> emp)
 
 /// Atomically executing function [f] which relies on the predicate [p] stored in invariant [i]
 /// as long as it maintains the validity of [p]
@@ -213,12 +213,13 @@ val with_invariant (#a:Type)
                    (#fp:vprop)
                    (#fp':a -> vprop)
                    (#opened_invariants:inames)
+                   (#obs:observability)
                    (#p:vprop)
                    (i:inv p{not (mem_inv opened_invariants i)})
-                   ($f:unit -> STAtomicT a (add_inv opened_invariants i)
-                                          (p `star` fp)
-                                          (fun x -> p `star` fp' x))
-  : STAtomicT a opened_invariants fp fp'
+                   ($f:unit -> STAtomicBaseT a (add_inv opened_invariants i) obs
+                                            (p `star` fp)
+                                            (fun x -> p `star` fp' x))
+  : STAtomicBaseT a opened_invariants obs fp fp'
 
 /// Variant of the above combinator for ghost computations
 val with_invariant_g (#a:Type)
@@ -230,7 +231,7 @@ val with_invariant_g (#a:Type)
                      ($f:unit -> STGhostT a (add_inv opened_invariants i)
                                          (p `star` fp)
                                          (fun x -> p `star` fp' x))
-  : STGhostT a opened_invariants fp fp'
+  : STAtomicUT (erased a) opened_invariants fp (fun x -> fp' x)
 
 /// Parallel composition of two STT functions
 [@@noextract_to "Plugin"]

--- a/ulib/experimental/Steel.SpinLock.fst
+++ b/ulib/experimental/Steel.SpinLock.fst
@@ -31,9 +31,7 @@ let lockinv (p:vprop) (r:ref bool) : vprop =
   h_exists (fun b -> pts_to r full_perm b `star` (if b then emp else p))
 
 noeq
-type lock_t = | Lock: r: ref bool -> i: erased iname -> lock_t
-
-let protects (l:lock_t) (p:vprop) : prop = l.i >--> lockinv p l.r
+type lock (p:vprop) = | Lock: r: ref bool -> i: inv (lockinv p r) -> lock p
 
 val intro_lockinv_available (#uses:inames) (p:vprop) (r:ref bool)
   : SteelGhostT unit uses (pts_to r full_perm available `star` p) (fun _ -> lockinv p r)

--- a/ulib/experimental/Steel.SpinLock.fsti
+++ b/ulib/experimental/Steel.SpinLock.fsti
@@ -22,13 +22,8 @@ open Steel.Effect
 
 /// The type of a lock.
 /// This is implemented as a pair of a boolean reference, and an invariant name
-val lock_t : Type u#0
+val lock (p:vprop) : Type u#0
 
-/// A predicate relating a lock to a vprop.
-val protects (l:lock_t) (p:vprop) : prop
-
-/// The type of locks associated to a given vprop [p]
-let lock (p:vprop) = l:lock_t{l `protects` p}
 
 /// If we have vprop [p] in the context, we can create a new lock
 /// associated to [p]. [p] is then removed from the context, and only accessible

--- a/ulib/tactics_ml/Steel_Memory.ml
+++ b/ulib/tactics_ml/Steel_Memory.ml
@@ -1,0 +1,1 @@
+type 'p inv = unit

--- a/ulib/tactics_ml/Steel_Memory.ml
+++ b/ulib/tactics_ml/Steel_Memory.ml
@@ -1,1 +1,0 @@
-type 'p inv = unit


### PR DESCRIPTION
In response to issue #2814 , this PR revises the monotonic state effect in FStar.MST and MSTTotal to use an explicit token for the witnessed predicate.

This change bubbles up through to Steel as an explicit token for invariants too.

Recapping the changes here, as discussed also on #2814 


* The main change is that inv p is now also an explicit token of type Type0 and the `i >--> p` prop is no longer visible in the Steel.Memory interface.

* Additionally, the libraries that provide monotonic references are changed to provide their own witnessed tokens, rather than just providing prop-based witnesses.

* The new_invariant, with_invariant and with_invariant_g operations are no longer ghost, since this would allow them to reveal an erased (witnessed p) as a witnessed p and break the abstraction. Instead, with_invariant_g is now classified as SteelAtomic unobservable and with_invariariant is parametric in the observability flag of computation it takes as argument.

* All the Steel files (except one, noted below) in the F* repo work again without significant change. Also, the Zeta project is also not significantly impacted.

* However, the this change results in a loss of expressiveness since it is no longer possible to turn an invariant into an slprop/vprop. That is, `pure (i >--> p)` is no longer expressible in the Steel---you need an explicit invariant token inv p. This results in a change to the style used in specifying the invariant of a lock-coupling list in Steel.LockCoupling.fsti. That invariants is now phrased using a combination of a inductive type that simultaneously specifies the type of a list cell and the invariant that the lock protects, combined with a recursive predicate on that structure, where the two interact via the use of fractional permissions.

* We also have extraction support for invariant-related constructs in F*. It is important from the F* type checker's perspective that witnessed and hence inv is not an erasable type. However, for concrete executions, these tokens have no information content (since they are only eliminated by recall, an axiom). So, in FStar.Extraction.ML.Term, applying to extracting Steel to both OCaml and C, we now

  - extract inv p​ to unit​
  - extract (with_invariant_g ... (fun _ -> some ghost function)​) to ()​
  - extract (with_invariant ... f​) to f()​.
  
With these changes, the extraction behavior is mostly unchanged:

For example,

```
let test (_:unit)
  : STT (inv emp & nat) emp (fun _ -> emp)
  = let i = new_invariant emp in
    i, 17
```

is extracted to ML as

```
let (test : unit -> (unit * Prims.nat)) =
  fun uu___ -> ((), (Prims.of_int (17)))
```

and via krml (which does unit elimination) to C as

```
Prims_int TestDTup_test(void)
{
  return (krml_checked_int_t)17;
}
```