### PR TITLE
Removing with_type (and vcgen.optimize_bind_as_seq)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -546,6 +546,10 @@ Guidelines for the changelog:
      expected output location, we raise Warning 321.
 
 ## Command line options
+   * F* no longer supports the vcgen.optimize_bind_as_seq command line
+			  option for tweaking the verification condition generation.
+					The option was not on by-default, and hence was not maintained well.
+					Further, as issue #2868 observed, it relied on a strange SMT axiom.
 
    * [Issue #2385](https://github.com/FStarLang/FStar/issues/2385).
      The behavior of the --extract option was changed so that it no

--- a/ocaml/fstar-lib/generated/FStar_Options.ml
+++ b/ocaml/fstar-lib/generated/FStar_Options.ml
@@ -369,7 +369,6 @@ let (defaults : (Prims.string * option_val) Prims.list) =
   ("use_hints", (Bool false));
   ("use_hint_hashes", (Bool false));
   ("using_facts_from", Unset);
-  ("vcgen.optimize_bind_as_seq", Unset);
   ("verify_module", (List []));
   ("warn_default_effects", (Bool false));
   ("z3refresh", (Bool false));
@@ -430,7 +429,6 @@ let (set_verification_options : optionstate -> unit) =
       "tcnorm";
       "no_plugins";
       "no_tactics";
-      "vcgen.optimize_bind_as_seq";
       "z3cliopt";
       "z3smtopt";
       "z3refresh";
@@ -648,9 +646,6 @@ let (get_no_tactics : unit -> Prims.bool) =
 let (get_using_facts_from :
   unit -> Prims.string Prims.list FStar_Pervasives_Native.option) =
   fun uu___ -> lookup_opt "using_facts_from" (as_option (as_list as_string))
-let (get_vcgen_optimize_bind_as_seq :
-  unit -> Prims.string FStar_Pervasives_Native.option) =
-  fun uu___ -> lookup_opt "vcgen.optimize_bind_as_seq" (as_option as_string)
 let (get_verify_module : unit -> Prims.string Prims.list) =
   fun uu___ -> lookup_opt "verify_module" (as_list as_string)
 let (get_version : unit -> Prims.bool) =
@@ -959,7 +954,7 @@ let (interp_quake_arg : Prims.string -> (Prims.int * Prims.int * Prims.bool))
           let uu___ = ios f1 in let uu___1 = ios f2 in (uu___, uu___1, true)
         else failwith "unexpected value for --quake"
     | uu___ -> failwith "unexpected value for --quake"
-let (uu___448 : (((Prims.string -> unit) -> unit) * (Prims.string -> unit)))
+let (uu___447 : (((Prims.string -> unit) -> unit) * (Prims.string -> unit)))
   =
   let cb = FStar_Compiler_Util.mk_ref FStar_Pervasives_Native.None in
   let set1 f =
@@ -971,11 +966,11 @@ let (uu___448 : (((Prims.string -> unit) -> unit) * (Prims.string -> unit)))
     | FStar_Pervasives_Native.Some f -> f msg in
   (set1, call)
 let (set_option_warning_callback_aux : (Prims.string -> unit) -> unit) =
-  match uu___448 with
+  match uu___447 with
   | (set_option_warning_callback_aux1, option_warning_callback) ->
       set_option_warning_callback_aux1
 let (option_warning_callback : Prims.string -> unit) =
-  match uu___448 with
+  match uu___447 with
   | (set_option_warning_callback_aux1, option_warning_callback1) ->
       option_warning_callback1
 let (set_option_warning_callback : (Prims.string -> unit) -> unit) =
@@ -1297,9 +1292,6 @@ let rec (specs_with_types :
          (SimpleStr
             "One or more space-separated occurrences of '[+|-]( * | namespace | fact id)'")),
       "\n\t\tPrunes the context to include only the facts from the given namespace or fact id. \n\t\t\tFacts can be include or excluded using the [+|-] qualifier. \n\t\t\tFor example --using_facts_from '* -FStar.Reflection +FStar.Compiler.List -FStar.Compiler.List.Tot' will \n\t\t\t\tremove all facts from FStar.Compiler.List.Tot.*, \n\t\t\t\tretain all remaining facts from FStar.Compiler.List.*, \n\t\t\t\tremove all facts from FStar.Reflection.*, \n\t\t\t\tand retain all the rest.\n\t\tNote, the '+' is optional: --using_facts_from 'FStar.Compiler.List' is equivalent to --using_facts_from '+FStar.Compiler.List'. \n\t\tMultiple uses of this option accumulate, e.g., --using_facts_from A --using_facts_from B is interpreted as --using_facts_from A^B.");
