### PR TITLE
Add functions to check the upper bounds of FStar.PtrdiffT

### DIFF
--- a/ulib/experimental/Steel.Array.fsti
+++ b/ulib/experimental/Steel.Array.fsti
@@ -404,6 +404,24 @@ let intro_fits_u64 (_:unit)
            emp (fun _ -> emp)
   = A.intro_fits_u64 ()
 
+/// Determining whether int32 values fit in a ptrdiff
+/// It will be natively extracted to static_assert (INT32_MAX <= PTRDIFF_MAX) by krml
+inline_for_extraction
+[@@noextract_to "krml"]
+let intro_fits_ptrdiff32 (_:unit)
+  : SteelT (squash (UP.fits (FStar.Int.max_int 32)))
+        emp (fun _ -> emp)
+  = A.intro_fits_ptrdiff32 ()
+
+/// Determining whether int64 values fit in a ptrdiff
+/// It will be natively extracted to static_assert (INT64_MAX <= PTRDIFF_MAX) by krml
+inline_for_extraction
+[@@noextract_to "krml"]
+let intro_fits_ptrdiff64 (_:unit)
+  : SteelT (squash (UP.fits (FStar.Int.max_int 64)))
+        emp (fun _ -> emp)
+  = A.intro_fits_ptrdiff64 ()
+
 inline_for_extraction
 [@@noextract_to "krml"]
 let ptrdiff (#a: Type) (#p1 #p2:P.perm) (arr1 arr2: array a)

--- a/ulib/experimental/Steel.ST.Array.fst
+++ b/ulib/experimental/Steel.ST.Array.fst
@@ -535,6 +535,8 @@ let compare
 
 let intro_fits_u32 () = H.intro_fits_u32 ()
 let intro_fits_u64 () = H.intro_fits_u64 ()
+let intro_fits_ptrdiff32 () = H.intro_fits_ptrdiff32 ()
+let intro_fits_ptrdiff64 () = H.intro_fits_ptrdiff64 ()
 
 let ptrdiff #_ #p0 #p1 #s0 #s1 a0 a1 =
   rewrite

--- a/ulib/experimental/Steel.ST.Array.fsti
+++ b/ulib/experimental/Steel.ST.Array.fsti
@@ -473,6 +473,22 @@ val intro_fits_u64 (_:unit)
   : STT (squash (US.fits_u64))
         emp (fun _ -> emp)
 
+/// Determining whether int32 values fit in a ptrdiff
+/// It will be natively extracted to static_assert (INT32_MAX <= PTRDIFF_MAX) by krml
+inline_for_extraction
+[@@noextract_to "krml"]
+val intro_fits_ptrdiff32 (_:unit)
+  : STT (squash (UP.fits (FStar.Int.max_int 32)))
+        emp (fun _ -> emp)
+
+/// Determining whether int64 values fit in a ptrdiff
+/// It will be natively extracted to static_assert (INT64_MAX <= PTRDIFF_MAX) by krml
+inline_for_extraction
+[@@noextract_to "krml"]
+val intro_fits_ptrdiff64 (_:unit)
+  : STT (squash (UP.fits (FStar.Int.max_int 64)))
+        emp (fun _ -> emp)
+
 inline_for_extraction
 [@@noextract_to "krml"]
 val ptrdiff (#t:_) (#p0 #p1:perm) (#s0 #s1:Ghost.erased (Seq.seq t))

--- a/ulib/experimental/Steel.ST.HigherArray.fst
+++ b/ulib/experimental/Steel.ST.HigherArray.fst
@@ -684,9 +684,11 @@ let blit_ptr
   src len_src idx_src dst len_dst idx_dst len
 = blit0 _ idx_src _ idx_dst len
 
-/// These two functions will be natively extracted, we can simply admit them
+/// These functions will be natively extracted, we can simply admit them
 let intro_fits_u32 () = admit_ ()
 let intro_fits_u64 () = admit_ ()
+let intro_fits_ptrdiff32 () = admit_ ()
+let intro_fits_ptrdiff64 () = admit_ ()
 
 let ptrdiff_ptr a0 len0 a1 len1 =
   let res = a0.offset - a1.offset in

--- a/ulib/experimental/Steel.ST.HigherArray.fsti
+++ b/ulib/experimental/Steel.ST.HigherArray.fsti
@@ -565,17 +565,31 @@ let memcpy (#t:_) (#p0:perm)
 
 
 /// An introduction function for the fits_u32 predicate.
-/// It will be natively extracted to static_assert (UINT32_MAX <= SIZE_T_MAX) by krml
+/// It will be natively extracted to static_assert (UINT32_MAX <= SIZE_MAX) by krml
 [@@noextract_to "krml"]
 val intro_fits_u32 (_:unit)
   : STT (squash (US.fits_u32))
         emp (fun _ -> emp)
 
 /// An introduction function for the fits_u64 predicate.
-/// It will be natively extracted to static_assert (UINT64_MAX <= SIZE_T_MAX) by krml
+/// It will be natively extracted to static_assert (UINT64_MAX <= SIZE_MAX) by krml
 [@@noextract_to "krml"]
 val intro_fits_u64 (_:unit)
   : STT (squash (US.fits_u64))
+        emp (fun _ -> emp)
+
+/// Determining whether int32 values fit in a ptrdiff
+/// It will be natively extracted to static_assert (INT32_MAX <= PTRDIFF_MAX) by krml
+[@@noextract_to "krml"]
+val intro_fits_ptrdiff32 (_:unit)
+  : STT (squash (UP.fits (FStar.Int.max_int 32)))
+        emp (fun _ -> emp)
+
+/// Determining whether int32 values fit in a ptrdiff
+/// It will be natively extracted to static_assert (INT64_MAX <= PTRDIFF_MAX) by krml
+[@@noextract_to "krml"]
+val intro_fits_ptrdiff64 (_:unit)
+  : STT (squash (UP.fits (FStar.Int.max_int 64)))
         emp (fun _ -> emp)
 
 /// The pointer substraction, returning a ptrdiff_t.


### PR DESCRIPTION
Following the same approach as for SizeT, this PR adds two Steel functions, called `intro_fits_ptrdiff32` and `intro_fits_ptrdiff64`, which enable to add information about the upper bound of a ptrdiff_t.
These functions will be natively extracted to static_asserts by karamel (added in a companion karamel PR).