### PR TITLE
Fixes to AST + pretty printer for typeclass arguments

### DIFF
--- a/src/ocaml-output/FStar_Parser_AST.ml
+++ b/src/ocaml-output/FStar_Parser_AST.ml
@@ -137,6 +137,7 @@ and arg_qualifier =
   | Implicit 
   | Equality 
   | Meta of term 
+  | TypeClassArg 
 and imp =
   | FsTypApp 
   | Hash 
@@ -543,6 +544,9 @@ let (uu___is_Meta : arg_qualifier -> Prims.bool) =
   fun projectee -> match projectee with | Meta _0 -> true | uu___ -> false
 let (__proj__Meta__item___0 : arg_qualifier -> term) =
   fun projectee -> match projectee with | Meta _0 -> _0
+let (uu___is_TypeClassArg : arg_qualifier -> Prims.bool) =
+  fun projectee ->
+    match projectee with | TypeClassArg -> true | uu___ -> false
 let (uu___is_FsTypApp : imp -> Prims.bool) =
   fun projectee -> match projectee with | FsTypApp -> true | uu___ -> false
 let (uu___is_Hash : imp -> Prims.bool) =
@@ -2130,34 +2134,43 @@ and (calc_step_to_string : calc_step -> Prims.string) =
         FStar_Compiler_Util.format3 "%s{ %s } %s" uu___1 uu___2 uu___3
 and (binder_to_string : binder -> Prims.string) =
   fun x ->
-    let s =
-      match x.b with
-      | Variable i -> FStar_Ident.string_of_id i
-      | TVariable i ->
-          let uu___ = FStar_Ident.string_of_id i in
-          FStar_Compiler_Util.format1 "%s:_" uu___
-      | TAnnotated (i, t) ->
-          let uu___ = FStar_Ident.string_of_id i in
-          let uu___1 = FStar_Compiler_Effect.op_Bar_Greater t term_to_string in
-          FStar_Compiler_Util.format2 "%s:%s" uu___ uu___1
-      | Annotated (i, t) ->
-          let uu___ = FStar_Ident.string_of_id i in
-          let uu___1 = FStar_Compiler_Effect.op_Bar_Greater t term_to_string in
-          FStar_Compiler_Util.format2 "%s:%s" uu___ uu___1
-      | NoName t -> FStar_Compiler_Effect.op_Bar_Greater t term_to_string in
-    let uu___ = aqual_to_string x.aqual in
-    let uu___1 = attr_list_to_string x.battributes in
-    FStar_Compiler_Util.format3 "%s%s%s" uu___ uu___1 s
+    let pr x1 =
+      let s =
+        match x1.b with
+        | Variable i -> FStar_Ident.string_of_id i
+        | TVariable i ->
+            let uu___ = FStar_Ident.string_of_id i in
+            FStar_Compiler_Util.format1 "%s:_" uu___
+        | TAnnotated (i, t) ->
+            let uu___ = FStar_Ident.string_of_id i in
+            let uu___1 =
+              FStar_Compiler_Effect.op_Bar_Greater t term_to_string in
+            FStar_Compiler_Util.format2 "%s:%s" uu___ uu___1
+        | Annotated (i, t) ->
+            let uu___ = FStar_Ident.string_of_id i in
+            let uu___1 =
+              FStar_Compiler_Effect.op_Bar_Greater t term_to_string in
+            FStar_Compiler_Util.format2 "%s:%s" uu___ uu___1
+        | NoName t -> FStar_Compiler_Effect.op_Bar_Greater t term_to_string in
+      let uu___ = aqual_to_string x1.aqual in
+      let uu___1 = attr_list_to_string x1.battributes in
+      FStar_Compiler_Util.format3 "%s%s%s" uu___ uu___1 s in
+    match x.aqual with
+    | FStar_Pervasives_Native.Some (TypeClassArg) ->
+        let uu___ = let uu___1 = pr x in Prims.op_Hat uu___1 " |}" in
+        Prims.op_Hat "{| " uu___
+    | uu___ -> pr x
 and (aqual_to_string :
   arg_qualifier FStar_Pervasives_Native.option -> Prims.string) =
   fun uu___ ->
     match uu___ with
     | FStar_Pervasives_Native.Some (Equality) -> "$"
     | FStar_Pervasives_Native.Some (Implicit) -> "#"
-    | FStar_Pervasives_Native.Some (Meta t) ->
-        let uu___1 = let uu___2 = term_to_string t in Prims.op_Hat uu___2 "]" in
-        Prims.op_Hat "#[" uu___1
     | FStar_Pervasives_Native.None -> ""
+    | FStar_Pervasives_Native.Some (Meta uu___1) ->
+        failwith "aqual_to_strings: meta arg qualifier?"
+    | FStar_Pervasives_Native.Some (TypeClassArg) ->
+        failwith "aqual_to_strings: meta arg qualifier?"
 and (attr_list_to_string : term Prims.list -> Prims.string) =
   fun uu___ ->
     match uu___ with