-    (FStar_Getopt.noshort, "vcgen.optimize_bind_as_seq",
-      (EnumStr ["off"; "without_type"; "with_type"]),
-      "\n\t\tOptimize the generation of verification conditions, \n\t\t\tspecifically the construction of monadic `bind`,\n\t\t\tgenerating `seq` instead of `bind` when the first computation as a trivial post-condition.\n\t\t\tBy default, this optimization does not apply.\n\t\t\tWhen the `without_type` option is chosen, this imposes a cost on the SMT solver\n\t\t\tto reconstruct type information.\n\t\t\tWhen `with_type` is chosen, type information is provided to the SMT solver,\n\t\t\tbut at the cost of VC bloat, which may often be redundant.");
     (FStar_Getopt.noshort, "__temp_fast_implicits", (Const (Bool true)),
       "Don't use this option yet");
     (118, "version",
@@ -1454,7 +1446,6 @@ let (settable : Prims.string -> Prims.bool) =
     | "unthrottle_inductives" -> true
     | "use_eq_at_higher_order" -> true
     | "using_facts_from" -> true
-    | "vcgen.optimize_bind_as_seq" -> true
     | "warn_error" -> true
     | "z3cliopt" -> true
     | "z3smtopt" -> true
@@ -1479,7 +1470,7 @@ let (settable_specs :
     (FStar_Compiler_List.filter
        (fun uu___ ->
           match uu___ with | (uu___1, x, uu___2, uu___3) -> settable x))
-let (uu___640 :
+let (uu___638 :
   (((unit -> FStar_Getopt.parse_cmdline_res) -> unit) *
     (unit -> FStar_Getopt.parse_cmdline_res)))
   =
@@ -1496,11 +1487,11 @@ let (uu___640 :
   (set1, call)
 let (set_error_flags_callback_aux :
   (unit -> FStar_Getopt.parse_cmdline_res) -> unit) =
-  match uu___640 with
+  match uu___638 with
   | (set_error_flags_callback_aux1, set_error_flags) ->
       set_error_flags_callback_aux1
 let (set_error_flags : unit -> FStar_Getopt.parse_cmdline_res) =
-  match uu___640 with
+  match uu___638 with
   | (set_error_flags_callback_aux1, set_error_flags1) -> set_error_flags1
 let (set_error_flags_callback :
   (unit -> FStar_Getopt.parse_cmdline_res) -> unit) =
@@ -2046,16 +2037,6 @@ let (using_facts_from :
     match uu___1 with
     | FStar_Pervasives_Native.None -> [([], true)]
     | FStar_Pervasives_Native.Some ns -> parse_settings ns
-let (vcgen_optimize_bind_as_seq : unit -> Prims.bool) =
-  fun uu___ ->
-    let uu___1 = get_vcgen_optimize_bind_as_seq () in
-    FStar_Compiler_Option.isSome uu___1
-let (vcgen_decorate_with_type : unit -> Prims.bool) =
-  fun uu___ ->
-    let uu___1 = get_vcgen_optimize_bind_as_seq () in
-    match uu___1 with
-    | FStar_Pervasives_Native.Some "with_type" -> true
-    | uu___2 -> false
 let (warn_default_effects : unit -> Prims.bool) =
   fun uu___ -> get_warn_default_effects ()
 let (warn_error : unit -> Prims.string) =
@@ -2437,15 +2418,14 @@ let (get_vconfig : unit -> FStar_VConfig.vconfig) =
       let uu___17 = get_tcnorm () in
       let uu___18 = get_no_plugins () in
       let uu___19 = get_no_tactics () in
-      let uu___20 = get_vcgen_optimize_bind_as_seq () in
-      let uu___21 = get_z3cliopt () in
-      let uu___22 = get_z3smtopt () in
-      let uu___23 = get_z3refresh () in
-      let uu___24 = get_z3rlimit () in
-      let uu___25 = get_z3rlimit_factor () in
-      let uu___26 = get_z3seed () in
-      let uu___27 = get_trivial_pre_for_unannotated_effectful_fns () in
-      let uu___28 = get_reuse_hint_for () in
+      let uu___20 = get_z3cliopt () in
+      let uu___21 = get_z3smtopt () in
+      let uu___22 = get_z3refresh () in
+      let uu___23 = get_z3rlimit () in
+      let uu___24 = get_z3rlimit_factor () in
+      let uu___25 = get_z3seed () in
+      let uu___26 = get_trivial_pre_for_unannotated_effectful_fns () in
+      let uu___27 = get_reuse_hint_for () in
       {
         FStar_VConfig.initial_fuel = uu___1;
         FStar_VConfig.max_fuel = uu___2;
@@ -2466,15 +2446,14 @@ let (get_vconfig : unit -> FStar_VConfig.vconfig) =
         FStar_VConfig.tcnorm = uu___17;
         FStar_VConfig.no_plugins = uu___18;
         FStar_VConfig.no_tactics = uu___19;
-        FStar_VConfig.vcgen_optimize_bind_as_seq = uu___20;
-        FStar_VConfig.z3cliopt = uu___21;
-        FStar_VConfig.z3smtopt = uu___22;
-        FStar_VConfig.z3refresh = uu___23;
-        FStar_VConfig.z3rlimit = uu___24;
-        FStar_VConfig.z3rlimit_factor = uu___25;
-        FStar_VConfig.z3seed = uu___26;
-        FStar_VConfig.trivial_pre_for_unannotated_effectful_fns = uu___27;
-        FStar_VConfig.reuse_hint_for = uu___28
+        FStar_VConfig.z3cliopt = uu___20;
+        FStar_VConfig.z3smtopt = uu___21;
+        FStar_VConfig.z3refresh = uu___22;
+        FStar_VConfig.z3rlimit = uu___23;
+        FStar_VConfig.z3rlimit_factor = uu___24;
+        FStar_VConfig.z3seed = uu___25;
+        FStar_VConfig.trivial_pre_for_unannotated_effectful_fns = uu___26;
+        FStar_VConfig.reuse_hint_for = uu___27
       } in
     vcfg
 let (set_vconfig : FStar_VConfig.vconfig -> unit) =
@@ -2509,28 +2488,24 @@ let (set_vconfig : FStar_VConfig.vconfig -> unit) =
     set_option "no_plugins" (Bool (vcfg.FStar_VConfig.no_plugins));
     set_option "no_tactics" (Bool (vcfg.FStar_VConfig.no_tactics));
     (let uu___20 =
-       option_as (fun uu___21 -> String uu___21)
-         vcfg.FStar_VConfig.vcgen_optimize_bind_as_seq in
-     set_option "vcgen.optimize_bind_as_seq" uu___20);
+       let uu___21 =
+         FStar_Compiler_List.map (fun uu___22 -> String uu___22)
+           vcfg.FStar_VConfig.z3cliopt in
+       List uu___21 in
+     set_option "z3cliopt" uu___20);
     (let uu___21 =
        let uu___22 =
          FStar_Compiler_List.map (fun uu___23 -> String uu___23)
-           vcfg.FStar_VConfig.z3cliopt in
-       List uu___22 in
-     set_option "z3cliopt" uu___21);
-    (let uu___22 =
-       let uu___23 =
-         FStar_Compiler_List.map (fun uu___24 -> String uu___24)
            vcfg.FStar_VConfig.z3smtopt in
-       List uu___23 in
-     set_option "z3smtopt" uu___22);
+       List uu___22 in
+     set_option "z3smtopt" uu___21);
     set_option "z3refresh" (Bool (vcfg.FStar_VConfig.z3refresh));
     set_option "z3rlimit" (Int (vcfg.FStar_VConfig.z3rlimit));
     set_option "z3rlimit_factor" (Int (vcfg.FStar_VConfig.z3rlimit_factor));
     set_option "z3seed" (Int (vcfg.FStar_VConfig.z3seed));
     set_option "trivial_pre_for_unannotated_effectful_fns"
       (Bool (vcfg.FStar_VConfig.trivial_pre_for_unannotated_effectful_fns));
-    (let uu___28 =
-       option_as (fun uu___29 -> String uu___29)
+    (let uu___27 =
+       option_as (fun uu___28 -> String uu___28)
          vcfg.FStar_VConfig.reuse_hint_for in
-     set_option "reuse_hint_for" uu___28)
+     set_option "reuse_hint_for" uu___27)

--- a/ocaml/fstar-lib/generated/FStar_Parser_Const.ml
+++ b/ocaml/fstar-lib/generated/FStar_Parser_Const.ml
@@ -264,7 +264,6 @@ let (range_0 : FStar_Ident.lident) = pconst "range_0"
 let (guard_free : FStar_Ident.lident) = pconst "guard_free"
 let (inversion_lid : FStar_Ident.lident) =
   p2l ["FStar"; "Pervasives"; "inversion"]
-let (with_type_lid : FStar_Ident.lident) = psconst "with_type"
 let (normalize : FStar_Ident.lident) = psconst "normalize"
 let (normalize_term : FStar_Ident.lident) = psconst "normalize_term"
 let (norm : FStar_Ident.lident) = psconst "norm"

--- a/ocaml/fstar-lib/generated/FStar_Pervasives.ml
+++ b/ocaml/fstar-lib/generated/FStar_Pervasives.ml
@@ -271,7 +271,6 @@ let (uu___is_CIfDef : __internal_ocaml_attributes -> Prims.bool) =
 let (uu___is_CMacro : __internal_ocaml_attributes -> Prims.bool) =
   fun projectee -> match projectee with | CMacro -> true | uu___ -> false
 let singleton : 'uuuuu . 'uuuuu -> 'uuuuu = fun x -> x
-let with_type : 'uuuuu . 'uuuuu -> 'uuuuu = fun e -> e
 type 'a eqtype_as_type = 'a
 let coerce_eq : 'a 'b . unit -> 'a -> 'b =
   fun uu___1 -> fun uu___ -> (fun uu___ -> fun x -> Obj.magic x) uu___1 uu___

--- a/ocaml/fstar-lib/generated/FStar_SMTEncoding_Encode.ml
+++ b/ocaml/fstar-lib/generated/FStar_SMTEncoding_Encode.ml
@@ -1310,34 +1310,6 @@ let (primitive_type_axioms :
           "inversion-interp") in
       FStar_SMTEncoding_Util.mkAssume uu___1 in
     [uu___] in
-  let mk_with_type_axiom env with_type tt =
-    let tt1 =
-      FStar_SMTEncoding_Term.mk_fv ("t", FStar_SMTEncoding_Term.Term_sort) in
-    let t = FStar_SMTEncoding_Util.mkFreeV tt1 in
-    let ee =
-      FStar_SMTEncoding_Term.mk_fv ("e", FStar_SMTEncoding_Term.Term_sort) in
-    let e = FStar_SMTEncoding_Util.mkFreeV ee in
-    let with_type_t_e = FStar_SMTEncoding_Util.mkApp (with_type, [t; e]) in
-    let uu___ =
-      let uu___1 =
-        let uu___2 =
-          let uu___3 = FStar_TypeChecker_Env.get_range env in
-          let uu___4 =
-            let uu___5 =
-              let uu___6 =
-                let uu___7 = FStar_SMTEncoding_Util.mkEq (with_type_t_e, e) in
-                let uu___8 =
-                  FStar_SMTEncoding_Term.mk_HasType with_type_t_e t in
-                (uu___7, uu___8) in
-              FStar_SMTEncoding_Util.mkAnd uu___6 in
-            ([[with_type_t_e]],
-              (FStar_Pervasives_Native.Some Prims.int_zero), [tt1; ee],
-              uu___5) in
-          FStar_SMTEncoding_Term.mkForall' uu___3 uu___4 in
-        (uu___2, (FStar_Pervasives_Native.Some "with_type primitive axiom"),
-          "@with_type_primitive_axiom") in
-      FStar_SMTEncoding_Util.mkAssume uu___1 in
-    [uu___] in
   let prims1 =
     [(FStar_Parser_Const.unit_lid, mk_unit);
     (FStar_Parser_Const.bool_lid, mk_bool);
@@ -1353,8 +1325,7 @@ let (primitive_type_axioms :
     (FStar_Parser_Const.iff_lid, mk_iff_interp);
     (FStar_Parser_Const.not_lid, mk_not_interp);
     (FStar_Parser_Const.range_lid, mk_range_interp);
-    (FStar_Parser_Const.inversion_lid, mk_inversion_axiom);
-    (FStar_Parser_Const.with_type_lid, mk_with_type_axiom)] in
+    (FStar_Parser_Const.inversion_lid, mk_inversion_axiom)] in
   fun env ->
     fun t ->
       fun s ->

--- a/ocaml/fstar-lib/generated/FStar_Syntax_Embeddings.ml
+++ b/ocaml/fstar-lib/generated/FStar_Syntax_Embeddings.ml
@@ -1749,10 +1749,8 @@ let (e_vconfig : FStar_VConfig.vconfig embedding) =
                                             let uu___40 =
                                               let uu___41 =
                                                 let uu___42 =
-                                                  let uu___43 =
-                                                    e_option e_string in
-                                                  embed uu___43
-                                                    vcfg.FStar_VConfig.vcgen_optimize_bind_as_seq in
+                                                  embed e_string_list
+                                                    vcfg.FStar_VConfig.z3cliopt in
                                                 uu___42 rng
                                                   FStar_Pervasives_Native.None
                                                   norm in
@@ -1763,7 +1761,7 @@ let (e_vconfig : FStar_VConfig.vconfig embedding) =
                                                 let uu___43 =
                                                   let uu___44 =
                                                     embed e_string_list
-                                                      vcfg.FStar_VConfig.z3cliopt in
+                                                      vcfg.FStar_VConfig.z3smtopt in
                                                   uu___44 rng
                                                     FStar_Pervasives_Native.None
                                                     norm in
@@ -1773,8 +1771,8 @@ let (e_vconfig : FStar_VConfig.vconfig embedding) =
                                                 let uu___44 =
                                                   let uu___45 =
                                                     let uu___46 =
-                                                      embed e_string_list
-                                                        vcfg.FStar_VConfig.z3smtopt in
+                                                      embed e_bool
+                                                        vcfg.FStar_VConfig.z3refresh in
                                                     uu___46 rng
                                                       FStar_Pervasives_Native.None
                                                       norm in
@@ -1784,8 +1782,8 @@ let (e_vconfig : FStar_VConfig.vconfig embedding) =
                                                   let uu___46 =
                                                     let uu___47 =
                                                       let uu___48 =
-                                                        embed e_bool
-                                                          vcfg.FStar_VConfig.z3refresh in
+                                                        embed e_fsint
+                                                          vcfg.FStar_VConfig.z3rlimit in
                                                       uu___48 rng
                                                         FStar_Pervasives_Native.None
                                                         norm in
@@ -1796,7 +1794,7 @@ let (e_vconfig : FStar_VConfig.vconfig embedding) =
                                                       let uu___49 =
                                                         let uu___50 =
                                                           embed e_fsint
-                                                            vcfg.FStar_VConfig.z3rlimit in
+                                                            vcfg.FStar_VConfig.z3rlimit_factor in
                                                         uu___50 rng
                                                           FStar_Pervasives_Native.None
                                                           norm in
@@ -1807,7 +1805,7 @@ let (e_vconfig : FStar_VConfig.vconfig embedding) =
                                                         let uu___51 =
                                                           let uu___52 =
                                                             embed e_fsint
-                                                              vcfg.FStar_VConfig.z3rlimit_factor in
+                                                              vcfg.FStar_VConfig.z3seed in
                                                           uu___52 rng
                                                             FStar_Pervasives_Native.None
                                                             norm in
@@ -1817,8 +1815,8 @@ let (e_vconfig : FStar_VConfig.vconfig embedding) =
                                                         let uu___52 =
                                                           let uu___53 =
                                                             let uu___54 =
-                                                              embed e_fsint
-                                                                vcfg.FStar_VConfig.z3seed in
+                                                              embed e_bool
+                                                                vcfg.FStar_VConfig.trivial_pre_for_unannotated_effectful_fns in
                                                             uu___54 rng
                                                               FStar_Pervasives_Native.None
                                                               norm in
@@ -1828,31 +1826,17 @@ let (e_vconfig : FStar_VConfig.vconfig embedding) =
                                                           let uu___54 =
                                                             let uu___55 =
                                                               let uu___56 =
-                                                                embed e_bool
-                                                                  vcfg.FStar_VConfig.trivial_pre_for_unannotated_effectful_fns in
+                                                                let uu___57 =
+                                                                  e_option
+                                                                    e_string in
+                                                                embed uu___57
+                                                                  vcfg.FStar_VConfig.reuse_hint_for in
                                                               uu___56 rng
                                                                 FStar_Pervasives_Native.None
                                                                 norm in
                                                             FStar_Syntax_Syntax.as_arg
                                                               uu___55 in
-                                                          let uu___55 =
-                                                            let uu___56 =
-                                                              let uu___57 =
-                                                                let uu___58 =
-                                                                  let uu___59
-                                                                    =
-                                                                    e_option
-                                                                    e_string in
-                                                                  embed
-                                                                    uu___59
-                                                                    vcfg.FStar_VConfig.reuse_hint_for in
-                                                                uu___58 rng
-                                                                  FStar_Pervasives_Native.None
-                                                                  norm in
-                                                              FStar_Syntax_Syntax.as_arg
-                                                                uu___57 in
-                                                            [uu___56] in
-                                                          uu___54 :: uu___55 in
+                                                          [uu___54] in
                                                         uu___52 :: uu___53 in
                                                       uu___50 :: uu___51 in
                                                     uu___48 :: uu___49 in
@@ -1904,99 +1888,114 @@ let (e_vconfig : FStar_VConfig.vconfig embedding) =
                                                   uu___16)::(smtencoding_valid_elim,
                                                              uu___17)::
             (tcnorm, uu___18)::(no_plugins, uu___19)::(no_tactics, uu___20)::
-            (vcgen_optimize_bind_as_seq, uu___21)::(z3cliopt, uu___22)::
-            (z3smtopt, uu___23)::(z3refresh, uu___24)::(z3rlimit, uu___25)::
-            (z3rlimit_factor, uu___26)::(z3seed, uu___27)::(trivial_pre_for_unannotated_effectful_fns,
-                                                            uu___28)::
-            (reuse_hint_for, uu___29)::[]) when
+            (z3cliopt, uu___21)::(z3smtopt, uu___22)::(z3refresh, uu___23)::
+            (z3rlimit, uu___24)::(z3rlimit_factor, uu___25)::(z3seed,
+                                                              uu___26)::
+            (trivial_pre_for_unannotated_effectful_fns, uu___27)::(reuse_hint_for,
+                                                                   uu___28)::[])
+             when
              FStar_Syntax_Syntax.fv_eq_lid fv
                FStar_Parser_Const.mkvconfig_lid
              ->
