### PR TITLE
Fix minor typo in book

### DIFF
--- a/doc/book/part1/part1_getting_off_the_ground.rst
+++ b/doc/book/part1/part1_getting_off_the_ground.rst
@@ -392,7 +392,7 @@ languages.
 * F*'s arrows are dependent---the type of the result depends on the
   argument. For example, we can write a function that returns a
   ``bool`` when applied to an even number and returns a ``string``
-  when applied to an odd number. Or, more commonly, a function that
+  when applied to an odd number. Or, more commonly, a function
   whose result is one greater than its argument.
 
 * In F*'s core language, all functions are total, i.e., a function


### PR DESCRIPTION
Use either ”that“ or ”whose”.

(reading the book at the moment. I love it 👍)