--- a/src/ocaml-output/FStar_Parser_Dep.ml
+++ b/src/ocaml-output/FStar_Parser_Dep.ml
@@ -1352,6 +1352,9 @@ let (collect_one :
              match uu___2 with
              | FStar_Pervasives_Native.Some (FStar_Parser_AST.Meta t) ->
                  collect_term t
+             | FStar_Pervasives_Native.Some (FStar_Parser_AST.TypeClassArg)
+                 ->
+                 add_to_parsing_data (P_lid FStar_Parser_Const.tcresolve_lid)
              | uu___3 -> ()
            and collect_term t = collect_term' t.FStar_Parser_AST.tm
            and collect_constant uu___2 =

--- a/src/ocaml-output/FStar_Parser_ToDocument.ml
+++ b/src/ocaml-output/FStar_Parser_ToDocument.ml
@@ -185,6 +185,28 @@ let (soft_begin_end_with_nesting :
     let uu___1 = str "end" in
     FStar_Pprint.soft_surround (Prims.of_int (2)) Prims.int_one uu___
       contents uu___1
+let (tc_arg : FStar_Pprint.document -> FStar_Pprint.document) =
+  fun contents ->
+    let uu___ = str "{|" in
+    let uu___1 = str "|}" in
+    FStar_Pprint.soft_surround (Prims.of_int (2)) Prims.int_one uu___
+      contents uu___1
+let (is_tc_binder : FStar_Parser_AST.binder -> Prims.bool) =
+  fun b ->
+    match b.FStar_Parser_AST.aqual with
+    | FStar_Pervasives_Native.Some (FStar_Parser_AST.TypeClassArg) -> true
+    | uu___ -> false
+let (is_meta_qualifier :
+  FStar_Parser_AST.arg_qualifier FStar_Pervasives_Native.option -> Prims.bool)
+  =
+  fun aq ->
+    match aq with
+    | FStar_Pervasives_Native.Some (FStar_Parser_AST.Meta uu___) -> true
+    | uu___ -> false
+let (is_joinable_binder : FStar_Parser_AST.binder -> Prims.bool) =
+  fun b ->
+    (let uu___ = is_tc_binder b in Prims.op_Negation uu___) &&
+      (Prims.op_Negation (is_meta_qualifier b.FStar_Parser_AST.aqual))
 let separate_map_last :
   'uuuuu .
     FStar_Pprint.document ->
@@ -1540,16 +1562,10 @@ and (p_letlhs :
                         if inner_let
                         then
                           let uu___7 = pats_as_binders_if_possible pats in
-                          match uu___7 with
-                          | (bs, style) ->
-                              ((FStar_Compiler_List.op_At bs [ascr_doc]),
-                                style)
+                          match uu___7 with | (bs, style) -> (bs, style)
                         else
                           (let uu___8 = pats_as_binders_if_possible pats in
-                           match uu___8 with
-                           | (bs, style) ->
-                               ((FStar_Compiler_List.op_At bs [ascr_doc]),
-                                 style)) in
+                           match uu___8 with | (bs, style) -> (bs, style)) in
                       (match uu___6 with
                        | (terms, style) ->
                            let uu___7 =
@@ -1557,7 +1573,7 @@ and (p_letlhs :
                                let uu___9 =
                                  let uu___10 = p_lident lid in
                                  let uu___11 =
-                                   format_sig style terms true true in
+                                   format_sig style terms ascr_doc true true in
                                  FStar_Pprint.op_Hat_Hat uu___10 uu___11 in
                                FStar_Pprint.op_Hat_Hat FStar_Pprint.space
                                  uu___9 in
@@ -1821,6 +1837,7 @@ and (p_aqual : FStar_Parser_AST.arg_qualifier -> FStar_Pprint.document) =
             let uu___5 = str "]" in FStar_Pprint.op_Hat_Hat uu___5 break1 in
           FStar_Pprint.op_Hat_Hat uu___3 uu___4 in
         FStar_Pprint.op_Hat_Hat uu___1 uu___2
+    | FStar_Parser_AST.TypeClassArg -> FStar_Pprint.empty
 and (p_disjunctivePattern :
   FStar_Parser_AST.pattern -> FStar_Pprint.document) =
   fun p ->
@@ -1896,6 +1913,36 @@ and (p_atomicPattern : FStar_Parser_AST.pattern -> FStar_Pprint.document) =
              let uu___4 =
                p_refinement aqual attrs FStar_Pprint.underscore t1 phi in
              soft_parens_with_nesting uu___4
+         | (FStar_Parser_AST.PatVar (uu___, aqual, uu___1), uu___2) ->
+             let wrap =
+               if
+                 aqual =
+                   (FStar_Pervasives_Native.Some
+                      FStar_Parser_AST.TypeClassArg)
+               then tc_arg
+               else soft_parens_with_nesting in
+             let uu___3 =
+               let uu___4 = p_tuplePattern pat in
+               let uu___5 =
+                 let uu___6 = p_tmEqNoRefinement t in
+                 FStar_Pprint.op_Hat_Slash_Hat FStar_Pprint.colon uu___6 in
+               FStar_Pprint.op_Hat_Hat uu___4 uu___5 in
+             wrap uu___3
+         | (FStar_Parser_AST.PatWild (aqual, uu___), uu___1) ->
+             let wrap =
+               if
+                 aqual =
+                   (FStar_Pervasives_Native.Some
+                      FStar_Parser_AST.TypeClassArg)
+               then tc_arg
+               else soft_parens_with_nesting in
+             let uu___2 =
+               let uu___3 = p_tuplePattern pat in
+               let uu___4 =
+                 let uu___5 = p_tmEqNoRefinement t in
+                 FStar_Pprint.op_Hat_Slash_Hat FStar_Pprint.colon uu___5 in
+               FStar_Pprint.op_Hat_Hat uu___3 uu___4 in
+             wrap uu___2
          | uu___ ->
              let uu___1 =
                let uu___2 = p_tuplePattern pat in
@@ -1977,29 +2024,25 @@ and (is_typ_tuple : FStar_Parser_AST.term -> Prims.bool) =
     | FStar_Parser_AST.Op (id, uu___) when
         let uu___1 = FStar_Ident.string_of_id id in uu___1 = "*" -> true
     | uu___ -> false
-and (is_meta_qualifier :
-  FStar_Parser_AST.arg_qualifier FStar_Pervasives_Native.option -> Prims.bool)
-  =
-  fun aq ->
-    match aq with
-    | FStar_Pervasives_Native.Some (FStar_Parser_AST.Meta uu___) -> true
-    | uu___ -> false
 and (p_binder :
   Prims.bool -> FStar_Parser_AST.binder -> FStar_Pprint.document) =
   fun is_atomic ->
     fun b ->
-      let uu___ = p_binder' false is_atomic b in
+      let is_tc = is_tc_binder b in
+      let uu___ = p_binder' false (is_atomic && (Prims.op_Negation is_tc)) b in
       match uu___ with
-      | (b', t', catf1) ->
-          (match t' with
-           | FStar_Pervasives_Native.Some typ -> catf1 b' typ
-           | FStar_Pervasives_Native.None -> b')
+      | (b', t') ->
+          let d =
+            match t' with
+            | FStar_Pervasives_Native.Some (typ, catf1) -> catf1 b' typ
+            | FStar_Pervasives_Native.None -> b' in
+          if is_tc then tc_arg d else d
 and (p_binder' :
   Prims.bool ->
     Prims.bool ->
       FStar_Parser_AST.binder ->
-        (FStar_Pprint.document * FStar_Pprint.document
-          FStar_Pervasives_Native.option * catf))
+        (FStar_Pprint.document * (FStar_Pprint.document * catf)
+          FStar_Pervasives_Native.option))
   =
   fun no_pars ->
     fun is_atomic ->
@@ -2015,13 +2058,13 @@ and (p_binder' :
                 let uu___4 = p_lident lid in
                 FStar_Pprint.op_Hat_Hat uu___3 uu___4 in
               FStar_Pprint.op_Hat_Hat uu___1 uu___2 in
-            (uu___, FStar_Pervasives_Native.None, cat_with_colon)
+            (uu___, FStar_Pervasives_Native.None)
         | FStar_Parser_AST.TVariable lid ->
             let uu___ =
               let uu___1 = p_attributes false b.FStar_Parser_AST.battributes in
               let uu___2 = p_lident lid in
               FStar_Pprint.op_Hat_Hat uu___1 uu___2 in
-            (uu___, FStar_Pervasives_Native.None, cat_with_colon)
+            (uu___, FStar_Pervasives_Native.None)
         | FStar_Parser_AST.Annotated (lid, t) ->
             let uu___ =
               match t.FStar_Parser_AST.tm with
@@ -2062,27 +2105,26 @@ and (p_binder' :
             (match uu___ with
              | (b', t') ->
                  let catf1 =
-                   let uu___1 =
+                   if
                      is_atomic ||
                        ((is_meta_qualifier b.FStar_Parser_AST.aqual) &&
-                          (Prims.op_Negation no_pars)) in
-                   if uu___1
+                          (Prims.op_Negation no_pars))
                    then
                      fun x ->
                        fun y ->
-                         let uu___2 =
-                           let uu___3 =
-                             let uu___4 = cat_with_colon x y in
-                             FStar_Pprint.op_Hat_Hat uu___4
+                         let uu___1 =
+                           let uu___2 =
+                             let uu___3 = cat_with_colon x y in
+                             FStar_Pprint.op_Hat_Hat uu___3
                                FStar_Pprint.rparen in
-                           FStar_Pprint.op_Hat_Hat FStar_Pprint.lparen uu___3 in
-                         FStar_Pprint.group uu___2
+                           FStar_Pprint.op_Hat_Hat FStar_Pprint.lparen uu___2 in
+                         FStar_Pprint.group uu___1
                    else
                      (fun x ->
                         fun y ->
-                          let uu___3 = cat_with_colon x y in
-                          FStar_Pprint.group uu___3) in
-                 (b', (FStar_Pervasives_Native.Some t'), catf1))
+                          let uu___2 = cat_with_colon x y in
+                          FStar_Pprint.group uu___2) in
+                 (b', (FStar_Pervasives_Native.Some (t', catf1))))
         | FStar_Parser_AST.TAnnotated uu___ ->
             failwith "Is this still used ?"
         | FStar_Parser_AST.NoName t ->
@@ -2101,23 +2143,19 @@ and (p_binder' :
                      t1 phi in
                  (match uu___4 with
                   | (b', t') ->
-                      (b', (FStar_Pervasives_Native.Some t'), cat_with_colon))
+                      (b',
+                        (FStar_Pervasives_Native.Some (t', cat_with_colon))))
              | uu___ ->
-                 if is_atomic
-                 then
+                 let pref =
                    let uu___1 =
-                     let uu___2 =
-                       p_attributes false b.FStar_Parser_AST.battributes in
-                     let uu___3 = p_atomicTerm t in
-                     FStar_Pprint.op_Hat_Hat uu___2 uu___3 in
-                   (uu___1, FStar_Pervasives_Native.None, cat_with_colon)
-                 else
-                   (let uu___2 =
-                      let uu___3 =
-                        p_attributes false b.FStar_Parser_AST.battributes in
-                      let uu___4 = p_appTerm t in
-                      FStar_Pprint.op_Hat_Hat uu___3 uu___4 in
-                    (uu___2, FStar_Pervasives_Native.None, cat_with_colon)))
+                     FStar_Pprint.optional p_aqual b.FStar_Parser_AST.aqual in
+                   let uu___2 =
+                     p_attributes false b.FStar_Parser_AST.battributes in
+                   FStar_Pprint.op_Hat_Hat uu___1 uu___2 in
+                 let p_Tm = if is_atomic then p_atomicTerm else p_appTerm in
+                 let uu___1 =
+                   let uu___2 = p_Tm t in FStar_Pprint.op_Hat_Hat pref uu___2 in
+                 (uu___1, FStar_Pervasives_Native.None))
 and (p_refinement :
   FStar_Parser_AST.arg_qualifier FStar_Pervasives_Native.option ->
     FStar_Parser_AST.term Prims.list ->
@@ -3495,39 +3533,42 @@ and (sig_as_binders_if_possible :
            FStar_Pprint.op_Hat_Hat FStar_Pprint.colon uu___3 in
          FStar_Pprint.group uu___2)
 and (collapse_pats :
-  (FStar_Pprint.document * FStar_Pprint.document) Prims.list ->
-    FStar_Pprint.document Prims.list)
+  (FStar_Pprint.document * FStar_Pprint.document * Prims.bool * Prims.bool)
+    Prims.list -> FStar_Pprint.document Prims.list)
   =
   fun pats ->
     let fold_fun bs x =
       let uu___ = x in
       match uu___ with
-      | (b1, t1) ->
+      | (b1, t1, tc1, j1) ->
           (match bs with
-           | [] -> [([b1], t1)]
+           | [] -> [([b1], t1, tc1, j1)]
            | hd::tl ->
                let uu___1 = hd in
                (match uu___1 with
-                | (b2s, t2) ->
-                    if t1 = t2
-                    then ((FStar_Compiler_List.op_At b2s [b1]), t1) :: tl
-                    else ([b1], t1) :: hd :: tl)) in
+                | (b2s, t2, tc2, j2) ->
+                    if ((t1 = t2) && j1) && j2
+                    then
+                      ((FStar_Compiler_List.op_At b2s [b1]), t1, false, true)
+                      :: tl
+                    else ([b1], t1, tc1, j1) :: hd :: tl)) in
     let p_collapsed_binder cb =
       let uu___ = cb in
       match uu___ with