-             let uu___30 =
-               let uu___31 = unembed e_fsint initial_fuel in uu___31 w norm in
-             FStar_Compiler_Util.bind_opt uu___30
+             let uu___29 =
+               let uu___30 = unembed e_fsint initial_fuel in uu___30 w norm in
+             FStar_Compiler_Util.bind_opt uu___29
                (fun initial_fuel1 ->
-                  let uu___31 =
-                    let uu___32 = unembed e_fsint max_fuel in uu___32 w norm in
-                  FStar_Compiler_Util.bind_opt uu___31
+                  let uu___30 =
+                    let uu___31 = unembed e_fsint max_fuel in uu___31 w norm in
+                  FStar_Compiler_Util.bind_opt uu___30
                     (fun max_fuel1 ->
-                       let uu___32 =
-                         let uu___33 = unembed e_fsint initial_ifuel in
-                         uu___33 w norm in
-                       FStar_Compiler_Util.bind_opt uu___32
+                       let uu___31 =
+                         let uu___32 = unembed e_fsint initial_ifuel in
+                         uu___32 w norm in
+                       FStar_Compiler_Util.bind_opt uu___31
                          (fun initial_ifuel1 ->
-                            let uu___33 =
-                              let uu___34 = unembed e_fsint max_ifuel in
-                              uu___34 w norm in
-                            FStar_Compiler_Util.bind_opt uu___33
+                            let uu___32 =
+                              let uu___33 = unembed e_fsint max_ifuel in
+                              uu___33 w norm in
+                            FStar_Compiler_Util.bind_opt uu___32
                               (fun max_ifuel1 ->
-                                 let uu___34 =
-                                   let uu___35 = unembed e_bool detail_errors in
-                                   uu___35 w norm in
-                                 FStar_Compiler_Util.bind_opt uu___34
+                                 let uu___33 =
+                                   let uu___34 = unembed e_bool detail_errors in
+                                   uu___34 w norm in
+                                 FStar_Compiler_Util.bind_opt uu___33
                                    (fun detail_errors1 ->
-                                      let uu___35 =
-                                        let uu___36 =
+                                      let uu___34 =
+                                        let uu___35 =
                                           unembed e_bool detail_hint_replay in
-                                        uu___36 w norm in
-                                      FStar_Compiler_Util.bind_opt uu___35
+                                        uu___35 w norm in
+                                      FStar_Compiler_Util.bind_opt uu___34
                                         (fun detail_hint_replay1 ->
-                                           let uu___36 =
-                                             let uu___37 =
+                                           let uu___35 =
+                                             let uu___36 =
                                                unembed e_bool no_smt in
-                                             uu___37 w norm in
+                                             uu___36 w norm in
                                            FStar_Compiler_Util.bind_opt
-                                             uu___36
+                                             uu___35
                                              (fun no_smt1 ->
-                                                let uu___37 =
-                                                  let uu___38 =
+                                                let uu___36 =
+                                                  let uu___37 =
                                                     unembed e_fsint quake_lo in
-                                                  uu___38 w norm in
+                                                  uu___37 w norm in
                                                 FStar_Compiler_Util.bind_opt
-                                                  uu___37
+                                                  uu___36
                                                   (fun quake_lo1 ->
-                                                     let uu___38 =
-                                                       let uu___39 =
+                                                     let uu___37 =
+                                                       let uu___38 =
                                                          unembed e_fsint
                                                            quake_hi in
-                                                       uu___39 w norm in
+                                                       uu___38 w norm in
                                                      FStar_Compiler_Util.bind_opt
-                                                       uu___38
+                                                       uu___37
                                                        (fun quake_hi1 ->
-                                                          let uu___39 =
-                                                            let uu___40 =
+                                                          let uu___38 =
+                                                            let uu___39 =
                                                               unembed e_bool
                                                                 quake_keep in
-                                                            uu___40 w norm in
+                                                            uu___39 w norm in
                                                           FStar_Compiler_Util.bind_opt
-                                                            uu___39
+                                                            uu___38
                                                             (fun quake_keep1
                                                                ->
-                                                               let uu___40 =
-                                                                 let uu___41
+                                                               let uu___39 =
+                                                                 let uu___40
                                                                    =
                                                                    unembed
                                                                     e_bool
                                                                     retry in
-                                                                 uu___41 w
+                                                                 uu___40 w
                                                                    norm in
                                                                FStar_Compiler_Util.bind_opt
-                                                                 uu___40
+                                                                 uu___39
                                                                  (fun retry1
+                                                                    ->
+                                                                    let uu___40
+                                                                    =
+                                                                    let uu___41
+                                                                    =
+                                                                    unembed
+                                                                    e_bool
+                                                                    smtencoding_elim_box in
+                                                                    uu___41 w
+                                                                    norm in
+                                                                    FStar_Compiler_Util.bind_opt
+                                                                    uu___40
+                                                                    (fun
+                                                                    smtencoding_elim_box1
                                                                     ->
                                                                     let uu___41
                                                                     =
                                                                     let uu___42
                                                                     =
                                                                     unembed
-                                                                    e_bool
-                                                                    smtencoding_elim_box in
+                                                                    e_string
+                                                                    smtencoding_nl_arith_repr in
                                                                     uu___42 w
                                                                     norm in
                                                                     FStar_Compiler_Util.bind_opt
                                                                     uu___41
                                                                     (fun
-                                                                    smtencoding_elim_box1
+                                                                    smtencoding_nl_arith_repr1
                                                                     ->
                                                                     let uu___42
                                                                     =
@@ -2004,27 +2003,27 @@ let (e_vconfig : FStar_VConfig.vconfig embedding) =
                                                                     =
                                                                     unembed
                                                                     e_string
-                                                                    smtencoding_nl_arith_repr in
+                                                                    smtencoding_l_arith_repr in
                                                                     uu___43 w
                                                                     norm in
                                                                     FStar_Compiler_Util.bind_opt
                                                                     uu___42
                                                                     (fun
-                                                                    smtencoding_nl_arith_repr1
+                                                                    smtencoding_l_arith_repr1
                                                                     ->
                                                                     let uu___43
                                                                     =
                                                                     let uu___44
                                                                     =
                                                                     unembed
-                                                                    e_string
-                                                                    smtencoding_l_arith_repr in
+                                                                    e_bool
+                                                                    smtencoding_valid_intro in
                                                                     uu___44 w
                                                                     norm in
                                                                     FStar_Compiler_Util.bind_opt
                                                                     uu___43
                                                                     (fun
-                                                                    smtencoding_l_arith_repr1
+                                                                    smtencoding_valid_intro1
                                                                     ->
                                                                     let uu___44
                                                                     =
@@ -2032,13 +2031,13 @@ let (e_vconfig : FStar_VConfig.vconfig embedding) =
                                                                     =
                                                                     unembed
                                                                     e_bool
-                                                                    smtencoding_valid_intro in
+                                                                    smtencoding_valid_elim in
                                                                     uu___45 w
                                                                     norm in
                                                                     FStar_Compiler_Util.bind_opt
                                                                     uu___44
                                                                     (fun
-                                                                    smtencoding_valid_intro1
+                                                                    smtencoding_valid_elim1
                                                                     ->
                                                                     let uu___45
                                                                     =
@@ -2046,13 +2045,13 @@ let (e_vconfig : FStar_VConfig.vconfig embedding) =
                                                                     =
                                                                     unembed
                                                                     e_bool
-                                                                    smtencoding_valid_elim in
+                                                                    tcnorm in
                                                                     uu___46 w
                                                                     norm in
                                                                     FStar_Compiler_Util.bind_opt
                                                                     uu___45
                                                                     (fun
-                                                                    smtencoding_valid_elim1
+                                                                    tcnorm1
                                                                     ->
                                                                     let uu___46
                                                                     =
@@ -2060,13 +2059,13 @@ let (e_vconfig : FStar_VConfig.vconfig embedding) =
                                                                     =
                                                                     unembed
                                                                     e_bool
-                                                                    tcnorm in
+                                                                    no_plugins in
                                                                     uu___47 w
                                                                     norm in
                                                                     FStar_Compiler_Util.bind_opt
                                                                     uu___46
                                                                     (fun
-                                                                    tcnorm1
+                                                                    no_plugins1
                                                                     ->
                                                                     let uu___47
                                                                     =
@@ -2074,87 +2073,83 @@ let (e_vconfig : FStar_VConfig.vconfig embedding) =
                                                                     =
                                                                     unembed
                                                                     e_bool
-                                                                    no_plugins in
+                                                                    no_tactics in
                                                                     uu___48 w
                                                                     norm in
                                                                     FStar_Compiler_Util.bind_opt
                                                                     uu___47
                                                                     (fun
-                                                                    no_plugins1
+                                                                    no_tactics1
                                                                     ->
                                                                     let uu___48
                                                                     =
                                                                     let uu___49
                                                                     =
                                                                     unembed
-                                                                    e_bool
-                                                                    no_tactics in
+                                                                    e_string_list
+                                                                    z3cliopt in
                                                                     uu___49 w
                                                                     norm in
                                                                     FStar_Compiler_Util.bind_opt
                                                                     uu___48
                                                                     (fun
-                                                                    no_tactics1
+                                                                    z3cliopt1
                                                                     ->
                                                                     let uu___49
                                                                     =
                                                                     let uu___50
                                                                     =
-                                                                    let uu___51
-                                                                    =
-                                                                    e_option
-                                                                    e_string in
                                                                     unembed
-                                                                    uu___51
-                                                                    vcgen_optimize_bind_as_seq in
+                                                                    e_string_list
+                                                                    z3smtopt in
                                                                     uu___50 w
                                                                     norm in
                                                                     FStar_Compiler_Util.bind_opt
                                                                     uu___49
                                                                     (fun
-                                                                    vcgen_optimize_bind_as_seq1
+                                                                    z3smtopt1
                                                                     ->
                                                                     let uu___50
                                                                     =
                                                                     let uu___51
                                                                     =
                                                                     unembed
-                                                                    e_string_list
-                                                                    z3cliopt in
+                                                                    e_bool
+                                                                    z3refresh in
                                                                     uu___51 w
                                                                     norm in
                                                                     FStar_Compiler_Util.bind_opt
                                                                     uu___50
                                                                     (fun
-                                                                    z3cliopt1
+                                                                    z3refresh1
                                                                     ->
                                                                     let uu___51
                                                                     =
                                                                     let uu___52
                                                                     =
                                                                     unembed
-                                                                    e_string_list
-                                                                    z3smtopt in
+                                                                    e_fsint
+                                                                    z3rlimit in
                                                                     uu___52 w
                                                                     norm in
                                                                     FStar_Compiler_Util.bind_opt
                                                                     uu___51
                                                                     (fun
-                                                                    z3smtopt1
+                                                                    z3rlimit1
                                                                     ->
                                                                     let uu___52
                                                                     =
                                                                     let uu___53
                                                                     =
                                                                     unembed
-                                                                    e_bool
-                                                                    z3refresh in
+                                                                    e_fsint
+                                                                    z3rlimit_factor in
                                                                     uu___53 w
                                                                     norm in
                                                                     FStar_Compiler_Util.bind_opt
                                                                     uu___52
                                                                     (fun
-                                                                    z3refresh1
+                                                                    z3rlimit_factor1
                                                                     ->
                                                                     let uu___53
                                                                     =
@@ -2162,71 +2157,43 @@ let (e_vconfig : FStar_VConfig.vconfig embedding) =
                                                                     =
                                                                     unembed
                                                                     e_fsint
-                                                                    z3rlimit in
+                                                                    z3seed in
                                                                     uu___54 w
                                                                     norm in
                                                                     FStar_Compiler_Util.bind_opt
                                                                     uu___53
                                                                     (fun
-                                                                    z3rlimit1
+                                                                    z3seed1
                                                                     ->
                                                                     let uu___54
                                                                     =
                                                                     let uu___55
                                                                     =
                                                                     unembed
-                                                                    e_fsint
-                                                                    z3rlimit_factor in
+                                                                    e_bool
+                                                                    trivial_pre_for_unannotated_effectful_fns in
                                                                     uu___55 w
                                                                     norm in
                                                                     FStar_Compiler_Util.bind_opt
                                                                     uu___54
                                                                     (fun
-                                                                    z3rlimit_factor1
+                                                                    trivial_pre_for_unannotated_effectful_fns1
                                                                     ->
                                                                     let uu___55
                                                                     =
                                                                     let uu___56
                                                                     =
-                                                                    unembed
-                                                                    e_fsint
-                                                                    z3seed in
-                                                                    uu___56 w
-                                                                    norm in
-                                                                    FStar_Compiler_Util.bind_opt
-                                                                    uu___55
-                                                                    (fun
-                                                                    z3seed1
-                                                                    ->
-                                                                    let uu___56
-                                                                    =
                                                                     let uu___57
-                                                                    =
-                                                                    unembed
-                                                                    e_bool
-                                                                    trivial_pre_for_unannotated_effectful_fns in
-                                                                    uu___57 w
-                                                                    norm in
-                                                                    FStar_Compiler_Util.bind_opt
-                                                                    uu___56
-                                                                    (fun
-                                                                    trivial_pre_for_unannotated_effectful_fns1
-                                                                    ->
-                                                                    let uu___57
-                                                                    =
-                                                                    let uu___58
-                                                                    =
-                                                                    let uu___59
                                                                     =
                                                                     e_option
                                                                     e_string in
                                                                     unembed
-                                                                    uu___59
+                                                                    uu___57
                                                                     reuse_hint_for in
-                                                                    uu___58 w
+                                                                    uu___56 w
                                                                     norm in
                                                                     FStar_Compiler_Util.bind_opt
-                                                                    uu___57
+                                                                    uu___55
                                                                     (fun
                                                                     reuse_hint_for1
                                                                     ->
@@ -2286,9 +2253,6 @@ let (e_vconfig : FStar_VConfig.vconfig embedding) =
                                                                     FStar_VConfig.no_tactics
                                                                     =
                                                                     no_tactics1;
-                                                                    FStar_VConfig.vcgen_optimize_bind_as_seq
-                                                                    =
-                                                                    vcgen_optimize_bind_as_seq1;
                                                                     FStar_VConfig.z3cliopt
                                                                     =
                                                                     z3cliopt1;
@@ -2312,7 +2276,7 @@ let (e_vconfig : FStar_VConfig.vconfig embedding) =
                                                                     FStar_VConfig.reuse_hint_for
                                                                     =
                                                                     reuse_hint_for1
-                                                                    }))))))))))))))))))))))))))))
+                                                                    })))))))))))))))))))))))))))
          | uu___2 ->
              (if w
               then

--- a/ocaml/fstar-lib/generated/FStar_Syntax_Util.ml
+++ b/ocaml/fstar-lib/generated/FStar_Syntax_Util.ml
@@ -2497,32 +2497,6 @@ let (mk_has_type :
             (t_has_type1, uu___2) in
           FStar_Syntax_Syntax.Tm_app uu___1 in
         FStar_Syntax_Syntax.mk uu___ FStar_Compiler_Range.dummyRange
-let (mk_with_type :
-  FStar_Syntax_Syntax.universe ->
-    FStar_Syntax_Syntax.term ->
-      FStar_Syntax_Syntax.term ->
-        FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax)
-  =
-  fun u ->
-    fun t ->
-      fun e ->
-        let t_with_type =
-          FStar_Syntax_Syntax.fvar FStar_Parser_Const.with_type_lid
-            FStar_Syntax_Syntax.delta_equational FStar_Pervasives_Native.None in
-        let t_with_type1 =
-          FStar_Syntax_Syntax.mk
-            (FStar_Syntax_Syntax.Tm_uinst (t_with_type, [u]))
-            FStar_Compiler_Range.dummyRange in
-        let uu___ =
-          let uu___1 =
-            let uu___2 =
-              let uu___3 = FStar_Syntax_Syntax.iarg t in
-              let uu___4 =
-                let uu___5 = FStar_Syntax_Syntax.as_arg e in [uu___5] in
-              uu___3 :: uu___4 in
-            (t_with_type1, uu___2) in
-          FStar_Syntax_Syntax.Tm_app uu___1 in
-        FStar_Syntax_Syntax.mk uu___ FStar_Compiler_Range.dummyRange
 let (tforall : FStar_Syntax_Syntax.term) =
   FStar_Syntax_Syntax.fvar FStar_Parser_Const.forall_lid
     (FStar_Syntax_Syntax.Delta_constant_at_level Prims.int_one)

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_Util.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_Util.ml
@@ -2835,40 +2835,6 @@ let (lcomp_has_trivial_postcondition :
             | FStar_Syntax_Syntax.SOMETRIVIAL -> true
             | FStar_Syntax_Syntax.TRIVIAL_POSTCONDITION -> true
             | uu___1 -> false) lc.FStar_TypeChecker_Common.cflags)
-let (maybe_add_with_type :
-  FStar_TypeChecker_Env.env ->
-    FStar_Syntax_Syntax.universe FStar_Pervasives_Native.option ->
-      FStar_TypeChecker_Common.lcomp ->
-        FStar_Syntax_Syntax.term ->
-          FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax)
-  =
-  fun env ->
-    fun uopt ->
-      fun lc ->
-        fun e ->
-          let uu___ =
-            (FStar_TypeChecker_Common.is_lcomp_partial_return lc) ||
-              env.FStar_TypeChecker_Env.lax in
-          if uu___
-          then e
-          else
-            (let uu___2 =
-               (lcomp_has_trivial_postcondition lc) &&
-                 (let uu___3 =
-                    FStar_TypeChecker_Env.try_lookup_lid env
-                      FStar_Parser_Const.with_type_lid in
-                  FStar_Compiler_Option.isSome uu___3) in
-             if uu___2
-             then
-               let u =
-                 match uopt with
-                 | FStar_Pervasives_Native.Some u1 -> u1
-                 | FStar_Pervasives_Native.None ->
-                     env.FStar_TypeChecker_Env.universe_of env
-                       lc.FStar_TypeChecker_Common.res_typ in
-               FStar_Syntax_Util.mk_with_type u
-                 lc.FStar_TypeChecker_Common.res_typ e
-             else e)
 let (maybe_capture_unit_refinement :
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.term ->
@@ -3240,77 +3206,6 @@ let (bind :
                                                    FStar_TypeChecker_Env.conj_guard
                                                      g g_bind in
                                                  (c, uu___11) in
-                                           let mk_seq c11 b1 c21 =
-                                             let c12 =
-                                               FStar_TypeChecker_Env.unfold_effect_abbrev
-                                                 env c11 in
-                                             let c22 =
-                                               FStar_TypeChecker_Env.unfold_effect_abbrev
-                                                 env c21 in
-                                             let uu___10 =
-                                               FStar_TypeChecker_Env.join env
-                                                 c12.FStar_Syntax_Syntax.effect_name
-                                                 c22.FStar_Syntax_Syntax.effect_name in
-                                             match uu___10 with
-                                             | (m, uu___11, lift2) ->
-                                                 let uu___12 =
-                                                   lift_comp env c22 lift2 in
-                                                 (match uu___12 with
-                                                  | (c23, g2) ->
-                                                      let uu___13 =
-                                                        destruct_wp_comp c12 in
-                                                      (match uu___13 with
-                                                       | (u1, t1, wp1) ->
-                                                           let md_pure_or_ghost
-                                                             =
-                                                             FStar_TypeChecker_Env.get_effect_decl
-                                                               env
-                                                               c12.FStar_Syntax_Syntax.effect_name in
-                                                           let trivial =
-                                                             let uu___14 =
-                                                               FStar_Compiler_Effect.op_Bar_Greater
-                                                                 md_pure_or_ghost
-                                                                 FStar_Syntax_Util.get_wp_trivial_combinator in
-                                                             FStar_Compiler_Effect.op_Bar_Greater
-                                                               uu___14
-                                                               FStar_Compiler_Util.must in
-                                                           let vc1 =
-                                                             let uu___14 =
-                                                               FStar_TypeChecker_Env.inst_effect_fun_with
-                                                                 [u1] env
-                                                                 md_pure_or_ghost
-                                                                 trivial in
-                                                             let uu___15 =
-                                                               let uu___16 =
-                                                                 FStar_Syntax_Syntax.as_arg
-                                                                   t1 in
-                                                               let uu___17 =
-                                                                 let uu___18
-                                                                   =
-                                                                   FStar_Syntax_Syntax.as_arg
-                                                                    wp1 in
-                                                                 [uu___18] in
-                                                               uu___16 ::
-                                                                 uu___17 in
-                                                             FStar_Syntax_Syntax.mk_Tm_app
-                                                               uu___14
-                                                               uu___15 r1 in
-                                                           let uu___14 =
-                                                             strengthen_comp
-                                                               env
-                                                               FStar_Pervasives_Native.None
-                                                               c23 vc1
-                                                               bind_flags in
-                                                           (match uu___14
-                                                            with
-                                                            | (c, g_s) ->
-                                                                let uu___15 =
-                                                                  FStar_TypeChecker_Env.conj_guards
-                                                                    [g_c1;
-                                                                    g_c2;
-                                                                    g2;
-                                                                    g_s] in
-                                                                (c, uu___15)))) in
                                            let uu___10 =
                                              let t =
                                                FStar_Syntax_Util.comp_result
@@ -3371,91 +3266,58 @@ let (bind :
                                                           g_c1 uu___14 in
                                                       mk_bind1 c1 b c21 g))
                                                   else
-                                                    (let uu___14 =
-                                                       ((FStar_Options.vcgen_optimize_bind_as_seq
-                                                           ())
-                                                          &&
-                                                          (lcomp_has_trivial_postcondition
-                                                             lc11))
-                                                         &&
-                                                         (let uu___15 =
-                                                            FStar_TypeChecker_Env.try_lookup_lid
-                                                              env
-                                                              FStar_Parser_Const.with_type_lid in
-                                                          FStar_Compiler_Option.isSome
-                                                            uu___15) in
-                                                     if uu___14
-                                                     then
-                                                       let e1' =
-                                                         let uu___15 =
-                                                           FStar_Options.vcgen_decorate_with_type
-                                                             () in
-                                                         if uu___15
-                                                         then
-                                                           FStar_Syntax_Util.mk_with_type
-                                                             u_res_t1 res_t1
-                                                             e1
-                                                         else e1 in
-                                                       (debug
-                                                          (fun uu___16 ->
-                                                             let uu___17 =
-                                                               FStar_TypeChecker_Normalize.term_to_string
-                                                                 env e1' in
-                                                             let uu___18 =
-                                                               FStar_Syntax_Print.bv_to_string
-                                                                 x in
-                                                             FStar_Compiler_Util.print2
-                                                               "(3) bind (case b): Substituting %s for %s\n"
-                                                               uu___17
-                                                               uu___18);
-                                                        (let c21 =
-                                                           FStar_Syntax_Subst.subst_comp
-                                                             [FStar_Syntax_Syntax.NT
-                                                                (x, e1')] c2 in
-                                                         mk_seq c1 b c21))
-                                                     else
-                                                       (debug
-                                                          (fun uu___17 ->
-                                                             let uu___18 =
-                                                               FStar_TypeChecker_Normalize.term_to_string
-                                                                 env e1 in
-                                                             let uu___19 =
-                                                               FStar_Syntax_Print.bv_to_string
-                                                                 x in
-                                                             FStar_Compiler_Util.print2
-                                                               "(3) bind (case c): Adding equality %s = %s\n"
-                                                               uu___18
-                                                               uu___19);
-                                                        (let c21 =
-                                                           FStar_Syntax_Subst.subst_comp
-                                                             [FStar_Syntax_Syntax.NT
-                                                                (x, e1)] c2 in
-                                                         let x_eq_e =
-                                                           let uu___17 =
-                                                             FStar_Syntax_Syntax.bv_to_name
-                                                               x in
-                                                           FStar_Syntax_Util.mk_eq2
-                                                             u_res_t1 res_t1
-                                                             e1 uu___17 in
-                                                         let uu___17 =
-                                                           let uu___18 =
-                                                             let uu___19 =
-                                                               let uu___20 =
-                                                                 FStar_Syntax_Syntax.mk_binder
-                                                                   x in
-                                                               [uu___20] in
-                                                             FStar_TypeChecker_Env.push_binders
-                                                               env uu___19 in
-                                                           weaken_comp
-                                                             uu___18 c21
-                                                             x_eq_e in
-                                                         match uu___17 with
-                                                         | (c22, g_w) ->
-                                                             let g =
-                                                               let uu___18 =
-                                                                 let uu___19
-                                                                   =
-                                                                   let uu___20
+                                                    (debug
+                                                       (fun uu___15 ->
+                                                          let uu___16 =
+                                                            FStar_TypeChecker_Normalize.term_to_string
+                                                              env e1 in
+                                                          let uu___17 =
+                                                            FStar_Syntax_Print.bv_to_string
+                                                              x in
+                                                          FStar_Compiler_Util.print2
+                                                            "(3) bind (case b): Adding equality %s = %s\n"
+                                                            uu___16 uu___17);
+                                                     (let c21 =
+                                                        FStar_Syntax_Subst.subst_comp
+                                                          [FStar_Syntax_Syntax.NT
+                                                             (x, e1)] c2 in
+                                                      let x_eq_e =
+                                                        let uu___15 =
+                                                          FStar_Syntax_Syntax.bv_to_name
+                                                            x in
+                                                        FStar_Syntax_Util.mk_eq2
+                                                          u_res_t1 res_t1 e1
+                                                          uu___15 in
+                                                      let uu___15 =
+                                                        let uu___16 =
+                                                          let uu___17 =
+                                                            let uu___18 =
+                                                              FStar_Syntax_Syntax.mk_binder
+                                                                x in
+                                                            [uu___18] in
+                                                          FStar_TypeChecker_Env.push_binders
+                                                            env uu___17 in
+                                                        weaken_comp uu___16
+                                                          c21 x_eq_e in
+                                                      match uu___15 with
+                                                      | (c22, g_w) ->
+                                                          let g =
+                                                            let uu___16 =
+                                                              let uu___17 =
+                                                                let uu___18 =
+                                                                  let uu___19
+                                                                    =
+                                                                    let uu___20
+                                                                    =
+                                                                    FStar_Syntax_Syntax.mk_binder
+                                                                    x in
+                                                                    [uu___20] in
+                                                                  FStar_TypeChecker_Env.close_guard
+                                                                    env
+                                                                    uu___19
+                                                                    g_w in
+                                                                let uu___19 =
+                                                                  let uu___20
                                                                     =
                                                                     let uu___21
                                                                     =
@@ -3464,39 +3326,22 @@ let (bind :
                                                                     FStar_Syntax_Syntax.mk_binder
                                                                     x in
                                                                     [uu___22] in
-                                                                    FStar_TypeChecker_Env.close_guard
-                                                                    env
-                                                                    uu___21
-                                                                    g_w in
-                                                                   let uu___21
-                                                                    =
                                                                     let uu___22
-                                                                    =
-                                                                    let uu___23
-                                                                    =
-                                                                    let uu___24
-                                                                    =
-                                                                    FStar_Syntax_Syntax.mk_binder
-                                                                    x in
-                                                                    [uu___24] in
-                                                                    let uu___24
                                                                     =
                                                                     FStar_TypeChecker_Common.weaken_guard_formula
                                                                     g_c2
                                                                     x_eq_e in
                                                                     FStar_TypeChecker_Env.close_guard
                                                                     env
-                                                                    uu___23
-                                                                    uu___24 in
-                                                                    [uu___22] in
-                                                                   uu___20 ::
-                                                                    uu___21 in
-                                                                 g_c1 ::
-                                                                   uu___19 in
-                                                               FStar_TypeChecker_Env.conj_guards
-                                                                 uu___18 in
-                                                             mk_bind1 c1 b
-                                                               c22 g))))
+                                                                    uu___21
+                                                                    uu___22 in
+                                                                  [uu___20] in
+                                                                uu___18 ::
+                                                                  uu___19 in
+                                                              g_c1 :: uu___17 in
+                                                            FStar_TypeChecker_Env.conj_guards
+                                                              uu___16 in
+                                                          mk_bind1 c1 b c22 g)))
                                                else
                                                  mk_bind1 c1 b c2
                                                    trivial_guard)))))) in

