### PR TITLE
Some annotations, comments and debugging infrastructure.

### DIFF
--- a/src/basic/FStar.Errors.fst
+++ b/src/basic/FStar.Errors.fst
@@ -904,11 +904,13 @@ let compare_issues i1 i2 =
 let mk_default_handler print =
     let issues : ref (list issue) = BU.mk_ref [] in
     let add_one (e: issue) =
+        begin match e.issue_level with
+          | EInfo -> print_issue e
+          | _ -> issues := e :: !issues
+        end;
         if Options.defensive_abort () && e.issue_number = Some defensive_errno then
           failwith "Aborting due to --defensive abort";
-        match e.issue_level with
-        | EInfo -> print_issue e
-        | _ -> issues := e :: !issues
+        ()
     in
     let count_errors () =
         List.fold_left (fun n i ->

--- a/src/ocaml-output/FStar_Errors.ml
+++ b/src/ocaml-output/FStar_Errors.ml
@@ -2572,16 +2572,16 @@ let (mk_default_handler : Prims.bool -> error_handler) =
   fun print ->
     let issues = FStar_Compiler_Util.mk_ref [] in
     let add_one e =
-      (let uu___1 =
-         (FStar_Options.defensive_abort ()) &&
-           (e.issue_number = (FStar_Pervasives_Native.Some defensive_errno)) in
-       if uu___1 then failwith "Aborting due to --defensive abort" else ());
       (match e.issue_level with
        | EInfo -> print_issue e
        | uu___1 ->
            let uu___2 =
              let uu___3 = FStar_Compiler_Effect.op_Bang issues in e :: uu___3 in
-           FStar_Compiler_Effect.op_Colon_Equals issues uu___2) in
+           FStar_Compiler_Effect.op_Colon_Equals issues uu___2);
+      (let uu___2 =
+         (FStar_Options.defensive_abort ()) &&
+           (e.issue_number = (FStar_Pervasives_Native.Some defensive_errno)) in
+       if uu___2 then failwith "Aborting due to --defensive abort" else ()) in
     let count_errors uu___ =
       let uu___1 = FStar_Compiler_Effect.op_Bang issues in
       FStar_Compiler_List.fold_left
@@ -2756,7 +2756,7 @@ let (set_option_warning_callback_range :
   FStar_Compiler_Range.range FStar_Pervasives_Native.option -> unit) =
   fun ropt ->
     FStar_Options.set_option_warning_callback (warn_unsafe_options ropt)