-      | (bs, typ) ->
-          (match bs with
-           | [] -> failwith "Impossible"
-           | b::[] -> cat_with_colon b typ
-           | hd::tl ->
-               let uu___1 =
-                 FStar_Compiler_List.fold_left
-                   (fun x ->
-                      fun y ->
-                        let uu___2 =
-                          FStar_Pprint.op_Hat_Hat FStar_Pprint.space y in
-                        FStar_Pprint.op_Hat_Hat x uu___2) hd tl in
-               cat_with_colon uu___1 typ) in
+      | (bs, typ, istcarg, uu___1) ->
+          let body =
+            match bs with
+            | [] -> failwith "Impossible"
+            | hd::tl ->
+                let uu___2 =
+                  FStar_Compiler_List.fold_left
+                    (fun x ->
+                       fun y ->
+                         let uu___3 =
+                           FStar_Pprint.op_Hat_Hat FStar_Pprint.space y in
+                         FStar_Pprint.op_Hat_Hat x uu___3) hd tl in
+                cat_with_colon uu___2 typ in
+          if istcarg then tc_arg body else soft_parens_with_nesting body in
     let binders =
       FStar_Compiler_List.fold_left fold_fun []
         (FStar_Compiler_List.rev pats) in
@@ -3556,8 +3597,18 @@ and (pats_as_binders_if_possible :
                let uu___4 =
                  let uu___5 = p_ident lid in
                  p_refinement' aqual attrs uu___5 t1 phi in
-               FStar_Pervasives_Native.Some uu___4
+               (match uu___4 with
+                | (x, y) -> FStar_Pervasives_Native.Some (x, y, false, false))
            | (FStar_Parser_AST.PatVar (lid, aqual, attrs), uu___) ->
+               let is_tc =
+                 aqual =
+                   (FStar_Pervasives_Native.Some
+                      FStar_Parser_AST.TypeClassArg) in
+               let is_meta =
+                 match aqual with
+                 | FStar_Pervasives_Native.Some (FStar_Parser_AST.Meta
+                     uu___1) -> true
+                 | uu___1 -> false in
                let uu___1 =
                  let uu___2 =
                    let uu___3 = FStar_Pprint.optional p_aqual aqual in
@@ -3566,14 +3617,12 @@ and (pats_as_binders_if_possible :
                      let uu___6 = p_ident lid in
                      FStar_Pprint.op_Hat_Hat uu___5 uu___6 in
                    FStar_Pprint.op_Hat_Hat uu___3 uu___4 in
-                 let uu___3 = p_tmEqNoRefinement t in (uu___2, uu___3) in
+                 let uu___3 = p_tmEqNoRefinement t in
+                 (uu___2, uu___3, is_tc,
+                   ((Prims.op_Negation is_tc) && (Prims.op_Negation is_meta))) in
                FStar_Pervasives_Native.Some uu___1
            | uu___ -> FStar_Pervasives_Native.None)
       | uu___ -> FStar_Pervasives_Native.None in
-    let all_unbound p =
-      match p.FStar_Parser_AST.pat with
-      | FStar_Parser_AST.PatAscribed uu___ -> false
-      | uu___ -> true in
     let uu___ = map_if_all all_binders pats in
     match uu___ with
     | FStar_Pervasives_Native.Some bs ->
@@ -3785,110 +3834,97 @@ and (p_tmImplies : FStar_Parser_AST.term -> FStar_Pprint.document) =
 and (format_sig :
   annotation_style ->
     FStar_Pprint.document Prims.list ->
-      Prims.bool -> Prims.bool -> FStar_Pprint.document)
+      FStar_Pprint.document ->
+        Prims.bool -> Prims.bool -> FStar_Pprint.document)
   =
   fun style ->
     fun terms ->