--- a/ocaml/fstar-lib/generated/FStar_VConfig.ml
+++ b/ocaml/fstar-lib/generated/FStar_VConfig.ml
@@ -20,7 +20,6 @@ type vconfig =
   tcnorm: Prims.bool ;
   no_plugins: Prims.bool ;
   no_tactics: Prims.bool ;
-  vcgen_optimize_bind_as_seq: Prims.string FStar_Pervasives_Native.option ;
   z3cliopt: Prims.string Prims.list ;
   z3smtopt: Prims.string Prims.list ;
   z3refresh: Prims.bool ;
@@ -36,10 +35,10 @@ let (__proj__Mkvconfig__item__initial_fuel : vconfig -> Prims.int) =
         detail_hint_replay; no_smt; quake_lo; quake_hi; quake_keep; retry;
         smtencoding_elim_box; smtencoding_nl_arith_repr;
         smtencoding_l_arith_repr; smtencoding_valid_intro;
-        smtencoding_valid_elim; tcnorm; no_plugins; no_tactics;
-        vcgen_optimize_bind_as_seq; z3cliopt; z3smtopt; z3refresh; z3rlimit;
-        z3rlimit_factor; z3seed; trivial_pre_for_unannotated_effectful_fns;
-        reuse_hint_for;_} -> initial_fuel
+        smtencoding_valid_elim; tcnorm; no_plugins; no_tactics; z3cliopt;
+        z3smtopt; z3refresh; z3rlimit; z3rlimit_factor; z3seed;
+        trivial_pre_for_unannotated_effectful_fns; reuse_hint_for;_} ->
+        initial_fuel
 let (__proj__Mkvconfig__item__max_fuel : vconfig -> Prims.int) =
   fun projectee ->
     match projectee with
