### PR TITLE
Normalize residual comps

### DIFF
--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_Normalize.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_Normalize.ml
@@ -7788,7 +7788,7 @@ and (norm_residual_comp :
     fun env1 ->
       fun rc ->
         let uu___ =
-          FStar_Compiler_Util.map_option (closure_as_term cfg env1)
+          FStar_Compiler_Util.map_option (norm cfg env1 [])
             rc.FStar_Syntax_Syntax.residual_typ in
         {
           FStar_Syntax_Syntax.residual_effect =

--- a/src/typechecker/FStar.TypeChecker.Normalize.fst
+++ b/src/typechecker/FStar.TypeChecker.Normalize.fst
@@ -2971,7 +2971,7 @@ and norm_ascription cfg env (tc, tacopt, use_eq) =
   use_eq
 
 and norm_residual_comp cfg env (rc:residual_comp) : residual_comp =
-  {rc with residual_typ = BU.map_option (closure_as_term cfg env) rc.residual_typ}
+  {rc with residual_typ = BU.map_option (norm cfg env []) rc.residual_typ}
 
 let reflection_env_hook = BU.mk_ref None
 

--- a/ulib/FStar.MRef.fsti
+++ b/ulib/FStar.MRef.fsti
@@ -19,6 +19,8 @@ open FStar.ST
 
 open FStar.Preorder
 
+let _unused x = x
+
 let stable = FStar.Preorder.stable
 
 val token (#a:Type) (#b:preorder a) (r:mref a b) (p:(a -> Type){stable p b}) : Type0


### PR DESCRIPTION
The normalizer is not currently reducing lambdas in the types of residual comps in Tm_abs and Tm_match nodes. This simple patch makes it so, opening the PR just to:

- Make sure this is in fact desirable?
- Confirm that performance is acceptable. I ran the diff script and got the images below, with mixed results. I understand the <1 slope means that things are in average slightly better?
- Point to the last patch, which works around another gensym-related Heisenbug! I don't plan to get that commit to master, just adding it here to get a green. It will hopefully go away once other patches land.

I ran into this while trying to removing Tm_names from checked files, and some remained in unreduced residual comps. They should not be there anyway.. as it's supposed to be closed, but still tracking that down.
 
![Figure_1](https://user-images.githubusercontent.com/4195583/223469593-0b7544ef-216a-48f4-8e65-56aca469f7d2.png)
![Figure_2](https://user-images.githubusercontent.com/4195583/223469599-98e5f2a1-4370-46d9-933a-aebde1e58176.png)