-      fun no_last_op ->
-        fun flat_space ->
-          let uu___ =
-            FStar_Compiler_List.splitAt
-              ((FStar_Compiler_List.length terms) - Prims.int_one) terms in
-          match uu___ with
-          | (terms', last) ->
-              let uu___1 =
-                match style with
-                | Arrows (n, ln) ->
+      fun ret_d ->
+        fun no_last_op ->
+          fun flat_space ->
+            let uu___ =
+              match style with
+              | Arrows (n, ln) ->
+                  let uu___1 =
                     let uu___2 =
-                      let uu___3 =
-                        FStar_Pprint.op_Hat_Hat FStar_Pprint.rarrow break1 in
-                      FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu___3 in
-                    let uu___3 =
-                      FStar_Pprint.op_Hat_Hat FStar_Pprint.rarrow
-                        FStar_Pprint.space in
-                    (n, ln, terms', uu___2, uu___3)
-                | Binders (n, ln, parens) ->
-                    let uu___2 =
-                      if parens
-                      then
-                        FStar_Compiler_List.map soft_parens_with_nesting
-                          terms'
-                      else terms' in
-                    let uu___3 =
-                      FStar_Pprint.op_Hat_Hat FStar_Pprint.colon
-                        FStar_Pprint.space in
-                    (n, ln, uu___2, break1, uu___3) in
-              (match uu___1 with
-               | (n, last_n, terms'1, sep, last_op) ->
-                   let last1 = FStar_Compiler_List.hd last in
-                   let last_op1 =
-                     if
-                       ((FStar_Compiler_List.length terms) > Prims.int_one)
-                         && (Prims.op_Negation no_last_op)
-                     then last_op
-                     else FStar_Pprint.empty in
-                   let one_line_space =
-                     if
-                       (Prims.op_Negation (last1 = FStar_Pprint.empty)) ||
-                         (Prims.op_Negation no_last_op)
-                     then FStar_Pprint.space
-                     else FStar_Pprint.empty in
-                   let single_line_arg_indent =
-                     FStar_Pprint.repeat n FStar_Pprint.space in
-                   let fs =
-                     if flat_space
-                     then FStar_Pprint.space
-                     else FStar_Pprint.empty in
-                   (match FStar_Compiler_List.length terms with
-                    | uu___2 when uu___2 = Prims.int_one ->
-                        FStar_Compiler_List.hd terms
-                    | uu___2 ->
-                        let uu___3 =
-                          let uu___4 =
-                            let uu___5 =
-                              let uu___6 = FStar_Pprint.separate sep terms'1 in
-                              let uu___7 =
-                                let uu___8 =
-                                  FStar_Pprint.op_Hat_Hat last_op1 last1 in
-                                FStar_Pprint.op_Hat_Hat one_line_space uu___8 in
-                              FStar_Pprint.op_Hat_Hat uu___6 uu___7 in
-                            FStar_Pprint.op_Hat_Hat fs uu___5 in
-                          let uu___5 =
-                            let uu___6 =
-                              let uu___7 =
-                                let uu___8 =
-                                  let uu___9 =
-                                    FStar_Pprint.separate sep terms'1 in
-                                  FStar_Pprint.op_Hat_Hat fs uu___9 in
-                                let uu___9 =
-                                  let uu___10 =
-                                    let uu___11 =
-                                      let uu___12 =
-                                        FStar_Pprint.op_Hat_Hat sep
-                                          single_line_arg_indent in
-                                      let uu___13 =
-                                        FStar_Compiler_List.map
-                                          (fun x ->
-                                             let uu___14 =
-                                               FStar_Pprint.hang
-                                                 (Prims.of_int (2)) x in
-                                             FStar_Pprint.align uu___14)
-                                          terms'1 in
-                                      FStar_Pprint.separate uu___12 uu___13 in
-                                    FStar_Pprint.op_Hat_Hat
-                                      single_line_arg_indent uu___11 in
-                                  jump2 uu___10 in
-                                FStar_Pprint.ifflat uu___8 uu___9 in
-                              FStar_Pprint.group uu___7 in
-                            let uu___7 =
-                              let uu___8 =
-                                let uu___9 =
-                                  FStar_Pprint.op_Hat_Hat last_op1 last1 in
-                                FStar_Pprint.hang last_n uu___9 in
-                              FStar_Pprint.align uu___8 in
-                            FStar_Pprint.prefix n Prims.int_one uu___6 uu___7 in
-                          FStar_Pprint.ifflat uu___4 uu___5 in
-                        FStar_Pprint.group uu___3))
+                      FStar_Pprint.op_Hat_Hat FStar_Pprint.rarrow break1 in
+                    FStar_Pprint.op_Hat_Hat FStar_Pprint.space uu___2 in
+                  let uu___2 =
+                    FStar_Pprint.op_Hat_Hat FStar_Pprint.rarrow
+                      FStar_Pprint.space in
+                  (n, ln, uu___1, uu___2)
+              | Binders (n, ln, parens) ->
+                  let uu___1 =
+                    FStar_Pprint.op_Hat_Hat FStar_Pprint.colon
+                      FStar_Pprint.space in
+                  (n, ln, break1, uu___1) in
+            match uu___ with
+            | (n, last_n, sep, last_op) ->
+                let last_op1 =
+                  if
+                    ((FStar_Compiler_List.length terms) > Prims.int_zero) &&
+                      (Prims.op_Negation no_last_op)
+                  then last_op
+                  else FStar_Pprint.empty in
+                let one_line_space =
+                  if
+                    (Prims.op_Negation (ret_d = FStar_Pprint.empty)) ||
+                      (Prims.op_Negation no_last_op)
+                  then FStar_Pprint.space
+                  else FStar_Pprint.empty in
+                let single_line_arg_indent =
+                  FStar_Pprint.repeat n FStar_Pprint.space in
+                let fs =
+                  if flat_space
+                  then FStar_Pprint.space
+                  else FStar_Pprint.empty in
+                (match FStar_Compiler_List.length terms with
+                 | uu___1 when uu___1 = Prims.int_zero -> ret_d
+                 | uu___1 ->
+                     let uu___2 =
+                       let uu___3 =
+                         let uu___4 =
+                           let uu___5 = FStar_Pprint.separate sep terms in
+                           let uu___6 =
+                             let uu___7 =
+                               FStar_Pprint.op_Hat_Hat last_op1 ret_d in
+                             FStar_Pprint.op_Hat_Hat one_line_space uu___7 in
+                           FStar_Pprint.op_Hat_Hat uu___5 uu___6 in
+                         FStar_Pprint.op_Hat_Hat fs uu___4 in
+                       let uu___4 =
+                         let uu___5 =
+                           let uu___6 =
+                             let uu___7 =
+                               let uu___8 = FStar_Pprint.separate sep terms in
+                               FStar_Pprint.op_Hat_Hat fs uu___8 in
+                             let uu___8 =
+                               let uu___9 =
+                                 let uu___10 =
+                                   let uu___11 =
+                                     FStar_Pprint.op_Hat_Hat sep
+                                       single_line_arg_indent in
+                                   let uu___12 =
+                                     FStar_Compiler_List.map
+                                       (fun x ->
+                                          let uu___13 =
+                                            FStar_Pprint.hang
+                                              (Prims.of_int (2)) x in
+                                          FStar_Pprint.align uu___13) terms in
+                                   FStar_Pprint.separate uu___11 uu___12 in
+                                 FStar_Pprint.op_Hat_Hat
+                                   single_line_arg_indent uu___10 in
+                               jump2 uu___9 in
+                             FStar_Pprint.ifflat uu___7 uu___8 in
+                           FStar_Pprint.group uu___6 in
+                         let uu___6 =
+                           let uu___7 =
+                             let uu___8 =
+                               FStar_Pprint.op_Hat_Hat last_op1 ret_d in
+                             FStar_Pprint.hang last_n uu___8 in
+                           FStar_Pprint.align uu___7 in
+                         FStar_Pprint.prefix n Prims.int_one uu___5 uu___6 in
+                       FStar_Pprint.ifflat uu___3 uu___4 in
+                     FStar_Pprint.group uu___2)
 and (p_tmArrow :
   annotation_style ->
     Prims.bool ->
@@ -3899,86 +3935,104 @@ and (p_tmArrow :
     fun flat_space ->
       fun p_Tm ->
         fun e ->
-          let terms =
+          let uu___ =
             match style with
-            | Arrows uu___ -> p_tmArrow' p_Tm e
-            | Binders uu___ -> collapse_binders p_Tm e in
-          format_sig style terms false flat_space
+            | Arrows uu___1 -> p_tmArrow' p_Tm e
+            | Binders uu___1 -> collapse_binders style p_Tm e in
+          match uu___ with
+          | (terms, ret_d) -> format_sig style terms ret_d false flat_space
 and (p_tmArrow' :
   (FStar_Parser_AST.term -> FStar_Pprint.document) ->
-    FStar_Parser_AST.term -> FStar_Pprint.document Prims.list)
+    FStar_Parser_AST.term ->
+      (FStar_Pprint.document Prims.list * FStar_Pprint.document))
   =
   fun p_Tm ->
     fun e ->
       match e.FStar_Parser_AST.tm with
       | FStar_Parser_AST.Product (bs, tgt) ->
-          let uu___ = FStar_Compiler_List.map (fun b -> p_binder false b) bs in
-          let uu___1 = p_tmArrow' p_Tm tgt in
-          FStar_Compiler_List.op_At uu___ uu___1
-      | uu___ -> let uu___1 = p_Tm e in [uu___1]
+          let bs_ds = FStar_Compiler_List.map (fun b -> p_binder false b) bs in
+          let uu___ = p_tmArrow' p_Tm tgt in
+          (match uu___ with
+           | (bs_ds', ret) -> ((FStar_Compiler_List.op_At bs_ds bs_ds'), ret))
+      | uu___ -> let uu___1 = p_Tm e in ([], uu___1)
 and (collapse_binders :
-  (FStar_Parser_AST.term -> FStar_Pprint.document) ->
-    FStar_Parser_AST.term -> FStar_Pprint.document Prims.list)
+  annotation_style ->
+    (FStar_Parser_AST.term -> FStar_Pprint.document) ->
+      FStar_Parser_AST.term ->
+        (FStar_Pprint.document Prims.list * FStar_Pprint.document))
   =
-  fun p_Tm ->
-    fun e ->
-      let rec accumulate_binders p_Tm1 e1 =
-        match e1.FStar_Parser_AST.tm with
-        | FStar_Parser_AST.Product (bs, tgt) ->
-            let uu___ =
-              FStar_Compiler_List.map (fun b -> p_binder' true false b) bs in
-            let uu___1 = accumulate_binders p_Tm1 tgt in
-            FStar_Compiler_List.op_At uu___ uu___1
-        | uu___ ->
-            let uu___1 =
-              let uu___2 = p_Tm1 e1 in
-              (uu___2, FStar_Pervasives_Native.None, cat_with_colon) in
-            [uu___1] in
-      let fold_fun bs x =
-        let uu___ = x in
-        match uu___ with
-        | (b1, t1, f1) ->
-            (match bs with
-             | [] -> [([b1], t1, f1)]
-             | hd::tl ->
-                 let uu___1 = hd in
-                 (match uu___1 with
-                  | (b2s, t2, uu___2) ->
-                      (match (t1, t2) with
-                       | (FStar_Pervasives_Native.Some typ1,
-                          FStar_Pervasives_Native.Some typ2) ->
-                           if typ1 = typ2
-                           then
-                             ((FStar_Compiler_List.op_At b2s [b1]), t1, f1)
+  fun style ->
+    fun p_Tm ->
+      fun e ->
+        let atomize =
+          match style with | Binders (uu___, uu___1, a) -> a | uu___ -> false in
+        let wrap is_tc doc =
+          if is_tc
+          then tc_arg doc
+          else if atomize then soft_parens_with_nesting doc else doc in
+        let rec accumulate_binders p_Tm1 e1 =
+          match e1.FStar_Parser_AST.tm with
+          | FStar_Parser_AST.Product (bs, tgt) ->
+              let bs_ds =
+                FStar_Compiler_List.map
+                  (fun b ->
+                     let uu___ = p_binder' true false b in
+                     let uu___1 = is_tc_binder b in
+                     let uu___2 = is_joinable_binder b in
+                     (uu___, uu___1, uu___2)) bs in
+              let uu___ = accumulate_binders p_Tm1 tgt in
+              (match uu___ with
+               | (bs_ds', ret) ->
+                   ((FStar_Compiler_List.op_At bs_ds bs_ds'), ret))
+          | uu___ -> let uu___1 = p_Tm1 e1 in ([], uu___1) in
+        let fold_fun bs x =
+          let uu___ = x in
+          match uu___ with
+          | ((b1, t1), tc1, j1) ->
+              (match bs with
+               | [] -> [([b1], t1, tc1, j1)]
+               | hd::tl ->
+                   let uu___1 = hd in
+                   (match uu___1 with
+                    | (b2s, t2, tc2, j2) ->
+                        (match (t1, t2) with
+                         | (FStar_Pervasives_Native.Some (typ1, catf1),
+                            FStar_Pervasives_Native.Some (typ2, uu___2)) when
+                             ((typ1 = typ2) && j1) && j2 ->
+                             ((FStar_Compiler_List.op_At b2s [b1]), t1,
+                               false, true)
                              :: tl
-                           else ([b1], t1, f1) :: hd :: tl
-                       | uu___3 -> ([b1], t1, f1) :: bs))) in
-      let p_collapsed_binder cb =
-        let uu___ = cb in
-        match uu___ with
-        | (bs, t, f) ->
-            (match t with
-             | FStar_Pervasives_Native.None ->
-                 (match bs with
-                  | b::[] -> b
-                  | uu___1 -> failwith "Impossible")
-             | FStar_Pervasives_Native.Some typ ->
-                 (match bs with
-                  | [] -> failwith "Impossible"
-                  | b::[] -> f b typ
-                  | hd::tl ->
-                      let uu___1 =
-                        FStar_Compiler_List.fold_left
-                          (fun x ->
-                             fun y ->
-                               let uu___2 =
-                                 FStar_Pprint.op_Hat_Hat FStar_Pprint.space y in
-                               FStar_Pprint.op_Hat_Hat x uu___2) hd tl in
-                      f uu___1 typ)) in
-      let binders =
+                         | uu___2 -> ([b1], t1, tc1, j1) :: bs))) in
+        let p_collapsed_binder cb =
+          let uu___ = cb in
+          match uu___ with
+          | (bs, t, is_tc, uu___1) ->
+              (match t with
+               | FStar_Pervasives_Native.None ->
+                   (match bs with
+                    | b::[] -> wrap is_tc b
+                    | uu___2 -> failwith "Impossible")
+               | FStar_Pervasives_Native.Some (typ, f) ->
+                   (match bs with
+                    | [] -> failwith "Impossible"
+                    | hd::tl ->
+                        let uu___2 =
+                          let uu___3 =
+                            FStar_Compiler_List.fold_left
+                              (fun x ->
+                                 fun y ->
+                                   let uu___4 =
+                                     FStar_Pprint.op_Hat_Hat
+                                       FStar_Pprint.space y in
+                                   FStar_Pprint.op_Hat_Hat x uu___4) hd tl in
+                          f uu___3 typ in
+                        FStar_Compiler_Effect.op_Less_Bar (wrap is_tc) uu___2)) in
         let uu___ = accumulate_binders p_Tm e in
-        FStar_Compiler_List.fold_left fold_fun [] uu___ in
-      map_rev p_collapsed_binder binders
+        match uu___ with
+        | (bs_ds, ret_d) ->
+            let binders = FStar_Compiler_List.fold_left fold_fun [] bs_ds in
+            let uu___1 = map_rev p_collapsed_binder binders in
+            (uu___1, ret_d)
 and (p_tmFormula : FStar_Parser_AST.term -> FStar_Pprint.document) =
   fun e ->
     let conj =
@@ -4672,14 +4726,16 @@ and (p_constant : FStar_Const.sconst -> FStar_Pprint.document) =
           | FStar_Const.Int16 -> str "s"
           | FStar_Const.Int32 -> str "l"
           | FStar_Const.Int64 -> str "L" in
-        let ending =
-          default_or_map FStar_Pprint.empty
-            (fun uu___1 ->
-               match uu___1 with
-               | (s, w) ->
-                   let uu___2 = signedness s in
-                   let uu___3 = width w in
-                   FStar_Pprint.op_Hat_Hat uu___2 uu___3) sign_width_opt in
+        let suffix uu___1 =
+          match uu___1 with
+          | (s, w) ->
+              (match (s, w) with
+               | (uu___2, FStar_Const.Sizet) -> str "sz"
+               | uu___2 ->
+                   let uu___3 = signedness s in
+                   let uu___4 = width w in
+                   FStar_Pprint.op_Hat_Hat uu___3 uu___4) in
+        let ending = default_or_map FStar_Pprint.empty suffix sign_width_opt in
         let uu___1 = str repr in FStar_Pprint.op_Hat_Hat uu___1 ending
     | FStar_Const.Const_range_of -> str "range_of"
     | FStar_Const.Const_set_range_of -> str "set_range_of"

--- a/src/ocaml-output/FStar_Syntax_Resugar.ml
+++ b/src/ocaml-output/FStar_Syntax_Resugar.ml
@@ -2191,6 +2191,10 @@ and (resugar_bqual :
       | FStar_Pervasives_Native.Some (FStar_Syntax_Syntax.Equality) ->
           FStar_Pervasives_Native.Some
             (FStar_Pervasives_Native.Some FStar_Parser_AST.Equality)
+      | FStar_Pervasives_Native.Some (FStar_Syntax_Syntax.Meta t) when
+          FStar_Syntax_Util.is_fvar FStar_Parser_Const.tcresolve_lid t ->
+          FStar_Pervasives_Native.Some
+            (FStar_Pervasives_Native.Some FStar_Parser_AST.TypeClassArg)
       | FStar_Pervasives_Native.Some (FStar_Syntax_Syntax.Meta t) ->
           let uu___ =
             let uu___1 =

--- a/src/ocaml-output/FStar_ToSyntax_ToSyntax.ml
+++ b/src/ocaml-output/FStar_ToSyntax_ToSyntax.ml
@@ -6128,6 +6128,8 @@ let rec (desugar_tycon :
                   FStar_Parser_AST.Hash
               | FStar_Pervasives_Native.Some (FStar_Parser_AST.Meta uu___) ->
                   FStar_Parser_AST.Hash
+              | FStar_Pervasives_Native.Some (FStar_Parser_AST.TypeClassArg)
+                  -> FStar_Parser_AST.Hash
               | uu___ -> FStar_Parser_AST.Nothing in
             FStar_Compiler_List.fold_left
               (fun out ->

--- a/src/ocaml-output/FStar_ToSyntax_ToSyntax.ml
+++ b/src/ocaml-output/FStar_ToSyntax_ToSyntax.ml
@@ -5697,6 +5697,13 @@ and (trans_bqual :
             let uu___2 = desugar_term env t in
             FStar_Syntax_Syntax.Meta uu___2 in
           FStar_Pervasives_Native.Some uu___1
+      | FStar_Pervasives_Native.Some (FStar_Parser_AST.TypeClassArg) ->
+          let tcresolve =
+            desugar_term env
+              (FStar_Parser_AST.mk_term
+                 (FStar_Parser_AST.Var FStar_Parser_Const.tcresolve_lid)
+                 FStar_Compiler_Range.dummyRange FStar_Parser_AST.Expr) in
+          FStar_Pervasives_Native.Some (FStar_Syntax_Syntax.Meta tcresolve)
       | FStar_Pervasives_Native.None -> FStar_Pervasives_Native.None
 let (typars_of_binders :
   FStar_Syntax_DsEnv.env ->

--- a/src/parser/FStar.Parser.Dep.fst
+++ b/src/parser/FStar.Parser.Dep.fst
@@ -857,6 +857,7 @@ let collect_one
 
       and collect_aqual = function
         | Some (Meta t) -> collect_term t
+        | Some TypeClassArg -> add_to_parsing_data (P_lid Const.tcresolve_lid)
         | _ -> ()
 
       and collect_term t =

--- a/src/parser/FStar.Parser.ToDocument.fst
+++ b/src/parser/FStar.Parser.ToDocument.fst
@@ -971,6 +971,9 @@ and p_aqual = function
       | _ -> mk_term (App (t, unit_const t.range, Nothing)) t.range Expr
     in
     str "#[" ^^ p_term false false t ^^ str "]" ^^ break1
+  | TypeClassArg ->
+    (* fake it for now *)
+    str "#[tcresolve()]"
 
 (* ****************************************************************************)
 (*                                                                            *)

--- a/src/parser/FStar.Parser.ToDocument.fst
+++ b/src/parser/FStar.Parser.ToDocument.fst
@@ -2087,7 +2087,14 @@ and p_constant = function
           | Int32 -> str "l"
           | Int64 -> str "L"
       in
-      let ending = default_or_map empty (fun (s, w) -> signedness s ^^ width w) sign_width_opt in
+      let suffix (s, w) =
+        (* This handles the Sizet case, which is unsigned but
+         * does not have a "u" suffix. *)
+        match (s, w) with
+        | _, Sizet -> str "sz"
+        | _ -> signedness s ^^ width w
+      in
+      let ending = default_or_map empty suffix sign_width_opt in
       str repr ^^ ending
   | Const_range_of -> str "range_of"
   | Const_set_range_of -> str "set_range_of"

--- a/src/parser/FStar.Parser.ToDocument.fst
+++ b/src/parser/FStar.Parser.ToDocument.fst
@@ -162,6 +162,22 @@ let soft_brackets_with_nesting contents =
 let soft_begin_end_with_nesting contents =
   soft_surround 2 1 (str "begin") contents (str "end")
 
+let tc_arg contents =
+  soft_surround 2 1 (str "{|") contents (str "|}")
+
+let is_tc_binder (b:binder) : bool =
+  match b.aqual with
+  | Some TypeClassArg -> true
+  | _ -> false
+
+let is_meta_qualifier aq =
+  match aq with
+  | Some (Meta _) -> true
+  | _ -> false
+
+let is_joinable_binder (b:binder) : bool =
+  not (is_tc_binder b) && not (is_meta_qualifier b.aqual)
+
 let separate_map_last sep f es =
   let l = List.length es in
   let es = List.mapi (fun i e -> f (i <> l - 1) e) es in
@@ -850,12 +866,12 @@ and p_letlhs kw (pat, _) inner_let =
         // VD: should we indent inner lets less?
         if inner_let then
           let bs, style = pats_as_binders_if_possible pats in
-          bs @ [ascr_doc], style
+          bs, style
         else
           let bs, style = pats_as_binders_if_possible pats in
-          bs @ [ascr_doc], style
+          bs, style
       in
-      group <| kw ^^ space ^^ p_lident lid ^^ (format_sig style terms true true)
+      group <| kw ^^ space ^^ p_lident lid ^^ (format_sig style terms ascr_doc true true)
   | _ ->
       (* doesn't have binders *)
       let ascr_doc =
@@ -961,6 +977,8 @@ and p_letqualifier = function
   | Rec -> space ^^ str "rec"
   | NoLetQualifier -> empty
 
+(* This prints both arg qualifiers and binder qualifiers. Note that Meta and
+Typeclass do not make sense for arg qualifiers. *)
 and p_aqual = function
   | Implicit -> str "#"
   | Equality -> str "$"
@@ -971,9 +989,7 @@ and p_aqual = function
       | _ -> mk_term (App (t, unit_const t.range, Nothing)) t.range Expr
     in
     str "#[" ^^ p_term false false t ^^ str "]" ^^ break1
-  | TypeClassArg ->
-    (* fake it for now *)
-    str "#[tcresolve()]"
+  | TypeClassArg -> empty (* This is handled externally *)
 
 (* ****************************************************************************)
 (*                                                                            *)
@@ -1015,6 +1031,14 @@ and p_atomicPattern p = match p.pat with
       soft_parens_with_nesting (p_refinement aqual attrs (p_ident lid) t phi)
     | PatWild (aqual, attrs), Refine({b = NoName t}, phi) ->
       soft_parens_with_nesting (p_refinement aqual attrs underscore t phi)
+    | PatVar (_, aqual, _), _
+    | PatWild (aqual, _), _ ->
+        let wrap =
+          if aqual = Some TypeClassArg
+          then tc_arg
+          else soft_parens_with_nesting
+        in
+        wrap (p_tuplePattern pat ^^ colon ^/^ p_tmEqNoRefinement t)
     | _ ->
         (* TODO implement p_simpleArrow *)
         soft_parens_with_nesting (p_tuplePattern pat ^^ colon ^/^ p_tmEqNoRefinement t)
@@ -1053,22 +1077,28 @@ and is_typ_tuple e = match e.tm with
   | Op(id, _) when string_of_id id = "*" -> true
   | _ -> false
 
-and is_meta_qualifier aq =
-  match aq with
-  | Some (Meta _) -> true
-  | _ -> false
-
 and p_binder is_atomic b =
-  let b', t', catf = p_binder' false is_atomic b in
-  match t' with
-  | Some typ -> catf b' typ
-  | None -> b'
+  let is_tc = is_tc_binder b in
+  let b', t' = p_binder' false (is_atomic && not is_tc) b in
+  let d =
+    match t' with
+    | Some (typ, catf) -> catf b' typ
+    | None -> b'
+  in
+  if is_tc
+  then tc_arg d
+  else d
 
 (* is_atomic is true if the binder must be parsed atomically *)
-and p_binder' (no_pars: bool) (is_atomic: bool) (b: binder): document * option document * catf =
+// Returns:
+//  1- a doc for binder
+//  2- optionally: a doc for the type annotation (if any), and a function to concat it to the binder
+// When the binder is nameless, the at
+// This does NOT handle typeclass arguments. The wrapping is done from the outside.
+and p_binder' (no_pars: bool) (is_atomic: bool) (b: binder): document * option (document * catf) =
   match b.b with
-  | Variable lid -> optional p_aqual b.aqual ^^ p_attributes false b.battributes ^^ p_lident lid, None, cat_with_colon
-  | TVariable lid -> p_attributes false b.battributes ^^ p_lident lid, None, cat_with_colon
+  | Variable lid -> optional p_aqual b.aqual ^^ p_attributes false b.battributes ^^ p_lident lid, None
+  | TVariable lid -> p_attributes false b.battributes ^^ p_lident lid, None
   | Annotated (lid, t) ->
       let b', t' =
         match t.tm with
@@ -1088,17 +1118,17 @@ and p_binder' (no_pars: bool) (is_atomic: bool) (b: binder): document * option d
           else
             (fun x y -> group (cat_with_colon x y))
         in
-        b', Some t', catf
+        b', Some (t', catf)
   | TAnnotated _ -> failwith "Is this still used ?"
   | NoName t ->
     begin match t.tm with
       | Refine ({b = NoName t}, phi) ->
         let b', t' = p_refinement' b.aqual b.battributes underscore t phi in
-        b', Some t', cat_with_colon
+        b', Some (t', cat_with_colon)
       | _ ->
-        if is_atomic
-        then p_attributes false b.battributes ^^ p_atomicTerm t, None, cat_with_colon (* t is a type but it might need some parenthesis *)
-        else p_attributes false b.battributes ^^ p_appTerm t, None, cat_with_colon (* This choice seems valid (used in p_tmNoEq') *)
+        let pref = optional p_aqual b.aqual ^^ p_attributes false b.battributes in
+        let p_Tm = if is_atomic then p_atomicTerm else p_appTerm in
+        pref ^^ p_Tm t, None
     end 
 
 and p_refinement aqual_opt attrs binder t phi =
@@ -1549,43 +1579,49 @@ and sig_as_binders_if_possible t extra_space =
   else
     group (colon ^^ s ^^ p_typ_top (Arrows (2, 2)) false false t)
 
-and collapse_pats (pats: list (document * document)): list document =
-  let fold_fun (bs: list (list document * document)) (x: document * document) =
-    let b1, t1 = x in
+// Typeclass arguments are not collapsed.
+and collapse_pats (pats: list (document * document * bool * bool)): list document =
+  let fold_fun (bs: list (list document * document * bool * bool)) (x: document * document * bool * bool) =
+    let b1, t1, tc1, j1 = x in
     match bs with
-    | [] -> [([b1], t1)]
+    | [] -> [([b1], t1, tc1, j1)]
     | hd::tl ->
-      let b2s, t2 = hd in
-      if t1 = t2 then
-        (b2s @ [b1], t1) :: tl
+      let b2s, t2, tc2, j2 = hd in
+      if t1 = t2 && j1 && j2 then
+        (b2s @ [b1], t1, false, true) :: tl
       else
-        ([b1], t1) :: hd :: tl
+        ([b1], t1, tc1, j1) :: hd :: tl
   in
-  let p_collapsed_binder (cb: list document * document): document =
-    let bs, typ = cb in
-    match bs with
-    | [] -> failwith "Impossible" // can't have dangling type
-    | [b] -> cat_with_colon b typ
-    | hd::tl -> cat_with_colon (List.fold_left (fun x y -> x ^^ space ^^ y) hd tl) typ
+  let p_collapsed_binder (cb: list document * document * bool * bool): document =
+    let bs, typ, istcarg, _ = cb in
+    let body =
+      match bs with
+      | [] -> failwith "Impossible" // can't have dangling type
+      | hd::tl -> cat_with_colon (List.fold_left (fun x y -> x ^^ space ^^ y) hd tl) typ
+    in
+    if istcarg
+    then tc_arg body
+    else soft_parens_with_nesting body
   in
   let binders = List.fold_left fold_fun [] (List.rev pats) in
   map_rev p_collapsed_binder binders
 
-and pats_as_binders_if_possible pats =
-  let all_binders p = match p.pat with
+and pats_as_binders_if_possible pats : list document & annotation_style =
+  // returns: doc for name, doc for type, boolean if typeclass arg
+  let all_binders (p:pattern) : option (document & document & bool & bool) =
+  match p.pat with
   | PatAscribed(pat, (t, None)) ->
-    (match pat.pat, t.tm  with
+    (match pat.pat, t.tm with
      | PatVar (lid, aqual, attrs), Refine({b = Annotated(lid', t)}, phi)
        when (string_of_id lid) = (string_of_id lid') ->
-         Some (p_refinement' aqual attrs (p_ident lid) t phi)
+         let (x, y) = p_refinement' aqual attrs (p_ident lid) t phi in
+         Some (x, y, false, false)
      | PatVar (lid, aqual, attrs), _ ->
-       Some (optional p_aqual aqual ^^ p_attributes false attrs ^^  p_ident lid, p_tmEqNoRefinement t)
+       let is_tc = aqual = Some TypeClassArg in
+       let is_meta = match aqual with | Some (Meta _) -> true | _ -> false in
+       Some (optional p_aqual aqual ^^ p_attributes false attrs ^^  p_ident lid, p_tmEqNoRefinement t, is_tc, not is_tc && not is_meta)
      | _ -> None)
   | _ -> None
-  in
-  let all_unbound p = match p.pat with
-  | PatAscribed _ -> false
-  | _ -> true
   in
   match map_if_all all_binders pats with
   | Some bs ->
@@ -1689,41 +1725,41 @@ and p_tmImplies e = match e.tm with
 // It also needs to make adjustments depending on which style a signature
 // is to be printed in. For more details see the `annotation_style` type
 // definition.
-and format_sig style terms no_last_op flat_space =
-  let terms', last = List.splitAt (List.length terms - 1) terms in
-  let n, last_n, terms', sep, last_op =
+and format_sig style terms ret_d no_last_op flat_space =
+  let n, last_n, sep, last_op =
     match style with
     | Arrows (n, ln)->
-        n, ln, terms', space ^^ rarrow ^^ break1, rarrow ^^ space
+        n, ln, space ^^ rarrow ^^ break1, rarrow ^^ space
     | Binders (n, ln, parens) ->
-        n, ln,
-        (if parens then List.map soft_parens_with_nesting terms' else terms'),
-        break1, colon ^^ space
+        n, ln, break1, colon ^^ space
   in
-  let last = List.hd last in
-  let last_op = if List.length terms > 1 && (not no_last_op) then last_op else empty in
-  let one_line_space = if not (last = empty) || not no_last_op then space else empty in
+  let last_op = if List.length terms > 0 && (not no_last_op) then last_op else empty in
+  let one_line_space = if not (ret_d = empty) || not no_last_op then space else empty in
   let single_line_arg_indent = repeat n space in
   let fs = if flat_space then space else empty in
   match List.length terms with
-  | 1 -> List.hd terms
-  | _ -> group (ifflat (fs ^^ (separate sep terms') ^^ one_line_space ^^ last_op ^^ last)
-           (prefix n 1 (group ((ifflat (fs ^^ separate sep terms')
-             (jump2 ((single_line_arg_indent ^^ separate (sep ^^ single_line_arg_indent) (List.map (fun x -> align (hang 2 x)) terms')))))))
-               (align (hang last_n (last_op ^^ last)))))
+  | 0 -> ret_d
+  | _ -> group (ifflat (fs ^^ (separate sep terms) ^^ one_line_space ^^ last_op ^^ ret_d)
+           (prefix n 1 (group ((ifflat (fs ^^ separate sep terms)
+             (jump2 ((single_line_arg_indent ^^ separate (sep ^^ single_line_arg_indent) (List.map (fun x -> align (hang 2 x)) terms)))))))
+               (align (hang last_n (last_op ^^ ret_d)))))
 
 and p_tmArrow style flat_space p_Tm e =
-  let terms =
+  let terms, ret_d =
     match style with
     | Arrows _ -> p_tmArrow' p_Tm e
-    | Binders _ -> collapse_binders p_Tm e
+    | Binders _ -> collapse_binders style p_Tm e
   in
-  format_sig style terms false flat_space
+  format_sig style terms ret_d false flat_space
 
-and p_tmArrow' p_Tm e =
+and p_tmArrow' p_Tm e : list document & document =
   match e.tm with
-  | Product(bs, tgt) -> (List.map (fun b -> p_binder false b) bs) @ (p_tmArrow' p_Tm tgt)
-  | _ -> [p_Tm e]
+  | Product(bs, tgt) ->
+    let bs_ds = List.map (fun b -> p_binder false b) bs in
+    let bs_ds', ret = p_tmArrow' p_Tm tgt in
+    bs_ds@bs_ds', ret
+  | _ ->
+    ([], p_Tm e)
 
 // When printing in `Binders` style, collapse binders which have the same
 // type, so instead of printing
@@ -1731,45 +1767,66 @@ and p_tmArrow' p_Tm e =
 // print
 //    val f (a b c: t) : Tot nat
 // For this, we use the generalised version of p_binder, which returns
-// the binder, its type (as an optional) and a function which
+// the binder, and optionally its type and a function which
 // concatenates them.
-and collapse_binders (p_Tm: term -> document) (e: term): list document =
-  let rec accumulate_binders p_Tm e: list (document * option document * catf) =
+and collapse_binders (style : annotation_style) (p_Tm: term -> document) (e: term): list document & document =
+  let atomize = match style with
+   | Binders (_, _, a) -> a
+   | _ -> false
+  in
+  let wrap is_tc doc =
+    if is_tc then tc_arg doc
+    else if atomize then soft_parens_with_nesting doc
+    else doc
+  in
+  // For each binder, return:
+  // - document for binder
+  // - optional annotation doc + cat function
+  // - whether it was a typeclass arg
+  // - whether it is joinable (tc args and meta args are not)
+  let rec accumulate_binders p_Tm e: list ((document * option (document * catf)) * bool * bool) & document =
     match e.tm with
-    | Product(bs, tgt) -> (List.map (fun b -> p_binder' true false b) bs) @ (accumulate_binders p_Tm tgt)
-    | _ -> [(p_Tm e, None, cat_with_colon)]
+    | Product(bs, tgt) ->
+        let bs_ds = List.map (fun b -> p_binder' true false b, is_tc_binder b, is_joinable_binder b) bs in
+        let bs_ds', ret = accumulate_binders p_Tm tgt in
+        bs_ds@bs_ds', ret
+    | _ -> ([], p_Tm e)
   in
-  let fold_fun (bs: list (list document * option document * catf)) (x: document * option document * catf) =
-    let b1, t1, f1 = x in
+  let fold_fun (bs: list (list document * option (document * catf) * bool * bool)) (x: (document * option (document * catf)) * bool * bool) =
+    let (b1, t1), tc1, j1 = x in
     match bs with
-    | [] -> [([b1], t1, f1)]
+    | [] -> [([b1], t1, tc1, j1)]
     | hd::tl ->
-      let b2s, t2, _ = hd in
+      let b2s, t2, tc2, j2 = hd in
       match (t1, t2) with
-      | (Some typ1, Some typ2) ->
-        if typ1 = typ2 then
-          (b2s @ [b1], t1, f1) :: tl
-        else
-          ([b1], t1, f1) :: hd :: tl
-      | _ -> ([b1], t1, f1) :: bs
+      | Some (typ1, catf1), Some (typ2, _)
+        when typ1 = typ2 && j1 && j2 ->
+        (* If the `x` binder has the same type as the group that follows,
+         * and both are joinable (the group and the new binder), then join
+         * them. Take the cat function from x. NOTE: if they were joinable,
+         * then they are not tc-args, hence the false. *)
+          (b2s @ [b1], t1, false, true) :: tl
+      | _ ->
+        (* Otherwise just make a new group *)
+        ([b1], t1, tc1, j1) :: bs
   in
-  let p_collapsed_binder (cb: list document * option document * catf): document =
-    let bs, t, f = cb in
+  let p_collapsed_binder (cb: list document * option (document * catf) * bool * bool): document =
+    let bs, t, is_tc, _ = cb in
     match t with
     | None -> begin
       match bs with
-      | [b] -> b
+      | [b] -> wrap is_tc b
       | _ -> failwith "Impossible" // can't have dangling type or collapse unannotated binders
     end
-    | Some typ -> begin
+    | Some (typ, f) -> begin
       match bs with
       | [] -> failwith "Impossible" // can't have dangling type
-      | [b] -> f b typ
-      | hd::tl -> f (List.fold_left (fun x y -> x ^^ space ^^ y) hd tl) typ
+      | hd::tl -> wrap is_tc <| f (List.fold_left (fun x y -> x ^^ space ^^ y) hd tl) typ
     end
   in
-  let binders = List.fold_left fold_fun [] (accumulate_binders p_Tm e) in
-  map_rev p_collapsed_binder binders
+  let bs_ds, ret_d = accumulate_binders p_Tm e in
+  let binders = List.fold_left fold_fun [] bs_ds in
+  map_rev p_collapsed_binder binders, ret_d
 
 and p_tmFormula e =
     let conj = space ^^ (str "/\\") ^^ break1 in

--- a/src/parser/parse.mly
+++ b/src/parser/parse.mly
@@ -557,31 +557,19 @@ fieldPattern:
   (* we do *NOT* allow _ in multibinder () since it creates reduce/reduce conflicts when*)
   (* preprocessing to ocamlyacc/fsyacc (which is expected since the macro are expanded) *)
 patternOrMultibinder:
-  | LBRACE_BAR UNDERSCORE COLON t=simpleArrow BAR_RBRACE
-      { let mt = mk_term (Var tcresolve_lid) (rhs parseState 4) Type_level in
-        let w = mk_pattern (PatWild (Some (mk_meta_tac mt), []))
-                                 (rhs2 parseState 1 5) in
+  | LBRACE_BAR id=lidentOrUnderscore COLON t=simpleArrow BAR_RBRACE
+      { let r = rhs2 parseState 1 5 in
+        let w = mk_pattern (PatVar (id, Some TypeClassArg, [])) r in
         let asc = (t, None) in
-        [mk_pattern (PatAscribed(w, asc)) (rhs2 parseState 1 5)]
-      }
-
-  (* GM: I would rather use lidentOrUnderscore and delete the rule above,
-   * but I need to produce a PatWild above, and a PatVar here. However
-   * why does PatWild even exist..? *)
-  | LBRACE_BAR i=lident COLON t=simpleArrow BAR_RBRACE
-      { let mt = mk_term (Var tcresolve_lid) (rhs parseState 4) Type_level in
-        let w = mk_pattern (PatVar (i, Some (mk_meta_tac mt), []))
-                                 (rhs2 parseState 1 5) in
-        let asc = (t, None) in
-        [mk_pattern (PatAscribed(w, asc)) (rhs2 parseState 1 5)]
+        [mk_pattern (PatAscribed(w, asc)) r]
       }
 
   | LBRACE_BAR t=simpleArrow BAR_RBRACE
-      { let mt = mk_term (Var tcresolve_lid) (rhs parseState 2) Type_level in
-        let w = mk_pattern (PatVar (gen (rhs2 parseState 1 3), Some (mk_meta_tac mt), []))
-                                 (rhs2 parseState 1 3) in
+      { let r = rhs2 parseState 1 3 in
+        let id = gen r in
+        let w = mk_pattern (PatVar (id, Some TypeClassArg, [])) r in
         let asc = (t, None) in
-        [mk_pattern (PatAscribed(w, asc)) (rhs2 parseState 1 3)]
+        [mk_pattern (PatAscribed(w, asc)) r]
       }
   | pat=atomicPattern { [pat] }
   | LPAREN qual_id0=aqualifiedWithAttrs(lident) qual_ids=nonempty_list(aqualifiedWithAttrs(lident)) COLON t=simpleArrow r=refineOpt RPAREN
@@ -604,16 +592,14 @@ binder:
 
 multiBinder:
   | LBRACE_BAR id=lidentOrUnderscore COLON t=simpleArrow BAR_RBRACE
-      { let mt = mk_term (Var tcresolve_lid) (rhs parseState 4) Type_level in
-        let r = rhs2 parseState 1 5 in
-        [mk_binder (Annotated (id, t)) r Type_level (Some (mk_meta_tac mt))]
+      { let r = rhs2 parseState 1 5 in
+        [mk_binder (Annotated (id, t)) r Type_level (Some TypeClassArg)]
       }
 
   | LBRACE_BAR t=simpleArrow BAR_RBRACE
-      { let mt = mk_term (Var tcresolve_lid) (rhs parseState 2) Type_level in
-        let r = rhs2 parseState 1 3 in
+      { let r = rhs2 parseState 1 3 in
         let id = gen r in
-        [mk_binder (Annotated (id, t)) r Type_level (Some (mk_meta_tac mt))]
+        [mk_binder (Annotated (id, t)) r Type_level (Some TypeClassArg)]
       }
 
   | LPAREN qual_ids=nonempty_list(aqualifiedWithAttrs(lidentOrUnderscore)) COLON t=simpleArrow r=refineOpt RPAREN
@@ -1028,18 +1014,12 @@ simpleArrow:
   | e=tmEqNoRefinement { e }
 
 simpleArrowDomain:
-  | LBRACE_BAR t=tmEqNoRefinement BAR_RBRACE
-      { let mt = mk_term (Var tcresolve_lid) (rhs parseState 4) Type_level in
-        ((Some (mk_meta_tac mt), []), t)
-      }
+  | LBRACE_BAR t=tmEqNoRefinement BAR_RBRACE { ((Some TypeClassArg, []), t) }
   | aq_opt=ioption(aqual) attrs_opt=ioption(binderAttributes) dom_tm=tmEqNoRefinement { (aq_opt, none_to_empty_list attrs_opt), dom_tm }
 
 (* Tm already account for ( term ), we need to add an explicit case for (#Tm) *)
 %inline tmArrowDomain(Tm):
-  | LBRACE_BAR t=Tm BAR_RBRACE
-      { let mt = mk_term (Var tcresolve_lid) (rhs parseState 4) Type_level in
-        ((Some (mk_meta_tac mt), []), t)
-      }
+  | LBRACE_BAR t=Tm BAR_RBRACE { ((Some TypeClassArg, []), t) }
   | LPAREN q=aqual attrs_opt=ioption(binderAttributes) dom_tm=Tm RPAREN { (Some q, none_to_empty_list attrs_opt), dom_tm }
   | aq_opt=ioption(aqual) attrs_opt=ioption(binderAttributes) dom_tm=Tm { (aq_opt, none_to_empty_list attrs_opt), dom_tm }
 

--- a/src/syntax/FStar.Syntax.Resugar.fst
+++ b/src/syntax/FStar.Syntax.Resugar.fst
@@ -1159,6 +1159,8 @@ and resugar_bqual env (q:S.bqual) : option (option A.arg_qualifier) =
     if b then None
     else Some (Some A.Implicit)
   | Some S.Equality -> Some (Some A.Equality)
+  | Some (S.Meta t) when U.is_fvar C.tcresolve_lid t ->
+    Some (Some (A.TypeClassArg))
   | Some (S.Meta t) ->
     Some (Some (A.Meta (resugar_term' env t)))
 

--- a/src/tosyntax/FStar.ToSyntax.ToSyntax.fst
+++ b/src/tosyntax/FStar.ToSyntax.ToSyntax.fst
@@ -2773,8 +2773,9 @@ let rec desugar_tycon env (d: AST.decl) quals tcs : (env_t * sigelts) =
   let with_constructor_effect t = mk_term (App(tot, t, Nothing)) t.range t.level in
   let apply_binders t binders =
     let imp_of_aqual (b:AST.binder) = match b.aqual with
-        | Some Implicit -> Hash
-        | Some (Meta _) -> Hash
+        | Some Implicit
+        | Some (Meta _)
+        | Some TypeClassArg -> Hash
         | _ -> Nothing in
     List.fold_left (fun out b -> mk_term (App(out, binder_to_term b, imp_of_aqual b)) out.range out.level)
       t binders in

--- a/src/tosyntax/FStar.ToSyntax.ToSyntax.fst
+++ b/src/tosyntax/FStar.ToSyntax.ToSyntax.fst
@@ -2603,6 +2603,9 @@ and trans_bqual env = function
   | Some AST.Equality -> Some S.Equality
   | Some (AST.Meta t) ->
     Some (S.Meta (desugar_term env t))
+  | Some (AST.TypeClassArg) ->
+    let tcresolve = desugar_term env (mk_term (Var C.tcresolve_lid) Range.dummyRange Expr) in
+    Some (S.Meta tcresolve)
   | None -> None
 
 let typars_of_binders env bs : _ * binders =

--- a/tests/prettyprinting/MetaArgs.fst
+++ b/tests/prettyprinting/MetaArgs.fst
@@ -1,0 +1,13 @@
+module MetaArgs
+
+open FStar.Tactics
+let sometac () : Tac unit = exact (`42)
+
+let diag (x : int) (#[exact (quote x)] y : int) : tuple2 int int = (x, y)
+
+val ee (#a: Type) (#[sometac()] dict: int) : unit
+val ff (#a: Type) (#[sometac()] _: int) : unit
+val gg: #a: Type -> #[sometac()] int -> unit
+val ee': #a: Type -> _: int -> (#[sometac()] dict: int) -> int -> unit
+val ff' (#a: Type) (_: int) (#[sometac()] _: int) (_: int) : unit
+val gg': #a: Type -> int -> #[sometac()] int -> int -> unit

--- a/tests/prettyprinting/MetaArgs.fst.expected
+++ b/tests/prettyprinting/MetaArgs.fst.expected
@@ -1,0 +1,14 @@
+module MetaArgs
+
+open FStar.Tactics
+let sometac () : Tac unit = exact (`42)
+
+let diag (x: int) (#[exact (quote x)] y: int) : tuple2 int int = (x, y)
+
+val ee (#a: Type) (#[sometac ()] dict: int) : unit
+val ff (#a: Type) (#[sometac ()] _: int) : unit
+val gg: #a: Type -> #[sometac ()] int -> unit
+val ee': #a: Type -> _: int -> (#[sometac ()] dict: int) -> int -> unit
+val ff' (#a: Type) (_: int) (#[sometac ()] _: int) (_: int) : unit
+val gg': #a: Type -> int -> #[sometac ()] int -> int -> unit
+

--- a/tests/prettyprinting/TypeClasses.fst
+++ b/tests/prettyprinting/TypeClasses.fst
@@ -1,0 +1,21 @@
+module TypeClasses
+
+class foo 'a = { test :'a -> string }
+
+val ee (#a: Type) {| dict: foo a |} : unit
+let ee {| dict: foo 'a |} = ()
+
+val ff (#a: Type) {| _: foo a |} : unit
+let ff {| _: foo 'a |} = ()
+
+val gg: #a: Type -> {| foo a |} -> unit
+let gg {| foo 'a |} = ()
+
+val ee': #a: Type -> _: int -> {| dict: foo a |} -> int -> unit
+let ee' x {| dict: foo 'a |} y = ()
+
+val ff' (#a: Type) (_: int) {| _: foo a |} (_: int) : unit
+let ff' x {| _: foo 'a |} y = ()
+
+val gg': #a: Type -> int -> {| foo a |} -> int -> unit
+let gg' x {| foo 'a |} y = ()

--- a/tests/prettyprinting/TypeClasses.fst.expected
+++ b/tests/prettyprinting/TypeClasses.fst.expected
@@ -1,0 +1,22 @@
+module TypeClasses
+
+class foo 'a = { test:'a -> string }
+
+val ee (#a: Type) {| dict: foo a |} : unit
+let ee {| dict: foo 'a |} = ()
+
+val ff (#a: Type) {| _: foo a |} : unit
+let ff {| _: foo 'a |} = ()
+
+val gg: #a: Type -> {| foo a |} -> unit
+let gg {| _: foo 'a |} = ()
+
+val ee': #a: Type -> _: int -> {| dict: foo a |} -> int -> unit
+let ee' x {| dict: foo 'a |} y = ()
+
+val ff' (#a: Type) (_: int) {| _: foo a |} (_: int) : unit
+let ff' x {| _: foo 'a |} y = ()
+
+val gg': #a: Type -> int -> {| foo a |} -> int -> unit
+let gg' x {| _: foo 'a |} y = ()
+


### PR DESCRIPTION
This is to fix #2821. However, it includes a bit of refactoring of the pretty printer, so a second look would be good... 

This also now forbids meta args (`#[tac] b : t`) from being collapsed a consecutive binder of type `t`. Even if that parses, I find it unidiomatic, but opinions welcome.