@@ -47,10 +46,10 @@ let (__proj__Mkvconfig__item__max_fuel : vconfig -> Prims.int) =
         detail_hint_replay; no_smt; quake_lo; quake_hi; quake_keep; retry;
         smtencoding_elim_box; smtencoding_nl_arith_repr;
         smtencoding_l_arith_repr; smtencoding_valid_intro;
-        smtencoding_valid_elim; tcnorm; no_plugins; no_tactics;
-        vcgen_optimize_bind_as_seq; z3cliopt; z3smtopt; z3refresh; z3rlimit;
-        z3rlimit_factor; z3seed; trivial_pre_for_unannotated_effectful_fns;
-        reuse_hint_for;_} -> max_fuel
+        smtencoding_valid_elim; tcnorm; no_plugins; no_tactics; z3cliopt;
+        z3smtopt; z3refresh; z3rlimit; z3rlimit_factor; z3seed;
+        trivial_pre_for_unannotated_effectful_fns; reuse_hint_for;_} ->
+        max_fuel
 let (__proj__Mkvconfig__item__initial_ifuel : vconfig -> Prims.int) =
   fun projectee ->
     match projectee with
@@ -58,10 +57,10 @@ let (__proj__Mkvconfig__item__initial_ifuel : vconfig -> Prims.int) =
         detail_hint_replay; no_smt; quake_lo; quake_hi; quake_keep; retry;
         smtencoding_elim_box; smtencoding_nl_arith_repr;
         smtencoding_l_arith_repr; smtencoding_valid_intro;
-        smtencoding_valid_elim; tcnorm; no_plugins; no_tactics;
-        vcgen_optimize_bind_as_seq; z3cliopt; z3smtopt; z3refresh; z3rlimit;
-        z3rlimit_factor; z3seed; trivial_pre_for_unannotated_effectful_fns;
-        reuse_hint_for;_} -> initial_ifuel
+        smtencoding_valid_elim; tcnorm; no_plugins; no_tactics; z3cliopt;
+        z3smtopt; z3refresh; z3rlimit; z3rlimit_factor; z3seed;
+        trivial_pre_for_unannotated_effectful_fns; reuse_hint_for;_} ->
+        initial_ifuel
 let (__proj__Mkvconfig__item__max_ifuel : vconfig -> Prims.int) =
   fun projectee ->
     match projectee with
@@ -69,10 +68,10 @@ let (__proj__Mkvconfig__item__max_ifuel : vconfig -> Prims.int) =
         detail_hint_replay; no_smt; quake_lo; quake_hi; quake_keep; retry;
         smtencoding_elim_box; smtencoding_nl_arith_repr;
         smtencoding_l_arith_repr; smtencoding_valid_intro;
-        smtencoding_valid_elim; tcnorm; no_plugins; no_tactics;
-        vcgen_optimize_bind_as_seq; z3cliopt; z3smtopt; z3refresh; z3rlimit;
-        z3rlimit_factor; z3seed; trivial_pre_for_unannotated_effectful_fns;
-        reuse_hint_for;_} -> max_ifuel
+        smtencoding_valid_elim; tcnorm; no_plugins; no_tactics; z3cliopt;
+        z3smtopt; z3refresh; z3rlimit; z3rlimit_factor; z3seed;
+        trivial_pre_for_unannotated_effectful_fns; reuse_hint_for;_} ->
+        max_ifuel
 let (__proj__Mkvconfig__item__detail_errors : vconfig -> Prims.bool) =
   fun projectee ->
     match projectee with
@@ -80,10 +79,10 @@ let (__proj__Mkvconfig__item__detail_errors : vconfig -> Prims.bool) =
         detail_hint_replay; no_smt; quake_lo; quake_hi; quake_keep; retry;
         smtencoding_elim_box; smtencoding_nl_arith_repr;
         smtencoding_l_arith_repr; smtencoding_valid_intro;
-        smtencoding_valid_elim; tcnorm; no_plugins; no_tactics;
-        vcgen_optimize_bind_as_seq; z3cliopt; z3smtopt; z3refresh; z3rlimit;
-        z3rlimit_factor; z3seed; trivial_pre_for_unannotated_effectful_fns;
-        reuse_hint_for;_} -> detail_errors
+        smtencoding_valid_elim; tcnorm; no_plugins; no_tactics; z3cliopt;
+        z3smtopt; z3refresh; z3rlimit; z3rlimit_factor; z3seed;
+        trivial_pre_for_unannotated_effectful_fns; reuse_hint_for;_} ->
+        detail_errors
 let (__proj__Mkvconfig__item__detail_hint_replay : vconfig -> Prims.bool) =
   fun projectee ->
     match projectee with
@@ -91,10 +90,10 @@ let (__proj__Mkvconfig__item__detail_hint_replay : vconfig -> Prims.bool) =
         detail_hint_replay; no_smt; quake_lo; quake_hi; quake_keep; retry;
         smtencoding_elim_box; smtencoding_nl_arith_repr;
         smtencoding_l_arith_repr; smtencoding_valid_intro;
-        smtencoding_valid_elim; tcnorm; no_plugins; no_tactics;
-        vcgen_optimize_bind_as_seq; z3cliopt; z3smtopt; z3refresh; z3rlimit;
-        z3rlimit_factor; z3seed; trivial_pre_for_unannotated_effectful_fns;
-        reuse_hint_for;_} -> detail_hint_replay
+        smtencoding_valid_elim; tcnorm; no_plugins; no_tactics; z3cliopt;
+        z3smtopt; z3refresh; z3rlimit; z3rlimit_factor; z3seed;
+        trivial_pre_for_unannotated_effectful_fns; reuse_hint_for;_} ->
+        detail_hint_replay
 let (__proj__Mkvconfig__item__no_smt : vconfig -> Prims.bool) =
   fun projectee ->
     match projectee with
@@ -102,10 +101,10 @@ let (__proj__Mkvconfig__item__no_smt : vconfig -> Prims.bool) =
         detail_hint_replay; no_smt; quake_lo; quake_hi; quake_keep; retry;
         smtencoding_elim_box; smtencoding_nl_arith_repr;
         smtencoding_l_arith_repr; smtencoding_valid_intro;
-        smtencoding_valid_elim; tcnorm; no_plugins; no_tactics;
-        vcgen_optimize_bind_as_seq; z3cliopt; z3smtopt; z3refresh; z3rlimit;
-        z3rlimit_factor; z3seed; trivial_pre_for_unannotated_effectful_fns;
-        reuse_hint_for;_} -> no_smt
+        smtencoding_valid_elim; tcnorm; no_plugins; no_tactics; z3cliopt;
+        z3smtopt; z3refresh; z3rlimit; z3rlimit_factor; z3seed;
+        trivial_pre_for_unannotated_effectful_fns; reuse_hint_for;_} ->
+        no_smt
 let (__proj__Mkvconfig__item__quake_lo : vconfig -> Prims.int) =
   fun projectee ->
     match projectee with
@@ -113,10 +112,10 @@ let (__proj__Mkvconfig__item__quake_lo : vconfig -> Prims.int) =
         detail_hint_replay; no_smt; quake_lo; quake_hi; quake_keep; retry;
         smtencoding_elim_box; smtencoding_nl_arith_repr;
         smtencoding_l_arith_repr; smtencoding_valid_intro;
-        smtencoding_valid_elim; tcnorm; no_plugins; no_tactics;
-        vcgen_optimize_bind_as_seq; z3cliopt; z3smtopt; z3refresh; z3rlimit;
-        z3rlimit_factor; z3seed; trivial_pre_for_unannotated_effectful_fns;
-        reuse_hint_for;_} -> quake_lo
+        smtencoding_valid_elim; tcnorm; no_plugins; no_tactics; z3cliopt;
+        z3smtopt; z3refresh; z3rlimit; z3rlimit_factor; z3seed;
+        trivial_pre_for_unannotated_effectful_fns; reuse_hint_for;_} ->
+        quake_lo
 let (__proj__Mkvconfig__item__quake_hi : vconfig -> Prims.int) =
   fun projectee ->
     match projectee with
