### PR TITLE
Do not install fstar_tests.exe by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,7 +115,8 @@ output:
 
 .PHONY: ci-utest-prelude
 
-ci-utest-prelude: dune
+ci-utest-prelude:
+	$(Q)+$(MAKE) dune FSTAR_BUILD_PROFILE=test
 	$(Q)+$(MAKE) dune-bootstrap
 	$(Q)+$(MAKE) -C src ocaml-unit-tests
 	$(Q)+$(MAKE) -C ulib ulib-in-fsharp    #build ulibfs

--- a/Makefile
+++ b/Makefile
@@ -19,13 +19,14 @@ else
 endif
 
 .PHONY: dune dune-fstar verify-ulib
+FSTAR_BUILD_PROFILE ?= release
 dune-fstar:
 	$(Q)cp version.txt $(DUNE_SNAPSHOT)/
 	@# Call Dune to build the snapshot.
 	@echo "  DUNE BUILD"
-	$(Q)cd $(DUNE_SNAPSHOT) && dune build --profile release
+	$(Q)cd $(DUNE_SNAPSHOT) && dune build --profile=$(FSTAR_BUILD_PROFILE)
 	@echo "  DUNE INSTALL"
-	$(Q)cd $(DUNE_SNAPSHOT) && dune install --prefix=$(FSTAR_CURDIR)
+	$(Q)cd $(DUNE_SNAPSHOT) && dune install --profile=$(FSTAR_BUILD_PROFILE) --prefix=$(FSTAR_CURDIR)
 
 verify-ulib:
 	+$(MAKE) -C ulib

--- a/ocaml/dune
+++ b/ocaml/dune
@@ -1,3 +1,3 @@
 (env
-  (release
+  (_
     (flags (:standard -w -A))))

--- a/ocaml/fstar-tests/dune
+++ b/ocaml/fstar-tests/dune
@@ -6,4 +6,7 @@
     fstar_lib
  )
  (modes (native exe))
+ (enabled_if
+   (= %{profile} test)
+ )
 )

--- a/src/ocaml-output/Makefile
+++ b/src/ocaml-output/Makefile
@@ -127,11 +127,13 @@ else
   FSTAR_PREFIX=$(PREFIX)
 endif
 
+FSTAR_BUILD_PROFILE ?= release
+
 install:
 	@# Rebuild everything
 	+$(MAKE) -C $(FSTAR_HOME)
 	@# Install the binary and the binary library
-	cd $(DUNE_SNAPSHOT) && dune install --prefix=$(FSTAR_PREFIX)
+	cd $(DUNE_SNAPSHOT) && dune install --profile=$(FSTAR_BUILD_PROFILE) --prefix=$(FSTAR_PREFIX)
 	@# Then the standard library sources and checked files
 	+$(MAKE) -C $(FSTAR_HOME)/ulib install
 	@# Then the rest


### PR DESCRIPTION
As pointed out by @mtzguido , since #2815 , `fstar_tests.exe` is built and installed everytime along with `fstar.exe`

This PR avoids that, by leveraging dune's build profiles (https://dune.readthedocs.io/en/stable/overview.html#term-build-profile). With this PR:
* `make` will build F* with the `release` profile by default, and the user can set the `FSTAR_BUILD_PROFILE` variable to override that default
* `fstar_tests.exe` is excluded from the `release` profile, but included in the `test` profile
* `fstar.exe` is always built
* warnings are disabled for all profiles, not just `release`
* CI uses the `test` profile to run unit tests via the `ci-utest-prelude` rule in the main `Makefile`