-let (uu___253 :
+let (uu___254 :
   (((Prims.string -> error_setting Prims.list) -> unit) *
     (unit -> error_setting Prims.list)))
   =
@@ -2801,10 +2801,10 @@ let (uu___253 :
   (set_callbacks, get_error_flags)
 let (set_parse_warn_error :
   (Prims.string -> error_setting Prims.list) -> unit) =
-  match uu___253 with
+  match uu___254 with
   | (set_parse_warn_error1, error_flags) -> set_parse_warn_error1
 let (error_flags : unit -> error_setting Prims.list) =
-  match uu___253 with | (set_parse_warn_error1, error_flags1) -> error_flags1
+  match uu___254 with | (set_parse_warn_error1, error_flags1) -> error_flags1
 let (lookup : raw_error -> (raw_error * error_flag * Prims.int)) =
   fun err ->
     let flags = error_flags () in

--- a/src/ocaml-output/FStar_Syntax_Print.ml
+++ b/src/ocaml-output/FStar_Syntax_Print.ml
@@ -527,7 +527,17 @@ and (term_to_string : FStar_Syntax_Syntax.term -> Prims.string) =
                  Prims.op_Hat ":(" uu___5 in
                Prims.op_Hat uu___3 uu___4
            | FStar_Syntax_Syntax.Tm_name x3 -> nm_to_string x3
-           | FStar_Syntax_Syntax.Tm_fvar f -> fv_to_string f
+           | FStar_Syntax_Syntax.Tm_fvar f ->
+               let pref =
+                 match f.FStar_Syntax_Syntax.fv_qual with
+                 | FStar_Pervasives_Native.Some
+                     (FStar_Syntax_Syntax.Unresolved_projector uu___3) ->
+                     "(Unresolved_projector)"
+                 | FStar_Pervasives_Native.Some
+                     (FStar_Syntax_Syntax.Unresolved_constructor uu___3) ->
+                     "(Unresolved_constructor)"
+                 | uu___3 -> "" in
+               let uu___3 = fv_to_string f in Prims.op_Hat pref uu___3
            | FStar_Syntax_Syntax.Tm_uvar (u, ([], uu___3)) ->
                let uu___4 =
                  (FStar_Options.print_bound_var_types ()) &&

--- a/src/ocaml-output/FStar_TypeChecker_Env.ml
+++ b/src/ocaml-output/FStar_TypeChecker_Env.ml
@@ -4352,30 +4352,230 @@ let (wp_signature :
   env ->
     FStar_Ident.lident -> (FStar_Syntax_Syntax.bv * FStar_Syntax_Syntax.term))
   = fun env1 -> fun m -> wp_sig_aux (env1.effects).decls m
+let (bound_vars_of_bindings :
+  FStar_Syntax_Syntax.binding Prims.list -> FStar_Syntax_Syntax.bv Prims.list)
+  =
+  fun bs ->
+    FStar_Compiler_Effect.op_Bar_Greater bs
+      (FStar_Compiler_List.collect
+         (fun uu___ ->
+            match uu___ with
+            | FStar_Syntax_Syntax.Binding_var x -> [x]
+            | FStar_Syntax_Syntax.Binding_lid uu___1 -> []
+            | FStar_Syntax_Syntax.Binding_univ uu___1 -> []))
+let (binders_of_bindings :
+  FStar_Syntax_Syntax.binding Prims.list -> FStar_Syntax_Syntax.binders) =
+  fun bs ->
+    let uu___ =
+      let uu___1 = bound_vars_of_bindings bs in
+      FStar_Compiler_Effect.op_Bar_Greater uu___1
+        (FStar_Compiler_List.map FStar_Syntax_Syntax.mk_binder) in
+    FStar_Compiler_Effect.op_Bar_Greater uu___ FStar_Compiler_List.rev
+let (bound_vars : env -> FStar_Syntax_Syntax.bv Prims.list) =
+  fun env1 -> bound_vars_of_bindings env1.gamma
+let (all_binders : env -> FStar_Syntax_Syntax.binders) =
+  fun env1 -> binders_of_bindings env1.gamma
+let (def_check_vars_in_set :
+  FStar_Compiler_Range.range ->
+    Prims.string ->
+      FStar_Syntax_Syntax.bv FStar_Compiler_Util.set ->
+        FStar_Syntax_Syntax.term -> unit)
+  =
+  fun rng ->
+    fun msg ->
+      fun vset ->
+        fun t ->
+          let uu___ = FStar_Options.defensive () in
+          if uu___
+          then
+            let s = FStar_Syntax_Free.names t in
+            let uu___1 =
+              let uu___2 =
+                let uu___3 = FStar_Compiler_Util.set_difference s vset in
+                FStar_Compiler_Effect.op_Less_Bar
+                  FStar_Compiler_Util.set_is_empty uu___3 in
+              Prims.op_Negation uu___2 in
+            (if uu___1
+             then
+               let uu___2 =
+                 let uu___3 =
+                   let uu___4 = FStar_Syntax_Print.term_to_string t in
+                   let uu___5 =
+                     let uu___6 = FStar_Compiler_Util.set_elements s in
+                     FStar_Compiler_Effect.op_Bar_Greater uu___6
+                       (FStar_Syntax_Print.bvs_to_string ",\n\t") in
+                   let uu___6 =
+                     let uu___7 = FStar_Compiler_Util.set_elements vset in
+                     FStar_Compiler_Effect.op_Bar_Greater uu___7
+                       (FStar_Syntax_Print.bvs_to_string ",") in
+                   FStar_Compiler_Util.format4
+                     "Internal: term is not closed (%s).\nt = (%s)\nFVs = (%s)\nScope = (%s)\n"
+                     msg uu___4 uu___5 uu___6 in
+                 (FStar_Errors.Warning_Defensive, uu___3) in
+               FStar_Errors.log_issue rng uu___2
+             else ())
+          else ()
+let (def_check_closed_in :
+  FStar_Compiler_Range.range ->
+    Prims.string ->
+      FStar_Syntax_Syntax.bv Prims.list -> FStar_Syntax_Syntax.term -> unit)
+  =
+  fun rng ->
+    fun msg ->
+      fun l ->
+        fun t ->
+          let uu___ =
+            let uu___1 = FStar_Options.defensive () in
+            Prims.op_Negation uu___1 in
+          if uu___
+          then ()
+          else
+            (let uu___2 =
+               FStar_Compiler_Util.as_set l FStar_Syntax_Syntax.order_bv in
+             def_check_vars_in_set rng msg uu___2 t)
+let (def_check_closed_in_env :
+  FStar_Compiler_Range.range ->
+    Prims.string -> env -> FStar_Syntax_Syntax.term -> unit)
+  =
+  fun rng ->
+    fun msg ->
+      fun e ->
+        fun t ->
+          let uu___ =
+            let uu___1 = FStar_Options.defensive () in
+            Prims.op_Negation uu___1 in
+          if uu___
+          then ()
+          else
+            (let uu___2 = bound_vars e in
+             def_check_closed_in rng msg uu___2 t)
+let (def_check_comp_closed_in :
+  FStar_Compiler_Range.range ->
+    Prims.string ->
+      FStar_Syntax_Syntax.bv Prims.list -> FStar_Syntax_Syntax.comp -> unit)
+  =
+  fun rng ->
+    fun msg ->
+      fun l ->
+        fun c ->
+          let uu___ =
+            let uu___1 = FStar_Options.defensive () in
+            Prims.op_Negation uu___1 in
+          if uu___
+          then ()
+          else
+            (match c.FStar_Syntax_Syntax.n with
+             | FStar_Syntax_Syntax.Total t ->
+                 def_check_closed_in rng (Prims.op_Hat msg ".typ") l t
+             | FStar_Syntax_Syntax.GTotal t ->
+                 def_check_closed_in rng (Prims.op_Hat msg ".typ") l t
+             | FStar_Syntax_Syntax.Comp ct ->
+                 (def_check_closed_in rng (Prims.op_Hat msg ".typ") l
+                    ct.FStar_Syntax_Syntax.result_typ;
+                  FStar_Compiler_List.iter
+                    (fun uu___3 ->
+                       match uu___3 with
+                       | (a, uu___4) ->
+                           def_check_closed_in rng (Prims.op_Hat msg ".arg")
+                             l a) ct.FStar_Syntax_Syntax.effect_args))
+let (def_check_comp_closed_in_env :
+  FStar_Compiler_Range.range ->
+    Prims.string -> env -> FStar_Syntax_Syntax.comp -> unit)
+  =
+  fun rng ->
+    fun msg ->
+      fun e ->
+        fun c ->
+          let uu___ =
+            let uu___1 = FStar_Options.defensive () in
+            Prims.op_Negation uu___1 in
+          if uu___
+          then ()
+          else
+            (match c.FStar_Syntax_Syntax.n with
+             | FStar_Syntax_Syntax.Total t ->
+                 def_check_closed_in_env rng (Prims.op_Hat msg ".typ") e t
+             | FStar_Syntax_Syntax.GTotal t ->
+                 def_check_closed_in_env rng (Prims.op_Hat msg ".typ") e t
+             | FStar_Syntax_Syntax.Comp ct ->
+                 (def_check_closed_in_env rng (Prims.op_Hat msg ".typ") e
+                    ct.FStar_Syntax_Syntax.result_typ;
+                  FStar_Compiler_List.iter
+                    (fun uu___3 ->
+                       match uu___3 with
+                       | (a, uu___4) ->
+                           def_check_closed_in_env rng
+                             (Prims.op_Hat msg ".arg") e a)
+                    ct.FStar_Syntax_Syntax.effect_args))
+let (def_check_lcomp_closed_in :
+  FStar_Compiler_Range.range ->
+    Prims.string ->
+      FStar_Syntax_Syntax.bv Prims.list ->
+        FStar_TypeChecker_Common.lcomp -> unit)
+  =
+  fun rng ->
+    fun msg ->
+      fun l ->
+        fun lc ->
+          let uu___ = FStar_Options.defensive () in
+          if uu___
+          then
+            let uu___1 = FStar_TypeChecker_Common.lcomp_comp lc in
+            match uu___1 with
+            | (c, uu___2) -> def_check_comp_closed_in rng msg l c
+          else ()
+let (def_check_lcomp_closed_in_env :
+  FStar_Compiler_Range.range ->
+    Prims.string -> env -> FStar_TypeChecker_Common.lcomp -> unit)
+  =
+  fun rng ->
+    fun msg ->
+      fun env1 ->
+        fun lc ->
+          let uu___ = FStar_Options.defensive () in
+          if uu___
+          then
+            let uu___1 = FStar_TypeChecker_Common.lcomp_comp lc in
+            match uu___1 with
+            | (c, uu___2) -> def_check_comp_closed_in_env rng msg env1 c
+          else ()
+let (def_check_guard_wf :
+  FStar_Compiler_Range.range -> Prims.string -> env -> guard_t -> unit) =
+  fun rng ->
+    fun msg ->
+      fun env1 ->
+        fun g ->
+          match g.FStar_TypeChecker_Common.guard_f with
+          | FStar_TypeChecker_Common.Trivial -> ()
+          | FStar_TypeChecker_Common.NonTrivial f ->
+              def_check_closed_in_env rng msg env1 f
 let (comp_to_comp_typ :
   env -> FStar_Syntax_Syntax.comp -> FStar_Syntax_Syntax.comp_typ) =
   fun env1 ->
     fun c ->
-      match c.FStar_Syntax_Syntax.n with
-      | FStar_Syntax_Syntax.Comp ct -> ct
-      | uu___ ->
-          let uu___1 =
-            match c.FStar_Syntax_Syntax.n with
-            | FStar_Syntax_Syntax.Total t ->
-                (FStar_Parser_Const.effect_Tot_lid, t)
-            | FStar_Syntax_Syntax.GTotal t ->
-                (FStar_Parser_Const.effect_GTot_lid, t) in
-          (match uu___1 with
-           | (effect_name, result_typ) ->
-               let uu___2 =
-                 let uu___3 = env1.universe_of env1 result_typ in [uu___3] in
-               {
-                 FStar_Syntax_Syntax.comp_univs = uu___2;
-                 FStar_Syntax_Syntax.effect_name = effect_name;
-                 FStar_Syntax_Syntax.result_typ = result_typ;
-                 FStar_Syntax_Syntax.effect_args = [];
-                 FStar_Syntax_Syntax.flags = (FStar_Syntax_Util.comp_flags c)
-               })
+      def_check_comp_closed_in_env c.FStar_Syntax_Syntax.pos
+        "comp_to_comp_typ" env1 c;
+      (match c.FStar_Syntax_Syntax.n with
+       | FStar_Syntax_Syntax.Comp ct -> ct
+       | uu___1 ->
+           let uu___2 =
+             match c.FStar_Syntax_Syntax.n with
+             | FStar_Syntax_Syntax.Total t ->
+                 (FStar_Parser_Const.effect_Tot_lid, t)
+             | FStar_Syntax_Syntax.GTotal t ->
+                 (FStar_Parser_Const.effect_GTot_lid, t) in
+           (match uu___2 with
+            | (effect_name, result_typ) ->
+                let uu___3 =
+                  let uu___4 = env1.universe_of env1 result_typ in [uu___4] in
+                {
+                  FStar_Syntax_Syntax.comp_univs = uu___3;
+                  FStar_Syntax_Syntax.effect_name = effect_name;
+                  FStar_Syntax_Syntax.result_typ = result_typ;
+                  FStar_Syntax_Syntax.effect_args = [];
+                  FStar_Syntax_Syntax.flags =
+                    (FStar_Syntax_Util.comp_flags c)
+                }))
 let (comp_set_flags :
   env ->
     FStar_Syntax_Syntax.comp ->
@@ -4384,101 +4584,110 @@ let (comp_set_flags :
   fun env1 ->
     fun c ->
       fun f ->
-        let uu___ =
-          let uu___1 =
-            let uu___2 = comp_to_comp_typ env1 c in
-            {
-              FStar_Syntax_Syntax.comp_univs =
-                (uu___2.FStar_Syntax_Syntax.comp_univs);
-              FStar_Syntax_Syntax.effect_name =
-                (uu___2.FStar_Syntax_Syntax.effect_name);
-              FStar_Syntax_Syntax.result_typ =
-                (uu___2.FStar_Syntax_Syntax.result_typ);
-              FStar_Syntax_Syntax.effect_args =
-                (uu___2.FStar_Syntax_Syntax.effect_args);
-              FStar_Syntax_Syntax.flags = f
-            } in
-          FStar_Syntax_Syntax.Comp uu___1 in
-        {
-          FStar_Syntax_Syntax.n = uu___;
-          FStar_Syntax_Syntax.pos = (c.FStar_Syntax_Syntax.pos);
-          FStar_Syntax_Syntax.vars = (c.FStar_Syntax_Syntax.vars);
-          FStar_Syntax_Syntax.hash_code = (c.FStar_Syntax_Syntax.hash_code)
-        }
+        def_check_comp_closed_in_env c.FStar_Syntax_Syntax.pos
+          "comp_set_flags.IN" env1 c;
+        (let r =
+           let uu___1 =
+             let uu___2 =
+               let uu___3 = comp_to_comp_typ env1 c in
+               {
+                 FStar_Syntax_Syntax.comp_univs =
+                   (uu___3.FStar_Syntax_Syntax.comp_univs);
+                 FStar_Syntax_Syntax.effect_name =
+                   (uu___3.FStar_Syntax_Syntax.effect_name);
+                 FStar_Syntax_Syntax.result_typ =
+                   (uu___3.FStar_Syntax_Syntax.result_typ);
+                 FStar_Syntax_Syntax.effect_args =
+                   (uu___3.FStar_Syntax_Syntax.effect_args);
+                 FStar_Syntax_Syntax.flags = f
+               } in
+             FStar_Syntax_Syntax.Comp uu___2 in
+           {
+             FStar_Syntax_Syntax.n = uu___1;
+             FStar_Syntax_Syntax.pos = (c.FStar_Syntax_Syntax.pos);
+             FStar_Syntax_Syntax.vars = (c.FStar_Syntax_Syntax.vars);
+             FStar_Syntax_Syntax.hash_code =
+               (c.FStar_Syntax_Syntax.hash_code)
+           } in
+         def_check_comp_closed_in_env c.FStar_Syntax_Syntax.pos
+           "comp_set_flags.OUT" env1 r;
+         r)
 let rec (unfold_effect_abbrev :
   env -> FStar_Syntax_Syntax.comp -> FStar_Syntax_Syntax.comp_typ) =
   fun env1 ->
     fun comp ->
-      let c = comp_to_comp_typ env1 comp in
-      let uu___ =
-        lookup_effect_abbrev env1 c.FStar_Syntax_Syntax.comp_univs
-          c.FStar_Syntax_Syntax.effect_name in
-      match uu___ with
-      | FStar_Pervasives_Native.None -> c
-      | FStar_Pervasives_Native.Some (binders, cdef) ->
-          let uu___1 = FStar_Syntax_Subst.open_comp binders cdef in
-          (match uu___1 with
-           | (binders1, cdef1) ->
-               (if
-                  (FStar_Compiler_List.length binders1) <>
-                    ((FStar_Compiler_List.length
-                        c.FStar_Syntax_Syntax.effect_args)
-                       + Prims.int_one)
-                then
-                  (let uu___3 =
-                     let uu___4 =
-                       let uu___5 =
-                         FStar_Compiler_Util.string_of_int
-                           (FStar_Compiler_List.length binders1) in
-                       let uu___6 =
-                         FStar_Compiler_Util.string_of_int
-                           ((FStar_Compiler_List.length
-                               c.FStar_Syntax_Syntax.effect_args)
-                              + Prims.int_one) in
-                       let uu___7 =
-                         let uu___8 = FStar_Syntax_Syntax.mk_Comp c in
-                         FStar_Syntax_Print.comp_to_string uu___8 in
-                       FStar_Compiler_Util.format3
-                         "Effect constructor is not fully applied; expected %s args, got %s args, i.e., %s"
-                         uu___5 uu___6 uu___7 in
-                     (FStar_Errors.Fatal_ConstructorArgLengthMismatch,
-                       uu___4) in
-                   FStar_Errors.raise_error uu___3
-                     comp.FStar_Syntax_Syntax.pos)
-                else ();
-                (let inst =
-                   let uu___3 =
-                     let uu___4 =
-                       FStar_Syntax_Syntax.as_arg
-                         c.FStar_Syntax_Syntax.result_typ in
-                     uu___4 :: (c.FStar_Syntax_Syntax.effect_args) in
-                   FStar_Compiler_List.map2
-                     (fun b ->
-                        fun uu___4 ->
-                          match uu___4 with
-                          | (t, uu___5) ->
-                              FStar_Syntax_Syntax.NT
-                                ((b.FStar_Syntax_Syntax.binder_bv), t))
-                     binders1 uu___3 in
-                 let c1 = FStar_Syntax_Subst.subst_comp inst cdef1 in
-                 let c2 =
-                   let uu___3 =
-                     let uu___4 = comp_to_comp_typ env1 c1 in
-                     {
-                       FStar_Syntax_Syntax.comp_univs =
-                         (uu___4.FStar_Syntax_Syntax.comp_univs);
-                       FStar_Syntax_Syntax.effect_name =
-                         (uu___4.FStar_Syntax_Syntax.effect_name);
-                       FStar_Syntax_Syntax.result_typ =
-                         (uu___4.FStar_Syntax_Syntax.result_typ);
-                       FStar_Syntax_Syntax.effect_args =
-                         (uu___4.FStar_Syntax_Syntax.effect_args);
-                       FStar_Syntax_Syntax.flags =
-                         (c.FStar_Syntax_Syntax.flags)
-                     } in
-                   FStar_Compiler_Effect.op_Bar_Greater uu___3
-                     FStar_Syntax_Syntax.mk_Comp in
-                 unfold_effect_abbrev env1 c2)))
+      def_check_comp_closed_in_env comp.FStar_Syntax_Syntax.pos
+        "unfold_effect_abbrev" env1 comp;
+      (let c = comp_to_comp_typ env1 comp in
+       let uu___1 =
+         lookup_effect_abbrev env1 c.FStar_Syntax_Syntax.comp_univs
+           c.FStar_Syntax_Syntax.effect_name in
+       match uu___1 with
+       | FStar_Pervasives_Native.None -> c
+       | FStar_Pervasives_Native.Some (binders, cdef) ->
+           let uu___2 = FStar_Syntax_Subst.open_comp binders cdef in
+           (match uu___2 with
+            | (binders1, cdef1) ->
+                (if
+                   (FStar_Compiler_List.length binders1) <>
+                     ((FStar_Compiler_List.length
+                         c.FStar_Syntax_Syntax.effect_args)
+                        + Prims.int_one)
+                 then
+                   (let uu___4 =
+                      let uu___5 =
+                        let uu___6 =
+                          FStar_Compiler_Util.string_of_int
+                            (FStar_Compiler_List.length binders1) in
+                        let uu___7 =
+                          FStar_Compiler_Util.string_of_int
+                            ((FStar_Compiler_List.length
+                                c.FStar_Syntax_Syntax.effect_args)
+                               + Prims.int_one) in
+                        let uu___8 =
+                          let uu___9 = FStar_Syntax_Syntax.mk_Comp c in
+                          FStar_Syntax_Print.comp_to_string uu___9 in
+                        FStar_Compiler_Util.format3
+                          "Effect constructor is not fully applied; expected %s args, got %s args, i.e., %s"
+                          uu___6 uu___7 uu___8 in
+                      (FStar_Errors.Fatal_ConstructorArgLengthMismatch,
+                        uu___5) in
+                    FStar_Errors.raise_error uu___4
+                      comp.FStar_Syntax_Syntax.pos)
+                 else ();
+                 (let inst =
+                    let uu___4 =
+                      let uu___5 =
+                        FStar_Syntax_Syntax.as_arg
+                          c.FStar_Syntax_Syntax.result_typ in
+                      uu___5 :: (c.FStar_Syntax_Syntax.effect_args) in
+                    FStar_Compiler_List.map2
+                      (fun b ->
+                         fun uu___5 ->
+                           match uu___5 with
+                           | (t, uu___6) ->
+                               FStar_Syntax_Syntax.NT
+                                 ((b.FStar_Syntax_Syntax.binder_bv), t))
+                      binders1 uu___4 in
+                  let c1 = FStar_Syntax_Subst.subst_comp inst cdef1 in
+                  let c2 =
+                    let uu___4 =
+                      let uu___5 = comp_to_comp_typ env1 c1 in
+                      {
+                        FStar_Syntax_Syntax.comp_univs =
+                          (uu___5.FStar_Syntax_Syntax.comp_univs);
+                        FStar_Syntax_Syntax.effect_name =
+                          (uu___5.FStar_Syntax_Syntax.effect_name);
+                        FStar_Syntax_Syntax.result_typ =
+                          (uu___5.FStar_Syntax_Syntax.result_typ);
+                        FStar_Syntax_Syntax.effect_args =
+                          (uu___5.FStar_Syntax_Syntax.effect_args);
+                        FStar_Syntax_Syntax.flags =
+                          (c.FStar_Syntax_Syntax.flags)
+                      } in
+                    FStar_Compiler_Effect.op_Bar_Greater uu___4
+                      FStar_Syntax_Syntax.mk_Comp in
+                  unfold_effect_abbrev env1 c2))))
 let effect_repr_aux :
   'uuuuu .
     'uuuuu ->
@@ -5864,29 +6073,6 @@ let (univnames :
             let uu___3 = FStar_Syntax_Free.univnames t in ext out uu___3 in
           aux uu___2 tl in
     aux no_univ_names env1.gamma
-let (bound_vars_of_bindings :
-  FStar_Syntax_Syntax.binding Prims.list -> FStar_Syntax_Syntax.bv Prims.list)
-  =
-  fun bs ->
-    FStar_Compiler_Effect.op_Bar_Greater bs
-      (FStar_Compiler_List.collect
-         (fun uu___ ->
-            match uu___ with
-            | FStar_Syntax_Syntax.Binding_var x -> [x]
-            | FStar_Syntax_Syntax.Binding_lid uu___1 -> []
-            | FStar_Syntax_Syntax.Binding_univ uu___1 -> []))
-let (binders_of_bindings :
-  FStar_Syntax_Syntax.binding Prims.list -> FStar_Syntax_Syntax.binders) =
-  fun bs ->
-    let uu___ =
-      let uu___1 = bound_vars_of_bindings bs in
-      FStar_Compiler_Effect.op_Bar_Greater uu___1
-        (FStar_Compiler_List.map FStar_Syntax_Syntax.mk_binder) in
-    FStar_Compiler_Effect.op_Bar_Greater uu___ FStar_Compiler_List.rev
-let (bound_vars : env -> FStar_Syntax_Syntax.bv Prims.list) =
-  fun env1 -> bound_vars_of_bindings env1.gamma
-let (all_binders : env -> FStar_Syntax_Syntax.binders) =
-  fun env1 -> binders_of_bindings env1.gamma
 let (print_gamma : FStar_Syntax_Syntax.gamma -> Prims.string) =
   fun gamma ->
     let uu___ =
@@ -6176,90 +6362,10 @@ let (abstract_guard_n :
           }
 let (abstract_guard : FStar_Syntax_Syntax.binder -> guard_t -> guard_t) =
   fun b -> fun g -> abstract_guard_n [b] g
-let (def_check_vars_in_set :
-  FStar_Compiler_Range.range ->
-    Prims.string ->
-      FStar_Syntax_Syntax.bv FStar_Compiler_Util.set ->
-        FStar_Syntax_Syntax.term -> unit)
-  =
-  fun rng ->
-    fun msg ->
-      fun vset ->
-        fun t ->
-          let uu___ = FStar_Options.defensive () in
-          if uu___
-          then
-            let s = FStar_Syntax_Free.names t in
-            let uu___1 =
-              let uu___2 =
-                let uu___3 = FStar_Compiler_Util.set_difference s vset in
-                FStar_Compiler_Effect.op_Less_Bar
-                  FStar_Compiler_Util.set_is_empty uu___3 in
-              Prims.op_Negation uu___2 in
-            (if uu___1
-             then
-               let uu___2 =
-                 let uu___3 =
-                   let uu___4 = FStar_Syntax_Print.term_to_string t in
-                   let uu___5 =
-                     let uu___6 = FStar_Compiler_Util.set_elements s in
-                     FStar_Compiler_Effect.op_Bar_Greater uu___6
-                       (FStar_Syntax_Print.bvs_to_string ",\n\t") in
-                   FStar_Compiler_Util.format3
-                     "Internal: term is not closed (%s).\nt = (%s)\nFVs = (%s)\n"
-                     msg uu___4 uu___5 in
-                 (FStar_Errors.Warning_Defensive, uu___3) in
-               FStar_Errors.log_issue rng uu___2
-             else ())
-          else ()
 let (too_early_in_prims : env -> Prims.bool) =
   fun env1 ->
     let uu___ = lid_exists env1 FStar_Parser_Const.effect_GTot_lid in
     Prims.op_Negation uu___
-let (def_check_closed_in :
-  FStar_Compiler_Range.range ->
-    Prims.string ->
-      FStar_Syntax_Syntax.bv Prims.list -> FStar_Syntax_Syntax.term -> unit)
-  =
-  fun rng ->
-    fun msg ->
-      fun l ->
-        fun t ->
-          let uu___ =
-            let uu___1 = FStar_Options.defensive () in
-            Prims.op_Negation uu___1 in
-          if uu___
-          then ()
-          else
-            (let uu___2 =
-               FStar_Compiler_Util.as_set l FStar_Syntax_Syntax.order_bv in
-             def_check_vars_in_set rng msg uu___2 t)
-let (def_check_closed_in_env :
-  FStar_Compiler_Range.range ->
-    Prims.string -> env -> FStar_Syntax_Syntax.term -> unit)
-  =
-  fun rng ->
-    fun msg ->
-      fun e ->
-        fun t ->
-          let uu___ =
-            let uu___1 = FStar_Options.defensive () in
-            Prims.op_Negation uu___1 in
-          if uu___
-          then ()
-          else
-            (let uu___2 = bound_vars e in
-             def_check_closed_in rng msg uu___2 t)
-let (def_check_guard_wf :
-  FStar_Compiler_Range.range -> Prims.string -> env -> guard_t -> unit) =
-  fun rng ->
-    fun msg ->
-      fun env1 ->
-        fun g ->
-          match g.FStar_TypeChecker_Common.guard_f with
-          | FStar_TypeChecker_Common.Trivial -> ()
-          | FStar_TypeChecker_Common.NonTrivial f ->
-              def_check_closed_in_env rng msg env1 f
 let (apply_guard : guard_t -> FStar_Syntax_Syntax.term -> guard_t) =
   fun g ->
     fun e ->

--- a/src/ocaml-output/FStar_TypeChecker_Rel.ml
+++ b/src/ocaml-output/FStar_TypeChecker_Rel.ml
@@ -978,22 +978,27 @@ let mk_eq2 :
     worklist ->
       FStar_TypeChecker_Env.env ->
         'uuuuu ->
-          FStar_Syntax_Syntax.term ->
-            FStar_Syntax_Syntax.term -> (FStar_Syntax_Syntax.term * worklist)
+          FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
+            FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
+              (FStar_Syntax_Syntax.term * worklist)
   =
   fun wl ->
     fun env ->
       fun prob ->
         fun t1 ->
           fun t2 ->
-            let uu___ =
-              env.FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term
-                env t1 false in
-            match uu___ with
-            | (tt, uu___1) ->
-                let u = env.FStar_TypeChecker_Env.universe_of env tt in
-                let uu___2 = FStar_Syntax_Util.mk_eq2 u tt t1 t2 in
-                (uu___2, wl)
+            FStar_TypeChecker_Env.def_check_closed_in_env
+              t1.FStar_Syntax_Syntax.pos "mk_eq2.t1" env t1;
+            FStar_TypeChecker_Env.def_check_closed_in_env
+              t2.FStar_Syntax_Syntax.pos "mk_eq2.t2" env t2;
+            (let uu___2 =
+               env.FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term
+                 env t1 false in
+             match uu___2 with
+             | (tt, uu___3) ->
+                 let u = env.FStar_TypeChecker_Env.universe_of env tt in
+                 let uu___4 = FStar_Syntax_Util.mk_eq2 u tt t1 t2 in
+                 (uu___4, wl))
 let (p_invert :
   FStar_TypeChecker_Common.prob -> FStar_TypeChecker_Common.prob) =
   fun uu___ ->
@@ -3743,27 +3748,32 @@ let (guard_of_prob :
       fun problem ->
         fun t1 ->
           fun t2 ->
-            let has_type_guard t11 t21 =
-              match problem.FStar_TypeChecker_Common.element with
-              | FStar_Pervasives_Native.Some t ->
-                  let uu___ = FStar_Syntax_Syntax.bv_to_name t in
-                  FStar_Syntax_Util.mk_has_type t11 uu___ t21
-              | FStar_Pervasives_Native.None ->
-                  let x =
-                    FStar_Syntax_Syntax.new_bv FStar_Pervasives_Native.None
-                      t11 in
-                  let u_x = env.FStar_TypeChecker_Env.universe_of env t11 in
-                  let uu___ =
-                    let uu___1 = FStar_Syntax_Syntax.bv_to_name x in
-                    FStar_Syntax_Util.mk_has_type t11 uu___1 t21 in
-                  FStar_Syntax_Util.mk_forall u_x x uu___ in
-            match problem.FStar_TypeChecker_Common.relation with
-            | FStar_TypeChecker_Common.EQ ->
-                mk_eq2 wl env (FStar_TypeChecker_Common.TProb problem) t1 t2
-            | FStar_TypeChecker_Common.SUB ->
-                let uu___ = has_type_guard t1 t2 in (uu___, wl)
-            | FStar_TypeChecker_Common.SUBINV ->
-                let uu___ = has_type_guard t2 t1 in (uu___, wl)
+            def_check_prob "guard_of_prob"
+              (FStar_TypeChecker_Common.TProb problem);
+            (let has_type_guard t11 t21 =
+               match problem.FStar_TypeChecker_Common.element with
+               | FStar_Pervasives_Native.Some t ->
+                   let uu___1 = FStar_Syntax_Syntax.bv_to_name t in
+                   FStar_Syntax_Util.mk_has_type t11 uu___1 t21
+               | FStar_Pervasives_Native.None ->
+                   let x =
+                     FStar_Syntax_Syntax.new_bv FStar_Pervasives_Native.None
+                       t11 in
+                   (FStar_TypeChecker_Env.def_check_closed_in_env
+                      t11.FStar_Syntax_Syntax.pos "guard_of_prob.universe_of"
+                      env t11;
+                    (let u_x = env.FStar_TypeChecker_Env.universe_of env t11 in
+                     let uu___2 =
+                       let uu___3 = FStar_Syntax_Syntax.bv_to_name x in
+                       FStar_Syntax_Util.mk_has_type t11 uu___3 t21 in
+                     FStar_Syntax_Util.mk_forall u_x x uu___2)) in
+             match problem.FStar_TypeChecker_Common.relation with
+             | FStar_TypeChecker_Common.EQ ->
+                 mk_eq2 wl env (FStar_TypeChecker_Common.TProb problem) t1 t2
+             | FStar_TypeChecker_Common.SUB ->
+                 let uu___1 = has_type_guard t1 t2 in (uu___1, wl)
+             | FStar_TypeChecker_Common.SUBINV ->
+                 let uu___1 = has_type_guard t2 t1 in (uu___1, wl))
 let (is_flex_pat : flex_t -> Prims.bool) =
   fun uu___ ->
     match uu___ with | Flex (uu___1, uu___2, []) -> true | uu___1 -> false
@@ -4225,7 +4235,9 @@ let (apply_substitutive_indexed_subcomp :
                                                                    uu___7
                                                                    subcomp_name
                                                                    uu___8
-                                                               else "") r1 in
+                                                               else
+                                                                 "apply_substitutive_indexed_subcomp")
+                                                            r1 in
                                                         (match uu___6 with
                                                          | (uv_t::[], g) ->
                                                              ((FStar_Compiler_List.op_At
@@ -4384,7 +4396,7 @@ let (apply_ad_hoc_indexed_subcomp :
                                  FStar_Compiler_Util.format3
                                    "implicit for binder %s in subcomp %s at %s"
                                    uu___2 subcomp_name uu___3
-                               else "") r1 in
+                               else "apply_ad_hoc_indexed_subcomp") r1 in
                         (match uu___1 with
                          | (rest_bs_uvars, g_uvars) ->
                              let wl1 =
@@ -13366,13 +13378,33 @@ let (sub_comp :
     FStar_Syntax_Syntax.comp ->
       FStar_Syntax_Syntax.comp ->
         FStar_TypeChecker_Common.guard_t FStar_Pervasives_Native.option)
-  = fun env -> fun c1 -> fun c2 -> sub_or_eq_comp env false c1 c2
+  =
+  fun env ->
+    fun c1 ->
+      fun c2 ->
+        FStar_Errors.with_ctx "While trying to subtype computation types"
+          (fun uu___ ->
+             FStar_TypeChecker_Env.def_check_comp_closed_in_env
+               c1.FStar_Syntax_Syntax.pos "sub_comp c1" env c1;
+             FStar_TypeChecker_Env.def_check_comp_closed_in_env
+               c2.FStar_Syntax_Syntax.pos "sub_comp c2" env c2;
+             sub_or_eq_comp env false c1 c2)
 let (eq_comp :
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.comp ->
       FStar_Syntax_Syntax.comp ->
         FStar_TypeChecker_Common.guard_t FStar_Pervasives_Native.option)
-  = fun env -> fun c1 -> fun c2 -> sub_or_eq_comp env true c1 c2
+  =
+  fun env ->
+    fun c1 ->
+      fun c2 ->
+        FStar_Errors.with_ctx "While trying to equate computation types"
+          (fun uu___ ->
+             FStar_TypeChecker_Env.def_check_comp_closed_in_env
+               c1.FStar_Syntax_Syntax.pos "sub_comp c1" env c1;
+             FStar_TypeChecker_Env.def_check_comp_closed_in_env
+               c2.FStar_Syntax_Syntax.pos "sub_comp c2" env c2;
+             sub_or_eq_comp env true c1 c2)
 let (solve_universe_inequalities' :
   FStar_Syntax_Unionfind.tx ->
     FStar_TypeChecker_Env.env ->
@@ -14127,14 +14159,20 @@ let (get_subtyping_predicate :
   fun env ->
     fun t1 ->
       fun t2 ->
-        let uu___ = check_subtyping env t1 t2 in
-        match uu___ with
-        | FStar_Pervasives_Native.None -> FStar_Pervasives_Native.None
-        | FStar_Pervasives_Native.Some (x, g) ->
-            let uu___1 =
-              let uu___2 = FStar_Syntax_Syntax.mk_binder x in
-              FStar_TypeChecker_Env.abstract_guard uu___2 g in
-            FStar_Pervasives_Native.Some uu___1
+        FStar_Errors.with_ctx "While trying to get a subtyping predicate"
+          (fun uu___ ->
+             FStar_TypeChecker_Env.def_check_closed_in_env
+               t1.FStar_Syntax_Syntax.pos "get_subtyping_predicate.1" env t1;
+             FStar_TypeChecker_Env.def_check_closed_in_env
+               t2.FStar_Syntax_Syntax.pos "get_subtyping_predicate.2" env t2;
+             (let uu___3 = check_subtyping env t1 t2 in
+              match uu___3 with
+              | FStar_Pervasives_Native.None -> FStar_Pervasives_Native.None
+              | FStar_Pervasives_Native.Some (x, g) ->
+                  let uu___4 =
+                    let uu___5 = FStar_Syntax_Syntax.mk_binder x in
+                    FStar_TypeChecker_Env.abstract_guard uu___5 g in
+                  FStar_Pervasives_Native.Some uu___4))
 let (get_subtyping_prop :
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.typ ->
@@ -14144,15 +14182,22 @@ let (get_subtyping_prop :
   fun env ->
     fun t1 ->
       fun t2 ->
-        let uu___ = check_subtyping env t1 t2 in
-        match uu___ with
-        | FStar_Pervasives_Native.None -> FStar_Pervasives_Native.None
-        | FStar_Pervasives_Native.Some (x, g) ->
-            let uu___1 =
-              let uu___2 =
-                let uu___3 = FStar_Syntax_Syntax.mk_binder x in [uu___3] in
-              FStar_TypeChecker_Env.close_guard env uu___2 g in
-            FStar_Pervasives_Native.Some uu___1
+        FStar_Errors.with_ctx "While trying to get a subtyping proposition"
+          (fun uu___ ->
+             FStar_TypeChecker_Env.def_check_closed_in_env
+               t1.FStar_Syntax_Syntax.pos "get_subtyping_prop.1" env t1;
+             FStar_TypeChecker_Env.def_check_closed_in_env
+               t2.FStar_Syntax_Syntax.pos "get_subtyping_prop.2" env t2;
+             (let uu___3 = check_subtyping env t1 t2 in
+              match uu___3 with
+              | FStar_Pervasives_Native.None -> FStar_Pervasives_Native.None
+              | FStar_Pervasives_Native.Some (x, g) ->
+                  let uu___4 =
+                    let uu___5 =
+                      let uu___6 = FStar_Syntax_Syntax.mk_binder x in
+                      [uu___6] in
+                    FStar_TypeChecker_Env.close_guard env uu___5 g in
+                  FStar_Pervasives_Native.Some uu___4))
 let (try_solve_single_valued_implicits :
   FStar_TypeChecker_Env.env ->
     Prims.bool ->

--- a/src/ocaml-output/FStar_TypeChecker_TcEffect.ml
+++ b/src/ocaml-output/FStar_TypeChecker_TcEffect.ml
@@ -5075,7 +5075,8 @@ let (tc_layered_eff_decl :
                                                                     FStar_Pervasives_Native.Some
                                                                     uu___24) in
                                                                     FStar_TypeChecker_Env.new_implicit_var_aux
-                                                                    "" r env1
+                                                                    "tc_layered_effect_decl.g_precondition"
+                                                                    r env1
                                                                     uu___22
                                                                     FStar_Syntax_Syntax.Strict
                                                                     uu___23 in

--- a/src/ocaml-output/FStar_TypeChecker_TcTerm.ml
+++ b/src/ocaml-output/FStar_TypeChecker_TcTerm.ml
@@ -1584,28 +1584,30 @@ let rec (tc_term :
   =
   fun env ->
     fun e ->
-      (let uu___1 = FStar_TypeChecker_Env.debug env FStar_Options.Medium in
-       if uu___1
+      FStar_TypeChecker_Env.def_check_closed_in_env e.FStar_Syntax_Syntax.pos
+        "tc_term.entry" env e;
+      (let uu___2 = FStar_TypeChecker_Env.debug env FStar_Options.Medium in
+       if uu___2
        then
-         let uu___2 =
-           let uu___3 = FStar_TypeChecker_Env.get_range env in
-           FStar_Compiler_Effect.op_Less_Bar
-             FStar_Compiler_Range.string_of_range uu___3 in
          let uu___3 =
+           let uu___4 = FStar_TypeChecker_Env.get_range env in
+           FStar_Compiler_Effect.op_Less_Bar
+             FStar_Compiler_Range.string_of_range uu___4 in
+         let uu___4 =
            FStar_Compiler_Util.string_of_bool
              env.FStar_TypeChecker_Env.phase1 in
-         let uu___4 = FStar_Syntax_Print.term_to_string e in
-         let uu___5 =
-           let uu___6 = FStar_Syntax_Subst.compress e in
-           FStar_Syntax_Print.tag_of_term uu___6 in
-         let uu___6 = print_expected_ty_str env in
+         let uu___5 = FStar_Syntax_Print.term_to_string e in
+         let uu___6 =
+           let uu___7 = FStar_Syntax_Subst.compress e in
+           FStar_Syntax_Print.tag_of_term uu___7 in
+         let uu___7 = print_expected_ty_str env in
          FStar_Compiler_Util.print5
-           "(%s) Starting tc_term (phase1=%s) of %s (%s), %s {\n" uu___2
-           uu___3 uu___4 uu___5 uu___6
+           "(%s) Starting tc_term (phase1=%s) of %s (%s), %s {\n" uu___3
+           uu___4 uu___5 uu___6 uu___7
        else ());
-      (let uu___1 =
+      (let uu___2 =
          FStar_Compiler_Util.record_time
-           (fun uu___2 ->
+           (fun uu___3 ->
               tc_maybe_toplevel_term
                 {
                   FStar_TypeChecker_Env.solver =
@@ -1708,39 +1710,40 @@ let rec (tc_term :
                   FStar_TypeChecker_Env.core_check =
                     (env.FStar_TypeChecker_Env.core_check)
                 } e) in
-       match uu___1 with
+       match uu___2 with
        | (r, ms) ->
-           ((let uu___3 =
+           ((let uu___4 =
                FStar_TypeChecker_Env.debug env FStar_Options.Medium in
-             if uu___3
+             if uu___4
              then
-               ((let uu___5 =
-                   let uu___6 = FStar_TypeChecker_Env.get_range env in
+               ((let uu___6 =
+                   let uu___7 = FStar_TypeChecker_Env.get_range env in
                    FStar_Compiler_Effect.op_Less_Bar
-                     FStar_Compiler_Range.string_of_range uu___6 in
-                 let uu___6 = FStar_Syntax_Print.term_to_string e in
-                 let uu___7 =
-                   let uu___8 = FStar_Syntax_Subst.compress e in
-                   FStar_Syntax_Print.tag_of_term uu___8 in
-                 let uu___8 = FStar_Compiler_Util.string_of_int ms in
+                     FStar_Compiler_Range.string_of_range uu___7 in
+                 let uu___7 = FStar_Syntax_Print.term_to_string e in
+                 let uu___8 =
+                   let uu___9 = FStar_Syntax_Subst.compress e in
+                   FStar_Syntax_Print.tag_of_term uu___9 in
+                 let uu___9 = FStar_Compiler_Util.string_of_int ms in
                  FStar_Compiler_Util.print4
-                   "(%s) } tc_term of %s (%s) took %sms\n" uu___5 uu___6
-                   uu___7 uu___8);
-                (let uu___5 = r in
-                 match uu___5 with
-                 | (e1, lc, uu___6) ->
-                     let uu___7 =
-                       let uu___8 = FStar_TypeChecker_Env.get_range env in
+                   "(%s) } tc_term of %s (%s) took %sms\n" uu___6 uu___7
+                   uu___8 uu___9);
+                (let uu___6 = r in
+                 match uu___6 with
+                 | (e1, lc, uu___7) ->
+                     let uu___8 =
+                       let uu___9 = FStar_TypeChecker_Env.get_range env in
                        FStar_Compiler_Effect.op_Less_Bar
-                         FStar_Compiler_Range.string_of_range uu___8 in
-                     let uu___8 = FStar_Syntax_Print.term_to_string e1 in
-                     let uu___9 = FStar_TypeChecker_Common.lcomp_to_string lc in
+                         FStar_Compiler_Range.string_of_range uu___9 in
+                     let uu___9 = FStar_Syntax_Print.term_to_string e1 in
                      let uu___10 =
-                       let uu___11 = FStar_Syntax_Subst.compress e1 in
-                       FStar_Syntax_Print.tag_of_term uu___11 in
+                       FStar_TypeChecker_Common.lcomp_to_string lc in
+                     let uu___11 =
+                       let uu___12 = FStar_Syntax_Subst.compress e1 in
+                       FStar_Syntax_Print.tag_of_term uu___12 in
                      FStar_Compiler_Util.print4
-                       "(%s) Result is: (%s:%s) (%s)\n" uu___7 uu___8 uu___9
-                       uu___10))
+                       "(%s) Result is: (%s:%s) (%s)\n" uu___8 uu___9 uu___10
+                       uu___11))
              else ());
             r))
 and (tc_maybe_toplevel_term :
@@ -1755,1681 +1758,1694 @@ and (tc_maybe_toplevel_term :
         if e.FStar_Syntax_Syntax.pos = FStar_Compiler_Range.dummyRange
         then env
         else FStar_TypeChecker_Env.set_range env e.FStar_Syntax_Syntax.pos in
-      let top = FStar_Syntax_Subst.compress e in
-      (let uu___1 = FStar_TypeChecker_Env.debug env1 FStar_Options.Medium in
-       if uu___1
-       then
-         let uu___2 =
-           let uu___3 = FStar_TypeChecker_Env.get_range env1 in
-           FStar_Compiler_Effect.op_Less_Bar
-             FStar_Compiler_Range.string_of_range uu___3 in
-         let uu___3 = FStar_Syntax_Print.tag_of_term top in
-         let uu___4 = FStar_Syntax_Print.term_to_string top in
-         FStar_Compiler_Util.print3 "Typechecking %s (%s): %s\n" uu___2
-           uu___3 uu___4
-       else ());
-      (match top.FStar_Syntax_Syntax.n with
-       | FStar_Syntax_Syntax.Tm_delayed uu___1 -> failwith "Impossible"
-       | FStar_Syntax_Syntax.Tm_uinst uu___1 -> tc_value env1 e
-       | FStar_Syntax_Syntax.Tm_uvar uu___1 -> tc_value env1 e
-       | FStar_Syntax_Syntax.Tm_bvar uu___1 -> tc_value env1 e
-       | FStar_Syntax_Syntax.Tm_name uu___1 -> tc_value env1 e
-       | FStar_Syntax_Syntax.Tm_fvar uu___1 -> tc_value env1 e
-       | FStar_Syntax_Syntax.Tm_constant uu___1 -> tc_value env1 e
-       | FStar_Syntax_Syntax.Tm_abs uu___1 -> tc_value env1 e
-       | FStar_Syntax_Syntax.Tm_arrow uu___1 -> tc_value env1 e
-       | FStar_Syntax_Syntax.Tm_refine uu___1 -> tc_value env1 e
-       | FStar_Syntax_Syntax.Tm_type uu___1 -> tc_value env1 e
-       | FStar_Syntax_Syntax.Tm_unknown -> tc_value env1 e
-       | FStar_Syntax_Syntax.Tm_quoted (qt, qi) ->
-           let projl uu___1 =
-             match uu___1 with
-             | FStar_Pervasives.Inl x -> x
-             | FStar_Pervasives.Inr uu___2 -> failwith "projl fail" in
-           let non_trivial_antiquotes qi1 =
-             let is_name t =
-               let uu___1 =
-                 let uu___2 = FStar_Syntax_Subst.compress t in
-                 uu___2.FStar_Syntax_Syntax.n in
-               match uu___1 with
-               | FStar_Syntax_Syntax.Tm_name uu___2 -> true
-               | uu___2 -> false in
-             FStar_Compiler_Util.for_some
-               (fun uu___1 ->
-                  match uu___1 with
-                  | (uu___2, t) ->
-                      let uu___3 = is_name t in Prims.op_Negation uu___3)
-               qi1.FStar_Syntax_Syntax.antiquotes in
-           (match qi.FStar_Syntax_Syntax.qkind with
-            | FStar_Syntax_Syntax.Quote_static when non_trivial_antiquotes qi
-                ->
-                let e0 = e in
-                let newbvs =
-                  FStar_Compiler_List.map
-                    (fun uu___1 ->
-                       FStar_Syntax_Syntax.new_bv
-                         FStar_Pervasives_Native.None
-                         FStar_Syntax_Syntax.t_term)
-                    qi.FStar_Syntax_Syntax.antiquotes in
-                let z =
-                  FStar_Compiler_List.zip qi.FStar_Syntax_Syntax.antiquotes
-                    newbvs in
-                let lbs =
-                  FStar_Compiler_List.map
-                    (fun uu___1 ->
-                       match uu___1 with
-                       | ((bv, t), bv') ->
-                           FStar_Syntax_Util.close_univs_and_mk_letbinding
-                             FStar_Pervasives_Native.None
-                             (FStar_Pervasives.Inl bv') []
-                             FStar_Syntax_Syntax.t_term
-                             FStar_Parser_Const.effect_Tot_lid t []
-                             t.FStar_Syntax_Syntax.pos) z in
-                let qi1 =
-                  let uu___1 =
-                    FStar_Compiler_List.map
-                      (fun uu___2 ->
-                         match uu___2 with
-                         | ((bv, uu___3), bv') ->
-                             let uu___4 = FStar_Syntax_Syntax.bv_to_name bv' in
-                             (bv, uu___4)) z in
-                  {
-                    FStar_Syntax_Syntax.qkind =
-                      (qi.FStar_Syntax_Syntax.qkind);
-                    FStar_Syntax_Syntax.antiquotes = uu___1
-                  } in
-                let nq =
-                  FStar_Syntax_Syntax.mk
-                    (FStar_Syntax_Syntax.Tm_quoted (qt, qi1))
-                    top.FStar_Syntax_Syntax.pos in
-                let e1 =
-                  FStar_Compiler_List.fold_left
-                    (fun t ->
-                       fun lb ->
-                         let uu___1 =
-                           let uu___2 =
-                             let uu___3 =
-                               let uu___4 =
-                                 let uu___5 =
-                                   let uu___6 =
-                                     projl lb.FStar_Syntax_Syntax.lbname in
-                                   FStar_Syntax_Syntax.mk_binder uu___6 in
-                                 [uu___5] in
-                               FStar_Syntax_Subst.close uu___4 t in
-                             ((false, [lb]), uu___3) in
-                           FStar_Syntax_Syntax.Tm_let uu___2 in
-                         FStar_Syntax_Syntax.mk uu___1
-                           top.FStar_Syntax_Syntax.pos) nq lbs in
-                tc_maybe_toplevel_term env1 e1
-            | FStar_Syntax_Syntax.Quote_static ->
-                let aqs = qi.FStar_Syntax_Syntax.antiquotes in
-                let env_tm =
-                  FStar_TypeChecker_Env.set_expected_typ env1
-                    FStar_Syntax_Syntax.t_term in
-                let uu___1 =
-                  FStar_Compiler_List.fold_right
-                    (fun uu___2 ->
-                       fun uu___3 ->
-                         match (uu___2, uu___3) with
-                         | ((bv, tm), (aqs_rev, guard)) ->
-                             let uu___4 = tc_term env_tm tm in
-                             (match uu___4 with
-                              | (tm1, uu___5, g) ->
-                                  let uu___6 =
-                                    FStar_TypeChecker_Env.conj_guard g guard in
-                                  (((bv, tm1) :: aqs_rev), uu___6))) aqs
-                    ([], FStar_TypeChecker_Env.trivial_guard) in
-                (match uu___1 with
-                 | (aqs_rev, guard) ->
-                     let qi1 =
-                       {
-                         FStar_Syntax_Syntax.qkind =
-                           (qi.FStar_Syntax_Syntax.qkind);
-                         FStar_Syntax_Syntax.antiquotes =
-                           (FStar_Compiler_List.rev aqs_rev)
-                       } in
-                     let tm =
-                       FStar_Syntax_Syntax.mk
-                         (FStar_Syntax_Syntax.Tm_quoted (qt, qi1))
-                         top.FStar_Syntax_Syntax.pos in
-                     value_check_expected_typ env1 tm
-                       (FStar_Pervasives.Inl FStar_Syntax_Syntax.t_term)
-                       guard)
-            | FStar_Syntax_Syntax.Quote_dynamic ->
-                let c = FStar_Syntax_Syntax.mk_Tac FStar_Syntax_Syntax.t_term in
-                let uu___1 = FStar_TypeChecker_Env.clear_expected_typ env1 in
-                (match uu___1 with
-                 | (env', uu___2) ->
-                     let env'1 =
-                       {
-                         FStar_TypeChecker_Env.solver =
-                           (env'.FStar_TypeChecker_Env.solver);
-                         FStar_TypeChecker_Env.range =
-                           (env'.FStar_TypeChecker_Env.range);
-                         FStar_TypeChecker_Env.curmodule =
-                           (env'.FStar_TypeChecker_Env.curmodule);
-                         FStar_TypeChecker_Env.gamma =
-                           (env'.FStar_TypeChecker_Env.gamma);
-                         FStar_TypeChecker_Env.gamma_sig =
-                           (env'.FStar_TypeChecker_Env.gamma_sig);
-                         FStar_TypeChecker_Env.gamma_cache =
-                           (env'.FStar_TypeChecker_Env.gamma_cache);
-                         FStar_TypeChecker_Env.modules =
-                           (env'.FStar_TypeChecker_Env.modules);
-                         FStar_TypeChecker_Env.expected_typ =
-                           (env'.FStar_TypeChecker_Env.expected_typ);
-                         FStar_TypeChecker_Env.sigtab =
-                           (env'.FStar_TypeChecker_Env.sigtab);
-                         FStar_TypeChecker_Env.attrtab =
-                           (env'.FStar_TypeChecker_Env.attrtab);
-                         FStar_TypeChecker_Env.instantiate_imp =
-                           (env'.FStar_TypeChecker_Env.instantiate_imp);
-                         FStar_TypeChecker_Env.effects =
-                           (env'.FStar_TypeChecker_Env.effects);
-                         FStar_TypeChecker_Env.generalize =
-                           (env'.FStar_TypeChecker_Env.generalize);
-                         FStar_TypeChecker_Env.letrecs =
-                           (env'.FStar_TypeChecker_Env.letrecs);
-                         FStar_TypeChecker_Env.top_level =
-                           (env'.FStar_TypeChecker_Env.top_level);
-                         FStar_TypeChecker_Env.check_uvars =
-                           (env'.FStar_TypeChecker_Env.check_uvars);
-                         FStar_TypeChecker_Env.use_eq_strict =
-                           (env'.FStar_TypeChecker_Env.use_eq_strict);
-                         FStar_TypeChecker_Env.is_iface =
-                           (env'.FStar_TypeChecker_Env.is_iface);
-                         FStar_TypeChecker_Env.admit =
-                           (env'.FStar_TypeChecker_Env.admit);
-                         FStar_TypeChecker_Env.lax = true;
-                         FStar_TypeChecker_Env.lax_universes =
-                           (env'.FStar_TypeChecker_Env.lax_universes);
-                         FStar_TypeChecker_Env.phase1 =
-                           (env'.FStar_TypeChecker_Env.phase1);
-                         FStar_TypeChecker_Env.failhard =
-                           (env'.FStar_TypeChecker_Env.failhard);
-                         FStar_TypeChecker_Env.nosynth =
-                           (env'.FStar_TypeChecker_Env.nosynth);
-                         FStar_TypeChecker_Env.uvar_subtyping =
-                           (env'.FStar_TypeChecker_Env.uvar_subtyping);
-                         FStar_TypeChecker_Env.tc_term =
-                           (env'.FStar_TypeChecker_Env.tc_term);
-                         FStar_TypeChecker_Env.typeof_tot_or_gtot_term =
-                           (env'.FStar_TypeChecker_Env.typeof_tot_or_gtot_term);
-                         FStar_TypeChecker_Env.universe_of =
-                           (env'.FStar_TypeChecker_Env.universe_of);
-                         FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term
-                           =
-                           (env'.FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term);
-                         FStar_TypeChecker_Env.teq_nosmt_force =
-                           (env'.FStar_TypeChecker_Env.teq_nosmt_force);
-                         FStar_TypeChecker_Env.subtype_nosmt_force =
-                           (env'.FStar_TypeChecker_Env.subtype_nosmt_force);
-                         FStar_TypeChecker_Env.use_bv_sorts =
-                           (env'.FStar_TypeChecker_Env.use_bv_sorts);
-                         FStar_TypeChecker_Env.qtbl_name_and_index =
-                           (env'.FStar_TypeChecker_Env.qtbl_name_and_index);
-                         FStar_TypeChecker_Env.normalized_eff_names =
-                           (env'.FStar_TypeChecker_Env.normalized_eff_names);
-                         FStar_TypeChecker_Env.fv_delta_depths =
-                           (env'.FStar_TypeChecker_Env.fv_delta_depths);
-                         FStar_TypeChecker_Env.proof_ns =
-                           (env'.FStar_TypeChecker_Env.proof_ns);
-                         FStar_TypeChecker_Env.synth_hook =
-                           (env'.FStar_TypeChecker_Env.synth_hook);
-                         FStar_TypeChecker_Env.try_solve_implicits_hook =
-                           (env'.FStar_TypeChecker_Env.try_solve_implicits_hook);
-                         FStar_TypeChecker_Env.splice =
-                           (env'.FStar_TypeChecker_Env.splice);
-                         FStar_TypeChecker_Env.mpreprocess =
-                           (env'.FStar_TypeChecker_Env.mpreprocess);
-                         FStar_TypeChecker_Env.postprocess =
-                           (env'.FStar_TypeChecker_Env.postprocess);
-                         FStar_TypeChecker_Env.identifier_info =
-                           (env'.FStar_TypeChecker_Env.identifier_info);
-                         FStar_TypeChecker_Env.tc_hooks =
-                           (env'.FStar_TypeChecker_Env.tc_hooks);
-                         FStar_TypeChecker_Env.dsenv =
-                           (env'.FStar_TypeChecker_Env.dsenv);
-                         FStar_TypeChecker_Env.nbe =
-                           (env'.FStar_TypeChecker_Env.nbe);
-                         FStar_TypeChecker_Env.strict_args_tab =
-                           (env'.FStar_TypeChecker_Env.strict_args_tab);
-                         FStar_TypeChecker_Env.erasable_types_tab =
-                           (env'.FStar_TypeChecker_Env.erasable_types_tab);
-                         FStar_TypeChecker_Env.enable_defer_to_tac =
-                           (env'.FStar_TypeChecker_Env.enable_defer_to_tac);
-                         FStar_TypeChecker_Env.unif_allow_ref_guards =
-                           (env'.FStar_TypeChecker_Env.unif_allow_ref_guards);
-                         FStar_TypeChecker_Env.erase_erasable_args =
-                           (env'.FStar_TypeChecker_Env.erase_erasable_args);
-                         FStar_TypeChecker_Env.core_check =
-                           (env'.FStar_TypeChecker_Env.core_check)
-                       } in
-                     let uu___3 = tc_term env'1 qt in
-                     (match uu___3 with
-                      | (qt1, uu___4, g) ->
-                          let g0 =
-                            {
-                              FStar_TypeChecker_Common.guard_f =
-                                FStar_TypeChecker_Common.Trivial;
-                              FStar_TypeChecker_Common.deferred_to_tac =
-                                (g.FStar_TypeChecker_Common.deferred_to_tac);
-                              FStar_TypeChecker_Common.deferred =
-                                (g.FStar_TypeChecker_Common.deferred);
-                              FStar_TypeChecker_Common.univ_ineqs =
-                                (g.FStar_TypeChecker_Common.univ_ineqs);
-                              FStar_TypeChecker_Common.implicits =
-                                (g.FStar_TypeChecker_Common.implicits)
-                            } in
-                          let g01 =
-                            FStar_TypeChecker_Rel.resolve_implicits env'1 g0 in
-                          let t =
-                            FStar_Syntax_Syntax.mk
-                              (FStar_Syntax_Syntax.Tm_quoted (qt1, qi))
-                              top.FStar_Syntax_Syntax.pos in
-                          let uu___5 =
-                            let uu___6 =
-                              let uu___7 =
-                                FStar_TypeChecker_Common.lcomp_of_comp c in
-                              FStar_Pervasives.Inr uu___7 in
-                            value_check_expected_typ env1 t uu___6
-                              FStar_TypeChecker_Env.trivial_guard in
-                          (match uu___5 with
-                           | (t1, lc, g1) ->
-                               let t2 =
-                                 FStar_Syntax_Syntax.mk
-                                   (FStar_Syntax_Syntax.Tm_meta
-                                      (t1,
-                                        (FStar_Syntax_Syntax.Meta_monadic_lift
-                                           (FStar_Parser_Const.effect_PURE_lid,
-                                             FStar_Parser_Const.effect_TAC_lid,
-                                             FStar_Syntax_Syntax.t_term))))
-                                   t1.FStar_Syntax_Syntax.pos in
-                               let uu___6 =
-                                 FStar_TypeChecker_Env.conj_guard g01 g1 in
-                               (t2, lc, uu___6)))))
-       | FStar_Syntax_Syntax.Tm_lazy
-           { FStar_Syntax_Syntax.blob = uu___1;
-             FStar_Syntax_Syntax.lkind = FStar_Syntax_Syntax.Lazy_embedding
-               uu___2;
-             FStar_Syntax_Syntax.ltyp = uu___3;
-             FStar_Syntax_Syntax.rng = uu___4;_}
-           ->
-           let uu___5 = FStar_Syntax_Util.unlazy top in tc_term env1 uu___5
-       | FStar_Syntax_Syntax.Tm_lazy i ->
-           value_check_expected_typ env1 top
-             (FStar_Pervasives.Inl (i.FStar_Syntax_Syntax.ltyp))
-             FStar_TypeChecker_Env.trivial_guard
-       | FStar_Syntax_Syntax.Tm_meta
-           (e1, FStar_Syntax_Syntax.Meta_desugared
-            (FStar_Syntax_Syntax.Meta_smt_pat))
-           ->
-           let uu___1 = tc_tot_or_gtot_term env1 e1 in
-           (match uu___1 with
-            | (e2, c, g) ->
-                let g1 =
-                  {
-                    FStar_TypeChecker_Common.guard_f =
-                      FStar_TypeChecker_Common.Trivial;
-                    FStar_TypeChecker_Common.deferred_to_tac =
-                      (g.FStar_TypeChecker_Common.deferred_to_tac);
-                    FStar_TypeChecker_Common.deferred =
-                      (g.FStar_TypeChecker_Common.deferred);
-                    FStar_TypeChecker_Common.univ_ineqs =
-                      (g.FStar_TypeChecker_Common.univ_ineqs);
-                    FStar_TypeChecker_Common.implicits =
-                      (g.FStar_TypeChecker_Common.implicits)
-                  } in
+      FStar_TypeChecker_Env.def_check_closed_in_env e.FStar_Syntax_Syntax.pos
+        "tc_maybe_toplevel_term.entry" env1 e;
+      (let top = FStar_Syntax_Subst.compress e in
+       (let uu___2 = FStar_TypeChecker_Env.debug env1 FStar_Options.Medium in
+        if uu___2
+        then
+          let uu___3 =
+            let uu___4 = FStar_TypeChecker_Env.get_range env1 in
+            FStar_Compiler_Effect.op_Less_Bar
+              FStar_Compiler_Range.string_of_range uu___4 in
+          let uu___4 = FStar_Syntax_Print.tag_of_term top in
+          let uu___5 = FStar_Syntax_Print.term_to_string top in
+          FStar_Compiler_Util.print3 "Typechecking %s (%s): %s\n" uu___3
+            uu___4 uu___5
+        else ());
+       (match top.FStar_Syntax_Syntax.n with
+        | FStar_Syntax_Syntax.Tm_delayed uu___2 -> failwith "Impossible"
+        | FStar_Syntax_Syntax.Tm_uinst uu___2 -> tc_value env1 e
+        | FStar_Syntax_Syntax.Tm_uvar uu___2 -> tc_value env1 e
+        | FStar_Syntax_Syntax.Tm_bvar uu___2 -> tc_value env1 e
+        | FStar_Syntax_Syntax.Tm_name uu___2 -> tc_value env1 e
+        | FStar_Syntax_Syntax.Tm_fvar uu___2 -> tc_value env1 e
+        | FStar_Syntax_Syntax.Tm_constant uu___2 -> tc_value env1 e
+        | FStar_Syntax_Syntax.Tm_abs uu___2 -> tc_value env1 e
+        | FStar_Syntax_Syntax.Tm_arrow uu___2 -> tc_value env1 e
+        | FStar_Syntax_Syntax.Tm_refine uu___2 -> tc_value env1 e
+        | FStar_Syntax_Syntax.Tm_type uu___2 -> tc_value env1 e
+        | FStar_Syntax_Syntax.Tm_unknown -> tc_value env1 e
+        | FStar_Syntax_Syntax.Tm_quoted (qt, qi) ->
+            let projl uu___2 =
+              match uu___2 with
+              | FStar_Pervasives.Inl x -> x
+              | FStar_Pervasives.Inr uu___3 -> failwith "projl fail" in
+            let non_trivial_antiquotes qi1 =
+              let is_name t =
                 let uu___2 =
-                  FStar_Syntax_Syntax.mk
-                    (FStar_Syntax_Syntax.Tm_meta
-                       (e2,
-                         (FStar_Syntax_Syntax.Meta_desugared
-                            FStar_Syntax_Syntax.Meta_smt_pat)))
-                    top.FStar_Syntax_Syntax.pos in
-                (uu___2, c, g1))
-       | FStar_Syntax_Syntax.Tm_meta
-           (e1, FStar_Syntax_Syntax.Meta_pattern (names, pats)) ->
-           let uu___1 = FStar_Syntax_Util.type_u () in
-           (match uu___1 with
-            | (t, u) ->
-                let uu___2 = tc_check_tot_or_gtot_term env1 e1 t "" in
-                (match uu___2 with
-                 | (e2, c, g) ->
-                     let uu___3 =
-                       let uu___4 =
-                         FStar_TypeChecker_Env.clear_expected_typ env1 in
-                       match uu___4 with
-                       | (env2, uu___5) -> tc_smt_pats env2 pats in
-                     (match uu___3 with
-                      | (pats1, g') ->
-                          let g'1 =
-                            {
-                              FStar_TypeChecker_Common.guard_f =
-                                FStar_TypeChecker_Common.Trivial;
-                              FStar_TypeChecker_Common.deferred_to_tac =
-                                (g'.FStar_TypeChecker_Common.deferred_to_tac);
-                              FStar_TypeChecker_Common.deferred =
-                                (g'.FStar_TypeChecker_Common.deferred);
-                              FStar_TypeChecker_Common.univ_ineqs =
-                                (g'.FStar_TypeChecker_Common.univ_ineqs);
-                              FStar_TypeChecker_Common.implicits =
-                                (g'.FStar_TypeChecker_Common.implicits)
-                            } in
-                          let uu___4 =
+                  let uu___3 = FStar_Syntax_Subst.compress t in
+                  uu___3.FStar_Syntax_Syntax.n in
+                match uu___2 with
+                | FStar_Syntax_Syntax.Tm_name uu___3 -> true
+                | uu___3 -> false in
+              FStar_Compiler_Util.for_some
+                (fun uu___2 ->
+                   match uu___2 with
+                   | (uu___3, t) ->
+                       let uu___4 = is_name t in Prims.op_Negation uu___4)
+                qi1.FStar_Syntax_Syntax.antiquotes in
+            (match qi.FStar_Syntax_Syntax.qkind with
+             | FStar_Syntax_Syntax.Quote_static when
+                 non_trivial_antiquotes qi ->
+                 let e0 = e in
+                 let newbvs =
+                   FStar_Compiler_List.map
+                     (fun uu___2 ->
+                        FStar_Syntax_Syntax.new_bv
+                          FStar_Pervasives_Native.None
+                          FStar_Syntax_Syntax.t_term)
+                     qi.FStar_Syntax_Syntax.antiquotes in
+                 let z =
+                   FStar_Compiler_List.zip qi.FStar_Syntax_Syntax.antiquotes
+                     newbvs in
+                 let lbs =
+                   FStar_Compiler_List.map
+                     (fun uu___2 ->
+                        match uu___2 with
+                        | ((bv, t), bv') ->
+                            FStar_Syntax_Util.close_univs_and_mk_letbinding
+                              FStar_Pervasives_Native.None
+                              (FStar_Pervasives.Inl bv') []
+                              FStar_Syntax_Syntax.t_term
+                              FStar_Parser_Const.effect_Tot_lid t []
+                              t.FStar_Syntax_Syntax.pos) z in
+                 let qi1 =
+                   let uu___2 =
+                     FStar_Compiler_List.map
+                       (fun uu___3 ->
+                          match uu___3 with
+                          | ((bv, uu___4), bv') ->
+                              let uu___5 = FStar_Syntax_Syntax.bv_to_name bv' in
+                              (bv, uu___5)) z in
+                   {
+                     FStar_Syntax_Syntax.qkind =
+                       (qi.FStar_Syntax_Syntax.qkind);
+                     FStar_Syntax_Syntax.antiquotes = uu___2
+                   } in
+                 let nq =
+                   FStar_Syntax_Syntax.mk
+                     (FStar_Syntax_Syntax.Tm_quoted (qt, qi1))
+                     top.FStar_Syntax_Syntax.pos in
+                 let e1 =
+                   FStar_Compiler_List.fold_left
+                     (fun t ->
+                        fun lb ->
+                          let uu___2 =
+                            let uu___3 =
+                              let uu___4 =
+                                let uu___5 =
+                                  let uu___6 =
+                                    let uu___7 =
+                                      projl lb.FStar_Syntax_Syntax.lbname in
+                                    FStar_Syntax_Syntax.mk_binder uu___7 in
+                                  [uu___6] in
+                                FStar_Syntax_Subst.close uu___5 t in
+                              ((false, [lb]), uu___4) in
+                            FStar_Syntax_Syntax.Tm_let uu___3 in
+                          FStar_Syntax_Syntax.mk uu___2
+                            top.FStar_Syntax_Syntax.pos) nq lbs in
+                 tc_maybe_toplevel_term env1 e1
+             | FStar_Syntax_Syntax.Quote_static ->
+                 let aqs = qi.FStar_Syntax_Syntax.antiquotes in
+                 let env_tm =
+                   FStar_TypeChecker_Env.set_expected_typ env1
+                     FStar_Syntax_Syntax.t_term in
+                 let uu___2 =
+                   FStar_Compiler_List.fold_right
+                     (fun uu___3 ->
+                        fun uu___4 ->
+                          match (uu___3, uu___4) with
+                          | ((bv, tm), (aqs_rev, guard)) ->
+                              let uu___5 = tc_term env_tm tm in
+                              (match uu___5 with
+                               | (tm1, uu___6, g) ->
+                                   let uu___7 =
+                                     FStar_TypeChecker_Env.conj_guard g guard in
+                                   (((bv, tm1) :: aqs_rev), uu___7))) aqs
+                     ([], FStar_TypeChecker_Env.trivial_guard) in
+                 (match uu___2 with
+                  | (aqs_rev, guard) ->
+                      let qi1 =
+                        {
+                          FStar_Syntax_Syntax.qkind =
+                            (qi.FStar_Syntax_Syntax.qkind);
+                          FStar_Syntax_Syntax.antiquotes =
+                            (FStar_Compiler_List.rev aqs_rev)
+                        } in
+                      let tm =
+                        FStar_Syntax_Syntax.mk
+                          (FStar_Syntax_Syntax.Tm_quoted (qt, qi1))
+                          top.FStar_Syntax_Syntax.pos in
+                      value_check_expected_typ env1 tm
+                        (FStar_Pervasives.Inl FStar_Syntax_Syntax.t_term)
+                        guard)
+             | FStar_Syntax_Syntax.Quote_dynamic ->
+                 let c =
+                   FStar_Syntax_Syntax.mk_Tac FStar_Syntax_Syntax.t_term in
+                 let uu___2 = FStar_TypeChecker_Env.clear_expected_typ env1 in
+                 (match uu___2 with
+                  | (env', uu___3) ->
+                      let env'1 =
+                        {
+                          FStar_TypeChecker_Env.solver =
+                            (env'.FStar_TypeChecker_Env.solver);
+                          FStar_TypeChecker_Env.range =
+                            (env'.FStar_TypeChecker_Env.range);
+                          FStar_TypeChecker_Env.curmodule =
+                            (env'.FStar_TypeChecker_Env.curmodule);
+                          FStar_TypeChecker_Env.gamma =
+                            (env'.FStar_TypeChecker_Env.gamma);
+                          FStar_TypeChecker_Env.gamma_sig =
+                            (env'.FStar_TypeChecker_Env.gamma_sig);
+                          FStar_TypeChecker_Env.gamma_cache =
+                            (env'.FStar_TypeChecker_Env.gamma_cache);
+                          FStar_TypeChecker_Env.modules =
+                            (env'.FStar_TypeChecker_Env.modules);
+                          FStar_TypeChecker_Env.expected_typ =
+                            (env'.FStar_TypeChecker_Env.expected_typ);
+                          FStar_TypeChecker_Env.sigtab =
+                            (env'.FStar_TypeChecker_Env.sigtab);
+                          FStar_TypeChecker_Env.attrtab =
+                            (env'.FStar_TypeChecker_Env.attrtab);
+                          FStar_TypeChecker_Env.instantiate_imp =
+                            (env'.FStar_TypeChecker_Env.instantiate_imp);
+                          FStar_TypeChecker_Env.effects =
+                            (env'.FStar_TypeChecker_Env.effects);
+                          FStar_TypeChecker_Env.generalize =
+                            (env'.FStar_TypeChecker_Env.generalize);
+                          FStar_TypeChecker_Env.letrecs =
+                            (env'.FStar_TypeChecker_Env.letrecs);
+                          FStar_TypeChecker_Env.top_level =
+                            (env'.FStar_TypeChecker_Env.top_level);
+                          FStar_TypeChecker_Env.check_uvars =
+                            (env'.FStar_TypeChecker_Env.check_uvars);
+                          FStar_TypeChecker_Env.use_eq_strict =
+                            (env'.FStar_TypeChecker_Env.use_eq_strict);
+                          FStar_TypeChecker_Env.is_iface =
+                            (env'.FStar_TypeChecker_Env.is_iface);
+                          FStar_TypeChecker_Env.admit =
+                            (env'.FStar_TypeChecker_Env.admit);
+                          FStar_TypeChecker_Env.lax = true;
+                          FStar_TypeChecker_Env.lax_universes =
+                            (env'.FStar_TypeChecker_Env.lax_universes);
+                          FStar_TypeChecker_Env.phase1 =
+                            (env'.FStar_TypeChecker_Env.phase1);
+                          FStar_TypeChecker_Env.failhard =
+                            (env'.FStar_TypeChecker_Env.failhard);
+                          FStar_TypeChecker_Env.nosynth =
+                            (env'.FStar_TypeChecker_Env.nosynth);
+                          FStar_TypeChecker_Env.uvar_subtyping =
+                            (env'.FStar_TypeChecker_Env.uvar_subtyping);
+                          FStar_TypeChecker_Env.tc_term =
+                            (env'.FStar_TypeChecker_Env.tc_term);
+                          FStar_TypeChecker_Env.typeof_tot_or_gtot_term =
+                            (env'.FStar_TypeChecker_Env.typeof_tot_or_gtot_term);
+                          FStar_TypeChecker_Env.universe_of =
+                            (env'.FStar_TypeChecker_Env.universe_of);
+                          FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term
+                            =
+                            (env'.FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term);
+                          FStar_TypeChecker_Env.teq_nosmt_force =
+                            (env'.FStar_TypeChecker_Env.teq_nosmt_force);
+                          FStar_TypeChecker_Env.subtype_nosmt_force =
+                            (env'.FStar_TypeChecker_Env.subtype_nosmt_force);
+                          FStar_TypeChecker_Env.use_bv_sorts =
+                            (env'.FStar_TypeChecker_Env.use_bv_sorts);
+                          FStar_TypeChecker_Env.qtbl_name_and_index =
+                            (env'.FStar_TypeChecker_Env.qtbl_name_and_index);
+                          FStar_TypeChecker_Env.normalized_eff_names =
+                            (env'.FStar_TypeChecker_Env.normalized_eff_names);
+                          FStar_TypeChecker_Env.fv_delta_depths =
+                            (env'.FStar_TypeChecker_Env.fv_delta_depths);
+                          FStar_TypeChecker_Env.proof_ns =
+                            (env'.FStar_TypeChecker_Env.proof_ns);
+                          FStar_TypeChecker_Env.synth_hook =
+                            (env'.FStar_TypeChecker_Env.synth_hook);
+                          FStar_TypeChecker_Env.try_solve_implicits_hook =
+                            (env'.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                          FStar_TypeChecker_Env.splice =
+                            (env'.FStar_TypeChecker_Env.splice);
+                          FStar_TypeChecker_Env.mpreprocess =
+                            (env'.FStar_TypeChecker_Env.mpreprocess);
+                          FStar_TypeChecker_Env.postprocess =
+                            (env'.FStar_TypeChecker_Env.postprocess);
+                          FStar_TypeChecker_Env.identifier_info =
+                            (env'.FStar_TypeChecker_Env.identifier_info);
+                          FStar_TypeChecker_Env.tc_hooks =
+                            (env'.FStar_TypeChecker_Env.tc_hooks);
+                          FStar_TypeChecker_Env.dsenv =
+                            (env'.FStar_TypeChecker_Env.dsenv);
+                          FStar_TypeChecker_Env.nbe =
+                            (env'.FStar_TypeChecker_Env.nbe);
+                          FStar_TypeChecker_Env.strict_args_tab =
+                            (env'.FStar_TypeChecker_Env.strict_args_tab);
+                          FStar_TypeChecker_Env.erasable_types_tab =
+                            (env'.FStar_TypeChecker_Env.erasable_types_tab);
+                          FStar_TypeChecker_Env.enable_defer_to_tac =
+                            (env'.FStar_TypeChecker_Env.enable_defer_to_tac);
+                          FStar_TypeChecker_Env.unif_allow_ref_guards =
+                            (env'.FStar_TypeChecker_Env.unif_allow_ref_guards);
+                          FStar_TypeChecker_Env.erase_erasable_args =
+                            (env'.FStar_TypeChecker_Env.erase_erasable_args);
+                          FStar_TypeChecker_Env.core_check =
+                            (env'.FStar_TypeChecker_Env.core_check)
+                        } in
+                      let uu___4 = tc_term env'1 qt in
+                      (match uu___4 with
+                       | (qt1, uu___5, g) ->
+                           let g0 =
+                             {
+                               FStar_TypeChecker_Common.guard_f =
+                                 FStar_TypeChecker_Common.Trivial;
+                               FStar_TypeChecker_Common.deferred_to_tac =
+                                 (g.FStar_TypeChecker_Common.deferred_to_tac);
+                               FStar_TypeChecker_Common.deferred =
+                                 (g.FStar_TypeChecker_Common.deferred);
+                               FStar_TypeChecker_Common.univ_ineqs =
+                                 (g.FStar_TypeChecker_Common.univ_ineqs);
+                               FStar_TypeChecker_Common.implicits =
+                                 (g.FStar_TypeChecker_Common.implicits)
+                             } in
+                           let g01 =
+                             FStar_TypeChecker_Rel.resolve_implicits env'1 g0 in
+                           let t =
+                             FStar_Syntax_Syntax.mk
+                               (FStar_Syntax_Syntax.Tm_quoted (qt1, qi))
+                               top.FStar_Syntax_Syntax.pos in
+                           let uu___6 =
+                             let uu___7 =
+                               let uu___8 =
+                                 FStar_TypeChecker_Common.lcomp_of_comp c in
+                               FStar_Pervasives.Inr uu___8 in
+                             value_check_expected_typ env1 t uu___7
+                               FStar_TypeChecker_Env.trivial_guard in
+                           (match uu___6 with
+                            | (t1, lc, g1) ->
+                                let t2 =
+                                  FStar_Syntax_Syntax.mk
+                                    (FStar_Syntax_Syntax.Tm_meta
+                                       (t1,
+                                         (FStar_Syntax_Syntax.Meta_monadic_lift
+                                            (FStar_Parser_Const.effect_PURE_lid,
+                                              FStar_Parser_Const.effect_TAC_lid,
+                                              FStar_Syntax_Syntax.t_term))))
+                                    t1.FStar_Syntax_Syntax.pos in
+                                let uu___7 =
+                                  FStar_TypeChecker_Env.conj_guard g01 g1 in
+                                (t2, lc, uu___7)))))
+        | FStar_Syntax_Syntax.Tm_lazy
+            { FStar_Syntax_Syntax.blob = uu___2;
+              FStar_Syntax_Syntax.lkind = FStar_Syntax_Syntax.Lazy_embedding
+                uu___3;
+              FStar_Syntax_Syntax.ltyp = uu___4;
+              FStar_Syntax_Syntax.rng = uu___5;_}
+            ->
+            let uu___6 = FStar_Syntax_Util.unlazy top in tc_term env1 uu___6
+        | FStar_Syntax_Syntax.Tm_lazy i ->
+            value_check_expected_typ env1 top
+              (FStar_Pervasives.Inl (i.FStar_Syntax_Syntax.ltyp))
+              FStar_TypeChecker_Env.trivial_guard
+        | FStar_Syntax_Syntax.Tm_meta
+            (e1, FStar_Syntax_Syntax.Meta_desugared
+             (FStar_Syntax_Syntax.Meta_smt_pat))
+            ->
+            let uu___2 = tc_tot_or_gtot_term env1 e1 in
+            (match uu___2 with
+             | (e2, c, g) ->
+                 let g1 =
+                   {
+                     FStar_TypeChecker_Common.guard_f =
+                       FStar_TypeChecker_Common.Trivial;
+                     FStar_TypeChecker_Common.deferred_to_tac =
+                       (g.FStar_TypeChecker_Common.deferred_to_tac);
+                     FStar_TypeChecker_Common.deferred =
+                       (g.FStar_TypeChecker_Common.deferred);
+                     FStar_TypeChecker_Common.univ_ineqs =
+                       (g.FStar_TypeChecker_Common.univ_ineqs);
+                     FStar_TypeChecker_Common.implicits =
+                       (g.FStar_TypeChecker_Common.implicits)
+                   } in
+                 let uu___3 =
+                   FStar_Syntax_Syntax.mk
+                     (FStar_Syntax_Syntax.Tm_meta
+                        (e2,
+                          (FStar_Syntax_Syntax.Meta_desugared
+                             FStar_Syntax_Syntax.Meta_smt_pat)))
+                     top.FStar_Syntax_Syntax.pos in
+                 (uu___3, c, g1))
+        | FStar_Syntax_Syntax.Tm_meta
+            (e1, FStar_Syntax_Syntax.Meta_pattern (names, pats)) ->
+            let uu___2 = FStar_Syntax_Util.type_u () in
+            (match uu___2 with
+             | (t, u) ->
+                 let uu___3 = tc_check_tot_or_gtot_term env1 e1 t "" in
+                 (match uu___3 with
+                  | (e2, c, g) ->
+                      let uu___4 =
+                        let uu___5 =
+                          FStar_TypeChecker_Env.clear_expected_typ env1 in
+                        match uu___5 with
+                        | (env2, uu___6) -> tc_smt_pats env2 pats in
+                      (match uu___4 with
+                       | (pats1, g') ->
+                           let g'1 =
+                             {
+                               FStar_TypeChecker_Common.guard_f =
+                                 FStar_TypeChecker_Common.Trivial;
+                               FStar_TypeChecker_Common.deferred_to_tac =
+                                 (g'.FStar_TypeChecker_Common.deferred_to_tac);
+                               FStar_TypeChecker_Common.deferred =
+                                 (g'.FStar_TypeChecker_Common.deferred);
+                               FStar_TypeChecker_Common.univ_ineqs =
+                                 (g'.FStar_TypeChecker_Common.univ_ineqs);
+                               FStar_TypeChecker_Common.implicits =
+                                 (g'.FStar_TypeChecker_Common.implicits)
+                             } in
+                           let uu___5 =
+                             FStar_Syntax_Syntax.mk
+                               (FStar_Syntax_Syntax.Tm_meta
+                                  (e2,
+                                    (FStar_Syntax_Syntax.Meta_pattern
+                                       (names, pats1))))
+                               top.FStar_Syntax_Syntax.pos in
+                           let uu___6 =
+                             FStar_TypeChecker_Env.conj_guard g g'1 in
+                           (uu___5, c, uu___6))))
+        | FStar_Syntax_Syntax.Tm_meta
+            (e1, FStar_Syntax_Syntax.Meta_desugared
+             (FStar_Syntax_Syntax.Sequence))
+            ->
+            let uu___2 = tc_term env1 e1 in
+            (match uu___2 with
+             | (e2, c, g) ->
+                 let e3 =
+                   FStar_Syntax_Syntax.mk
+                     (FStar_Syntax_Syntax.Tm_meta
+                        (e2,
+                          (FStar_Syntax_Syntax.Meta_desugared
+                             FStar_Syntax_Syntax.Sequence)))
+                     top.FStar_Syntax_Syntax.pos in
+                 (e3, c, g))
+        | FStar_Syntax_Syntax.Tm_meta
+            (e1, FStar_Syntax_Syntax.Meta_monadic uu___2) -> tc_term env1 e1
+        | FStar_Syntax_Syntax.Tm_meta
+            (e1, FStar_Syntax_Syntax.Meta_monadic_lift uu___2) ->
+            tc_term env1 e1
+        | FStar_Syntax_Syntax.Tm_meta (e1, m) ->
+            let uu___2 = tc_term env1 e1 in
+            (match uu___2 with
+             | (e2, c, g) ->
+                 let e3 =
+                   FStar_Syntax_Syntax.mk
+                     (FStar_Syntax_Syntax.Tm_meta (e2, m))
+                     top.FStar_Syntax_Syntax.pos in
+                 (e3, c, g))
+        | FStar_Syntax_Syntax.Tm_ascribed
+            (e1, (asc, FStar_Pervasives_Native.Some tac, use_eq), labopt) ->
+            let uu___2 =
+              tc_tactic FStar_Syntax_Syntax.t_unit FStar_Syntax_Syntax.t_unit
+                env1 tac in
+            (match uu___2 with
+             | (tac1, uu___3, g_tac) ->
+                 let t' =
+                   FStar_Syntax_Syntax.mk
+                     (FStar_Syntax_Syntax.Tm_ascribed
+                        (e1, (asc, FStar_Pervasives_Native.None, use_eq),
+                          labopt)) top.FStar_Syntax_Syntax.pos in
+                 let uu___4 = tc_term env1 t' in
+                 (match uu___4 with
+                  | (t'1, c, g) ->
+                      let t'2 =
+                        let uu___5 =
+                          let uu___6 = FStar_Syntax_Subst.compress t'1 in
+                          uu___6.FStar_Syntax_Syntax.n in
+                        match uu___5 with
+                        | FStar_Syntax_Syntax.Tm_ascribed
+                            (e2,
+                             (asc1, FStar_Pervasives_Native.None, _use_eq),
+                             labopt1)
+                            ->
                             FStar_Syntax_Syntax.mk
-                              (FStar_Syntax_Syntax.Tm_meta
+                              (FStar_Syntax_Syntax.Tm_ascribed
                                  (e2,
-                                   (FStar_Syntax_Syntax.Meta_pattern
-                                      (names, pats1))))
-                              top.FStar_Syntax_Syntax.pos in
-                          let uu___5 = FStar_TypeChecker_Env.conj_guard g g'1 in
-                          (uu___4, c, uu___5))))
-       | FStar_Syntax_Syntax.Tm_meta
-           (e1, FStar_Syntax_Syntax.Meta_desugared
-            (FStar_Syntax_Syntax.Sequence))
-           ->
-           let uu___1 = tc_term env1 e1 in
-           (match uu___1 with
-            | (e2, c, g) ->
-                let e3 =
-                  FStar_Syntax_Syntax.mk
-                    (FStar_Syntax_Syntax.Tm_meta
-                       (e2,
-                         (FStar_Syntax_Syntax.Meta_desugared
-                            FStar_Syntax_Syntax.Sequence)))
-                    top.FStar_Syntax_Syntax.pos in
-                (e3, c, g))
-       | FStar_Syntax_Syntax.Tm_meta
-           (e1, FStar_Syntax_Syntax.Meta_monadic uu___1) -> tc_term env1 e1
-       | FStar_Syntax_Syntax.Tm_meta
-           (e1, FStar_Syntax_Syntax.Meta_monadic_lift uu___1) ->
-           tc_term env1 e1
-       | FStar_Syntax_Syntax.Tm_meta (e1, m) ->
-           let uu___1 = tc_term env1 e1 in
-           (match uu___1 with
-            | (e2, c, g) ->
-                let e3 =
-                  FStar_Syntax_Syntax.mk
-                    (FStar_Syntax_Syntax.Tm_meta (e2, m))
-                    top.FStar_Syntax_Syntax.pos in
-                (e3, c, g))
-       | FStar_Syntax_Syntax.Tm_ascribed
-           (e1, (asc, FStar_Pervasives_Native.Some tac, use_eq), labopt) ->
-           let uu___1 =
-             tc_tactic FStar_Syntax_Syntax.t_unit FStar_Syntax_Syntax.t_unit
-               env1 tac in
-           (match uu___1 with
-            | (tac1, uu___2, g_tac) ->
-                let t' =
-                  FStar_Syntax_Syntax.mk
-                    (FStar_Syntax_Syntax.Tm_ascribed
-                       (e1, (asc, FStar_Pervasives_Native.None, use_eq),
-                         labopt)) top.FStar_Syntax_Syntax.pos in
-                let uu___3 = tc_term env1 t' in
-                (match uu___3 with
-                 | (t'1, c, g) ->
-                     let t'2 =
-                       let uu___4 =
-                         let uu___5 = FStar_Syntax_Subst.compress t'1 in
-                         uu___5.FStar_Syntax_Syntax.n in
-                       match uu___4 with
-                       | FStar_Syntax_Syntax.Tm_ascribed
-                           (e2,
-                            (asc1, FStar_Pervasives_Native.None, _use_eq),
-                            labopt1)
-                           ->
-                           FStar_Syntax_Syntax.mk
-                             (FStar_Syntax_Syntax.Tm_ascribed
-                                (e2,
-                                  (asc1, (FStar_Pervasives_Native.Some tac1),
-                                    use_eq), labopt1))
-                             t'1.FStar_Syntax_Syntax.pos
-                       | uu___5 -> failwith "impossible" in
-                     let g1 =
-                       wrap_guard_with_tactic_opt
-                         (FStar_Pervasives_Native.Some tac1) g in
-                     let uu___4 = FStar_TypeChecker_Env.conj_guard g1 g_tac in
-                     (t'2, c, uu___4)))
-       | FStar_Syntax_Syntax.Tm_ascribed
-           (uu___1,
-            (FStar_Pervasives.Inr expected_c, FStar_Pervasives_Native.None,
-             use_eq),
-            uu___2)
-           when
-           let uu___3 =
-             FStar_Compiler_Effect.op_Bar_Greater top
-               is_comp_ascribed_reflect in
-           FStar_Compiler_Effect.op_Bar_Greater uu___3
-             FStar_Compiler_Util.is_some
-           ->
-           let uu___3 =
-             let uu___4 =
-               FStar_Compiler_Effect.op_Bar_Greater top
-                 is_comp_ascribed_reflect in
-             FStar_Compiler_Effect.op_Bar_Greater uu___4
-               FStar_Compiler_Util.must in
-           (match uu___3 with
-            | (effect_lid, e1, aqual) ->
-                let uu___4 = FStar_TypeChecker_Env.clear_expected_typ env1 in
-                (match uu___4 with
-                 | (env0, uu___5) ->
-                     let uu___6 = tc_comp env0 expected_c in
-                     (match uu___6 with
-                      | (expected_c1, uu___7, g_c) ->
-                          let expected_ct =
-                            FStar_TypeChecker_Env.unfold_effect_abbrev env0
-                              expected_c1 in
-                          ((let uu___9 =
-                              let uu___10 =
-                                FStar_Ident.lid_equals effect_lid
-                                  expected_ct.FStar_Syntax_Syntax.effect_name in
-                              Prims.op_Negation uu___10 in
-                            if uu___9
-                            then
-                              let uu___10 =
-                                let uu___11 =
-                                  let uu___12 =
-                                    FStar_Ident.string_of_lid effect_lid in
-                                  let uu___13 =
-                                    FStar_Ident.string_of_lid
-                                      expected_ct.FStar_Syntax_Syntax.effect_name in
-                                  FStar_Compiler_Util.format2
-                                    "The effect on reflect %s does not match with the annotation %s\n"
-                                    uu___12 uu___13 in
-                                (FStar_Errors.Fatal_UnexpectedEffect,
-                                  uu___11) in
-                              FStar_Errors.raise_error uu___10
-                                top.FStar_Syntax_Syntax.pos
-                            else ());
-                           (let uu___10 =
-                              let uu___11 =
-                                FStar_TypeChecker_Env.is_user_reflectable_effect
-                                  env1 effect_lid in
-                              Prims.op_Negation uu___11 in
-                            if uu___10
-                            then
-                              let uu___11 =
-                                let uu___12 =
-                                  let uu___13 =
-                                    FStar_Ident.string_of_lid effect_lid in
-                                  FStar_Compiler_Util.format1
-                                    "Effect %s cannot be reflected" uu___13 in
-                                (FStar_Errors.Fatal_EffectCannotBeReified,
-                                  uu___12) in
-                              FStar_Errors.raise_error uu___11
-                                top.FStar_Syntax_Syntax.pos
-                            else ());
-                           (let u_c =
-                              FStar_Compiler_Effect.op_Bar_Greater
-                                expected_ct.FStar_Syntax_Syntax.comp_univs
-                                FStar_Compiler_List.hd in
-                            let repr =
-                              let uu___10 =
-                                let uu___11 =
-                                  FStar_Compiler_Effect.op_Bar_Greater
-                                    expected_ct FStar_Syntax_Syntax.mk_Comp in
-                                FStar_TypeChecker_Env.effect_repr env0
-                                  uu___11 u_c in
-                              FStar_Compiler_Effect.op_Bar_Greater uu___10
-                                FStar_Compiler_Util.must in
-                            let e2 =
-                              let uu___10 =
-                                let uu___11 =
-                                  let uu___12 =
-                                    let uu___13 =
-                                      let uu___14 =
-                                        FStar_Syntax_Syntax.mk_Total repr in
-                                      FStar_Pervasives.Inr uu___14 in
-                                    (uu___13, FStar_Pervasives_Native.None,
-                                      use_eq) in
-                                  (e1, uu___12, FStar_Pervasives_Native.None) in
-                                FStar_Syntax_Syntax.Tm_ascribed uu___11 in
-                              FStar_Syntax_Syntax.mk uu___10
-                                e1.FStar_Syntax_Syntax.pos in
+                                   (asc1,
+                                     (FStar_Pervasives_Native.Some tac1),
+                                     use_eq), labopt1))
+                              t'1.FStar_Syntax_Syntax.pos
+                        | uu___6 -> failwith "impossible" in
+                      let g1 =
+                        wrap_guard_with_tactic_opt
+                          (FStar_Pervasives_Native.Some tac1) g in
+                      let uu___5 = FStar_TypeChecker_Env.conj_guard g1 g_tac in
+                      (t'2, c, uu___5)))
+        | FStar_Syntax_Syntax.Tm_ascribed
+            (uu___2,
+             (FStar_Pervasives.Inr expected_c, FStar_Pervasives_Native.None,
+              use_eq),
+             uu___3)
+            when
+            let uu___4 =
+              FStar_Compiler_Effect.op_Bar_Greater top
+                is_comp_ascribed_reflect in
+            FStar_Compiler_Effect.op_Bar_Greater uu___4
+              FStar_Compiler_Util.is_some
+            ->
+            let uu___4 =
+              let uu___5 =
+                FStar_Compiler_Effect.op_Bar_Greater top
+                  is_comp_ascribed_reflect in
+              FStar_Compiler_Effect.op_Bar_Greater uu___5
+                FStar_Compiler_Util.must in
+            (match uu___4 with
+             | (effect_lid, e1, aqual) ->
+                 let uu___5 = FStar_TypeChecker_Env.clear_expected_typ env1 in
+                 (match uu___5 with
+                  | (env0, uu___6) ->
+                      let uu___7 = tc_comp env0 expected_c in
+                      (match uu___7 with
+                       | (expected_c1, uu___8, g_c) ->
+                           let expected_ct =
+                             FStar_TypeChecker_Env.unfold_effect_abbrev env0
+                               expected_c1 in
+                           ((let uu___10 =
+                               let uu___11 =
+                                 FStar_Ident.lid_equals effect_lid
+                                   expected_ct.FStar_Syntax_Syntax.effect_name in
+                               Prims.op_Negation uu___11 in
+                             if uu___10
+                             then
+                               let uu___11 =
+                                 let uu___12 =
+                                   let uu___13 =
+                                     FStar_Ident.string_of_lid effect_lid in
+                                   let uu___14 =
+                                     FStar_Ident.string_of_lid
+                                       expected_ct.FStar_Syntax_Syntax.effect_name in
+                                   FStar_Compiler_Util.format2
+                                     "The effect on reflect %s does not match with the annotation %s\n"
+                                     uu___13 uu___14 in
+                                 (FStar_Errors.Fatal_UnexpectedEffect,
+                                   uu___12) in
+                               FStar_Errors.raise_error uu___11
+                                 top.FStar_Syntax_Syntax.pos
+                             else ());
                             (let uu___11 =
-                               FStar_Compiler_Effect.op_Less_Bar
-                                 (FStar_TypeChecker_Env.debug env0)
-                                 FStar_Options.Extreme in
+                               let uu___12 =
+                                 FStar_TypeChecker_Env.is_user_reflectable_effect
+                                   env1 effect_lid in
+                               Prims.op_Negation uu___12 in
                              if uu___11
                              then
                                let uu___12 =
-                                 FStar_Syntax_Print.term_to_string e2 in
-                               FStar_Compiler_Util.print1
-                                 "Typechecking ascribed reflect, inner ascribed term: %s\n"
-                                 uu___12
+                                 let uu___13 =
+                                   let uu___14 =
+                                     FStar_Ident.string_of_lid effect_lid in
+                                   FStar_Compiler_Util.format1
+                                     "Effect %s cannot be reflected" uu___14 in
+                                 (FStar_Errors.Fatal_EffectCannotBeReified,
+                                   uu___13) in
+                               FStar_Errors.raise_error uu___12
+                                 top.FStar_Syntax_Syntax.pos
                              else ());
-                            (let uu___11 = tc_tot_or_gtot_term env0 e2 in
-                             match uu___11 with
-                             | (e3, uu___12, g_e) ->
-                                 let e4 = FStar_Syntax_Util.unascribe e3 in
-                                 ((let uu___14 =
-                                     FStar_Compiler_Effect.op_Less_Bar
-                                       (FStar_TypeChecker_Env.debug env0)
-                                       FStar_Options.Extreme in
-                                   if uu___14
+                            (let u_c =
+                               FStar_Compiler_Effect.op_Bar_Greater
+                                 expected_ct.FStar_Syntax_Syntax.comp_univs
+                                 FStar_Compiler_List.hd in
+                             let repr =
+                               let uu___11 =
+                                 let uu___12 =
+                                   FStar_Compiler_Effect.op_Bar_Greater
+                                     expected_ct FStar_Syntax_Syntax.mk_Comp in
+                                 FStar_TypeChecker_Env.effect_repr env0
+                                   uu___12 u_c in
+                               FStar_Compiler_Effect.op_Bar_Greater uu___11
+                                 FStar_Compiler_Util.must in
+                             let e2 =
+                               let uu___11 =
+                                 let uu___12 =
+                                   let uu___13 =
+                                     let uu___14 =
+                                       let uu___15 =
+                                         FStar_Syntax_Syntax.mk_Total repr in
+                                       FStar_Pervasives.Inr uu___15 in
+                                     (uu___14, FStar_Pervasives_Native.None,
+                                       use_eq) in
+                                   (e1, uu___13,
+                                     FStar_Pervasives_Native.None) in
+                                 FStar_Syntax_Syntax.Tm_ascribed uu___12 in
+                               FStar_Syntax_Syntax.mk uu___11
+                                 e1.FStar_Syntax_Syntax.pos in
+                             (let uu___12 =
+                                FStar_Compiler_Effect.op_Less_Bar
+                                  (FStar_TypeChecker_Env.debug env0)
+                                  FStar_Options.Extreme in
+                              if uu___12
+                              then
+                                let uu___13 =
+                                  FStar_Syntax_Print.term_to_string e2 in
+                                FStar_Compiler_Util.print1
+                                  "Typechecking ascribed reflect, inner ascribed term: %s\n"
+                                  uu___13
+                              else ());
+                             (let uu___12 = tc_tot_or_gtot_term env0 e2 in
+                              match uu___12 with
+                              | (e3, uu___13, g_e) ->
+                                  let e4 = FStar_Syntax_Util.unascribe e3 in
+                                  ((let uu___15 =
+                                      FStar_Compiler_Effect.op_Less_Bar
+                                        (FStar_TypeChecker_Env.debug env0)
+                                        FStar_Options.Extreme in
+                                    if uu___15
+                                    then
+                                      let uu___16 =
+                                        FStar_Syntax_Print.term_to_string e4 in
+                                      let uu___17 =
+                                        FStar_TypeChecker_Rel.guard_to_string
+                                          env0 g_e in
+                                      FStar_Compiler_Util.print2
+                                        "Typechecking ascribed reflect, after typechecking inner ascribed term: %s and guard: %s\n"
+                                        uu___16 uu___17
+                                    else ());
+                                   (let top1 =
+                                      let r = top.FStar_Syntax_Syntax.pos in
+                                      let tm =
+                                        FStar_Syntax_Syntax.mk
+                                          (FStar_Syntax_Syntax.Tm_constant
+                                             (FStar_Const.Const_reflect
+                                                effect_lid)) r in
+                                      let tm1 =
+                                        FStar_Syntax_Syntax.mk
+                                          (FStar_Syntax_Syntax.Tm_app
+                                             (tm, [(e4, aqual)])) r in
+                                      let uu___15 =
+                                        let uu___16 =
+                                          let uu___17 =
+                                            let uu___18 =
+                                              FStar_Compiler_Effect.op_Bar_Greater
+                                                expected_c1
+                                                FStar_Syntax_Util.comp_effect_name in
+                                            FStar_Compiler_Effect.op_Bar_Greater
+                                              uu___18
+                                              (fun uu___19 ->
+                                                 FStar_Pervasives_Native.Some
+                                                   uu___19) in
+                                          (tm1,
+                                            ((FStar_Pervasives.Inr
+                                                expected_c1),
+                                              FStar_Pervasives_Native.None,
+                                              use_eq), uu___17) in
+                                        FStar_Syntax_Syntax.Tm_ascribed
+                                          uu___16 in
+                                      FStar_Syntax_Syntax.mk uu___15 r in
+                                    let uu___15 =
+                                      let uu___16 =
+                                        FStar_Compiler_Effect.op_Bar_Greater
+                                          expected_c1
+                                          FStar_TypeChecker_Common.lcomp_of_comp in
+                                      comp_check_expected_typ env1 top1
+                                        uu___16 in
+                                    match uu___15 with
+                                    | (top2, c, g_env) ->
+                                        let uu___16 =
+                                          FStar_TypeChecker_Env.conj_guards
+                                            [g_c; g_e; g_env] in
+                                        (top2, c, uu___16)))))))))
+        | FStar_Syntax_Syntax.Tm_ascribed
+            (e1,
+             (FStar_Pervasives.Inr expected_c, FStar_Pervasives_Native.None,
+              use_eq),
+             uu___2)
+            ->
+            let uu___3 = FStar_TypeChecker_Env.clear_expected_typ env1 in
+            (match uu___3 with
+             | (env0, uu___4) ->
+                 let uu___5 = tc_comp env0 expected_c in
+                 (match uu___5 with
+                  | (expected_c1, uu___6, g) ->
+                      let uu___7 =
+                        let uu___8 =
+                          FStar_Compiler_Effect.op_Bar_Greater
+                            (FStar_Syntax_Util.comp_result expected_c1)
+                            (fun t ->
+                               FStar_TypeChecker_Env.set_expected_typ_maybe_eq
+                                 env0 t use_eq) in
+                        tc_term uu___8 e1 in
+                      (match uu___7 with
+                       | (e2, c', g') ->
+                           let uu___8 =
+                             let uu___9 =
+                               FStar_TypeChecker_Common.lcomp_comp c' in
+                             match uu___9 with
+                             | (c'1, g_c') ->
+                                 let uu___10 =
+                                   check_expected_effect env0 use_eq
+                                     (FStar_Pervasives_Native.Some
+                                        expected_c1) (e2, c'1) in
+                                 (match uu___10 with
+                                  | (e3, expected_c2, g'') ->
+                                      let uu___11 =
+                                        FStar_TypeChecker_Env.conj_guard g_c'
+                                          g'' in
+                                      (e3, expected_c2, uu___11)) in
+                           (match uu___8 with
+                            | (e3, expected_c2, g'') ->
+                                let e4 =
+                                  FStar_Syntax_Syntax.mk
+                                    (FStar_Syntax_Syntax.Tm_ascribed
+                                       (e3,
+                                         ((FStar_Pervasives.Inr expected_c2),
+                                           FStar_Pervasives_Native.None,
+                                           use_eq),
+                                         (FStar_Pervasives_Native.Some
+                                            (FStar_Syntax_Util.comp_effect_name
+                                               expected_c2))))
+                                    top.FStar_Syntax_Syntax.pos in
+                                let lc =
+                                  FStar_TypeChecker_Common.lcomp_of_comp
+                                    expected_c2 in
+                                let f =
+                                  let uu___9 =
+                                    FStar_TypeChecker_Env.conj_guard g' g'' in
+                                  FStar_TypeChecker_Env.conj_guard g uu___9 in
+                                let uu___9 =
+                                  comp_check_expected_typ env1 e4 lc in
+                                (match uu___9 with
+                                 | (e5, c, f2) ->
+                                     let uu___10 =
+                                       FStar_TypeChecker_Env.conj_guard f f2 in
+                                     (e5, c, uu___10))))))
+        | FStar_Syntax_Syntax.Tm_ascribed
+            (e1,
+             (FStar_Pervasives.Inl t, FStar_Pervasives_Native.None, use_eq),
+             uu___2)
+            ->
+            let uu___3 = FStar_Syntax_Util.type_u () in
+            (match uu___3 with
+             | (k, u) ->
+                 let uu___4 = tc_check_tot_or_gtot_term env1 t k "" in
+                 (match uu___4 with
+                  | (t1, uu___5, f) ->
+                      let uu___6 =
+                        let uu___7 =
+                          FStar_TypeChecker_Env.set_expected_typ_maybe_eq
+                            env1 t1 use_eq in
+                        tc_term uu___7 e1 in
+                      (match uu___6 with
+                       | (e2, c, g) ->
+                           let uu___7 =
+                             let uu___8 =
+                               FStar_TypeChecker_Env.set_range env1
+                                 t1.FStar_Syntax_Syntax.pos in
+                             FStar_TypeChecker_Util.strengthen_precondition
+                               (FStar_Pervasives_Native.Some
+                                  (fun uu___9 ->
+                                     FStar_Compiler_Util.return_all
+                                       FStar_TypeChecker_Err.ill_kinded_type))
+                               uu___8 e2 c f in
+                           (match uu___7 with
+                            | (c1, f1) ->
+                                let uu___8 =
+                                  let uu___9 =
+                                    FStar_Syntax_Syntax.mk
+                                      (FStar_Syntax_Syntax.Tm_ascribed
+                                         (e2,
+                                           ((FStar_Pervasives.Inl t1),
+                                             FStar_Pervasives_Native.None,
+                                             use_eq),
+                                           (FStar_Pervasives_Native.Some
+                                              (c1.FStar_TypeChecker_Common.eff_name))))
+                                      top.FStar_Syntax_Syntax.pos in
+                                  comp_check_expected_typ env1 uu___9 c1 in
+                                (match uu___8 with
+                                 | (e3, c2, f2) ->
+                                     let uu___9 =
+                                       let uu___10 =
+                                         FStar_TypeChecker_Env.conj_guard g
+                                           f2 in
+                                       FStar_TypeChecker_Env.conj_guard f1
+                                         uu___10 in
+                                     (e3, c2, uu___9))))))
+        | FStar_Syntax_Syntax.Tm_app
+            ({
+               FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
+                 (FStar_Const.Const_range_of);
+               FStar_Syntax_Syntax.pos = uu___2;
+               FStar_Syntax_Syntax.vars = uu___3;
+               FStar_Syntax_Syntax.hash_code = uu___4;_},
+             a::hd::rest)
+            ->
+            let rest1 = hd :: rest in
+            let uu___5 = FStar_Syntax_Util.head_and_args top in
+            (match uu___5 with
+             | (unary_op, uu___6) ->
+                 let head =
+                   let uu___7 =
+                     FStar_Compiler_Range.union_ranges
+                       unary_op.FStar_Syntax_Syntax.pos
+                       (FStar_Pervasives_Native.fst a).FStar_Syntax_Syntax.pos in
+                   FStar_Syntax_Syntax.mk
+                     (FStar_Syntax_Syntax.Tm_app (unary_op, [a])) uu___7 in
+                 let t =
+                   FStar_Syntax_Syntax.mk
+                     (FStar_Syntax_Syntax.Tm_app (head, rest1))
+                     top.FStar_Syntax_Syntax.pos in
+                 tc_term env1 t)
+        | FStar_Syntax_Syntax.Tm_app
+            ({
+               FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
+                 (FStar_Const.Const_reify);
+               FStar_Syntax_Syntax.pos = uu___2;
+               FStar_Syntax_Syntax.vars = uu___3;
+               FStar_Syntax_Syntax.hash_code = uu___4;_},
+             a::hd::rest)
+            ->
+            let rest1 = hd :: rest in
+            let uu___5 = FStar_Syntax_Util.head_and_args top in
+            (match uu___5 with
+             | (unary_op, uu___6) ->
+                 let head =
+                   let uu___7 =
+                     FStar_Compiler_Range.union_ranges
+                       unary_op.FStar_Syntax_Syntax.pos
+                       (FStar_Pervasives_Native.fst a).FStar_Syntax_Syntax.pos in
+                   FStar_Syntax_Syntax.mk
+                     (FStar_Syntax_Syntax.Tm_app (unary_op, [a])) uu___7 in
+                 let t =
+                   FStar_Syntax_Syntax.mk
+                     (FStar_Syntax_Syntax.Tm_app (head, rest1))
+                     top.FStar_Syntax_Syntax.pos in
+                 tc_term env1 t)
+        | FStar_Syntax_Syntax.Tm_app
+            ({
+               FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
+                 (FStar_Const.Const_reflect uu___2);
+               FStar_Syntax_Syntax.pos = uu___3;
+               FStar_Syntax_Syntax.vars = uu___4;
+               FStar_Syntax_Syntax.hash_code = uu___5;_},
+             a::hd::rest)
+            ->
+            let rest1 = hd :: rest in
+            let uu___6 = FStar_Syntax_Util.head_and_args top in
+            (match uu___6 with
+             | (unary_op, uu___7) ->
+                 let head =
+                   let uu___8 =
+                     FStar_Compiler_Range.union_ranges
+                       unary_op.FStar_Syntax_Syntax.pos
+                       (FStar_Pervasives_Native.fst a).FStar_Syntax_Syntax.pos in
+                   FStar_Syntax_Syntax.mk
+                     (FStar_Syntax_Syntax.Tm_app (unary_op, [a])) uu___8 in
+                 let t =
+                   FStar_Syntax_Syntax.mk
+                     (FStar_Syntax_Syntax.Tm_app (head, rest1))
+                     top.FStar_Syntax_Syntax.pos in
+                 tc_term env1 t)
+        | FStar_Syntax_Syntax.Tm_app
+            ({
+               FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
+                 (FStar_Const.Const_set_range_of);
+               FStar_Syntax_Syntax.pos = uu___2;
+               FStar_Syntax_Syntax.vars = uu___3;
+               FStar_Syntax_Syntax.hash_code = uu___4;_},
+             a1::a2::hd::rest)
+            ->
+            let rest1 = hd :: rest in
+            let uu___5 = FStar_Syntax_Util.head_and_args top in
+            (match uu___5 with
+             | (unary_op, uu___6) ->
+                 let head =
+                   let uu___7 =
+                     FStar_Compiler_Range.union_ranges
+                       unary_op.FStar_Syntax_Syntax.pos
+                       (FStar_Pervasives_Native.fst a1).FStar_Syntax_Syntax.pos in
+                   FStar_Syntax_Syntax.mk
+                     (FStar_Syntax_Syntax.Tm_app (unary_op, [a1; a2])) uu___7 in
+                 let t =
+                   FStar_Syntax_Syntax.mk
+                     (FStar_Syntax_Syntax.Tm_app (head, rest1))
+                     top.FStar_Syntax_Syntax.pos in
+                 tc_term env1 t)
+        | FStar_Syntax_Syntax.Tm_app
+            ({
+               FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
+                 (FStar_Const.Const_range_of);
+               FStar_Syntax_Syntax.pos = uu___2;
+               FStar_Syntax_Syntax.vars = uu___3;
+               FStar_Syntax_Syntax.hash_code = uu___4;_},
+             (e1, FStar_Pervasives_Native.None)::[])
+            ->
+            let uu___5 =
+              let uu___6 =
+                let uu___7 = FStar_TypeChecker_Env.clear_expected_typ env1 in
+                FStar_Compiler_Effect.op_Less_Bar FStar_Pervasives_Native.fst
+                  uu___7 in
+              tc_term uu___6 e1 in
+            (match uu___5 with
+             | (e2, c, g) ->
+                 let uu___6 = FStar_Syntax_Util.head_and_args top in
+                 (match uu___6 with
+                  | (head, uu___7) ->
+                      let uu___8 =
+                        FStar_Syntax_Syntax.mk
+                          (FStar_Syntax_Syntax.Tm_app
+                             (head, [(e2, FStar_Pervasives_Native.None)]))
+                          top.FStar_Syntax_Syntax.pos in
+                      let uu___9 =
+                        let uu___10 =
+                          let uu___11 =
+                            FStar_Syntax_Syntax.tabbrev
+                              FStar_Parser_Const.range_lid in
+                          FStar_Syntax_Syntax.mk_Total uu___11 in
+                        FStar_Compiler_Effect.op_Less_Bar
+                          FStar_TypeChecker_Common.lcomp_of_comp uu___10 in
+                      (uu___8, uu___9, g)))
+        | FStar_Syntax_Syntax.Tm_app
+            ({
+               FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
+                 (FStar_Const.Const_set_range_of);
+               FStar_Syntax_Syntax.pos = uu___2;
+               FStar_Syntax_Syntax.vars = uu___3;
+               FStar_Syntax_Syntax.hash_code = uu___4;_},
+             (t, FStar_Pervasives_Native.None)::(r,
+                                                 FStar_Pervasives_Native.None)::[])
+            ->
+            let uu___5 = FStar_Syntax_Util.head_and_args top in
+            (match uu___5 with
+             | (head, uu___6) ->
+                 let env' =
+                   let uu___7 =
+                     FStar_Syntax_Syntax.tabbrev FStar_Parser_Const.range_lid in
+                   FStar_TypeChecker_Env.set_expected_typ env1 uu___7 in
+                 let uu___7 = tc_term env' r in
+                 (match uu___7 with
+                  | (er, uu___8, gr) ->
+                      let uu___9 = tc_term env1 t in
+                      (match uu___9 with
+                       | (t1, tt, gt) ->
+                           let g = FStar_TypeChecker_Env.conj_guard gr gt in
+                           let uu___10 =
+                             let uu___11 =
+                               let uu___12 = FStar_Syntax_Syntax.as_arg t1 in
+                               let uu___13 =
+                                 let uu___14 = FStar_Syntax_Syntax.as_arg r in
+                                 [uu___14] in
+                               uu___12 :: uu___13 in
+                             FStar_Syntax_Syntax.mk_Tm_app head uu___11
+                               top.FStar_Syntax_Syntax.pos in
+                           (uu___10, tt, g))))
+        | FStar_Syntax_Syntax.Tm_app
+            ({
+               FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
+                 (FStar_Const.Const_range_of);
+               FStar_Syntax_Syntax.pos = uu___2;
+               FStar_Syntax_Syntax.vars = uu___3;
+               FStar_Syntax_Syntax.hash_code = uu___4;_},
+             uu___5)
+            ->
+            let uu___6 =
+              let uu___7 =
+                let uu___8 = FStar_Syntax_Print.term_to_string top in
+                FStar_Compiler_Util.format1 "Ill-applied constant %s" uu___8 in
+              (FStar_Errors.Fatal_IllAppliedConstant, uu___7) in
+            FStar_Errors.raise_error uu___6 e.FStar_Syntax_Syntax.pos
+        | FStar_Syntax_Syntax.Tm_app
+            ({
+               FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
+                 (FStar_Const.Const_set_range_of);
+               FStar_Syntax_Syntax.pos = uu___2;
+               FStar_Syntax_Syntax.vars = uu___3;
+               FStar_Syntax_Syntax.hash_code = uu___4;_},
+             uu___5)
+            ->
+            let uu___6 =
+              let uu___7 =
+                let uu___8 = FStar_Syntax_Print.term_to_string top in
+                FStar_Compiler_Util.format1 "Ill-applied constant %s" uu___8 in
+              (FStar_Errors.Fatal_IllAppliedConstant, uu___7) in
+            FStar_Errors.raise_error uu___6 e.FStar_Syntax_Syntax.pos
+        | FStar_Syntax_Syntax.Tm_app
+            ({
+               FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
+                 (FStar_Const.Const_reify);
+               FStar_Syntax_Syntax.pos = uu___2;
+               FStar_Syntax_Syntax.vars = uu___3;
+               FStar_Syntax_Syntax.hash_code = uu___4;_},
+             (e1, aqual)::[])
+            ->
+            (if FStar_Compiler_Option.isSome aqual
+             then
+               FStar_Errors.log_issue e1.FStar_Syntax_Syntax.pos
+                 (FStar_Errors.Warning_IrrelevantQualifierOnArgumentToReify,
+                   "Qualifier on argument to reify is irrelevant and will be ignored")
+             else ();
+             (let uu___6 = FStar_TypeChecker_Env.clear_expected_typ env1 in
+              match uu___6 with
+              | (env0, uu___7) ->
+                  let uu___8 = tc_term env0 e1 in
+                  (match uu___8 with
+                   | (e2, c, g) ->
+                       let uu___9 = FStar_Syntax_Util.head_and_args top in
+                       (match uu___9 with
+                        | (reify_op, uu___10) ->
+                            let uu___11 =
+                              let uu___12 =
+                                FStar_TypeChecker_Common.lcomp_comp c in
+                              match uu___12 with
+                              | (c1, g_c) ->
+                                  let uu___13 =
+                                    FStar_TypeChecker_Env.unfold_effect_abbrev
+                                      env1 c1 in
+                                  (uu___13, g_c) in
+                            (match uu___11 with
+                             | (c1, g_c) ->
+                                 ((let uu___13 =
+                                     let uu___14 =
+                                       FStar_TypeChecker_Env.is_user_reifiable_effect
+                                         env1
+                                         c1.FStar_Syntax_Syntax.effect_name in
+                                     Prims.op_Negation uu___14 in
+                                   if uu___13
                                    then
-                                     let uu___15 =
-                                       FStar_Syntax_Print.term_to_string e4 in
-                                     let uu___16 =
-                                       FStar_TypeChecker_Rel.guard_to_string
-                                         env0 g_e in
-                                     FStar_Compiler_Util.print2
-                                       "Typechecking ascribed reflect, after typechecking inner ascribed term: %s and guard: %s\n"
-                                       uu___15 uu___16
-                                   else ());
-                                  (let top1 =
-                                     let r = top.FStar_Syntax_Syntax.pos in
-                                     let tm =
-                                       FStar_Syntax_Syntax.mk
-                                         (FStar_Syntax_Syntax.Tm_constant
-                                            (FStar_Const.Const_reflect
-                                               effect_lid)) r in
-                                     let tm1 =
-                                       FStar_Syntax_Syntax.mk
-                                         (FStar_Syntax_Syntax.Tm_app
-                                            (tm, [(e4, aqual)])) r in
                                      let uu___14 =
                                        let uu___15 =
                                          let uu___16 =
-                                           let uu___17 =
-                                             FStar_Compiler_Effect.op_Bar_Greater
-                                               expected_c1
-                                               FStar_Syntax_Util.comp_effect_name in
-                                           FStar_Compiler_Effect.op_Bar_Greater
-                                             uu___17
-                                             (fun uu___18 ->
-                                                FStar_Pervasives_Native.Some
-                                                  uu___18) in
-                                         (tm1,
-                                           ((FStar_Pervasives.Inr expected_c1),
-                                             FStar_Pervasives_Native.None,
-                                             use_eq), uu___16) in
-                                       FStar_Syntax_Syntax.Tm_ascribed
-                                         uu___15 in
-                                     FStar_Syntax_Syntax.mk uu___14 r in
-                                   let uu___14 =
-                                     let uu___15 =
-                                       FStar_Compiler_Effect.op_Bar_Greater
-                                         expected_c1
-                                         FStar_TypeChecker_Common.lcomp_of_comp in
-                                     comp_check_expected_typ env1 top1
-                                       uu___15 in
-                                   match uu___14 with
-                                   | (top2, c, g_env) ->
-                                       let uu___15 =
-                                         FStar_TypeChecker_Env.conj_guards
-                                           [g_c; g_e; g_env] in
-                                       (top2, c, uu___15)))))))))
-       | FStar_Syntax_Syntax.Tm_ascribed
-           (e1,
-            (FStar_Pervasives.Inr expected_c, FStar_Pervasives_Native.None,
-             use_eq),
-            uu___1)
-           ->
-           let uu___2 = FStar_TypeChecker_Env.clear_expected_typ env1 in
-           (match uu___2 with
-            | (env0, uu___3) ->
-                let uu___4 = tc_comp env0 expected_c in
-                (match uu___4 with
-                 | (expected_c1, uu___5, g) ->
-                     let uu___6 =
-                       let uu___7 =
-                         FStar_Compiler_Effect.op_Bar_Greater
-                           (FStar_Syntax_Util.comp_result expected_c1)
-                           (fun t ->
-                              FStar_TypeChecker_Env.set_expected_typ_maybe_eq
-                                env0 t use_eq) in
-                       tc_term uu___7 e1 in
-                     (match uu___6 with
-                      | (e2, c', g') ->
-                          let uu___7 =
-                            let uu___8 =
-                              FStar_TypeChecker_Common.lcomp_comp c' in
-                            match uu___8 with
-                            | (c'1, g_c') ->
-                                let uu___9 =
-                                  check_expected_effect env0 use_eq
-                                    (FStar_Pervasives_Native.Some expected_c1)
-                                    (e2, c'1) in
-                                (match uu___9 with
-                                 | (e3, expected_c2, g'') ->
-                                     let uu___10 =
-                                       FStar_TypeChecker_Env.conj_guard g_c'
-                                         g'' in
-                                     (e3, expected_c2, uu___10)) in
-                          (match uu___7 with
-                           | (e3, expected_c2, g'') ->
-                               let e4 =
-                                 FStar_Syntax_Syntax.mk
-                                   (FStar_Syntax_Syntax.Tm_ascribed
-                                      (e3,
-                                        ((FStar_Pervasives.Inr expected_c2),
-                                          FStar_Pervasives_Native.None,
-                                          use_eq),
-                                        (FStar_Pervasives_Native.Some
-                                           (FStar_Syntax_Util.comp_effect_name
-                                              expected_c2))))
-                                   top.FStar_Syntax_Syntax.pos in
-                               let lc =
-                                 FStar_TypeChecker_Common.lcomp_of_comp
-                                   expected_c2 in
-                               let f =
-                                 let uu___8 =
-                                   FStar_TypeChecker_Env.conj_guard g' g'' in
-                                 FStar_TypeChecker_Env.conj_guard g uu___8 in
-                               let uu___8 =
-                                 comp_check_expected_typ env1 e4 lc in
-                               (match uu___8 with
-                                | (e5, c, f2) ->
-                                    let uu___9 =
-                                      FStar_TypeChecker_Env.conj_guard f f2 in
-                                    (e5, c, uu___9))))))
-       | FStar_Syntax_Syntax.Tm_ascribed
-           (e1,
-            (FStar_Pervasives.Inl t, FStar_Pervasives_Native.None, use_eq),
-            uu___1)
-           ->
-           let uu___2 = FStar_Syntax_Util.type_u () in
-           (match uu___2 with
-            | (k, u) ->
-                let uu___3 = tc_check_tot_or_gtot_term env1 t k "" in
-                (match uu___3 with
-                 | (t1, uu___4, f) ->
-                     let uu___5 =
-                       let uu___6 =
-                         FStar_TypeChecker_Env.set_expected_typ_maybe_eq env1
-                           t1 use_eq in
-                       tc_term uu___6 e1 in
-                     (match uu___5 with
-                      | (e2, c, g) ->
-                          let uu___6 =
-                            let uu___7 =
-                              FStar_TypeChecker_Env.set_range env1
-                                t1.FStar_Syntax_Syntax.pos in
-                            FStar_TypeChecker_Util.strengthen_precondition
-                              (FStar_Pervasives_Native.Some
-                                 (fun uu___8 ->
-                                    FStar_Compiler_Util.return_all
-                                      FStar_TypeChecker_Err.ill_kinded_type))
-                              uu___7 e2 c f in
-                          (match uu___6 with
-                           | (c1, f1) ->
-                               let uu___7 =
-                                 let uu___8 =
-                                   FStar_Syntax_Syntax.mk
-                                     (FStar_Syntax_Syntax.Tm_ascribed
-                                        (e2,
-                                          ((FStar_Pervasives.Inl t1),
-                                            FStar_Pervasives_Native.None,
-                                            use_eq),
-                                          (FStar_Pervasives_Native.Some
-                                             (c1.FStar_TypeChecker_Common.eff_name))))
-                                     top.FStar_Syntax_Syntax.pos in
-                                 comp_check_expected_typ env1 uu___8 c1 in
-                               (match uu___7 with
-                                | (e3, c2, f2) ->
-                                    let uu___8 =
-                                      let uu___9 =
-                                        FStar_TypeChecker_Env.conj_guard g f2 in
-                                      FStar_TypeChecker_Env.conj_guard f1
-                                        uu___9 in
-                                    (e3, c2, uu___8))))))
-       | FStar_Syntax_Syntax.Tm_app
-           ({
-              FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
-                (FStar_Const.Const_range_of);
-              FStar_Syntax_Syntax.pos = uu___1;
-              FStar_Syntax_Syntax.vars = uu___2;
-              FStar_Syntax_Syntax.hash_code = uu___3;_},
-            a::hd::rest)
-           ->
-           let rest1 = hd :: rest in
-           let uu___4 = FStar_Syntax_Util.head_and_args top in
-           (match uu___4 with
-            | (unary_op, uu___5) ->
-                let head =
-                  let uu___6 =
-                    FStar_Compiler_Range.union_ranges
-                      unary_op.FStar_Syntax_Syntax.pos
-                      (FStar_Pervasives_Native.fst a).FStar_Syntax_Syntax.pos in
-                  FStar_Syntax_Syntax.mk
-                    (FStar_Syntax_Syntax.Tm_app (unary_op, [a])) uu___6 in
-                let t =
-                  FStar_Syntax_Syntax.mk
-                    (FStar_Syntax_Syntax.Tm_app (head, rest1))
-                    top.FStar_Syntax_Syntax.pos in
-                tc_term env1 t)
-       | FStar_Syntax_Syntax.Tm_app
-           ({
-              FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
-                (FStar_Const.Const_reify);
-              FStar_Syntax_Syntax.pos = uu___1;
-              FStar_Syntax_Syntax.vars = uu___2;
-              FStar_Syntax_Syntax.hash_code = uu___3;_},
-            a::hd::rest)
-           ->
-           let rest1 = hd :: rest in
-           let uu___4 = FStar_Syntax_Util.head_and_args top in
-           (match uu___4 with
-            | (unary_op, uu___5) ->
-                let head =
-                  let uu___6 =
-                    FStar_Compiler_Range.union_ranges
-                      unary_op.FStar_Syntax_Syntax.pos
-                      (FStar_Pervasives_Native.fst a).FStar_Syntax_Syntax.pos in
-                  FStar_Syntax_Syntax.mk
-                    (FStar_Syntax_Syntax.Tm_app (unary_op, [a])) uu___6 in
-                let t =
-                  FStar_Syntax_Syntax.mk
-                    (FStar_Syntax_Syntax.Tm_app (head, rest1))
-                    top.FStar_Syntax_Syntax.pos in
-                tc_term env1 t)
-       | FStar_Syntax_Syntax.Tm_app
-           ({
-              FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
-                (FStar_Const.Const_reflect uu___1);
-              FStar_Syntax_Syntax.pos = uu___2;
-              FStar_Syntax_Syntax.vars = uu___3;
-              FStar_Syntax_Syntax.hash_code = uu___4;_},
-            a::hd::rest)
-           ->
-           let rest1 = hd :: rest in
-           let uu___5 = FStar_Syntax_Util.head_and_args top in
-           (match uu___5 with
-            | (unary_op, uu___6) ->
-                let head =
-                  let uu___7 =
-                    FStar_Compiler_Range.union_ranges
-                      unary_op.FStar_Syntax_Syntax.pos
-                      (FStar_Pervasives_Native.fst a).FStar_Syntax_Syntax.pos in
-                  FStar_Syntax_Syntax.mk
-                    (FStar_Syntax_Syntax.Tm_app (unary_op, [a])) uu___7 in
-                let t =
-                  FStar_Syntax_Syntax.mk
-                    (FStar_Syntax_Syntax.Tm_app (head, rest1))
-                    top.FStar_Syntax_Syntax.pos in
-                tc_term env1 t)
-       | FStar_Syntax_Syntax.Tm_app
-           ({
-              FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
-                (FStar_Const.Const_set_range_of);
-              FStar_Syntax_Syntax.pos = uu___1;
-              FStar_Syntax_Syntax.vars = uu___2;
-              FStar_Syntax_Syntax.hash_code = uu___3;_},
-            a1::a2::hd::rest)
-           ->
-           let rest1 = hd :: rest in
-           let uu___4 = FStar_Syntax_Util.head_and_args top in
-           (match uu___4 with
-            | (unary_op, uu___5) ->
-                let head =
-                  let uu___6 =
-                    FStar_Compiler_Range.union_ranges
-                      unary_op.FStar_Syntax_Syntax.pos
-                      (FStar_Pervasives_Native.fst a1).FStar_Syntax_Syntax.pos in
-                  FStar_Syntax_Syntax.mk
-                    (FStar_Syntax_Syntax.Tm_app (unary_op, [a1; a2])) uu___6 in
-                let t =
-                  FStar_Syntax_Syntax.mk
-                    (FStar_Syntax_Syntax.Tm_app (head, rest1))
-                    top.FStar_Syntax_Syntax.pos in
-                tc_term env1 t)
-       | FStar_Syntax_Syntax.Tm_app
-           ({
-              FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
-                (FStar_Const.Const_range_of);
-              FStar_Syntax_Syntax.pos = uu___1;
-              FStar_Syntax_Syntax.vars = uu___2;
-              FStar_Syntax_Syntax.hash_code = uu___3;_},
-            (e1, FStar_Pervasives_Native.None)::[])
-           ->
-           let uu___4 =
-             let uu___5 =
-               let uu___6 = FStar_TypeChecker_Env.clear_expected_typ env1 in
-               FStar_Compiler_Effect.op_Less_Bar FStar_Pervasives_Native.fst
-                 uu___6 in
-             tc_term uu___5 e1 in
-           (match uu___4 with
-            | (e2, c, g) ->
-                let uu___5 = FStar_Syntax_Util.head_and_args top in
-                (match uu___5 with
-                 | (head, uu___6) ->
-                     let uu___7 =
-                       FStar_Syntax_Syntax.mk
-                         (FStar_Syntax_Syntax.Tm_app
-                            (head, [(e2, FStar_Pervasives_Native.None)]))
-                         top.FStar_Syntax_Syntax.pos in
-                     let uu___8 =
-                       let uu___9 =
-                         let uu___10 =
-                           FStar_Syntax_Syntax.tabbrev
-                             FStar_Parser_Const.range_lid in
-                         FStar_Syntax_Syntax.mk_Total uu___10 in
-                       FStar_Compiler_Effect.op_Less_Bar
-                         FStar_TypeChecker_Common.lcomp_of_comp uu___9 in
-                     (uu___7, uu___8, g)))
-       | FStar_Syntax_Syntax.Tm_app
-           ({
-              FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
-                (FStar_Const.Const_set_range_of);
-              FStar_Syntax_Syntax.pos = uu___1;
-              FStar_Syntax_Syntax.vars = uu___2;
-              FStar_Syntax_Syntax.hash_code = uu___3;_},
-            (t, FStar_Pervasives_Native.None)::(r,
-                                                FStar_Pervasives_Native.None)::[])
-           ->
-           let uu___4 = FStar_Syntax_Util.head_and_args top in
-           (match uu___4 with
-            | (head, uu___5) ->
-                let env' =
-                  let uu___6 =
-                    FStar_Syntax_Syntax.tabbrev FStar_Parser_Const.range_lid in
-                  FStar_TypeChecker_Env.set_expected_typ env1 uu___6 in
-                let uu___6 = tc_term env' r in
-                (match uu___6 with
-                 | (er, uu___7, gr) ->
-                     let uu___8 = tc_term env1 t in
-                     (match uu___8 with
-                      | (t1, tt, gt) ->
-                          let g = FStar_TypeChecker_Env.conj_guard gr gt in
-                          let uu___9 =
-                            let uu___10 =
-                              let uu___11 = FStar_Syntax_Syntax.as_arg t1 in
-                              let uu___12 =
-                                let uu___13 = FStar_Syntax_Syntax.as_arg r in
-                                [uu___13] in
-                              uu___11 :: uu___12 in
-                            FStar_Syntax_Syntax.mk_Tm_app head uu___10
-                              top.FStar_Syntax_Syntax.pos in
-                          (uu___9, tt, g))))
-       | FStar_Syntax_Syntax.Tm_app
-           ({
-              FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
-                (FStar_Const.Const_range_of);
-              FStar_Syntax_Syntax.pos = uu___1;
-              FStar_Syntax_Syntax.vars = uu___2;
-              FStar_Syntax_Syntax.hash_code = uu___3;_},
-            uu___4)
-           ->
-           let uu___5 =
-             let uu___6 =
-               let uu___7 = FStar_Syntax_Print.term_to_string top in
-               FStar_Compiler_Util.format1 "Ill-applied constant %s" uu___7 in
-             (FStar_Errors.Fatal_IllAppliedConstant, uu___6) in
-           FStar_Errors.raise_error uu___5 e.FStar_Syntax_Syntax.pos
-       | FStar_Syntax_Syntax.Tm_app
-           ({
-              FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
-                (FStar_Const.Const_set_range_of);
-              FStar_Syntax_Syntax.pos = uu___1;
-              FStar_Syntax_Syntax.vars = uu___2;
-              FStar_Syntax_Syntax.hash_code = uu___3;_},
-            uu___4)
-           ->
-           let uu___5 =
-             let uu___6 =
-               let uu___7 = FStar_Syntax_Print.term_to_string top in
-               FStar_Compiler_Util.format1 "Ill-applied constant %s" uu___7 in
-             (FStar_Errors.Fatal_IllAppliedConstant, uu___6) in
-           FStar_Errors.raise_error uu___5 e.FStar_Syntax_Syntax.pos
-       | FStar_Syntax_Syntax.Tm_app
-           ({
-              FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
-                (FStar_Const.Const_reify);
-              FStar_Syntax_Syntax.pos = uu___1;
-              FStar_Syntax_Syntax.vars = uu___2;
-              FStar_Syntax_Syntax.hash_code = uu___3;_},
-            (e1, aqual)::[])
-           ->
-           (if FStar_Compiler_Option.isSome aqual
-            then
-              FStar_Errors.log_issue e1.FStar_Syntax_Syntax.pos
-                (FStar_Errors.Warning_IrrelevantQualifierOnArgumentToReify,
-                  "Qualifier on argument to reify is irrelevant and will be ignored")
-            else ();
-            (let uu___5 = FStar_TypeChecker_Env.clear_expected_typ env1 in
-             match uu___5 with
-             | (env0, uu___6) ->
-                 let uu___7 = tc_term env0 e1 in
-                 (match uu___7 with
-                  | (e2, c, g) ->
-                      let uu___8 = FStar_Syntax_Util.head_and_args top in
-                      (match uu___8 with
-                       | (reify_op, uu___9) ->
-                           let uu___10 =
-                             let uu___11 =
-                               FStar_TypeChecker_Common.lcomp_comp c in
-                             match uu___11 with
-                             | (c1, g_c) ->
-                                 let uu___12 =
-                                   FStar_TypeChecker_Env.unfold_effect_abbrev
-                                     env1 c1 in
-                                 (uu___12, g_c) in
-                           (match uu___10 with
-                            | (c1, g_c) ->
-                                ((let uu___12 =
-                                    let uu___13 =
-                                      FStar_TypeChecker_Env.is_user_reifiable_effect
-                                        env1
-                                        c1.FStar_Syntax_Syntax.effect_name in
-                                    Prims.op_Negation uu___13 in
-                                  if uu___12
-                                  then
-                                    let uu___13 =
-                                      let uu___14 =
-                                        let uu___15 =
-                                          FStar_Ident.string_of_lid
-                                            c1.FStar_Syntax_Syntax.effect_name in
-                                        FStar_Compiler_Util.format1
-                                          "Effect %s cannot be reified"
-                                          uu___15 in
-                                      (FStar_Errors.Fatal_EffectCannotBeReified,
-                                        uu___14) in
-                                    FStar_Errors.raise_error uu___13
-                                      e2.FStar_Syntax_Syntax.pos
-                                  else ());
-                                 (let u_c =
-                                    FStar_Compiler_List.hd
-                                      c1.FStar_Syntax_Syntax.comp_univs in
-                                  let e3 =
-                                    let uu___12 =
-                                      (FStar_TypeChecker_Env.is_layered_effect
-                                         env1
-                                         c1.FStar_Syntax_Syntax.effect_name)
-                                        &&
-                                        (Prims.op_Negation
-                                           env1.FStar_TypeChecker_Env.phase1) in
-                                    if uu___12
-                                    then
-                                      let reify_val_tm =
-                                        let uu___13 =
-                                          let uu___14 =
-                                            FStar_Parser_Const.layered_effect_reify_val_lid
-                                              c1.FStar_Syntax_Syntax.effect_name
-                                              e2.FStar_Syntax_Syntax.pos in
-                                          FStar_Compiler_Effect.op_Bar_Greater
-                                            uu___14
-                                            FStar_Syntax_Syntax.tconst in
-                                        FStar_Syntax_Syntax.mk_Tm_uinst
-                                          uu___13 [u_c] in
-                                      let thunked_e =
-                                        let uu___13 =
-                                          let uu___14 =
-                                            let uu___15 =
-                                              let uu___16 =
-                                                let uu___17 =
-                                                  FStar_Syntax_Syntax.null_bv
-                                                    FStar_Syntax_Syntax.t_unit in
-                                                FStar_Syntax_Syntax.mk_binder
-                                                  uu___17 in
-                                              [uu___16] in
-                                            (uu___15, e2,
-                                              (FStar_Pervasives_Native.Some
-                                                 {
-                                                   FStar_Syntax_Syntax.residual_effect
-                                                     =
-                                                     (c1.FStar_Syntax_Syntax.effect_name);
-                                                   FStar_Syntax_Syntax.residual_typ
-                                                     =
-                                                     FStar_Pervasives_Native.None;
-                                                   FStar_Syntax_Syntax.residual_flags
-                                                     = []
-                                                 })) in
-                                          FStar_Syntax_Syntax.Tm_abs uu___14 in
-                                        FStar_Syntax_Syntax.mk uu___13
-                                          e2.FStar_Syntax_Syntax.pos in
-                                      let implicit_args =
-                                        let a_arg =
-                                          FStar_Syntax_Syntax.iarg
-                                            c1.FStar_Syntax_Syntax.result_typ in
-                                        let indices_args =
-                                          FStar_Compiler_Effect.op_Bar_Greater
-                                            c1.FStar_Syntax_Syntax.effect_args
-                                            (FStar_Compiler_List.map
-                                               (fun uu___13 ->
-                                                  match uu___13 with
-                                                  | (t, uu___14) ->
-                                                      FStar_Syntax_Syntax.iarg
-                                                        t)) in
-                                        a_arg :: indices_args in
-                                      let uu___13 =
-                                        let uu___14 =
-                                          let uu___15 =
-                                            FStar_Syntax_Syntax.as_arg
-                                              thunked_e in
-                                          [uu___15] in
-                                        FStar_Compiler_List.op_At
-                                          implicit_args uu___14 in
-                                      FStar_Syntax_Syntax.mk_Tm_app
-                                        reify_val_tm uu___13
-                                        e2.FStar_Syntax_Syntax.pos
-                                    else
-                                      FStar_Syntax_Syntax.mk
-                                        (FStar_Syntax_Syntax.Tm_app
-                                           (reify_op, [(e2, aqual)]))
-                                        top.FStar_Syntax_Syntax.pos in
-                                  let repr =
-                                    let uu___12 =
-                                      FStar_Syntax_Syntax.mk_Comp c1 in
-                                    FStar_TypeChecker_Env.reify_comp env1
-                                      uu___12 u_c in
-                                  let c2 =
-                                    let uu___12 =
-                                      FStar_TypeChecker_Env.is_total_effect
-                                        env1
-                                        c1.FStar_Syntax_Syntax.effect_name in
-                                    if uu___12
-                                    then
-                                      let uu___13 =
-                                        FStar_Syntax_Syntax.mk_Total repr in
-                                      FStar_Compiler_Effect.op_Bar_Greater
-                                        uu___13
-                                        FStar_TypeChecker_Common.lcomp_of_comp
-                                    else
-                                      (let ct =
-                                         {
-                                           FStar_Syntax_Syntax.comp_univs =
-                                             [u_c];
-                                           FStar_Syntax_Syntax.effect_name =
-                                             FStar_Parser_Const.effect_Dv_lid;
-                                           FStar_Syntax_Syntax.result_typ =
-                                             repr;
-                                           FStar_Syntax_Syntax.effect_args =
-                                             [];
-                                           FStar_Syntax_Syntax.flags = []
-                                         } in
-                                       let uu___14 =
-                                         FStar_Syntax_Syntax.mk_Comp ct in
-                                       FStar_Compiler_Effect.op_Bar_Greater
-                                         uu___14
-                                         FStar_TypeChecker_Common.lcomp_of_comp) in
-                                  let uu___12 =
-                                    comp_check_expected_typ env1 e3 c2 in
-                                  match uu___12 with
-                                  | (e4, c3, g') ->
-                                      let uu___13 =
-                                        let uu___14 =
-                                          FStar_TypeChecker_Env.conj_guard
-                                            g_c g' in
-                                        FStar_TypeChecker_Env.conj_guard g
-                                          uu___14 in
-                                      (e4, c3, uu___13))))))))
-       | FStar_Syntax_Syntax.Tm_app
-           ({
-              FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
-                (FStar_Const.Const_reflect l);
-              FStar_Syntax_Syntax.pos = uu___1;
-              FStar_Syntax_Syntax.vars = uu___2;
-              FStar_Syntax_Syntax.hash_code = uu___3;_},
-            (e1, aqual)::[])
-           ->
-           (if FStar_Compiler_Option.isSome aqual
-            then
-              FStar_Errors.log_issue e1.FStar_Syntax_Syntax.pos
-                (FStar_Errors.Warning_IrrelevantQualifierOnArgumentToReflect,
-                  "Qualifier on argument to reflect is irrelevant and will be ignored")
-            else ();
-            (let uu___6 =
-               let uu___7 =
-                 FStar_TypeChecker_Env.is_user_reflectable_effect env1 l in
-               Prims.op_Negation uu___7 in
-             if uu___6
-             then
-               let uu___7 =
-                 let uu___8 =
-                   let uu___9 = FStar_Ident.string_of_lid l in
-                   FStar_Compiler_Util.format1
-                     "Effect %s cannot be reflected" uu___9 in
-                 (FStar_Errors.Fatal_EffectCannotBeReified, uu___8) in
-               FStar_Errors.raise_error uu___7 e1.FStar_Syntax_Syntax.pos
-             else ());
-            (let uu___6 = FStar_Syntax_Util.head_and_args top in
-             match uu___6 with
-             | (reflect_op, uu___7) ->
-                 let uu___8 = FStar_TypeChecker_Env.effect_decl_opt env1 l in
-                 (match uu___8 with
-                  | FStar_Pervasives_Native.None ->
-                      let uu___9 =
-                        let uu___10 =
-                          let uu___11 = FStar_Ident.string_of_lid l in
-                          FStar_Compiler_Util.format1
-                            "Effect %s not found (for reflect)" uu___11 in
-                        (FStar_Errors.Fatal_EffectNotFound, uu___10) in
-                      FStar_Errors.raise_error uu___9
-                        e1.FStar_Syntax_Syntax.pos
-                  | FStar_Pervasives_Native.Some (ed, qualifiers) ->
-                      let uu___9 =
-                        FStar_TypeChecker_Env.clear_expected_typ env1 in
-                      (match uu___9 with
-                       | (env_no_ex, uu___10) ->
-                           let uu___11 =
-                             let uu___12 = tc_tot_or_gtot_term env_no_ex e1 in
-                             match uu___12 with
-                             | (e2, c, g) ->
-                                 ((let uu___14 =
-                                     let uu___15 =
-                                       FStar_TypeChecker_Common.is_total_lcomp
-                                         c in
-                                     FStar_Compiler_Effect.op_Less_Bar
-                                       Prims.op_Negation uu___15 in
-                                   if uu___14
-                                   then
-                                     FStar_Errors.log_issue
+                                           FStar_Ident.string_of_lid
+                                             c1.FStar_Syntax_Syntax.effect_name in
+                                         FStar_Compiler_Util.format1
+                                           "Effect %s cannot be reified"
+                                           uu___16 in
+                                       (FStar_Errors.Fatal_EffectCannotBeReified,
+                                         uu___15) in
+                                     FStar_Errors.raise_error uu___14
                                        e2.FStar_Syntax_Syntax.pos
-                                       (FStar_Errors.Error_UnexpectedGTotComputation,
-                                         "Expected Tot, got a GTot computation")
                                    else ());
-                                  (e2, c, g)) in
-                           (match uu___11 with
-                            | (e2, c_e, g_e) ->
-                                let uu___12 =
-                                  let uu___13 = FStar_Syntax_Util.type_u () in
-                                  match uu___13 with
-                                  | (a, u_a) ->
-                                      let uu___14 =
-                                        FStar_TypeChecker_Util.new_implicit_var
-                                          "" e2.FStar_Syntax_Syntax.pos
-                                          env_no_ex a in
-                                      (match uu___14 with
-                                       | (a_uvar, uu___15, g_a) ->
-                                           let uu___16 =
-                                             FStar_TypeChecker_Util.fresh_effect_repr_en
-                                               env_no_ex
-                                               e2.FStar_Syntax_Syntax.pos l
-                                               u_a a_uvar in
-                                           (uu___16, u_a, a_uvar, g_a)) in
-                                (match uu___12 with
-                                 | ((expected_repr_typ, g_repr), u_a, a, g_a)
-                                     ->
-                                     let g_eq =
-                                       FStar_TypeChecker_Rel.teq env_no_ex
-                                         c_e.FStar_TypeChecker_Common.res_typ
-                                         expected_repr_typ in
-                                     let eff_args =
-                                       let uu___13 =
+                                  (let u_c =
+                                     FStar_Compiler_List.hd
+                                       c1.FStar_Syntax_Syntax.comp_univs in
+                                   let e3 =
+                                     let uu___13 =
+                                       (FStar_TypeChecker_Env.is_layered_effect
+                                          env1
+                                          c1.FStar_Syntax_Syntax.effect_name)
+                                         &&
+                                         (Prims.op_Negation
+                                            env1.FStar_TypeChecker_Env.phase1) in
+                                     if uu___13
+                                     then
+                                       let reify_val_tm =
                                          let uu___14 =
-                                           FStar_Syntax_Subst.compress
-                                             expected_repr_typ in
-                                         uu___14.FStar_Syntax_Syntax.n in
-                                       match uu___13 with
-                                       | FStar_Syntax_Syntax.Tm_app
-                                           (uu___14, uu___15::args) -> args
-                                       | uu___14 ->
+                                           let uu___15 =
+                                             FStar_Parser_Const.layered_effect_reify_val_lid
+                                               c1.FStar_Syntax_Syntax.effect_name
+                                               e2.FStar_Syntax_Syntax.pos in
+                                           FStar_Compiler_Effect.op_Bar_Greater
+                                             uu___15
+                                             FStar_Syntax_Syntax.tconst in
+                                         FStar_Syntax_Syntax.mk_Tm_uinst
+                                           uu___14 [u_c] in
+                                       let thunked_e =
+                                         let uu___14 =
                                            let uu___15 =
                                              let uu___16 =
                                                let uu___17 =
-                                                 FStar_Ident.string_of_lid l in
-                                               let uu___18 =
-                                                 FStar_Syntax_Print.tag_of_term
-                                                   expected_repr_typ in
-                                               let uu___19 =
-                                                 FStar_Syntax_Print.term_to_string
-                                                   expected_repr_typ in
-                                               FStar_Compiler_Util.format3
-                                                 "Expected repr type for %s is not an application node (%s:%s)"
-                                                 uu___17 uu___18 uu___19 in
-                                             (FStar_Errors.Fatal_UnexpectedEffect,
-                                               uu___16) in
-                                           FStar_Errors.raise_error uu___15
-                                             top.FStar_Syntax_Syntax.pos in
-                                     let c =
-                                       let uu___13 =
-                                         FStar_Syntax_Syntax.mk_Comp
-                                           {
-                                             FStar_Syntax_Syntax.comp_univs =
-                                               [u_a];
-                                             FStar_Syntax_Syntax.effect_name
-                                               =
-                                               (ed.FStar_Syntax_Syntax.mname);
-                                             FStar_Syntax_Syntax.result_typ =
-                                               a;
-                                             FStar_Syntax_Syntax.effect_args
-                                               = eff_args;
-                                             FStar_Syntax_Syntax.flags = []
-                                           } in
-                                       FStar_Compiler_Effect.op_Bar_Greater
-                                         uu___13
-                                         FStar_TypeChecker_Common.lcomp_of_comp in
-                                     let e3 =
+                                                 let uu___18 =
+                                                   FStar_Syntax_Syntax.null_bv
+                                                     FStar_Syntax_Syntax.t_unit in
+                                                 FStar_Syntax_Syntax.mk_binder
+                                                   uu___18 in
+                                               [uu___17] in
+                                             (uu___16, e2,
+                                               (FStar_Pervasives_Native.Some
+                                                  {
+                                                    FStar_Syntax_Syntax.residual_effect
+                                                      =
+                                                      (c1.FStar_Syntax_Syntax.effect_name);
+                                                    FStar_Syntax_Syntax.residual_typ
+                                                      =
+                                                      FStar_Pervasives_Native.None;
+                                                    FStar_Syntax_Syntax.residual_flags
+                                                      = []
+                                                  })) in
+                                           FStar_Syntax_Syntax.Tm_abs uu___15 in
+                                         FStar_Syntax_Syntax.mk uu___14
+                                           e2.FStar_Syntax_Syntax.pos in
+                                       let implicit_args =
+                                         let a_arg =
+                                           FStar_Syntax_Syntax.iarg
+                                             c1.FStar_Syntax_Syntax.result_typ in
+                                         let indices_args =
+                                           FStar_Compiler_Effect.op_Bar_Greater
+                                             c1.FStar_Syntax_Syntax.effect_args
+                                             (FStar_Compiler_List.map
+                                                (fun uu___14 ->
+                                                   match uu___14 with
+                                                   | (t, uu___15) ->
+                                                       FStar_Syntax_Syntax.iarg
+                                                         t)) in
+                                         a_arg :: indices_args in
+                                       let uu___14 =
+                                         let uu___15 =
+                                           let uu___16 =
+                                             FStar_Syntax_Syntax.as_arg
+                                               thunked_e in
+                                           [uu___16] in
+                                         FStar_Compiler_List.op_At
+                                           implicit_args uu___15 in
+                                       FStar_Syntax_Syntax.mk_Tm_app
+                                         reify_val_tm uu___14
+                                         e2.FStar_Syntax_Syntax.pos
+                                     else
                                        FStar_Syntax_Syntax.mk
                                          (FStar_Syntax_Syntax.Tm_app
-                                            (reflect_op, [(e2, aqual)]))
+                                            (reify_op, [(e2, aqual)]))
                                          top.FStar_Syntax_Syntax.pos in
+                                   let repr =
                                      let uu___13 =
-                                       comp_check_expected_typ env1 e3 c in
-                                     (match uu___13 with
-                                      | (e4, c1, g') ->
-                                          let e5 =
-                                            FStar_Syntax_Syntax.mk
-                                              (FStar_Syntax_Syntax.Tm_meta
-                                                 (e4,
-                                                   (FStar_Syntax_Syntax.Meta_monadic
-                                                      ((c1.FStar_TypeChecker_Common.eff_name),
-                                                        (c1.FStar_TypeChecker_Common.res_typ)))))
-                                              e4.FStar_Syntax_Syntax.pos in
-                                          let uu___14 =
-                                            FStar_TypeChecker_Env.conj_guards
-                                              [g_e; g_repr; g_a; g_eq; g'] in
-                                          (e5, c1, uu___14))))))))
-       | FStar_Syntax_Syntax.Tm_app
-           ({
-              FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar
-                { FStar_Syntax_Syntax.fv_name = uu___1;
-                  FStar_Syntax_Syntax.fv_delta = uu___2;
-                  FStar_Syntax_Syntax.fv_qual = FStar_Pervasives_Native.Some
-                    (FStar_Syntax_Syntax.Unresolved_constructor uc);_};
-              FStar_Syntax_Syntax.pos = uu___3;
-              FStar_Syntax_Syntax.vars = uu___4;
-              FStar_Syntax_Syntax.hash_code = uu___5;_},
-            args)
-           ->
-           let uu___6 =
-             let uu___7 =
-               if uc.FStar_Syntax_Syntax.uc_base_term
-               then
-                 match args with
-                 | (b, uu___8)::rest ->
-                     ((FStar_Pervasives_Native.Some b), rest)
-                 | uu___8 -> failwith "Impossible"
-               else (FStar_Pervasives_Native.None, args) in
-             match uu___7 with
-             | (base_term, fields) ->
-                 let uu___8 =
-                   let uu___9 =
-                     FStar_Compiler_List.map FStar_Pervasives_Native.fst
-                       fields in
-                   FStar_Compiler_List.zip uc.FStar_Syntax_Syntax.uc_fields
-                     uu___9 in
-                 (base_term, uu___8) in
-           (match uu___6 with
-            | (base_term, uc_fields) ->
-                let uu___7 =
-                  let uu___8 = FStar_TypeChecker_Env.expected_typ env1 in
-                  match uu___8 with
-                  | FStar_Pervasives_Native.Some (t, uu___9) ->
-                      let uu___10 =
-                        FStar_TypeChecker_Util.find_record_or_dc_from_typ
-                          env1 (FStar_Pervasives_Native.Some t) uc
-                          top.FStar_Syntax_Syntax.pos in
-                      (uu___10,
-                        (FStar_Pervasives_Native.Some
-                           (FStar_Pervasives.Inl t)))
-                  | FStar_Pervasives_Native.None ->
-                      (match base_term with
-                       | FStar_Pervasives_Native.Some e1 ->
-                           let uu___9 = tc_term env1 e1 in
-                           (match uu___9 with
-                            | (uu___10, lc, uu___11) ->
-                                let uu___12 =
-                                  FStar_TypeChecker_Util.find_record_or_dc_from_typ
-                                    env1
-                                    (FStar_Pervasives_Native.Some
-                                       (lc.FStar_TypeChecker_Common.res_typ))
-                                    uc top.FStar_Syntax_Syntax.pos in
-                                (uu___12,
-                                  (FStar_Pervasives_Native.Some
-                                     (FStar_Pervasives.Inr
-                                        (lc.FStar_TypeChecker_Common.res_typ)))))
-                       | FStar_Pervasives_Native.None ->
-                           let uu___9 =
-                             FStar_TypeChecker_Util.find_record_or_dc_from_typ
-                               env1 FStar_Pervasives_Native.None uc
-                               top.FStar_Syntax_Syntax.pos in
-                           (uu___9, FStar_Pervasives_Native.None)) in
-                (match uu___7 with
-                 | ((rdc, constrname, constructor), topt) ->
-                     let rdc1 = rdc in
-                     let constructor1 =
-                       FStar_Syntax_Syntax.fv_to_tm constructor in
-                     let mk_field_projector i x =
-                       let projname =
-                         FStar_Syntax_Util.mk_field_projector_name_from_ident
-                           constrname i in
-                       let qual =
-                         if rdc1.FStar_Syntax_DsEnv.is_record
-                         then
-                           FStar_Pervasives_Native.Some
-                             (FStar_Syntax_Syntax.Record_projector
-                                (constrname, i))
-                         else FStar_Pervasives_Native.None in
-                       let candidate =
-                         let uu___8 =
-                           FStar_Ident.set_lid_range projname
-                             x.FStar_Syntax_Syntax.pos in
-                         FStar_Syntax_Syntax.fvar uu___8
-                           (FStar_Syntax_Syntax.Delta_equational_at_level
-                              Prims.int_one) qual in
-                       FStar_Syntax_Syntax.mk_Tm_app candidate
-                         [(x, FStar_Pervasives_Native.None)]
-                         x.FStar_Syntax_Syntax.pos in
-                     let fields =
-                       FStar_TypeChecker_Util.make_record_fields_in_order
-                         env1 uc topt rdc1 uc_fields
-                         (fun field_name ->
-                            match base_term with
-                            | FStar_Pervasives_Native.Some x ->
-                                let uu___8 = mk_field_projector field_name x in
-                                FStar_Pervasives_Native.Some uu___8
-                            | uu___8 -> FStar_Pervasives_Native.None)
-                         top.FStar_Syntax_Syntax.pos in
-                     let args1 =
-                       FStar_Compiler_List.map
-                         (fun x -> (x, FStar_Pervasives_Native.None)) fields in
-                     let term =
-                       FStar_Syntax_Syntax.mk_Tm_app constructor1 args1
-                         top.FStar_Syntax_Syntax.pos in
-                     tc_term env1 term))
-       | FStar_Syntax_Syntax.Tm_app
-           ({
-              FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar
-                {
-                  FStar_Syntax_Syntax.fv_name =
-                    { FStar_Syntax_Syntax.v = field_name;
-                      FStar_Syntax_Syntax.p = uu___1;_};
-                  FStar_Syntax_Syntax.fv_delta = uu___2;
-                  FStar_Syntax_Syntax.fv_qual = FStar_Pervasives_Native.Some
-                    (FStar_Syntax_Syntax.Unresolved_projector candidate);_};
-              FStar_Syntax_Syntax.pos = uu___3;
-              FStar_Syntax_Syntax.vars = uu___4;
-              FStar_Syntax_Syntax.hash_code = uu___5;_},
-            (e1, FStar_Pervasives_Native.None)::rest)
-           ->
-           let proceed_with choice =
-             match choice with
-             | FStar_Pervasives_Native.None ->
-                 let uu___6 =
-                   let uu___7 =
-                     let uu___8 = FStar_Ident.string_of_lid field_name in
-                     FStar_Compiler_Util.format1
-                       "Field name %s could not be resolved" uu___8 in
-                   (FStar_Errors.Fatal_IdentifierNotFound, uu___7) in
-                 let uu___7 = FStar_Ident.range_of_lid field_name in
-                 FStar_Errors.raise_error uu___6 uu___7
-             | FStar_Pervasives_Native.Some choice1 ->
-                 let f = FStar_Syntax_Syntax.fv_to_tm choice1 in
-                 let term =
-                   FStar_Syntax_Syntax.mk_Tm_app f
-                     ((e1, FStar_Pervasives_Native.None) :: rest)
-                     top.FStar_Syntax_Syntax.pos in
-                 tc_term env1 term in
-           let uu___6 =
-             let uu___7 = FStar_TypeChecker_Env.clear_expected_typ env1 in
-             match uu___7 with | (env2, uu___8) -> tc_term env2 e1 in
-           (match uu___6 with
-            | (uu___7, lc, uu___8) ->
-                let t0 =
-                  FStar_TypeChecker_Normalize.unfold_whnf'
-                    [FStar_TypeChecker_Env.Unascribe;
-                    FStar_TypeChecker_Env.Unmeta;
-                    FStar_TypeChecker_Env.Unrefine] env1
-                    lc.FStar_TypeChecker_Common.res_typ in
-                let uu___9 = FStar_Syntax_Util.head_and_args t0 in
-                (match uu___9 with
-                 | (thead, uu___10) ->
-                     ((let uu___12 =
-                         FStar_Compiler_Effect.op_Less_Bar
-                           (FStar_TypeChecker_Env.debug env1)
-                           (FStar_Options.Other "RFD") in
-                       if uu___12
-                       then
-                         let uu___13 =
-                           FStar_Syntax_Print.term_to_string
-                             lc.FStar_TypeChecker_Common.res_typ in
-                         let uu___14 = FStar_Syntax_Print.term_to_string t0 in
-                         let uu___15 =
-                           FStar_Syntax_Print.term_to_string thead in
-                         FStar_Compiler_Util.print3
-                           "Got lc.res_typ=%s; t0 = %s; thead = %s\n" uu___13
-                           uu___14 uu___15
-                       else ());
-                      (let uu___12 =
-                         let uu___13 =
-                           let uu___14 = FStar_Syntax_Util.un_uinst thead in
-                           FStar_Syntax_Subst.compress uu___14 in
-                         uu___13.FStar_Syntax_Syntax.n in
-                       match uu___12 with
-                       | FStar_Syntax_Syntax.Tm_fvar type_name ->
-                           let uu___13 =
-                             FStar_TypeChecker_Util.try_lookup_record_type
-                               env1
-                               (type_name.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-                           (match uu___13 with
-                            | FStar_Pervasives_Native.None ->
-                                proceed_with candidate
-                            | FStar_Pervasives_Native.Some rdc ->
-                                let i =
-                                  FStar_Compiler_List.tryFind
-                                    (fun uu___14 ->
-                                       match uu___14 with
-                                       | (i1, uu___15) ->
-                                           FStar_TypeChecker_Util.field_name_matches
-                                             field_name rdc i1)
-                                    rdc.FStar_Syntax_DsEnv.fields in
-                                (match i with
-                                 | FStar_Pervasives_Native.None ->
-                                     proceed_with candidate
-                                 | FStar_Pervasives_Native.Some (i1, uu___14)
-                                     ->
-                                     let constrname =
-                                       let uu___15 =
-                                         let uu___16 =
-                                           FStar_Ident.ns_of_lid
-                                             rdc.FStar_Syntax_DsEnv.typename in
-                                         FStar_Compiler_List.op_At uu___16
-                                           [rdc.FStar_Syntax_DsEnv.constrname] in
-                                       FStar_Ident.lid_of_ids uu___15 in
-                                     let projname =
-                                       FStar_Syntax_Util.mk_field_projector_name_from_ident
-                                         constrname i1 in
-                                     let qual =
-                                       if rdc.FStar_Syntax_DsEnv.is_record
-                                       then
-                                         FStar_Pervasives_Native.Some
-                                           (FStar_Syntax_Syntax.Record_projector
-                                              (constrname, i1))
-                                       else FStar_Pervasives_Native.None in
-                                     let choice =
-                                       let uu___15 =
-                                         let uu___16 =
-                                           FStar_Ident.range_of_lid
-                                             field_name in
-                                         FStar_Ident.set_lid_range projname
-                                           uu___16 in
-                                       FStar_Syntax_Syntax.lid_as_fv uu___15
-                                         (FStar_Syntax_Syntax.Delta_equational_at_level
-                                            Prims.int_one) qual in
-                                     proceed_with
-                                       (FStar_Pervasives_Native.Some choice)))
-                       | uu___13 -> proceed_with candidate))))
-       | FStar_Syntax_Syntax.Tm_app
-           (head, (tau, FStar_Pervasives_Native.None)::[]) when
-           (FStar_Syntax_Util.is_synth_by_tactic head) &&
-             (Prims.op_Negation env1.FStar_TypeChecker_Env.phase1)
-           ->
-           let uu___1 = FStar_Syntax_Util.head_and_args top in
-           (match uu___1 with
-            | (head1, args) ->
-                tc_synth head1 env1 args top.FStar_Syntax_Syntax.pos)
-       | FStar_Syntax_Syntax.Tm_app
-           (head,
-            (uu___1, FStar_Pervasives_Native.Some
-             { FStar_Syntax_Syntax.aqual_implicit = true;
-               FStar_Syntax_Syntax.aqual_attributes = uu___2;_})::(tau,
-                                                                   FStar_Pervasives_Native.None)::[])
-           when
-           (FStar_Syntax_Util.is_synth_by_tactic head) &&
-             (Prims.op_Negation env1.FStar_TypeChecker_Env.phase1)
-           ->
-           let uu___3 = FStar_Syntax_Util.head_and_args top in
-           (match uu___3 with
-            | (head1, args) ->
-                tc_synth head1 env1 args top.FStar_Syntax_Syntax.pos)
-       | FStar_Syntax_Syntax.Tm_app (head, args) when
-           (FStar_Syntax_Util.is_synth_by_tactic head) &&
-             (Prims.op_Negation env1.FStar_TypeChecker_Env.phase1)
-           ->
-           let uu___1 =
-             match args with
-             | (tau, FStar_Pervasives_Native.None)::rest ->
-                 ([(tau, FStar_Pervasives_Native.None)], rest)
-             | (a, FStar_Pervasives_Native.Some aq)::(tau,
-                                                      FStar_Pervasives_Native.None)::rest
-                 when aq.FStar_Syntax_Syntax.aqual_implicit ->
-                 ([(a, (FStar_Pervasives_Native.Some aq));
-                  (tau, FStar_Pervasives_Native.None)], rest)
-             | uu___2 ->
-                 FStar_Errors.raise_error
-                   (FStar_Errors.Fatal_SynthByTacticError,
-                     "synth_by_tactic: bad application")
-                   top.FStar_Syntax_Syntax.pos in
-           (match uu___1 with
-            | (args1, args2) ->
-                let t1 = FStar_Syntax_Util.mk_app head args1 in
-                let t2 = FStar_Syntax_Util.mk_app t1 args2 in tc_term env1 t2)
-       | FStar_Syntax_Syntax.Tm_app (head, args) ->
-           let env0 = env1 in
-           let env2 =
-             let uu___1 =
-               let uu___2 = FStar_TypeChecker_Env.clear_expected_typ env1 in
-               FStar_Compiler_Effect.op_Bar_Greater uu___2
-                 FStar_Pervasives_Native.fst in
-             FStar_Compiler_Effect.op_Bar_Greater uu___1 instantiate_both in
-           ((let uu___2 = FStar_TypeChecker_Env.debug env2 FStar_Options.High in
-             if uu___2
+                                       FStar_Syntax_Syntax.mk_Comp c1 in
+                                     FStar_TypeChecker_Env.reify_comp env1
+                                       uu___13 u_c in
+                                   let c2 =
+                                     let uu___13 =
+                                       FStar_TypeChecker_Env.is_total_effect
+                                         env1
+                                         c1.FStar_Syntax_Syntax.effect_name in
+                                     if uu___13
+                                     then
+                                       let uu___14 =
+                                         FStar_Syntax_Syntax.mk_Total repr in
+                                       FStar_Compiler_Effect.op_Bar_Greater
+                                         uu___14
+                                         FStar_TypeChecker_Common.lcomp_of_comp
+                                     else
+                                       (let ct =
+                                          {
+                                            FStar_Syntax_Syntax.comp_univs =
+                                              [u_c];
+                                            FStar_Syntax_Syntax.effect_name =
+                                              FStar_Parser_Const.effect_Dv_lid;
+                                            FStar_Syntax_Syntax.result_typ =
+                                              repr;
+                                            FStar_Syntax_Syntax.effect_args =
+                                              [];
+                                            FStar_Syntax_Syntax.flags = []
+                                          } in
+                                        let uu___15 =
+                                          FStar_Syntax_Syntax.mk_Comp ct in
+                                        FStar_Compiler_Effect.op_Bar_Greater
+                                          uu___15
+                                          FStar_TypeChecker_Common.lcomp_of_comp) in
+                                   let uu___13 =
+                                     comp_check_expected_typ env1 e3 c2 in
+                                   match uu___13 with
+                                   | (e4, c3, g') ->
+                                       let uu___14 =
+                                         let uu___15 =
+                                           FStar_TypeChecker_Env.conj_guard
+                                             g_c g' in
+                                         FStar_TypeChecker_Env.conj_guard g
+                                           uu___15 in
+                                       (e4, c3, uu___14))))))))
+        | FStar_Syntax_Syntax.Tm_app
+            ({
+               FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
+                 (FStar_Const.Const_reflect l);
+               FStar_Syntax_Syntax.pos = uu___2;
+               FStar_Syntax_Syntax.vars = uu___3;
+               FStar_Syntax_Syntax.hash_code = uu___4;_},
+             (e1, aqual)::[])
+            ->
+            (if FStar_Compiler_Option.isSome aqual
              then
-               let uu___3 =
-                 FStar_Compiler_Range.string_of_range
-                   top.FStar_Syntax_Syntax.pos in
-               let uu___4 = FStar_Syntax_Print.term_to_string top in
-               let uu___5 = print_expected_ty_str env0 in
-               FStar_Compiler_Util.print3 "(%s) Checking app %s, %s\n" uu___3
-                 uu___4 uu___5
-             else ());
-            (let uu___2 = tc_term (no_inst env2) head in
-             match uu___2 with
-             | (head1, chead, g_head) ->
-                 let uu___3 =
-                   let uu___4 = FStar_TypeChecker_Common.lcomp_comp chead in
-                   FStar_Compiler_Effect.op_Bar_Greater uu___4
-                     (fun uu___5 ->
-                        match uu___5 with
-                        | (c, g) ->
-                            let uu___6 =
-                              FStar_TypeChecker_Env.conj_guard g_head g in
-                            (c, uu___6)) in
-                 (match uu___3 with
-                  | (chead1, g_head1) ->
-                      let uu___4 =
-                        let uu___5 =
-                          ((Prims.op_Negation env2.FStar_TypeChecker_Env.lax)
-                             &&
-                             (let uu___6 = FStar_Options.lax () in
-                              Prims.op_Negation uu___6))
-                            &&
-                            (FStar_TypeChecker_Util.short_circuit_head head1) in
-                        if uu___5
+               FStar_Errors.log_issue e1.FStar_Syntax_Syntax.pos
+                 (FStar_Errors.Warning_IrrelevantQualifierOnArgumentToReflect,
+                   "Qualifier on argument to reflect is irrelevant and will be ignored")
+             else ();
+             (let uu___7 =
+                let uu___8 =
+                  FStar_TypeChecker_Env.is_user_reflectable_effect env1 l in
+                Prims.op_Negation uu___8 in
+              if uu___7
+              then
+                let uu___8 =
+                  let uu___9 =
+                    let uu___10 = FStar_Ident.string_of_lid l in
+                    FStar_Compiler_Util.format1
+                      "Effect %s cannot be reflected" uu___10 in
+                  (FStar_Errors.Fatal_EffectCannotBeReified, uu___9) in
+                FStar_Errors.raise_error uu___8 e1.FStar_Syntax_Syntax.pos
+              else ());
+             (let uu___7 = FStar_Syntax_Util.head_and_args top in
+              match uu___7 with
+              | (reflect_op, uu___8) ->
+                  let uu___9 = FStar_TypeChecker_Env.effect_decl_opt env1 l in
+                  (match uu___9 with
+                   | FStar_Pervasives_Native.None ->
+                       let uu___10 =
+                         let uu___11 =
+                           let uu___12 = FStar_Ident.string_of_lid l in
+                           FStar_Compiler_Util.format1
+                             "Effect %s not found (for reflect)" uu___12 in
+                         (FStar_Errors.Fatal_EffectNotFound, uu___11) in
+                       FStar_Errors.raise_error uu___10
+                         e1.FStar_Syntax_Syntax.pos
+                   | FStar_Pervasives_Native.Some (ed, qualifiers) ->
+                       let uu___10 =
+                         FStar_TypeChecker_Env.clear_expected_typ env1 in
+                       (match uu___10 with
+                        | (env_no_ex, uu___11) ->
+                            let uu___12 =
+                              let uu___13 = tc_tot_or_gtot_term env_no_ex e1 in
+                              match uu___13 with
+                              | (e2, c, g) ->
+                                  ((let uu___15 =
+                                      let uu___16 =
+                                        FStar_TypeChecker_Common.is_total_lcomp
+                                          c in
+                                      FStar_Compiler_Effect.op_Less_Bar
+                                        Prims.op_Negation uu___16 in
+                                    if uu___15
+                                    then
+                                      FStar_Errors.log_issue
+                                        e2.FStar_Syntax_Syntax.pos
+                                        (FStar_Errors.Error_UnexpectedGTotComputation,
+                                          "Expected Tot, got a GTot computation")
+                                    else ());
+                                   (e2, c, g)) in
+                            (match uu___12 with
+                             | (e2, c_e, g_e) ->
+                                 let uu___13 =
+                                   let uu___14 = FStar_Syntax_Util.type_u () in
+                                   match uu___14 with
+                                   | (a, u_a) ->
+                                       let uu___15 =
+                                         FStar_TypeChecker_Util.new_implicit_var
+                                           "tc_term reflect"
+                                           e2.FStar_Syntax_Syntax.pos
+                                           env_no_ex a in
+                                       (match uu___15 with
+                                        | (a_uvar, uu___16, g_a) ->
+                                            let uu___17 =
+                                              FStar_TypeChecker_Util.fresh_effect_repr_en
+                                                env_no_ex
+                                                e2.FStar_Syntax_Syntax.pos l
+                                                u_a a_uvar in
+                                            (uu___17, u_a, a_uvar, g_a)) in
+                                 (match uu___13 with
+                                  | ((expected_repr_typ, g_repr), u_a, a,
+                                     g_a) ->
+                                      let g_eq =
+                                        FStar_TypeChecker_Rel.teq env_no_ex
+                                          c_e.FStar_TypeChecker_Common.res_typ
+                                          expected_repr_typ in
+                                      let eff_args =
+                                        let uu___14 =
+                                          let uu___15 =
+                                            FStar_Syntax_Subst.compress
+                                              expected_repr_typ in
+                                          uu___15.FStar_Syntax_Syntax.n in
+                                        match uu___14 with
+                                        | FStar_Syntax_Syntax.Tm_app
+                                            (uu___15, uu___16::args) -> args
+                                        | uu___15 ->
+                                            let uu___16 =
+                                              let uu___17 =
+                                                let uu___18 =
+                                                  FStar_Ident.string_of_lid l in
+                                                let uu___19 =
+                                                  FStar_Syntax_Print.tag_of_term
+                                                    expected_repr_typ in
+                                                let uu___20 =
+                                                  FStar_Syntax_Print.term_to_string
+                                                    expected_repr_typ in
+                                                FStar_Compiler_Util.format3
+                                                  "Expected repr type for %s is not an application node (%s:%s)"
+                                                  uu___18 uu___19 uu___20 in
+                                              (FStar_Errors.Fatal_UnexpectedEffect,
+                                                uu___17) in
+                                            FStar_Errors.raise_error uu___16
+                                              top.FStar_Syntax_Syntax.pos in
+                                      let c =
+                                        let uu___14 =
+                                          FStar_Syntax_Syntax.mk_Comp
+                                            {
+                                              FStar_Syntax_Syntax.comp_univs
+                                                = [u_a];
+                                              FStar_Syntax_Syntax.effect_name
+                                                =
+                                                (ed.FStar_Syntax_Syntax.mname);
+                                              FStar_Syntax_Syntax.result_typ
+                                                = a;
+                                              FStar_Syntax_Syntax.effect_args
+                                                = eff_args;
+                                              FStar_Syntax_Syntax.flags = []
+                                            } in
+                                        FStar_Compiler_Effect.op_Bar_Greater
+                                          uu___14
+                                          FStar_TypeChecker_Common.lcomp_of_comp in
+                                      let e3 =
+                                        FStar_Syntax_Syntax.mk
+                                          (FStar_Syntax_Syntax.Tm_app
+                                             (reflect_op, [(e2, aqual)]))
+                                          top.FStar_Syntax_Syntax.pos in
+                                      let uu___14 =
+                                        comp_check_expected_typ env1 e3 c in
+                                      (match uu___14 with
+                                       | (e4, c1, g') ->
+                                           let e5 =
+                                             FStar_Syntax_Syntax.mk
+                                               (FStar_Syntax_Syntax.Tm_meta
+                                                  (e4,
+                                                    (FStar_Syntax_Syntax.Meta_monadic
+                                                       ((c1.FStar_TypeChecker_Common.eff_name),
+                                                         (c1.FStar_TypeChecker_Common.res_typ)))))
+                                               e4.FStar_Syntax_Syntax.pos in
+                                           let uu___15 =
+                                             FStar_TypeChecker_Env.conj_guards
+                                               [g_e; g_repr; g_a; g_eq; g'] in
+                                           (e5, c1, uu___15))))))))
+        | FStar_Syntax_Syntax.Tm_app
+            ({
+               FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar
+                 { FStar_Syntax_Syntax.fv_name = uu___2;
+                   FStar_Syntax_Syntax.fv_delta = uu___3;
+                   FStar_Syntax_Syntax.fv_qual = FStar_Pervasives_Native.Some
+                     (FStar_Syntax_Syntax.Unresolved_constructor uc);_};
+               FStar_Syntax_Syntax.pos = uu___4;
+               FStar_Syntax_Syntax.vars = uu___5;
+               FStar_Syntax_Syntax.hash_code = uu___6;_},
+             args)
+            ->
+            let uu___7 =
+              let uu___8 =
+                if uc.FStar_Syntax_Syntax.uc_base_term
+                then
+                  match args with
+                  | (b, uu___9)::rest ->
+                      ((FStar_Pervasives_Native.Some b), rest)
+                  | uu___9 -> failwith "Impossible"
+                else (FStar_Pervasives_Native.None, args) in
+              match uu___8 with
+              | (base_term, fields) ->
+                  let uu___9 =
+                    let uu___10 =
+                      FStar_Compiler_List.map FStar_Pervasives_Native.fst
+                        fields in
+                    FStar_Compiler_List.zip uc.FStar_Syntax_Syntax.uc_fields
+                      uu___10 in
+                  (base_term, uu___9) in
+            (match uu___7 with
+             | (base_term, uc_fields) ->
+                 let uu___8 =
+                   let uu___9 = FStar_TypeChecker_Env.expected_typ env1 in
+                   match uu___9 with
+                   | FStar_Pervasives_Native.Some (t, uu___10) ->
+                       let uu___11 =
+                         FStar_TypeChecker_Util.find_record_or_dc_from_typ
+                           env1 (FStar_Pervasives_Native.Some t) uc
+                           top.FStar_Syntax_Syntax.pos in
+                       (uu___11,
+                         (FStar_Pervasives_Native.Some
+                            (FStar_Pervasives.Inl t)))
+                   | FStar_Pervasives_Native.None ->
+                       (match base_term with
+                        | FStar_Pervasives_Native.Some e1 ->
+                            let uu___10 = tc_term env1 e1 in
+                            (match uu___10 with
+                             | (uu___11, lc, uu___12) ->
+                                 let uu___13 =
+                                   FStar_TypeChecker_Util.find_record_or_dc_from_typ
+                                     env1
+                                     (FStar_Pervasives_Native.Some
+                                        (lc.FStar_TypeChecker_Common.res_typ))
+                                     uc top.FStar_Syntax_Syntax.pos in
+                                 (uu___13,
+                                   (FStar_Pervasives_Native.Some
+                                      (FStar_Pervasives.Inr
+                                         (lc.FStar_TypeChecker_Common.res_typ)))))
+                        | FStar_Pervasives_Native.None ->
+                            let uu___10 =
+                              FStar_TypeChecker_Util.find_record_or_dc_from_typ
+                                env1 FStar_Pervasives_Native.None uc
+                                top.FStar_Syntax_Syntax.pos in
+                            (uu___10, FStar_Pervasives_Native.None)) in
+                 (match uu___8 with
+                  | ((rdc, constrname, constructor), topt) ->
+                      let rdc1 = rdc in
+                      let constructor1 =
+                        FStar_Syntax_Syntax.fv_to_tm constructor in
+                      let mk_field_projector i x =
+                        let projname =
+                          FStar_Syntax_Util.mk_field_projector_name_from_ident
+                            constrname i in
+                        let qual =
+                          if rdc1.FStar_Syntax_DsEnv.is_record
+                          then
+                            FStar_Pervasives_Native.Some
+                              (FStar_Syntax_Syntax.Record_projector
+                                 (constrname, i))
+                          else FStar_Pervasives_Native.None in
+                        let candidate =
+                          let uu___9 =
+                            FStar_Ident.set_lid_range projname
+                              x.FStar_Syntax_Syntax.pos in
+                          FStar_Syntax_Syntax.fvar uu___9
+                            (FStar_Syntax_Syntax.Delta_equational_at_level
+                               Prims.int_one) qual in
+                        FStar_Syntax_Syntax.mk_Tm_app candidate
+                          [(x, FStar_Pervasives_Native.None)]
+                          x.FStar_Syntax_Syntax.pos in
+                      let fields =
+                        FStar_TypeChecker_Util.make_record_fields_in_order
+                          env1 uc topt rdc1 uc_fields
+                          (fun field_name ->
+                             match base_term with
+                             | FStar_Pervasives_Native.Some x ->
+                                 let uu___9 = mk_field_projector field_name x in
+                                 FStar_Pervasives_Native.Some uu___9
+                             | uu___9 -> FStar_Pervasives_Native.None)
+                          top.FStar_Syntax_Syntax.pos in
+                      let args1 =
+                        FStar_Compiler_List.map
+                          (fun x -> (x, FStar_Pervasives_Native.None)) fields in
+                      let term =
+                        FStar_Syntax_Syntax.mk_Tm_app constructor1 args1
+                          top.FStar_Syntax_Syntax.pos in
+                      tc_term env1 term))
+        | FStar_Syntax_Syntax.Tm_app
+            ({
+               FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar
+                 {
+                   FStar_Syntax_Syntax.fv_name =
+                     { FStar_Syntax_Syntax.v = field_name;
+                       FStar_Syntax_Syntax.p = uu___2;_};
+                   FStar_Syntax_Syntax.fv_delta = uu___3;
+                   FStar_Syntax_Syntax.fv_qual = FStar_Pervasives_Native.Some
+                     (FStar_Syntax_Syntax.Unresolved_projector candidate);_};
+               FStar_Syntax_Syntax.pos = uu___4;
+               FStar_Syntax_Syntax.vars = uu___5;
+               FStar_Syntax_Syntax.hash_code = uu___6;_},
+             (e1, FStar_Pervasives_Native.None)::rest)
+            ->
+            let proceed_with choice =
+              match choice with
+              | FStar_Pervasives_Native.None ->
+                  let uu___7 =
+                    let uu___8 =
+                      let uu___9 = FStar_Ident.string_of_lid field_name in
+                      FStar_Compiler_Util.format1
+                        "Field name %s could not be resolved" uu___9 in
+                    (FStar_Errors.Fatal_IdentifierNotFound, uu___8) in
+                  let uu___8 = FStar_Ident.range_of_lid field_name in
+                  FStar_Errors.raise_error uu___7 uu___8
+              | FStar_Pervasives_Native.Some choice1 ->
+                  let f = FStar_Syntax_Syntax.fv_to_tm choice1 in
+                  let term =
+                    FStar_Syntax_Syntax.mk_Tm_app f
+                      ((e1, FStar_Pervasives_Native.None) :: rest)
+                      top.FStar_Syntax_Syntax.pos in
+                  tc_term env1 term in
+            let uu___7 =
+              let uu___8 = FStar_TypeChecker_Env.clear_expected_typ env1 in
+              match uu___8 with | (env2, uu___9) -> tc_term env2 e1 in
+            (match uu___7 with
+             | (uu___8, lc, uu___9) ->
+                 let t0 =
+                   FStar_TypeChecker_Normalize.unfold_whnf'
+                     [FStar_TypeChecker_Env.Unascribe;
+                     FStar_TypeChecker_Env.Unmeta;
+                     FStar_TypeChecker_Env.Unrefine] env1
+                     lc.FStar_TypeChecker_Common.res_typ in
+                 let uu___10 = FStar_Syntax_Util.head_and_args t0 in
+                 (match uu___10 with
+                  | (thead, uu___11) ->
+                      ((let uu___13 =
+                          FStar_Compiler_Effect.op_Less_Bar
+                            (FStar_TypeChecker_Env.debug env1)
+                            (FStar_Options.Other "RFD") in
+                        if uu___13
                         then
-                          let uu___6 =
-                            let uu___7 =
-                              FStar_TypeChecker_Env.expected_typ env0 in
-                            check_short_circuit_args env2 head1 chead1
-                              g_head1 args uu___7 in
-                          match uu___6 with | (e1, c, g) -> (e1, c, g)
-                        else
-                          (let uu___7 =
-                             FStar_TypeChecker_Env.expected_typ env0 in
-                           check_application_args env2 head1 chead1 g_head1
-                             args uu___7) in
-                      (match uu___4 with
-                       | (e1, c, g) ->
-                           let uu___5 =
-                             let uu___6 =
-                               (FStar_TypeChecker_Common.is_tot_or_gtot_lcomp
-                                  c)
-                                 ||
-                                 (env2.FStar_TypeChecker_Env.phase1 &&
-                                    (FStar_TypeChecker_Common.is_pure_or_ghost_lcomp
-                                       c)) in
-                             if uu___6
-                             then
-                               let uu___7 =
-                                 FStar_TypeChecker_Util.maybe_instantiate
-                                   env0 e1 c.FStar_TypeChecker_Common.res_typ in
-                               match uu___7 with
-                               | (e2, res_typ, implicits) ->
-                                   let uu___8 =
-                                     FStar_TypeChecker_Common.set_result_typ_lc
-                                       c res_typ in
-                                   (e2, uu___8, implicits)
-                             else
-                               (e1, c, FStar_TypeChecker_Env.trivial_guard) in
-                           (match uu___5 with
-                            | (e2, c1, implicits) ->
-                                ((let uu___7 =
-                                    FStar_TypeChecker_Env.debug env2
-                                      FStar_Options.Extreme in
-                                  if uu___7
-                                  then
-                                    let uu___8 =
-                                      FStar_TypeChecker_Rel.print_pending_implicits
-                                        g in
-                                    FStar_Compiler_Util.print1
-                                      "Introduced {%s} implicits in application\n"
-                                      uu___8
-                                  else ());
-                                 (let uu___7 =
-                                    comp_check_expected_typ env0 e2 c1 in
-                                  match uu___7 with
-                                  | (e3, c2, g') ->
-                                      let gres =
-                                        FStar_TypeChecker_Env.conj_guard g g' in
-                                      let gres1 =
-                                        FStar_TypeChecker_Env.conj_guard gres
-                                          implicits in
-                                      ((let uu___9 =
-                                          FStar_TypeChecker_Env.debug env2
-                                            FStar_Options.Extreme in
-                                        if uu___9
+                          let uu___14 =
+                            FStar_Syntax_Print.term_to_string
+                              lc.FStar_TypeChecker_Common.res_typ in
+                          let uu___15 = FStar_Syntax_Print.term_to_string t0 in
+                          let uu___16 =
+                            FStar_Syntax_Print.term_to_string thead in
+                          FStar_Compiler_Util.print3
+                            "Got lc.res_typ=%s; t0 = %s; thead = %s\n"
+                            uu___14 uu___15 uu___16
+                        else ());
+                       (let uu___13 =
+                          let uu___14 =
+                            let uu___15 = FStar_Syntax_Util.un_uinst thead in
+                            FStar_Syntax_Subst.compress uu___15 in
+                          uu___14.FStar_Syntax_Syntax.n in
+                        match uu___13 with
+                        | FStar_Syntax_Syntax.Tm_fvar type_name ->
+                            let uu___14 =
+                              FStar_TypeChecker_Util.try_lookup_record_type
+                                env1
+                                (type_name.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
+                            (match uu___14 with
+                             | FStar_Pervasives_Native.None ->
+                                 proceed_with candidate
+                             | FStar_Pervasives_Native.Some rdc ->
+                                 let i =
+                                   FStar_Compiler_List.tryFind
+                                     (fun uu___15 ->
+                                        match uu___15 with
+                                        | (i1, uu___16) ->
+                                            FStar_TypeChecker_Util.field_name_matches
+                                              field_name rdc i1)
+                                     rdc.FStar_Syntax_DsEnv.fields in
+                                 (match i with
+                                  | FStar_Pervasives_Native.None ->
+                                      proceed_with candidate
+                                  | FStar_Pervasives_Native.Some
+                                      (i1, uu___15) ->
+                                      let constrname =
+                                        let uu___16 =
+                                          let uu___17 =
+                                            FStar_Ident.ns_of_lid
+                                              rdc.FStar_Syntax_DsEnv.typename in
+                                          FStar_Compiler_List.op_At uu___17
+                                            [rdc.FStar_Syntax_DsEnv.constrname] in
+                                        FStar_Ident.lid_of_ids uu___16 in
+                                      let projname =
+                                        FStar_Syntax_Util.mk_field_projector_name_from_ident
+                                          constrname i1 in
+                                      let qual =
+                                        if rdc.FStar_Syntax_DsEnv.is_record
                                         then
-                                          let uu___10 =
-                                            FStar_Syntax_Print.term_to_string
-                                              e3 in
-                                          let uu___11 =
-                                            FStar_TypeChecker_Rel.guard_to_string
-                                              env2 gres1 in
-                                          FStar_Compiler_Util.print2
-                                            "Guard from application node %s is %s\n"
-                                            uu___10 uu___11
-                                        else ());
-                                       (e3, c2, gres1)))))))))
-       | FStar_Syntax_Syntax.Tm_match uu___1 -> tc_match env1 top
-       | FStar_Syntax_Syntax.Tm_let
-           ((false,
-             { FStar_Syntax_Syntax.lbname = FStar_Pervasives.Inr uu___1;
-               FStar_Syntax_Syntax.lbunivs = uu___2;
-               FStar_Syntax_Syntax.lbtyp = uu___3;
-               FStar_Syntax_Syntax.lbeff = uu___4;
-               FStar_Syntax_Syntax.lbdef = uu___5;
-               FStar_Syntax_Syntax.lbattrs = uu___6;
-               FStar_Syntax_Syntax.lbpos = uu___7;_}::[]),
-            uu___8)
-           -> check_top_level_let env1 top
-       | FStar_Syntax_Syntax.Tm_let ((false, uu___1), uu___2) ->
-           check_inner_let env1 top
-       | FStar_Syntax_Syntax.Tm_let
-           ((true,
-             { FStar_Syntax_Syntax.lbname = FStar_Pervasives.Inr uu___1;
-               FStar_Syntax_Syntax.lbunivs = uu___2;
-               FStar_Syntax_Syntax.lbtyp = uu___3;
-               FStar_Syntax_Syntax.lbeff = uu___4;
-               FStar_Syntax_Syntax.lbdef = uu___5;
-               FStar_Syntax_Syntax.lbattrs = uu___6;
-               FStar_Syntax_Syntax.lbpos = uu___7;_}::uu___8),
-            uu___9)
-           -> check_top_level_let_rec env1 top
-       | FStar_Syntax_Syntax.Tm_let ((true, uu___1), uu___2) ->
-           check_inner_let_rec env1 top)
+                                          FStar_Pervasives_Native.Some
+                                            (FStar_Syntax_Syntax.Record_projector
+                                               (constrname, i1))
+                                        else FStar_Pervasives_Native.None in
+                                      let choice =
+                                        let uu___16 =
+                                          let uu___17 =
+                                            FStar_Ident.range_of_lid
+                                              field_name in
+                                          FStar_Ident.set_lid_range projname
+                                            uu___17 in
+                                        FStar_Syntax_Syntax.lid_as_fv uu___16
+                                          (FStar_Syntax_Syntax.Delta_equational_at_level
+                                             Prims.int_one) qual in
+                                      proceed_with
+                                        (FStar_Pervasives_Native.Some choice)))
+                        | uu___14 -> proceed_with candidate))))
+        | FStar_Syntax_Syntax.Tm_app
+            (head, (tau, FStar_Pervasives_Native.None)::[]) when
+            (FStar_Syntax_Util.is_synth_by_tactic head) &&
+              (Prims.op_Negation env1.FStar_TypeChecker_Env.phase1)
+            ->
+            let uu___2 = FStar_Syntax_Util.head_and_args top in
+            (match uu___2 with
+             | (head1, args) ->
+                 tc_synth head1 env1 args top.FStar_Syntax_Syntax.pos)
+        | FStar_Syntax_Syntax.Tm_app
+            (head,
+             (uu___2, FStar_Pervasives_Native.Some
+              { FStar_Syntax_Syntax.aqual_implicit = true;
+                FStar_Syntax_Syntax.aqual_attributes = uu___3;_})::(tau,
+                                                                    FStar_Pervasives_Native.None)::[])
+            when
+            (FStar_Syntax_Util.is_synth_by_tactic head) &&
+              (Prims.op_Negation env1.FStar_TypeChecker_Env.phase1)
+            ->
+            let uu___4 = FStar_Syntax_Util.head_and_args top in
+            (match uu___4 with
+             | (head1, args) ->
+                 tc_synth head1 env1 args top.FStar_Syntax_Syntax.pos)
+        | FStar_Syntax_Syntax.Tm_app (head, args) when
+            (FStar_Syntax_Util.is_synth_by_tactic head) &&
+              (Prims.op_Negation env1.FStar_TypeChecker_Env.phase1)
+            ->
+            let uu___2 =
+              match args with
+              | (tau, FStar_Pervasives_Native.None)::rest ->
+                  ([(tau, FStar_Pervasives_Native.None)], rest)
+              | (a, FStar_Pervasives_Native.Some aq)::(tau,
+                                                       FStar_Pervasives_Native.None)::rest
+                  when aq.FStar_Syntax_Syntax.aqual_implicit ->
+                  ([(a, (FStar_Pervasives_Native.Some aq));
+                   (tau, FStar_Pervasives_Native.None)], rest)
+              | uu___3 ->
+                  FStar_Errors.raise_error
+                    (FStar_Errors.Fatal_SynthByTacticError,
+                      "synth_by_tactic: bad application")
+                    top.FStar_Syntax_Syntax.pos in
+            (match uu___2 with
+             | (args1, args2) ->
+                 let t1 = FStar_Syntax_Util.mk_app head args1 in
+                 let t2 = FStar_Syntax_Util.mk_app t1 args2 in
+                 tc_term env1 t2)
+        | FStar_Syntax_Syntax.Tm_app (head, args) ->
+            let env0 = env1 in
+            let env2 =
+              let uu___2 =
+                let uu___3 = FStar_TypeChecker_Env.clear_expected_typ env1 in
+                FStar_Compiler_Effect.op_Bar_Greater uu___3
+                  FStar_Pervasives_Native.fst in
+              FStar_Compiler_Effect.op_Bar_Greater uu___2 instantiate_both in
+            ((let uu___3 =
+                FStar_TypeChecker_Env.debug env2 FStar_Options.High in
+              if uu___3
+              then
+                let uu___4 =
+                  FStar_Compiler_Range.string_of_range
+                    top.FStar_Syntax_Syntax.pos in
+                let uu___5 = FStar_Syntax_Print.term_to_string top in
+                let uu___6 = print_expected_ty_str env0 in
+                FStar_Compiler_Util.print3 "(%s) Checking app %s, %s\n"
+                  uu___4 uu___5 uu___6
+              else ());
+             (let uu___3 = tc_term (no_inst env2) head in
+              match uu___3 with
+              | (head1, chead, g_head) ->
+                  let uu___4 =
+                    let uu___5 = FStar_TypeChecker_Common.lcomp_comp chead in
+                    FStar_Compiler_Effect.op_Bar_Greater uu___5
+                      (fun uu___6 ->
+                         match uu___6 with
+                         | (c, g) ->
+                             let uu___7 =
+                               FStar_TypeChecker_Env.conj_guard g_head g in
+                             (c, uu___7)) in
+                  (match uu___4 with
+                   | (chead1, g_head1) ->
+                       let uu___5 =
+                         let uu___6 =
+                           ((Prims.op_Negation env2.FStar_TypeChecker_Env.lax)
+                              &&
+                              (let uu___7 = FStar_Options.lax () in
+                               Prims.op_Negation uu___7))
+                             &&
+                             (FStar_TypeChecker_Util.short_circuit_head head1) in
+                         if uu___6
+                         then
+                           let uu___7 =
+                             let uu___8 =
+                               FStar_TypeChecker_Env.expected_typ env0 in
+                             check_short_circuit_args env2 head1 chead1
+                               g_head1 args uu___8 in
+                           match uu___7 with | (e1, c, g) -> (e1, c, g)
+                         else
+                           (let uu___8 =
+                              FStar_TypeChecker_Env.expected_typ env0 in
+                            check_application_args env2 head1 chead1 g_head1
+                              args uu___8) in
+                       (match uu___5 with
+                        | (e1, c, g) ->
+                            let uu___6 =
+                              let uu___7 =
+                                (FStar_TypeChecker_Common.is_tot_or_gtot_lcomp
+                                   c)
+                                  ||
+                                  (env2.FStar_TypeChecker_Env.phase1 &&
+                                     (FStar_TypeChecker_Common.is_pure_or_ghost_lcomp
+                                        c)) in
+                              if uu___7
+                              then
+                                let uu___8 =
+                                  FStar_TypeChecker_Util.maybe_instantiate
+                                    env0 e1
+                                    c.FStar_TypeChecker_Common.res_typ in
+                                match uu___8 with
+                                | (e2, res_typ, implicits) ->
+                                    let uu___9 =
+                                      FStar_TypeChecker_Common.set_result_typ_lc
+                                        c res_typ in
+                                    (e2, uu___9, implicits)
+                              else
+                                (e1, c, FStar_TypeChecker_Env.trivial_guard) in
+                            (match uu___6 with
+                             | (e2, c1, implicits) ->
+                                 ((let uu___8 =
+                                     FStar_TypeChecker_Env.debug env2
+                                       FStar_Options.Extreme in
+                                   if uu___8
+                                   then
+                                     let uu___9 =
+                                       FStar_TypeChecker_Rel.print_pending_implicits
+                                         g in
+                                     FStar_Compiler_Util.print1
+                                       "Introduced {%s} implicits in application\n"
+                                       uu___9
+                                   else ());
+                                  (let uu___8 =
+                                     comp_check_expected_typ env0 e2 c1 in
+                                   match uu___8 with
+                                   | (e3, c2, g') ->
+                                       let gres =
+                                         FStar_TypeChecker_Env.conj_guard g
+                                           g' in
+                                       let gres1 =
+                                         FStar_TypeChecker_Env.conj_guard
+                                           gres implicits in
+                                       ((let uu___10 =
+                                           FStar_TypeChecker_Env.debug env2
+                                             FStar_Options.Extreme in
+                                         if uu___10
+                                         then
+                                           let uu___11 =
+                                             FStar_Syntax_Print.term_to_string
+                                               e3 in
+                                           let uu___12 =
+                                             FStar_TypeChecker_Rel.guard_to_string
+                                               env2 gres1 in
+                                           FStar_Compiler_Util.print2
+                                             "Guard from application node %s is %s\n"
+                                             uu___11 uu___12
+                                         else ());
+                                        (e3, c2, gres1)))))))))
+        | FStar_Syntax_Syntax.Tm_match uu___2 -> tc_match env1 top
+        | FStar_Syntax_Syntax.Tm_let
+            ((false,
+              { FStar_Syntax_Syntax.lbname = FStar_Pervasives.Inr uu___2;
+                FStar_Syntax_Syntax.lbunivs = uu___3;
+                FStar_Syntax_Syntax.lbtyp = uu___4;
+                FStar_Syntax_Syntax.lbeff = uu___5;
+                FStar_Syntax_Syntax.lbdef = uu___6;
+                FStar_Syntax_Syntax.lbattrs = uu___7;
+                FStar_Syntax_Syntax.lbpos = uu___8;_}::[]),
+             uu___9)
+            -> check_top_level_let env1 top
+        | FStar_Syntax_Syntax.Tm_let ((false, uu___2), uu___3) ->
+            check_inner_let env1 top
+        | FStar_Syntax_Syntax.Tm_let
+            ((true,
+              { FStar_Syntax_Syntax.lbname = FStar_Pervasives.Inr uu___2;
+                FStar_Syntax_Syntax.lbunivs = uu___3;
+                FStar_Syntax_Syntax.lbtyp = uu___4;
+                FStar_Syntax_Syntax.lbeff = uu___5;
+                FStar_Syntax_Syntax.lbdef = uu___6;
+                FStar_Syntax_Syntax.lbattrs = uu___7;
+                FStar_Syntax_Syntax.lbpos = uu___8;_}::uu___9),
+             uu___10)
+            -> check_top_level_let_rec env1 top
+        | FStar_Syntax_Syntax.Tm_let ((true, uu___2), uu___3) ->
+            check_inner_let_rec env1 top))
 and (tc_match :
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.term ->
@@ -8817,19 +8833,12 @@ and (tc_pat :
 and (tc_eqn :
   FStar_Syntax_Syntax.bv ->
     FStar_TypeChecker_Env.env ->
-      (FStar_Syntax_Syntax.binder *
-        ((FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax,
-        FStar_Syntax_Syntax.comp' FStar_Syntax_Syntax.syntax)
-        FStar_Pervasives.either * FStar_Syntax_Syntax.term'
-        FStar_Syntax_Syntax.syntax FStar_Pervasives_Native.option *
-        Prims.bool)) FStar_Pervasives_Native.option ->
-        (FStar_Syntax_Syntax.pat' FStar_Syntax_Syntax.withinfo_t *
-          FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax
-          FStar_Pervasives_Native.option * FStar_Syntax_Syntax.term'
-          FStar_Syntax_Syntax.syntax) ->
+      FStar_Syntax_Syntax.match_returns_ascription
+        FStar_Pervasives_Native.option ->
+        FStar_Syntax_Syntax.branch ->
           ((FStar_Syntax_Syntax.pat * FStar_Syntax_Syntax.term
             FStar_Pervasives_Native.option * FStar_Syntax_Syntax.term) *
-            FStar_Syntax_Syntax.term * FStar_Ident.lident *
+            FStar_Syntax_Syntax.formula * FStar_Ident.lident *
             FStar_Syntax_Syntax.cflag Prims.list
             FStar_Pervasives_Native.option *
             (Prims.bool -> FStar_TypeChecker_Common.lcomp)
@@ -12236,7 +12245,7 @@ let rec (apply_well_typed :
 let rec (universe_of_aux :
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
-      FStar_Syntax_Syntax.typ)
+      FStar_Syntax_Syntax.term)
   =
   fun env ->
     fun e ->
@@ -12574,22 +12583,30 @@ let (universe_of :
   =
   fun env ->
     fun e ->
-      (let uu___1 = FStar_TypeChecker_Env.debug env FStar_Options.High in
-       if uu___1
-       then
-         let uu___2 = FStar_Syntax_Print.term_to_string e in
-         FStar_Compiler_Util.print1 "Calling universe_of_aux with %s {\n"
-           uu___2
-       else ());
-      (let r = universe_of_aux env e in
-       (let uu___2 = FStar_TypeChecker_Env.debug env FStar_Options.High in
-        if uu___2
-        then
-          let uu___3 = FStar_Syntax_Print.term_to_string r in
-          FStar_Compiler_Util.print1
-            "Got result from universe_of_aux = %s }\n" uu___3
-        else ());
-       level_of_type env e r)
+      let uu___ =
+        let uu___1 = FStar_Syntax_Print.term_to_string e in
+        FStar_Compiler_Util.format1
+          "While attempting to compute a universe level (%s)" uu___1 in
+      FStar_Errors.with_ctx uu___
+        (fun uu___1 ->
+           (let uu___3 = FStar_TypeChecker_Env.debug env FStar_Options.High in
+            if uu___3
+            then
+              let uu___4 = FStar_Syntax_Print.term_to_string e in
+              FStar_Compiler_Util.print1
+                "Calling universe_of_aux with %s {\n" uu___4
+            else ());
+           FStar_TypeChecker_Env.def_check_closed_in_env
+             e.FStar_Syntax_Syntax.pos "universe_of entry" env e;
+           (let r = universe_of_aux env e in
+            (let uu___5 = FStar_TypeChecker_Env.debug env FStar_Options.High in
+             if uu___5
+             then
+               let uu___6 = FStar_Syntax_Print.term_to_string r in
+               FStar_Compiler_Util.print1
+                 "Got result from universe_of_aux = %s }\n" uu___6
+             else ());
+            level_of_type env e r))
 let (tc_tparams :
   FStar_TypeChecker_Env.env_t ->
     FStar_Syntax_Syntax.binders ->
@@ -12602,11 +12619,10 @@ let (tc_tparams :
       match uu___ with
       | (tps1, env, g, us) ->
           (FStar_TypeChecker_Rel.force_trivial_guard env0 g; (tps1, env, us))
-let rec (typeof_tot_or_gtot_term_fastpath :
+let rec (__typeof_tot_or_gtot_term_fastpath :
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.term ->
-      FStar_TypeChecker_Env.must_tot ->
-        FStar_Syntax_Syntax.typ FStar_Pervasives_Native.option)
+      Prims.bool -> FStar_Syntax_Syntax.typ FStar_Pervasives_Native.option)
   =
   fun env ->
     fun t ->
@@ -12659,7 +12675,7 @@ let rec (typeof_tot_or_gtot_term_fastpath :
               (fun uu___2 -> FStar_Pervasives_Native.Some uu___2)
         | FStar_Syntax_Syntax.Tm_lazy i ->
             let uu___ = FStar_Syntax_Util.unfold_lazy i in
-            typeof_tot_or_gtot_term_fastpath env uu___ must_tot
+            __typeof_tot_or_gtot_term_fastpath env uu___ must_tot
         | FStar_Syntax_Syntax.Tm_abs
             (bs, body, FStar_Pervasives_Native.Some
              { FStar_Syntax_Syntax.residual_effect = eff;
@@ -12691,7 +12707,7 @@ let rec (typeof_tot_or_gtot_term_fastpath :
                             let uu___2 =
                               let uu___3 =
                                 FStar_TypeChecker_Env.push_binders env bs1 in
-                              typeof_tot_or_gtot_term_fastpath uu___3 body1
+                              __typeof_tot_or_gtot_term_fastpath uu___3 body1
                                 false in
                             FStar_Compiler_Util.map_opt uu___2
                               (FStar_Syntax_Subst.close bs1)) in
@@ -12710,7 +12726,7 @@ let rec (typeof_tot_or_gtot_term_fastpath :
                           FStar_Pervasives_Native.Some uu___2))
         | FStar_Syntax_Syntax.Tm_abs uu___ -> FStar_Pervasives_Native.None
         | FStar_Syntax_Syntax.Tm_refine (x, uu___) ->
-            typeof_tot_or_gtot_term_fastpath env x.FStar_Syntax_Syntax.sort
+            __typeof_tot_or_gtot_term_fastpath env x.FStar_Syntax_Syntax.sort
               must_tot
         | FStar_Syntax_Syntax.Tm_app
             ({
@@ -12736,7 +12752,7 @@ let rec (typeof_tot_or_gtot_term_fastpath :
                    FStar_Syntax_Syntax.mk
                      (FStar_Syntax_Syntax.Tm_app (head, rest1))
                      t1.FStar_Syntax_Syntax.pos in
-                 typeof_tot_or_gtot_term_fastpath env t2 must_tot)
+                 __typeof_tot_or_gtot_term_fastpath env t2 must_tot)
         | FStar_Syntax_Syntax.Tm_app
             ({
                FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
@@ -12761,7 +12777,7 @@ let rec (typeof_tot_or_gtot_term_fastpath :
                    FStar_Syntax_Syntax.mk
                      (FStar_Syntax_Syntax.Tm_app (head, rest1))
                      t1.FStar_Syntax_Syntax.pos in
-                 typeof_tot_or_gtot_term_fastpath env t2 must_tot)
+                 __typeof_tot_or_gtot_term_fastpath env t2 must_tot)
         | FStar_Syntax_Syntax.Tm_app
             ({
                FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
@@ -12779,9 +12795,9 @@ let rec (typeof_tot_or_gtot_term_fastpath :
                FStar_Syntax_Syntax.vars = uu___1;
                FStar_Syntax_Syntax.hash_code = uu___2;_},
              (t2, uu___3)::uu___4::[])
-            -> typeof_tot_or_gtot_term_fastpath env t2 must_tot
+            -> __typeof_tot_or_gtot_term_fastpath env t2 must_tot
         | FStar_Syntax_Syntax.Tm_app (hd, args) ->
-            let t_hd = typeof_tot_or_gtot_term_fastpath env hd must_tot in
+            let t_hd = __typeof_tot_or_gtot_term_fastpath env hd must_tot in
             FStar_Compiler_Util.bind_opt t_hd
               (fun t_hd1 ->
                  let uu___ = apply_well_typed env t_hd1 args in
@@ -12794,8 +12810,8 @@ let rec (typeof_tot_or_gtot_term_fastpath :
                                 match uu___2 with
                                 | (a, uu___3) ->
                                     let uu___4 =
-                                      typeof_tot_or_gtot_term_fastpath env a
-                                        must_tot in
+                                      __typeof_tot_or_gtot_term_fastpath env
+                                        a must_tot in
                                     FStar_Compiler_Effect.op_Bar_Greater
                                       uu___4 FStar_Compiler_Util.is_some)
                              args) in
@@ -12807,7 +12823,7 @@ let rec (typeof_tot_or_gtot_term_fastpath :
             let uu___3 = effect_ok k in
             if uu___3
             then FStar_Pervasives_Native.Some k
-            else typeof_tot_or_gtot_term_fastpath env t2 must_tot
+            else __typeof_tot_or_gtot_term_fastpath env t2 must_tot
         | FStar_Syntax_Syntax.Tm_ascribed
             (uu___, (FStar_Pervasives.Inr c, uu___1, uu___2), uu___3) ->
             let k = FStar_Syntax_Util.comp_result c in
@@ -12839,7 +12855,7 @@ let rec (typeof_tot_or_gtot_term_fastpath :
             then FStar_Pervasives_Native.Some FStar_Syntax_Syntax.t_term
             else FStar_Pervasives_Native.None
         | FStar_Syntax_Syntax.Tm_meta (t2, uu___) ->
-            typeof_tot_or_gtot_term_fastpath env t2 must_tot
+            __typeof_tot_or_gtot_term_fastpath env t2 must_tot
         | FStar_Syntax_Syntax.Tm_match
             (uu___, uu___1, uu___2, FStar_Pervasives_Native.Some rc) ->
             rc.FStar_Syntax_Syntax.residual_typ
@@ -12871,6 +12887,23 @@ let rec (typeof_tot_or_gtot_term_fastpath :
                 Prims.op_Hat uu___3 ")" in
               Prims.op_Hat "Impossible! (" uu___2 in
             failwith uu___1
+let (typeof_tot_or_gtot_term_fastpath :
+  FStar_TypeChecker_Env.env ->
+    FStar_Syntax_Syntax.term ->
+      FStar_TypeChecker_Env.must_tot ->
+        FStar_Syntax_Syntax.typ FStar_Pervasives_Native.option)
+  =
+  fun env ->
+    fun t ->
+      fun must_tot ->
+        FStar_TypeChecker_Env.def_check_closed_in_env
+          t.FStar_Syntax_Syntax.pos "fastpath" env t;
+        (let uu___1 =
+           let uu___2 = FStar_Syntax_Print.term_to_string t in
+           FStar_Compiler_Util.format1
+             "In a call to typeof_tot_or_gtot_term_fastpath, t=%s" uu___2 in
+         FStar_Errors.with_ctx uu___1
+           (fun uu___2 -> __typeof_tot_or_gtot_term_fastpath env t must_tot))
 let rec (effectof_tot_or_gtot_term_fastpath :
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.term ->

--- a/src/ocaml-output/FStar_TypeChecker_Util.ml
+++ b/src/ocaml-output/FStar_TypeChecker_Util.ml
@@ -997,77 +997,80 @@ let (close_wp_comp :
   fun env ->
     fun bvs ->
       fun c ->
-        let uu___ = FStar_Syntax_Util.is_ml_comp c in
-        if uu___
-        then c
-        else
-          (let uu___2 =
-             env.FStar_TypeChecker_Env.lax && (FStar_Options.ml_ish ()) in
-           if uu___2
-           then c
-           else
-             (let close_wp u_res md res_t bvs1 wp0 =
-                let close =
-                  let uu___4 =
-                    FStar_Compiler_Effect.op_Bar_Greater md
-                      FStar_Syntax_Util.get_wp_close_combinator in
-                  FStar_Compiler_Effect.op_Bar_Greater uu___4
-                    FStar_Compiler_Util.must in
-                FStar_Compiler_List.fold_right
-                  (fun x ->
-                     fun wp ->
-                       let bs =
-                         let uu___4 = FStar_Syntax_Syntax.mk_binder x in
-                         [uu___4] in
-                       let us =
-                         let uu___4 =
-                           let uu___5 =
-                             env.FStar_TypeChecker_Env.universe_of env
-                               x.FStar_Syntax_Syntax.sort in
-                           [uu___5] in
-                         u_res :: uu___4 in
-                       let wp1 =
-                         FStar_Syntax_Util.abs bs wp
-                           (FStar_Pervasives_Native.Some
-                              (FStar_Syntax_Util.mk_residual_comp
-                                 FStar_Parser_Const.effect_Tot_lid
-                                 FStar_Pervasives_Native.None
-                                 [FStar_Syntax_Syntax.TOTAL])) in
-                       let uu___4 =
-                         FStar_TypeChecker_Env.inst_effect_fun_with us env md
-                           close in
-                       let uu___5 =
-                         let uu___6 = FStar_Syntax_Syntax.as_arg res_t in
-                         let uu___7 =
-                           let uu___8 =
-                             FStar_Syntax_Syntax.as_arg
-                               x.FStar_Syntax_Syntax.sort in
-                           let uu___9 =
-                             let uu___10 = FStar_Syntax_Syntax.as_arg wp1 in
-                             [uu___10] in
-                           uu___8 :: uu___9 in
-                         uu___6 :: uu___7 in
-                       FStar_Syntax_Syntax.mk_Tm_app uu___4 uu___5
-                         wp0.FStar_Syntax_Syntax.pos) bvs1 wp0 in
-              let c1 = FStar_TypeChecker_Env.unfold_effect_abbrev env c in
-              let uu___4 = destruct_wp_comp c1 in
-              match uu___4 with
-              | (u_res_t, res_t, wp) ->
-                  let md =
-                    FStar_TypeChecker_Env.get_effect_decl env
-                      c1.FStar_Syntax_Syntax.effect_name in
-                  let wp1 = close_wp u_res_t md res_t bvs wp in
-                  let uu___5 =
-                    FStar_Compiler_Effect.op_Bar_Greater
-                      c1.FStar_Syntax_Syntax.flags
-                      (FStar_Compiler_List.filter
-                         (fun uu___6 ->
-                            match uu___6 with
-                            | FStar_Syntax_Syntax.MLEFFECT -> true
-                            | FStar_Syntax_Syntax.SHOULD_NOT_INLINE -> true
-                            | uu___7 -> false)) in
-                  mk_comp md u_res_t c1.FStar_Syntax_Syntax.result_typ wp1
-                    uu___5))
+        (let uu___1 = FStar_TypeChecker_Env.push_bvs env bvs in
+         FStar_TypeChecker_Env.def_check_comp_closed_in_env
+           c.FStar_Syntax_Syntax.pos "close_wp_comp" uu___1 c);
+        (let uu___1 = FStar_Syntax_Util.is_ml_comp c in
+         if uu___1
+         then c
+         else
+           (let uu___3 =
+              env.FStar_TypeChecker_Env.lax && (FStar_Options.ml_ish ()) in
+            if uu___3
+            then c
+            else
+              (let close_wp u_res md res_t bvs1 wp0 =
+                 let close =
+                   let uu___5 =
+                     FStar_Compiler_Effect.op_Bar_Greater md
+                       FStar_Syntax_Util.get_wp_close_combinator in
+                   FStar_Compiler_Effect.op_Bar_Greater uu___5
+                     FStar_Compiler_Util.must in
+                 FStar_Compiler_List.fold_right
+                   (fun x ->
+                      fun wp ->
+                        let bs =
+                          let uu___5 = FStar_Syntax_Syntax.mk_binder x in
+                          [uu___5] in
+                        let us =
+                          let uu___5 =
+                            let uu___6 =
+                              env.FStar_TypeChecker_Env.universe_of env
+                                x.FStar_Syntax_Syntax.sort in
+                            [uu___6] in
+                          u_res :: uu___5 in
+                        let wp1 =
+                          FStar_Syntax_Util.abs bs wp
+                            (FStar_Pervasives_Native.Some
+                               (FStar_Syntax_Util.mk_residual_comp
+                                  FStar_Parser_Const.effect_Tot_lid
+                                  FStar_Pervasives_Native.None
+                                  [FStar_Syntax_Syntax.TOTAL])) in
+                        let uu___5 =
+                          FStar_TypeChecker_Env.inst_effect_fun_with us env
+                            md close in
+                        let uu___6 =
+                          let uu___7 = FStar_Syntax_Syntax.as_arg res_t in
+                          let uu___8 =
+                            let uu___9 =
+                              FStar_Syntax_Syntax.as_arg
+                                x.FStar_Syntax_Syntax.sort in
+                            let uu___10 =
+                              let uu___11 = FStar_Syntax_Syntax.as_arg wp1 in
+                              [uu___11] in
+                            uu___9 :: uu___10 in
+                          uu___7 :: uu___8 in
+                        FStar_Syntax_Syntax.mk_Tm_app uu___5 uu___6
+                          wp0.FStar_Syntax_Syntax.pos) bvs1 wp0 in
+               let c1 = FStar_TypeChecker_Env.unfold_effect_abbrev env c in
+               let uu___5 = destruct_wp_comp c1 in
+               match uu___5 with
+               | (u_res_t, res_t, wp) ->
+                   let md =
+                     FStar_TypeChecker_Env.get_effect_decl env
+                       c1.FStar_Syntax_Syntax.effect_name in
+                   let wp1 = close_wp u_res_t md res_t bvs wp in
+                   let uu___6 =
+                     FStar_Compiler_Effect.op_Bar_Greater
+                       c1.FStar_Syntax_Syntax.flags
+                       (FStar_Compiler_List.filter
+                          (fun uu___7 ->
+                             match uu___7 with
+                             | FStar_Syntax_Syntax.MLEFFECT -> true
+                             | FStar_Syntax_Syntax.SHOULD_NOT_INLINE -> true
+                             | uu___8 -> false)) in
+                   mk_comp md u_res_t c1.FStar_Syntax_Syntax.result_typ wp1
+                     uu___6)))
 let (close_wp_lcomp :
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.bv Prims.list ->
@@ -1461,7 +1464,8 @@ let (substitutive_indexed_bind_substs :
                                                                     uu___11
                                                                     uu___12
                                                                     uu___13
-                                                                    else "")
+                                                                    else
+                                                                    "substitutive_indexed_bind_substs.1")
                                                                     r1 in
                                                                   match uu___10
                                                                   with
@@ -1561,7 +1565,9 @@ let (substitutive_indexed_bind_substs :
                                                                    uu___6
                                                                    uu___7
                                                                    uu___8
-                                                               else "") r1 in
+                                                               else
+                                                                 "substitutive_indexed_bind_substs.2")
+                                                            r1 in
                                                         (match uu___5 with
                                                          | (uv_t::[], g_uv)
                                                              ->
@@ -1701,7 +1707,7 @@ let (ad_hoc_indexed_bind_substs :
                                    FStar_Compiler_Util.format3
                                      "implicit var for binder %s of %s at %s"
                                      uu___2 uu___3 uu___4
-                                 else "") r1 in
+                                 else "ad_hoc_indexed_bind_substs") r1 in
                           (match uu___1 with
                            | (rest_bs_uvars, g_uvars) ->
                                ((let uu___3 =
@@ -2010,7 +2016,7 @@ let (mk_indexed_return :
                                  FStar_Compiler_Util.format3
                                    "implicit var for binder %s of %s at %s"
                                    uu___5 uu___6 uu___7
-                               else "") r in
+                               else "mk_indexed_return_env") r in
                         (match uu___4 with
                          | (rest_bs_uvars, g_uvars) ->
                              let subst =
@@ -3932,7 +3938,9 @@ let (substitutive_indexed_ite_substs :
                                                                     uu___10
                                                                     uu___11
                                                                     uu___12
-                                                                else "") r in
+                                                                else
+                                                                  "substitutive_indexed_ite_substs")
+                                                             r in
                                                          (match uu___9 with
                                                           | (uv_t::[], g_uv)
                                                               ->
@@ -4030,7 +4038,7 @@ let (ad_hoc_indexed_ite_substs :
                              FStar_Compiler_Util.format3
                                "implicit var for binder %s of %s:conjunction at %s"
                                uu___2 uu___3 uu___4
-                           else "") r in
+                           else "ad_hoc_indexed_ite_substs") r in
                     (match uu___1 with
                      | (rest_bs_uvars, g_uvars) ->
                          let substs =
@@ -6300,206 +6308,228 @@ let (check_top_level :
   fun env ->
     fun g ->
       fun lc ->
-        (let uu___1 = FStar_TypeChecker_Env.debug env FStar_Options.Medium in
-         if uu___1
-         then
-           let uu___2 = FStar_TypeChecker_Common.lcomp_to_string lc in
-           FStar_Compiler_Util.print1 "check_top_level, lc = %s\n" uu___2
-         else ());
-        (let discharge g1 =
-           FStar_TypeChecker_Rel.force_trivial_guard env g1;
-           FStar_TypeChecker_Common.is_pure_lcomp lc in
-         let g1 = FStar_TypeChecker_Rel.solve_deferred_constraints env g in
-         let uu___1 = FStar_TypeChecker_Common.lcomp_comp lc in
-         match uu___1 with
-         | (c, g_c) ->
-             let uu___2 = FStar_TypeChecker_Common.is_total_lcomp lc in
-             if uu___2
-             then
-               let uu___3 =
-                 let uu___4 = FStar_TypeChecker_Env.conj_guard g1 g_c in
-                 discharge uu___4 in
-               (uu___3, c)
-             else
-               (let c1 = FStar_TypeChecker_Env.unfold_effect_abbrev env c in
-                let us = c1.FStar_Syntax_Syntax.comp_univs in
-                let uu___4 =
-                  FStar_TypeChecker_Env.is_layered_effect env
-                    c1.FStar_Syntax_Syntax.effect_name in
-                if uu___4
-                then
-                  let c_eff = c1.FStar_Syntax_Syntax.effect_name in
-                  let ret_comp =
-                    FStar_Compiler_Effect.op_Bar_Greater c1
-                      FStar_Syntax_Syntax.mk_Comp in
-                  let steps =
-                    [FStar_TypeChecker_Env.Eager_unfolding;
-                    FStar_TypeChecker_Env.Simplify;
-                    FStar_TypeChecker_Env.Primops;
-                    FStar_TypeChecker_Env.NoFullNorm] in
-                  let c2 =
-                    let uu___5 =
-                      FStar_Compiler_Effect.op_Bar_Greater c1
-                        FStar_Syntax_Syntax.mk_Comp in
-                    FStar_Compiler_Effect.op_Bar_Greater uu___5
-                      (FStar_TypeChecker_Normalize.normalize_comp steps env) in
-                  let top_level_eff_opt =
-                    FStar_TypeChecker_Env.get_top_level_effect env c_eff in
-                  match top_level_eff_opt with
-                  | FStar_Pervasives_Native.None ->
-                      let uu___5 =
-                        let uu___6 =
-                          let uu___7 =
-                            FStar_Compiler_Effect.op_Bar_Greater c_eff
-                              FStar_Ident.string_of_lid in
-                          FStar_Compiler_Util.format1
-                            "Indexed effect %s cannot be used as a top-level effect"
-                            uu___7 in
-                        (FStar_Errors.Fatal_UnexpectedEffect, uu___6) in
-                      let uu___6 = FStar_TypeChecker_Env.get_range env in
-                      FStar_Errors.raise_error uu___5 uu___6
-                  | FStar_Pervasives_Native.Some top_level_eff ->
-                      let uu___5 = FStar_Ident.lid_equals top_level_eff c_eff in
-                      (if uu___5
-                       then let uu___6 = discharge g_c in (uu___6, ret_comp)
-                       else
-                         (let bc_opt =
-                            FStar_TypeChecker_Env.lookup_effect_abbrev env us
-                              top_level_eff in
-                          match bc_opt with
-                          | FStar_Pervasives_Native.None ->
-                              let uu___7 =
-                                let uu___8 =
-                                  let uu___9 =
-                                    FStar_Ident.string_of_lid top_level_eff in
-                                  let uu___10 =
-                                    FStar_Compiler_Effect.op_Bar_Greater
-                                      c_eff FStar_Ident.string_of_lid in
-                                  FStar_Compiler_Util.format2
-                                    "Could not find top-level effect abbreviation %s for %s"
-                                    uu___9 uu___10 in
-                                (FStar_Errors.Fatal_UnexpectedEffect, uu___8) in
-                              let uu___8 =
-                                FStar_TypeChecker_Env.get_range env in
-                              FStar_Errors.raise_error uu___7 uu___8
-                          | FStar_Pervasives_Native.Some (bs, uu___7) ->
-                              let debug =
-                                FStar_Compiler_Effect.op_Less_Bar
-                                  (FStar_TypeChecker_Env.debug env)
-                                  (FStar_Options.Other "LayeredEffectsApp") in
-                              let uu___8 = FStar_Syntax_Subst.open_binders bs in
-                              (match uu___8 with
-                               | a::bs1 ->
+        FStar_Errors.with_ctx "While checking for top-level effects"
+          (fun uu___ ->
+             (let uu___2 =
+                FStar_TypeChecker_Env.debug env FStar_Options.Medium in
+              if uu___2
+              then
+                let uu___3 = FStar_TypeChecker_Common.lcomp_to_string lc in
+                FStar_Compiler_Util.print1 "check_top_level, lc = %s\n"
+                  uu___3
+              else ());
+             (let discharge g1 =
+                FStar_TypeChecker_Rel.force_trivial_guard env g1;
+                FStar_TypeChecker_Common.is_pure_lcomp lc in
+              let g1 = FStar_TypeChecker_Rel.solve_deferred_constraints env g in
+              let uu___2 = FStar_TypeChecker_Common.lcomp_comp lc in
+              match uu___2 with
+              | (c, g_c) ->
+                  let uu___3 = FStar_TypeChecker_Common.is_total_lcomp lc in
+                  if uu___3
+                  then
+                    let uu___4 =
+                      let uu___5 = FStar_TypeChecker_Env.conj_guard g1 g_c in
+                      discharge uu___5 in
+                    (uu___4, c)
+                  else
+                    (let c1 =
+                       FStar_TypeChecker_Env.unfold_effect_abbrev env c in
+                     let us = c1.FStar_Syntax_Syntax.comp_univs in
+                     let uu___5 =
+                       FStar_TypeChecker_Env.is_layered_effect env
+                         c1.FStar_Syntax_Syntax.effect_name in
+                     if uu___5
+                     then
+                       let c_eff = c1.FStar_Syntax_Syntax.effect_name in
+                       let ret_comp =
+                         FStar_Compiler_Effect.op_Bar_Greater c1
+                           FStar_Syntax_Syntax.mk_Comp in
+                       let steps =
+                         [FStar_TypeChecker_Env.Eager_unfolding;
+                         FStar_TypeChecker_Env.Simplify;
+                         FStar_TypeChecker_Env.Primops;
+                         FStar_TypeChecker_Env.NoFullNorm] in
+                       let c2 =
+                         let uu___6 =
+                           FStar_Compiler_Effect.op_Bar_Greater c1
+                             FStar_Syntax_Syntax.mk_Comp in
+                         FStar_Compiler_Effect.op_Bar_Greater uu___6
+                           (FStar_TypeChecker_Normalize.normalize_comp steps
+                              env) in
+                       let top_level_eff_opt =
+                         FStar_TypeChecker_Env.get_top_level_effect env c_eff in
+                       match top_level_eff_opt with
+                       | FStar_Pervasives_Native.None ->
+                           let uu___6 =
+                             let uu___7 =
+                               let uu___8 =
+                                 FStar_Compiler_Effect.op_Bar_Greater c_eff
+                                   FStar_Ident.string_of_lid in
+                               FStar_Compiler_Util.format1
+                                 "Indexed effect %s cannot be used as a top-level effect"
+                                 uu___8 in
+                             (FStar_Errors.Fatal_UnexpectedEffect, uu___7) in
+                           let uu___7 = FStar_TypeChecker_Env.get_range env in
+                           FStar_Errors.raise_error uu___6 uu___7
+                       | FStar_Pervasives_Native.Some top_level_eff ->
+                           let uu___6 =
+                             FStar_Ident.lid_equals top_level_eff c_eff in
+                           (if uu___6
+                            then
+                              let uu___7 = discharge g_c in
+                              (uu___7, ret_comp)
+                            else
+                              (let bc_opt =
+                                 FStar_TypeChecker_Env.lookup_effect_abbrev
+                                   env us top_level_eff in
+                               match bc_opt with
+                               | FStar_Pervasives_Native.None ->
+                                   let uu___8 =
+                                     let uu___9 =
+                                       let uu___10 =
+                                         FStar_Ident.string_of_lid
+                                           top_level_eff in
+                                       let uu___11 =
+                                         FStar_Compiler_Effect.op_Bar_Greater
+                                           c_eff FStar_Ident.string_of_lid in
+                                       FStar_Compiler_Util.format2
+                                         "Could not find top-level effect abbreviation %s for %s"
+                                         uu___10 uu___11 in
+                                     (FStar_Errors.Fatal_UnexpectedEffect,
+                                       uu___9) in
                                    let uu___9 =
-                                     let uu___10 =
-                                       FStar_TypeChecker_Env.get_range env in
-                                     FStar_TypeChecker_Env.uvars_for_binders
-                                       env bs1
-                                       [FStar_Syntax_Syntax.NT
-                                          ((a.FStar_Syntax_Syntax.binder_bv),
-                                            (FStar_Syntax_Util.comp_result c2))]
-                                       (fun b ->
-                                          if debug
-                                          then
-                                            let uu___11 =
-                                              FStar_Syntax_Print.binder_to_string
-                                                b in
-                                            let uu___12 =
-                                              FStar_Ident.string_of_lid
-                                                top_level_eff in
-                                            FStar_Compiler_Util.format2
-                                              "implicit for binder %s in effect abbreviation %s while checking top-level effect"
-                                              uu___11 uu___12
-                                          else "") uu___10 in
+                                     FStar_TypeChecker_Env.get_range env in
+                                   FStar_Errors.raise_error uu___8 uu___9
+                               | FStar_Pervasives_Native.Some (bs, uu___8) ->
+                                   let debug =
+                                     FStar_Compiler_Effect.op_Less_Bar
+                                       (FStar_TypeChecker_Env.debug env)
+                                       (FStar_Options.Other
+                                          "LayeredEffectsApp") in
+                                   let uu___9 =
+                                     FStar_Syntax_Subst.open_binders bs in
                                    (match uu___9 with
-                                    | (uvs, g_uvs) ->
-                                        let top_level_comp =
-                                          let uu___10 =
-                                            let uu___11 =
-                                              FStar_Compiler_Effect.op_Bar_Greater
-                                                uvs
-                                                (FStar_Compiler_List.map
-                                                   FStar_Syntax_Syntax.as_arg) in
-                                            {
-                                              FStar_Syntax_Syntax.comp_univs
-                                                = us;
-                                              FStar_Syntax_Syntax.effect_name
-                                                = top_level_eff;
-                                              FStar_Syntax_Syntax.result_typ
-                                                =
-                                                (FStar_Syntax_Util.comp_result
-                                                   c2);
-                                              FStar_Syntax_Syntax.effect_args
-                                                = uu___11;
-                                              FStar_Syntax_Syntax.flags = []
-                                            } in
-                                          FStar_Compiler_Effect.op_Bar_Greater
-                                            uu___10
-                                            FStar_Syntax_Syntax.mk_Comp in
-                                        let gopt =
-                                          FStar_TypeChecker_Rel.eq_comp env
-                                            top_level_comp c2 in
-                                        (match gopt with
-                                         | FStar_Pervasives_Native.None ->
-                                             let uu___10 =
+                                    | a::bs1 ->
+                                        let uu___10 =
+                                          let uu___11 =
+                                            FStar_TypeChecker_Env.get_range
+                                              env in
+                                          FStar_TypeChecker_Env.uvars_for_binders
+                                            env bs1
+                                            [FStar_Syntax_Syntax.NT
+                                               ((a.FStar_Syntax_Syntax.binder_bv),
+                                                 (FStar_Syntax_Util.comp_result
+                                                    c2))]
+                                            (fun b ->
+                                               if debug
+                                               then
+                                                 let uu___12 =
+                                                   FStar_Syntax_Print.binder_to_string
+                                                     b in
+                                                 let uu___13 =
+                                                   FStar_Ident.string_of_lid
+                                                     top_level_eff in
+                                                 FStar_Compiler_Util.format2
+                                                   "implicit for binder %s in effect abbreviation %s while checking top-level effect"
+                                                   uu___12 uu___13
+                                               else "check_top_level")
+                                            uu___11 in
+                                        (match uu___10 with
+                                         | (uvs, g_uvs) ->
+                                             let top_level_comp =
                                                let uu___11 =
                                                  let uu___12 =
-                                                   FStar_Syntax_Print.comp_to_string
-                                                     top_level_comp in
-                                                 let uu___13 =
-                                                   FStar_Syntax_Print.comp_to_string
-                                                     c2 in
-                                                 FStar_Compiler_Util.format2
-                                                   "Could not unify %s and %s when checking top-level effect"
-                                                   uu___12 uu___13 in
-                                               (FStar_Errors.Fatal_UnexpectedEffect,
-                                                 uu___11) in
-                                             let uu___11 =
-                                               FStar_TypeChecker_Env.get_range
-                                                 env in
-                                             FStar_Errors.raise_error uu___10
-                                               uu___11
-                                         | FStar_Pervasives_Native.Some g2 ->
-                                             let uu___10 =
-                                               let uu___11 =
-                                                 FStar_TypeChecker_Env.conj_guards
-                                                   [g_c; g_uvs; g2] in
-                                               discharge uu___11 in
-                                             (uu___10, ret_comp))))))
-                else
-                  (let steps =
-                     [FStar_TypeChecker_Env.Beta;
-                     FStar_TypeChecker_Env.NoFullNorm;
-                     FStar_TypeChecker_Env.DoNotUnfoldPureLets] in
-                   let c2 =
-                     let uu___6 =
-                       FStar_Compiler_Effect.op_Bar_Greater c1
-                         FStar_Syntax_Syntax.mk_Comp in
-                     FStar_Compiler_Effect.op_Bar_Greater uu___6
-                       (FStar_TypeChecker_Normalize.normalize_comp steps env) in
-                   let uu___6 = check_trivial_precondition_wp env c2 in
-                   match uu___6 with
-                   | (ct, vc, g_pre) ->
-                       ((let uu___8 =
-                           FStar_Compiler_Effect.op_Less_Bar
-                             (FStar_TypeChecker_Env.debug env)
-                             (FStar_Options.Other "Simplification") in
-                         if uu___8
-                         then
-                           let uu___9 = FStar_Syntax_Print.term_to_string vc in
-                           FStar_Compiler_Util.print1 "top-level VC: %s\n"
-                             uu___9
-                         else ());
-                        (let uu___8 =
-                           let uu___9 =
-                             let uu___10 =
-                               FStar_TypeChecker_Env.conj_guard g_c g_pre in
-                             FStar_TypeChecker_Env.conj_guard g1 uu___10 in
-                           discharge uu___9 in
-                         let uu___9 =
-                           FStar_Compiler_Effect.op_Bar_Greater ct
-                             FStar_Syntax_Syntax.mk_Comp in
-                         (uu___8, uu___9))))))
+                                                   FStar_Compiler_Effect.op_Bar_Greater
+                                                     uvs
+                                                     (FStar_Compiler_List.map
+                                                        FStar_Syntax_Syntax.as_arg) in
+                                                 {
+                                                   FStar_Syntax_Syntax.comp_univs
+                                                     = us;
+                                                   FStar_Syntax_Syntax.effect_name
+                                                     = top_level_eff;
+                                                   FStar_Syntax_Syntax.result_typ
+                                                     =
+                                                     (FStar_Syntax_Util.comp_result
+                                                        c2);
+                                                   FStar_Syntax_Syntax.effect_args
+                                                     = uu___12;
+                                                   FStar_Syntax_Syntax.flags
+                                                     = []
+                                                 } in
+                                               FStar_Compiler_Effect.op_Bar_Greater
+                                                 uu___11
+                                                 FStar_Syntax_Syntax.mk_Comp in
+                                             let gopt =
+                                               FStar_TypeChecker_Rel.eq_comp
+                                                 env top_level_comp c2 in
+                                             (match gopt with
+                                              | FStar_Pervasives_Native.None
+                                                  ->
+                                                  let uu___11 =
+                                                    let uu___12 =
+                                                      let uu___13 =
+                                                        FStar_Syntax_Print.comp_to_string
+                                                          top_level_comp in
+                                                      let uu___14 =
+                                                        FStar_Syntax_Print.comp_to_string
+                                                          c2 in
+                                                      FStar_Compiler_Util.format2
+                                                        "Could not unify %s and %s when checking top-level effect"
+                                                        uu___13 uu___14 in
+                                                    (FStar_Errors.Fatal_UnexpectedEffect,
+                                                      uu___12) in
+                                                  let uu___12 =
+                                                    FStar_TypeChecker_Env.get_range
+                                                      env in
+                                                  FStar_Errors.raise_error
+                                                    uu___11 uu___12
+                                              | FStar_Pervasives_Native.Some
+                                                  g2 ->
+                                                  let uu___11 =
+                                                    let uu___12 =
+                                                      FStar_TypeChecker_Env.conj_guards
+                                                        [g_c; g_uvs; g2] in
+                                                    discharge uu___12 in
+                                                  (uu___11, ret_comp))))))
+                     else
+                       (let steps =
+                          [FStar_TypeChecker_Env.Beta;
+                          FStar_TypeChecker_Env.NoFullNorm;
+                          FStar_TypeChecker_Env.DoNotUnfoldPureLets] in
+                        let c2 =
+                          let uu___7 =
+                            FStar_Compiler_Effect.op_Bar_Greater c1
+                              FStar_Syntax_Syntax.mk_Comp in
+                          FStar_Compiler_Effect.op_Bar_Greater uu___7
+                            (FStar_TypeChecker_Normalize.normalize_comp steps
+                               env) in
+                        let uu___7 = check_trivial_precondition_wp env c2 in
+                        match uu___7 with
+                        | (ct, vc, g_pre) ->
+                            ((let uu___9 =
+                                FStar_Compiler_Effect.op_Less_Bar
+                                  (FStar_TypeChecker_Env.debug env)
+                                  (FStar_Options.Other "Simplification") in
+                              if uu___9
+                              then
+                                let uu___10 =
+                                  FStar_Syntax_Print.term_to_string vc in
+                                FStar_Compiler_Util.print1
+                                  "top-level VC: %s\n" uu___10
+                              else ());
+                             (let uu___9 =
+                                let uu___10 =
+                                  let uu___11 =
+                                    FStar_TypeChecker_Env.conj_guard g_c
+                                      g_pre in
+                                  FStar_TypeChecker_Env.conj_guard g1 uu___11 in
+                                discharge uu___10 in
+                              let uu___10 =
+                                FStar_Compiler_Effect.op_Bar_Greater ct
+                                  FStar_Syntax_Syntax.mk_Comp in
+                              (uu___9, uu___10)))))))
 let (short_circuit :
   FStar_Syntax_Syntax.term ->
     FStar_Syntax_Syntax.args -> FStar_TypeChecker_Common.guard_formula)
@@ -7242,7 +7272,7 @@ let (fresh_effect_repr :
                                        FStar_Compiler_Util.format3
                                          "uvar for binder %s when creating a fresh repr for %s at %s"
                                          uu___5 uu___6 uu___7
-                                     else "") r in
+                                     else "fresh_effect_repr") r in
                               (match uu___4 with
                                | (is, g) ->
                                    let uu___5 =
@@ -7474,7 +7504,9 @@ let (substitutive_indexed_lift_substs :
                                          FStar_Compiler_Util.format3
                                            "implicit var for additional lift binder %s of %s at %s)"
                                            uu___4 lift_name uu___5
-                                       else "") r in
+                                       else
+                                         "substitutive_indexed_lift_substs")
+                                    r in
                                 (match uu___3 with
                                  | (uv_t::[], g_uv) ->
                                      let uu___4 =
@@ -7539,7 +7571,7 @@ let (ad_hoc_indexed_lift_substs :
                          FStar_Compiler_Util.format3
                            "implicit var for binder %s of %s at %s" uu___2
                            lift_name uu___3
-                       else "") r in
+                       else "ad_hoc_indexed_lift_substs") r in
                 (match uu___1 with
                  | (rest_bs_uvars, g) ->
                      let substs =
@@ -9146,126 +9178,137 @@ let (ty_positive_in_datacon :
         fun ty_bs ->
           fun us ->
             fun unfolded ->
-              let dt =
-                let uu___ =
-                  FStar_TypeChecker_Env.try_lookup_and_inst_lid env us dlid in
-                match uu___ with
-                | FStar_Pervasives_Native.Some (t, uu___1) -> t
-                | FStar_Pervasives_Native.None ->
-                    let uu___1 =
-                      let uu___2 =
-                        let uu___3 = FStar_Ident.string_of_lid dlid in
-                        FStar_Compiler_Util.format1
-                          "Error looking up data constructor %s when checking positivity"
-                          uu___3 in
-                      (FStar_Errors.Error_InductiveTypeNotSatisfyPositivityCondition,
-                        uu___2) in
-                    let uu___2 = FStar_Ident.range_of_lid ty_lid in
-                    FStar_Errors.raise_error uu___1 uu___2 in
-              debug_positivity env
+              let uu___ =
+                let uu___1 = FStar_Ident.string_of_lid dlid in
+                FStar_Compiler_Util.format1 "While checking constructor %s"
+                  uu___1 in
+              FStar_Errors.with_ctx uu___
                 (fun uu___1 ->
-                   let uu___2 = FStar_Syntax_Print.term_to_string dt in
-                   Prims.op_Hat "Checking data constructor type: " uu___2);
-              (let uu___1 =
-                 let uu___2 = FStar_Syntax_Subst.compress dt in
-                 uu___2.FStar_Syntax_Syntax.n in
-               match uu___1 with
-               | FStar_Syntax_Syntax.Tm_fvar uu___2 ->
-                   (debug_positivity env
-                      (fun uu___4 ->
-                         "Data constructor type is simply an fvar/Tm_uinst, returning true");
-                    true)
-               | FStar_Syntax_Syntax.Tm_uinst uu___2 ->
-                   (debug_positivity env
-                      (fun uu___4 ->
-                         "Data constructor type is simply an fvar/Tm_uinst, returning true");
-                    true)
-               | FStar_Syntax_Syntax.Tm_arrow (dbs, uu___2) ->
-                   let dbs1 =
-                     let uu___3 =
-                       FStar_Compiler_List.splitAt
-                         (FStar_Compiler_List.length ty_bs) dbs in
-                     FStar_Pervasives_Native.snd uu___3 in
-                   let dbs2 =
-                     let uu___3 = FStar_Syntax_Subst.opening_of_binders ty_bs in
-                     FStar_Syntax_Subst.subst_binders uu___3 dbs1 in
-                   let dbs3 = FStar_Syntax_Subst.open_binders dbs2 in
-                   (debug_positivity env
-                      (fun uu___4 ->
-                         let uu___5 =
-                           let uu___6 =
-                             FStar_Compiler_Util.string_of_int
-                               (FStar_Compiler_List.length dbs3) in
-                           Prims.op_Hat uu___6 " binders" in
-                         Prims.op_Hat
-                           "Data constructor type is an arrow type, so checking strict positivity in "
-                           uu___5);
-                    (let uu___4 =
-                       FStar_Compiler_List.fold_left
-                         (fun uu___5 ->
-                            fun b ->
-                              match uu___5 with
-                              | (r, env1) ->
-                                  if Prims.op_Negation r
-                                  then (r, env1)
-                                  else
-                                    (FStar_Compiler_List.iter
-                                       (fun uu___8 ->
-                                          match uu___8 with
-                                          | {
-                                              FStar_Syntax_Syntax.binder_bv =
-                                                ty_bv;
-                                              FStar_Syntax_Syntax.binder_qual
-                                                = uu___9;
-                                              FStar_Syntax_Syntax.binder_attrs
-                                                = ty_b_attrs;_}
-                                              ->
-                                              let uu___10 =
-                                                (FStar_Syntax_Util.has_attribute
-                                                   ty_b_attrs
-                                                   FStar_Parser_Const.binder_strictly_positive_attr)
-                                                  &&
-                                                  (let uu___11 =
-                                                     name_strictly_positive_in_type
-                                                       env1 ty_bv
-                                                       (b.FStar_Syntax_Syntax.binder_bv).FStar_Syntax_Syntax.sort in
-                                                   Prims.op_Negation uu___11) in
-                                              if uu___10
-                                              then
-                                                let uu___11 =
-                                                  let uu___12 =
-                                                    let uu___13 =
-                                                      FStar_Syntax_Print.bv_to_string
-                                                        ty_bv in
-                                                    FStar_Compiler_Util.format1
-                                                      "Binder %s is marked strictly positive, but its use in the definition is not"
-                                                      uu___13 in
-                                                  (FStar_Errors.Error_InductiveTypeNotSatisfyPositivityCondition,
-                                                    uu___12) in
-                                                let uu___12 =
-                                                  FStar_Syntax_Syntax.range_of_bv
-                                                    ty_bv in
-                                                FStar_Errors.raise_error
-                                                  uu___11 uu___12
-                                              else ()) ty_bs;
-                                     (let uu___8 =
-                                        ty_strictly_positive_in_type env1
-                                          ty_lid
-                                          (b.FStar_Syntax_Syntax.binder_bv).FStar_Syntax_Syntax.sort
-                                          unfolded in
-                                      let uu___9 =
-                                        FStar_TypeChecker_Env.push_binders
-                                          env1 [b] in
-                                      (uu___8, uu___9)))) (true, env) dbs3 in
-                     match uu___4 with | (b, uu___5) -> b))
-               | FStar_Syntax_Syntax.Tm_app (uu___2, uu___3) ->
-                   (debug_positivity env
-                      (fun uu___5 ->
-                         "Data constructor type is a Tm_app, so returning true");
-                    true)
-               | uu___2 ->
-                   failwith
-                     "Unexpected data constructor type when checking positivity")
+                   let dt =
+                     let uu___2 =
+                       FStar_TypeChecker_Env.try_lookup_and_inst_lid env us
+                         dlid in
+                     match uu___2 with
+                     | FStar_Pervasives_Native.Some (t, uu___3) -> t
+                     | FStar_Pervasives_Native.None ->
+                         let uu___3 =
+                           let uu___4 =
+                             let uu___5 = FStar_Ident.string_of_lid dlid in
+                             FStar_Compiler_Util.format1
+                               "Error looking up data constructor %s when checking positivity"
+                               uu___5 in
+                           (FStar_Errors.Error_InductiveTypeNotSatisfyPositivityCondition,
+                             uu___4) in
+                         let uu___4 = FStar_Ident.range_of_lid ty_lid in
+                         FStar_Errors.raise_error uu___3 uu___4 in
+                   debug_positivity env
+                     (fun uu___3 ->
+                        let uu___4 = FStar_Syntax_Print.term_to_string dt in
+                        Prims.op_Hat "Checking data constructor type: "
+                          uu___4);
+                   (let uu___3 =
+                      let uu___4 = FStar_Syntax_Subst.compress dt in
+                      uu___4.FStar_Syntax_Syntax.n in
+                    match uu___3 with
+                    | FStar_Syntax_Syntax.Tm_fvar uu___4 ->
+                        (debug_positivity env
+                           (fun uu___6 ->
+                              "Data constructor type is simply an fvar/Tm_uinst, returning true");
+                         true)
+                    | FStar_Syntax_Syntax.Tm_uinst uu___4 ->
+                        (debug_positivity env
+                           (fun uu___6 ->
+                              "Data constructor type is simply an fvar/Tm_uinst, returning true");
+                         true)
+                    | FStar_Syntax_Syntax.Tm_arrow (dbs, uu___4) ->
+                        let dbs1 =
+                          let uu___5 =
+                            FStar_Compiler_List.splitAt
+                              (FStar_Compiler_List.length ty_bs) dbs in
+                          FStar_Pervasives_Native.snd uu___5 in
+                        let dbs2 =
+                          let uu___5 =
+                            FStar_Syntax_Subst.opening_of_binders ty_bs in
+                          FStar_Syntax_Subst.subst_binders uu___5 dbs1 in
+                        let dbs3 = FStar_Syntax_Subst.open_binders dbs2 in
+                        (debug_positivity env
+                           (fun uu___6 ->
+                              let uu___7 =
+                                let uu___8 =
+                                  FStar_Compiler_Util.string_of_int
+                                    (FStar_Compiler_List.length dbs3) in
+                                Prims.op_Hat uu___8 " binders" in
+                              Prims.op_Hat
+                                "Data constructor type is an arrow type, so checking strict positivity in "
+                                uu___7);
+                         (let uu___6 =
+                            FStar_Compiler_List.fold_left
+                              (fun uu___7 ->
+                                 fun b ->
+                                   match uu___7 with
+                                   | (r, env1) ->
+                                       if Prims.op_Negation r
+                                       then (r, env1)
+                                       else
+                                         (FStar_Compiler_List.iter
+                                            (fun uu___10 ->
+                                               match uu___10 with
+                                               | {
+                                                   FStar_Syntax_Syntax.binder_bv
+                                                     = ty_bv;
+                                                   FStar_Syntax_Syntax.binder_qual
+                                                     = uu___11;
+                                                   FStar_Syntax_Syntax.binder_attrs
+                                                     = ty_b_attrs;_}
+                                                   ->
+                                                   let uu___12 =
+                                                     (FStar_Syntax_Util.has_attribute
+                                                        ty_b_attrs
+                                                        FStar_Parser_Const.binder_strictly_positive_attr)
+                                                       &&
+                                                       (let uu___13 =
+                                                          name_strictly_positive_in_type
+                                                            env1 ty_bv
+                                                            (b.FStar_Syntax_Syntax.binder_bv).FStar_Syntax_Syntax.sort in
+                                                        Prims.op_Negation
+                                                          uu___13) in
+                                                   if uu___12
+                                                   then
+                                                     let uu___13 =
+                                                       let uu___14 =
+                                                         let uu___15 =
+                                                           FStar_Syntax_Print.bv_to_string
+                                                             ty_bv in
+                                                         FStar_Compiler_Util.format1
+                                                           "Binder %s is marked strictly positive, but its use in the definition is not"
+                                                           uu___15 in
+                                                       (FStar_Errors.Error_InductiveTypeNotSatisfyPositivityCondition,
+                                                         uu___14) in
+                                                     let uu___14 =
+                                                       FStar_Syntax_Syntax.range_of_bv
+                                                         ty_bv in
+                                                     FStar_Errors.raise_error
+                                                       uu___13 uu___14
+                                                   else ()) ty_bs;
+                                          (let uu___10 =
+                                             ty_strictly_positive_in_type
+                                               env1 ty_lid
+                                               (b.FStar_Syntax_Syntax.binder_bv).FStar_Syntax_Syntax.sort
+                                               unfolded in
+                                           let uu___11 =
+                                             FStar_TypeChecker_Env.push_binders
+                                               env1 [b] in
+                                           (uu___10, uu___11)))) (true, env)
+                              dbs3 in
+                          match uu___6 with | (b, uu___7) -> b))
+                    | FStar_Syntax_Syntax.Tm_app (uu___4, uu___5) ->
+                        (debug_positivity env
+                           (fun uu___7 ->
+                              "Data constructor type is a Tm_app, so returning true");
+                         true)
+                    | uu___4 ->
+                        failwith
+                          "Unexpected data constructor type when checking positivity"))
 let (check_positivity :
   FStar_TypeChecker_Env.env ->
     FStar_Ident.lident Prims.list -> FStar_Syntax_Syntax.sigelt -> Prims.bool)
@@ -9273,37 +9316,44 @@ let (check_positivity :
   fun env ->
     fun mutuals ->
       fun ty ->
-        let unfolded_inductives = FStar_Compiler_Util.mk_ref [] in
-        let uu___ =
-          match ty.FStar_Syntax_Syntax.sigel with
-          | FStar_Syntax_Syntax.Sig_inductive_typ
-              (lid, us, bs, uu___1, uu___2, uu___3) -> (lid, us, bs)
-          | uu___1 -> failwith "Impossible!" in
-        match uu___ with
-        | (ty_lid, ty_us, ty_bs) ->
-            let ty_lids = ty_lid :: mutuals in
-            let uu___1 = FStar_Syntax_Subst.univ_var_opening ty_us in
-            (match uu___1 with
-             | (ty_usubst, ty_us1) ->
-                 let env1 = FStar_TypeChecker_Env.push_univ_vars env ty_us1 in
-                 let env2 = FStar_TypeChecker_Env.push_binders env1 ty_bs in
-                 let datacons =
-                   let uu___2 =
-                     FStar_TypeChecker_Env.datacons_of_typ env2 ty_lid in
-                   FStar_Pervasives_Native.snd uu___2 in
-                 let ty_bs1 =
-                   FStar_Syntax_Subst.subst_binders ty_usubst ty_bs in
-                 let ty_bs2 = FStar_Syntax_Subst.open_binders ty_bs1 in
-                 FStar_Compiler_List.for_all
-                   (fun d1 ->
+        FStar_Errors.with_ctx
+          "While checking the positivity of an inductive type"
+          (fun uu___ ->
+             let unfolded_inductives = FStar_Compiler_Util.mk_ref [] in
+             let uu___1 =
+               match ty.FStar_Syntax_Syntax.sigel with
+               | FStar_Syntax_Syntax.Sig_inductive_typ
+                   (lid, us, bs, uu___2, uu___3, uu___4) -> (lid, us, bs)
+               | uu___2 -> failwith "Impossible!" in
+             match uu___1 with
+             | (ty_lid, ty_us, ty_bs) ->
+                 let ty_lids = ty_lid :: mutuals in
+                 let uu___2 = FStar_Syntax_Subst.univ_var_opening ty_us in
+                 (match uu___2 with
+                  | (ty_usubst, ty_us1) ->
+                      let env1 =
+                        FStar_TypeChecker_Env.push_univ_vars env ty_us1 in
+                      let env2 =
+                        FStar_TypeChecker_Env.push_binders env1 ty_bs in
+                      let datacons =
+                        let uu___3 =
+                          FStar_TypeChecker_Env.datacons_of_typ env2 ty_lid in
+                        FStar_Pervasives_Native.snd uu___3 in
+                      let ty_bs1 =
+                        FStar_Syntax_Subst.subst_binders ty_usubst ty_bs in
+                      let ty_bs2 = FStar_Syntax_Subst.open_binders ty_bs1 in
                       FStar_Compiler_List.for_all
-                        (fun ty_lid1 ->
-                           let uu___2 =
-                             FStar_Compiler_List.map
-                               (fun uu___3 ->
-                                  FStar_Syntax_Syntax.U_name uu___3) ty_us1 in
-                           ty_positive_in_datacon env2 ty_lid1 d1 ty_bs2
-                             uu___2 unfolded_inductives) ty_lids) datacons)
+                        (fun d1 ->
+                           FStar_Compiler_List.for_all
+                             (fun ty_lid1 ->
+                                let uu___3 =
+                                  FStar_Compiler_List.map
+                                    (fun uu___4 ->
+                                       FStar_Syntax_Syntax.U_name uu___4)
+                                    ty_us1 in
+                                ty_positive_in_datacon env2 ty_lid1 d1 ty_bs2
+                                  uu___3 unfolded_inductives) ty_lids)
+                        datacons))
 let (check_exn_positivity :
   FStar_TypeChecker_Env.env -> FStar_Ident.lident -> Prims.bool) =
   fun env ->

--- a/src/syntax/FStar.Syntax.Print.fst
+++ b/src/syntax/FStar.Syntax.Print.fst
@@ -303,7 +303,16 @@ and term_to_string x =
 
       | Tm_bvar x ->        db_to_string x ^ ":(" ^ (tag_of_term x.sort) ^  ")"
       | Tm_name x ->        nm_to_string x // ^ "@@(" ^ term_to_string x.sort ^ ")"
-      | Tm_fvar f ->        fv_to_string f
+      | Tm_fvar f ->
+        // Add a prefix to unresolved constructors/projectors, otherwise
+        // we print a unqualified fvar, which looks exactly like a Tm_name
+        let pref =
+          match f.fv_qual with
+          | Some (Unresolved_projector _) -> "(Unresolved_projector)"
+          | Some (Unresolved_constructor _) -> "(Unresolved_constructor)"
+          | _ -> ""
+        in
+        pref ^ fv_to_string f
       | Tm_uvar (u, ([], _)) ->
         if Options.print_bound_var_types()
         && Options.print_effect_args()

--- a/src/typechecker/FStar.TypeChecker.Env.fst
+++ b/src/typechecker/FStar.TypeChecker.Env.fst
@@ -1084,6 +1084,75 @@ let wp_sig_aux decls m =
 
 let wp_signature env m = wp_sig_aux env.effects.decls m
 
+let bound_vars_of_bindings bs =
+  bs |> List.collect (function
+        | Binding_var x -> [x]
+        | Binding_lid _
+        | Binding_univ _ -> [])
+
+let binders_of_bindings bs = bound_vars_of_bindings bs |> List.map Syntax.mk_binder |> List.rev
+
+let bound_vars env = bound_vars_of_bindings env.gamma
+
+let all_binders env = binders_of_bindings env.gamma
+
+let def_check_vars_in_set rng msg vset t =
+    if Options.defensive () then begin
+        let s = Free.names t in
+        if not (BU.set_is_empty <| BU.set_difference s vset)
+        then Errors.log_issue rng
+                    (Errors.Warning_Defensive,
+                     BU.format4 "Internal: term is not closed (%s).\nt = (%s)\nFVs = (%s)\nScope = (%s)\n"
+                                      msg
+                                      (Print.term_to_string t)
+                                      (BU.set_elements s |> Print.bvs_to_string ",\n\t")
+                                      (BU.set_elements vset |> Print.bvs_to_string ",")
+                                      )
+    end
+
+let def_check_closed_in rng msg l t =
+    if not (Options.defensive ()) then () else
+    def_check_vars_in_set rng msg (BU.as_set l Syntax.order_bv) t
+
+let def_check_closed_in_env rng msg e t =
+    if not (Options.defensive ()) then () else
+    def_check_closed_in rng msg (bound_vars e) t
+
+let def_check_comp_closed_in rng msg l c =
+    if not (Options.defensive ()) then () else
+    match c.n with
+    | Total t
+    | GTotal t -> def_check_closed_in rng (msg^".typ") l t
+    | Comp ct -> begin
+      def_check_closed_in rng (msg^".typ") l (ct.result_typ);
+      List.iter (fun (a, _) -> def_check_closed_in rng (msg^".arg") l a) ct.effect_args
+    end
+
+let def_check_comp_closed_in_env rng msg e c =
+    if not (Options.defensive ()) then () else
+    match c.n with
+    | Total t
+    | GTotal t -> def_check_closed_in_env rng (msg^".typ") e t
+    | Comp ct -> begin
+      def_check_closed_in_env rng (msg^".typ") e (ct.result_typ);
+      List.iter (fun (a, _) -> def_check_closed_in_env rng (msg^".arg") e a) ct.effect_args
+    end
+
+let def_check_lcomp_closed_in rng msg l lc =
+  if Options.defensive () then
+    let c, _ = lcomp_comp lc in
+    def_check_comp_closed_in rng msg l c
+
+let def_check_lcomp_closed_in_env rng msg env lc =
+  if Options.defensive () then
+    let c, _ = lcomp_comp lc in
+    def_check_comp_closed_in_env rng msg env c
+
+let def_check_guard_wf rng msg env g =
+    match g.guard_f with
+    | Trivial -> ()
+    | NonTrivial f -> def_check_closed_in_env rng msg env f
+
 let comp_to_comp_typ (env:env) c =
   match c.n with
   | Comp ct -> ct
@@ -1588,18 +1657,6 @@ let univnames env =
     in
     aux no_univ_names env.gamma
 
-let bound_vars_of_bindings bs =
-  bs |> List.collect (function
-        | Binding_var x -> [x]
-        | Binding_lid _
-        | Binding_univ _ -> [])
-
-let binders_of_bindings bs = bound_vars_of_bindings bs |> List.map Syntax.mk_binder |> List.rev
-
-let bound_vars env = bound_vars_of_bindings env.gamma
-
-let all_binders env = binders_of_bindings env.gamma
-
 let print_gamma gamma =
     (gamma |> List.map (function
         | Binding_var x -> "Binding_var (" ^ (Print.bv_to_string x) ^ ":" ^ (Print.term_to_string x.sort) ^ ")"
@@ -1701,34 +1758,8 @@ let abstract_guard_n bs g =
 let abstract_guard b g =
     abstract_guard_n [b] g
 
-let def_check_vars_in_set rng msg vset t =
-    if Options.defensive () then begin
-        let s = Free.names t in
-        if not (BU.set_is_empty <| BU.set_difference s vset)
-        then Errors.log_issue rng
-                    (Errors.Warning_Defensive,
-                     BU.format3 "Internal: term is not closed (%s).\nt = (%s)\nFVs = (%s)\n"
-                                      msg
-                                      (Print.term_to_string t)
-                                      (BU.set_elements s |> Print.bvs_to_string ",\n\t"))
-    end
-
-
 let too_early_in_prims env =
   not (lid_exists env Const.effect_GTot_lid)
-
-let def_check_closed_in rng msg l t =
-    if not (Options.defensive ()) then () else
-    def_check_vars_in_set rng msg (BU.as_set l Syntax.order_bv) t
-
-let def_check_closed_in_env rng msg e t =
-    if not (Options.defensive ()) then () else
-    def_check_closed_in rng msg (bound_vars e) t
-
-let def_check_guard_wf rng msg env g =
-    match g.guard_f with
-    | Trivial -> ()
-    | NonTrivial f -> def_check_closed_in_env rng msg env f
 
 let apply_guard g e = match g.guard_f with
   | Trivial -> g

--- a/src/typechecker/FStar.TypeChecker.Env.fst
+++ b/src/typechecker/FStar.TypeChecker.Env.fst
@@ -1154,6 +1154,7 @@ let def_check_guard_wf rng msg env g =
     | NonTrivial f -> def_check_closed_in_env rng msg env f
 
 let comp_to_comp_typ (env:env) c =
+  def_check_comp_closed_in_env c.pos "comp_to_comp_typ" env c;
   match c.n with
   | Comp ct -> ct
   | _ ->
@@ -1167,9 +1168,14 @@ let comp_to_comp_typ (env:env) c =
      effect_args = [];
      flags = U.comp_flags c}
 
-let comp_set_flags env c f = {c with n=Comp ({comp_to_comp_typ env c with flags=f})}
+let comp_set_flags env c f =
+    def_check_comp_closed_in_env c.pos "comp_set_flags.IN" env c;
+    let r = {c with n=Comp ({comp_to_comp_typ env c with flags=f})} in
+    def_check_comp_closed_in_env c.pos "comp_set_flags.OUT" env r;
+    r
 
 let rec unfold_effect_abbrev env comp =
+  def_check_comp_closed_in_env comp.pos "unfold_effect_abbrev" env comp;
   let c = comp_to_comp_typ env comp in
   match lookup_effect_abbrev env c.comp_univs c.effect_name with
     | None -> c

--- a/src/typechecker/FStar.TypeChecker.Env.fsti
+++ b/src/typechecker/FStar.TypeChecker.Env.fsti
@@ -467,6 +467,13 @@ val too_early_in_prims : env -> bool
 
 val def_check_closed_in       : Range.range -> msg:string -> scope:list bv -> term -> unit
 val def_check_closed_in_env   : Range.range -> msg:string -> env -> term -> unit
+
+val def_check_comp_closed_in     : Range.range -> msg:string -> scope:list bv -> comp -> unit
+val def_check_comp_closed_in_env : Range.range -> msg:string -> env -> comp -> unit
+
+val def_check_lcomp_closed_in     : Range.range -> msg:string -> scope:list bv -> lcomp -> unit
+val def_check_lcomp_closed_in_env : Range.range -> msg:string -> env -> lcomp -> unit
+
 val def_check_guard_wf        : Range.range -> msg:string -> env -> guard_t -> unit
 val close_forall              : env -> binders -> term -> term
 

--- a/src/typechecker/FStar.TypeChecker.Rel.fst
+++ b/src/typechecker/FStar.TypeChecker.Rel.fst
@@ -1887,7 +1887,7 @@ let apply_substitutive_indexed_subcomp (env:Env.env)
                 (Print.binder_to_string b)
                 subcomp_name
                 (Range.string_of_range r1)
-         else "") r1 in
+         else "apply_substitutive_indexed_subcomp") r1 in
       ss@[NT (b.binder_bv, uv_t)],
       {wl with wl_implicits=g.implicits@wl.wl_implicits}) (subst, wl) bs in
 
@@ -1951,7 +1951,7 @@ let apply_ad_hoc_indexed_subcomp (env:Env.env)
               (Print.binder_to_string b)
               subcomp_name
               (Range.string_of_range r1)
-       else "") r1 in
+       else "apply_ad_hoc_indexed_subcomp") r1 in
 
   let wl = { wl with wl_implicits = g_uvars.implicits@wl.wl_implicits } in
 

--- a/src/typechecker/FStar.TypeChecker.Rel.fst
+++ b/src/typechecker/FStar.TypeChecker.Rel.fst
@@ -4662,8 +4662,19 @@ let sub_or_eq_comp env (use_eq:bool) c1 c2 =
   (Some (Ident.string_of_lid (Env.current_module env)))
   "FStar.TypeChecker.Rel.sub_comp"
 
-let sub_comp env c1 c2 = sub_or_eq_comp env false c1 c2
-let eq_comp env c1 c2 = sub_or_eq_comp env true c1 c2
+let sub_comp env c1 c2 =
+    Errors.with_ctx "While trying to subtype computation types" (fun () ->
+      def_check_comp_closed_in_env c1.pos "sub_comp c1" env c1;
+      def_check_comp_closed_in_env c2.pos "sub_comp c2" env c2;
+      sub_or_eq_comp env false c1 c2
+    )
+
+let eq_comp env c1 c2 =
+    Errors.with_ctx "While trying to equate computation types" (fun () ->
+      def_check_comp_closed_in_env c1.pos "sub_comp c1" env c1;
+      def_check_comp_closed_in_env c2.pos "sub_comp c2" env c2;
+      sub_or_eq_comp env true c1 c2
+    )
 
 let solve_universe_inequalities' tx env (variables, ineqs) : unit =
    //variables: ?u1, ..., ?un are the universes of the inductive types we're trying to compute
@@ -4971,16 +4982,24 @@ let check_subtyping env t1 t2 =
   "FStar.TypeChecker.Rel.check_subtyping"
 
 let get_subtyping_predicate env t1 t2 =
+  Errors.with_ctx "While trying to get a subtyping predicate" (fun () ->
+    def_check_closed_in_env t1.pos "get_subtyping_predicate.1" env t1;
+    def_check_closed_in_env t2.pos "get_subtyping_predicate.2" env t2;
     match check_subtyping env t1 t2 with
     | None -> None
     | Some (x, g) ->
       Some (abstract_guard (S.mk_binder x) g)
+  )
 
 let get_subtyping_prop env t1 t2 =
+  Errors.with_ctx "While trying to get a subtyping proposition" (fun () ->
+    def_check_closed_in_env t1.pos "get_subtyping_prop.1" env t1;
+    def_check_closed_in_env t2.pos "get_subtyping_prop.2" env t2;
     match check_subtyping env t1 t2 with
     | None -> None
     | Some (x, g) ->
       Some (close_guard env [S.mk_binder x] g)
+  )
 
 (*
  * Solve the uni-valued implicits

--- a/src/typechecker/FStar.TypeChecker.TcEffect.fst
+++ b/src/typechecker/FStar.TypeChecker.TcEffect.fst
@@ -1570,7 +1570,7 @@ Errors.with_ctx (BU.format1 "While checking layered effect definition `%s`" (str
         match attr_opt with
         | None -> fml  |> NonTrivial |> Env.guard_of_guard_formula
         | Some attr ->
-          let _, _, g = Env.new_implicit_var_aux "" r env
+          let _, _, g = Env.new_implicit_var_aux "tc_layered_effect_decl.g_precondition" r env
             (U.mk_squash S.U_zero fml)
             Strict
             (Ctx_uvar_meta_attr attr |> Some) in

--- a/src/typechecker/FStar.TypeChecker.TcTerm.fst
+++ b/src/typechecker/FStar.TypeChecker.TcTerm.fst
@@ -1080,7 +1080,7 @@ and tc_maybe_toplevel_term env (e:term) : term                  (* type-checked 
 
       let (expected_repr_typ, g_repr), u_a, a, g_a =
         let a, u_a = U.type_u () in
-        let a_uvar, _, g_a = TcUtil.new_implicit_var "" e.pos env_no_ex a in
+        let a_uvar, _, g_a = TcUtil.new_implicit_var "tc_term reflect" e.pos env_no_ex a in
         TcUtil.fresh_effect_repr_en env_no_ex e.pos l u_a a_uvar, u_a, a_uvar, g_a in
 
       let g_eq = Rel.teq env_no_ex c_e.res_typ expected_repr_typ in

--- a/src/typechecker/FStar.TypeChecker.TcTerm.fst
+++ b/src/typechecker/FStar.TypeChecker.TcTerm.fst
@@ -4485,8 +4485,10 @@ let rec apply_well_typed env (t_hd:typ) (args:args) : option typ =
       For instance, if e is an application (f _), we compute the type of f to be bs -> C,
       and we take the universe level of e to be (level_of (comp_result C)),
       disregarding the arguments of f.
+
+      This a returns a term of shape Tm_type at the wanted universe.
  *)
-let rec universe_of_aux env e =
+let rec universe_of_aux env e : term =
    match (SS.compress e).n with
    | Tm_bvar _
    | Tm_unknown
@@ -4610,13 +4612,17 @@ let rec universe_of_aux env e =
    | Tm_match(_, _, [], _) ->  //AR: TODO: use return annotation?
      level_of_type_fail env e "empty match cases"
 
-let universe_of env e =
+
+let universe_of env e = Errors.with_ctx (BU.format1 "While attempting to compute a universe level (%s)" (Print.term_to_string e)) (fun () ->
     if debug env Options.High then
       BU.print1 "Calling universe_of_aux with %s {\n" (Print.term_to_string e);
+    def_check_closed_in_env e.pos "universe_of entry" env e;
+
     let r = universe_of_aux env e in
     if debug env Options.High then
       BU.print1 "Got result from universe_of_aux = %s }\n" (Print.term_to_string r);
     level_of_type env e r
+)
 
 let tc_tparams env0 (tps:binders) : (binders * Env.env * universes) =
     let tps, env, g, us = tc_binders env0 tps in
@@ -4625,22 +4631,7 @@ let tc_tparams env0 (tps:binders) : (binders * Env.env * universes) =
 
 ////////////////////////////////////////////////////////////////////////////////
 
-(*
-    Pre-condition: exists k. env |- t : (G)Tot k
-    i.e., t is well-typed in env at some type k
-
-    And t is Tot or GTot, meaning if it is PURE or GHOST, its wp has been accounted for
-      (which is the case for the terms in the unifier)
-
-    Returns (Some k), if it can find k quickly and the effect of t is consistent with must_tot
-
-    If either the type cannot be computed or effect does not match with must_tot, returns None
-
-    A possible restructuring would be to treat these two (type and effect) separately
-      in the return type
-*)
-
-let rec typeof_tot_or_gtot_term_fastpath (env:env) (t:term) (must_tot:bool) : option typ =
+let rec __typeof_tot_or_gtot_term_fastpath (env:env) (t:term) (must_tot:bool) : option typ =
   let mk_tm_type u = S.mk (Tm_type u) t.pos in
   let effect_ok k = (not must_tot) || (N.non_info_norm env k) in
   let t = SS.compress t in
@@ -4654,6 +4645,10 @@ let rec typeof_tot_or_gtot_term_fastpath (env:env) (t:term) (must_tot:bool) : op
 
   //For the following nodes, use the universe_of_aux function
   //since these are already Tot, we don't need to check the must_tot flag
+  // GM: calling universe_of for Tm_name/Tv_fvar here is a bit shady,
+  // sinc the variable may not represent a type. However universe_of_aux
+  // will currently simply return the sort of bv from the environment,
+  // be it Tm_type or not, and that's what we want here.
   | Tm_name _
   | Tm_fvar _
   | Tm_uinst _
@@ -4662,7 +4657,7 @@ let rec typeof_tot_or_gtot_term_fastpath (env:env) (t:term) (must_tot:bool) : op
   | Tm_arrow _ -> universe_of_aux env t |> Some
 
   | Tm_lazy i ->
-    typeof_tot_or_gtot_term_fastpath env (U.unfold_lazy i) must_tot
+    __typeof_tot_or_gtot_term_fastpath env (U.unfold_lazy i) must_tot
 
   | Tm_abs(bs, body, Some ({residual_effect=eff; residual_typ=tbody})) ->  //AR: maybe keep residual univ too?
     let mk_comp =
@@ -4678,7 +4673,7 @@ let rec typeof_tot_or_gtot_term_fastpath (env:env) (t:term) (must_tot:bool) : op
         | Some _ -> tbody
         | None ->
           let bs, body = SS.open_term bs body in
-          BU.map_opt (typeof_tot_or_gtot_term_fastpath (Env.push_binders env bs) body false) (SS.close bs) in
+          BU.map_opt (__typeof_tot_or_gtot_term_fastpath (Env.push_binders env bs) body false) (SS.close bs) in
       bind_opt tbody (fun tbody ->
         let bs, tbody = SS.open_term bs tbody in
         let u = universe_of (Env.push_binders env bs) tbody in
@@ -4686,7 +4681,7 @@ let rec typeof_tot_or_gtot_term_fastpath (env:env) (t:term) (must_tot:bool) : op
 
   | Tm_abs _ -> None
 
-  | Tm_refine(x, _) -> typeof_tot_or_gtot_term_fastpath env x.sort must_tot
+  | Tm_refine(x, _) -> __typeof_tot_or_gtot_term_fastpath env x.sort must_tot
 
   (* Unary operators. Explicitly curry extra arguments *)
   | Tm_app({n=Tm_constant Const_range_of}, a::hd::rest) ->
@@ -4694,7 +4689,7 @@ let rec typeof_tot_or_gtot_term_fastpath (env:env) (t:term) (must_tot:bool) : op
     let unary_op, _ = U.head_and_args t in
     let head = mk (Tm_app(unary_op, [a])) (Range.union_ranges unary_op.pos (fst a).pos) in
     let t = mk (Tm_app(head, rest)) t.pos in
-    typeof_tot_or_gtot_term_fastpath env t must_tot
+    __typeof_tot_or_gtot_term_fastpath env t must_tot
 
   (* Binary operators *)
   | Tm_app({n=Tm_constant Const_set_range_of}, a1::a2::hd::rest) ->
@@ -4702,27 +4697,27 @@ let rec typeof_tot_or_gtot_term_fastpath (env:env) (t:term) (must_tot:bool) : op
     let unary_op, _ = U.head_and_args t in
     let head = mk (Tm_app(unary_op, [a1; a2])) (Range.union_ranges unary_op.pos (fst a1).pos) in
     let t = mk (Tm_app(head, rest)) t.pos in
-    typeof_tot_or_gtot_term_fastpath env t must_tot
+    __typeof_tot_or_gtot_term_fastpath env t must_tot
 
   | Tm_app({n=Tm_constant Const_range_of}, [_]) ->
     Some (t_range)
 
   | Tm_app({n=Tm_constant Const_set_range_of}, [(t, _); _]) ->
-    typeof_tot_or_gtot_term_fastpath env t must_tot
+    __typeof_tot_or_gtot_term_fastpath env t must_tot
 
   | Tm_app(hd, args) ->
-    let t_hd = typeof_tot_or_gtot_term_fastpath env hd must_tot in
+    let t_hd = __typeof_tot_or_gtot_term_fastpath env hd must_tot in
     bind_opt t_hd (fun t_hd ->
       bind_opt (apply_well_typed env t_hd args) (fun t ->
         if (effect_ok t) ||
-           (List.for_all (fun (a, _) -> typeof_tot_or_gtot_term_fastpath env a must_tot |> is_some) args)
+           (List.for_all (fun (a, _) -> __typeof_tot_or_gtot_term_fastpath env a must_tot |> is_some) args)
         then Some t
         else None))
 
   | Tm_ascribed(t, (Inl k, _, _), _) ->
     if effect_ok k
     then Some k
-    else typeof_tot_or_gtot_term_fastpath env t must_tot
+    else __typeof_tot_or_gtot_term_fastpath env t must_tot
 
   | Tm_ascribed(_, (Inr c, _, _), _) ->
     let k = U.comp_result c in
@@ -4736,13 +4731,33 @@ let rec typeof_tot_or_gtot_term_fastpath (env:env) (t:term) (must_tot:bool) : op
 
   | Tm_quoted (tm, qi) -> if not must_tot then Some (S.t_term) else None
 
-  | Tm_meta(t, _) -> typeof_tot_or_gtot_term_fastpath env t must_tot
+  | Tm_meta(t, _) -> __typeof_tot_or_gtot_term_fastpath env t must_tot
 
   | Tm_match (_, _, _, Some rc) -> rc.residual_typ
   | Tm_match _
   | Tm_let _
   | Tm_unknown
   | _ -> failwith ("Impossible! (" ^ (Print.tag_of_term t) ^ ")")
+
+(*
+    Pre-condition: exists k. env |- t : (G)Tot k
+    i.e., t is well-typed in env at some type k
+
+    And t is Tot or GTot, meaning if it is PURE or GHOST, its wp has been accounted for
+      (which is the case for the terms in the unifier)
+
+    Returns (Some k), if it can find k quickly and the effect of t is consistent with must_tot
+
+    If either the type cannot be computed or effect does not match with must_tot, returns None
+
+    A possible restructuring would be to treat these two (type and effect) separately
+      in the return type
+*)
+let typeof_tot_or_gtot_term_fastpath (env:env) (t:term) (must_tot:bool) : option typ =
+  def_check_closed_in_env t.pos "fastpath" env t;
+  Errors.with_ctx
+    (BU.format1 "In a call to typeof_tot_or_gtot_term_fastpath, t=%s" (Print.term_to_string t))
+    (fun () -> __typeof_tot_or_gtot_term_fastpath env t must_tot)
 
 (*
  * Precondition: G |- t : Tot _ or G |- t : GTot _

--- a/src/typechecker/FStar.TypeChecker.Util.fst
+++ b/src/typechecker/FStar.TypeChecker.Util.fst
@@ -4090,6 +4090,7 @@ let name_strictly_positive_in_type env bv t =
 
 //ty_bs are the opended type parameters of the inductive, and ty_usubst is the universe substitution, again from the ty_lid type
 let ty_positive_in_datacon env (ty_lid:lident) (dlid:lident) (ty_bs:binders) (us:universes) (unfolded:unfolded_memo_t) : bool =
+Errors.with_ctx (BU.format1 "While checking constructor %s" (string_of_lid dlid)) (fun () ->
   //get the type of the data constructor
   let dt =
     match Env.try_lookup_and_inst_lid env us dlid with
@@ -4149,7 +4150,7 @@ let ty_positive_in_datacon env (ty_lid:lident) (dlid:lident) (ty_bs:binders) (us
     true  //if the data constructor type is a simple app, it must be t ..., and we already don't allow t (t ..), so nothing to check here
 
   | _ -> failwith "Unexpected data constructor type when checking positivity"
-
+)
 
 let check_positivity (env:env_t) (mutuals:list lident) (ty:sigelt) :bool =
   //memo table, memoizes the Tm_app nodes for inductives that we have already unfolded

--- a/src/typechecker/FStar.TypeChecker.Util.fst
+++ b/src/typechecker/FStar.TypeChecker.Util.fst
@@ -2837,6 +2837,7 @@ let check_has_type_maybe_coerce env (e:term) (lc:lcomp) (t2:typ) use_eq : term *
 
 /////////////////////////////////////////////////////////////////////////////////
 let check_top_level env g lc : (bool * comp) =
+ Errors.with_ctx "While checking for top-level effects" (fun () ->
   if debug env Options.Medium then
     BU.print1 "check_top_level, lc = %s\n" (TcComm.lcomp_to_string lc);
   let discharge g =
@@ -2940,6 +2941,7 @@ let check_top_level env g lc : (bool * comp) =
             if Env.debug env <| Options.Other "Simplification"
             then BU.print1 "top-level VC: %s\n" (Print.term_to_string vc);
             discharge (Env.conj_guard g (Env.conj_guard g_c g_pre)), ct |> S.mk_Comp
+ )
 
 (* Having already seen_args to head (from right to left),
    compute the guard, if any, for the next argument,

--- a/src/typechecker/FStar.TypeChecker.Util.fst
+++ b/src/typechecker/FStar.TypeChecker.Util.fst
@@ -824,7 +824,7 @@ let substitutive_indexed_bind_substs env
                       (Print.binder_to_string b)
                       (bind_name ())
                       (Range.string_of_range r1)
-               else "")
+               else "substitutive_indexed_bind_substs.1")
                r1 in
           let g_unif = Rel.layered_effect_teq
             (Env.push_binders env [x_bv |> S.mk_binder])
@@ -857,7 +857,7 @@ let substitutive_indexed_bind_substs env
               (Print.binder_to_string b)
               (bind_name ())
               (Range.string_of_range r1)
-       else "") r1 in
+       else "substitutive_indexed_bind_substs.2") r1 in
     ss@[NT (b.binder_bv, uv_t)],
     Env.conj_guard g g_uv
   ) (subst, guard) bs
@@ -913,7 +913,7 @@ let ad_hoc_indexed_bind_substs env
        then BU.format3
               "implicit var for binder %s of %s at %s"
               (Print.binder_to_string b) (bind_name ()) (Range.string_of_range r1)
-       else "") r1 in
+       else "ad_hoc_indexed_bind_substs") r1 in
 
   if Env.debug env <| Options.Other "ResolveImplicitsHook"
   then rest_bs_uvars |>
@@ -1019,7 +1019,7 @@ let mk_indexed_return env (ed:S.eff_decl) (u_a:universe) (a:typ) (e:term) (r:Ran
               (Print.binder_to_string b)
               (BU.format1 "%s.return" (Ident.string_of_lid ed.mname))
               (Range.string_of_range r)
-       else "") r in
+       else "mk_indexed_return_env") r in
 
   let subst = List.map2
     (fun b t -> NT (b.binder_bv, t))
@@ -1862,7 +1862,7 @@ let substitutive_indexed_ite_substs (env:env)
               (Print.binder_to_string b)
               (string_of_lid ct_then.effect_name)
              (Range.string_of_range r)
-       else "")
+       else "substitutive_indexed_ite_substs")
       r in
     subst@[NT (b.binder_bv, uv_t)],
     Env.conj_guard g g_uv) (subst, guard) bs in
@@ -1907,7 +1907,7 @@ let ad_hoc_indexed_ite_substs (env:env)
               "implicit var for binder %s of %s:conjunction at %s"
               (Print.binder_to_string b) (Ident.string_of_lid ct_then.effect_name)
               (r |> Range.string_of_range)
-       else "") r in
+       else "ad_hoc_indexed_ite_substs") r in
 
   let substs = List.map2
     (fun b t -> NT (b.binder_bv, t))
@@ -2912,7 +2912,7 @@ let check_top_level env g lc : (bool * comp) =
                            "implicit for binder %s in effect abbreviation %s while checking top-level effect"
                            (Print.binder_to_string b)
                           (Ident.string_of_lid top_level_eff)
-                    else "")
+                    else "check_top_level")
                    (Env.get_range env) in
                let top_level_comp =
                  ({ comp_univs = us;
@@ -3321,7 +3321,7 @@ let fresh_effect_repr env r eff_name signature_ts repr_ts_opt u a_tm =
             then BU.format3
                    "uvar for binder %s when creating a fresh repr for %s at %s"
                    (Print.binder_to_string b) (string_of_lid eff_name) (Range.string_of_range r)
-            else "") r in
+            else "fresh_effect_repr") r in
        (match repr_ts_opt with
         | None ->  //no repr, return thunked computation type
           let eff_c = mk_Comp ({
@@ -3406,7 +3406,7 @@ let substitutive_indexed_lift_substs (env:env)
               (Print.binder_to_string b)
               lift_name
               (Range.string_of_range r)
-       else "") r in
+       else "substitutive_indexed_lift_substs") r in
     subst@[NT (b.binder_bv, uv_t)],
     Env.conj_guard g g_uv) (subst, Env.trivial_guard) bs
 
@@ -3441,7 +3441,7 @@ let ad_hoc_indexed_lift_substs (env:env)
               (Print.binder_to_string b)
               lift_name
               (Range.string_of_range r)
-       else "") r in
+       else "ad_hoc_indexed_lift_substs") r in
 
   let substs = List.map2
     (fun b t -> NT (b.binder_bv, t))

--- a/src/typechecker/FStar.TypeChecker.Util.fst
+++ b/src/typechecker/FStar.TypeChecker.Util.fst
@@ -4155,6 +4155,7 @@ Errors.with_ctx (BU.format1 "While checking constructor %s" (string_of_lid dlid)
 )
 
 let check_positivity (env:env_t) (mutuals:list lident) (ty:sigelt) :bool =
+ Errors.with_ctx ("While checking the positivity of an inductive type") (fun () ->
   //memo table, memoizes the Tm_app nodes for inductives that we have already unfolded
   let unfolded_inductives = BU.mk_ref [] in
 
@@ -4190,6 +4191,7 @@ let check_positivity (env:env_t) (mutuals:list lident) (ty:sigelt) :bool =
             unfolded_inductives)
           ty_lids)
     datacons
+ )
 
 (* Special-casing the check for exceptions, the single open inductive type we handle. *)
 let check_exn_positivity (env:env_t) (data_ctor_lid:lid) : bool =

--- a/tests/micro-benchmarks/.gitignore
+++ b/tests/micro-benchmarks/.gitignore
@@ -1,2 +1,1 @@
-fstar_log
-Erasable.ml
+*.ml-cmp

--- a/tests/micro-benchmarks/Makefile
+++ b/tests/micro-benchmarks/Makefile
@@ -26,9 +26,11 @@ $(CACHE_DIR)/MustEraseForExtraction.fst.checked: OTHERFLAGS += --warn_error @318
 
 %.ml-cmp: %.ml %.ml.expected
 	diff -u --strip-trailing-cr $< $<.expected
-
+	touch $@
 
 clean:
 	rm -f .depend
 	rm -rf _cache
 	rm -rf _output
+
+.PRECIOUS: *.ml

--- a/tests/micro-benchmarks/ResolveImplicitsHook.fst
+++ b/tests/micro-benchmarks/ResolveImplicitsHook.fst
@@ -122,7 +122,9 @@ let resolve_tac_alt () : Tac unit =
   else T.admit_all()
 #push-options "--warn_error @348"
 
-[@@expect_failure [348;348;348;348;348;66]] //raises 348 for ambiguity in resolve_implicits
+//raises 348 for ambiguity in resolve_implicits
+// GM 2023-02-01: Used to raise 348 five times, but now it's 15 after some scoping fixes in Tc (why?)
+[@@expect_failure [348; 348; 348; 348; 348; 348; 348; 348; 348; 348; 348; 348; 348; 348; 348; 66]]
 let test3 (b:bool)
   : cmd (r1 ** r2 ** r3 ** r4 ** r5)
         (r1 ** r2 ** r3 ** r4 ** r5)


### PR DESCRIPTION
This PR should not introduce any functional change. These came about while removing the use of bv_sorts and fixing the fallout. I would like to keep this for future debugging sessions.

The main contents are:
- Add some more `--defensive` checks (a dynamic assert) to catch ill-scoped terms. I've been using this heavily, and would prefer to leave some of this infrastructure in place. For instance, when --defensive is passed, `tc_term` will check that the term it is called on is well scoped in the given environment. I've mostly left these checks at entrypoints, so it's quick to get a rough estimate of the failure. The performance impact when `--defensive` is not passed should be negligible.
- Added some "error contexts" (#2104) to pinpoint where some errors are raised. Perhaps the ones I added are not so interesting for users (but so far I am the only one I believe :-) ). I could edit or remove some of them.
- Some comments and type annotations.
- Some random Makefile tweaks.

There is a quirk with error contexts creating "more" errors than before in one regression file, something which I hadn't noticed before. Briefly, if two errors have a different context then they are different and cannot be de-duplicated, so we now get more. Not sure what to do here...