@@ -124,10 +123,10 @@ let (__proj__Mkvconfig__item__quake_hi : vconfig -> Prims.int) =
         detail_hint_replay; no_smt; quake_lo; quake_hi; quake_keep; retry;
         smtencoding_elim_box; smtencoding_nl_arith_repr;
         smtencoding_l_arith_repr; smtencoding_valid_intro;
-        smtencoding_valid_elim; tcnorm; no_plugins; no_tactics;
-        vcgen_optimize_bind_as_seq; z3cliopt; z3smtopt; z3refresh; z3rlimit;
-        z3rlimit_factor; z3seed; trivial_pre_for_unannotated_effectful_fns;
-        reuse_hint_for;_} -> quake_hi
+        smtencoding_valid_elim; tcnorm; no_plugins; no_tactics; z3cliopt;
+        z3smtopt; z3refresh; z3rlimit; z3rlimit_factor; z3seed;
+        trivial_pre_for_unannotated_effectful_fns; reuse_hint_for;_} ->
+        quake_hi
 let (__proj__Mkvconfig__item__quake_keep : vconfig -> Prims.bool) =
   fun projectee ->
     match projectee with
@@ -135,10 +134,10 @@ let (__proj__Mkvconfig__item__quake_keep : vconfig -> Prims.bool) =
         detail_hint_replay; no_smt; quake_lo; quake_hi; quake_keep; retry;
         smtencoding_elim_box; smtencoding_nl_arith_repr;
         smtencoding_l_arith_repr; smtencoding_valid_intro;
-        smtencoding_valid_elim; tcnorm; no_plugins; no_tactics;
-        vcgen_optimize_bind_as_seq; z3cliopt; z3smtopt; z3refresh; z3rlimit;
-        z3rlimit_factor; z3seed; trivial_pre_for_unannotated_effectful_fns;
-        reuse_hint_for;_} -> quake_keep
+        smtencoding_valid_elim; tcnorm; no_plugins; no_tactics; z3cliopt;
+        z3smtopt; z3refresh; z3rlimit; z3rlimit_factor; z3seed;
+        trivial_pre_for_unannotated_effectful_fns; reuse_hint_for;_} ->
+        quake_keep
 let (__proj__Mkvconfig__item__retry : vconfig -> Prims.bool) =
   fun projectee ->
     match projectee with
@@ -146,10 +145,9 @@ let (__proj__Mkvconfig__item__retry : vconfig -> Prims.bool) =
         detail_hint_replay; no_smt; quake_lo; quake_hi; quake_keep; retry;
         smtencoding_elim_box; smtencoding_nl_arith_repr;
         smtencoding_l_arith_repr; smtencoding_valid_intro;
-        smtencoding_valid_elim; tcnorm; no_plugins; no_tactics;
-        vcgen_optimize_bind_as_seq; z3cliopt; z3smtopt; z3refresh; z3rlimit;
-        z3rlimit_factor; z3seed; trivial_pre_for_unannotated_effectful_fns;
-        reuse_hint_for;_} -> retry
+        smtencoding_valid_elim; tcnorm; no_plugins; no_tactics; z3cliopt;
+        z3smtopt; z3refresh; z3rlimit; z3rlimit_factor; z3seed;
+        trivial_pre_for_unannotated_effectful_fns; reuse_hint_for;_} -> retry
 let (__proj__Mkvconfig__item__smtencoding_elim_box : vconfig -> Prims.bool) =
   fun projectee ->
     match projectee with
@@ -157,10 +155,10 @@ let (__proj__Mkvconfig__item__smtencoding_elim_box : vconfig -> Prims.bool) =
         detail_hint_replay; no_smt; quake_lo; quake_hi; quake_keep; retry;
         smtencoding_elim_box; smtencoding_nl_arith_repr;
         smtencoding_l_arith_repr; smtencoding_valid_intro;
-        smtencoding_valid_elim; tcnorm; no_plugins; no_tactics;
-        vcgen_optimize_bind_as_seq; z3cliopt; z3smtopt; z3refresh; z3rlimit;
-        z3rlimit_factor; z3seed; trivial_pre_for_unannotated_effectful_fns;
-        reuse_hint_for;_} -> smtencoding_elim_box
+        smtencoding_valid_elim; tcnorm; no_plugins; no_tactics; z3cliopt;
+        z3smtopt; z3refresh; z3rlimit; z3rlimit_factor; z3seed;
+        trivial_pre_for_unannotated_effectful_fns; reuse_hint_for;_} ->
+        smtencoding_elim_box
 let (__proj__Mkvconfig__item__smtencoding_nl_arith_repr :
   vconfig -> Prims.string) =
   fun projectee ->
@@ -169,10 +167,10 @@ let (__proj__Mkvconfig__item__smtencoding_nl_arith_repr :
         detail_hint_replay; no_smt; quake_lo; quake_hi; quake_keep; retry;
         smtencoding_elim_box; smtencoding_nl_arith_repr;
         smtencoding_l_arith_repr; smtencoding_valid_intro;
-        smtencoding_valid_elim; tcnorm; no_plugins; no_tactics;
-        vcgen_optimize_bind_as_seq; z3cliopt; z3smtopt; z3refresh; z3rlimit;
-        z3rlimit_factor; z3seed; trivial_pre_for_unannotated_effectful_fns;
-        reuse_hint_for;_} -> smtencoding_nl_arith_repr
+        smtencoding_valid_elim; tcnorm; no_plugins; no_tactics; z3cliopt;
+        z3smtopt; z3refresh; z3rlimit; z3rlimit_factor; z3seed;
+        trivial_pre_for_unannotated_effectful_fns; reuse_hint_for;_} ->
+        smtencoding_nl_arith_repr
 let (__proj__Mkvconfig__item__smtencoding_l_arith_repr :
   vconfig -> Prims.string) =
   fun projectee ->
@@ -181,10 +179,10 @@ let (__proj__Mkvconfig__item__smtencoding_l_arith_repr :
         detail_hint_replay; no_smt; quake_lo; quake_hi; quake_keep; retry;
         smtencoding_elim_box; smtencoding_nl_arith_repr;
         smtencoding_l_arith_repr; smtencoding_valid_intro;
-        smtencoding_valid_elim; tcnorm; no_plugins; no_tactics;
-        vcgen_optimize_bind_as_seq; z3cliopt; z3smtopt; z3refresh; z3rlimit;
-        z3rlimit_factor; z3seed; trivial_pre_for_unannotated_effectful_fns;
-        reuse_hint_for;_} -> smtencoding_l_arith_repr
+        smtencoding_valid_elim; tcnorm; no_plugins; no_tactics; z3cliopt;
+        z3smtopt; z3refresh; z3rlimit; z3rlimit_factor; z3seed;
+        trivial_pre_for_unannotated_effectful_fns; reuse_hint_for;_} ->
+        smtencoding_l_arith_repr
 let (__proj__Mkvconfig__item__smtencoding_valid_intro :
   vconfig -> Prims.bool) =
   fun projectee ->
@@ -193,10 +191,10 @@ let (__proj__Mkvconfig__item__smtencoding_valid_intro :
         detail_hint_replay; no_smt; quake_lo; quake_hi; quake_keep; retry;
         smtencoding_elim_box; smtencoding_nl_arith_repr;
         smtencoding_l_arith_repr; smtencoding_valid_intro;
-        smtencoding_valid_elim; tcnorm; no_plugins; no_tactics;
-        vcgen_optimize_bind_as_seq; z3cliopt; z3smtopt; z3refresh; z3rlimit;
-        z3rlimit_factor; z3seed; trivial_pre_for_unannotated_effectful_fns;
-        reuse_hint_for;_} -> smtencoding_valid_intro
+        smtencoding_valid_elim; tcnorm; no_plugins; no_tactics; z3cliopt;
+        z3smtopt; z3refresh; z3rlimit; z3rlimit_factor; z3seed;
+        trivial_pre_for_unannotated_effectful_fns; reuse_hint_for;_} ->
+        smtencoding_valid_intro
 let (__proj__Mkvconfig__item__smtencoding_valid_elim : vconfig -> Prims.bool)
   =
   fun projectee ->
@@ -205,10 +203,10 @@ let (__proj__Mkvconfig__item__smtencoding_valid_elim : vconfig -> Prims.bool)
         detail_hint_replay; no_smt; quake_lo; quake_hi; quake_keep; retry;
         smtencoding_elim_box; smtencoding_nl_arith_repr;
         smtencoding_l_arith_repr; smtencoding_valid_intro;
-        smtencoding_valid_elim; tcnorm; no_plugins; no_tactics;
-        vcgen_optimize_bind_as_seq; z3cliopt; z3smtopt; z3refresh; z3rlimit;
-        z3rlimit_factor; z3seed; trivial_pre_for_unannotated_effectful_fns;
-        reuse_hint_for;_} -> smtencoding_valid_elim
+        smtencoding_valid_elim; tcnorm; no_plugins; no_tactics; z3cliopt;
+        z3smtopt; z3refresh; z3rlimit; z3rlimit_factor; z3seed;
+        trivial_pre_for_unannotated_effectful_fns; reuse_hint_for;_} ->
+        smtencoding_valid_elim
 let (__proj__Mkvconfig__item__tcnorm : vconfig -> Prims.bool) =
   fun projectee ->
     match projectee with
@@ -216,10 +214,10 @@ let (__proj__Mkvconfig__item__tcnorm : vconfig -> Prims.bool) =
         detail_hint_replay; no_smt; quake_lo; quake_hi; quake_keep; retry;
         smtencoding_elim_box; smtencoding_nl_arith_repr;
         smtencoding_l_arith_repr; smtencoding_valid_intro;
-        smtencoding_valid_elim; tcnorm; no_plugins; no_tactics;
-        vcgen_optimize_bind_as_seq; z3cliopt; z3smtopt; z3refresh; z3rlimit;
-        z3rlimit_factor; z3seed; trivial_pre_for_unannotated_effectful_fns;
-        reuse_hint_for;_} -> tcnorm
+        smtencoding_valid_elim; tcnorm; no_plugins; no_tactics; z3cliopt;
+        z3smtopt; z3refresh; z3rlimit; z3rlimit_factor; z3seed;
+        trivial_pre_for_unannotated_effectful_fns; reuse_hint_for;_} ->
+        tcnorm
 let (__proj__Mkvconfig__item__no_plugins : vconfig -> Prims.bool) =
   fun projectee ->
     match projectee with
@@ -227,10 +225,10 @@ let (__proj__Mkvconfig__item__no_plugins : vconfig -> Prims.bool) =
         detail_hint_replay; no_smt; quake_lo; quake_hi; quake_keep; retry;
         smtencoding_elim_box; smtencoding_nl_arith_repr;
         smtencoding_l_arith_repr; smtencoding_valid_intro;
-        smtencoding_valid_elim; tcnorm; no_plugins; no_tactics;
-        vcgen_optimize_bind_as_seq; z3cliopt; z3smtopt; z3refresh; z3rlimit;
-        z3rlimit_factor; z3seed; trivial_pre_for_unannotated_effectful_fns;
-        reuse_hint_for;_} -> no_plugins
+        smtencoding_valid_elim; tcnorm; no_plugins; no_tactics; z3cliopt;
+        z3smtopt; z3refresh; z3rlimit; z3rlimit_factor; z3seed;
+        trivial_pre_for_unannotated_effectful_fns; reuse_hint_for;_} ->
+        no_plugins
 let (__proj__Mkvconfig__item__no_tactics : vconfig -> Prims.bool) =
   fun projectee ->
     match projectee with
@@ -238,22 +236,10 @@ let (__proj__Mkvconfig__item__no_tactics : vconfig -> Prims.bool) =
         detail_hint_replay; no_smt; quake_lo; quake_hi; quake_keep; retry;
         smtencoding_elim_box; smtencoding_nl_arith_repr;
         smtencoding_l_arith_repr; smtencoding_valid_intro;
