### PR TITLE
Use leftmost head when checking for equatable symbols in the core typechecker

### DIFF
--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_Core.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_Core.ml
@@ -1005,11 +1005,11 @@ let no_guard : 'a . 'a result -> 'a result =
 let (equatable : env -> FStar_Syntax_Syntax.term -> Prims.bool) =
   fun g ->
     fun t ->
-      let uu___ = FStar_Syntax_Util.head_and_args t in
-      match uu___ with
-      | (head, uu___1) ->
-          FStar_TypeChecker_Rel.may_relate_with_logical_guard g.tcenv true
-            head
+      let uu___ =
+        FStar_Compiler_Effect.op_Bar_Greater t
+          FStar_Syntax_Util.leftmost_head in
+      FStar_Compiler_Effect.op_Bar_Greater uu___
+        (FStar_TypeChecker_Rel.may_relate_with_logical_guard g.tcenv true)
 let (apply_predicate :
   FStar_Syntax_Syntax.binder ->
     FStar_Syntax_Syntax.term ->

--- a/src/typechecker/FStar.TypeChecker.Core.fst
+++ b/src/typechecker/FStar.TypeChecker.Core.fst
@@ -514,8 +514,7 @@ let no_guard (g:result 'a)
       | err -> err
       
 let equatable g t = 
-  let head, _ = U.head_and_args t in
-  Rel.may_relate_with_logical_guard g.tcenv true head
+  t |> U.leftmost_head |> Rel.may_relate_with_logical_guard g.tcenv true
 
 let apply_predicate x p = fun e -> Subst.subst [NT(x.binder_bv, e)] p
 


### PR DESCRIPTION
It is a small change. Came up in the Pulse branch.