-        smtencoding_valid_elim; tcnorm; no_plugins; no_tactics;
-        vcgen_optimize_bind_as_seq; z3cliopt; z3smtopt; z3refresh; z3rlimit;
-        z3rlimit_factor; z3seed; trivial_pre_for_unannotated_effectful_fns;
-        reuse_hint_for;_} -> no_tactics
-let (__proj__Mkvconfig__item__vcgen_optimize_bind_as_seq :
-  vconfig -> Prims.string FStar_Pervasives_Native.option) =
-  fun projectee ->
-    match projectee with
-    | { initial_fuel; max_fuel; initial_ifuel; max_ifuel; detail_errors;
-        detail_hint_replay; no_smt; quake_lo; quake_hi; quake_keep; retry;
-        smtencoding_elim_box; smtencoding_nl_arith_repr;
-        smtencoding_l_arith_repr; smtencoding_valid_intro;
-        smtencoding_valid_elim; tcnorm; no_plugins; no_tactics;
-        vcgen_optimize_bind_as_seq; z3cliopt; z3smtopt; z3refresh; z3rlimit;
-        z3rlimit_factor; z3seed; trivial_pre_for_unannotated_effectful_fns;
-        reuse_hint_for;_} -> vcgen_optimize_bind_as_seq
+        smtencoding_valid_elim; tcnorm; no_plugins; no_tactics; z3cliopt;
+        z3smtopt; z3refresh; z3rlimit; z3rlimit_factor; z3seed;
+        trivial_pre_for_unannotated_effectful_fns; reuse_hint_for;_} ->
+        no_tactics
 let (__proj__Mkvconfig__item__z3cliopt : vconfig -> Prims.string Prims.list)
   =
   fun projectee ->
@@ -262,10 +248,10 @@ let (__proj__Mkvconfig__item__z3cliopt : vconfig -> Prims.string Prims.list)
         detail_hint_replay; no_smt; quake_lo; quake_hi; quake_keep; retry;
         smtencoding_elim_box; smtencoding_nl_arith_repr;
         smtencoding_l_arith_repr; smtencoding_valid_intro;
-        smtencoding_valid_elim; tcnorm; no_plugins; no_tactics;
-        vcgen_optimize_bind_as_seq; z3cliopt; z3smtopt; z3refresh; z3rlimit;
-        z3rlimit_factor; z3seed; trivial_pre_for_unannotated_effectful_fns;
-        reuse_hint_for;_} -> z3cliopt
+        smtencoding_valid_elim; tcnorm; no_plugins; no_tactics; z3cliopt;
+        z3smtopt; z3refresh; z3rlimit; z3rlimit_factor; z3seed;
+        trivial_pre_for_unannotated_effectful_fns; reuse_hint_for;_} ->
+        z3cliopt
 let (__proj__Mkvconfig__item__z3smtopt : vconfig -> Prims.string Prims.list)
   =
   fun projectee ->
@@ -274,10 +260,10 @@ let (__proj__Mkvconfig__item__z3smtopt : vconfig -> Prims.string Prims.list)
         detail_hint_replay; no_smt; quake_lo; quake_hi; quake_keep; retry;
         smtencoding_elim_box; smtencoding_nl_arith_repr;
         smtencoding_l_arith_repr; smtencoding_valid_intro;
-        smtencoding_valid_elim; tcnorm; no_plugins; no_tactics;
-        vcgen_optimize_bind_as_seq; z3cliopt; z3smtopt; z3refresh; z3rlimit;
-        z3rlimit_factor; z3seed; trivial_pre_for_unannotated_effectful_fns;
-        reuse_hint_for;_} -> z3smtopt
+        smtencoding_valid_elim; tcnorm; no_plugins; no_tactics; z3cliopt;
+        z3smtopt; z3refresh; z3rlimit; z3rlimit_factor; z3seed;
+        trivial_pre_for_unannotated_effectful_fns; reuse_hint_for;_} ->
+        z3smtopt
 let (__proj__Mkvconfig__item__z3refresh : vconfig -> Prims.bool) =
   fun projectee ->
     match projectee with
@@ -285,10 +271,10 @@ let (__proj__Mkvconfig__item__z3refresh : vconfig -> Prims.bool) =
         detail_hint_replay; no_smt; quake_lo; quake_hi; quake_keep; retry;
         smtencoding_elim_box; smtencoding_nl_arith_repr;
         smtencoding_l_arith_repr; smtencoding_valid_intro;
-        smtencoding_valid_elim; tcnorm; no_plugins; no_tactics;
-        vcgen_optimize_bind_as_seq; z3cliopt; z3smtopt; z3refresh; z3rlimit;
-        z3rlimit_factor; z3seed; trivial_pre_for_unannotated_effectful_fns;
-        reuse_hint_for;_} -> z3refresh
+        smtencoding_valid_elim; tcnorm; no_plugins; no_tactics; z3cliopt;
+        z3smtopt; z3refresh; z3rlimit; z3rlimit_factor; z3seed;
+        trivial_pre_for_unannotated_effectful_fns; reuse_hint_for;_} ->
+        z3refresh
 let (__proj__Mkvconfig__item__z3rlimit : vconfig -> Prims.int) =
   fun projectee ->
     match projectee with
@@ -296,10 +282,10 @@ let (__proj__Mkvconfig__item__z3rlimit : vconfig -> Prims.int) =
         detail_hint_replay; no_smt; quake_lo; quake_hi; quake_keep; retry;
         smtencoding_elim_box; smtencoding_nl_arith_repr;
         smtencoding_l_arith_repr; smtencoding_valid_intro;
-        smtencoding_valid_elim; tcnorm; no_plugins; no_tactics;
-        vcgen_optimize_bind_as_seq; z3cliopt; z3smtopt; z3refresh; z3rlimit;
-        z3rlimit_factor; z3seed; trivial_pre_for_unannotated_effectful_fns;
-        reuse_hint_for;_} -> z3rlimit
+        smtencoding_valid_elim; tcnorm; no_plugins; no_tactics; z3cliopt;
+        z3smtopt; z3refresh; z3rlimit; z3rlimit_factor; z3seed;
+        trivial_pre_for_unannotated_effectful_fns; reuse_hint_for;_} ->
+        z3rlimit
 let (__proj__Mkvconfig__item__z3rlimit_factor : vconfig -> Prims.int) =
   fun projectee ->
     match projectee with
@@ -307,10 +293,10 @@ let (__proj__Mkvconfig__item__z3rlimit_factor : vconfig -> Prims.int) =
         detail_hint_replay; no_smt; quake_lo; quake_hi; quake_keep; retry;
         smtencoding_elim_box; smtencoding_nl_arith_repr;
         smtencoding_l_arith_repr; smtencoding_valid_intro;
-        smtencoding_valid_elim; tcnorm; no_plugins; no_tactics;
-        vcgen_optimize_bind_as_seq; z3cliopt; z3smtopt; z3refresh; z3rlimit;
-        z3rlimit_factor; z3seed; trivial_pre_for_unannotated_effectful_fns;
-        reuse_hint_for;_} -> z3rlimit_factor
+        smtencoding_valid_elim; tcnorm; no_plugins; no_tactics; z3cliopt;
+        z3smtopt; z3refresh; z3rlimit; z3rlimit_factor; z3seed;
+        trivial_pre_for_unannotated_effectful_fns; reuse_hint_for;_} ->
+        z3rlimit_factor
 let (__proj__Mkvconfig__item__z3seed : vconfig -> Prims.int) =
   fun projectee ->
     match projectee with
@@ -318,10 +304,10 @@ let (__proj__Mkvconfig__item__z3seed : vconfig -> Prims.int) =
         detail_hint_replay; no_smt; quake_lo; quake_hi; quake_keep; retry;
         smtencoding_elim_box; smtencoding_nl_arith_repr;
         smtencoding_l_arith_repr; smtencoding_valid_intro;
-        smtencoding_valid_elim; tcnorm; no_plugins; no_tactics;
-        vcgen_optimize_bind_as_seq; z3cliopt; z3smtopt; z3refresh; z3rlimit;
-        z3rlimit_factor; z3seed; trivial_pre_for_unannotated_effectful_fns;
-        reuse_hint_for;_} -> z3seed
+        smtencoding_valid_elim; tcnorm; no_plugins; no_tactics; z3cliopt;
+        z3smtopt; z3refresh; z3rlimit; z3rlimit_factor; z3seed;
+        trivial_pre_for_unannotated_effectful_fns; reuse_hint_for;_} ->
+        z3seed
 let (__proj__Mkvconfig__item__trivial_pre_for_unannotated_effectful_fns :
   vconfig -> Prims.bool) =
   fun projectee ->
@@ -330,10 +316,10 @@ let (__proj__Mkvconfig__item__trivial_pre_for_unannotated_effectful_fns :
         detail_hint_replay; no_smt; quake_lo; quake_hi; quake_keep; retry;
         smtencoding_elim_box; smtencoding_nl_arith_repr;
         smtencoding_l_arith_repr; smtencoding_valid_intro;
-        smtencoding_valid_elim; tcnorm; no_plugins; no_tactics;
-        vcgen_optimize_bind_as_seq; z3cliopt; z3smtopt; z3refresh; z3rlimit;
-        z3rlimit_factor; z3seed; trivial_pre_for_unannotated_effectful_fns;
-        reuse_hint_for;_} -> trivial_pre_for_unannotated_effectful_fns
+        smtencoding_valid_elim; tcnorm; no_plugins; no_tactics; z3cliopt;
+        z3smtopt; z3refresh; z3rlimit; z3rlimit_factor; z3seed;
+        trivial_pre_for_unannotated_effectful_fns; reuse_hint_for;_} ->
+        trivial_pre_for_unannotated_effectful_fns
 let (__proj__Mkvconfig__item__reuse_hint_for :
   vconfig -> Prims.string FStar_Pervasives_Native.option) =
   fun projectee ->
@@ -342,7 +328,7 @@ let (__proj__Mkvconfig__item__reuse_hint_for :
         detail_hint_replay; no_smt; quake_lo; quake_hi; quake_keep; retry;
         smtencoding_elim_box; smtencoding_nl_arith_repr;
         smtencoding_l_arith_repr; smtencoding_valid_intro;
-        smtencoding_valid_elim; tcnorm; no_plugins; no_tactics;
-        vcgen_optimize_bind_as_seq; z3cliopt; z3smtopt; z3refresh; z3rlimit;
-        z3rlimit_factor; z3seed; trivial_pre_for_unannotated_effectful_fns;
-        reuse_hint_for;_} -> reuse_hint_for
+        smtencoding_valid_elim; tcnorm; no_plugins; no_tactics; z3cliopt;
+        z3smtopt; z3refresh; z3rlimit; z3rlimit_factor; z3seed;
+        trivial_pre_for_unannotated_effectful_fns; reuse_hint_for;_} ->
+        reuse_hint_for

--- a/src/basic/FStar.Options.fst
+++ b/src/basic/FStar.Options.fst
@@ -248,7 +248,6 @@ let defaults =
       ("use_hints"                    , Bool false);
       ("use_hint_hashes"              , Bool false);
       ("using_facts_from"             , Unset);
-      ("vcgen.optimize_bind_as_seq"   , Unset);
       ("verify_module"                , List []);
       ("warn_default_effects"         , Bool false);
       ("z3refresh"                    , Bool false);
@@ -312,7 +311,6 @@ let set_verification_options o =
     "tcnorm";
     "no_plugins";
     "no_tactics";
-    "vcgen.optimize_bind_as_seq";
     "z3cliopt";
     "z3smtopt";    
     "z3refresh";
@@ -430,7 +428,6 @@ let get_use_hint_hashes         ()      = lookup_opt "use_hint_hashes"          
 let get_use_native_tactics      ()      = lookup_opt "use_native_tactics"       (as_option as_string)
 let get_no_tactics              ()      = lookup_opt "no_tactics"               as_bool
 let get_using_facts_from        ()      = lookup_opt "using_facts_from"         (as_option (as_list as_string))
-let get_vcgen_optimize_bind_as_seq  ()  = lookup_opt "vcgen.optimize_bind_as_seq" (as_option as_string)
 let get_verify_module           ()      = lookup_opt "verify_module"            (as_list as_string)
 let get_version                 ()      = lookup_opt "version"                  as_bool
 let get_warn_default_effects    ()      = lookup_opt "warn_default_effects"     as_bool
@@ -1222,18 +1219,6 @@ let rec specs_with_types warn_unsafe : list (char * string * opt_type * string) 
          Multiple uses of this option accumulate, e.g., --using_facts_from A --using_facts_from B is interpreted as --using_facts_from A^B.");
 
        ( noshort,
-         "vcgen.optimize_bind_as_seq",
-          EnumStr ["off"; "without_type"; "with_type"],
-          "\n\t\tOptimize the generation of verification conditions, \n\t\t\t\
-           specifically the construction of monadic `bind`,\n\t\t\t\
-           generating `seq` instead of `bind` when the first computation as a trivial post-condition.\n\t\t\t\
-           By default, this optimization does not apply.\n\t\t\t\
-           When the `without_type` option is chosen, this imposes a cost on the SMT solver\n\t\t\t\
-           to reconstruct type information.\n\t\t\t\
-           When `with_type` is chosen, type information is provided to the SMT solver,\n\t\t\t\
-           but at the cost of VC bloat, which may often be redundant.");
-
-       ( noshort,
         "__temp_fast_implicits",
         Const (Bool true),
         "Don't use this option yet");
@@ -1426,7 +1411,6 @@ let settable = function
     | "unthrottle_inductives"
     | "use_eq_at_higher_order"
     | "using_facts_from"
-    | "vcgen.optimize_bind_as_seq"
     | "warn_error"
     | "z3cliopt"
     | "z3smtopt"    
@@ -1821,10 +1805,6 @@ let using_facts_from             () =
     match get_using_facts_from () with
     | None -> [ [], true ] //if not set, then retain all facts
     | Some ns -> parse_settings ns
-let vcgen_optimize_bind_as_seq   () = Option.isSome (get_vcgen_optimize_bind_as_seq  ())
-let vcgen_decorate_with_type     () = match get_vcgen_optimize_bind_as_seq  () with
-                                      | Some "with_type" -> true
-                                      | _ -> false
 let warn_default_effects         () = get_warn_default_effects        ()
 let warn_error                   () = String.concat " " (get_warn_error())
 let z3_exe                       () = match get_smt () with
@@ -2094,7 +2074,6 @@ let get_vconfig () =
     tcnorm                                    = get_tcnorm ();
     no_plugins                                = get_no_plugins ();
     no_tactics                                = get_no_tactics ();
-    vcgen_optimize_bind_as_seq                = get_vcgen_optimize_bind_as_seq ();
     z3cliopt                                  = get_z3cliopt ();
     z3smtopt                                  = get_z3smtopt ();    
     z3refresh                                 = get_z3refresh ();
@@ -2132,7 +2111,6 @@ let set_vconfig (vcfg:vconfig) : unit =
   set_option "tcnorm"                                    (Bool vcfg.tcnorm);
   set_option "no_plugins"                                (Bool vcfg.no_plugins);
   set_option "no_tactics"                                (Bool vcfg.no_tactics);
-  set_option "vcgen.optimize_bind_as_seq"                (option_as String vcfg.vcgen_optimize_bind_as_seq);
   set_option "z3cliopt"                                  (List (List.map String vcfg.z3cliopt));
   set_option "z3smtopt"                                  (List (List.map String vcfg.z3smtopt));  
   set_option "z3refresh"                                 (Bool vcfg.z3refresh);

--- a/src/basic/FStar.Options.fsti
+++ b/src/basic/FStar.Options.fsti
@@ -225,8 +225,6 @@ val use_hint_hashes             : unit    -> bool
 val use_native_tactics          : unit    -> option string
 val use_tactics                 : unit    -> bool
 val using_facts_from            : unit    -> list (list string * bool)
-val vcgen_optimize_bind_as_seq  : unit    -> bool
-val vcgen_decorate_with_type    : unit    -> bool
 val warn_default_effects        : unit    -> bool
 val with_saved_options          : (unit -> 'a) -> 'a
 val z3_exe                      : unit    -> string

--- a/src/parser/FStar.Parser.Const.fst
+++ b/src/parser/FStar.Parser.Const.fst
@@ -311,7 +311,6 @@ let labeled_lid    = pconst "labeled"
 let range_0        = pconst "range_0"
 let guard_free     = pconst "guard_free"
 let inversion_lid  = p2l ["FStar"; "Pervasives"; "inversion"]
-let with_type_lid  = psconst "with_type"
 
 (* Constants for marking terms with normalization hints *)
 let normalize      = psconst "normalize"

--- a/src/smtencoding/FStar.SMTEncoding.Encode.fst
+++ b/src/smtencoding/FStar.SMTEncoding.Encode.fst
@@ -333,27 +333,6 @@ let primitive_type_axioms : env -> lident -> string -> term -> list decl =
         in
         [Util.mkAssume(mkForall (Env.get_range env) ([[inversion_t]], [tt], mkImp(valid, body)), Some "inversion interpretation", "inversion-interp")]
    in
-   let mk_with_type_axiom : env -> string -> term -> list decl = fun env with_type tt ->
-        (* (assert (forall ((t Term) (e Term))
-                           (! (and (= (Prims.with_type t e)
-                                       e)
-                                   (HasType (Prims.with_type t e) t))
-                            :weight 0
-                            :pattern ((Prims.with_type t e)))))
-         *)
-        let tt = mk_fv ("t", Term_sort) in
-        let t = mkFreeV tt in
-        let ee = mk_fv ("e", Term_sort) in
-        let e = mkFreeV ee in
-        let with_type_t_e = mkApp(with_type, [t; e]) in
-        [Util.mkAssume(mkForall' (Env.get_range env) ([[with_type_t_e]],
-                                 Some 0, //weight
-                                 [tt;ee],
-                                 mkAnd(mkEq(with_type_t_e, e),
-                                       mk_HasType with_type_t_e t)),
-                       Some "with_type primitive axiom",
-                       "@with_type_primitive_axiom")] //the "@" in the name forces it to be retained even when the contex is pruned
-   in
    let prims =  [(Const.unit_lid,   mk_unit);
                  (Const.bool_lid,   mk_bool);
                  (Const.int_lid,    mk_int);
@@ -371,7 +350,6 @@ let primitive_type_axioms : env -> lident -> string -> term -> list decl =
                  //(Const.exists_lid, mk_exists_interp);
                  (Const.range_lid,  mk_range_interp);
                  (Const.inversion_lid,mk_inversion_axiom);
-                 (Const.with_type_lid, mk_with_type_axiom)
                 ] in
     (fun (env:env) (t:lident) (s:string) (tt:term) ->
         match BU.find_opt (fun (l, _) -> lid_equals l t) prims with

--- a/src/syntax/FStar.Syntax.Embeddings.fst
+++ b/src/syntax/FStar.Syntax.Embeddings.fst
@@ -911,7 +911,6 @@ let e_vconfig =
                    S.as_arg (embed e_bool              vcfg.tcnorm                                    rng None norm);
                    S.as_arg (embed e_bool              vcfg.no_plugins                                rng None norm);
                    S.as_arg (embed e_bool              vcfg.no_tactics                                rng None norm);
-                   S.as_arg (embed (e_option e_string) vcfg.vcgen_optimize_bind_as_seq                rng None norm);
                    S.as_arg (embed e_string_list       vcfg.z3cliopt                                  rng None norm);
                    S.as_arg (embed e_string_list       vcfg.z3smtopt                                  rng None norm);                   
                    S.as_arg (embed e_bool              vcfg.z3refresh                                 rng None norm);
@@ -948,7 +947,6 @@ let e_vconfig =
             (tcnorm, _);
             (no_plugins, _);
             (no_tactics, _);
-            (vcgen_optimize_bind_as_seq, _);
             (z3cliopt, _);
             (z3smtopt, _);            
             (z3refresh, _);
@@ -977,7 +975,6 @@ let e_vconfig =
                   BU.bind_opt (unembed e_bool              tcnorm w norm) (fun tcnorm ->
                   BU.bind_opt (unembed e_bool              no_plugins w norm) (fun no_plugins ->
                   BU.bind_opt (unembed e_bool              no_tactics w norm) (fun no_tactics ->
-                  BU.bind_opt (unembed (e_option e_string) vcgen_optimize_bind_as_seq w norm) (fun vcgen_optimize_bind_as_seq ->
                   BU.bind_opt (unembed e_string_list       z3cliopt w norm) (fun z3cliopt ->
                   BU.bind_opt (unembed e_string_list       z3smtopt w norm) (fun z3smtopt ->                  
                   BU.bind_opt (unembed e_bool              z3refresh w norm) (fun z3refresh ->
@@ -1006,7 +1003,6 @@ let e_vconfig =
                     tcnorm = tcnorm;
                     no_plugins = no_plugins;
                     no_tactics = no_tactics;
-                    vcgen_optimize_bind_as_seq = vcgen_optimize_bind_as_seq;
                     z3cliopt = z3cliopt;
                     z3smtopt = z3smtopt;
                     z3refresh = z3refresh;
@@ -1015,7 +1011,7 @@ let e_vconfig =
                     z3seed = z3seed;
                     trivial_pre_for_unannotated_effectful_fns = trivial_pre_for_unannotated_effectful_fns;
                     reuse_hint_for = reuse_hint_for;
-                  })))))))))))))))))))))))))))))
+                  }))))))))))))))))))))))))))))
         | _ ->
           if w then
             Err.log_issue t0.pos (Err.Warning_NotEmbedded, (BU.format1 "Not an embedded vconfig: %s" (Print.term_to_string t0)));

--- a/src/syntax/FStar.Syntax.Util.fst
+++ b/src/syntax/FStar.Syntax.Util.fst
@@ -1358,11 +1358,6 @@ let mk_has_type t x t' =
     let t_has_type = mk (Tm_uinst(t_has_type, [U_zero; U_zero])) dummyRange in
     mk (Tm_app(t_has_type, [iarg t; as_arg x; as_arg t'])) dummyRange
 
-let mk_with_type u t e =
-    let t_with_type = fvar PC.with_type_lid delta_equational None in
-    let t_with_type = mk (Tm_uinst(t_with_type, [u])) dummyRange in
-    mk (Tm_app(t_with_type, [iarg t; as_arg e])) dummyRange
-
 let tforall  = fvar PC.forall_lid (Delta_constant_at_level 1) None //NS delta: wrong level 2
 let texists  = fvar PC.exists_lid (Delta_constant_at_level 1) None //NS delta: wrong level 2
 let t_haseq   = fvar PC.haseq_lid delta_constant None //NS delta: wrong Delta_abstract (Delta_constant_at_level 0)?

--- a/ulib/FStar.Pervasives.fst
+++ b/ulib/FStar.Pervasives.fst
@@ -181,5 +181,3 @@ let no_auto_projectors = ()
 let no_subtyping = ()
 
 let singleton #_ x = x
-
-let with_type #_ e = e

--- a/ulib/FStar.Pervasives.fsti
+++ b/ulib/FStar.Pervasives.fsti
@@ -1150,12 +1150,6 @@ val no_subtyping : unit
     See the example usage in ulib/FStar.Algebra.Monoid.fst. *)
 val singleton (#a: Type) (x: a) : Tot (y: a{y == x})
 
-(** [with_type t e] is just an identity function, but it receives
-    special treatment in the SMT encoding, where in addition to being
-    an identity function, we have an SMT axiom:
-    [forall t e.{:pattern (with_type t e)} has_type (with_type t e) t] *)
-val with_type (#t: Type) (e: t) : Tot t
-
 (** A weakening coercion from eqtype to Type.
 
     One of its uses is in types of layered effect combinators that

--- a/ulib/FStar.VConfig.fsti
+++ b/ulib/FStar.VConfig.fsti
@@ -41,7 +41,6 @@ type vconfig = {
   tcnorm                                    : bool;
   no_plugins                                : bool;
   no_tactics                                : bool;
-  vcgen_optimize_bind_as_seq                : option string;
   z3cliopt                                  : list string;
   z3smtopt                                  : list string;  
   z3refresh                                 : bool;


### PR DESCRIPTION
This PR removes the `vcgen.optimize_bind_as_seq` option from F*. This option was added to customize bind VCs, but the option is not used (it is off by-default); plus supporting it required a strange smt axiom (cf. #2868).