### PR TITLE
Do not memoize free variables

### DIFF
--- a/ocaml/fstar-lib/generated/FStar_Extraction_ML_Modul.ml
+++ b/ocaml/fstar-lib/generated/FStar_Extraction_ML_Modul.ml
@@ -101,12 +101,12 @@ let rec (extract_meta :
     let uu___ = FStar_Syntax_Subst.compress x in
     match uu___ with
     | { FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar fv;
-        FStar_Syntax_Syntax.pos = uu___1; FStar_Syntax_Syntax.vars = uu___2;
-        FStar_Syntax_Syntax.hash_code = uu___3;_} ->
-        let uu___4 =
-          let uu___5 = FStar_Syntax_Syntax.lid_of_fv fv in
-          FStar_Ident.string_of_lid uu___5 in
-        (match uu___4 with
+        FStar_Syntax_Syntax.pos = uu___1;
+        FStar_Syntax_Syntax.hash_code = uu___2;_} ->
+        let uu___3 =
+          let uu___4 = FStar_Syntax_Syntax.lid_of_fv fv in
+          FStar_Ident.string_of_lid uu___4 in
+        (match uu___3 with
          | "FStar.Pervasives.PpxDerivingShow" ->
              FStar_Pervasives_Native.Some
                FStar_Extraction_ML_Syntax.PpxDerivingShow
@@ -130,26 +130,24 @@ let rec (extract_meta :
          | "Prims.deprecated" ->
              FStar_Pervasives_Native.Some
                (FStar_Extraction_ML_Syntax.Deprecated "")
-         | uu___5 -> FStar_Pervasives_Native.None)
+         | uu___4 -> FStar_Pervasives_Native.None)
     | {
         FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_app
           ({ FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar fv;
              FStar_Syntax_Syntax.pos = uu___1;
-             FStar_Syntax_Syntax.vars = uu___2;
-             FStar_Syntax_Syntax.hash_code = uu___3;_},
+             FStar_Syntax_Syntax.hash_code = uu___2;_},
            ({
               FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
-                (FStar_Const.Const_string (s, uu___4));
-              FStar_Syntax_Syntax.pos = uu___5;
-              FStar_Syntax_Syntax.vars = uu___6;
-              FStar_Syntax_Syntax.hash_code = uu___7;_},
-            uu___8)::[]);
-        FStar_Syntax_Syntax.pos = uu___9; FStar_Syntax_Syntax.vars = uu___10;
-        FStar_Syntax_Syntax.hash_code = uu___11;_} ->
-        let uu___12 =
-          let uu___13 = FStar_Syntax_Syntax.lid_of_fv fv in
-          FStar_Ident.string_of_lid uu___13 in
-        (match uu___12 with
+                (FStar_Const.Const_string (s, uu___3));
+              FStar_Syntax_Syntax.pos = uu___4;
+              FStar_Syntax_Syntax.hash_code = uu___5;_},
+            uu___6)::[]);
+        FStar_Syntax_Syntax.pos = uu___7;
+        FStar_Syntax_Syntax.hash_code = uu___8;_} ->
+        let uu___9 =
+          let uu___10 = FStar_Syntax_Syntax.lid_of_fv fv in
+          FStar_Ident.string_of_lid uu___10 in
+        (match uu___9 with
          | "FStar.Pervasives.PpxDerivingShowConstant" ->
              FStar_Pervasives_Native.Some
                (FStar_Extraction_ML_Syntax.PpxDerivingShowConstant s)
@@ -171,28 +169,28 @@ let rec (extract_meta :
          | "Prims.deprecated" ->
              FStar_Pervasives_Native.Some
                (FStar_Extraction_ML_Syntax.Deprecated s)
-         | uu___13 -> FStar_Pervasives_Native.None)
+         | uu___10 -> FStar_Pervasives_Native.None)
     | {
         FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
           (FStar_Const.Const_string ("KrmlPrivate", uu___1));
-        FStar_Syntax_Syntax.pos = uu___2; FStar_Syntax_Syntax.vars = uu___3;
-        FStar_Syntax_Syntax.hash_code = uu___4;_} ->
+        FStar_Syntax_Syntax.pos = uu___2;
+        FStar_Syntax_Syntax.hash_code = uu___3;_} ->
         FStar_Pervasives_Native.Some FStar_Extraction_ML_Syntax.Private
     | {
         FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
           (FStar_Const.Const_string ("c_inline", uu___1));
-        FStar_Syntax_Syntax.pos = uu___2; FStar_Syntax_Syntax.vars = uu___3;
-        FStar_Syntax_Syntax.hash_code = uu___4;_} ->
+        FStar_Syntax_Syntax.pos = uu___2;
+        FStar_Syntax_Syntax.hash_code = uu___3;_} ->
         FStar_Pervasives_Native.Some FStar_Extraction_ML_Syntax.CInline
     | {
         FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
           (FStar_Const.Const_string ("substitute", uu___1));
-        FStar_Syntax_Syntax.pos = uu___2; FStar_Syntax_Syntax.vars = uu___3;
-        FStar_Syntax_Syntax.hash_code = uu___4;_} ->
+        FStar_Syntax_Syntax.pos = uu___2;
+        FStar_Syntax_Syntax.hash_code = uu___3;_} ->
         FStar_Pervasives_Native.Some FStar_Extraction_ML_Syntax.Substitute
     | { FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_meta (x1, uu___1);
-        FStar_Syntax_Syntax.pos = uu___2; FStar_Syntax_Syntax.vars = uu___3;
-        FStar_Syntax_Syntax.hash_code = uu___4;_} -> extract_meta x1
+        FStar_Syntax_Syntax.pos = uu___2;
+        FStar_Syntax_Syntax.hash_code = uu___3;_} -> extract_meta x1
     | uu___1 ->
         let uu___2 = FStar_Syntax_Util.head_and_args x in
         (match uu___2 with
@@ -1966,13 +1964,12 @@ let (maybe_register_plugin :
                            FStar_Syntax_Syntax.Tm_constant
                            (FStar_Const.Const_int (s, uu___3));
                          FStar_Syntax_Syntax.pos = uu___4;
-                         FStar_Syntax_Syntax.vars = uu___5;
-                         FStar_Syntax_Syntax.hash_code = uu___6;_},
-                       uu___7)::[] ->
-                        let uu___8 =
-                          let uu___9 = FStar_Compiler_Util.int_of_string s in
-                          FStar_Pervasives_Native.Some uu___9 in
-                        FStar_Pervasives_Native.Some uu___8
+                         FStar_Syntax_Syntax.hash_code = uu___5;_},
+                       uu___6)::[] ->
+                        let uu___7 =
+                          let uu___8 = FStar_Compiler_Util.int_of_string s in
+                          FStar_Pervasives_Native.Some uu___8 in
+                        FStar_Pervasives_Native.Some uu___7
                     | uu___3 ->
                         FStar_Pervasives_Native.Some
                           FStar_Pervasives_Native.None)) in
@@ -2478,15 +2475,13 @@ let rec (extract_sig :
                                                               = uu___25;_};
                                                         FStar_Syntax_Syntax.pos
                                                           = uu___26;
-                                                        FStar_Syntax_Syntax.vars
-                                                          = uu___27;
                                                         FStar_Syntax_Syntax.hash_code
-                                                          = uu___28;_})
+                                                          = uu___27;_})
                                                      when
-                                                     let uu___29 =
+                                                     let uu___28 =
                                                        FStar_Ident.string_of_lid
                                                          e in
-                                                     uu___29 =
+                                                     uu___28 =
                                                        "FStar.HyperStack.ST.StackInline"
                                                      ->
                                                      [FStar_Extraction_ML_Syntax.StackInline]

--- a/ocaml/fstar-lib/generated/FStar_Extraction_ML_Term.ml
+++ b/ocaml/fstar-lib/generated/FStar_Extraction_ML_Term.ml
@@ -2573,8 +2573,6 @@ and (term_as_mlexpr' :
                                  (FStar_Syntax_Syntax.Tm_app (body, args));
                                FStar_Syntax_Syntax.pos =
                                  (body.FStar_Syntax_Syntax.pos);
-                               FStar_Syntax_Syntax.vars =
-                                 (body.FStar_Syntax_Syntax.vars);
                                FStar_Syntax_Syntax.hash_code =
                                  (body.FStar_Syntax_Syntax.hash_code)
                              }))) in
@@ -2584,7 +2582,6 @@ and (term_as_mlexpr' :
                     (scrutinee, FStar_Pervasives_Native.None, branches1,
                       FStar_Pervasives_Native.None));
                FStar_Syntax_Syntax.pos = (head.FStar_Syntax_Syntax.pos);
-               FStar_Syntax_Syntax.vars = (head.FStar_Syntax_Syntax.vars);
                FStar_Syntax_Syntax.hash_code =
                  (head.FStar_Syntax_Syntax.hash_code)
              }
@@ -2920,69 +2917,66 @@ and (term_as_mlexpr' :
               FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
                 (FStar_Const.Const_range_of);
               FStar_Syntax_Syntax.pos = uu___1;
-              FStar_Syntax_Syntax.vars = uu___2;
-              FStar_Syntax_Syntax.hash_code = uu___3;_},
-            (a1, uu___4)::[])
+              FStar_Syntax_Syntax.hash_code = uu___2;_},
+            (a1, uu___3)::[])
            ->
            let ty =
-             let uu___5 =
+             let uu___4 =
                FStar_Syntax_Syntax.tabbrev FStar_Parser_Const.range_lid in
-             term_as_mlty g uu___5 in
-           let uu___5 =
-             let uu___6 =
+             term_as_mlty g uu___4 in
+           let uu___4 =
+             let uu___5 =
                FStar_Extraction_ML_Util.mlexpr_of_range
                  a1.FStar_Syntax_Syntax.pos in
              FStar_Compiler_Effect.op_Less_Bar
-               (FStar_Extraction_ML_Syntax.with_ty ty) uu___6 in
-           (uu___5, FStar_Extraction_ML_Syntax.E_PURE, ty)
+               (FStar_Extraction_ML_Syntax.with_ty ty) uu___5 in
+           (uu___4, FStar_Extraction_ML_Syntax.E_PURE, ty)
        | FStar_Syntax_Syntax.Tm_app
            ({
               FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
                 (FStar_Const.Const_set_range_of);
               FStar_Syntax_Syntax.pos = uu___1;
-              FStar_Syntax_Syntax.vars = uu___2;
-              FStar_Syntax_Syntax.hash_code = uu___3;_},
-            (t1, uu___4)::(r, uu___5)::[])
+              FStar_Syntax_Syntax.hash_code = uu___2;_},
+            (t1, uu___3)::(r, uu___4)::[])
            -> term_as_mlexpr g t1
        | FStar_Syntax_Syntax.Tm_app
            ({
               FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
                 (FStar_Const.Const_reflect uu___1);
               FStar_Syntax_Syntax.pos = uu___2;
-              FStar_Syntax_Syntax.vars = uu___3;
-              FStar_Syntax_Syntax.hash_code = uu___4;_},
-            uu___5)
+              FStar_Syntax_Syntax.hash_code = uu___3;_},
+            uu___4)
            ->
-           let uu___6 =
-             let uu___7 =
-               let uu___8 = FStar_Parser_Const.failwith_lid () in
-               FStar_Syntax_Syntax.lid_as_fv uu___8
+           let uu___5 =
+             let uu___6 =
+               let uu___7 = FStar_Parser_Const.failwith_lid () in
+               FStar_Syntax_Syntax.lid_as_fv uu___7
                  FStar_Syntax_Syntax.delta_constant
                  FStar_Pervasives_Native.None in
              FStar_Extraction_ML_UEnv.lookup_fv t.FStar_Syntax_Syntax.pos g
-               uu___7 in
-           (match uu___6 with
-            | { FStar_Extraction_ML_UEnv.exp_b_name = uu___7;
+               uu___6 in
+           (match uu___5 with
+            | { FStar_Extraction_ML_UEnv.exp_b_name = uu___6;
                 FStar_Extraction_ML_UEnv.exp_b_expr = fw;
-                FStar_Extraction_ML_UEnv.exp_b_tscheme = uu___8;_} ->
-                let uu___9 =
-                  let uu___10 =
-                    let uu___11 =
-                      let uu___12 =
-                        let uu___13 =
+                FStar_Extraction_ML_UEnv.exp_b_tscheme = uu___7;_} ->
+                let uu___8 =
+                  let uu___9 =
+                    let uu___10 =
+                      let uu___11 =
+                        let uu___12 =
                           FStar_Compiler_Effect.op_Less_Bar
                             (FStar_Extraction_ML_Syntax.with_ty
                                FStar_Extraction_ML_Syntax.ml_string_ty)
                             (FStar_Extraction_ML_Syntax.MLE_Const
                                (FStar_Extraction_ML_Syntax.MLC_String
                                   "Extraction of reflect is not supported")) in
-                        [uu___13] in
-                      (fw, uu___12) in
-                    FStar_Extraction_ML_Syntax.MLE_App uu___11 in
+                        [uu___12] in
+                      (fw, uu___11) in
+                    FStar_Extraction_ML_Syntax.MLE_App uu___10 in
                   FStar_Compiler_Effect.op_Less_Bar
                     (FStar_Extraction_ML_Syntax.with_ty
-                       FStar_Extraction_ML_Syntax.ml_int_ty) uu___10 in
-                (uu___9, FStar_Extraction_ML_Syntax.E_PURE,
+                       FStar_Extraction_ML_Syntax.ml_int_ty) uu___9 in
+                (uu___8, FStar_Extraction_ML_Syntax.E_PURE,
                   FStar_Extraction_ML_Syntax.ml_int_ty))
        | FStar_Syntax_Syntax.Tm_app uu___1 when is_steel_with_invariant_g t
            ->
@@ -3682,8 +3676,6 @@ and (term_as_mlexpr' :
                   {
                     FStar_Syntax_Syntax.n = maybe_rewritten_let;
                     FStar_Syntax_Syntax.pos = (top1.FStar_Syntax_Syntax.pos);
-                    FStar_Syntax_Syntax.vars =
-                      (top1.FStar_Syntax_Syntax.vars);
                     FStar_Syntax_Syntax.hash_code =
                       (top1.FStar_Syntax_Syntax.hash_code)
                   } in

--- a/ocaml/fstar-lib/generated/FStar_Reflection_Embeddings.ml
+++ b/ocaml/fstar-lib/generated/FStar_Reflection_Embeddings.ml
@@ -211,7 +211,6 @@ let (e_aqualv :
     {
       FStar_Syntax_Syntax.n = (r.FStar_Syntax_Syntax.n);
       FStar_Syntax_Syntax.pos = rng;
-      FStar_Syntax_Syntax.vars = (r.FStar_Syntax_Syntax.vars);
       FStar_Syntax_Syntax.hash_code = (r.FStar_Syntax_Syntax.hash_code)
     } in
   let unembed_aqualv w t =
@@ -605,7 +604,6 @@ let (e_const :
     {
       FStar_Syntax_Syntax.n = (r.FStar_Syntax_Syntax.n);
       FStar_Syntax_Syntax.pos = rng;
-      FStar_Syntax_Syntax.vars = (r.FStar_Syntax_Syntax.vars);
       FStar_Syntax_Syntax.hash_code = (r.FStar_Syntax_Syntax.hash_code)
     } in
   let unembed_const w t =
@@ -1174,7 +1172,6 @@ let (e_term_view_aq :
           {
             FStar_Syntax_Syntax.n = (uu___.FStar_Syntax_Syntax.n);
             FStar_Syntax_Syntax.pos = rng;
-            FStar_Syntax_Syntax.vars = (uu___.FStar_Syntax_Syntax.vars);
             FStar_Syntax_Syntax.hash_code =
               (uu___.FStar_Syntax_Syntax.hash_code)
           } in
@@ -1807,7 +1804,6 @@ let (e_order : FStar_Order.order FStar_Syntax_Embeddings.embedding) =
     {
       FStar_Syntax_Syntax.n = (r.FStar_Syntax_Syntax.n);
       FStar_Syntax_Syntax.pos = rng;
-      FStar_Syntax_Syntax.vars = (r.FStar_Syntax_Syntax.vars);
       FStar_Syntax_Syntax.hash_code = (r.FStar_Syntax_Syntax.hash_code)
     } in
   let unembed_order w t =
@@ -2078,7 +2074,6 @@ let (e_sigelt_view :
         {
           FStar_Syntax_Syntax.n = (uu___.FStar_Syntax_Syntax.n);
           FStar_Syntax_Syntax.pos = rng;
-          FStar_Syntax_Syntax.vars = (uu___.FStar_Syntax_Syntax.vars);
           FStar_Syntax_Syntax.hash_code =
             (uu___.FStar_Syntax_Syntax.hash_code)
         } in
@@ -2210,7 +2205,6 @@ let (e_exp : FStar_Reflection_Data.exp FStar_Syntax_Embeddings.embedding) =
     {
       FStar_Syntax_Syntax.n = (r.FStar_Syntax_Syntax.n);
       FStar_Syntax_Syntax.pos = rng;
-      FStar_Syntax_Syntax.vars = (r.FStar_Syntax_Syntax.vars);
       FStar_Syntax_Syntax.hash_code = (r.FStar_Syntax_Syntax.hash_code)
     } in
   let rec unembed_exp w t =
@@ -2375,7 +2369,6 @@ let (e_qualifier :
     {
       FStar_Syntax_Syntax.n = (r.FStar_Syntax_Syntax.n);
       FStar_Syntax_Syntax.pos = rng;
-      FStar_Syntax_Syntax.vars = (r.FStar_Syntax_Syntax.vars);
       FStar_Syntax_Syntax.hash_code = (r.FStar_Syntax_Syntax.hash_code)
     } in
   let unembed w t =

--- a/ocaml/fstar-lib/generated/FStar_SMTEncoding_Encode.ml
+++ b/ocaml/fstar-lib/generated/FStar_SMTEncoding_Encode.ml
@@ -1780,11 +1780,9 @@ let (encode_free_var :
                                                         fv1;
                                                       FStar_Syntax_Syntax.pos
                                                         = uu___14;
-                                                      FStar_Syntax_Syntax.vars
-                                                        = uu___15;
                                                       FStar_Syntax_Syntax.hash_code
-                                                        = uu___16;_};_},
-                                                uu___17)
+                                                        = uu___15;_};_},
+                                                uu___16)
                                                ->
                                                FStar_Syntax_Syntax.fv_eq_lid
                                                  fv1
@@ -5308,20 +5306,18 @@ and (encode_sigelt' :
                                                          fv;
                                                        FStar_Syntax_Syntax.pos
                                                          = uu___12;
-                                                       FStar_Syntax_Syntax.vars
-                                                         = uu___13;
                                                        FStar_Syntax_Syntax.hash_code
-                                                         = uu___14;_},
-                                                     uu___15)
+                                                         = uu___13;_},
+                                                     uu___14)
                                                     ->
                                                     let encoded_head_fvb =
                                                       FStar_SMTEncoding_Env.lookup_free_var_name
                                                         env'
                                                         fv.FStar_Syntax_Syntax.fv_name in
-                                                    let uu___16 =
+                                                    let uu___15 =
                                                       FStar_SMTEncoding_EncodeTerm.encode_args
                                                         args env' in
-                                                    (match uu___16 with
+                                                    (match uu___15 with
                                                      | (encoded_args,
                                                         arg_decls) ->
                                                          let guards_for_parameter
@@ -5331,60 +5327,60 @@ and (encode_sigelt' :
                                                              with
                                                              | FStar_SMTEncoding_Term.FreeV
                                                                  fv2 -> fv2
-                                                             | uu___17 ->
-                                                                 let uu___18
+                                                             | uu___16 ->
+                                                                 let uu___17
                                                                    =
-                                                                   let uu___19
+                                                                   let uu___18
                                                                     =
-                                                                    let uu___20
+                                                                    let uu___19
                                                                     =
                                                                     FStar_Syntax_Print.term_to_string
                                                                     orig_arg in
                                                                     FStar_Compiler_Util.format1
                                                                     "Inductive type parameter %s must be a variable ; You may want to change it to an index."
-                                                                    uu___20 in
+                                                                    uu___19 in
                                                                    (FStar_Errors_Codes.Fatal_NonVariableInductiveTypeParameter,
-                                                                    uu___19) in
+                                                                    uu___18) in
                                                                  FStar_Errors.raise_error
-                                                                   uu___18
+                                                                   uu___17
                                                                    orig_arg.FStar_Syntax_Syntax.pos in
                                                            let guards1 =
                                                              FStar_Compiler_Effect.op_Bar_Greater
                                                                guards
                                                                (FStar_Compiler_List.collect
                                                                   (fun g ->
-                                                                    let uu___17
+                                                                    let uu___16
                                                                     =
-                                                                    let uu___18
+                                                                    let uu___17
                                                                     =
                                                                     FStar_SMTEncoding_Term.free_variables
                                                                     g in
                                                                     FStar_Compiler_List.contains
                                                                     fv1
-                                                                    uu___18 in
+                                                                    uu___17 in
                                                                     if
-                                                                    uu___17
+                                                                    uu___16
                                                                     then
-                                                                    let uu___18
+                                                                    let uu___17
                                                                     =
                                                                     FStar_SMTEncoding_Term.subst
                                                                     g fv1 xv in
-                                                                    [uu___18]
+                                                                    [uu___17]
                                                                     else [])) in
                                                            FStar_SMTEncoding_Util.mk_and_l
                                                              guards1 in
-                                                         let uu___17 =
-                                                           let uu___18 =
+                                                         let uu___16 =
+                                                           let uu___17 =
                                                              FStar_Compiler_List.zip
                                                                args
                                                                encoded_args in
                                                            FStar_Compiler_List.fold_left
-                                                             (fun uu___19 ->
-                                                                fun uu___20
+                                                             (fun uu___18 ->
+                                                                fun uu___19
                                                                   ->
                                                                   match 
-                                                                    (uu___19,
-                                                                    uu___20)
+                                                                    (uu___18,
+                                                                    uu___19)
                                                                   with
                                                                   | ((env2,
                                                                     arg_vars,
@@ -5392,20 +5388,20 @@ and (encode_sigelt' :
                                                                     i),
                                                                     (orig_arg,
                                                                     arg)) ->
-                                                                    let uu___21
+                                                                    let uu___20
                                                                     =
-                                                                    let uu___22
+                                                                    let uu___21
                                                                     =
                                                                     FStar_Syntax_Syntax.new_bv
                                                                     FStar_Pervasives_Native.None
                                                                     FStar_Syntax_Syntax.tun in
                                                                     FStar_SMTEncoding_Env.gen_term_var
                                                                     env2
-                                                                    uu___22 in
-                                                                    (match uu___21
+                                                                    uu___21 in
+                                                                    (match uu___20
                                                                     with
                                                                     | 
-                                                                    (uu___22,
+                                                                    (uu___21,
                                                                     xv, env3)
                                                                     ->
                                                                     let eqns
@@ -5413,21 +5409,21 @@ and (encode_sigelt' :
                                                                     if
                                                                     i < n_tps
                                                                     then
-                                                                    let uu___23
+                                                                    let uu___22
                                                                     =
                                                                     guards_for_parameter
                                                                     (FStar_Pervasives_Native.fst
                                                                     orig_arg)
                                                                     arg xv in
-                                                                    uu___23
+                                                                    uu___22
                                                                     ::
                                                                     eqns_or_guards
                                                                     else
-                                                                    (let uu___24
+                                                                    (let uu___23
                                                                     =
                                                                     FStar_SMTEncoding_Util.mkEq
                                                                     (arg, xv) in
-                                                                    uu___24
+                                                                    uu___23
                                                                     ::
                                                                     eqns_or_guards) in
                                                                     (env3,
@@ -5438,12 +5434,12 @@ and (encode_sigelt' :
                                                                     Prims.int_one))))
                                                              (env', [], [],
                                                                Prims.int_zero)
-                                                             uu___18 in
-                                                         (match uu___17 with
-                                                          | (uu___18,
+                                                             uu___17 in
+                                                         (match uu___16 with
+                                                          | (uu___17,
                                                              arg_vars,
                                                              elim_eqns_or_guards,
-                                                             uu___19) ->
+                                                             uu___18) ->
                                                               let arg_vars1 =
                                                                 FStar_Compiler_List.rev
                                                                   arg_vars in
@@ -5472,49 +5468,49 @@ and (encode_sigelt' :
                                                                   arg_vars1 in
                                                               let typing_inversion
                                                                 =
-                                                                let uu___20 =
-                                                                  let uu___21
+                                                                let uu___19 =
+                                                                  let uu___20
                                                                     =
-                                                                    let uu___22
+                                                                    let uu___21
                                                                     =
                                                                     FStar_Ident.range_of_lid
                                                                     d in
+                                                                    let uu___22
+                                                                    =
                                                                     let uu___23
                                                                     =
                                                                     let uu___24
-                                                                    =
-                                                                    let uu___25
                                                                     =
                                                                     FStar_SMTEncoding_Term.mk_fv
                                                                     (fuel_var,
                                                                     FStar_SMTEncoding_Term.Fuel_sort) in
                                                                     FStar_SMTEncoding_Env.add_fuel
-                                                                    uu___25
+                                                                    uu___24
                                                                     (FStar_Compiler_List.op_At
                                                                     vars
                                                                     arg_binders) in
+                                                                    let uu___24
+                                                                    =
                                                                     let uu___25
                                                                     =
                                                                     let uu___26
-                                                                    =
-                                                                    let uu___27
                                                                     =
                                                                     FStar_SMTEncoding_Util.mk_and_l
                                                                     (FStar_Compiler_List.op_At
                                                                     elim_eqns_or_guards
                                                                     guards) in
                                                                     (ty_pred,
-                                                                    uu___27) in
+                                                                    uu___26) in
                                                                     FStar_SMTEncoding_Util.mkImp
-                                                                    uu___26 in
+                                                                    uu___25 in
                                                                     ([
                                                                     [ty_pred]],
-                                                                    uu___24,
-                                                                    uu___25) in
+                                                                    uu___23,
+                                                                    uu___24) in
                                                                     FStar_SMTEncoding_Term.mkForall
-                                                                    uu___22
-                                                                    uu___23 in
-                                                                  (uu___21,
+                                                                    uu___21
+                                                                    uu___22 in
+                                                                  (uu___20,
                                                                     (
                                                                     FStar_Pervasives_Native.Some
                                                                     "data constructor typing elim"),
@@ -5523,26 +5519,26 @@ and (encode_sigelt' :
                                                                     "data_elim_"
                                                                     ddconstrsym)) in
                                                                 FStar_SMTEncoding_Util.mkAssume
-                                                                  uu___20 in
+                                                                  uu___19 in
                                                               let lex_t =
-                                                                let uu___20 =
-                                                                  let uu___21
+                                                                let uu___19 =
+                                                                  let uu___20
                                                                     =
-                                                                    let uu___22
+                                                                    let uu___21
                                                                     =
                                                                     FStar_Ident.string_of_lid
                                                                     FStar_Parser_Const.lex_t_lid in
-                                                                    (uu___22,
+                                                                    (uu___21,
                                                                     FStar_SMTEncoding_Term.Term_sort) in
                                                                   FStar_SMTEncoding_Term.mk_fv
-                                                                    uu___21 in
+                                                                    uu___20 in
                                                                 FStar_Compiler_Effect.op_Less_Bar
                                                                   FStar_SMTEncoding_Util.mkFreeV
-                                                                  uu___20 in
+                                                                  uu___19 in
                                                               let subterm_ordering
                                                                 =
                                                                 let prec =
-                                                                  let uu___20
+                                                                  let uu___19
                                                                     =
                                                                     FStar_Compiler_Effect.op_Bar_Greater
                                                                     vars
@@ -5553,62 +5549,62 @@ and (encode_sigelt' :
                                                                     i < n_tps
                                                                     then []
                                                                     else
-                                                                    (let uu___22
+                                                                    (let uu___21
                                                                     =
-                                                                    let uu___23
+                                                                    let uu___22
                                                                     =
                                                                     FStar_SMTEncoding_Util.mkFreeV
                                                                     v in
                                                                     FStar_SMTEncoding_Util.mk_Precedes
                                                                     lex_t
                                                                     lex_t
-                                                                    uu___23
+                                                                    uu___22
                                                                     dapp1 in
-                                                                    [uu___22]))) in
+                                                                    [uu___21]))) in
                                                                   FStar_Compiler_Effect.op_Bar_Greater
-                                                                    uu___20
+                                                                    uu___19
                                                                     FStar_Compiler_List.flatten in
-                                                                let uu___20 =
-                                                                  let uu___21
+                                                                let uu___19 =
+                                                                  let uu___20
                                                                     =
-                                                                    let uu___22
+                                                                    let uu___21
                                                                     =
                                                                     FStar_Ident.range_of_lid
                                                                     d in
+                                                                    let uu___22
+                                                                    =
                                                                     let uu___23
                                                                     =
                                                                     let uu___24
-                                                                    =
-                                                                    let uu___25
                                                                     =
                                                                     FStar_SMTEncoding_Term.mk_fv
                                                                     (fuel_var,
                                                                     FStar_SMTEncoding_Term.Fuel_sort) in
                                                                     FStar_SMTEncoding_Env.add_fuel
-                                                                    uu___25
+                                                                    uu___24
                                                                     (FStar_Compiler_List.op_At
                                                                     vars
                                                                     arg_binders) in
+                                                                    let uu___24
+                                                                    =
                                                                     let uu___25
                                                                     =
                                                                     let uu___26
                                                                     =
-                                                                    let uu___27
-                                                                    =
                                                                     FStar_SMTEncoding_Util.mk_and_l
                                                                     prec in
                                                                     (ty_pred,
-                                                                    uu___27) in
+                                                                    uu___26) in
                                                                     FStar_SMTEncoding_Util.mkImp
-                                                                    uu___26 in
+                                                                    uu___25 in
                                                                     ([
                                                                     [ty_pred]],
-                                                                    uu___24,
-                                                                    uu___25) in
+                                                                    uu___23,
+                                                                    uu___24) in
                                                                     FStar_SMTEncoding_Term.mkForall
-                                                                    uu___22
-                                                                    uu___23 in
-                                                                  (uu___21,
+                                                                    uu___21
+                                                                    uu___22 in
+                                                                  (uu___20,
                                                                     (
                                                                     FStar_Pervasives_Native.Some
                                                                     "subterm ordering"),
@@ -5617,38 +5613,38 @@ and (encode_sigelt' :
                                                                     "subterm_ordering_"
                                                                     ddconstrsym)) in
                                                                 FStar_SMTEncoding_Util.mkAssume
-                                                                  uu___20 in
-                                                              let uu___20 =
-                                                                let uu___21 =
+                                                                  uu___19 in
+                                                              let uu___19 =
+                                                                let uu___20 =
                                                                   FStar_Compiler_Util.first_N
                                                                     n_tps
                                                                     formals in
-                                                                match uu___21
+                                                                match uu___20
                                                                 with
-                                                                | (uu___22,
+                                                                | (uu___21,
                                                                    formals')
                                                                     ->
-                                                                    let uu___23
+                                                                    let uu___22
                                                                     =
                                                                     FStar_Compiler_Util.first_N
                                                                     n_tps
                                                                     vars in
-                                                                    (match uu___23
+                                                                    (match uu___22
                                                                     with
                                                                     | 
-                                                                    (uu___24,
+                                                                    (uu___23,
                                                                     vars') ->
-                                                                    let uu___25
+                                                                    let uu___24
                                                                     =
                                                                     FStar_Compiler_List.fold_left2
                                                                     (fun
-                                                                    uu___26
+                                                                    uu___25
                                                                     ->
                                                                     fun
                                                                     formal ->
                                                                     fun var
                                                                     ->
-                                                                    match uu___26
+                                                                    match uu___25
                                                                     with
                                                                     | 
                                                                     (codomain_prec_l,
@@ -5659,28 +5655,28 @@ and (encode_sigelt' :
                                                                     let t3 =
                                                                     FStar_Syntax_Util.unrefine
                                                                     t2 in
-                                                                    let uu___27
+                                                                    let uu___26
                                                                     =
-                                                                    let uu___28
+                                                                    let uu___27
                                                                     =
                                                                     FStar_Syntax_Subst.compress
                                                                     t3 in
-                                                                    uu___28.FStar_Syntax_Syntax.n in
-                                                                    match uu___27
+                                                                    uu___27.FStar_Syntax_Syntax.n in
+                                                                    match uu___26
                                                                     with
                                                                     | 
                                                                     FStar_Syntax_Syntax.Tm_arrow
-                                                                    uu___28
+                                                                    uu___27
                                                                     ->
-                                                                    let uu___29
+                                                                    let uu___28
                                                                     =
-                                                                    let uu___30
+                                                                    let uu___29
                                                                     =
                                                                     FStar_Syntax_Util.unrefine
                                                                     t3 in
                                                                     FStar_Syntax_Util.arrow_formals_comp
-                                                                    uu___30 in
-                                                                    (match uu___29
+                                                                    uu___29 in
+                                                                    (match uu___28
                                                                     with
                                                                     | 
                                                                     (bs, c)
@@ -5691,25 +5687,25 @@ and (encode_sigelt' :
                                                                     [] ->
                                                                     FStar_Pervasives_Native.None
                                                                     | 
-                                                                    uu___30
+                                                                    uu___29
                                                                     when
-                                                                    let uu___31
+                                                                    let uu___30
                                                                     =
                                                                     FStar_Syntax_Util.is_tot_or_gtot_comp
                                                                     c in
                                                                     Prims.op_Negation
-                                                                    uu___31
+                                                                    uu___30
                                                                     ->
                                                                     FStar_Pervasives_Native.None
                                                                     | 
-                                                                    uu___30
+                                                                    uu___29
                                                                     ->
-                                                                    let uu___31
+                                                                    let uu___30
                                                                     =
                                                                     FStar_Syntax_Util.is_lemma_comp
                                                                     c in
                                                                     if
-                                                                    uu___31
+                                                                    uu___30
                                                                     then
                                                                     FStar_Pervasives_Native.None
                                                                     else
@@ -5717,31 +5713,31 @@ and (encode_sigelt' :
                                                                     FStar_Syntax_Util.unrefine
                                                                     (FStar_Syntax_Util.comp_result
                                                                     c) in
-                                                                    let uu___33
+                                                                    let uu___32
                                                                     =
                                                                     (FStar_Syntax_Syntax.is_type
                                                                     t4) ||
                                                                     (FStar_Syntax_Util.is_sub_singleton
                                                                     t4) in
                                                                     if
-                                                                    uu___33
+                                                                    uu___32
                                                                     then
                                                                     FStar_Pervasives_Native.None
                                                                     else
                                                                     FStar_Pervasives_Native.Some
                                                                     (bs, c))))
                                                                     | 
-                                                                    uu___28
+                                                                    uu___27
                                                                     ->
-                                                                    let uu___29
+                                                                    let uu___28
                                                                     =
                                                                     FStar_Syntax_Util.head_and_args
                                                                     t3 in
-                                                                    (match uu___29
+                                                                    (match uu___28
                                                                     with
                                                                     | 
                                                                     (head1,
-                                                                    uu___30)
+                                                                    uu___29)
                                                                     ->
                                                                     let t' =
                                                                     FStar_TypeChecker_Normalize.unfold_whnf'
@@ -5752,22 +5748,22 @@ and (encode_sigelt' :
                                                                     FStar_TypeChecker_Env.Zeta]
                                                                     env'.FStar_SMTEncoding_Env.tcenv
                                                                     t3 in
-                                                                    let uu___31
+                                                                    let uu___30
                                                                     =
                                                                     FStar_Syntax_Util.head_and_args
                                                                     t' in
-                                                                    (match uu___31
+                                                                    (match uu___30
                                                                     with
                                                                     | 
                                                                     (head',
-                                                                    uu___32)
+                                                                    uu___31)
                                                                     ->
-                                                                    let uu___33
+                                                                    let uu___32
                                                                     =
                                                                     FStar_Syntax_Util.eq_tm
                                                                     head1
                                                                     head' in
-                                                                    (match uu___33
+                                                                    (match uu___32
                                                                     with
                                                                     | 
                                                                     FStar_Syntax_Util.Equal
@@ -5779,44 +5775,44 @@ and (encode_sigelt' :
                                                                     binder_and_codomain_type
                                                                     t'
                                                                     | 
-                                                                    uu___34
+                                                                    uu___33
                                                                     ->
-                                                                    let uu___35
+                                                                    let uu___34
                                                                     =
-                                                                    let uu___36
+                                                                    let uu___35
                                                                     =
                                                                     FStar_Syntax_Subst.compress
                                                                     head1 in
-                                                                    uu___36.FStar_Syntax_Syntax.n in
-                                                                    (match uu___35
+                                                                    uu___35.FStar_Syntax_Syntax.n in
+                                                                    (match uu___34
                                                                     with
                                                                     | 
                                                                     FStar_Syntax_Syntax.Tm_fvar
-                                                                    uu___36
+                                                                    uu___35
                                                                     ->
                                                                     binder_and_codomain_type
                                                                     t'
                                                                     | 
                                                                     FStar_Syntax_Syntax.Tm_name
-                                                                    uu___36
+                                                                    uu___35
                                                                     ->
                                                                     binder_and_codomain_type
                                                                     t'
                                                                     | 
                                                                     FStar_Syntax_Syntax.Tm_uinst
-                                                                    uu___36
+                                                                    uu___35
                                                                     ->
                                                                     binder_and_codomain_type
                                                                     t'
                                                                     | 
-                                                                    uu___36
+                                                                    uu___35
                                                                     ->
                                                                     FStar_Pervasives_Native.None)))) in
-                                                                    let uu___27
+                                                                    let uu___26
                                                                     =
                                                                     binder_and_codomain_type
                                                                     (formal.FStar_Syntax_Syntax.binder_bv).FStar_Syntax_Syntax.sort in
-                                                                    (match uu___27
+                                                                    (match uu___26
                                                                     with
                                                                     | 
                                                                     FStar_Pervasives_Native.None
@@ -5827,90 +5823,90 @@ and (encode_sigelt' :
                                                                     FStar_Pervasives_Native.Some
                                                                     (bs, c)
                                                                     ->
-                                                                    let uu___28
+                                                                    let uu___27
                                                                     =
                                                                     FStar_SMTEncoding_EncodeTerm.encode_binders
                                                                     FStar_Pervasives_Native.None
                                                                     bs env' in
-                                                                    (match uu___28
+                                                                    (match uu___27
                                                                     with
                                                                     | 
                                                                     (bs',
                                                                     guards',
                                                                     _env',
                                                                     bs_decls,
-                                                                    uu___29)
+                                                                    uu___28)
                                                                     ->
                                                                     let fun_app
                                                                     =
-                                                                    let uu___30
+                                                                    let uu___29
                                                                     =
                                                                     FStar_SMTEncoding_Util.mkFreeV
                                                                     var in
                                                                     FStar_SMTEncoding_EncodeTerm.mk_Apply
-                                                                    uu___30
+                                                                    uu___29
                                                                     bs' in
+                                                                    let uu___29
+                                                                    =
                                                                     let uu___30
                                                                     =
                                                                     let uu___31
                                                                     =
-                                                                    let uu___32
-                                                                    =
                                                                     FStar_Ident.range_of_lid
                                                                     d in
+                                                                    let uu___32
+                                                                    =
                                                                     let uu___33
                                                                     =
                                                                     let uu___34
                                                                     =
                                                                     let uu___35
                                                                     =
-                                                                    let uu___36
-                                                                    =
                                                                     FStar_SMTEncoding_Util.mk_Precedes
                                                                     lex_t
                                                                     lex_t
                                                                     fun_app
                                                                     dapp1 in
-                                                                    [uu___36] in
                                                                     [uu___35] in
+                                                                    [uu___34] in
+                                                                    let uu___34
+                                                                    =
                                                                     let uu___35
                                                                     =
                                                                     let uu___36
-                                                                    =
-                                                                    let uu___37
                                                                     =
                                                                     FStar_SMTEncoding_Util.mk_and_l
                                                                     (ty_pred'
                                                                     ::
                                                                     guards') in
-                                                                    let uu___38
+                                                                    let uu___37
                                                                     =
                                                                     FStar_SMTEncoding_Util.mk_Precedes
                                                                     lex_t
                                                                     lex_t
                                                                     fun_app
                                                                     dapp1 in
-                                                                    (uu___37,
-                                                                    uu___38) in
+                                                                    (uu___36,
+                                                                    uu___37) in
                                                                     FStar_SMTEncoding_Util.mkImp
-                                                                    uu___36 in
-                                                                    (uu___34,
+                                                                    uu___35 in
+                                                                    (uu___33,
                                                                     bs',
-                                                                    uu___35) in
+                                                                    uu___34) in
                                                                     FStar_SMTEncoding_Term.mkForall
-                                                                    uu___32
-                                                                    uu___33 in
                                                                     uu___31
+                                                                    uu___32 in
+                                                                    uu___30
                                                                     ::
                                                                     codomain_prec_l in
-                                                                    (uu___30,
+                                                                    (uu___29,
                                                                     (FStar_Compiler_List.op_At
                                                                     bs_decls
                                                                     cod_decls)))))
                                                                     ([], [])
                                                                     formals'
                                                                     vars' in
-                                                                    (match uu___25
+                                                                    (match uu___24
                                                                     with
                                                                     | 
                                                                     (codomain_prec_l,
@@ -5923,8 +5919,10 @@ and (encode_sigelt' :
                                                                     ([],
                                                                     cod_decls)
                                                                     | 
-                                                                    uu___26
+                                                                    uu___25
                                                                     ->
+                                                                    let uu___26
+                                                                    =
                                                                     let uu___27
                                                                     =
                                                                     let uu___28
@@ -5933,47 +5931,45 @@ and (encode_sigelt' :
                                                                     =
                                                                     let uu___30
                                                                     =
-                                                                    let uu___31
-                                                                    =
                                                                     FStar_Ident.range_of_lid
                                                                     d in
+                                                                    let uu___31
+                                                                    =
                                                                     let uu___32
                                                                     =
                                                                     let uu___33
-                                                                    =
-                                                                    let uu___34
                                                                     =
                                                                     FStar_SMTEncoding_Term.mk_fv
                                                                     (fuel_var,
                                                                     FStar_SMTEncoding_Term.Fuel_sort) in
                                                                     FStar_SMTEncoding_Env.add_fuel
-                                                                    uu___34
+                                                                    uu___33
                                                                     (FStar_Compiler_List.op_At
                                                                     vars
                                                                     arg_binders) in
-                                                                    let uu___34
+                                                                    let uu___33
                                                                     =
                                                                     FStar_SMTEncoding_Util.mk_and_l
                                                                     codomain_prec_l in
                                                                     ([
                                                                     [ty_pred]],
-                                                                    uu___33,
-                                                                    uu___34) in
+                                                                    uu___32,
+                                                                    uu___33) in
                                                                     FStar_SMTEncoding_Term.mkForall
-                                                                    uu___31
-                                                                    uu___32 in
-                                                                    (uu___30,
+                                                                    uu___30
+                                                                    uu___31 in
+                                                                    (uu___29,
                                                                     (FStar_Pervasives_Native.Some
                                                                     "well-founded ordering on codomain"),
                                                                     (Prims.op_Hat
                                                                     "well_founded_ordering_on_codomain_"
                                                                     ddconstrsym)) in
                                                                     FStar_SMTEncoding_Util.mkAssume
-                                                                    uu___29 in
-                                                                    [uu___28] in
-                                                                    (uu___27,
+                                                                    uu___28 in
+                                                                    [uu___27] in
+                                                                    (uu___26,
                                                                     cod_decls)))) in
-                                                              (match uu___20
+                                                              (match uu___19
                                                                with
                                                                | (codomain_ordering,
                                                                   codomain_decls)

--- a/ocaml/fstar-lib/generated/FStar_SMTEncoding_EncodeTerm.ml
+++ b/ocaml/fstar-lib/generated/FStar_SMTEncoding_EncodeTerm.ml
@@ -90,16 +90,15 @@ let (head_normal :
       | FStar_Syntax_Syntax.Tm_app
           ({ FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar fv;
              FStar_Syntax_Syntax.pos = uu___;
-             FStar_Syntax_Syntax.vars = uu___1;
-             FStar_Syntax_Syntax.hash_code = uu___2;_},
-           uu___3)
+             FStar_Syntax_Syntax.hash_code = uu___1;_},
+           uu___2)
           ->
-          let uu___4 =
+          let uu___3 =
             FStar_TypeChecker_Env.lookup_definition
               [FStar_TypeChecker_Env.Eager_unfolding_only]
               env.FStar_SMTEncoding_Env.tcenv
               (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-          FStar_Compiler_Effect.op_Bar_Greater uu___4
+          FStar_Compiler_Effect.op_Bar_Greater uu___3
             FStar_Compiler_Option.isNone
       | uu___ -> false
 let (head_redex :
@@ -1825,19 +1824,18 @@ and (encode_term :
                   FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_refine
                     (x, f);
                   FStar_Syntax_Syntax.pos = uu___5;
-                  FStar_Syntax_Syntax.vars = uu___6;
-                  FStar_Syntax_Syntax.hash_code = uu___7;_} ->
-                  let uu___8 =
-                    let uu___9 =
-                      let uu___10 = FStar_Syntax_Syntax.mk_binder x in
-                      [uu___10] in
-                    FStar_Syntax_Subst.open_term uu___9 f in
-                  (match uu___8 with
+                  FStar_Syntax_Syntax.hash_code = uu___6;_} ->
+                  let uu___7 =
+                    let uu___8 =
+                      let uu___9 = FStar_Syntax_Syntax.mk_binder x in
+                      [uu___9] in
+                    FStar_Syntax_Subst.open_term uu___8 f in
+                  (match uu___7 with
                    | (b, f1) ->
-                       let uu___9 =
-                         let uu___10 = FStar_Compiler_List.hd b in
-                         uu___10.FStar_Syntax_Syntax.binder_bv in
-                       (uu___9, f1))
+                       let uu___8 =
+                         let uu___9 = FStar_Compiler_List.hd b in
+                         uu___9.FStar_Syntax_Syntax.binder_bv in
+                       (uu___8, f1))
               | uu___5 -> failwith "impossible" in
             (match uu___3 with
              | (x, f) ->
@@ -2109,19 +2107,18 @@ and (encode_term :
                              FStar_Syntax_Syntax.n =
                                FStar_Syntax_Syntax.Tm_fvar fv;
                              FStar_Syntax_Syntax.pos = uu___6;
-                             FStar_Syntax_Syntax.vars = uu___7;
-                             FStar_Syntax_Syntax.hash_code = uu___8;_},
-                           uu___9),
-                          (arg, uu___10)::[]) when
+                             FStar_Syntax_Syntax.hash_code = uu___7;_},
+                           uu___8),
+                          (arg, uu___9)::[]) when
                            ((FStar_Syntax_Syntax.fv_eq_lid fv
                                FStar_Parser_Const.squash_lid)
                               ||
                               (FStar_Syntax_Syntax.fv_eq_lid fv
                                  FStar_Parser_Const.auto_squash_lid))
                              &&
-                             (let uu___11 =
+                             (let uu___10 =
                                 FStar_Syntax_Util.destruct_typ_as_formula arg in
-                              FStar_Compiler_Option.isSome uu___11)
+                              FStar_Compiler_Option.isSome uu___10)
                            ->
                            let dummy =
                              FStar_Syntax_Syntax.new_bv
@@ -2144,10 +2141,9 @@ and (encode_term :
                              FStar_Syntax_Syntax.n =
                                FStar_Syntax_Syntax.Tm_fvar fv;
                              FStar_Syntax_Syntax.pos = uu___6;
-                             FStar_Syntax_Syntax.vars = uu___7;
-                             FStar_Syntax_Syntax.hash_code = uu___8;_},
-                           uu___9),
-                          uu___10) when
+                             FStar_Syntax_Syntax.hash_code = uu___7;_},
+                           uu___8),
+                          uu___9) when
                            (Prims.op_Negation
                               env.FStar_SMTEncoding_Env.encoding_quantifier)
                              &&
@@ -2244,10 +2240,9 @@ and (encode_term :
                              FStar_Syntax_Syntax.n =
                                FStar_Syntax_Syntax.Tm_fvar fv;
                              FStar_Syntax_Syntax.pos = uu___6;
-                             FStar_Syntax_Syntax.vars = uu___7;
-                             FStar_Syntax_Syntax.hash_code = uu___8;_},
-                           uu___9),
-                          uu___10::(phi, uu___11)::[]) when
+                             FStar_Syntax_Syntax.hash_code = uu___7;_},
+                           uu___8),
+                          uu___9::(phi, uu___10)::[]) when
                            FStar_Syntax_Syntax.fv_eq_lid fv
                              FStar_Parser_Const.by_tactic_lid
                            -> encode_term phi env
@@ -2261,10 +2256,9 @@ and (encode_term :
                              FStar_Syntax_Syntax.n =
                                FStar_Syntax_Syntax.Tm_fvar fv;
                              FStar_Syntax_Syntax.pos = uu___6;
-                             FStar_Syntax_Syntax.vars = uu___7;
-                             FStar_Syntax_Syntax.hash_code = uu___8;_},
-                           uu___9),
-                          uu___10::uu___11::(phi, uu___12)::[]) when
+                             FStar_Syntax_Syntax.hash_code = uu___7;_},
+                           uu___8),
+                          uu___9::uu___10::(phi, uu___11)::[]) when
                            FStar_Syntax_Syntax.fv_eq_lid fv
                              FStar_Parser_Const.rewrite_by_tactic_lid
                            -> encode_term phi env
@@ -2622,10 +2616,9 @@ and (encode_term :
                                          FStar_Syntax_Syntax.n =
                                            FStar_Syntax_Syntax.Tm_name x;
                                          FStar_Syntax_Syntax.pos = uu___8;
-                                         FStar_Syntax_Syntax.vars = uu___9;
                                          FStar_Syntax_Syntax.hash_code =
-                                           uu___10;_},
-                                       uu___11)
+                                           uu___9;_},
+                                       uu___10)
                                       ->
                                       FStar_Pervasives_Native.Some
                                         (x.FStar_Syntax_Syntax.sort)
@@ -2637,23 +2630,22 @@ and (encode_term :
                                          FStar_Syntax_Syntax.n =
                                            FStar_Syntax_Syntax.Tm_fvar fv;
                                          FStar_Syntax_Syntax.pos = uu___8;
-                                         FStar_Syntax_Syntax.vars = uu___9;
                                          FStar_Syntax_Syntax.hash_code =
-                                           uu___10;_},
-                                       uu___11)
+                                           uu___9;_},
+                                       uu___10)
                                       ->
-                                      let uu___12 =
-                                        let uu___13 =
-                                          let uu___14 =
+                                      let uu___11 =
+                                        let uu___12 =
+                                          let uu___13 =
                                             FStar_TypeChecker_Env.lookup_lid
                                               env.FStar_SMTEncoding_Env.tcenv
                                               (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
                                           FStar_Compiler_Effect.op_Bar_Greater
-                                            uu___14
+                                            uu___13
                                             FStar_Pervasives_Native.fst in
                                         FStar_Compiler_Effect.op_Bar_Greater
-                                          uu___13 FStar_Pervasives_Native.snd in
-                                      FStar_Pervasives_Native.Some uu___12
+                                          uu___12 FStar_Pervasives_Native.snd in
+                                      FStar_Pervasives_Native.Some uu___11
                                   | FStar_Syntax_Syntax.Tm_fvar fv ->
                                       let uu___8 =
                                         let uu___9 =
@@ -2761,11 +2753,9 @@ and (encode_term :
                                                      fv;
                                                    FStar_Syntax_Syntax.pos =
                                                      uu___10;
-                                                   FStar_Syntax_Syntax.vars =
-                                                     uu___11;
                                                    FStar_Syntax_Syntax.hash_code
-                                                     = uu___12;_},
-                                                 uu___13)
+                                                     = uu___11;_},
+                                                 uu___12)
                                                 when
                                                 (FStar_Compiler_List.length
                                                    formals)
@@ -3770,10 +3760,9 @@ and (encode_formula :
              | (FStar_Syntax_Syntax.Tm_uinst
                 ({ FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar fv;
                    FStar_Syntax_Syntax.pos = uu___;
-                   FStar_Syntax_Syntax.vars = uu___1;
-                   FStar_Syntax_Syntax.hash_code = uu___2;_},
-                 uu___3),
-                uu___4::(phi2, uu___5)::[]) when
+                   FStar_Syntax_Syntax.hash_code = uu___1;_},
+                 uu___2),
+                uu___3::(phi2, uu___4)::[]) when
                  FStar_Syntax_Syntax.fv_eq_lid fv
                    FStar_Parser_Const.by_tactic_lid
                  -> encode_formula phi2 env
@@ -3785,10 +3774,9 @@ and (encode_formula :
              | (FStar_Syntax_Syntax.Tm_uinst
                 ({ FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar fv;
                    FStar_Syntax_Syntax.pos = uu___;
-                   FStar_Syntax_Syntax.vars = uu___1;
-                   FStar_Syntax_Syntax.hash_code = uu___2;_},
-                 uu___3),
-                uu___4::uu___5::(phi2, uu___6)::[]) when
+                   FStar_Syntax_Syntax.hash_code = uu___1;_},
+                 uu___2),
+                uu___3::uu___4::(phi2, uu___5)::[]) when
                  FStar_Syntax_Syntax.fv_eq_lid fv
                    FStar_Parser_Const.rewrite_by_tactic_lid
                  -> encode_formula phi2 env

--- a/ocaml/fstar-lib/generated/FStar_Syntax_DsEnv.ml
+++ b/ocaml/fstar-lib/generated/FStar_Syntax_DsEnv.ml
@@ -2324,8 +2324,6 @@ let (push_bv' :
             FStar_Syntax_Syntax.n =
               (FStar_Syntax_Syntax.tun.FStar_Syntax_Syntax.n);
             FStar_Syntax_Syntax.pos = r;
-            FStar_Syntax_Syntax.vars =
-              (FStar_Syntax_Syntax.tun.FStar_Syntax_Syntax.vars);
             FStar_Syntax_Syntax.hash_code =
               (FStar_Syntax_Syntax.tun.FStar_Syntax_Syntax.hash_code)
           } in

--- a/ocaml/fstar-lib/generated/FStar_Syntax_Embeddings.ml
+++ b/ocaml/fstar-lib/generated/FStar_Syntax_Embeddings.ml
@@ -410,8 +410,6 @@ let (e_unit : unit embedding) =
       FStar_Syntax_Syntax.n =
         (FStar_Syntax_Util.exp_unit.FStar_Syntax_Syntax.n);
       FStar_Syntax_Syntax.pos = rng;
-      FStar_Syntax_Syntax.vars =
-        (FStar_Syntax_Util.exp_unit.FStar_Syntax_Syntax.vars);
       FStar_Syntax_Syntax.hash_code =
         (FStar_Syntax_Util.exp_unit.FStar_Syntax_Syntax.hash_code)
     } in
@@ -448,7 +446,6 @@ let (e_bool : Prims.bool embedding) =
     {
       FStar_Syntax_Syntax.n = (t.FStar_Syntax_Syntax.n);
       FStar_Syntax_Syntax.pos = rng;
-      FStar_Syntax_Syntax.vars = (t.FStar_Syntax_Syntax.vars);
       FStar_Syntax_Syntax.hash_code = (t.FStar_Syntax_Syntax.hash_code)
     } in
   let un t0 w _norm =
@@ -482,7 +479,6 @@ let (e_char : FStar_Char.char embedding) =
     {
       FStar_Syntax_Syntax.n = (t.FStar_Syntax_Syntax.n);
       FStar_Syntax_Syntax.pos = rng;
-      FStar_Syntax_Syntax.vars = (t.FStar_Syntax_Syntax.vars);
       FStar_Syntax_Syntax.hash_code = (t.FStar_Syntax_Syntax.hash_code)
     } in
   let un t0 w _norm =

--- a/ocaml/fstar-lib/generated/FStar_Syntax_Resugar.ml
+++ b/ocaml/fstar-lib/generated/FStar_Syntax_Resugar.ml
@@ -694,26 +694,23 @@ let rec (resugar_term' :
       | FStar_Syntax_Syntax.Tm_app
           ({ FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar fv;
              FStar_Syntax_Syntax.pos = uu___1;
-             FStar_Syntax_Syntax.vars = uu___2;
-             FStar_Syntax_Syntax.hash_code = uu___3;_},
-           (e, uu___4)::[])
+             FStar_Syntax_Syntax.hash_code = uu___2;_},
+           (e, uu___3)::[])
           when
-          (let uu___5 = FStar_Options.print_implicits () in
-           Prims.op_Negation uu___5) &&
+          (let uu___4 = FStar_Options.print_implicits () in
+           Prims.op_Negation uu___4) &&
             (FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.b2t_lid)
           -> resugar_term' env e
       | FStar_Syntax_Syntax.Tm_app
           ({ FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar fv;
              FStar_Syntax_Syntax.pos = uu___1;
-             FStar_Syntax_Syntax.vars = uu___2;
-             FStar_Syntax_Syntax.hash_code = uu___3;_},
+             FStar_Syntax_Syntax.hash_code = uu___2;_},
            ({
               FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
                 (FStar_Const.Const_int (i, FStar_Pervasives_Native.None));
-              FStar_Syntax_Syntax.pos = uu___4;
-              FStar_Syntax_Syntax.vars = uu___5;
-              FStar_Syntax_Syntax.hash_code = uu___6;_},
-            uu___7)::[])
+              FStar_Syntax_Syntax.pos = uu___3;
+              FStar_Syntax_Syntax.hash_code = uu___4;_},
+            uu___5)::[])
           when can_resugar_machine_integer fv ->
           resugar_machine_integer fv i t.FStar_Syntax_Syntax.pos
       | FStar_Syntax_Syntax.Tm_app (e, args) ->
@@ -1938,8 +1935,7 @@ and (resugar_bv_as_pat' :
             | FStar_Pervasives_Native.Some
                 { FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_unknown;
                   FStar_Syntax_Syntax.pos = uu___;
-                  FStar_Syntax_Syntax.vars = uu___1;
-                  FStar_Syntax_Syntax.hash_code = uu___2;_}
+                  FStar_Syntax_Syntax.hash_code = uu___1;_}
                 -> pat
             | FStar_Pervasives_Native.Some typ ->
                 let uu___ = FStar_Options.print_bound_var_types () in

--- a/ocaml/fstar-lib/generated/FStar_Syntax_Subst.ml
+++ b/ocaml/fstar-lib/generated/FStar_Syntax_Subst.ml
@@ -270,7 +270,6 @@ let tag_with_range :
              {
                FStar_Syntax_Syntax.n = t';
                FStar_Syntax_Syntax.pos = r1;
-               FStar_Syntax_Syntax.vars = (t.FStar_Syntax_Syntax.vars);
                FStar_Syntax_Syntax.hash_code =
                  (t.FStar_Syntax_Syntax.hash_code)
              })
@@ -788,7 +787,6 @@ let rec (push_subst_aux :
                 {
                   FStar_Syntax_Syntax.n = uu___2;
                   FStar_Syntax_Syntax.pos = (t.FStar_Syntax_Syntax.pos);
-                  FStar_Syntax_Syntax.vars = (t.FStar_Syntax_Syntax.vars);
                   FStar_Syntax_Syntax.hash_code =
                     (t.FStar_Syntax_Syntax.hash_code)
                 } in

--- a/ocaml/fstar-lib/generated/FStar_Syntax_Syntax.ml
+++ b/ocaml/fstar-lib/generated/FStar_Syntax_Syntax.ml
@@ -331,7 +331,6 @@ and 'a syntax =
   {
   n: 'a ;
   pos: FStar_Compiler_Range.range ;
-  vars: free_vars memo ;
   hash_code: FStar_Hash.hash_code memo }
 and bv = {
   ppname: FStar_Ident.ident ;
@@ -842,17 +841,13 @@ let (uu___is_UD : subst_elt -> Prims.bool) =
 let (__proj__UD__item___0 : subst_elt -> (univ_name * Prims.int)) =
   fun projectee -> match projectee with | UD _0 -> _0
 let __proj__Mksyntax__item__n : 'a . 'a syntax -> 'a =
-  fun projectee -> match projectee with | { n; pos; vars; hash_code;_} -> n
+  fun projectee -> match projectee with | { n; pos; hash_code;_} -> n
 let __proj__Mksyntax__item__pos :
   'a . 'a syntax -> FStar_Compiler_Range.range =
-  fun projectee -> match projectee with | { n; pos; vars; hash_code;_} -> pos
-let __proj__Mksyntax__item__vars : 'a . 'a syntax -> free_vars memo =
-  fun projectee ->
-    match projectee with | { n; pos; vars; hash_code;_} -> vars
+  fun projectee -> match projectee with | { n; pos; hash_code;_} -> pos
 let __proj__Mksyntax__item__hash_code :
   'a . 'a syntax -> FStar_Hash.hash_code memo =
-  fun projectee ->
-    match projectee with | { n; pos; vars; hash_code;_} -> hash_code
+  fun projectee -> match projectee with | { n; pos; hash_code;_} -> hash_code
 let (__proj__Mkbv__item__ppname : bv -> FStar_Ident.ident) =
   fun projectee -> match projectee with | { ppname; index; sort;_} -> ppname
 let (__proj__Mkbv__item__index : bv -> Prims.int) =
@@ -1813,8 +1808,7 @@ let mk : 'a . 'a -> FStar_Compiler_Range.range -> 'a syntax =
   fun t ->
     fun r ->
       let uu___ = FStar_Compiler_Util.mk_ref FStar_Pervasives_Native.None in
-      let uu___1 = FStar_Compiler_Util.mk_ref FStar_Pervasives_Native.None in
-      { n = t; pos = r; vars = uu___; hash_code = uu___1 }
+      { n = t; pos = r; hash_code = uu___ }
 let (bv_to_tm : bv -> term) =
   fun bv1 -> let uu___ = range_of_bv bv1 in mk (Tm_bvar bv1) uu___
 let (bv_to_name : bv -> term) =
@@ -2126,8 +2120,7 @@ let (has_simple_attribute : term Prims.list -> Prims.string -> Prims.bool) =
         (fun uu___ ->
            match uu___ with
            | { n = Tm_constant (FStar_Const.Const_string (data, uu___1));
-               pos = uu___2; vars = uu___3; hash_code = uu___4;_} when
-               data = s -> true
+               pos = uu___2; hash_code = uu___3;_} when data = s -> true
            | uu___1 -> false) l
 let rec (eq_pat : pat -> pat -> Prims.bool) =
   fun p1 ->

--- a/ocaml/fstar-lib/generated/FStar_Syntax_Util.ml
+++ b/ocaml/fstar-lib/generated/FStar_Syntax_Util.ml
@@ -1704,7 +1704,6 @@ let rec (canon_arrow :
           {
             FStar_Syntax_Syntax.n = cn;
             FStar_Syntax_Syntax.pos = (c.FStar_Syntax_Syntax.pos);
-            FStar_Syntax_Syntax.vars = (c.FStar_Syntax_Syntax.vars);
             FStar_Syntax_Syntax.hash_code = (c.FStar_Syntax_Syntax.hash_code)
           } in
         flat_arrow bs c1
@@ -2886,10 +2885,9 @@ let (is_squash :
          | (FStar_Syntax_Syntax.Tm_uinst
             ({ FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar fv;
                FStar_Syntax_Syntax.pos = uu___2;
-               FStar_Syntax_Syntax.vars = uu___3;
-               FStar_Syntax_Syntax.hash_code = uu___4;_},
+               FStar_Syntax_Syntax.hash_code = uu___3;_},
              u::[]),
-            (t1, uu___5)::[]) when
+            (t1, uu___4)::[]) when
              FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.squash_lid
              -> FStar_Pervasives_Native.Some (u, t1)
          | uu___2 -> FStar_Pervasives_Native.None)
@@ -2911,10 +2909,9 @@ let (is_auto_squash :
          | (FStar_Syntax_Syntax.Tm_uinst
             ({ FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar fv;
                FStar_Syntax_Syntax.pos = uu___2;
-               FStar_Syntax_Syntax.vars = uu___3;
-               FStar_Syntax_Syntax.hash_code = uu___4;_},
+               FStar_Syntax_Syntax.hash_code = uu___3;_},
              u::[]),
-            (t1, uu___5)::[]) when
+            (t1, uu___4)::[]) when
              FStar_Syntax_Syntax.fv_eq_lid fv
                FStar_Parser_Const.auto_squash_lid
              -> FStar_Pervasives_Native.Some (u, t1)
@@ -3170,69 +3167,61 @@ let (destruct_typ_as_formula :
         | (FStar_Pervasives_Native.Some fa,
            ({ FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar tc;
               FStar_Syntax_Syntax.pos = uu___1;
-              FStar_Syntax_Syntax.vars = uu___2;
-              FStar_Syntax_Syntax.hash_code = uu___3;_},
+              FStar_Syntax_Syntax.hash_code = uu___2;_},
             ({
                FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_abs
-                 (b::[], t2, uu___4);
-               FStar_Syntax_Syntax.pos = uu___5;
-               FStar_Syntax_Syntax.vars = uu___6;
-               FStar_Syntax_Syntax.hash_code = uu___7;_},
-             uu___8)::[]))
+                 (b::[], t2, uu___3);
+               FStar_Syntax_Syntax.pos = uu___4;
+               FStar_Syntax_Syntax.hash_code = uu___5;_},
+             uu___6)::[]))
             when is_q fa tc -> aux qopt (b :: out) t2
         | (FStar_Pervasives_Native.Some fa,
            ({ FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar tc;
               FStar_Syntax_Syntax.pos = uu___1;
-              FStar_Syntax_Syntax.vars = uu___2;
-              FStar_Syntax_Syntax.hash_code = uu___3;_},
-            uu___4::({
+              FStar_Syntax_Syntax.hash_code = uu___2;_},
+            uu___3::({
                        FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_abs
-                         (b::[], t2, uu___5);
-                       FStar_Syntax_Syntax.pos = uu___6;
-                       FStar_Syntax_Syntax.vars = uu___7;
-                       FStar_Syntax_Syntax.hash_code = uu___8;_},
-                     uu___9)::[]))
+                         (b::[], t2, uu___4);
+                       FStar_Syntax_Syntax.pos = uu___5;
+                       FStar_Syntax_Syntax.hash_code = uu___6;_},
+                     uu___7)::[]))
             when is_q fa tc -> aux qopt (b :: out) t2
         | (FStar_Pervasives_Native.None,
            ({ FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar tc;
               FStar_Syntax_Syntax.pos = uu___1;
-              FStar_Syntax_Syntax.vars = uu___2;
-              FStar_Syntax_Syntax.hash_code = uu___3;_},
+              FStar_Syntax_Syntax.hash_code = uu___2;_},
             ({
                FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_abs
-                 (b::[], t2, uu___4);
-               FStar_Syntax_Syntax.pos = uu___5;
-               FStar_Syntax_Syntax.vars = uu___6;
-               FStar_Syntax_Syntax.hash_code = uu___7;_},
-             uu___8)::[]))
+                 (b::[], t2, uu___3);
+               FStar_Syntax_Syntax.pos = uu___4;
+               FStar_Syntax_Syntax.hash_code = uu___5;_},
+             uu___6)::[]))
             when
             is_qlid (tc.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v ->
-            let uu___9 =
-              let uu___10 =
+            let uu___7 =
+              let uu___8 =
                 is_forall
                   (tc.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-              FStar_Pervasives_Native.Some uu___10 in
-            aux uu___9 (b :: out) t2
+              FStar_Pervasives_Native.Some uu___8 in
+            aux uu___7 (b :: out) t2
         | (FStar_Pervasives_Native.None,
            ({ FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar tc;
               FStar_Syntax_Syntax.pos = uu___1;
-              FStar_Syntax_Syntax.vars = uu___2;
-              FStar_Syntax_Syntax.hash_code = uu___3;_},
-            uu___4::({
+              FStar_Syntax_Syntax.hash_code = uu___2;_},
+            uu___3::({
                        FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_abs
-                         (b::[], t2, uu___5);
-                       FStar_Syntax_Syntax.pos = uu___6;
-                       FStar_Syntax_Syntax.vars = uu___7;
-                       FStar_Syntax_Syntax.hash_code = uu___8;_},
-                     uu___9)::[]))
+                         (b::[], t2, uu___4);
+                       FStar_Syntax_Syntax.pos = uu___5;
+                       FStar_Syntax_Syntax.hash_code = uu___6;_},
+                     uu___7)::[]))
             when
             is_qlid (tc.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v ->
-            let uu___10 =
-              let uu___11 =
+            let uu___8 =
+              let uu___9 =
                 is_forall
                   (tc.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-              FStar_Pervasives_Native.Some uu___11 in
-            aux uu___10 (b :: out) t2
+              FStar_Pervasives_Native.Some uu___9 in
+            aux uu___8 (b :: out) t2
         | (FStar_Pervasives_Native.Some b, uu___1) ->
             let bs = FStar_Compiler_List.rev out in
             let uu___2 = FStar_Syntax_Subst.open_term bs t1 in
@@ -4757,10 +4746,9 @@ let (is_erased_head :
          | (FStar_Syntax_Syntax.Tm_uinst
             ({ FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar fv;
                FStar_Syntax_Syntax.pos = uu___1;
-               FStar_Syntax_Syntax.vars = uu___2;
-               FStar_Syntax_Syntax.hash_code = uu___3;_},
+               FStar_Syntax_Syntax.hash_code = uu___2;_},
              u::[]),
-            (ty, uu___4)::[]) when
+            (ty, uu___3)::[]) when
              FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.erased_lid
              -> FStar_Pervasives_Native.Some (u, ty)
          | uu___1 -> FStar_Pervasives_Native.None)

--- a/ocaml/fstar-lib/generated/FStar_Tactics_Basic.ml
+++ b/ocaml/fstar-lib/generated/FStar_Tactics_Basic.ml
@@ -4925,9 +4925,8 @@ let (unshelve : FStar_Syntax_Syntax.term -> unit FStar_Tactics_Monad.tac) =
                 FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_uvar
                   (ctx_uvar, uu___2);
                 FStar_Syntax_Syntax.pos = uu___3;
-                FStar_Syntax_Syntax.vars = uu___4;
-                FStar_Syntax_Syntax.hash_code = uu___5;_},
-              uu___6) ->
+                FStar_Syntax_Syntax.hash_code = uu___4;_},
+              uu___5) ->
                let env2 =
                  {
                    FStar_TypeChecker_Env.solver =

--- a/ocaml/fstar-lib/generated/FStar_Tactics_CtrlRewrite.ml
+++ b/ocaml/fstar-lib/generated/FStar_Tactics_CtrlRewrite.ml
@@ -761,8 +761,6 @@ and (on_subterms :
                             FStar_Syntax_Syntax.n = tmn';
                             FStar_Syntax_Syntax.pos =
                               (tm.FStar_Syntax_Syntax.pos);
-                            FStar_Syntax_Syntax.vars =
-                              (tm.FStar_Syntax_Syntax.vars);
                             FStar_Syntax_Syntax.hash_code =
                               (tm.FStar_Syntax_Syntax.hash_code)
                           }, flag))

--- a/ocaml/fstar-lib/generated/FStar_Tactics_Embedding.ml
+++ b/ocaml/fstar-lib/generated/FStar_Tactics_Embedding.ml
@@ -368,7 +368,6 @@ let (e_exn : Prims.exn FStar_Syntax_Embeddings.embedding) =
         {
           FStar_Syntax_Syntax.n = (t.FStar_Syntax_Syntax.n);
           FStar_Syntax_Syntax.pos = rng;
-          FStar_Syntax_Syntax.vars = (t.FStar_Syntax_Syntax.vars);
           FStar_Syntax_Syntax.hash_code = (t.FStar_Syntax_Syntax.hash_code)
         }
     | e1 ->

--- a/ocaml/fstar-lib/generated/FStar_Tactics_Hooks.ml
+++ b/ocaml/fstar-lib/generated/FStar_Tactics_Hooks.ml
@@ -318,9 +318,8 @@ let rec (traverse :
             | FStar_Syntax_Syntax.Tm_app
                 ({ FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar fv;
                    FStar_Syntax_Syntax.pos = uu___1;
-                   FStar_Syntax_Syntax.vars = uu___2;
-                   FStar_Syntax_Syntax.hash_code = uu___3;_},
-                 (p, uu___4)::(q, uu___5)::[])
+                   FStar_Syntax_Syntax.hash_code = uu___2;_},
+                 (p, uu___3)::(q, uu___4)::[])
                 when
                 FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.imp_lid
                 ->
@@ -328,19 +327,18 @@ let rec (traverse :
                   FStar_Syntax_Syntax.new_bv FStar_Pervasives_Native.None p in
                 let r1 = traverse f (flip pol1) e p in
                 let r2 =
-                  let uu___6 = FStar_TypeChecker_Env.push_bv e x in
-                  traverse f pol1 uu___6 q in
+                  let uu___5 = FStar_TypeChecker_Env.push_bv e x in
+                  traverse f pol1 uu___5 q in
                 comb2
                   (fun l ->
                      fun r3 ->
-                       let uu___6 = FStar_Syntax_Util.mk_imp l r3 in
-                       uu___6.FStar_Syntax_Syntax.n) r1 r2
+                       let uu___5 = FStar_Syntax_Util.mk_imp l r3 in
+                       uu___5.FStar_Syntax_Syntax.n) r1 r2
             | FStar_Syntax_Syntax.Tm_app
                 ({ FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar fv;
                    FStar_Syntax_Syntax.pos = uu___1;
-                   FStar_Syntax_Syntax.vars = uu___2;
-                   FStar_Syntax_Syntax.hash_code = uu___3;_},
-                 (p, uu___4)::(q, uu___5)::[])
+                   FStar_Syntax_Syntax.hash_code = uu___2;_},
+                 (p, uu___3)::(q, uu___4)::[])
                 when
                 FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.iff_lid
                 ->
@@ -349,29 +347,29 @@ let rec (traverse :
                 let xq =
                   FStar_Syntax_Syntax.new_bv FStar_Pervasives_Native.None q in
                 let r1 =
-                  let uu___6 = FStar_TypeChecker_Env.push_bv e xq in
-                  traverse f Both uu___6 p in
+                  let uu___5 = FStar_TypeChecker_Env.push_bv e xq in
+                  traverse f Both uu___5 p in
                 let r2 =
-                  let uu___6 = FStar_TypeChecker_Env.push_bv e xp in
-                  traverse f Both uu___6 q in
+                  let uu___5 = FStar_TypeChecker_Env.push_bv e xp in
+                  traverse f Both uu___5 q in
                 (match (r1, r2) with
-                 | (Unchanged uu___6, Unchanged uu___7) ->
+                 | (Unchanged uu___5, Unchanged uu___6) ->
                      comb2
                        (fun l ->
                           fun r3 ->
-                            let uu___8 = FStar_Syntax_Util.mk_iff l r3 in
-                            uu___8.FStar_Syntax_Syntax.n) r1 r2
-                 | uu___6 ->
-                     let uu___7 = explode r1 in
-                     (match uu___7 with
+                            let uu___7 = FStar_Syntax_Util.mk_iff l r3 in
+                            uu___7.FStar_Syntax_Syntax.n) r1 r2
+                 | uu___5 ->
+                     let uu___6 = explode r1 in
+                     (match uu___6 with
                       | (pn, pp, gs1) ->
-                          let uu___8 = explode r2 in
-                          (match uu___8 with
+                          let uu___7 = explode r2 in
+                          (match uu___7 with
                            | (qn, qp, gs2) ->
                                let t1 =
-                                 let uu___9 = FStar_Syntax_Util.mk_imp pn qp in
-                                 let uu___10 = FStar_Syntax_Util.mk_imp qn pp in
-                                 FStar_Syntax_Util.mk_conj uu___9 uu___10 in
+                                 let uu___8 = FStar_Syntax_Util.mk_imp pn qp in
+                                 let uu___9 = FStar_Syntax_Util.mk_imp qn pp in
+                                 FStar_Syntax_Util.mk_conj uu___8 uu___9 in
                                Simplified
                                  ((t1.FStar_Syntax_Syntax.n),
                                    (FStar_Compiler_List.op_At gs1 gs2)))))
@@ -467,7 +465,6 @@ let rec (traverse :
                 {
                   FStar_Syntax_Syntax.n = tn';
                   FStar_Syntax_Syntax.pos = (t.FStar_Syntax_Syntax.pos);
-                  FStar_Syntax_Syntax.vars = (t.FStar_Syntax_Syntax.vars);
                   FStar_Syntax_Syntax.hash_code =
                     (t.FStar_Syntax_Syntax.hash_code)
                 }
@@ -477,7 +474,6 @@ let rec (traverse :
                   {
                     FStar_Syntax_Syntax.n = tn';
                     FStar_Syntax_Syntax.pos = (t.FStar_Syntax_Syntax.pos);
-                    FStar_Syntax_Syntax.vars = (t.FStar_Syntax_Syntax.vars);
                     FStar_Syntax_Syntax.hash_code =
                       (t.FStar_Syntax_Syntax.hash_code)
                   } in
@@ -488,7 +484,6 @@ let rec (traverse :
                   {
                     FStar_Syntax_Syntax.n = tp;
                     FStar_Syntax_Syntax.pos = (t.FStar_Syntax_Syntax.pos);
-                    FStar_Syntax_Syntax.vars = (t.FStar_Syntax_Syntax.vars);
                     FStar_Syntax_Syntax.hash_code =
                       (t.FStar_Syntax_Syntax.hash_code)
                   } in
@@ -499,8 +494,6 @@ let rec (traverse :
                      ({
                         FStar_Syntax_Syntax.n = tn;
                         FStar_Syntax_Syntax.pos = (t.FStar_Syntax_Syntax.pos);
-                        FStar_Syntax_Syntax.vars =
-                          (t.FStar_Syntax_Syntax.vars);
                         FStar_Syntax_Syntax.hash_code =
                           (t.FStar_Syntax_Syntax.hash_code)
                       }, p', (FStar_Compiler_List.op_At gs gs')))
@@ -1078,9 +1071,8 @@ let rec (traverse_for_spinoff :
                           FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar
                             fv;
                           FStar_Syntax_Syntax.pos = uu___4;
-                          FStar_Syntax_Syntax.vars = uu___5;
-                          FStar_Syntax_Syntax.hash_code = uu___6;_},
-                        (p, uu___7)::(q, uu___8)::[])
+                          FStar_Syntax_Syntax.hash_code = uu___5;_},
+                        (p, uu___6)::(q, uu___7)::[])
                        when
                        FStar_Syntax_Syntax.fv_eq_lid fv
                          FStar_Parser_Const.imp_lid
@@ -1090,13 +1082,13 @@ let rec (traverse_for_spinoff :
                            FStar_Pervasives_Native.None p in
                        let r1 = traverse1 (flip pol1) e p in
                        let r2 =
-                         let uu___9 = FStar_TypeChecker_Env.push_bv e x in
-                         traverse1 pol1 uu___9 q in
+                         let uu___8 = FStar_TypeChecker_Env.push_bv e x in
+                         traverse1 pol1 uu___8 q in
                        comb2
                          (fun l ->
                             fun r3 ->
-                              let uu___9 = FStar_Syntax_Util.mk_imp l r3 in
-                              uu___9.FStar_Syntax_Syntax.n) r1 r2
+                              let uu___8 = FStar_Syntax_Util.mk_imp l r3 in
+                              uu___8.FStar_Syntax_Syntax.n) r1 r2
                    | FStar_Syntax_Syntax.Tm_app (hd, args) ->
                        let uu___4 =
                          let uu___5 =
@@ -1228,8 +1220,6 @@ let rec (traverse_for_spinoff :
                      {
                        FStar_Syntax_Syntax.n = tn';
                        FStar_Syntax_Syntax.pos = (t.FStar_Syntax_Syntax.pos);
-                       FStar_Syntax_Syntax.vars =
-                         (t.FStar_Syntax_Syntax.vars);
                        FStar_Syntax_Syntax.hash_code =
                          (t.FStar_Syntax_Syntax.hash_code)
                      }
@@ -1240,8 +1230,6 @@ let rec (traverse_for_spinoff :
                          FStar_Syntax_Syntax.n = tn';
                          FStar_Syntax_Syntax.pos =
                            (t.FStar_Syntax_Syntax.pos);
-                         FStar_Syntax_Syntax.vars =
-                           (t.FStar_Syntax_Syntax.vars);
                          FStar_Syntax_Syntax.hash_code =
                            (t.FStar_Syntax_Syntax.hash_code)
                        } in
@@ -1253,8 +1241,6 @@ let rec (traverse_for_spinoff :
                          FStar_Syntax_Syntax.n = tp;
                          FStar_Syntax_Syntax.pos =
                            (t.FStar_Syntax_Syntax.pos);
-                         FStar_Syntax_Syntax.vars =
-                           (t.FStar_Syntax_Syntax.vars);
                          FStar_Syntax_Syntax.hash_code =
                            (t.FStar_Syntax_Syntax.hash_code)
                        } in
@@ -1266,8 +1252,6 @@ let rec (traverse_for_spinoff :
                              FStar_Syntax_Syntax.n = tn;
                              FStar_Syntax_Syntax.pos =
                                (t.FStar_Syntax_Syntax.pos);
-                             FStar_Syntax_Syntax.vars =
-                               (t.FStar_Syntax_Syntax.vars);
                              FStar_Syntax_Syntax.hash_code =
                                (t.FStar_Syntax_Syntax.hash_code)
                            }, p', (FStar_Compiler_List.op_At gs gs'))))

--- a/ocaml/fstar-lib/generated/FStar_ToSyntax_ToSyntax.ml
+++ b/ocaml/fstar-lib/generated/FStar_ToSyntax_ToSyntax.ml
@@ -6,8 +6,6 @@ let (tun_r : FStar_Compiler_Range.range -> FStar_Syntax_Syntax.term) =
     {
       FStar_Syntax_Syntax.n = (FStar_Syntax_Syntax.tun.FStar_Syntax_Syntax.n);
       FStar_Syntax_Syntax.pos = r;
-      FStar_Syntax_Syntax.vars =
-        (FStar_Syntax_Syntax.tun.FStar_Syntax_Syntax.vars);
       FStar_Syntax_Syntax.hash_code =
         (FStar_Syntax_Syntax.tun.FStar_Syntax_Syntax.hash_code)
     }
@@ -419,7 +417,6 @@ let (op_as_term :
                {
                  FStar_Syntax_Syntax.n = (t.FStar_Syntax_Syntax.n);
                  FStar_Syntax_Syntax.pos = uu___2;
-                 FStar_Syntax_Syntax.vars = (t.FStar_Syntax_Syntax.vars);
                  FStar_Syntax_Syntax.hash_code =
                    (t.FStar_Syntax_Syntax.hash_code)
                }) env true uu___1 in
@@ -1425,16 +1422,16 @@ let (check_no_aq : antiquotations_temp -> unit) =
            (e,
             { FStar_Syntax_Syntax.qkind = FStar_Syntax_Syntax.Quote_dynamic;
               FStar_Syntax_Syntax.antiquotations = uu___;_});
-         FStar_Syntax_Syntax.pos = uu___1; FStar_Syntax_Syntax.vars = uu___2;
-         FStar_Syntax_Syntax.hash_code = uu___3;_})::uu___4
+         FStar_Syntax_Syntax.pos = uu___1;
+         FStar_Syntax_Syntax.hash_code = uu___2;_})::uu___3
         ->
-        let uu___5 =
-          let uu___6 =
-            let uu___7 = FStar_Syntax_Print.term_to_string e in
+        let uu___4 =
+          let uu___5 =
+            let uu___6 = FStar_Syntax_Print.term_to_string e in
             FStar_Compiler_Util.format1 "Unexpected antiquotation: `@(%s)"
-              uu___7 in
-          (FStar_Errors_Codes.Fatal_UnexpectedAntiquotation, uu___6) in
-        FStar_Errors.raise_error uu___5 e.FStar_Syntax_Syntax.pos
+              uu___6 in
+          (FStar_Errors_Codes.Fatal_UnexpectedAntiquotation, uu___5) in
+        FStar_Errors.raise_error uu___4 e.FStar_Syntax_Syntax.pos
     | (bv, e)::uu___ ->
         let uu___1 =
           let uu___2 =
@@ -2248,8 +2245,6 @@ and (desugar_machine_integer :
                                (FStar_Syntax_Syntax.Tm_fvar private_fv);
                              FStar_Syntax_Syntax.pos =
                                (intro_term.FStar_Syntax_Syntax.pos);
-                             FStar_Syntax_Syntax.vars =
-                               (intro_term.FStar_Syntax_Syntax.vars);
                              FStar_Syntax_Syntax.hash_code =
                                (intro_term.FStar_Syntax_Syntax.hash_code)
                            }
@@ -2305,7 +2300,6 @@ and (desugar_term_maybe_top :
           {
             FStar_Syntax_Syntax.n = (e.FStar_Syntax_Syntax.n);
             FStar_Syntax_Syntax.pos = (top.FStar_Parser_AST.range);
-            FStar_Syntax_Syntax.vars = (e.FStar_Syntax_Syntax.vars);
             FStar_Syntax_Syntax.hash_code = (e.FStar_Syntax_Syntax.hash_code)
           } in
         let desugar_binders env1 binders =
@@ -4132,7 +4126,6 @@ and (desugar_term_maybe_top :
               {
                 FStar_Syntax_Syntax.n = (uu___2.FStar_Syntax_Syntax.n);
                 FStar_Syntax_Syntax.pos = (e.FStar_Parser_AST.range);
-                FStar_Syntax_Syntax.vars = (uu___2.FStar_Syntax_Syntax.vars);
                 FStar_Syntax_Syntax.hash_code =
                   (uu___2.FStar_Syntax_Syntax.hash_code)
               } in
@@ -5536,7 +5529,6 @@ and (desugar_formula :
         {
           FStar_Syntax_Syntax.n = (t.FStar_Syntax_Syntax.n);
           FStar_Syntax_Syntax.pos = (f.FStar_Parser_AST.range);
-          FStar_Syntax_Syntax.vars = (t.FStar_Syntax_Syntax.vars);
           FStar_Syntax_Syntax.hash_code = (t.FStar_Syntax_Syntax.hash_code)
         } in
       let desugar_quant q b pats body =
@@ -5570,8 +5562,6 @@ and (desugar_formula :
                                FStar_Syntax_Syntax.n =
                                  (uu___2.FStar_Syntax_Syntax.n);
                                FStar_Syntax_Syntax.pos = uu___3;
-                               FStar_Syntax_Syntax.vars =
-                                 (uu___2.FStar_Syntax_Syntax.vars);
                                FStar_Syntax_Syntax.hash_code =
                                  (uu___2.FStar_Syntax_Syntax.hash_code)
                              })) in
@@ -7663,9 +7653,6 @@ let rec (desugar_effect :
                                                              FStar_Syntax_Syntax.pos
                                                                =
                                                                (eff_t1.FStar_Syntax_Syntax.pos);
-                                                             FStar_Syntax_Syntax.vars
-                                                               =
-                                                               (eff_t1.FStar_Syntax_Syntax.vars);
                                                              FStar_Syntax_Syntax.hash_code
                                                                =
                                                                (eff_t1.FStar_Syntax_Syntax.hash_code)

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_Cfg.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_Cfg.ml
@@ -3886,8 +3886,6 @@ let (equality_ops : primitive_step FStar_Compiler_Util.psmap) =
                  FStar_Syntax_Syntax.n =
                    (FStar_Syntax_Util.t_true.FStar_Syntax_Syntax.n);
                  FStar_Syntax_Syntax.pos = r;
-                 FStar_Syntax_Syntax.vars =
-                   (FStar_Syntax_Util.t_true.FStar_Syntax_Syntax.vars);
                  FStar_Syntax_Syntax.hash_code =
                    (FStar_Syntax_Util.t_true.FStar_Syntax_Syntax.hash_code)
                }
@@ -3897,8 +3895,6 @@ let (equality_ops : primitive_step FStar_Compiler_Util.psmap) =
                  FStar_Syntax_Syntax.n =
                    (FStar_Syntax_Util.t_false.FStar_Syntax_Syntax.n);
                  FStar_Syntax_Syntax.pos = r;
-                 FStar_Syntax_Syntax.vars =
-                   (FStar_Syntax_Util.t_false.FStar_Syntax_Syntax.vars);
                  FStar_Syntax_Syntax.hash_code =
                    (FStar_Syntax_Util.t_false.FStar_Syntax_Syntax.hash_code)
                }

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_Common.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_Common.ml
@@ -799,7 +799,6 @@ let (lcomp_set_flags :
             {
               FStar_Syntax_Syntax.n = (FStar_Syntax_Syntax.Comp ct1);
               FStar_Syntax_Syntax.pos = (c.FStar_Syntax_Syntax.pos);
-              FStar_Syntax_Syntax.vars = (c.FStar_Syntax_Syntax.vars);
               FStar_Syntax_Syntax.hash_code =
                 (c.FStar_Syntax_Syntax.hash_code)
             } in
@@ -900,7 +899,6 @@ let (simplify :
         {
           FStar_Syntax_Syntax.n = (t.FStar_Syntax_Syntax.n);
           FStar_Syntax_Syntax.pos = (tm.FStar_Syntax_Syntax.pos);
-          FStar_Syntax_Syntax.vars = (t.FStar_Syntax_Syntax.vars);
           FStar_Syntax_Syntax.hash_code = (t.FStar_Syntax_Syntax.hash_code)
         } in
       let simp_t t =
@@ -1047,254 +1045,249 @@ let (simplify :
              FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_uinst
                ({ FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar fv;
                   FStar_Syntax_Syntax.pos = uu___1;
-                  FStar_Syntax_Syntax.vars = uu___2;
-                  FStar_Syntax_Syntax.hash_code = uu___3;_},
-                uu___4);
-             FStar_Syntax_Syntax.pos = uu___5;
-             FStar_Syntax_Syntax.vars = uu___6;
-             FStar_Syntax_Syntax.hash_code = uu___7;_},
+                  FStar_Syntax_Syntax.hash_code = uu___2;_},
+                uu___3);
+             FStar_Syntax_Syntax.pos = uu___4;
+             FStar_Syntax_Syntax.hash_code = uu___5;_},
            args)
           ->
-          let uu___8 =
+          let uu___6 =
             FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.and_lid in
-          if uu___8
+          if uu___6
           then
-            let uu___9 =
+            let uu___7 =
               FStar_Compiler_Effect.op_Bar_Greater args
                 (FStar_Compiler_List.map simplify1) in
-            (match uu___9 with
-             | (FStar_Pervasives_Native.Some (true), uu___10)::(uu___11,
-                                                                (arg,
-                                                                 uu___12))::[]
+            (match uu___7 with
+             | (FStar_Pervasives_Native.Some (true), uu___8)::(uu___9,
+                                                               (arg, uu___10))::[]
                  -> maybe_auto_squash arg
-             | (uu___10, (arg, uu___11))::(FStar_Pervasives_Native.Some
-                                           (true), uu___12)::[]
+             | (uu___8, (arg, uu___9))::(FStar_Pervasives_Native.Some (true),
+                                         uu___10)::[]
                  -> maybe_auto_squash arg
-             | (FStar_Pervasives_Native.Some (false), uu___10)::uu___11::[]
-                 -> w FStar_Syntax_Util.t_false
-             | uu___10::(FStar_Pervasives_Native.Some (false), uu___11)::[]
-                 -> w FStar_Syntax_Util.t_false
-             | uu___10 -> squashed_head_un_auto_squash_args tm)
+             | (FStar_Pervasives_Native.Some (false), uu___8)::uu___9::[] ->
+                 w FStar_Syntax_Util.t_false
+             | uu___8::(FStar_Pervasives_Native.Some (false), uu___9)::[] ->
+                 w FStar_Syntax_Util.t_false
+             | uu___8 -> squashed_head_un_auto_squash_args tm)
           else
-            (let uu___10 =
+            (let uu___8 =
                FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.or_lid in
-             if uu___10
+             if uu___8
              then
-               let uu___11 =
+               let uu___9 =
                  FStar_Compiler_Effect.op_Bar_Greater args
                    (FStar_Compiler_List.map simplify1) in
-               match uu___11 with
-               | (FStar_Pervasives_Native.Some (true), uu___12)::uu___13::[]
+               match uu___9 with
+               | (FStar_Pervasives_Native.Some (true), uu___10)::uu___11::[]
                    -> w FStar_Syntax_Util.t_true
-               | uu___12::(FStar_Pervasives_Native.Some (true), uu___13)::[]
+               | uu___10::(FStar_Pervasives_Native.Some (true), uu___11)::[]
                    -> w FStar_Syntax_Util.t_true
-               | (FStar_Pervasives_Native.Some (false), uu___12)::(uu___13,
+               | (FStar_Pervasives_Native.Some (false), uu___10)::(uu___11,
                                                                    (arg,
-                                                                    uu___14))::[]
+                                                                    uu___12))::[]
                    -> maybe_auto_squash arg
-               | (uu___12, (arg, uu___13))::(FStar_Pervasives_Native.Some
-                                             (false), uu___14)::[]
+               | (uu___10, (arg, uu___11))::(FStar_Pervasives_Native.Some
+                                             (false), uu___12)::[]
                    -> maybe_auto_squash arg
-               | uu___12 -> squashed_head_un_auto_squash_args tm
+               | uu___10 -> squashed_head_un_auto_squash_args tm
              else
-               (let uu___12 =
+               (let uu___10 =
                   FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.imp_lid in
-                if uu___12
+                if uu___10
                 then
-                  let uu___13 =
+                  let uu___11 =
                     FStar_Compiler_Effect.op_Bar_Greater args
                       (FStar_Compiler_List.map simplify1) in
-                  match uu___13 with
-                  | uu___14::(FStar_Pervasives_Native.Some (true), uu___15)::[]
+                  match uu___11 with
+                  | uu___12::(FStar_Pervasives_Native.Some (true), uu___13)::[]
                       -> w FStar_Syntax_Util.t_true
-                  | (FStar_Pervasives_Native.Some (false), uu___14)::uu___15::[]
+                  | (FStar_Pervasives_Native.Some (false), uu___12)::uu___13::[]
                       -> w FStar_Syntax_Util.t_true
-                  | (FStar_Pervasives_Native.Some (true), uu___14)::(uu___15,
+                  | (FStar_Pervasives_Native.Some (true), uu___12)::(uu___13,
                                                                     (arg,
-                                                                    uu___16))::[]
+                                                                    uu___14))::[]
                       -> maybe_auto_squash arg
-                  | (uu___14, (p, uu___15))::(uu___16, (q, uu___17))::[] ->
-                      let uu___18 = FStar_Syntax_Util.term_eq p q in
-                      (if uu___18
+                  | (uu___12, (p, uu___13))::(uu___14, (q, uu___15))::[] ->
+                      let uu___16 = FStar_Syntax_Util.term_eq p q in
+                      (if uu___16
                        then w FStar_Syntax_Util.t_true
                        else squashed_head_un_auto_squash_args tm)
-                  | uu___14 -> squashed_head_un_auto_squash_args tm
+                  | uu___12 -> squashed_head_un_auto_squash_args tm
                 else
-                  (let uu___14 =
+                  (let uu___12 =
                      FStar_Syntax_Syntax.fv_eq_lid fv
                        FStar_Parser_Const.iff_lid in
-                   if uu___14
+                   if uu___12
                    then
-                     let uu___15 =
+                     let uu___13 =
                        FStar_Compiler_Effect.op_Bar_Greater args
                          (FStar_Compiler_List.map simplify1) in
-                     match uu___15 with
-                     | (FStar_Pervasives_Native.Some (true), uu___16)::
-                         (FStar_Pervasives_Native.Some (true), uu___17)::[]
+                     match uu___13 with
+                     | (FStar_Pervasives_Native.Some (true), uu___14)::
+                         (FStar_Pervasives_Native.Some (true), uu___15)::[]
                          -> w FStar_Syntax_Util.t_true
-                     | (FStar_Pervasives_Native.Some (false), uu___16)::
-                         (FStar_Pervasives_Native.Some (false), uu___17)::[]
+                     | (FStar_Pervasives_Native.Some (false), uu___14)::
+                         (FStar_Pervasives_Native.Some (false), uu___15)::[]
                          -> w FStar_Syntax_Util.t_true
-                     | (FStar_Pervasives_Native.Some (true), uu___16)::
-                         (FStar_Pervasives_Native.Some (false), uu___17)::[]
+                     | (FStar_Pervasives_Native.Some (true), uu___14)::
+                         (FStar_Pervasives_Native.Some (false), uu___15)::[]
                          -> w FStar_Syntax_Util.t_false
-                     | (FStar_Pervasives_Native.Some (false), uu___16)::
-                         (FStar_Pervasives_Native.Some (true), uu___17)::[]
+                     | (FStar_Pervasives_Native.Some (false), uu___14)::
+                         (FStar_Pervasives_Native.Some (true), uu___15)::[]
                          -> w FStar_Syntax_Util.t_false
-                     | (uu___16, (arg, uu___17))::(FStar_Pervasives_Native.Some
-                                                   (true), uu___18)::[]
+                     | (uu___14, (arg, uu___15))::(FStar_Pervasives_Native.Some
+                                                   (true), uu___16)::[]
                          -> maybe_auto_squash arg
-                     | (FStar_Pervasives_Native.Some (true), uu___16)::
-                         (uu___17, (arg, uu___18))::[] ->
+                     | (FStar_Pervasives_Native.Some (true), uu___14)::
+                         (uu___15, (arg, uu___16))::[] ->
                          maybe_auto_squash arg
-                     | (uu___16, (arg, uu___17))::(FStar_Pervasives_Native.Some
-                                                   (false), uu___18)::[]
+                     | (uu___14, (arg, uu___15))::(FStar_Pervasives_Native.Some
+                                                   (false), uu___16)::[]
                          ->
-                         let uu___19 = FStar_Syntax_Util.mk_neg arg in
-                         maybe_auto_squash uu___19
-                     | (FStar_Pervasives_Native.Some (false), uu___16)::
-                         (uu___17, (arg, uu___18))::[] ->
-                         let uu___19 = FStar_Syntax_Util.mk_neg arg in
-                         maybe_auto_squash uu___19
-                     | (uu___16, (p, uu___17))::(uu___18, (q, uu___19))::[]
+                         let uu___17 = FStar_Syntax_Util.mk_neg arg in
+                         maybe_auto_squash uu___17
+                     | (FStar_Pervasives_Native.Some (false), uu___14)::
+                         (uu___15, (arg, uu___16))::[] ->
+                         let uu___17 = FStar_Syntax_Util.mk_neg arg in
+                         maybe_auto_squash uu___17
+                     | (uu___14, (p, uu___15))::(uu___16, (q, uu___17))::[]
                          ->
-                         let uu___20 = FStar_Syntax_Util.term_eq p q in
-                         (if uu___20
+                         let uu___18 = FStar_Syntax_Util.term_eq p q in
+                         (if uu___18
                           then w FStar_Syntax_Util.t_true
                           else squashed_head_un_auto_squash_args tm)
-                     | uu___16 -> squashed_head_un_auto_squash_args tm
+                     | uu___14 -> squashed_head_un_auto_squash_args tm
                    else
-                     (let uu___16 =
+                     (let uu___14 =
                         FStar_Syntax_Syntax.fv_eq_lid fv
                           FStar_Parser_Const.not_lid in
-                      if uu___16
+                      if uu___14
                       then
-                        let uu___17 =
+                        let uu___15 =
                           FStar_Compiler_Effect.op_Bar_Greater args
                             (FStar_Compiler_List.map simplify1) in
-                        match uu___17 with
-                        | (FStar_Pervasives_Native.Some (true), uu___18)::[]
+                        match uu___15 with
+                        | (FStar_Pervasives_Native.Some (true), uu___16)::[]
                             -> w FStar_Syntax_Util.t_false
-                        | (FStar_Pervasives_Native.Some (false), uu___18)::[]
+                        | (FStar_Pervasives_Native.Some (false), uu___16)::[]
                             -> w FStar_Syntax_Util.t_true
-                        | uu___18 -> squashed_head_un_auto_squash_args tm
+                        | uu___16 -> squashed_head_un_auto_squash_args tm
                       else
-                        (let uu___18 =
+                        (let uu___16 =
                            FStar_Syntax_Syntax.fv_eq_lid fv
                              FStar_Parser_Const.forall_lid in
-                         if uu___18
+                         if uu___16
                          then
                            match args with
-                           | (t, uu___19)::[] ->
-                               let uu___20 =
-                                 let uu___21 = FStar_Syntax_Subst.compress t in
-                                 uu___21.FStar_Syntax_Syntax.n in
-                               (match uu___20 with
+                           | (t, uu___17)::[] ->
+                               let uu___18 =
+                                 let uu___19 = FStar_Syntax_Subst.compress t in
+                                 uu___19.FStar_Syntax_Syntax.n in
+                               (match uu___18 with
                                 | FStar_Syntax_Syntax.Tm_abs
-                                    (uu___21::[], body, uu___22) ->
-                                    let uu___23 = simp_t body in
-                                    (match uu___23 with
+                                    (uu___19::[], body, uu___20) ->
+                                    let uu___21 = simp_t body in
+                                    (match uu___21 with
                                      | FStar_Pervasives_Native.Some (true) ->
                                          w FStar_Syntax_Util.t_true
-                                     | uu___24 -> tm)
-                                | uu___21 -> tm)
+                                     | uu___22 -> tm)
+                                | uu___19 -> tm)
                            | (ty, FStar_Pervasives_Native.Some
                               { FStar_Syntax_Syntax.aqual_implicit = true;
                                 FStar_Syntax_Syntax.aqual_attributes =
-                                  uu___19;_})::(t, uu___20)::[]
+                                  uu___17;_})::(t, uu___18)::[]
                                ->
-                               let uu___21 =
-                                 let uu___22 = FStar_Syntax_Subst.compress t in
-                                 uu___22.FStar_Syntax_Syntax.n in
-                               (match uu___21 with
+                               let uu___19 =
+                                 let uu___20 = FStar_Syntax_Subst.compress t in
+                                 uu___20.FStar_Syntax_Syntax.n in
+                               (match uu___19 with
                                 | FStar_Syntax_Syntax.Tm_abs
-                                    (uu___22::[], body, uu___23) ->
-                                    let uu___24 = simp_t body in
-                                    (match uu___24 with
+                                    (uu___20::[], body, uu___21) ->
+                                    let uu___22 = simp_t body in
+                                    (match uu___22 with
                                      | FStar_Pervasives_Native.Some (true) ->
                                          w FStar_Syntax_Util.t_true
                                      | FStar_Pervasives_Native.Some (false)
                                          when clearly_inhabited ty ->
                                          w FStar_Syntax_Util.t_false
-                                     | uu___25 -> tm)
-                                | uu___22 -> tm)
-                           | uu___19 -> tm
+                                     | uu___23 -> tm)
+                                | uu___20 -> tm)
+                           | uu___17 -> tm
                          else
-                           (let uu___20 =
+                           (let uu___18 =
                               FStar_Syntax_Syntax.fv_eq_lid fv
                                 FStar_Parser_Const.exists_lid in
-                            if uu___20
+                            if uu___18
                             then
                               match args with
-                              | (t, uu___21)::[] ->
-                                  let uu___22 =
-                                    let uu___23 =
+                              | (t, uu___19)::[] ->
+                                  let uu___20 =
+                                    let uu___21 =
                                       FStar_Syntax_Subst.compress t in
-                                    uu___23.FStar_Syntax_Syntax.n in
-                                  (match uu___22 with
+                                    uu___21.FStar_Syntax_Syntax.n in
+                                  (match uu___20 with
                                    | FStar_Syntax_Syntax.Tm_abs
-                                       (uu___23::[], body, uu___24) ->
-                                       let uu___25 = simp_t body in
-                                       (match uu___25 with
+                                       (uu___21::[], body, uu___22) ->
+                                       let uu___23 = simp_t body in
+                                       (match uu___23 with
                                         | FStar_Pervasives_Native.Some
                                             (false) ->
                                             w FStar_Syntax_Util.t_false
-                                        | uu___26 -> tm)
-                                   | uu___23 -> tm)
+                                        | uu___24 -> tm)
+                                   | uu___21 -> tm)
                               | (ty, FStar_Pervasives_Native.Some
                                  { FStar_Syntax_Syntax.aqual_implicit = true;
                                    FStar_Syntax_Syntax.aqual_attributes =
-                                     uu___21;_})::(t, uu___22)::[]
+                                     uu___19;_})::(t, uu___20)::[]
                                   ->
-                                  let uu___23 =
-                                    let uu___24 =
+                                  let uu___21 =
+                                    let uu___22 =
                                       FStar_Syntax_Subst.compress t in
-                                    uu___24.FStar_Syntax_Syntax.n in
-                                  (match uu___23 with
+                                    uu___22.FStar_Syntax_Syntax.n in
+                                  (match uu___21 with
                                    | FStar_Syntax_Syntax.Tm_abs
-                                       (uu___24::[], body, uu___25) ->
-                                       let uu___26 = simp_t body in
-                                       (match uu___26 with
+                                       (uu___22::[], body, uu___23) ->
+                                       let uu___24 = simp_t body in
+                                       (match uu___24 with
                                         | FStar_Pervasives_Native.Some
                                             (false) ->
                                             w FStar_Syntax_Util.t_false
                                         | FStar_Pervasives_Native.Some (true)
                                             when clearly_inhabited ty ->
                                             w FStar_Syntax_Util.t_true
-                                        | uu___27 -> tm)
-                                   | uu___24 -> tm)
-                              | uu___21 -> tm
+                                        | uu___25 -> tm)
+                                   | uu___22 -> tm)
+                              | uu___19 -> tm
                             else
-                              (let uu___22 =
+                              (let uu___20 =
                                  FStar_Syntax_Syntax.fv_eq_lid fv
                                    FStar_Parser_Const.b2t_lid in
-                               if uu___22
+                               if uu___20
                                then
                                  match args with
                                  | ({
                                       FStar_Syntax_Syntax.n =
                                         FStar_Syntax_Syntax.Tm_constant
                                         (FStar_Const.Const_bool (true));
-                                      FStar_Syntax_Syntax.pos = uu___23;
-                                      FStar_Syntax_Syntax.vars = uu___24;
-                                      FStar_Syntax_Syntax.hash_code = uu___25;_},
-                                    uu___26)::[] ->
+                                      FStar_Syntax_Syntax.pos = uu___21;
+                                      FStar_Syntax_Syntax.hash_code = uu___22;_},
+                                    uu___23)::[] ->
                                      w FStar_Syntax_Util.t_true
                                  | ({
                                       FStar_Syntax_Syntax.n =
                                         FStar_Syntax_Syntax.Tm_constant
                                         (FStar_Const.Const_bool (false));
-                                      FStar_Syntax_Syntax.pos = uu___23;
-                                      FStar_Syntax_Syntax.vars = uu___24;
-                                      FStar_Syntax_Syntax.hash_code = uu___25;_},
-                                    uu___26)::[] ->
+                                      FStar_Syntax_Syntax.pos = uu___21;
+                                      FStar_Syntax_Syntax.hash_code = uu___22;_},
+                                    uu___23)::[] ->
                                      w FStar_Syntax_Util.t_false
-                                 | uu___23 -> tm
+                                 | uu___21 -> tm
                                else
-                                 (let uu___24 =
+                                 (let uu___22 =
                                     FStar_Syntax_Syntax.fv_eq_lid fv
                                       FStar_Parser_Const.haseq_lid in
-                                  if uu___24
+                                  if uu___22
                                   then
                                     let t_has_eq_for_sure t =
                                       let haseq_lids =
@@ -1302,11 +1295,11 @@ let (simplify :
                                         FStar_Parser_Const.bool_lid;
                                         FStar_Parser_Const.unit_lid;
                                         FStar_Parser_Const.string_lid] in
-                                      let uu___25 =
-                                        let uu___26 =
+                                      let uu___23 =
+                                        let uu___24 =
                                           FStar_Syntax_Subst.compress t in
-                                        uu___26.FStar_Syntax_Syntax.n in
-                                      match uu___25 with
+                                        uu___24.FStar_Syntax_Syntax.n in
+                                      match uu___23 with
                                       | FStar_Syntax_Syntax.Tm_fvar fv1 when
                                           FStar_Compiler_Effect.op_Bar_Greater
                                             haseq_lids
@@ -1315,228 +1308,244 @@ let (simplify :
                                                   FStar_Syntax_Syntax.fv_eq_lid
                                                     fv1 l))
                                           -> true
-                                      | uu___26 -> false in
+                                      | uu___24 -> false in
                                     (if
                                        (FStar_Compiler_List.length args) =
                                          Prims.int_one
                                      then
                                        let t =
-                                         let uu___25 =
+                                         let uu___23 =
                                            FStar_Compiler_Effect.op_Bar_Greater
                                              args FStar_Compiler_List.hd in
                                          FStar_Compiler_Effect.op_Bar_Greater
-                                           uu___25
+                                           uu___23
                                            FStar_Pervasives_Native.fst in
-                                       let uu___25 =
+                                       let uu___23 =
                                          FStar_Compiler_Effect.op_Bar_Greater
                                            t t_has_eq_for_sure in
-                                       (if uu___25
+                                       (if uu___23
                                         then w FStar_Syntax_Util.t_true
                                         else
-                                          (let uu___27 =
-                                             let uu___28 =
+                                          (let uu___25 =
+                                             let uu___26 =
                                                FStar_Syntax_Subst.compress t in
-                                             uu___28.FStar_Syntax_Syntax.n in
-                                           match uu___27 with
+                                             uu___26.FStar_Syntax_Syntax.n in
+                                           match uu___25 with
                                            | FStar_Syntax_Syntax.Tm_refine
-                                               uu___28 ->
+                                               uu___26 ->
                                                let t1 =
                                                  FStar_Syntax_Util.unrefine t in
-                                               let uu___29 =
+                                               let uu___27 =
                                                  FStar_Compiler_Effect.op_Bar_Greater
                                                    t1 t_has_eq_for_sure in
-                                               if uu___29
+                                               if uu___27
                                                then
                                                  w FStar_Syntax_Util.t_true
                                                else
                                                  (let haseq_tm =
-                                                    let uu___31 =
-                                                      let uu___32 =
+                                                    let uu___29 =
+                                                      let uu___30 =
                                                         FStar_Syntax_Subst.compress
                                                           tm in
-                                                      uu___32.FStar_Syntax_Syntax.n in
-                                                    match uu___31 with
+                                                      uu___30.FStar_Syntax_Syntax.n in
+                                                    match uu___29 with
                                                     | FStar_Syntax_Syntax.Tm_app
-                                                        (hd, uu___32) -> hd
-                                                    | uu___32 ->
+                                                        (hd, uu___30) -> hd
+                                                    | uu___30 ->
                                                         failwith
                                                           "Impossible! We have already checked that this is a Tm_app" in
-                                                  let uu___31 =
-                                                    let uu___32 =
+                                                  let uu___29 =
+                                                    let uu___30 =
                                                       FStar_Compiler_Effect.op_Bar_Greater
                                                         t1
                                                         FStar_Syntax_Syntax.as_arg in
-                                                    [uu___32] in
+                                                    [uu___30] in
                                                   FStar_Syntax_Util.mk_app
-                                                    haseq_tm uu___31)
-                                           | uu___28 -> tm))
+                                                    haseq_tm uu___29)
+                                           | uu___26 -> tm))
                                      else tm)
                                   else
-                                    (let uu___26 =
+                                    (let uu___24 =
                                        FStar_Syntax_Syntax.fv_eq_lid fv
                                          FStar_Parser_Const.eq2_lid in
-                                     if uu___26
+                                     if uu___24
                                      then
                                        match args with
-                                       | (_typ, uu___27)::(a1, uu___28)::
-                                           (a2, uu___29)::[] ->
-                                           let uu___30 =
+                                       | (_typ, uu___25)::(a1, uu___26)::
+                                           (a2, uu___27)::[] ->
+                                           let uu___28 =
                                              FStar_Syntax_Util.eq_tm a1 a2 in
-                                           (match uu___30 with
+                                           (match uu___28 with
                                             | FStar_Syntax_Util.Equal ->
                                                 w FStar_Syntax_Util.t_true
                                             | FStar_Syntax_Util.NotEqual ->
                                                 w FStar_Syntax_Util.t_false
-                                            | uu___31 -> tm)
-                                       | uu___27 -> tm
+                                            | uu___29 -> tm)
+                                       | uu___25 -> tm
                                      else
-                                       (let uu___28 =
+                                       (let uu___26 =
                                           FStar_Syntax_Util.is_auto_squash tm in
-                                        match uu___28 with
+                                        match uu___26 with
                                         | FStar_Pervasives_Native.Some
                                             (FStar_Syntax_Syntax.U_zero, t)
                                             when
                                             FStar_Syntax_Util.is_sub_singleton
                                               t
                                             -> t
-                                        | uu___29 -> tm))))))))))
+                                        | uu___27 -> tm))))))))))
       | FStar_Syntax_Syntax.Tm_app
           ({ FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar fv;
              FStar_Syntax_Syntax.pos = uu___1;
-             FStar_Syntax_Syntax.vars = uu___2;
-             FStar_Syntax_Syntax.hash_code = uu___3;_},
+             FStar_Syntax_Syntax.hash_code = uu___2;_},
            args)
           ->
-          let uu___4 =
+          let uu___3 =
             FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.and_lid in
-          if uu___4
+          if uu___3
           then
-            let uu___5 =
+            let uu___4 =
               FStar_Compiler_Effect.op_Bar_Greater args
                 (FStar_Compiler_List.map simplify1) in
-            (match uu___5 with
-             | (FStar_Pervasives_Native.Some (true), uu___6)::(uu___7,
-                                                               (arg, uu___8))::[]
+            (match uu___4 with
+             | (FStar_Pervasives_Native.Some (true), uu___5)::(uu___6,
+                                                               (arg, uu___7))::[]
                  -> maybe_auto_squash arg
-             | (uu___6, (arg, uu___7))::(FStar_Pervasives_Native.Some (true),
-                                         uu___8)::[]
+             | (uu___5, (arg, uu___6))::(FStar_Pervasives_Native.Some (true),
+                                         uu___7)::[]
                  -> maybe_auto_squash arg
-             | (FStar_Pervasives_Native.Some (false), uu___6)::uu___7::[] ->
+             | (FStar_Pervasives_Native.Some (false), uu___5)::uu___6::[] ->
                  w FStar_Syntax_Util.t_false
-             | uu___6::(FStar_Pervasives_Native.Some (false), uu___7)::[] ->
+             | uu___5::(FStar_Pervasives_Native.Some (false), uu___6)::[] ->
                  w FStar_Syntax_Util.t_false
-             | uu___6 -> squashed_head_un_auto_squash_args tm)
+             | uu___5 -> squashed_head_un_auto_squash_args tm)
           else
-            (let uu___6 =
+            (let uu___5 =
                FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.or_lid in
-             if uu___6
+             if uu___5
              then
-               let uu___7 =
+               let uu___6 =
                  FStar_Compiler_Effect.op_Bar_Greater args
                    (FStar_Compiler_List.map simplify1) in
-               match uu___7 with
-               | (FStar_Pervasives_Native.Some (true), uu___8)::uu___9::[] ->
+               match uu___6 with
+               | (FStar_Pervasives_Native.Some (true), uu___7)::uu___8::[] ->
                    w FStar_Syntax_Util.t_true
-               | uu___8::(FStar_Pervasives_Native.Some (true), uu___9)::[] ->
+               | uu___7::(FStar_Pervasives_Native.Some (true), uu___8)::[] ->
                    w FStar_Syntax_Util.t_true
-               | (FStar_Pervasives_Native.Some (false), uu___8)::(uu___9,
+               | (FStar_Pervasives_Native.Some (false), uu___7)::(uu___8,
                                                                   (arg,
-                                                                   uu___10))::[]
+                                                                   uu___9))::[]
                    -> maybe_auto_squash arg
-               | (uu___8, (arg, uu___9))::(FStar_Pervasives_Native.Some
-                                           (false), uu___10)::[]
+               | (uu___7, (arg, uu___8))::(FStar_Pervasives_Native.Some
+                                           (false), uu___9)::[]
                    -> maybe_auto_squash arg
-               | uu___8 -> squashed_head_un_auto_squash_args tm
+               | uu___7 -> squashed_head_un_auto_squash_args tm
              else
-               (let uu___8 =
+               (let uu___7 =
                   FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.imp_lid in
-                if uu___8
+                if uu___7
                 then
-                  let uu___9 =
+                  let uu___8 =
                     FStar_Compiler_Effect.op_Bar_Greater args
                       (FStar_Compiler_List.map simplify1) in
-                  match uu___9 with
-                  | uu___10::(FStar_Pervasives_Native.Some (true), uu___11)::[]
+                  match uu___8 with
+                  | uu___9::(FStar_Pervasives_Native.Some (true), uu___10)::[]
                       -> w FStar_Syntax_Util.t_true
-                  | (FStar_Pervasives_Native.Some (false), uu___10)::uu___11::[]
+                  | (FStar_Pervasives_Native.Some (false), uu___9)::uu___10::[]
                       -> w FStar_Syntax_Util.t_true
-                  | (FStar_Pervasives_Native.Some (true), uu___10)::(uu___11,
+                  | (FStar_Pervasives_Native.Some (true), uu___9)::(uu___10,
                                                                     (arg,
-                                                                    uu___12))::[]
+                                                                    uu___11))::[]
                       -> maybe_auto_squash arg
-                  | (uu___10, (p, uu___11))::(uu___12, (q, uu___13))::[] ->
-                      let uu___14 = FStar_Syntax_Util.term_eq p q in
-                      (if uu___14
+                  | (uu___9, (p, uu___10))::(uu___11, (q, uu___12))::[] ->
+                      let uu___13 = FStar_Syntax_Util.term_eq p q in
+                      (if uu___13
                        then w FStar_Syntax_Util.t_true
                        else squashed_head_un_auto_squash_args tm)
-                  | uu___10 -> squashed_head_un_auto_squash_args tm
+                  | uu___9 -> squashed_head_un_auto_squash_args tm
                 else
-                  (let uu___10 =
+                  (let uu___9 =
                      FStar_Syntax_Syntax.fv_eq_lid fv
                        FStar_Parser_Const.iff_lid in
-                   if uu___10
+                   if uu___9
                    then
-                     let uu___11 =
+                     let uu___10 =
                        FStar_Compiler_Effect.op_Bar_Greater args
                          (FStar_Compiler_List.map simplify1) in
-                     match uu___11 with
-                     | (FStar_Pervasives_Native.Some (true), uu___12)::
-                         (FStar_Pervasives_Native.Some (true), uu___13)::[]
+                     match uu___10 with
+                     | (FStar_Pervasives_Native.Some (true), uu___11)::
+                         (FStar_Pervasives_Native.Some (true), uu___12)::[]
                          -> w FStar_Syntax_Util.t_true
-                     | (FStar_Pervasives_Native.Some (false), uu___12)::
-                         (FStar_Pervasives_Native.Some (false), uu___13)::[]
+                     | (FStar_Pervasives_Native.Some (false), uu___11)::
+                         (FStar_Pervasives_Native.Some (false), uu___12)::[]
                          -> w FStar_Syntax_Util.t_true
-                     | (FStar_Pervasives_Native.Some (true), uu___12)::
-                         (FStar_Pervasives_Native.Some (false), uu___13)::[]
+                     | (FStar_Pervasives_Native.Some (true), uu___11)::
+                         (FStar_Pervasives_Native.Some (false), uu___12)::[]
                          -> w FStar_Syntax_Util.t_false
-                     | (FStar_Pervasives_Native.Some (false), uu___12)::
-                         (FStar_Pervasives_Native.Some (true), uu___13)::[]
+                     | (FStar_Pervasives_Native.Some (false), uu___11)::
+                         (FStar_Pervasives_Native.Some (true), uu___12)::[]
                          -> w FStar_Syntax_Util.t_false
-                     | (uu___12, (arg, uu___13))::(FStar_Pervasives_Native.Some
-                                                   (true), uu___14)::[]
+                     | (uu___11, (arg, uu___12))::(FStar_Pervasives_Native.Some
+                                                   (true), uu___13)::[]
                          -> maybe_auto_squash arg
-                     | (FStar_Pervasives_Native.Some (true), uu___12)::
-                         (uu___13, (arg, uu___14))::[] ->
+                     | (FStar_Pervasives_Native.Some (true), uu___11)::
+                         (uu___12, (arg, uu___13))::[] ->
                          maybe_auto_squash arg
-                     | (uu___12, (arg, uu___13))::(FStar_Pervasives_Native.Some
-                                                   (false), uu___14)::[]
+                     | (uu___11, (arg, uu___12))::(FStar_Pervasives_Native.Some
+                                                   (false), uu___13)::[]
                          ->
-                         let uu___15 = FStar_Syntax_Util.mk_neg arg in
-                         maybe_auto_squash uu___15
-                     | (FStar_Pervasives_Native.Some (false), uu___12)::
-                         (uu___13, (arg, uu___14))::[] ->
-                         let uu___15 = FStar_Syntax_Util.mk_neg arg in
-                         maybe_auto_squash uu___15
-                     | (uu___12, (p, uu___13))::(uu___14, (q, uu___15))::[]
+                         let uu___14 = FStar_Syntax_Util.mk_neg arg in
+                         maybe_auto_squash uu___14
+                     | (FStar_Pervasives_Native.Some (false), uu___11)::
+                         (uu___12, (arg, uu___13))::[] ->
+                         let uu___14 = FStar_Syntax_Util.mk_neg arg in
+                         maybe_auto_squash uu___14
+                     | (uu___11, (p, uu___12))::(uu___13, (q, uu___14))::[]
                          ->
-                         let uu___16 = FStar_Syntax_Util.term_eq p q in
-                         (if uu___16
+                         let uu___15 = FStar_Syntax_Util.term_eq p q in
+                         (if uu___15
                           then w FStar_Syntax_Util.t_true
                           else squashed_head_un_auto_squash_args tm)
-                     | uu___12 -> squashed_head_un_auto_squash_args tm
+                     | uu___11 -> squashed_head_un_auto_squash_args tm
                    else
-                     (let uu___12 =
+                     (let uu___11 =
                         FStar_Syntax_Syntax.fv_eq_lid fv
                           FStar_Parser_Const.not_lid in
-                      if uu___12
+                      if uu___11
                       then
-                        let uu___13 =
+                        let uu___12 =
                           FStar_Compiler_Effect.op_Bar_Greater args
                             (FStar_Compiler_List.map simplify1) in
-                        match uu___13 with
-                        | (FStar_Pervasives_Native.Some (true), uu___14)::[]
+                        match uu___12 with
+                        | (FStar_Pervasives_Native.Some (true), uu___13)::[]
                             -> w FStar_Syntax_Util.t_false
-                        | (FStar_Pervasives_Native.Some (false), uu___14)::[]
+                        | (FStar_Pervasives_Native.Some (false), uu___13)::[]
                             -> w FStar_Syntax_Util.t_true
-                        | uu___14 -> squashed_head_un_auto_squash_args tm
+                        | uu___13 -> squashed_head_un_auto_squash_args tm
                       else
-                        (let uu___14 =
+                        (let uu___13 =
                            FStar_Syntax_Syntax.fv_eq_lid fv
                              FStar_Parser_Const.forall_lid in
-                         if uu___14
+                         if uu___13
                          then
                            match args with
-                           | (t, uu___15)::[] ->
+                           | (t, uu___14)::[] ->
+                               let uu___15 =
+                                 let uu___16 = FStar_Syntax_Subst.compress t in
+                                 uu___16.FStar_Syntax_Syntax.n in
+                               (match uu___15 with
+                                | FStar_Syntax_Syntax.Tm_abs
+                                    (uu___16::[], body, uu___17) ->
+                                    let uu___18 = simp_t body in
+                                    (match uu___18 with
+                                     | FStar_Pervasives_Native.Some (true) ->
+                                         w FStar_Syntax_Util.t_true
+                                     | uu___19 -> tm)
+                                | uu___16 -> tm)
+                           | (ty, FStar_Pervasives_Native.Some
+                              { FStar_Syntax_Syntax.aqual_implicit = true;
+                                FStar_Syntax_Syntax.aqual_attributes =
+                                  uu___14;_})::(t, uu___15)::[]
+                               ->
                                let uu___16 =
                                  let uu___17 = FStar_Syntax_Subst.compress t in
                                  uu___17.FStar_Syntax_Syntax.n in
@@ -1547,37 +1556,39 @@ let (simplify :
                                     (match uu___19 with
                                      | FStar_Pervasives_Native.Some (true) ->
                                          w FStar_Syntax_Util.t_true
-                                     | uu___20 -> tm)
-                                | uu___17 -> tm)
-                           | (ty, FStar_Pervasives_Native.Some
-                              { FStar_Syntax_Syntax.aqual_implicit = true;
-                                FStar_Syntax_Syntax.aqual_attributes =
-                                  uu___15;_})::(t, uu___16)::[]
-                               ->
-                               let uu___17 =
-                                 let uu___18 = FStar_Syntax_Subst.compress t in
-                                 uu___18.FStar_Syntax_Syntax.n in
-                               (match uu___17 with
-                                | FStar_Syntax_Syntax.Tm_abs
-                                    (uu___18::[], body, uu___19) ->
-                                    let uu___20 = simp_t body in
-                                    (match uu___20 with
-                                     | FStar_Pervasives_Native.Some (true) ->
-                                         w FStar_Syntax_Util.t_true
                                      | FStar_Pervasives_Native.Some (false)
                                          when clearly_inhabited ty ->
                                          w FStar_Syntax_Util.t_false
-                                     | uu___21 -> tm)
-                                | uu___18 -> tm)
-                           | uu___15 -> tm
+                                     | uu___20 -> tm)
+                                | uu___17 -> tm)
+                           | uu___14 -> tm
                          else
-                           (let uu___16 =
+                           (let uu___15 =
                               FStar_Syntax_Syntax.fv_eq_lid fv
                                 FStar_Parser_Const.exists_lid in
-                            if uu___16
+                            if uu___15
                             then
                               match args with
-                              | (t, uu___17)::[] ->
+                              | (t, uu___16)::[] ->
+                                  let uu___17 =
+                                    let uu___18 =
+                                      FStar_Syntax_Subst.compress t in
+                                    uu___18.FStar_Syntax_Syntax.n in
+                                  (match uu___17 with
+                                   | FStar_Syntax_Syntax.Tm_abs
+                                       (uu___18::[], body, uu___19) ->
+                                       let uu___20 = simp_t body in
+                                       (match uu___20 with
+                                        | FStar_Pervasives_Native.Some
+                                            (false) ->
+                                            w FStar_Syntax_Util.t_false
+                                        | uu___21 -> tm)
+                                   | uu___18 -> tm)
+                              | (ty, FStar_Pervasives_Native.Some
+                                 { FStar_Syntax_Syntax.aqual_implicit = true;
+                                   FStar_Syntax_Syntax.aqual_attributes =
+                                     uu___16;_})::(t, uu___17)::[]
+                                  ->
                                   let uu___18 =
                                     let uu___19 =
                                       FStar_Syntax_Subst.compress t in
@@ -1590,62 +1601,41 @@ let (simplify :
                                         | FStar_Pervasives_Native.Some
                                             (false) ->
                                             w FStar_Syntax_Util.t_false
-                                        | uu___22 -> tm)
-                                   | uu___19 -> tm)
-                              | (ty, FStar_Pervasives_Native.Some
-                                 { FStar_Syntax_Syntax.aqual_implicit = true;
-                                   FStar_Syntax_Syntax.aqual_attributes =
-                                     uu___17;_})::(t, uu___18)::[]
-                                  ->
-                                  let uu___19 =
-                                    let uu___20 =
-                                      FStar_Syntax_Subst.compress t in
-                                    uu___20.FStar_Syntax_Syntax.n in
-                                  (match uu___19 with
-                                   | FStar_Syntax_Syntax.Tm_abs
-                                       (uu___20::[], body, uu___21) ->
-                                       let uu___22 = simp_t body in
-                                       (match uu___22 with
-                                        | FStar_Pervasives_Native.Some
-                                            (false) ->
-                                            w FStar_Syntax_Util.t_false
                                         | FStar_Pervasives_Native.Some (true)
                                             when clearly_inhabited ty ->
                                             w FStar_Syntax_Util.t_true
-                                        | uu___23 -> tm)
-                                   | uu___20 -> tm)
-                              | uu___17 -> tm
+                                        | uu___22 -> tm)
+                                   | uu___19 -> tm)
+                              | uu___16 -> tm
                             else
-                              (let uu___18 =
+                              (let uu___17 =
                                  FStar_Syntax_Syntax.fv_eq_lid fv
                                    FStar_Parser_Const.b2t_lid in
-                               if uu___18
+                               if uu___17
                                then
                                  match args with
                                  | ({
                                       FStar_Syntax_Syntax.n =
                                         FStar_Syntax_Syntax.Tm_constant
                                         (FStar_Const.Const_bool (true));
-                                      FStar_Syntax_Syntax.pos = uu___19;
-                                      FStar_Syntax_Syntax.vars = uu___20;
-                                      FStar_Syntax_Syntax.hash_code = uu___21;_},
-                                    uu___22)::[] ->
+                                      FStar_Syntax_Syntax.pos = uu___18;
+                                      FStar_Syntax_Syntax.hash_code = uu___19;_},
+                                    uu___20)::[] ->
                                      w FStar_Syntax_Util.t_true
                                  | ({
                                       FStar_Syntax_Syntax.n =
                                         FStar_Syntax_Syntax.Tm_constant
                                         (FStar_Const.Const_bool (false));
-                                      FStar_Syntax_Syntax.pos = uu___19;
-                                      FStar_Syntax_Syntax.vars = uu___20;
-                                      FStar_Syntax_Syntax.hash_code = uu___21;_},
-                                    uu___22)::[] ->
+                                      FStar_Syntax_Syntax.pos = uu___18;
+                                      FStar_Syntax_Syntax.hash_code = uu___19;_},
+                                    uu___20)::[] ->
                                      w FStar_Syntax_Util.t_false
-                                 | uu___19 -> tm
+                                 | uu___18 -> tm
                                else
-                                 (let uu___20 =
+                                 (let uu___19 =
                                     FStar_Syntax_Syntax.fv_eq_lid fv
                                       FStar_Parser_Const.haseq_lid in
-                                  if uu___20
+                                  if uu___19
                                   then
                                     let t_has_eq_for_sure t =
                                       let haseq_lids =
@@ -1653,11 +1643,11 @@ let (simplify :
                                         FStar_Parser_Const.bool_lid;
                                         FStar_Parser_Const.unit_lid;
                                         FStar_Parser_Const.string_lid] in
-                                      let uu___21 =
-                                        let uu___22 =
+                                      let uu___20 =
+                                        let uu___21 =
                                           FStar_Syntax_Subst.compress t in
-                                        uu___22.FStar_Syntax_Syntax.n in
-                                      match uu___21 with
+                                        uu___21.FStar_Syntax_Syntax.n in
+                                      match uu___20 with
                                       | FStar_Syntax_Syntax.Tm_fvar fv1 when
                                           FStar_Compiler_Effect.op_Bar_Greater
                                             haseq_lids
@@ -1666,91 +1656,91 @@ let (simplify :
                                                   FStar_Syntax_Syntax.fv_eq_lid
                                                     fv1 l))
                                           -> true
-                                      | uu___22 -> false in
+                                      | uu___21 -> false in
                                     (if
                                        (FStar_Compiler_List.length args) =
                                          Prims.int_one
                                      then
                                        let t =
-                                         let uu___21 =
+                                         let uu___20 =
                                            FStar_Compiler_Effect.op_Bar_Greater
                                              args FStar_Compiler_List.hd in
                                          FStar_Compiler_Effect.op_Bar_Greater
-                                           uu___21
+                                           uu___20
                                            FStar_Pervasives_Native.fst in
-                                       let uu___21 =
+                                       let uu___20 =
                                          FStar_Compiler_Effect.op_Bar_Greater
                                            t t_has_eq_for_sure in
-                                       (if uu___21
+                                       (if uu___20
                                         then w FStar_Syntax_Util.t_true
                                         else
-                                          (let uu___23 =
-                                             let uu___24 =
+                                          (let uu___22 =
+                                             let uu___23 =
                                                FStar_Syntax_Subst.compress t in
-                                             uu___24.FStar_Syntax_Syntax.n in
-                                           match uu___23 with
+                                             uu___23.FStar_Syntax_Syntax.n in
+                                           match uu___22 with
                                            | FStar_Syntax_Syntax.Tm_refine
-                                               uu___24 ->
+                                               uu___23 ->
                                                let t1 =
                                                  FStar_Syntax_Util.unrefine t in
-                                               let uu___25 =
+                                               let uu___24 =
                                                  FStar_Compiler_Effect.op_Bar_Greater
                                                    t1 t_has_eq_for_sure in
-                                               if uu___25
+                                               if uu___24
                                                then
                                                  w FStar_Syntax_Util.t_true
                                                else
                                                  (let haseq_tm =
-                                                    let uu___27 =
-                                                      let uu___28 =
+                                                    let uu___26 =
+                                                      let uu___27 =
                                                         FStar_Syntax_Subst.compress
                                                           tm in
-                                                      uu___28.FStar_Syntax_Syntax.n in
-                                                    match uu___27 with
+                                                      uu___27.FStar_Syntax_Syntax.n in
+                                                    match uu___26 with
                                                     | FStar_Syntax_Syntax.Tm_app
-                                                        (hd, uu___28) -> hd
-                                                    | uu___28 ->
+                                                        (hd, uu___27) -> hd
+                                                    | uu___27 ->
                                                         failwith
                                                           "Impossible! We have already checked that this is a Tm_app" in
-                                                  let uu___27 =
-                                                    let uu___28 =
+                                                  let uu___26 =
+                                                    let uu___27 =
                                                       FStar_Compiler_Effect.op_Bar_Greater
                                                         t1
                                                         FStar_Syntax_Syntax.as_arg in
-                                                    [uu___28] in
+                                                    [uu___27] in
                                                   FStar_Syntax_Util.mk_app
-                                                    haseq_tm uu___27)
-                                           | uu___24 -> tm))
+                                                    haseq_tm uu___26)
+                                           | uu___23 -> tm))
                                      else tm)
                                   else
-                                    (let uu___22 =
+                                    (let uu___21 =
                                        FStar_Syntax_Syntax.fv_eq_lid fv
                                          FStar_Parser_Const.eq2_lid in
-                                     if uu___22
+                                     if uu___21
                                      then
                                        match args with
-                                       | (_typ, uu___23)::(a1, uu___24)::
-                                           (a2, uu___25)::[] ->
-                                           let uu___26 =
+                                       | (_typ, uu___22)::(a1, uu___23)::
+                                           (a2, uu___24)::[] ->
+                                           let uu___25 =
                                              FStar_Syntax_Util.eq_tm a1 a2 in
-                                           (match uu___26 with
+                                           (match uu___25 with
                                             | FStar_Syntax_Util.Equal ->
                                                 w FStar_Syntax_Util.t_true
                                             | FStar_Syntax_Util.NotEqual ->
                                                 w FStar_Syntax_Util.t_false
-                                            | uu___27 -> tm)
-                                       | uu___23 -> tm
+                                            | uu___26 -> tm)
+                                       | uu___22 -> tm
                                      else
-                                       (let uu___24 =
+                                       (let uu___23 =
                                           FStar_Syntax_Util.is_auto_squash tm in
-                                        match uu___24 with
+                                        match uu___23 with
                                         | FStar_Pervasives_Native.Some
                                             (FStar_Syntax_Syntax.U_zero, t)
                                             when
                                             FStar_Syntax_Util.is_sub_singleton
                                               t
                                             -> t
-                                        | uu___25 -> tm))))))))))
+                                        | uu___24 -> tm))))))))))
       | FStar_Syntax_Syntax.Tm_refine (bv, t) ->
           let uu___1 = simp_t t in
           (match uu___1 with

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_Core.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_Core.ml
@@ -2505,23 +2505,22 @@ and (check' :
       | FStar_Syntax_Syntax.Tm_uinst
           ({ FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar f;
              FStar_Syntax_Syntax.pos = uu___;
-             FStar_Syntax_Syntax.vars = uu___1;
-             FStar_Syntax_Syntax.hash_code = uu___2;_},
+             FStar_Syntax_Syntax.hash_code = uu___1;_},
            us)
           ->
-          let uu___3 =
+          let uu___2 =
             FStar_TypeChecker_Env.try_lookup_and_inst_lid g.tcenv us
               (f.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-          (match uu___3 with
+          (match uu___2 with
            | FStar_Pervasives_Native.None ->
-               let uu___4 =
-                 let uu___5 =
+               let uu___3 =
+                 let uu___4 =
                    FStar_Ident.string_of_lid
                      (f.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
                  FStar_Compiler_Util.format1 "Top-level name not found: %s"
-                   uu___5 in
-               fail uu___4
-           | FStar_Pervasives_Native.Some (t, uu___4) -> return (E_TOTAL, t))
+                   uu___4 in
+               fail uu___3
+           | FStar_Pervasives_Native.Some (t, uu___3) -> return (E_TOTAL, t))
       | FStar_Syntax_Syntax.Tm_constant c ->
           (match c with
            | FStar_Const.Const_range_of -> fail "Unhandled constant"
@@ -3771,24 +3770,22 @@ and (check_scrutinee_pattern_type_compatible :
                          FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar
                            fv_head;
                          FStar_Syntax_Syntax.pos = uu___4;
-                         FStar_Syntax_Syntax.vars = uu___5;
-                         FStar_Syntax_Syntax.hash_code = uu___6;_},
+                         FStar_Syntax_Syntax.hash_code = uu___5;_},
                        us_head),
                       FStar_Syntax_Syntax.Tm_uinst
                       ({
                          FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar
                            fv_pat;
-                         FStar_Syntax_Syntax.pos = uu___7;
-                         FStar_Syntax_Syntax.vars = uu___8;
-                         FStar_Syntax_Syntax.hash_code = uu___9;_},
+                         FStar_Syntax_Syntax.pos = uu___6;
+                         FStar_Syntax_Syntax.hash_code = uu___7;_},
                        us_pat)) when
-                       let uu___10 = FStar_Syntax_Syntax.lid_of_fv fv_head in
-                       let uu___11 = FStar_Syntax_Syntax.lid_of_fv fv_pat in
-                       FStar_Ident.lid_equals uu___10 uu___11 ->
-                       let uu___10 =
+                       let uu___8 = FStar_Syntax_Syntax.lid_of_fv fv_head in
+                       let uu___9 = FStar_Syntax_Syntax.lid_of_fv fv_pat in
+                       FStar_Ident.lid_equals uu___8 uu___9 ->
+                       let uu___8 =
                          FStar_TypeChecker_Rel.teq_nosmt_force g.tcenv
                            head_sc head_pat in
-                       if uu___10
+                       if uu___8
                        then return fv_head
                        else err "Incompatible universe instantiations"
                    | (uu___4, uu___5) ->

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_DMFF.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_DMFF.ml
@@ -759,18 +759,25 @@ let (gen_wps_for_free :
                            FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.GTotal
                              b;
                            FStar_Syntax_Syntax.pos = uu___4;
-                           FStar_Syntax_Syntax.vars = uu___5;
-                           FStar_Syntax_Syntax.hash_code = uu___6;_})
+                           FStar_Syntax_Syntax.hash_code = uu___5;_})
                         ->
                         let a2 =
                           (binder.FStar_Syntax_Syntax.binder_bv).FStar_Syntax_Syntax.sort in
-                        let uu___7 = (is_monotonic a2) || (is_monotonic b) in
-                        if uu___7
+                        let uu___6 = (is_monotonic a2) || (is_monotonic b) in
+                        if uu___6
                         then
                           let a11 =
                             FStar_Syntax_Syntax.gen_bv "a1"
                               FStar_Pervasives_Native.None a2 in
                           let body =
+                            let uu___7 =
+                              let uu___8 =
+                                let uu___9 =
+                                  let uu___10 =
+                                    FStar_Syntax_Syntax.bv_to_name a11 in
+                                  FStar_Syntax_Syntax.as_arg uu___10 in
+                                [uu___9] in
+                              FStar_Syntax_Util.mk_app x uu___8 in
                             let uu___8 =
                               let uu___9 =
                                 let uu___10 =
@@ -778,16 +785,8 @@ let (gen_wps_for_free :
                                     FStar_Syntax_Syntax.bv_to_name a11 in
                                   FStar_Syntax_Syntax.as_arg uu___11 in
                                 [uu___10] in
-                              FStar_Syntax_Util.mk_app x uu___9 in
-                            let uu___9 =
-                              let uu___10 =
-                                let uu___11 =
-                                  let uu___12 =
-                                    FStar_Syntax_Syntax.bv_to_name a11 in
-                                  FStar_Syntax_Syntax.as_arg uu___12 in
-                                [uu___11] in
-                              FStar_Syntax_Util.mk_app y uu___10 in
-                            mk_rel1 b uu___8 uu___9 in
+                              FStar_Syntax_Util.mk_app y uu___9 in
+                            mk_rel1 b uu___7 uu___8 in
                           mk_forall a11 body
                         else
                           (let a11 =
@@ -797,51 +796,58 @@ let (gen_wps_for_free :
                              FStar_Syntax_Syntax.gen_bv "a2"
                                FStar_Pervasives_Native.None a2 in
                            let body =
+                             let uu___8 =
+                               let uu___9 =
+                                 FStar_Syntax_Syntax.bv_to_name a11 in
+                               let uu___10 =
+                                 FStar_Syntax_Syntax.bv_to_name a21 in
+                               mk_rel1 a2 uu___9 uu___10 in
                              let uu___9 =
                                let uu___10 =
-                                 FStar_Syntax_Syntax.bv_to_name a11 in
-                               let uu___11 =
-                                 FStar_Syntax_Syntax.bv_to_name a21 in
-                               mk_rel1 a2 uu___10 uu___11 in
-                             let uu___10 =
+                                 let uu___11 =
+                                   let uu___12 =
+                                     let uu___13 =
+                                       FStar_Syntax_Syntax.bv_to_name a11 in
+                                     FStar_Syntax_Syntax.as_arg uu___13 in
+                                   [uu___12] in
+                                 FStar_Syntax_Util.mk_app x uu___11 in
                                let uu___11 =
                                  let uu___12 =
                                    let uu___13 =
                                      let uu___14 =
-                                       FStar_Syntax_Syntax.bv_to_name a11 in
+                                       FStar_Syntax_Syntax.bv_to_name a21 in
                                      FStar_Syntax_Syntax.as_arg uu___14 in
                                    [uu___13] in
-                                 FStar_Syntax_Util.mk_app x uu___12 in
-                               let uu___12 =
-                                 let uu___13 =
-                                   let uu___14 =
-                                     let uu___15 =
-                                       FStar_Syntax_Syntax.bv_to_name a21 in
-                                     FStar_Syntax_Syntax.as_arg uu___15 in
-                                   [uu___14] in
-                                 FStar_Syntax_Util.mk_app y uu___13 in
-                               mk_rel1 b uu___11 uu___12 in
-                             FStar_Syntax_Util.mk_imp uu___9 uu___10 in
-                           let uu___9 = mk_forall a21 body in
-                           mk_forall a11 uu___9)
+                                 FStar_Syntax_Util.mk_app y uu___12 in
+                               mk_rel1 b uu___10 uu___11 in
+                             FStar_Syntax_Util.mk_imp uu___8 uu___9 in
+                           let uu___8 = mk_forall a21 body in
+                           mk_forall a11 uu___8)
                     | FStar_Syntax_Syntax.Tm_arrow
                         (binder::[],
                          {
                            FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Total
                              b;
                            FStar_Syntax_Syntax.pos = uu___4;
-                           FStar_Syntax_Syntax.vars = uu___5;
-                           FStar_Syntax_Syntax.hash_code = uu___6;_})
+                           FStar_Syntax_Syntax.hash_code = uu___5;_})
                         ->
                         let a2 =
                           (binder.FStar_Syntax_Syntax.binder_bv).FStar_Syntax_Syntax.sort in
-                        let uu___7 = (is_monotonic a2) || (is_monotonic b) in
-                        if uu___7
+                        let uu___6 = (is_monotonic a2) || (is_monotonic b) in
+                        if uu___6
                         then
                           let a11 =
                             FStar_Syntax_Syntax.gen_bv "a1"
                               FStar_Pervasives_Native.None a2 in
                           let body =
+                            let uu___7 =
+                              let uu___8 =
+                                let uu___9 =
+                                  let uu___10 =
+                                    FStar_Syntax_Syntax.bv_to_name a11 in
+                                  FStar_Syntax_Syntax.as_arg uu___10 in
+                                [uu___9] in
+                              FStar_Syntax_Util.mk_app x uu___8 in
                             let uu___8 =
                               let uu___9 =
                                 let uu___10 =
@@ -849,16 +855,8 @@ let (gen_wps_for_free :
                                     FStar_Syntax_Syntax.bv_to_name a11 in
                                   FStar_Syntax_Syntax.as_arg uu___11 in
                                 [uu___10] in
-                              FStar_Syntax_Util.mk_app x uu___9 in
-                            let uu___9 =
-                              let uu___10 =
-                                let uu___11 =
-                                  let uu___12 =
-                                    FStar_Syntax_Syntax.bv_to_name a11 in
-                                  FStar_Syntax_Syntax.as_arg uu___12 in
-                                [uu___11] in
-                              FStar_Syntax_Util.mk_app y uu___10 in
-                            mk_rel1 b uu___8 uu___9 in
+                              FStar_Syntax_Util.mk_app y uu___9 in
+                            mk_rel1 b uu___7 uu___8 in
                           mk_forall a11 body
                         else
                           (let a11 =
@@ -868,33 +866,33 @@ let (gen_wps_for_free :
                              FStar_Syntax_Syntax.gen_bv "a2"
                                FStar_Pervasives_Native.None a2 in
                            let body =
+                             let uu___8 =
+                               let uu___9 =
+                                 FStar_Syntax_Syntax.bv_to_name a11 in
+                               let uu___10 =
+                                 FStar_Syntax_Syntax.bv_to_name a21 in
+                               mk_rel1 a2 uu___9 uu___10 in
                              let uu___9 =
                                let uu___10 =
-                                 FStar_Syntax_Syntax.bv_to_name a11 in
-                               let uu___11 =
-                                 FStar_Syntax_Syntax.bv_to_name a21 in
-                               mk_rel1 a2 uu___10 uu___11 in
-                             let uu___10 =
+                                 let uu___11 =
+                                   let uu___12 =
+                                     let uu___13 =
+                                       FStar_Syntax_Syntax.bv_to_name a11 in
+                                     FStar_Syntax_Syntax.as_arg uu___13 in
+                                   [uu___12] in
+                                 FStar_Syntax_Util.mk_app x uu___11 in
                                let uu___11 =
                                  let uu___12 =
                                    let uu___13 =
                                      let uu___14 =
-                                       FStar_Syntax_Syntax.bv_to_name a11 in
+                                       FStar_Syntax_Syntax.bv_to_name a21 in
                                      FStar_Syntax_Syntax.as_arg uu___14 in
                                    [uu___13] in
-                                 FStar_Syntax_Util.mk_app x uu___12 in
-                               let uu___12 =
-                                 let uu___13 =
-                                   let uu___14 =
-                                     let uu___15 =
-                                       FStar_Syntax_Syntax.bv_to_name a21 in
-                                     FStar_Syntax_Syntax.as_arg uu___15 in
-                                   [uu___14] in
-                                 FStar_Syntax_Util.mk_app y uu___13 in
-                               mk_rel1 b uu___11 uu___12 in
-                             FStar_Syntax_Util.mk_imp uu___9 uu___10 in
-                           let uu___9 = mk_forall a21 body in
-                           mk_forall a11 uu___9)
+                                 FStar_Syntax_Util.mk_app y uu___12 in
+                               mk_rel1 b uu___10 uu___11 in
+                             FStar_Syntax_Util.mk_imp uu___8 uu___9 in
+                           let uu___8 = mk_forall a21 body in
+                           mk_forall a11 uu___8)
                     | FStar_Syntax_Syntax.Tm_arrow (binder::binders1, comp)
                         ->
                         let t2 =
@@ -910,8 +908,6 @@ let (gen_wps_for_free :
                             FStar_Syntax_Syntax.n = uu___4;
                             FStar_Syntax_Syntax.pos =
                               (t1.FStar_Syntax_Syntax.pos);
-                            FStar_Syntax_Syntax.vars =
-                              (t1.FStar_Syntax_Syntax.vars);
                             FStar_Syntax_Syntax.hash_code =
                               (t1.FStar_Syntax_Syntax.hash_code)
                           } in
@@ -982,40 +978,39 @@ let (gen_wps_for_free :
                              FStar_Syntax_Syntax.n =
                                FStar_Syntax_Syntax.GTotal b;
                              FStar_Syntax_Syntax.pos = uu___4;
-                             FStar_Syntax_Syntax.vars = uu___5;
-                             FStar_Syntax_Syntax.hash_code = uu___6;_})
+                             FStar_Syntax_Syntax.hash_code = uu___5;_})
                           ->
                           let bvs =
                             FStar_Compiler_List.mapi
                               (fun i ->
-                                 fun uu___7 ->
-                                   match uu___7 with
+                                 fun uu___6 ->
+                                   match uu___6 with
                                    | { FStar_Syntax_Syntax.binder_bv = bv;
                                        FStar_Syntax_Syntax.binder_qual = q;
                                        FStar_Syntax_Syntax.binder_positivity
-                                         = uu___8;
+                                         = uu___7;
                                        FStar_Syntax_Syntax.binder_attrs =
-                                         uu___9;_}
+                                         uu___8;_}
                                        ->
-                                       let uu___10 =
-                                         let uu___11 =
+                                       let uu___9 =
+                                         let uu___10 =
                                            FStar_Compiler_Util.string_of_int
                                              i in
-                                         Prims.op_Hat "a" uu___11 in
-                                       FStar_Syntax_Syntax.gen_bv uu___10
+                                         Prims.op_Hat "a" uu___10 in
+                                       FStar_Syntax_Syntax.gen_bv uu___9
                                          FStar_Pervasives_Native.None
                                          bv.FStar_Syntax_Syntax.sort)
                               binders1 in
                           let args =
                             FStar_Compiler_List.map
                               (fun ai ->
-                                 let uu___7 =
+                                 let uu___6 =
                                    FStar_Syntax_Syntax.bv_to_name ai in
-                                 FStar_Syntax_Syntax.as_arg uu___7) bvs in
+                                 FStar_Syntax_Syntax.as_arg uu___6) bvs in
                           let body =
-                            let uu___7 = FStar_Syntax_Util.mk_app x args in
-                            let uu___8 = FStar_Syntax_Util.mk_app y args in
-                            mk_stronger b uu___7 uu___8 in
+                            let uu___6 = FStar_Syntax_Util.mk_app x args in
+                            let uu___7 = FStar_Syntax_Util.mk_app y args in
+                            mk_stronger b uu___6 uu___7 in
                           FStar_Compiler_List.fold_right
                             (fun bv -> fun body1 -> mk_forall bv body1) bvs
                             body
@@ -1025,40 +1020,39 @@ let (gen_wps_for_free :
                              FStar_Syntax_Syntax.n =
                                FStar_Syntax_Syntax.Total b;
                              FStar_Syntax_Syntax.pos = uu___4;
-                             FStar_Syntax_Syntax.vars = uu___5;
-                             FStar_Syntax_Syntax.hash_code = uu___6;_})
+                             FStar_Syntax_Syntax.hash_code = uu___5;_})
                           ->
                           let bvs =
                             FStar_Compiler_List.mapi
                               (fun i ->
-                                 fun uu___7 ->
-                                   match uu___7 with
+                                 fun uu___6 ->
+                                   match uu___6 with
                                    | { FStar_Syntax_Syntax.binder_bv = bv;
                                        FStar_Syntax_Syntax.binder_qual = q;
                                        FStar_Syntax_Syntax.binder_positivity
-                                         = uu___8;
+                                         = uu___7;
                                        FStar_Syntax_Syntax.binder_attrs =
-                                         uu___9;_}
+                                         uu___8;_}
                                        ->
-                                       let uu___10 =
-                                         let uu___11 =
+                                       let uu___9 =
+                                         let uu___10 =
                                            FStar_Compiler_Util.string_of_int
                                              i in
-                                         Prims.op_Hat "a" uu___11 in
-                                       FStar_Syntax_Syntax.gen_bv uu___10
+                                         Prims.op_Hat "a" uu___10 in
+                                       FStar_Syntax_Syntax.gen_bv uu___9
                                          FStar_Pervasives_Native.None
                                          bv.FStar_Syntax_Syntax.sort)
                               binders1 in
                           let args =
                             FStar_Compiler_List.map
                               (fun ai ->
-                                 let uu___7 =
+                                 let uu___6 =
                                    FStar_Syntax_Syntax.bv_to_name ai in
-                                 FStar_Syntax_Syntax.as_arg uu___7) bvs in
+                                 FStar_Syntax_Syntax.as_arg uu___6) bvs in
                           let body =
-                            let uu___7 = FStar_Syntax_Util.mk_app x args in
-                            let uu___8 = FStar_Syntax_Util.mk_app y args in
-                            mk_stronger b uu___7 uu___8 in
+                            let uu___6 = FStar_Syntax_Util.mk_app x args in
+                            let uu___7 = FStar_Syntax_Util.mk_app y args in
+                            mk_stronger b uu___6 uu___7 in
                           FStar_Compiler_List.fold_right
                             (fun bv -> fun body1 -> mk_forall bv body1) bvs
                             body
@@ -1450,17 +1444,16 @@ and (star_type' :
                (uu___1,
                 { FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.GTotal hn;
                   FStar_Syntax_Syntax.pos = uu___2;
-                  FStar_Syntax_Syntax.vars = uu___3;
-                  FStar_Syntax_Syntax.hash_code = uu___4;_})
+                  FStar_Syntax_Syntax.hash_code = uu___3;_})
                ->
-               let uu___5 =
-                 let uu___6 =
-                   let uu___7 =
-                     let uu___8 = star_type' env1 hn in
-                     FStar_Syntax_Syntax.mk_GTotal uu___8 in
-                   (binders1, uu___7) in
-                 FStar_Syntax_Syntax.Tm_arrow uu___6 in
-               mk uu___5
+               let uu___4 =
+                 let uu___5 =
+                   let uu___6 =
+                     let uu___7 = star_type' env1 hn in
+                     FStar_Syntax_Syntax.mk_GTotal uu___7 in
+                   (binders1, uu___6) in
+                 FStar_Syntax_Syntax.Tm_arrow uu___5 in
+               mk uu___4
            | uu___1 ->
                let uu___2 = is_monadic_arrow t1.FStar_Syntax_Syntax.n in
                (match uu___2 with
@@ -2405,14 +2398,13 @@ and (infer :
              FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
                (FStar_Const.Const_range_of);
              FStar_Syntax_Syntax.pos = uu___1;
-             FStar_Syntax_Syntax.vars = uu___2;
-             FStar_Syntax_Syntax.hash_code = uu___3;_},
+             FStar_Syntax_Syntax.hash_code = uu___2;_},
            a::hd::rest)
           ->
           let rest1 = hd :: rest in
-          let uu___4 = FStar_Syntax_Util.head_and_args e in
-          (match uu___4 with
-           | (unary_op, uu___5) ->
+          let uu___3 = FStar_Syntax_Util.head_and_args e in
+          (match uu___3 with
+           | (unary_op, uu___4) ->
                let head = mk (FStar_Syntax_Syntax.Tm_app (unary_op, [a])) in
                let t = mk (FStar_Syntax_Syntax.Tm_app (head, rest1)) in
                infer env1 t)
@@ -2421,14 +2413,13 @@ and (infer :
              FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
                (FStar_Const.Const_set_range_of);
              FStar_Syntax_Syntax.pos = uu___1;
-             FStar_Syntax_Syntax.vars = uu___2;
-             FStar_Syntax_Syntax.hash_code = uu___3;_},
+             FStar_Syntax_Syntax.hash_code = uu___2;_},
            a1::a2::hd::rest)
           ->
           let rest1 = hd :: rest in
-          let uu___4 = FStar_Syntax_Util.head_and_args e in
-          (match uu___4 with
-           | (unary_op, uu___5) ->
+          let uu___3 = FStar_Syntax_Util.head_and_args e in
+          (match uu___3 with
+           | (unary_op, uu___4) ->
                let head =
                  mk (FStar_Syntax_Syntax.Tm_app (unary_op, [a1; a2])) in
                let t = mk (FStar_Syntax_Syntax.Tm_app (head, rest1)) in
@@ -2438,11 +2429,48 @@ and (infer :
              FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
                (FStar_Const.Const_range_of);
              FStar_Syntax_Syntax.pos = uu___1;
-             FStar_Syntax_Syntax.vars = uu___2;
-             FStar_Syntax_Syntax.hash_code = uu___3;_},
+             FStar_Syntax_Syntax.hash_code = uu___2;_},
            (a, FStar_Pervasives_Native.None)::[])
           ->
-          let uu___4 = infer env1 a in
+          let uu___3 = infer env1 a in
+          (match uu___3 with
+           | (t, s, u) ->
+               let uu___4 = FStar_Syntax_Util.head_and_args e in
+               (match uu___4 with
+                | (head, uu___5) ->
+                    let uu___6 =
+                      let uu___7 =
+                        FStar_Syntax_Syntax.tabbrev
+                          FStar_Parser_Const.range_lid in
+                      N uu___7 in
+                    let uu___7 =
+                      let uu___8 =
+                        let uu___9 =
+                          let uu___10 =
+                            let uu___11 = FStar_Syntax_Syntax.as_arg s in
+                            [uu___11] in
+                          (head, uu___10) in
+                        FStar_Syntax_Syntax.Tm_app uu___9 in
+                      mk uu___8 in
+                    let uu___8 =
+                      let uu___9 =
+                        let uu___10 =
+                          let uu___11 =
+                            let uu___12 = FStar_Syntax_Syntax.as_arg u in
+                            [uu___12] in
+                          (head, uu___11) in
+                        FStar_Syntax_Syntax.Tm_app uu___10 in
+                      mk uu___9 in
+                    (uu___6, uu___7, uu___8)))
+      | FStar_Syntax_Syntax.Tm_app
+          ({
+             FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
+               (FStar_Const.Const_set_range_of);
+             FStar_Syntax_Syntax.pos = uu___1;
+             FStar_Syntax_Syntax.hash_code = uu___2;_},
+           (a1, uu___3)::a2::[])
+          ->
+          let uu___4 = infer env1 a1 in
           (match uu___4 with
            | (t, s, u) ->
                let uu___5 = FStar_Syntax_Util.head_and_args e in
@@ -2450,94 +2478,53 @@ and (infer :
                 | (head, uu___6) ->
                     let uu___7 =
                       let uu___8 =
-                        FStar_Syntax_Syntax.tabbrev
-                          FStar_Parser_Const.range_lid in
-                      N uu___8 in
+                        let uu___9 =
+                          let uu___10 =
+                            let uu___11 = FStar_Syntax_Syntax.as_arg s in
+                            [uu___11; a2] in
+                          (head, uu___10) in
+                        FStar_Syntax_Syntax.Tm_app uu___9 in
+                      mk uu___8 in
                     let uu___8 =
                       let uu___9 =
                         let uu___10 =
                           let uu___11 =
-                            let uu___12 = FStar_Syntax_Syntax.as_arg s in
-                            [uu___12] in
-                          (head, uu___11) in
-                        FStar_Syntax_Syntax.Tm_app uu___10 in
-                      mk uu___9 in
-                    let uu___9 =
-                      let uu___10 =
-                        let uu___11 =
-                          let uu___12 =
-                            let uu___13 = FStar_Syntax_Syntax.as_arg u in
-                            [uu___13] in
-                          (head, uu___12) in
-                        FStar_Syntax_Syntax.Tm_app uu___11 in
-                      mk uu___10 in
-                    (uu___7, uu___8, uu___9)))
-      | FStar_Syntax_Syntax.Tm_app
-          ({
-             FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
-               (FStar_Const.Const_set_range_of);
-             FStar_Syntax_Syntax.pos = uu___1;
-             FStar_Syntax_Syntax.vars = uu___2;
-             FStar_Syntax_Syntax.hash_code = uu___3;_},
-           (a1, uu___4)::a2::[])
-          ->
-          let uu___5 = infer env1 a1 in
-          (match uu___5 with
-           | (t, s, u) ->
-               let uu___6 = FStar_Syntax_Util.head_and_args e in
-               (match uu___6 with
-                | (head, uu___7) ->
-                    let uu___8 =
-                      let uu___9 =
-                        let uu___10 =
-                          let uu___11 =
-                            let uu___12 = FStar_Syntax_Syntax.as_arg s in
+                            let uu___12 = FStar_Syntax_Syntax.as_arg u in
                             [uu___12; a2] in
                           (head, uu___11) in
                         FStar_Syntax_Syntax.Tm_app uu___10 in
                       mk uu___9 in
-                    let uu___9 =
-                      let uu___10 =
-                        let uu___11 =
-                          let uu___12 =
-                            let uu___13 = FStar_Syntax_Syntax.as_arg u in
-                            [uu___13; a2] in
-                          (head, uu___12) in
-                        FStar_Syntax_Syntax.Tm_app uu___11 in
-                      mk uu___10 in
-                    (t, uu___8, uu___9)))
+                    (t, uu___7, uu___8)))
       | FStar_Syntax_Syntax.Tm_app
           ({
              FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
                (FStar_Const.Const_range_of);
              FStar_Syntax_Syntax.pos = uu___1;
-             FStar_Syntax_Syntax.vars = uu___2;
-             FStar_Syntax_Syntax.hash_code = uu___3;_},
-           uu___4)
+             FStar_Syntax_Syntax.hash_code = uu___2;_},
+           uu___3)
           ->
-          let uu___5 =
-            let uu___6 =
-              let uu___7 = FStar_Syntax_Print.term_to_string e in
+          let uu___4 =
+            let uu___5 =
+              let uu___6 = FStar_Syntax_Print.term_to_string e in
               FStar_Compiler_Util.format1 "DMFF: Ill-applied constant %s"
-                uu___7 in
-            (FStar_Errors_Codes.Fatal_IllAppliedConstant, uu___6) in
-          FStar_Errors.raise_error uu___5 e.FStar_Syntax_Syntax.pos
+                uu___6 in
+            (FStar_Errors_Codes.Fatal_IllAppliedConstant, uu___5) in
+          FStar_Errors.raise_error uu___4 e.FStar_Syntax_Syntax.pos
       | FStar_Syntax_Syntax.Tm_app
           ({
              FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
                (FStar_Const.Const_set_range_of);
              FStar_Syntax_Syntax.pos = uu___1;
-             FStar_Syntax_Syntax.vars = uu___2;
-             FStar_Syntax_Syntax.hash_code = uu___3;_},
-           uu___4)
+             FStar_Syntax_Syntax.hash_code = uu___2;_},
+           uu___3)
           ->
-          let uu___5 =
-            let uu___6 =
-              let uu___7 = FStar_Syntax_Print.term_to_string e in
+          let uu___4 =
+            let uu___5 =
+              let uu___6 = FStar_Syntax_Print.term_to_string e in
               FStar_Compiler_Util.format1 "DMFF: Ill-applied constant %s"
-                uu___7 in
-            (FStar_Errors_Codes.Fatal_IllAppliedConstant, uu___6) in
-          FStar_Errors.raise_error uu___5 e.FStar_Syntax_Syntax.pos
+                uu___6 in
+            (FStar_Errors_Codes.Fatal_IllAppliedConstant, uu___5) in
+          FStar_Errors.raise_error uu___4 e.FStar_Syntax_Syntax.pos
       | FStar_Syntax_Syntax.Tm_app (head, args) ->
           let uu___1 = check_n env1 head in
           (match uu___1 with
@@ -2558,11 +2545,10 @@ and (infer :
                      (binders,
                       { FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Total t1;
                         FStar_Syntax_Syntax.pos = uu___3;
-                        FStar_Syntax_Syntax.vars = uu___4;
-                        FStar_Syntax_Syntax.hash_code = uu___5;_})
+                        FStar_Syntax_Syntax.hash_code = uu___4;_})
                      when is_arrow t1 ->
-                     let uu___6 = flatten t1 in
-                     (match uu___6 with
+                     let uu___5 = flatten t1 in
+                     (match uu___5 with
                       | (binders', comp) ->
                           ((FStar_Compiler_List.op_At binders binders'),
                             comp))

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_Env.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_Env.ml
@@ -3029,7 +3029,6 @@ let (try_lookup_lid_aux :
                   {
                     FStar_Syntax_Syntax.n = (t.FStar_Syntax_Syntax.n);
                     FStar_Syntax_Syntax.pos = uu___4;
-                    FStar_Syntax_Syntax.vars = (t.FStar_Syntax_Syntax.vars);
                     FStar_Syntax_Syntax.hash_code =
                       (t.FStar_Syntax_Syntax.hash_code)
                   } in
@@ -4613,7 +4612,6 @@ let (comp_set_flags :
            {
              FStar_Syntax_Syntax.n = uu___1;
              FStar_Syntax_Syntax.pos = (c.FStar_Syntax_Syntax.pos);
-             FStar_Syntax_Syntax.vars = (c.FStar_Syntax_Syntax.vars);
              FStar_Syntax_Syntax.hash_code =
                (c.FStar_Syntax_Syntax.hash_code)
            } in

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_NBE.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_NBE.ml
@@ -722,7 +722,6 @@ let rec (translate :
                  FStar_Syntax_Syntax.n =
                    (FStar_Syntax_Syntax.Tm_uvar (u, (subst1, set_use_range)));
                  FStar_Syntax_Syntax.pos = (e.FStar_Syntax_Syntax.pos);
-                 FStar_Syntax_Syntax.vars = (e.FStar_Syntax_Syntax.vars);
                  FStar_Syntax_Syntax.hash_code =
                    (e.FStar_Syntax_Syntax.hash_code)
                } in
@@ -764,46 +763,43 @@ let rec (translate :
                 FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
                   (FStar_Const.Const_reify uu___2);
                 FStar_Syntax_Syntax.pos = uu___3;
-                FStar_Syntax_Syntax.vars = uu___4;
-                FStar_Syntax_Syntax.hash_code = uu___5;_},
+                FStar_Syntax_Syntax.hash_code = uu___4;_},
               arg::more::args)
              ->
-             let uu___6 = FStar_Syntax_Util.head_and_args e in
-             (match uu___6 with
-              | (head, uu___7) ->
+             let uu___5 = FStar_Syntax_Util.head_and_args e in
+             (match uu___5 with
+              | (head, uu___6) ->
                   let head1 =
                     FStar_Syntax_Syntax.mk_Tm_app head [arg]
                       e.FStar_Syntax_Syntax.pos in
-                  let uu___8 =
+                  let uu___7 =
                     FStar_Syntax_Syntax.mk_Tm_app head1 (more :: args)
                       e.FStar_Syntax_Syntax.pos in
-                  translate cfg bs uu___8)
+                  translate cfg bs uu___7)
          | FStar_Syntax_Syntax.Tm_app
              ({
                 FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
                   (FStar_Const.Const_reflect uu___2);
                 FStar_Syntax_Syntax.pos = uu___3;
-                FStar_Syntax_Syntax.vars = uu___4;
-                FStar_Syntax_Syntax.hash_code = uu___5;_},
+                FStar_Syntax_Syntax.hash_code = uu___4;_},
               arg::more::args)
              ->
-             let uu___6 = FStar_Syntax_Util.head_and_args e in
-             (match uu___6 with
-              | (head, uu___7) ->
+             let uu___5 = FStar_Syntax_Util.head_and_args e in
+             (match uu___5 with
+              | (head, uu___6) ->
                   let head1 =
                     FStar_Syntax_Syntax.mk_Tm_app head [arg]
                       e.FStar_Syntax_Syntax.pos in
-                  let uu___8 =
+                  let uu___7 =
                     FStar_Syntax_Syntax.mk_Tm_app head1 (more :: args)
                       e.FStar_Syntax_Syntax.pos in
-                  translate cfg bs uu___8)
+                  translate cfg bs uu___7)
          | FStar_Syntax_Syntax.Tm_app
              ({
                 FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
                   (FStar_Const.Const_reflect uu___2);
                 FStar_Syntax_Syntax.pos = uu___3;
-                FStar_Syntax_Syntax.vars = uu___4;
-                FStar_Syntax_Syntax.hash_code = uu___5;_},
+                FStar_Syntax_Syntax.hash_code = uu___4;_},
               arg::[])
              when (cfg.core_cfg).FStar_TypeChecker_Cfg.reifying ->
              let cfg1 = reifying_false cfg in
@@ -813,22 +809,20 @@ let rec (translate :
                 FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
                   (FStar_Const.Const_reflect uu___2);
                 FStar_Syntax_Syntax.pos = uu___3;
-                FStar_Syntax_Syntax.vars = uu___4;
-                FStar_Syntax_Syntax.hash_code = uu___5;_},
+                FStar_Syntax_Syntax.hash_code = uu___4;_},
               arg::[])
              ->
-             let uu___6 =
-               let uu___7 =
+             let uu___5 =
+               let uu___6 =
                  translate cfg bs (FStar_Pervasives_Native.fst arg) in
-               FStar_TypeChecker_NBETerm.Reflect uu___7 in
-             FStar_Compiler_Effect.op_Less_Bar mk_t1 uu___6
+               FStar_TypeChecker_NBETerm.Reflect uu___6 in
+             FStar_Compiler_Effect.op_Less_Bar mk_t1 uu___5
          | FStar_Syntax_Syntax.Tm_app
              ({
                 FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
                   (FStar_Const.Const_reify uu___2);
                 FStar_Syntax_Syntax.pos = uu___3;
-                FStar_Syntax_Syntax.vars = uu___4;
-                FStar_Syntax_Syntax.hash_code = uu___5;_},
+                FStar_Syntax_Syntax.hash_code = uu___4;_},
               arg::[])
              when
              ((cfg.core_cfg).FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.reify_
@@ -840,21 +834,19 @@ let rec (translate :
                 FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
                   (FStar_Const.Const_reflect uu___2);
                 FStar_Syntax_Syntax.pos = uu___3;
-                FStar_Syntax_Syntax.vars = uu___4;
-                FStar_Syntax_Syntax.hash_code = uu___5;_},
+                FStar_Syntax_Syntax.hash_code = uu___4;_},
               arg::[])
              ->
-             let uu___6 =
-               let uu___7 =
+             let uu___5 =
+               let uu___6 =
                  translate cfg bs (FStar_Pervasives_Native.fst arg) in
-               FStar_TypeChecker_NBETerm.Reflect uu___7 in
-             FStar_Compiler_Effect.op_Less_Bar mk_t1 uu___6
+               FStar_TypeChecker_NBETerm.Reflect uu___6 in
+             FStar_Compiler_Effect.op_Less_Bar mk_t1 uu___5
          | FStar_Syntax_Syntax.Tm_app
              ({ FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar fv;
                 FStar_Syntax_Syntax.pos = uu___2;
-                FStar_Syntax_Syntax.vars = uu___3;
-                FStar_Syntax_Syntax.hash_code = uu___4;_},
-              uu___5::[])
+                FStar_Syntax_Syntax.hash_code = uu___3;_},
+              uu___4::[])
              when
              (FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.assert_lid)
                ||
@@ -862,7 +854,7 @@ let rec (translate :
                   FStar_Parser_Const.assert_norm_lid)
              ->
              (debug1
-                (fun uu___7 ->
+                (fun uu___6 ->
                    FStar_Compiler_Util.print_string "Eliminated assertion\n");
               mk_t1
                 (FStar_TypeChecker_NBETerm.Constant
@@ -2390,11 +2382,10 @@ and (translate_monadic :
                       FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
                         (FStar_Const.Const_reflect uu___1);
                       FStar_Syntax_Syntax.pos = uu___2;
-                      FStar_Syntax_Syntax.vars = uu___3;
-                      FStar_Syntax_Syntax.hash_code = uu___4;_},
-                    (e2, uu___5)::[])
+                      FStar_Syntax_Syntax.hash_code = uu___3;_},
+                    (e2, uu___4)::[])
                    ->
-                   let uu___6 = reifying_false cfg in translate uu___6 bs e2
+                   let uu___5 = reifying_false cfg in translate uu___5 bs e2
                | FStar_Syntax_Syntax.Tm_app (head, args) ->
                    (debug cfg
                       (fun uu___2 ->
@@ -2639,7 +2630,6 @@ and (readback :
         {
           FStar_Syntax_Syntax.n = (t.FStar_Syntax_Syntax.n);
           FStar_Syntax_Syntax.pos = (x.FStar_TypeChecker_NBETerm.nbe_r);
-          FStar_Syntax_Syntax.vars = (t.FStar_Syntax_Syntax.vars);
           FStar_Syntax_Syntax.hash_code = (t.FStar_Syntax_Syntax.hash_code)
         } in
       let mk t = FStar_Syntax_Syntax.mk t x.FStar_TypeChecker_NBETerm.nbe_r in

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_Normalize.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_Normalize.ml
@@ -527,8 +527,6 @@ let rec (inline_closure_env :
                                 (uv, (s', (FStar_Pervasives_Native.snd s))));
                            FStar_Syntax_Syntax.pos =
                              (t.FStar_Syntax_Syntax.pos);
-                           FStar_Syntax_Syntax.vars =
-                             (t.FStar_Syntax_Syntax.vars);
                            FStar_Syntax_Syntax.hash_code =
                              (t.FStar_Syntax_Syntax.hash_code)
                          } in
@@ -850,8 +848,6 @@ and (rebuild_closure :
                         FStar_Syntax_Syntax.n =
                           (uu___4.FStar_Syntax_Syntax.n);
                         FStar_Syntax_Syntax.pos = r;
-                        FStar_Syntax_Syntax.vars =
-                          (uu___4.FStar_Syntax_Syntax.vars);
                         FStar_Syntax_Syntax.hash_code =
                           (uu___4.FStar_Syntax_Syntax.hash_code)
                       } in
@@ -1334,15 +1330,14 @@ let (mk_psc_subst :
                                            FStar_Syntax_Syntax.n =
                                              FStar_Syntax_Syntax.Tm_name b';
                                            FStar_Syntax_Syntax.pos = uu___8;
-                                           FStar_Syntax_Syntax.vars = uu___9;
                                            FStar_Syntax_Syntax.hash_code =
-                                             uu___10;_})
+                                             uu___9;_})
                                         ->
-                                        let uu___11 =
+                                        let uu___10 =
                                           FStar_Ident.ident_equals
                                             b1.FStar_Syntax_Syntax.ppname
                                             b'.FStar_Syntax_Syntax.ppname in
-                                        Prims.op_Negation uu___11
+                                        Prims.op_Negation uu___10
                                     | uu___7 -> true) subst in
                              b_for_x :: subst1)
                   | uu___1 -> subst)) env1 []
@@ -1837,9 +1832,8 @@ let (should_reify :
              FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
                (FStar_Const.Const_reify uu___2);
              FStar_Syntax_Syntax.pos = uu___3;
-             FStar_Syntax_Syntax.vars = uu___4;
-             FStar_Syntax_Syntax.hash_code = uu___5;_},
-           uu___6, uu___7))::uu___8
+             FStar_Syntax_Syntax.hash_code = uu___4;_},
+           uu___5, uu___6))::uu___7
           -> (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.reify_
       | uu___1 -> false
 let rec (maybe_weakly_reduced :
@@ -3765,14 +3759,13 @@ let rec (norm :
                          FStar_Syntax_Syntax.Tm_constant
                          (FStar_Const.Const_reify uu___3);
                        FStar_Syntax_Syntax.pos = uu___4;
-                       FStar_Syntax_Syntax.vars = uu___5;
-                       FStar_Syntax_Syntax.hash_code = uu___6;_},
-                     uu___7, uu___8))::uu___9
+                       FStar_Syntax_Syntax.hash_code = uu___5;_},
+                     uu___6, uu___7))::uu___8
                     when
                     (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.beta
                     ->
                     (FStar_TypeChecker_Cfg.log cfg
-                       (fun uu___11 ->
+                       (fun uu___10 ->
                           FStar_Compiler_Util.print_string
                             "+++ Dropping ascription \n");
                      norm cfg env1 stack2 t11)
@@ -4257,8 +4250,6 @@ let rec (norm :
                                   ((true, lbs3), body3));
                              FStar_Syntax_Syntax.pos =
                                (t1.FStar_Syntax_Syntax.pos);
-                             FStar_Syntax_Syntax.vars =
-                               (t1.FStar_Syntax_Syntax.vars);
                              FStar_Syntax_Syntax.hash_code =
                                (t1.FStar_Syntax_Syntax.hash_code)
                            } in
@@ -4605,9 +4596,8 @@ and (do_reify_monadic :
                           FStar_Syntax_Syntax.Tm_constant
                           (FStar_Const.Const_reify uu___2);
                         FStar_Syntax_Syntax.pos = uu___3;
-                        FStar_Syntax_Syntax.vars = uu___4;
-                        FStar_Syntax_Syntax.hash_code = uu___5;_},
-                      uu___6, uu___7))::uu___8
+                        FStar_Syntax_Syntax.hash_code = uu___4;_},
+                      uu___5, uu___6))::uu___7
                      -> ()
                  | uu___1 ->
                      let uu___2 =
@@ -4737,10 +4727,8 @@ and (do_reify_monadic :
                                                     y;
                                                   FStar_Syntax_Syntax.pos =
                                                     uu___10;
-                                                  FStar_Syntax_Syntax.vars =
-                                                    uu___11;
                                                   FStar_Syntax_Syntax.hash_code
-                                                    = uu___12;_}
+                                                    = uu___11;_}
                                                 ->
                                                 FStar_Syntax_Syntax.bv_eq x y
                                             | uu___10 -> false in
@@ -5517,7 +5505,6 @@ and (norm_comp :
              {
                FStar_Syntax_Syntax.n = (uu___1.FStar_Syntax_Syntax.n);
                FStar_Syntax_Syntax.pos = (comp.FStar_Syntax_Syntax.pos);
-               FStar_Syntax_Syntax.vars = (uu___1.FStar_Syntax_Syntax.vars);
                FStar_Syntax_Syntax.hash_code =
                  (uu___1.FStar_Syntax_Syntax.hash_code)
              }
@@ -5527,7 +5514,6 @@ and (norm_comp :
              {
                FStar_Syntax_Syntax.n = (uu___1.FStar_Syntax_Syntax.n);
                FStar_Syntax_Syntax.pos = (comp.FStar_Syntax_Syntax.pos);
-               FStar_Syntax_Syntax.vars = (uu___1.FStar_Syntax_Syntax.vars);
                FStar_Syntax_Syntax.hash_code =
                  (uu___1.FStar_Syntax_Syntax.hash_code)
              }
@@ -5603,7 +5589,6 @@ and (norm_comp :
              {
                FStar_Syntax_Syntax.n = (uu___1.FStar_Syntax_Syntax.n);
                FStar_Syntax_Syntax.pos = (comp.FStar_Syntax_Syntax.pos);
-               FStar_Syntax_Syntax.vars = (uu___1.FStar_Syntax_Syntax.vars);
                FStar_Syntax_Syntax.hash_code =
                  (uu___1.FStar_Syntax_Syntax.hash_code)
              })
@@ -5711,7 +5696,6 @@ and (maybe_simplify_aux :
                {
                  FStar_Syntax_Syntax.n = (t.FStar_Syntax_Syntax.n);
                  FStar_Syntax_Syntax.pos = (tm1.FStar_Syntax_Syntax.pos);
-                 FStar_Syntax_Syntax.vars = (t.FStar_Syntax_Syntax.vars);
                  FStar_Syntax_Syntax.hash_code =
                    (t.FStar_Syntax_Syntax.hash_code)
                } in
@@ -6024,202 +6008,200 @@ and (maybe_simplify_aux :
                               FStar_Syntax_Syntax.n =
                                 FStar_Syntax_Syntax.Tm_fvar fv;
                               FStar_Syntax_Syntax.pos = uu___4;
-                              FStar_Syntax_Syntax.vars = uu___5;
-                              FStar_Syntax_Syntax.hash_code = uu___6;_},
-                            uu___7);
-                         FStar_Syntax_Syntax.pos = uu___8;
-                         FStar_Syntax_Syntax.vars = uu___9;
-                         FStar_Syntax_Syntax.hash_code = uu___10;_},
+                              FStar_Syntax_Syntax.hash_code = uu___5;_},
+                            uu___6);
+                         FStar_Syntax_Syntax.pos = uu___7;
+                         FStar_Syntax_Syntax.hash_code = uu___8;_},
                        args)
                       ->
-                      let uu___11 =
+                      let uu___9 =
                         FStar_Syntax_Syntax.fv_eq_lid fv
                           FStar_Parser_Const.and_lid in
-                      if uu___11
+                      if uu___9
                       then
-                        let uu___12 =
+                        let uu___10 =
                           FStar_Compiler_Effect.op_Bar_Greater args
                             (FStar_Compiler_List.map simplify) in
-                        (match uu___12 with
-                         | (FStar_Pervasives_Native.Some (true), uu___13)::
-                             (uu___14, (arg, uu___15))::[] ->
+                        (match uu___10 with
+                         | (FStar_Pervasives_Native.Some (true), uu___11)::
+                             (uu___12, (arg, uu___13))::[] ->
                              maybe_auto_squash arg
-                         | (uu___13, (arg, uu___14))::(FStar_Pervasives_Native.Some
-                                                       (true), uu___15)::[]
+                         | (uu___11, (arg, uu___12))::(FStar_Pervasives_Native.Some
+                                                       (true), uu___13)::[]
                              -> maybe_auto_squash arg
-                         | (FStar_Pervasives_Native.Some (false), uu___13)::uu___14::[]
+                         | (FStar_Pervasives_Native.Some (false), uu___11)::uu___12::[]
                              -> w FStar_Syntax_Util.t_false
-                         | uu___13::(FStar_Pervasives_Native.Some (false),
-                                     uu___14)::[]
+                         | uu___11::(FStar_Pervasives_Native.Some (false),
+                                     uu___12)::[]
                              -> w FStar_Syntax_Util.t_false
-                         | uu___13 -> squashed_head_un_auto_squash_args tm1)
+                         | uu___11 -> squashed_head_un_auto_squash_args tm1)
                       else
-                        (let uu___13 =
+                        (let uu___11 =
                            FStar_Syntax_Syntax.fv_eq_lid fv
                              FStar_Parser_Const.or_lid in
-                         if uu___13
+                         if uu___11
                          then
-                           let uu___14 =
+                           let uu___12 =
                              FStar_Compiler_Effect.op_Bar_Greater args
                                (FStar_Compiler_List.map simplify) in
-                           match uu___14 with
-                           | (FStar_Pervasives_Native.Some (true), uu___15)::uu___16::[]
+                           match uu___12 with
+                           | (FStar_Pervasives_Native.Some (true), uu___13)::uu___14::[]
                                -> w FStar_Syntax_Util.t_true
-                           | uu___15::(FStar_Pervasives_Native.Some (true),
-                                       uu___16)::[]
+                           | uu___13::(FStar_Pervasives_Native.Some (true),
+                                       uu___14)::[]
                                -> w FStar_Syntax_Util.t_true
-                           | (FStar_Pervasives_Native.Some (false), uu___15)::
-                               (uu___16, (arg, uu___17))::[] ->
+                           | (FStar_Pervasives_Native.Some (false), uu___13)::
+                               (uu___14, (arg, uu___15))::[] ->
                                maybe_auto_squash arg
-                           | (uu___15, (arg, uu___16))::(FStar_Pervasives_Native.Some
-                                                         (false), uu___17)::[]
+                           | (uu___13, (arg, uu___14))::(FStar_Pervasives_Native.Some
+                                                         (false), uu___15)::[]
                                -> maybe_auto_squash arg
-                           | uu___15 -> squashed_head_un_auto_squash_args tm1
+                           | uu___13 -> squashed_head_un_auto_squash_args tm1
                          else
-                           (let uu___15 =
+                           (let uu___13 =
                               FStar_Syntax_Syntax.fv_eq_lid fv
                                 FStar_Parser_Const.imp_lid in
-                            if uu___15
+                            if uu___13
                             then
-                              let uu___16 =
+                              let uu___14 =
                                 FStar_Compiler_Effect.op_Bar_Greater args
                                   (FStar_Compiler_List.map simplify) in
-                              match uu___16 with
-                              | uu___17::(FStar_Pervasives_Native.Some
-                                          (true), uu___18)::[]
+                              match uu___14 with
+                              | uu___15::(FStar_Pervasives_Native.Some
+                                          (true), uu___16)::[]
                                   -> w FStar_Syntax_Util.t_true
                               | (FStar_Pervasives_Native.Some (false),
-                                 uu___17)::uu___18::[] ->
+                                 uu___15)::uu___16::[] ->
                                   w FStar_Syntax_Util.t_true
                               | (FStar_Pervasives_Native.Some (true),
-                                 uu___17)::(uu___18, (arg, uu___19))::[] ->
+                                 uu___15)::(uu___16, (arg, uu___17))::[] ->
                                   maybe_auto_squash arg
-                              | (uu___17, (p, uu___18))::(uu___19,
-                                                          (q, uu___20))::[]
+                              | (uu___15, (p, uu___16))::(uu___17,
+                                                          (q, uu___18))::[]
                                   ->
-                                  let uu___21 = FStar_Syntax_Util.term_eq p q in
-                                  (if uu___21
+                                  let uu___19 = FStar_Syntax_Util.term_eq p q in
+                                  (if uu___19
                                    then w FStar_Syntax_Util.t_true
                                    else squashed_head_un_auto_squash_args tm1)
-                              | uu___17 ->
+                              | uu___15 ->
                                   squashed_head_un_auto_squash_args tm1
                             else
-                              (let uu___17 =
+                              (let uu___15 =
                                  FStar_Syntax_Syntax.fv_eq_lid fv
                                    FStar_Parser_Const.iff_lid in
-                               if uu___17
+                               if uu___15
                                then
-                                 let uu___18 =
+                                 let uu___16 =
                                    FStar_Compiler_Effect.op_Bar_Greater args
                                      (FStar_Compiler_List.map simplify) in
-                                 match uu___18 with
+                                 match uu___16 with
                                  | (FStar_Pervasives_Native.Some (true),
-                                    uu___19)::(FStar_Pervasives_Native.Some
-                                               (true), uu___20)::[]
+                                    uu___17)::(FStar_Pervasives_Native.Some
+                                               (true), uu___18)::[]
                                      -> w FStar_Syntax_Util.t_true
                                  | (FStar_Pervasives_Native.Some (false),
-                                    uu___19)::(FStar_Pervasives_Native.Some
-                                               (false), uu___20)::[]
+                                    uu___17)::(FStar_Pervasives_Native.Some
+                                               (false), uu___18)::[]
                                      -> w FStar_Syntax_Util.t_true
                                  | (FStar_Pervasives_Native.Some (true),
-                                    uu___19)::(FStar_Pervasives_Native.Some
-                                               (false), uu___20)::[]
+                                    uu___17)::(FStar_Pervasives_Native.Some
+                                               (false), uu___18)::[]
                                      -> w FStar_Syntax_Util.t_false
                                  | (FStar_Pervasives_Native.Some (false),
-                                    uu___19)::(FStar_Pervasives_Native.Some
-                                               (true), uu___20)::[]
+                                    uu___17)::(FStar_Pervasives_Native.Some
+                                               (true), uu___18)::[]
                                      -> w FStar_Syntax_Util.t_false
-                                 | (uu___19, (arg, uu___20))::(FStar_Pervasives_Native.Some
+                                 | (uu___17, (arg, uu___18))::(FStar_Pervasives_Native.Some
                                                                (true),
-                                                               uu___21)::[]
+                                                               uu___19)::[]
                                      -> maybe_auto_squash arg
                                  | (FStar_Pervasives_Native.Some (true),
-                                    uu___19)::(uu___20, (arg, uu___21))::[]
+                                    uu___17)::(uu___18, (arg, uu___19))::[]
                                      -> maybe_auto_squash arg
-                                 | (uu___19, (arg, uu___20))::(FStar_Pervasives_Native.Some
+                                 | (uu___17, (arg, uu___18))::(FStar_Pervasives_Native.Some
                                                                (false),
-                                                               uu___21)::[]
+                                                               uu___19)::[]
                                      ->
-                                     let uu___22 =
+                                     let uu___20 =
                                        FStar_Syntax_Util.mk_neg arg in
-                                     maybe_auto_squash uu___22
+                                     maybe_auto_squash uu___20
                                  | (FStar_Pervasives_Native.Some (false),
-                                    uu___19)::(uu___20, (arg, uu___21))::[]
+                                    uu___17)::(uu___18, (arg, uu___19))::[]
                                      ->
-                                     let uu___22 =
+                                     let uu___20 =
                                        FStar_Syntax_Util.mk_neg arg in
-                                     maybe_auto_squash uu___22
-                                 | (uu___19, (p, uu___20))::(uu___21,
-                                                             (q, uu___22))::[]
+                                     maybe_auto_squash uu___20
+                                 | (uu___17, (p, uu___18))::(uu___19,
+                                                             (q, uu___20))::[]
                                      ->
-                                     let uu___23 =
+                                     let uu___21 =
                                        FStar_Syntax_Util.term_eq p q in
-                                     (if uu___23
+                                     (if uu___21
                                       then w FStar_Syntax_Util.t_true
                                       else
                                         squashed_head_un_auto_squash_args tm1)
-                                 | uu___19 ->
+                                 | uu___17 ->
                                      squashed_head_un_auto_squash_args tm1
                                else
-                                 (let uu___19 =
+                                 (let uu___17 =
                                     FStar_Syntax_Syntax.fv_eq_lid fv
                                       FStar_Parser_Const.not_lid in
-                                  if uu___19
+                                  if uu___17
                                   then
-                                    let uu___20 =
+                                    let uu___18 =
                                       FStar_Compiler_Effect.op_Bar_Greater
                                         args
                                         (FStar_Compiler_List.map simplify) in
-                                    match uu___20 with
+                                    match uu___18 with
                                     | (FStar_Pervasives_Native.Some (true),
-                                       uu___21)::[] ->
+                                       uu___19)::[] ->
                                         w FStar_Syntax_Util.t_false
                                     | (FStar_Pervasives_Native.Some (false),
-                                       uu___21)::[] ->
+                                       uu___19)::[] ->
                                         w FStar_Syntax_Util.t_true
-                                    | uu___21 ->
+                                    | uu___19 ->
                                         squashed_head_un_auto_squash_args tm1
                                   else
-                                    (let uu___21 =
+                                    (let uu___19 =
                                        FStar_Syntax_Syntax.fv_eq_lid fv
                                          FStar_Parser_Const.forall_lid in
-                                     if uu___21
+                                     if uu___19
                                      then
                                        match args with
-                                       | (t, uu___22)::[] ->
-                                           let uu___23 =
-                                             let uu___24 =
+                                       | (t, uu___20)::[] ->
+                                           let uu___21 =
+                                             let uu___22 =
                                                FStar_Syntax_Subst.compress t in
-                                             uu___24.FStar_Syntax_Syntax.n in
-                                           (match uu___23 with
+                                             uu___22.FStar_Syntax_Syntax.n in
+                                           (match uu___21 with
                                             | FStar_Syntax_Syntax.Tm_abs
-                                                (uu___24::[], body, uu___25)
+                                                (uu___22::[], body, uu___23)
                                                 ->
-                                                let uu___26 = simp_t body in
-                                                (match uu___26 with
+                                                let uu___24 = simp_t body in
+                                                (match uu___24 with
                                                  | FStar_Pervasives_Native.Some
                                                      (true) ->
                                                      w
                                                        FStar_Syntax_Util.t_true
-                                                 | uu___27 -> tm1)
-                                            | uu___24 -> tm1)
+                                                 | uu___25 -> tm1)
+                                            | uu___22 -> tm1)
                                        | (ty, FStar_Pervasives_Native.Some
                                           {
                                             FStar_Syntax_Syntax.aqual_implicit
                                               = true;
                                             FStar_Syntax_Syntax.aqual_attributes
-                                              = uu___22;_})::(t, uu___23)::[]
+                                              = uu___20;_})::(t, uu___21)::[]
                                            ->
-                                           let uu___24 =
-                                             let uu___25 =
+                                           let uu___22 =
+                                             let uu___23 =
                                                FStar_Syntax_Subst.compress t in
-                                             uu___25.FStar_Syntax_Syntax.n in
-                                           (match uu___24 with
+                                             uu___23.FStar_Syntax_Syntax.n in
+                                           (match uu___22 with
                                             | FStar_Syntax_Syntax.Tm_abs
-                                                (uu___25::[], body, uu___26)
+                                                (uu___23::[], body, uu___24)
                                                 ->
-                                                let uu___27 = simp_t body in
-                                                (match uu___27 with
+                                                let uu___25 = simp_t body in
+                                                (match uu___25 with
                                                  | FStar_Pervasives_Native.Some
                                                      (true) ->
                                                      w
@@ -6229,54 +6211,54 @@ and (maybe_simplify_aux :
                                                      clearly_inhabited ty ->
                                                      w
                                                        FStar_Syntax_Util.t_false
-                                                 | uu___28 -> tm1)
-                                            | uu___25 -> tm1)
-                                       | uu___22 -> tm1
+                                                 | uu___26 -> tm1)
+                                            | uu___23 -> tm1)
+                                       | uu___20 -> tm1
                                      else
-                                       (let uu___23 =
+                                       (let uu___21 =
                                           FStar_Syntax_Syntax.fv_eq_lid fv
                                             FStar_Parser_Const.exists_lid in
-                                        if uu___23
+                                        if uu___21
                                         then
                                           match args with
-                                          | (t, uu___24)::[] ->
-                                              let uu___25 =
-                                                let uu___26 =
+                                          | (t, uu___22)::[] ->
+                                              let uu___23 =
+                                                let uu___24 =
                                                   FStar_Syntax_Subst.compress
                                                     t in
-                                                uu___26.FStar_Syntax_Syntax.n in
-                                              (match uu___25 with
+                                                uu___24.FStar_Syntax_Syntax.n in
+                                              (match uu___23 with
                                                | FStar_Syntax_Syntax.Tm_abs
-                                                   (uu___26::[], body,
-                                                    uu___27)
+                                                   (uu___24::[], body,
+                                                    uu___25)
                                                    ->
-                                                   let uu___28 = simp_t body in
-                                                   (match uu___28 with
+                                                   let uu___26 = simp_t body in
+                                                   (match uu___26 with
                                                     | FStar_Pervasives_Native.Some
                                                         (false) ->
                                                         w
                                                           FStar_Syntax_Util.t_false
-                                                    | uu___29 -> tm1)
-                                               | uu___26 -> tm1)
+                                                    | uu___27 -> tm1)
+                                               | uu___24 -> tm1)
                                           | (ty, FStar_Pervasives_Native.Some
                                              {
                                                FStar_Syntax_Syntax.aqual_implicit
                                                  = true;
                                                FStar_Syntax_Syntax.aqual_attributes
-                                                 = uu___24;_})::(t, uu___25)::[]
+                                                 = uu___22;_})::(t, uu___23)::[]
                                               ->
-                                              let uu___26 =
-                                                let uu___27 =
+                                              let uu___24 =
+                                                let uu___25 =
                                                   FStar_Syntax_Subst.compress
                                                     t in
-                                                uu___27.FStar_Syntax_Syntax.n in
-                                              (match uu___26 with
+                                                uu___25.FStar_Syntax_Syntax.n in
+                                              (match uu___24 with
                                                | FStar_Syntax_Syntax.Tm_abs
-                                                   (uu___27::[], body,
-                                                    uu___28)
+                                                   (uu___25::[], body,
+                                                    uu___26)
                                                    ->
-                                                   let uu___29 = simp_t body in
-                                                   (match uu___29 with
+                                                   let uu___27 = simp_t body in
+                                                   (match uu___27 with
                                                     | FStar_Pervasives_Native.Some
                                                         (false) ->
                                                         w
@@ -6287,14 +6269,14 @@ and (maybe_simplify_aux :
                                                         ->
                                                         w
                                                           FStar_Syntax_Util.t_true
-                                                    | uu___30 -> tm1)
-                                               | uu___27 -> tm1)
-                                          | uu___24 -> tm1
+                                                    | uu___28 -> tm1)
+                                               | uu___25 -> tm1)
+                                          | uu___22 -> tm1
                                         else
-                                          (let uu___25 =
+                                          (let uu___23 =
                                              FStar_Syntax_Syntax.fv_eq_lid fv
                                                FStar_Parser_Const.b2t_lid in
-                                           if uu___25
+                                           if uu___23
                                            then
                                              match args with
                                              | ({
@@ -6303,12 +6285,10 @@ and (maybe_simplify_aux :
                                                     (FStar_Const.Const_bool
                                                     (true));
                                                   FStar_Syntax_Syntax.pos =
-                                                    uu___26;
-                                                  FStar_Syntax_Syntax.vars =
-                                                    uu___27;
+                                                    uu___24;
                                                   FStar_Syntax_Syntax.hash_code
-                                                    = uu___28;_},
-                                                uu___29)::[] ->
+                                                    = uu___25;_},
+                                                uu___26)::[] ->
                                                  w FStar_Syntax_Util.t_true
                                              | ({
                                                   FStar_Syntax_Syntax.n =
@@ -6316,20 +6296,18 @@ and (maybe_simplify_aux :
                                                     (FStar_Const.Const_bool
                                                     (false));
                                                   FStar_Syntax_Syntax.pos =
-                                                    uu___26;
-                                                  FStar_Syntax_Syntax.vars =
-                                                    uu___27;
+                                                    uu___24;
                                                   FStar_Syntax_Syntax.hash_code
-                                                    = uu___28;_},
-                                                uu___29)::[] ->
+                                                    = uu___25;_},
+                                                uu___26)::[] ->
                                                  w FStar_Syntax_Util.t_false
-                                             | uu___26 -> tm1
+                                             | uu___24 -> tm1
                                            else
-                                             (let uu___27 =
+                                             (let uu___25 =
                                                 FStar_Syntax_Syntax.fv_eq_lid
                                                   fv
                                                   FStar_Parser_Const.haseq_lid in
-                                              if uu___27
+                                              if uu___25
                                               then
                                                 let t_has_eq_for_sure t =
                                                   let haseq_lids =
@@ -6337,12 +6315,12 @@ and (maybe_simplify_aux :
                                                     FStar_Parser_Const.bool_lid;
                                                     FStar_Parser_Const.unit_lid;
                                                     FStar_Parser_Const.string_lid] in
-                                                  let uu___28 =
-                                                    let uu___29 =
+                                                  let uu___26 =
+                                                    let uu___27 =
                                                       FStar_Syntax_Subst.compress
                                                         t in
-                                                    uu___29.FStar_Syntax_Syntax.n in
-                                                  match uu___28 with
+                                                    uu___27.FStar_Syntax_Syntax.n in
+                                                  match uu___26 with
                                                   | FStar_Syntax_Syntax.Tm_fvar
                                                       fv1 when
                                                       FStar_Compiler_Effect.op_Bar_Greater
@@ -6352,80 +6330,80 @@ and (maybe_simplify_aux :
                                                               FStar_Syntax_Syntax.fv_eq_lid
                                                                 fv1 l))
                                                       -> true
-                                                  | uu___29 -> false in
+                                                  | uu___27 -> false in
                                                 (if
                                                    (FStar_Compiler_List.length
                                                       args)
                                                      = Prims.int_one
                                                  then
                                                    let t =
-                                                     let uu___28 =
+                                                     let uu___26 =
                                                        FStar_Compiler_Effect.op_Bar_Greater
                                                          args
                                                          FStar_Compiler_List.hd in
                                                      FStar_Compiler_Effect.op_Bar_Greater
-                                                       uu___28
+                                                       uu___26
                                                        FStar_Pervasives_Native.fst in
-                                                   let uu___28 =
+                                                   let uu___26 =
                                                      FStar_Compiler_Effect.op_Bar_Greater
                                                        t t_has_eq_for_sure in
-                                                   (if uu___28
+                                                   (if uu___26
                                                     then
                                                       w
                                                         FStar_Syntax_Util.t_true
                                                     else
-                                                      (let uu___30 =
-                                                         let uu___31 =
+                                                      (let uu___28 =
+                                                         let uu___29 =
                                                            FStar_Syntax_Subst.compress
                                                              t in
-                                                         uu___31.FStar_Syntax_Syntax.n in
-                                                       match uu___30 with
+                                                         uu___29.FStar_Syntax_Syntax.n in
+                                                       match uu___28 with
                                                        | FStar_Syntax_Syntax.Tm_refine
-                                                           uu___31 ->
+                                                           uu___29 ->
                                                            let t1 =
                                                              FStar_Syntax_Util.unrefine
                                                                t in
-                                                           let uu___32 =
+                                                           let uu___30 =
                                                              FStar_Compiler_Effect.op_Bar_Greater
                                                                t1
                                                                t_has_eq_for_sure in
-                                                           if uu___32
+                                                           if uu___30
                                                            then
                                                              w
                                                                FStar_Syntax_Util.t_true
                                                            else
                                                              (let haseq_tm =
-                                                                let uu___34 =
-                                                                  let uu___35
+                                                                let uu___32 =
+                                                                  let uu___33
                                                                     =
                                                                     FStar_Syntax_Subst.compress
                                                                     tm1 in
-                                                                  uu___35.FStar_Syntax_Syntax.n in
-                                                                match uu___34
+                                                                  uu___33.FStar_Syntax_Syntax.n in
+                                                                match uu___32
                                                                 with
                                                                 | FStar_Syntax_Syntax.Tm_app
                                                                     (hd,
-                                                                    uu___35)
+                                                                    uu___33)
                                                                     -> hd
-                                                                | uu___35 ->
+                                                                | uu___33 ->
                                                                     failwith
                                                                     "Impossible! We have already checked that this is a Tm_app" in
-                                                              let uu___34 =
-                                                                let uu___35 =
+                                                              let uu___32 =
+                                                                let uu___33 =
                                                                   FStar_Compiler_Effect.op_Bar_Greater
                                                                     t1
                                                                     FStar_Syntax_Syntax.as_arg in
-                                                                [uu___35] in
+                                                                [uu___33] in
                                                               FStar_Syntax_Util.mk_app
                                                                 haseq_tm
-                                                                uu___34)
-                                                       | uu___31 -> tm1))
+                                                                uu___32)
+                                                       | uu___29 -> tm1))
                                                  else tm1)
                                               else
-                                                (let uu___29 =
+                                                (let uu___27 =
                                                    FStar_Syntax_Util.is_auto_squash
                                                      tm1 in
-                                                 match uu___29 with
+                                                 match uu___27 with
                                                  | FStar_Pervasives_Native.Some
                                                      (FStar_Syntax_Syntax.U_zero,
                                                       t)
@@ -6433,175 +6411,197 @@ and (maybe_simplify_aux :
                                                      FStar_Syntax_Util.is_sub_singleton
                                                        t
                                                      -> t
-                                                 | uu___30 ->
-                                                     let uu___31 =
+                                                 | uu___28 ->
+                                                     let uu___29 =
                                                        norm_cb cfg in
-                                                     reduce_equality uu___31
+                                                     reduce_equality uu___29
                                                        cfg env1 tm1)))))))))
                   | FStar_Syntax_Syntax.Tm_app
                       ({
                          FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar
                            fv;
                          FStar_Syntax_Syntax.pos = uu___4;
-                         FStar_Syntax_Syntax.vars = uu___5;
-                         FStar_Syntax_Syntax.hash_code = uu___6;_},
+                         FStar_Syntax_Syntax.hash_code = uu___5;_},
                        args)
                       ->
-                      let uu___7 =
+                      let uu___6 =
                         FStar_Syntax_Syntax.fv_eq_lid fv
                           FStar_Parser_Const.and_lid in
-                      if uu___7
+                      if uu___6
                       then
-                        let uu___8 =
+                        let uu___7 =
                           FStar_Compiler_Effect.op_Bar_Greater args
                             (FStar_Compiler_List.map simplify) in
-                        (match uu___8 with
-                         | (FStar_Pervasives_Native.Some (true), uu___9)::
-                             (uu___10, (arg, uu___11))::[] ->
+                        (match uu___7 with
+                         | (FStar_Pervasives_Native.Some (true), uu___8)::
+                             (uu___9, (arg, uu___10))::[] ->
                              maybe_auto_squash arg
-                         | (uu___9, (arg, uu___10))::(FStar_Pervasives_Native.Some
-                                                      (true), uu___11)::[]
+                         | (uu___8, (arg, uu___9))::(FStar_Pervasives_Native.Some
+                                                     (true), uu___10)::[]
                              -> maybe_auto_squash arg
-                         | (FStar_Pervasives_Native.Some (false), uu___9)::uu___10::[]
+                         | (FStar_Pervasives_Native.Some (false), uu___8)::uu___9::[]
                              -> w FStar_Syntax_Util.t_false
-                         | uu___9::(FStar_Pervasives_Native.Some (false),
-                                    uu___10)::[]
+                         | uu___8::(FStar_Pervasives_Native.Some (false),
+                                    uu___9)::[]
                              -> w FStar_Syntax_Util.t_false
-                         | uu___9 -> squashed_head_un_auto_squash_args tm1)
+                         | uu___8 -> squashed_head_un_auto_squash_args tm1)
                       else
-                        (let uu___9 =
+                        (let uu___8 =
                            FStar_Syntax_Syntax.fv_eq_lid fv
                              FStar_Parser_Const.or_lid in
-                         if uu___9
+                         if uu___8
                          then
-                           let uu___10 =
+                           let uu___9 =
                              FStar_Compiler_Effect.op_Bar_Greater args
                                (FStar_Compiler_List.map simplify) in
-                           match uu___10 with
-                           | (FStar_Pervasives_Native.Some (true), uu___11)::uu___12::[]
+                           match uu___9 with
+                           | (FStar_Pervasives_Native.Some (true), uu___10)::uu___11::[]
                                -> w FStar_Syntax_Util.t_true
-                           | uu___11::(FStar_Pervasives_Native.Some (true),
-                                       uu___12)::[]
+                           | uu___10::(FStar_Pervasives_Native.Some (true),
+                                       uu___11)::[]
                                -> w FStar_Syntax_Util.t_true
-                           | (FStar_Pervasives_Native.Some (false), uu___11)::
-                               (uu___12, (arg, uu___13))::[] ->
+                           | (FStar_Pervasives_Native.Some (false), uu___10)::
+                               (uu___11, (arg, uu___12))::[] ->
                                maybe_auto_squash arg
-                           | (uu___11, (arg, uu___12))::(FStar_Pervasives_Native.Some
-                                                         (false), uu___13)::[]
+                           | (uu___10, (arg, uu___11))::(FStar_Pervasives_Native.Some
+                                                         (false), uu___12)::[]
                                -> maybe_auto_squash arg
-                           | uu___11 -> squashed_head_un_auto_squash_args tm1
+                           | uu___10 -> squashed_head_un_auto_squash_args tm1
                          else
-                           (let uu___11 =
+                           (let uu___10 =
                               FStar_Syntax_Syntax.fv_eq_lid fv
                                 FStar_Parser_Const.imp_lid in
-                            if uu___11
+                            if uu___10
                             then
-                              let uu___12 =
+                              let uu___11 =
                                 FStar_Compiler_Effect.op_Bar_Greater args
                                   (FStar_Compiler_List.map simplify) in
-                              match uu___12 with
-                              | uu___13::(FStar_Pervasives_Native.Some
-                                          (true), uu___14)::[]
+                              match uu___11 with
+                              | uu___12::(FStar_Pervasives_Native.Some
+                                          (true), uu___13)::[]
                                   -> w FStar_Syntax_Util.t_true
                               | (FStar_Pervasives_Native.Some (false),
-                                 uu___13)::uu___14::[] ->
+                                 uu___12)::uu___13::[] ->
                                   w FStar_Syntax_Util.t_true
                               | (FStar_Pervasives_Native.Some (true),
-                                 uu___13)::(uu___14, (arg, uu___15))::[] ->
+                                 uu___12)::(uu___13, (arg, uu___14))::[] ->
                                   maybe_auto_squash arg
-                              | (uu___13, (p, uu___14))::(uu___15,
-                                                          (q, uu___16))::[]
+                              | (uu___12, (p, uu___13))::(uu___14,
+                                                          (q, uu___15))::[]
                                   ->
-                                  let uu___17 = FStar_Syntax_Util.term_eq p q in
-                                  (if uu___17
+                                  let uu___16 = FStar_Syntax_Util.term_eq p q in
+                                  (if uu___16
                                    then w FStar_Syntax_Util.t_true
                                    else squashed_head_un_auto_squash_args tm1)
-                              | uu___13 ->
+                              | uu___12 ->
                                   squashed_head_un_auto_squash_args tm1
                             else
-                              (let uu___13 =
+                              (let uu___12 =
                                  FStar_Syntax_Syntax.fv_eq_lid fv
                                    FStar_Parser_Const.iff_lid in
-                               if uu___13
+                               if uu___12
                                then
-                                 let uu___14 =
+                                 let uu___13 =
                                    FStar_Compiler_Effect.op_Bar_Greater args
                                      (FStar_Compiler_List.map simplify) in
-                                 match uu___14 with
+                                 match uu___13 with
                                  | (FStar_Pervasives_Native.Some (true),
-                                    uu___15)::(FStar_Pervasives_Native.Some
-                                               (true), uu___16)::[]
+                                    uu___14)::(FStar_Pervasives_Native.Some
+                                               (true), uu___15)::[]
                                      -> w FStar_Syntax_Util.t_true
                                  | (FStar_Pervasives_Native.Some (false),
-                                    uu___15)::(FStar_Pervasives_Native.Some
-                                               (false), uu___16)::[]
+                                    uu___14)::(FStar_Pervasives_Native.Some
+                                               (false), uu___15)::[]
                                      -> w FStar_Syntax_Util.t_true
                                  | (FStar_Pervasives_Native.Some (true),
-                                    uu___15)::(FStar_Pervasives_Native.Some
-                                               (false), uu___16)::[]
+                                    uu___14)::(FStar_Pervasives_Native.Some
+                                               (false), uu___15)::[]
                                      -> w FStar_Syntax_Util.t_false
                                  | (FStar_Pervasives_Native.Some (false),
-                                    uu___15)::(FStar_Pervasives_Native.Some
-                                               (true), uu___16)::[]
+                                    uu___14)::(FStar_Pervasives_Native.Some
+                                               (true), uu___15)::[]
                                      -> w FStar_Syntax_Util.t_false
-                                 | (uu___15, (arg, uu___16))::(FStar_Pervasives_Native.Some
+                                 | (uu___14, (arg, uu___15))::(FStar_Pervasives_Native.Some
                                                                (true),
-                                                               uu___17)::[]
+                                                               uu___16)::[]
                                      -> maybe_auto_squash arg
                                  | (FStar_Pervasives_Native.Some (true),
-                                    uu___15)::(uu___16, (arg, uu___17))::[]
+                                    uu___14)::(uu___15, (arg, uu___16))::[]
                                      -> maybe_auto_squash arg
-                                 | (uu___15, (arg, uu___16))::(FStar_Pervasives_Native.Some
+                                 | (uu___14, (arg, uu___15))::(FStar_Pervasives_Native.Some
                                                                (false),
-                                                               uu___17)::[]
+                                                               uu___16)::[]
                                      ->
-                                     let uu___18 =
+                                     let uu___17 =
                                        FStar_Syntax_Util.mk_neg arg in
-                                     maybe_auto_squash uu___18
+                                     maybe_auto_squash uu___17
                                  | (FStar_Pervasives_Native.Some (false),
-                                    uu___15)::(uu___16, (arg, uu___17))::[]
+                                    uu___14)::(uu___15, (arg, uu___16))::[]
+                                     ->
+                                     let uu___17 =
+                                       FStar_Syntax_Util.mk_neg arg in
+                                     maybe_auto_squash uu___17
+                                 | (uu___14, (p, uu___15))::(uu___16,
+                                                             (q, uu___17))::[]
                                      ->
                                      let uu___18 =
-                                       FStar_Syntax_Util.mk_neg arg in
-                                     maybe_auto_squash uu___18
-                                 | (uu___15, (p, uu___16))::(uu___17,
-                                                             (q, uu___18))::[]
-                                     ->
-                                     let uu___19 =
                                        FStar_Syntax_Util.term_eq p q in
-                                     (if uu___19
+                                     (if uu___18
                                       then w FStar_Syntax_Util.t_true
                                       else
                                         squashed_head_un_auto_squash_args tm1)
-                                 | uu___15 ->
+                                 | uu___14 ->
                                      squashed_head_un_auto_squash_args tm1
                                else
-                                 (let uu___15 =
+                                 (let uu___14 =
                                     FStar_Syntax_Syntax.fv_eq_lid fv
                                       FStar_Parser_Const.not_lid in
-                                  if uu___15
+                                  if uu___14
                                   then
-                                    let uu___16 =
+                                    let uu___15 =
                                       FStar_Compiler_Effect.op_Bar_Greater
                                         args
                                         (FStar_Compiler_List.map simplify) in
-                                    match uu___16 with
+                                    match uu___15 with
                                     | (FStar_Pervasives_Native.Some (true),
-                                       uu___17)::[] ->
+                                       uu___16)::[] ->
                                         w FStar_Syntax_Util.t_false
                                     | (FStar_Pervasives_Native.Some (false),
-                                       uu___17)::[] ->
+                                       uu___16)::[] ->
                                         w FStar_Syntax_Util.t_true
-                                    | uu___17 ->
+                                    | uu___16 ->
                                         squashed_head_un_auto_squash_args tm1
                                   else
-                                    (let uu___17 =
+                                    (let uu___16 =
                                        FStar_Syntax_Syntax.fv_eq_lid fv
                                          FStar_Parser_Const.forall_lid in
-                                     if uu___17
+                                     if uu___16
                                      then
                                        match args with
-                                       | (t, uu___18)::[] ->
+                                       | (t, uu___17)::[] ->
+                                           let uu___18 =
+                                             let uu___19 =
+                                               FStar_Syntax_Subst.compress t in
+                                             uu___19.FStar_Syntax_Syntax.n in
+                                           (match uu___18 with
+                                            | FStar_Syntax_Syntax.Tm_abs
+                                                (uu___19::[], body, uu___20)
+                                                ->
+                                                let uu___21 = simp_t body in
+                                                (match uu___21 with
+                                                 | FStar_Pervasives_Native.Some
+                                                     (true) ->
+                                                     w
+                                                       FStar_Syntax_Util.t_true
+                                                 | uu___22 -> tm1)
+                                            | uu___19 -> tm1)
+                                       | (ty, FStar_Pervasives_Native.Some
+                                          {
+                                            FStar_Syntax_Syntax.aqual_implicit
+                                              = true;
+                                            FStar_Syntax_Syntax.aqual_attributes
+                                              = uu___17;_})::(t, uu___18)::[]
+                                           ->
                                            let uu___19 =
                                              let uu___20 =
                                                FStar_Syntax_Subst.compress t in
@@ -6616,45 +6616,47 @@ and (maybe_simplify_aux :
                                                      (true) ->
                                                      w
                                                        FStar_Syntax_Util.t_true
-                                                 | uu___23 -> tm1)
-                                            | uu___20 -> tm1)
-                                       | (ty, FStar_Pervasives_Native.Some
-                                          {
-                                            FStar_Syntax_Syntax.aqual_implicit
-                                              = true;
-                                            FStar_Syntax_Syntax.aqual_attributes
-                                              = uu___18;_})::(t, uu___19)::[]
-                                           ->
-                                           let uu___20 =
-                                             let uu___21 =
-                                               FStar_Syntax_Subst.compress t in
-                                             uu___21.FStar_Syntax_Syntax.n in
-                                           (match uu___20 with
-                                            | FStar_Syntax_Syntax.Tm_abs
-                                                (uu___21::[], body, uu___22)
-                                                ->
-                                                let uu___23 = simp_t body in
-                                                (match uu___23 with
-                                                 | FStar_Pervasives_Native.Some
-                                                     (true) ->
-                                                     w
-                                                       FStar_Syntax_Util.t_true
                                                  | FStar_Pervasives_Native.Some
                                                      (false) when
                                                      clearly_inhabited ty ->
                                                      w
                                                        FStar_Syntax_Util.t_false
-                                                 | uu___24 -> tm1)
-                                            | uu___21 -> tm1)
-                                       | uu___18 -> tm1
+                                                 | uu___23 -> tm1)
+                                            | uu___20 -> tm1)
+                                       | uu___17 -> tm1
                                      else
-                                       (let uu___19 =
+                                       (let uu___18 =
                                           FStar_Syntax_Syntax.fv_eq_lid fv
                                             FStar_Parser_Const.exists_lid in
-                                        if uu___19
+                                        if uu___18
                                         then
                                           match args with
-                                          | (t, uu___20)::[] ->
+                                          | (t, uu___19)::[] ->
+                                              let uu___20 =
+                                                let uu___21 =
+                                                  FStar_Syntax_Subst.compress
+                                                    t in
+                                                uu___21.FStar_Syntax_Syntax.n in
+                                              (match uu___20 with
+                                               | FStar_Syntax_Syntax.Tm_abs
+                                                   (uu___21::[], body,
+                                                    uu___22)
+                                                   ->
+                                                   let uu___23 = simp_t body in
+                                                   (match uu___23 with
+                                                    | FStar_Pervasives_Native.Some
+                                                        (false) ->
+                                                        w
+                                                          FStar_Syntax_Util.t_false
+                                                    | uu___24 -> tm1)
+                                               | uu___21 -> tm1)
+                                          | (ty, FStar_Pervasives_Native.Some
+                                             {
+                                               FStar_Syntax_Syntax.aqual_implicit
+                                                 = true;
+                                               FStar_Syntax_Syntax.aqual_attributes
+                                                 = uu___19;_})::(t, uu___20)::[]
+                                              ->
                                               let uu___21 =
                                                 let uu___22 =
                                                   FStar_Syntax_Subst.compress
@@ -6671,45 +6673,20 @@ and (maybe_simplify_aux :
                                                         (false) ->
                                                         w
                                                           FStar_Syntax_Util.t_false
-                                                    | uu___25 -> tm1)
-                                               | uu___22 -> tm1)
-                                          | (ty, FStar_Pervasives_Native.Some
-                                             {
-                                               FStar_Syntax_Syntax.aqual_implicit
-                                                 = true;
-                                               FStar_Syntax_Syntax.aqual_attributes
-                                                 = uu___20;_})::(t, uu___21)::[]
-                                              ->
-                                              let uu___22 =
-                                                let uu___23 =
-                                                  FStar_Syntax_Subst.compress
-                                                    t in
-                                                uu___23.FStar_Syntax_Syntax.n in
-                                              (match uu___22 with
-                                               | FStar_Syntax_Syntax.Tm_abs
-                                                   (uu___23::[], body,
-                                                    uu___24)
-                                                   ->
-                                                   let uu___25 = simp_t body in
-                                                   (match uu___25 with
-                                                    | FStar_Pervasives_Native.Some
-                                                        (false) ->
-                                                        w
-                                                          FStar_Syntax_Util.t_false
                                                     | FStar_Pervasives_Native.Some
                                                         (true) when
                                                         clearly_inhabited ty
                                                         ->
                                                         w
                                                           FStar_Syntax_Util.t_true
-                                                    | uu___26 -> tm1)
-                                               | uu___23 -> tm1)
-                                          | uu___20 -> tm1
+                                                    | uu___25 -> tm1)
+                                               | uu___22 -> tm1)
+                                          | uu___19 -> tm1
                                         else
-                                          (let uu___21 =
+                                          (let uu___20 =
                                              FStar_Syntax_Syntax.fv_eq_lid fv
                                                FStar_Parser_Const.b2t_lid in
-                                           if uu___21
+                                           if uu___20
                                            then
                                              match args with
                                              | ({
@@ -6718,12 +6695,10 @@ and (maybe_simplify_aux :
                                                     (FStar_Const.Const_bool
                                                     (true));
                                                   FStar_Syntax_Syntax.pos =
-                                                    uu___22;
-                                                  FStar_Syntax_Syntax.vars =
-                                                    uu___23;
+                                                    uu___21;
                                                   FStar_Syntax_Syntax.hash_code
-                                                    = uu___24;_},
-                                                uu___25)::[] ->
+                                                    = uu___22;_},
+                                                uu___23)::[] ->
                                                  w FStar_Syntax_Util.t_true
                                              | ({
                                                   FStar_Syntax_Syntax.n =
@@ -6731,20 +6706,18 @@ and (maybe_simplify_aux :
                                                     (FStar_Const.Const_bool
                                                     (false));
                                                   FStar_Syntax_Syntax.pos =
-                                                    uu___22;
-                                                  FStar_Syntax_Syntax.vars =
-                                                    uu___23;
+                                                    uu___21;
                                                   FStar_Syntax_Syntax.hash_code
-                                                    = uu___24;_},
-                                                uu___25)::[] ->
+                                                    = uu___22;_},
+                                                uu___23)::[] ->
                                                  w FStar_Syntax_Util.t_false
-                                             | uu___22 -> tm1
+                                             | uu___21 -> tm1
                                            else
-                                             (let uu___23 =
+                                             (let uu___22 =
                                                 FStar_Syntax_Syntax.fv_eq_lid
                                                   fv
                                                   FStar_Parser_Const.haseq_lid in
-                                              if uu___23
+                                              if uu___22
                                               then
                                                 let t_has_eq_for_sure t =
                                                   let haseq_lids =
@@ -6752,12 +6725,12 @@ and (maybe_simplify_aux :
                                                     FStar_Parser_Const.bool_lid;
                                                     FStar_Parser_Const.unit_lid;
                                                     FStar_Parser_Const.string_lid] in
-                                                  let uu___24 =
-                                                    let uu___25 =
+                                                  let uu___23 =
+                                                    let uu___24 =
                                                       FStar_Syntax_Subst.compress
                                                         t in
-                                                    uu___25.FStar_Syntax_Syntax.n in
-                                                  match uu___24 with
+                                                    uu___24.FStar_Syntax_Syntax.n in
+                                                  match uu___23 with
                                                   | FStar_Syntax_Syntax.Tm_fvar
                                                       fv1 when
                                                       FStar_Compiler_Effect.op_Bar_Greater
@@ -6767,80 +6740,80 @@ and (maybe_simplify_aux :
                                                               FStar_Syntax_Syntax.fv_eq_lid
                                                                 fv1 l))
                                                       -> true
-                                                  | uu___25 -> false in
+                                                  | uu___24 -> false in
                                                 (if
                                                    (FStar_Compiler_List.length
                                                       args)
                                                      = Prims.int_one
                                                  then
                                                    let t =
-                                                     let uu___24 =
+                                                     let uu___23 =
                                                        FStar_Compiler_Effect.op_Bar_Greater
                                                          args
                                                          FStar_Compiler_List.hd in
                                                      FStar_Compiler_Effect.op_Bar_Greater
-                                                       uu___24
+                                                       uu___23
                                                        FStar_Pervasives_Native.fst in
-                                                   let uu___24 =
+                                                   let uu___23 =
                                                      FStar_Compiler_Effect.op_Bar_Greater
                                                        t t_has_eq_for_sure in
-                                                   (if uu___24
+                                                   (if uu___23
                                                     then
                                                       w
                                                         FStar_Syntax_Util.t_true
                                                     else
-                                                      (let uu___26 =
-                                                         let uu___27 =
+                                                      (let uu___25 =
+                                                         let uu___26 =
                                                            FStar_Syntax_Subst.compress
                                                              t in
-                                                         uu___27.FStar_Syntax_Syntax.n in
-                                                       match uu___26 with
+                                                         uu___26.FStar_Syntax_Syntax.n in
+                                                       match uu___25 with
                                                        | FStar_Syntax_Syntax.Tm_refine
-                                                           uu___27 ->
+                                                           uu___26 ->
                                                            let t1 =
                                                              FStar_Syntax_Util.unrefine
                                                                t in
-                                                           let uu___28 =
+                                                           let uu___27 =
                                                              FStar_Compiler_Effect.op_Bar_Greater
                                                                t1
                                                                t_has_eq_for_sure in
-                                                           if uu___28
+                                                           if uu___27
                                                            then
                                                              w
                                                                FStar_Syntax_Util.t_true
                                                            else
                                                              (let haseq_tm =
-                                                                let uu___30 =
-                                                                  let uu___31
+                                                                let uu___29 =
+                                                                  let uu___30
                                                                     =
                                                                     FStar_Syntax_Subst.compress
                                                                     tm1 in
-                                                                  uu___31.FStar_Syntax_Syntax.n in
-                                                                match uu___30
+                                                                  uu___30.FStar_Syntax_Syntax.n in
+                                                                match uu___29
                                                                 with
                                                                 | FStar_Syntax_Syntax.Tm_app
                                                                     (hd,
-                                                                    uu___31)
+                                                                    uu___30)
                                                                     -> hd
-                                                                | uu___31 ->
+                                                                | uu___30 ->
                                                                     failwith
                                                                     "Impossible! We have already checked that this is a Tm_app" in
-                                                              let uu___30 =
-                                                                let uu___31 =
+                                                              let uu___29 =
+                                                                let uu___30 =
                                                                   FStar_Compiler_Effect.op_Bar_Greater
                                                                     t1
                                                                     FStar_Syntax_Syntax.as_arg in
-                                                                [uu___31] in
+                                                                [uu___30] in
                                                               FStar_Syntax_Util.mk_app
                                                                 haseq_tm
-                                                                uu___30)
-                                                       | uu___27 -> tm1))
+                                                                uu___29)
+                                                       | uu___26 -> tm1))
                                                  else tm1)
                                               else
-                                                (let uu___25 =
+                                                (let uu___24 =
                                                    FStar_Syntax_Util.is_auto_squash
                                                      tm1 in
-                                                 match uu___25 with
+                                                 match uu___24 with
                                                  | FStar_Pervasives_Native.Some
                                                      (FStar_Syntax_Syntax.U_zero,
                                                       t)
@@ -6848,10 +6821,10 @@ and (maybe_simplify_aux :
                                                      FStar_Syntax_Util.is_sub_singleton
                                                        t
                                                      -> t
-                                                 | uu___26 ->
-                                                     let uu___27 =
+                                                 | uu___25 ->
+                                                     let uu___26 =
                                                        norm_cb cfg in
-                                                     reduce_equality uu___27
+                                                     reduce_equality uu___26
                                                        cfg env1 tm1)))))))))
                   | FStar_Syntax_Syntax.Tm_refine (bv, t) ->
                       let uu___4 = simp_t t in
@@ -6979,8 +6952,6 @@ and (rebuild :
                     {
                       FStar_Syntax_Syntax.n = (uu___4.FStar_Syntax_Syntax.n);
                       FStar_Syntax_Syntax.pos = r;
-                      FStar_Syntax_Syntax.vars =
-                        (uu___4.FStar_Syntax_Syntax.vars);
                       FStar_Syntax_Syntax.hash_code =
                         (uu___4.FStar_Syntax_Syntax.hash_code)
                     } in
@@ -7203,9 +7174,8 @@ and (rebuild :
                             FStar_Syntax_Syntax.Tm_constant
                             (FStar_Const.Const_reflect uu___4);
                           FStar_Syntax_Syntax.pos = uu___5;
-                          FStar_Syntax_Syntax.vars = uu___6;
-                          FStar_Syntax_Syntax.hash_code = uu___7;_},
-                        (e, uu___8)::[])
+                          FStar_Syntax_Syntax.hash_code = uu___6;_},
+                        (e, uu___7)::[])
                        -> norm cfg env2 stack' e
                    | FStar_Syntax_Syntax.Tm_app uu___4 when
                        (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.primops
@@ -8112,7 +8082,6 @@ let (ghost_to_pure_aux :
               {
                 FStar_Syntax_Syntax.n = (FStar_Syntax_Syntax.Total t);
                 FStar_Syntax_Syntax.pos = (c.FStar_Syntax_Syntax.pos);
-                FStar_Syntax_Syntax.vars = (c.FStar_Syntax_Syntax.vars);
                 FStar_Syntax_Syntax.hash_code =
                   (c.FStar_Syntax_Syntax.hash_code)
               }
@@ -8169,7 +8138,6 @@ let (ghost_to_pure_aux :
               {
                 FStar_Syntax_Syntax.n = (FStar_Syntax_Syntax.Comp ct1);
                 FStar_Syntax_Syntax.pos = (c.FStar_Syntax_Syntax.pos);
-                FStar_Syntax_Syntax.vars = (c.FStar_Syntax_Syntax.vars);
                 FStar_Syntax_Syntax.hash_code =
                   (c.FStar_Syntax_Syntax.hash_code)
               }
@@ -9308,8 +9276,7 @@ let (unfold_head_once :
            | FStar_Syntax_Syntax.Tm_uinst
                ({ FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar fv;
                   FStar_Syntax_Syntax.pos = uu___2;
-                  FStar_Syntax_Syntax.vars = uu___3;
-                  FStar_Syntax_Syntax.hash_code = uu___4;_},
+                  FStar_Syntax_Syntax.hash_code = uu___3;_},
                 us)
                -> aux fv us args
            | uu___2 -> FStar_Pervasives_Native.None)
@@ -9366,8 +9333,7 @@ let (maybe_unfold_head_fv :
         | FStar_Syntax_Syntax.Tm_uinst
             ({ FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar fv;
                FStar_Syntax_Syntax.pos = uu___1;
-               FStar_Syntax_Syntax.vars = uu___2;
-               FStar_Syntax_Syntax.hash_code = uu___3;_},
+               FStar_Syntax_Syntax.hash_code = uu___2;_},
              us)
             -> FStar_Pervasives_Native.Some (fv, us)
         | FStar_Syntax_Syntax.Tm_fvar fv ->

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_Rel.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_Rel.ml
@@ -1707,8 +1707,7 @@ let (base_and_refinement_maybe_delta :
                      FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_refine
                        (x1, phi1);
                      FStar_Syntax_Syntax.pos = uu___2;
-                     FStar_Syntax_Syntax.vars = uu___3;
-                     FStar_Syntax_Syntax.hash_code = uu___4;_} ->
+                     FStar_Syntax_Syntax.hash_code = uu___3;_} ->
                      ((x1.FStar_Syntax_Syntax.sort),
                        (FStar_Pervasives_Native.Some (x1, phi1)))
                  | tt ->
@@ -4854,14 +4853,12 @@ and (solve_maybe_uinsts :
            | (FStar_Syntax_Syntax.Tm_uinst
               ({ FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar f;
                  FStar_Syntax_Syntax.pos = uu___2;
-                 FStar_Syntax_Syntax.vars = uu___3;
-                 FStar_Syntax_Syntax.hash_code = uu___4;_},
+                 FStar_Syntax_Syntax.hash_code = uu___3;_},
                us1),
               FStar_Syntax_Syntax.Tm_uinst
               ({ FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar g;
-                 FStar_Syntax_Syntax.pos = uu___5;
-                 FStar_Syntax_Syntax.vars = uu___6;
-                 FStar_Syntax_Syntax.hash_code = uu___7;_},
+                 FStar_Syntax_Syntax.pos = uu___4;
+                 FStar_Syntax_Syntax.hash_code = uu___5;_},
                us2)) ->
                let b = FStar_Syntax_Syntax.fv_eq f g in aux wl us1 us2
            | (FStar_Syntax_Syntax.Tm_uinst uu___2, uu___3) ->
@@ -5872,8 +5869,6 @@ and (imitate_arrow :
                                     (FStar_Syntax_Syntax.Comp ct');
                                   FStar_Syntax_Syntax.pos =
                                     (c.FStar_Syntax_Syntax.pos);
-                                  FStar_Syntax_Syntax.vars =
-                                    (c.FStar_Syntax_Syntax.vars);
                                   FStar_Syntax_Syntax.hash_code =
                                     (c.FStar_Syntax_Syntax.hash_code)
                                 }, wl2)) in
@@ -7267,34 +7262,33 @@ and (solve_t_flex_flex :
                                 | Flex
                                     ({ FStar_Syntax_Syntax.n = uu___9;
                                        FStar_Syntax_Syntax.pos = range;
-                                       FStar_Syntax_Syntax.vars = uu___10;
                                        FStar_Syntax_Syntax.hash_code =
-                                         uu___11;_},
-                                     u_lhs, uu___12)
+                                         uu___10;_},
+                                     u_lhs, uu___11)
                                     ->
-                                    let uu___13 = rhs in
-                                    (match uu___13 with
-                                     | Flex (uu___14, u_rhs, uu___15) ->
-                                         let uu___16 =
+                                    let uu___12 = rhs in
+                                    (match uu___12 with
+                                     | Flex (uu___13, u_rhs, uu___14) ->
+                                         let uu___15 =
                                            (FStar_Syntax_Unionfind.equiv
                                               u_lhs.FStar_Syntax_Syntax.ctx_uvar_head
                                               u_rhs.FStar_Syntax_Syntax.ctx_uvar_head)
                                              &&
                                              (binders_eq binders_lhs
                                                 binders_rhs) in
-                                         if uu___16
+                                         if uu___15
                                          then
-                                           let uu___17 =
+                                           let uu___16 =
                                              solve_prob orig
                                                FStar_Pervasives_Native.None
                                                [] wl in
-                                           solve uu___17
+                                           solve uu___16
                                          else
-                                           (let uu___18 =
+                                           (let uu___17 =
                                               maximal_prefix
                                                 u_lhs.FStar_Syntax_Syntax.ctx_uvar_binders
                                                 u_rhs.FStar_Syntax_Syntax.ctx_uvar_binders in
-                                            match uu___18 with
+                                            match uu___17 with
                                             | (ctx_w, (ctx_l, ctx_r)) ->
                                                 let gamma_w =
                                                   gamma_until
@@ -7307,90 +7301,90 @@ and (solve_t_flex_flex :
                                                     (FStar_Compiler_List.op_At
                                                        ctx_r binders_rhs) in
                                                 let new_uvar_typ =
-                                                  let uu___19 =
+                                                  let uu___18 =
                                                     FStar_Syntax_Syntax.mk_Total
                                                       t_res_lhs in
                                                   FStar_Syntax_Util.arrow zs
-                                                    uu___19 in
-                                                let uu___19 =
-                                                  (let uu___20 =
+                                                    uu___18 in
+                                                let uu___18 =
+                                                  (let uu___19 =
                                                      occurs u_lhs
                                                        new_uvar_typ in
                                                    FStar_Pervasives_Native.snd
-                                                     uu___20)
+                                                     uu___19)
                                                     ||
-                                                    ((let uu___20 =
+                                                    ((let uu___19 =
                                                         FStar_Syntax_Unionfind.equiv
                                                           u_lhs.FStar_Syntax_Syntax.ctx_uvar_head
                                                           u_rhs.FStar_Syntax_Syntax.ctx_uvar_head in
                                                       Prims.op_Negation
-                                                        uu___20)
+                                                        uu___19)
                                                        &&
-                                                       (let uu___20 =
+                                                       (let uu___19 =
                                                           occurs u_rhs
                                                             new_uvar_typ in
                                                         FStar_Pervasives_Native.snd
-                                                          uu___20)) in
-                                                if uu___19
+                                                          uu___19)) in
+                                                if uu___18
                                                 then
-                                                  let uu___20 =
-                                                    let uu___21 =
+                                                  let uu___19 =
+                                                    let uu___20 =
                                                       FStar_Compiler_Util.format1
                                                         "flex-flex: occurs\n defer_ok=%s\n"
                                                         (string_of_defer_ok
                                                            wl.defer_ok) in
-                                                    FStar_Thunk.mkv uu___21 in
+                                                    FStar_Thunk.mkv uu___20 in
                                                   giveup_or_defer_flex_flex
                                                     orig wl
                                                     FStar_TypeChecker_Common.Deferred_flex_flex_nonpattern
-                                                    uu___20
+                                                    uu___19
                                                 else
-                                                  ((let uu___22 =
+                                                  ((let uu___21 =
                                                       FStar_Compiler_Effect.op_Less_Bar
                                                         (debug wl)
                                                         (FStar_Options.Other
                                                            "Rel") in
-                                                    if uu___22
+                                                    if uu___21
                                                     then
-                                                      let uu___23 =
+                                                      let uu___22 =
                                                         FStar_Compiler_Util.stack_dump
                                                           () in
                                                       FStar_Compiler_Util.print1
                                                         "flex-flex quasi: %s\n"
-                                                        uu___23
+                                                        uu___22
                                                     else ());
-                                                   (let uu___22 =
-                                                      let uu___23 =
-                                                        let uu___24 =
+                                                   (let uu___21 =
+                                                      let uu___22 =
+                                                        let uu___23 =
                                                           FStar_Syntax_Util.ctx_uvar_should_check
                                                             u_lhs in
-                                                        let uu___25 =
+                                                        let uu___24 =
                                                           FStar_Syntax_Util.ctx_uvar_should_check
                                                             u_rhs in
-                                                        (uu___24, uu___25) in
-                                                      match uu___23 with
+                                                        (uu___23, uu___24) in
+                                                      match uu___22 with
                                                       | (FStar_Syntax_Syntax.Allow_untyped
                                                          r,
                                                          FStar_Syntax_Syntax.Allow_untyped
-                                                         uu___24) ->
+                                                         uu___23) ->
                                                           ((FStar_Syntax_Syntax.Allow_untyped
                                                               r), false)
                                                       | (FStar_Syntax_Syntax.Allow_ghost
-                                                         r, uu___24) ->
+                                                         r, uu___23) ->
                                                           ((FStar_Syntax_Syntax.Allow_ghost
                                                               r), true)
-                                                      | (uu___24,
+                                                      | (uu___23,
                                                          FStar_Syntax_Syntax.Allow_ghost
                                                          r) ->
                                                           ((FStar_Syntax_Syntax.Allow_ghost
                                                               r), true)
-                                                      | uu___24 ->
+                                                      | uu___23 ->
                                                           (FStar_Syntax_Syntax.Strict,
                                                             false) in
-                                                    match uu___22 with
+                                                    match uu___21 with
                                                     | (new_uvar_should_check,
                                                        is_ghost) ->
-                                                        let uu___23 =
+                                                        let uu___22 =
                                                           new_uvar
                                                             (Prims.op_Hat
                                                                "flex-flex quasi:"
@@ -7406,105 +7400,105 @@ and (solve_t_flex_flex :
                                                             new_uvar_typ
                                                             new_uvar_should_check
                                                             FStar_Pervasives_Native.None in
-                                                        (match uu___23 with
-                                                         | (uu___24, w, wl1)
+                                                        (match uu___22 with
+                                                         | (uu___23, w, wl1)
                                                              ->
                                                              let w_app =
-                                                               let uu___25 =
+                                                               let uu___24 =
                                                                  FStar_Compiler_List.map
                                                                    (fun
-                                                                    uu___26
+                                                                    uu___25
                                                                     ->
-                                                                    match uu___26
+                                                                    match uu___25
                                                                     with
                                                                     | 
                                                                     {
                                                                     FStar_Syntax_Syntax.binder_bv
                                                                     = z;
                                                                     FStar_Syntax_Syntax.binder_qual
-                                                                    = uu___27;
+                                                                    = uu___26;
                                                                     FStar_Syntax_Syntax.binder_positivity
-                                                                    = uu___28;
+                                                                    = uu___27;
                                                                     FStar_Syntax_Syntax.binder_attrs
-                                                                    = uu___29;_}
+                                                                    = uu___28;_}
                                                                     ->
-                                                                    let uu___30
+                                                                    let uu___29
                                                                     =
                                                                     FStar_Syntax_Syntax.bv_to_name
                                                                     z in
                                                                     FStar_Syntax_Syntax.as_arg
-                                                                    uu___30)
+                                                                    uu___29)
                                                                    zs in
                                                                FStar_Syntax_Syntax.mk_Tm_app
-                                                                 w uu___25
+                                                                 w uu___24
                                                                  w.FStar_Syntax_Syntax.pos in
-                                                             ((let uu___26 =
+                                                             ((let uu___25 =
                                                                  FStar_Compiler_Effect.op_Less_Bar
                                                                    (debug wl1)
                                                                    (FStar_Options.Other
                                                                     "Rel") in
-                                                               if uu___26
+                                                               if uu___25
                                                                then
-                                                                 let uu___27
+                                                                 let uu___26
                                                                    =
-                                                                   let uu___28
+                                                                   let uu___27
                                                                     =
                                                                     flex_t_to_string
                                                                     lhs in
-                                                                   let uu___29
+                                                                   let uu___28
                                                                     =
-                                                                    let uu___30
+                                                                    let uu___29
                                                                     =
                                                                     flex_t_to_string
                                                                     rhs in
-                                                                    let uu___31
+                                                                    let uu___30
                                                                     =
-                                                                    let uu___32
+                                                                    let uu___31
                                                                     =
                                                                     term_to_string
                                                                     w in
-                                                                    let uu___33
+                                                                    let uu___32
                                                                     =
-                                                                    let uu___34
+                                                                    let uu___33
                                                                     =
                                                                     FStar_Syntax_Print.binders_to_string
                                                                     ", "
                                                                     (FStar_Compiler_List.op_At
                                                                     ctx_l
                                                                     binders_lhs) in
-                                                                    let uu___35
+                                                                    let uu___34
                                                                     =
-                                                                    let uu___36
+                                                                    let uu___35
                                                                     =
                                                                     FStar_Syntax_Print.binders_to_string
                                                                     ", "
                                                                     (FStar_Compiler_List.op_At
                                                                     ctx_r
                                                                     binders_rhs) in
-                                                                    let uu___37
+                                                                    let uu___36
                                                                     =
-                                                                    let uu___38
+                                                                    let uu___37
                                                                     =
                                                                     FStar_Syntax_Print.binders_to_string
                                                                     ", " zs in
-                                                                    [uu___38] in
-                                                                    uu___36
+                                                                    [uu___37] in
+                                                                    uu___35
                                                                     ::
-                                                                    uu___37 in
-                                                                    uu___34
+                                                                    uu___36 in
+                                                                    uu___33
                                                                     ::
-                                                                    uu___35 in
-                                                                    uu___32
+                                                                    uu___34 in
+                                                                    uu___31
                                                                     ::
-                                                                    uu___33 in
-                                                                    uu___30
+                                                                    uu___32 in
+                                                                    uu___29
                                                                     ::
-                                                                    uu___31 in
-                                                                   uu___28 ::
-                                                                    uu___29 in
+                                                                    uu___30 in
+                                                                   uu___27 ::
+                                                                    uu___28 in
                                                                  FStar_Compiler_Util.print
                                                                    "flex-flex quasi:\n\tlhs=%s\n\trhs=%s\n\tsol=%s\n\tctx_l@binders_lhs=%s\n\tctx_r@binders_rhs=%s\n\tzs=%s\n"
-                                                                   uu___27
+                                                                   uu___26
                                                                else ());
                                                               (let rc =
                                                                  if is_ghost
@@ -7524,20 +7518,20 @@ and (solve_t_flex_flex :
                                                                  TERM
                                                                    (u_lhs,
                                                                     s1_sol) in
-                                                               let uu___26 =
+                                                               let uu___25 =
                                                                  FStar_Syntax_Unionfind.equiv
                                                                    u_lhs.FStar_Syntax_Syntax.ctx_uvar_head
                                                                    u_rhs.FStar_Syntax_Syntax.ctx_uvar_head in
-                                                               if uu___26
+                                                               if uu___25
                                                                then
-                                                                 let uu___27
+                                                                 let uu___26
                                                                    =
                                                                    solve_prob
                                                                     orig
                                                                     FStar_Pervasives_Native.None
                                                                     [s1] wl1 in
                                                                  solve
-                                                                   uu___27
+                                                                   uu___26
                                                                else
                                                                  (let s2_sol
                                                                     =
@@ -7550,7 +7544,7 @@ and (solve_t_flex_flex :
                                                                     TERM
                                                                     (u_rhs,
                                                                     s2_sol) in
-                                                                  let uu___28
+                                                                  let uu___27
                                                                     =
                                                                     solve_prob
                                                                     orig
@@ -7558,7 +7552,7 @@ and (solve_t_flex_flex :
                                                                     [s1; s2]
                                                                     wl1 in
                                                                   solve
-                                                                    uu___28)))))))))
+                                                                    uu___27)))))))))
                            | uu___8 ->
                                let uu___9 =
                                  FStar_Thunk.mkv "flex-flex: non-patterns" in
@@ -8221,276 +8215,274 @@ and (solve_t' : tprob -> worklist -> solution) =
                      FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_match
                        (scrutinee, uu___4, branches, uu___5);
                      FStar_Syntax_Syntax.pos = uu___6;
-                     FStar_Syntax_Syntax.vars = uu___7;
-                     FStar_Syntax_Syntax.hash_code = uu___8;_}),
+                     FStar_Syntax_Syntax.hash_code = uu___7;_}),
                   (s, t)) ->
-                   let uu___9 =
-                     let uu___10 = is_flex scrutinee in
-                     Prims.op_Negation uu___10 in
-                   if uu___9
+                   let uu___8 =
+                     let uu___9 = is_flex scrutinee in
+                     Prims.op_Negation uu___9 in
+                   if uu___8
                    then
-                     ((let uu___11 =
+                     ((let uu___10 =
                          FStar_Compiler_Effect.op_Less_Bar (debug wl1)
                            (FStar_Options.Other "Rel") in
-                       if uu___11
+                       if uu___10
                        then
-                         let uu___12 =
+                         let uu___11 =
                            FStar_Syntax_Print.term_to_string scrutinee in
                          FStar_Compiler_Util.print1
-                           "match head %s is not a flex term\n" uu___12
+                           "match head %s is not a flex term\n" uu___11
                        else ());
                       FStar_Pervasives.Inr FStar_Pervasives_Native.None)
                    else
                      if wl1.defer_ok = DeferAny
                      then
-                       ((let uu___12 =
+                       ((let uu___11 =
                            FStar_Compiler_Effect.op_Less_Bar (debug wl1)
                              (FStar_Options.Other "Rel") in
-                         if uu___12
+                         if uu___11
                          then
                            FStar_Compiler_Util.print_string
                              "Deferring ... \n"
                          else ());
                         FStar_Pervasives.Inl "defer")
                      else
-                       ((let uu___13 =
+                       ((let uu___12 =
                            FStar_Compiler_Effect.op_Less_Bar (debug wl1)
                              (FStar_Options.Other "Rel") in
-                         if uu___13
+                         if uu___12
                          then
-                           let uu___14 =
+                           let uu___13 =
                              FStar_Syntax_Print.term_to_string scrutinee in
-                           let uu___15 = FStar_Syntax_Print.term_to_string t in
+                           let uu___14 = FStar_Syntax_Print.term_to_string t in
                            FStar_Compiler_Util.print2
                              "Heuristic applicable with scrutinee %s and other side = %s\n"
-                             uu___14 uu___15
+                             uu___13 uu___14
                          else ());
-                        (let pat_discriminates uu___13 =
-                           match uu___13 with
+                        (let pat_discriminates uu___12 =
+                           match uu___12 with
                            | ({
                                 FStar_Syntax_Syntax.v =
-                                  FStar_Syntax_Syntax.Pat_constant uu___14;
-                                FStar_Syntax_Syntax.p = uu___15;_},
-                              FStar_Pervasives_Native.None, uu___16) -> true
+                                  FStar_Syntax_Syntax.Pat_constant uu___13;
+                                FStar_Syntax_Syntax.p = uu___14;_},
+                              FStar_Pervasives_Native.None, uu___15) -> true
                            | ({
                                 FStar_Syntax_Syntax.v =
-                                  FStar_Syntax_Syntax.Pat_cons uu___14;
-                                FStar_Syntax_Syntax.p = uu___15;_},
-                              FStar_Pervasives_Native.None, uu___16) -> true
-                           | uu___14 -> false in
+                                  FStar_Syntax_Syntax.Pat_cons uu___13;
+                                FStar_Syntax_Syntax.p = uu___14;_},
+                              FStar_Pervasives_Native.None, uu___15) -> true
+                           | uu___13 -> false in
                          let head_matching_branch =
                            FStar_Compiler_Effect.op_Bar_Greater branches
                              (FStar_Compiler_Util.try_find
                                 (fun b ->
                                    if pat_discriminates b
                                    then
-                                     let uu___13 =
+                                     let uu___12 =
                                        FStar_Syntax_Subst.open_branch b in
-                                     match uu___13 with
-                                     | (uu___14, uu___15, t') ->
-                                         let uu___16 =
+                                     match uu___12 with
+                                     | (uu___13, uu___14, t') ->
+                                         let uu___15 =
                                            head_matches_delta
                                              (p_env wl1 orig) wl1.smt_ok s t' in
-                                         (match uu___16 with
-                                          | (FullMatch, uu___17) -> true
-                                          | (HeadMatch uu___17, uu___18) ->
+                                         (match uu___15 with
+                                          | (FullMatch, uu___16) -> true
+                                          | (HeadMatch uu___16, uu___17) ->
                                               true
-                                          | uu___17 -> false)
+                                          | uu___16 -> false)
                                    else false)) in
                          match head_matching_branch with
                          | FStar_Pervasives_Native.None ->
-                             ((let uu___14 =
+                             ((let uu___13 =
                                  FStar_Compiler_Effect.op_Less_Bar
                                    (debug wl1) (FStar_Options.Other "Rel") in
-                               if uu___14
+                               if uu___13
                                then
                                  FStar_Compiler_Util.print_string
                                    "No head_matching branch\n"
                                else ());
                               (let try_branches =
-                                 let uu___14 =
+                                 let uu___13 =
                                    FStar_Compiler_Util.prefix_until
                                      (fun b ->
                                         Prims.op_Negation
                                           (pat_discriminates b)) branches in
-                                 match uu___14 with
+                                 match uu___13 with
                                  | FStar_Pervasives_Native.Some
-                                     (branches1, uu___15, uu___16) ->
+                                     (branches1, uu___14, uu___15) ->
                                      branches1
-                                 | uu___15 -> branches in
-                               let uu___14 =
+                                 | uu___14 -> branches in
+                               let uu___13 =
                                  FStar_Compiler_Util.find_map try_branches
                                    (fun b ->
-                                      let uu___15 =
+                                      let uu___14 =
                                         FStar_Syntax_Subst.open_branch b in
-                                      match uu___15 with
-                                      | (p, uu___16, uu___17) ->
+                                      match uu___14 with
+                                      | (p, uu___15, uu___16) ->
                                           try_solve_branch scrutinee p) in
                                FStar_Compiler_Effect.op_Less_Bar
-                                 (fun uu___15 -> FStar_Pervasives.Inr uu___15)
-                                 uu___14))
+                                 (fun uu___14 -> FStar_Pervasives.Inr uu___14)
+                                 uu___13))
                          | FStar_Pervasives_Native.Some b ->
-                             let uu___13 = FStar_Syntax_Subst.open_branch b in
-                             (match uu___13 with
-                              | (p, uu___14, e) ->
-                                  ((let uu___16 =
+                             let uu___12 = FStar_Syntax_Subst.open_branch b in
+                             (match uu___12 with
+                              | (p, uu___13, e) ->
+                                  ((let uu___15 =
                                       FStar_Compiler_Effect.op_Less_Bar
                                         (debug wl1)
                                         (FStar_Options.Other "Rel") in
-                                    if uu___16
+                                    if uu___15
                                     then
-                                      let uu___17 =
+                                      let uu___16 =
                                         FStar_Syntax_Print.pat_to_string p in
-                                      let uu___18 =
+                                      let uu___17 =
                                         FStar_Syntax_Print.term_to_string e in
                                       FStar_Compiler_Util.print2
                                         "Found head matching branch %s -> %s\n"
-                                        uu___17 uu___18
+                                        uu___16 uu___17
                                     else ());
-                                   (let uu___16 =
+                                   (let uu___15 =
                                       try_solve_branch scrutinee p in
                                     FStar_Compiler_Effect.op_Less_Bar
-                                      (fun uu___17 ->
-                                         FStar_Pervasives.Inr uu___17)
-                                      uu___16)))))
+                                      (fun uu___16 ->
+                                         FStar_Pervasives.Inr uu___16)
+                                      uu___15)))))
                | ((s, t),
                   (uu___3,
                    {
                      FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_match
                        (scrutinee, uu___4, branches, uu___5);
                      FStar_Syntax_Syntax.pos = uu___6;
-                     FStar_Syntax_Syntax.vars = uu___7;
-                     FStar_Syntax_Syntax.hash_code = uu___8;_}))
+                     FStar_Syntax_Syntax.hash_code = uu___7;_}))
                    ->
-                   let uu___9 =
-                     let uu___10 = is_flex scrutinee in
-                     Prims.op_Negation uu___10 in
-                   if uu___9
+                   let uu___8 =
+                     let uu___9 = is_flex scrutinee in
+                     Prims.op_Negation uu___9 in
+                   if uu___8
                    then
-                     ((let uu___11 =
+                     ((let uu___10 =
                          FStar_Compiler_Effect.op_Less_Bar (debug wl1)
                            (FStar_Options.Other "Rel") in
-                       if uu___11
+                       if uu___10
                        then
-                         let uu___12 =
+                         let uu___11 =
                            FStar_Syntax_Print.term_to_string scrutinee in
                          FStar_Compiler_Util.print1
-                           "match head %s is not a flex term\n" uu___12
+                           "match head %s is not a flex term\n" uu___11
                        else ());
                       FStar_Pervasives.Inr FStar_Pervasives_Native.None)
                    else
                      if wl1.defer_ok = DeferAny
                      then
-                       ((let uu___12 =
+                       ((let uu___11 =
                            FStar_Compiler_Effect.op_Less_Bar (debug wl1)
                              (FStar_Options.Other "Rel") in
-                         if uu___12
+                         if uu___11
                          then
                            FStar_Compiler_Util.print_string
                              "Deferring ... \n"
                          else ());
                         FStar_Pervasives.Inl "defer")
                      else
-                       ((let uu___13 =
+                       ((let uu___12 =
                            FStar_Compiler_Effect.op_Less_Bar (debug wl1)
                              (FStar_Options.Other "Rel") in
-                         if uu___13
+                         if uu___12
                          then
-                           let uu___14 =
+                           let uu___13 =
                              FStar_Syntax_Print.term_to_string scrutinee in
-                           let uu___15 = FStar_Syntax_Print.term_to_string t in
+                           let uu___14 = FStar_Syntax_Print.term_to_string t in
                            FStar_Compiler_Util.print2
                              "Heuristic applicable with scrutinee %s and other side = %s\n"
-                             uu___14 uu___15
+                             uu___13 uu___14
                          else ());
-                        (let pat_discriminates uu___13 =
-                           match uu___13 with
+                        (let pat_discriminates uu___12 =
+                           match uu___12 with
                            | ({
                                 FStar_Syntax_Syntax.v =
-                                  FStar_Syntax_Syntax.Pat_constant uu___14;
-                                FStar_Syntax_Syntax.p = uu___15;_},
-                              FStar_Pervasives_Native.None, uu___16) -> true
+                                  FStar_Syntax_Syntax.Pat_constant uu___13;
+                                FStar_Syntax_Syntax.p = uu___14;_},
+                              FStar_Pervasives_Native.None, uu___15) -> true
                            | ({
                                 FStar_Syntax_Syntax.v =
-                                  FStar_Syntax_Syntax.Pat_cons uu___14;
-                                FStar_Syntax_Syntax.p = uu___15;_},
-                              FStar_Pervasives_Native.None, uu___16) -> true
-                           | uu___14 -> false in
+                                  FStar_Syntax_Syntax.Pat_cons uu___13;
+                                FStar_Syntax_Syntax.p = uu___14;_},
+                              FStar_Pervasives_Native.None, uu___15) -> true
+                           | uu___13 -> false in
                          let head_matching_branch =
                            FStar_Compiler_Effect.op_Bar_Greater branches
                              (FStar_Compiler_Util.try_find
                                 (fun b ->
                                    if pat_discriminates b
                                    then
-                                     let uu___13 =
+                                     let uu___12 =
                                        FStar_Syntax_Subst.open_branch b in
-                                     match uu___13 with
-                                     | (uu___14, uu___15, t') ->
-                                         let uu___16 =
+                                     match uu___12 with
+                                     | (uu___13, uu___14, t') ->
+                                         let uu___15 =
                                            head_matches_delta
                                              (p_env wl1 orig) wl1.smt_ok s t' in
-                                         (match uu___16 with
-                                          | (FullMatch, uu___17) -> true
-                                          | (HeadMatch uu___17, uu___18) ->
+                                         (match uu___15 with
+                                          | (FullMatch, uu___16) -> true
+                                          | (HeadMatch uu___16, uu___17) ->
                                               true
-                                          | uu___17 -> false)
+                                          | uu___16 -> false)
                                    else false)) in
                          match head_matching_branch with
                          | FStar_Pervasives_Native.None ->
-                             ((let uu___14 =
+                             ((let uu___13 =
                                  FStar_Compiler_Effect.op_Less_Bar
                                    (debug wl1) (FStar_Options.Other "Rel") in
-                               if uu___14
+                               if uu___13
                                then
                                  FStar_Compiler_Util.print_string
                                    "No head_matching branch\n"
                                else ());
                               (let try_branches =
-                                 let uu___14 =
+                                 let uu___13 =
                                    FStar_Compiler_Util.prefix_until
                                      (fun b ->
                                         Prims.op_Negation
                                           (pat_discriminates b)) branches in
-                                 match uu___14 with
+                                 match uu___13 with
                                  | FStar_Pervasives_Native.Some
-                                     (branches1, uu___15, uu___16) ->
+                                     (branches1, uu___14, uu___15) ->
                                      branches1
-                                 | uu___15 -> branches in
-                               let uu___14 =
+                                 | uu___14 -> branches in
+                               let uu___13 =
                                  FStar_Compiler_Util.find_map try_branches
                                    (fun b ->
-                                      let uu___15 =
+                                      let uu___14 =
                                         FStar_Syntax_Subst.open_branch b in
-                                      match uu___15 with
-                                      | (p, uu___16, uu___17) ->
+                                      match uu___14 with
+                                      | (p, uu___15, uu___16) ->
                                           try_solve_branch scrutinee p) in
                                FStar_Compiler_Effect.op_Less_Bar
-                                 (fun uu___15 -> FStar_Pervasives.Inr uu___15)
-                                 uu___14))
+                                 (fun uu___14 -> FStar_Pervasives.Inr uu___14)
+                                 uu___13))
                          | FStar_Pervasives_Native.Some b ->
-                             let uu___13 = FStar_Syntax_Subst.open_branch b in
-                             (match uu___13 with
-                              | (p, uu___14, e) ->
-                                  ((let uu___16 =
+                             let uu___12 = FStar_Syntax_Subst.open_branch b in
+                             (match uu___12 with
+                              | (p, uu___13, e) ->
+                                  ((let uu___15 =
                                       FStar_Compiler_Effect.op_Less_Bar
                                         (debug wl1)
                                         (FStar_Options.Other "Rel") in
-                                    if uu___16
+                                    if uu___15
                                     then
-                                      let uu___17 =
+                                      let uu___16 =
                                         FStar_Syntax_Print.pat_to_string p in
-                                      let uu___18 =
+                                      let uu___17 =
                                         FStar_Syntax_Print.term_to_string e in
                                       FStar_Compiler_Util.print2
                                         "Found head matching branch %s -> %s\n"
-                                        uu___17 uu___18
+                                        uu___16 uu___17
                                     else ());
-                                   (let uu___16 =
+                                   (let uu___15 =
                                       try_solve_branch scrutinee p in
                                     FStar_Compiler_Effect.op_Less_Bar
-                                      (fun uu___17 ->
-                                         FStar_Pervasives.Inr uu___17)
-                                      uu___16)))))
+                                      (fun uu___16 ->
+                                         FStar_Pervasives.Inr uu___16)
+                                      uu___15)))))
                | uu___3 ->
                    ((let uu___5 =
                        FStar_Compiler_Effect.op_Less_Bar (debug wl1)
@@ -9286,17 +9278,16 @@ and (solve_t' : tprob -> worklist -> solution) =
             | (FStar_Syntax_Syntax.Tm_app
                ({ FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_uvar uu___7;
                   FStar_Syntax_Syntax.pos = uu___8;
-                  FStar_Syntax_Syntax.vars = uu___9;
-                  FStar_Syntax_Syntax.hash_code = uu___10;_},
-                uu___11),
-               FStar_Syntax_Syntax.Tm_uvar uu___12) ->
+                  FStar_Syntax_Syntax.hash_code = uu___9;_},
+                uu___10),
+               FStar_Syntax_Syntax.Tm_uvar uu___11) ->
                 let env = p_env wl (FStar_TypeChecker_Common.TProb problem) in
-                let uu___13 = ensure_no_uvar_subst env t1 wl in
-                (match uu___13 with
+                let uu___12 = ensure_no_uvar_subst env t1 wl in
+                (match uu___12 with
                  | (t11, wl1) ->
                      let t21 = FStar_Syntax_Util.canon_app t2 in
-                     let uu___14 = ensure_no_uvar_subst env t21 wl1 in
-                     (match uu___14 with
+                     let uu___13 = ensure_no_uvar_subst env t21 wl1 in
+                     (match uu___13 with
                       | (t22, wl2) ->
                           let f1 = destruct_flex_t' t11 in
                           let f2 = destruct_flex_t' t22 in
@@ -9304,16 +9295,15 @@ and (solve_t' : tprob -> worklist -> solution) =
             | (FStar_Syntax_Syntax.Tm_uvar uu___7, FStar_Syntax_Syntax.Tm_app
                ({ FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_uvar uu___8;
                   FStar_Syntax_Syntax.pos = uu___9;
-                  FStar_Syntax_Syntax.vars = uu___10;
-                  FStar_Syntax_Syntax.hash_code = uu___11;_},
-                uu___12)) ->
+                  FStar_Syntax_Syntax.hash_code = uu___10;_},
+                uu___11)) ->
                 let env = p_env wl (FStar_TypeChecker_Common.TProb problem) in
-                let uu___13 = ensure_no_uvar_subst env t1 wl in
-                (match uu___13 with
+                let uu___12 = ensure_no_uvar_subst env t1 wl in
+                (match uu___12 with
                  | (t11, wl1) ->
                      let t21 = FStar_Syntax_Util.canon_app t2 in
-                     let uu___14 = ensure_no_uvar_subst env t21 wl1 in
-                     (match uu___14 with
+                     let uu___13 = ensure_no_uvar_subst env t21 wl1 in
+                     (match uu___13 with
                       | (t22, wl2) ->
                           let f1 = destruct_flex_t' t11 in
                           let f2 = destruct_flex_t' t22 in
@@ -9321,23 +9311,21 @@ and (solve_t' : tprob -> worklist -> solution) =
             | (FStar_Syntax_Syntax.Tm_app
                ({ FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_uvar uu___7;
                   FStar_Syntax_Syntax.pos = uu___8;
-                  FStar_Syntax_Syntax.vars = uu___9;
-                  FStar_Syntax_Syntax.hash_code = uu___10;_},
-                uu___11),
+                  FStar_Syntax_Syntax.hash_code = uu___9;_},
+                uu___10),
                FStar_Syntax_Syntax.Tm_app
                ({
-                  FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_uvar uu___12;
-                  FStar_Syntax_Syntax.pos = uu___13;
-                  FStar_Syntax_Syntax.vars = uu___14;
-                  FStar_Syntax_Syntax.hash_code = uu___15;_},
-                uu___16)) ->
+                  FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_uvar uu___11;
+                  FStar_Syntax_Syntax.pos = uu___12;
+                  FStar_Syntax_Syntax.hash_code = uu___13;_},
+                uu___14)) ->
                 let env = p_env wl (FStar_TypeChecker_Common.TProb problem) in
-                let uu___17 = ensure_no_uvar_subst env t1 wl in
-                (match uu___17 with
+                let uu___15 = ensure_no_uvar_subst env t1 wl in
+                (match uu___15 with
                  | (t11, wl1) ->
                      let t21 = FStar_Syntax_Util.canon_app t2 in
-                     let uu___18 = ensure_no_uvar_subst env t21 wl1 in
-                     (match uu___18 with
+                     let uu___16 = ensure_no_uvar_subst env t21 wl1 in
+                     (match uu___16 with
                       | (t22, wl2) ->
                           let f1 = destruct_flex_t' t11 in
                           let f2 = destruct_flex_t' t22 in
@@ -9352,15 +9340,14 @@ and (solve_t' : tprob -> worklist -> solution) =
             | (FStar_Syntax_Syntax.Tm_app
                ({ FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_uvar uu___7;
                   FStar_Syntax_Syntax.pos = uu___8;
-                  FStar_Syntax_Syntax.vars = uu___9;
-                  FStar_Syntax_Syntax.hash_code = uu___10;_},
-                uu___11),
-               uu___12) when
+                  FStar_Syntax_Syntax.hash_code = uu___9;_},
+                uu___10),
+               uu___11) when
                 problem.FStar_TypeChecker_Common.relation =
                   FStar_TypeChecker_Common.EQ
                 ->
-                let uu___13 = destruct_flex_t t1 wl in
-                (match uu___13 with
+                let uu___12 = destruct_flex_t t1 wl in
+                (match uu___12 with
                  | (f1, wl1) -> solve_t_flex_rigid_eq orig wl1 f1 t2)
             | (uu___7, FStar_Syntax_Syntax.Tm_uvar uu___8) when
                 problem.FStar_TypeChecker_Common.relation =
@@ -9369,9 +9356,8 @@ and (solve_t' : tprob -> worklist -> solution) =
             | (uu___7, FStar_Syntax_Syntax.Tm_app
                ({ FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_uvar uu___8;
                   FStar_Syntax_Syntax.pos = uu___9;
-                  FStar_Syntax_Syntax.vars = uu___10;
-                  FStar_Syntax_Syntax.hash_code = uu___11;_},
-                uu___12)) when
+                  FStar_Syntax_Syntax.hash_code = uu___10;_},
+                uu___11)) when
                 problem.FStar_TypeChecker_Common.relation =
                   FStar_TypeChecker_Common.EQ
                 -> solve_t' (invert problem) wl
@@ -9403,10 +9389,9 @@ and (solve_t' : tprob -> worklist -> solution) =
             | (FStar_Syntax_Syntax.Tm_app
                ({ FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_uvar uu___7;
                   FStar_Syntax_Syntax.pos = uu___8;
-                  FStar_Syntax_Syntax.vars = uu___9;
-                  FStar_Syntax_Syntax.hash_code = uu___10;_},
-                uu___11),
-               FStar_Syntax_Syntax.Tm_arrow uu___12) ->
+                  FStar_Syntax_Syntax.hash_code = uu___9;_},
+                uu___10),
+               FStar_Syntax_Syntax.Tm_arrow uu___11) ->
                 solve_t'
                   {
                     FStar_TypeChecker_Common.pid =
@@ -9437,12 +9422,11 @@ and (solve_t' : tprob -> worklist -> solution) =
             | (uu___7, FStar_Syntax_Syntax.Tm_app
                ({ FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_uvar uu___8;
                   FStar_Syntax_Syntax.pos = uu___9;
-                  FStar_Syntax_Syntax.vars = uu___10;
-                  FStar_Syntax_Syntax.hash_code = uu___11;_},
-                uu___12)) ->
-                let uu___13 =
+                  FStar_Syntax_Syntax.hash_code = uu___10;_},
+                uu___11)) ->
+                let uu___12 =
                   attempt [FStar_TypeChecker_Common.TProb problem] wl in
-                solve uu___13
+                solve uu___12
             | (FStar_Syntax_Syntax.Tm_uvar uu___7, uu___8) ->
                 let uu___9 =
                   attempt [FStar_TypeChecker_Common.TProb problem] wl in
@@ -9450,13 +9434,12 @@ and (solve_t' : tprob -> worklist -> solution) =
             | (FStar_Syntax_Syntax.Tm_app
                ({ FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_uvar uu___7;
                   FStar_Syntax_Syntax.pos = uu___8;
-                  FStar_Syntax_Syntax.vars = uu___9;
-                  FStar_Syntax_Syntax.hash_code = uu___10;_},
-                uu___11),
-               uu___12) ->
-                let uu___13 =
+                  FStar_Syntax_Syntax.hash_code = uu___9;_},
+                uu___10),
+               uu___11) ->
+                let uu___12 =
                   attempt [FStar_TypeChecker_Common.TProb problem] wl in
-                solve uu___13
+                solve uu___12
             | (FStar_Syntax_Syntax.Tm_abs uu___7, uu___8) ->
                 let is_abs t =
                   match t.FStar_Syntax_Syntax.n with
@@ -14305,8 +14288,6 @@ let (check_implicit_solution_and_discharge_guard :
                                                })));
                                      FStar_Syntax_Syntax.pos =
                                        (imp_tm.FStar_Syntax_Syntax.pos);
-                                     FStar_Syntax_Syntax.vars =
-                                       (imp_tm.FStar_Syntax_Syntax.vars);
                                      FStar_Syntax_Syntax.hash_code =
                                        (imp_tm.FStar_Syntax_Syntax.hash_code)
                                    }

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_Tc.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_Tc.ml
@@ -817,55 +817,54 @@ let (tc_sig_let :
                     FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_arrow
                       (val_bs, c);
                     FStar_Syntax_Syntax.pos = r1;
-                    FStar_Syntax_Syntax.vars = uu___;
-                    FStar_Syntax_Syntax.hash_code = uu___1;_} ->
+                    FStar_Syntax_Syntax.hash_code = uu___;_} ->
                     let has_auto_name bv =
-                      let uu___2 =
+                      let uu___1 =
                         FStar_Ident.string_of_id
                           bv.FStar_Syntax_Syntax.ppname in
-                      FStar_Compiler_Util.starts_with uu___2
+                      FStar_Compiler_Util.starts_with uu___1
                         FStar_Ident.reserved_prefix in
                     let rec rename_binders def_bs1 val_bs1 =
                       match (def_bs1, val_bs1) with
-                      | ([], uu___2) -> val_bs1
-                      | (uu___2, []) -> val_bs1
+                      | ([], uu___1) -> val_bs1
+                      | (uu___1, []) -> val_bs1
                       | ({ FStar_Syntax_Syntax.binder_bv = body_bv;
-                           FStar_Syntax_Syntax.binder_qual = uu___2;
-                           FStar_Syntax_Syntax.binder_positivity = uu___3;
-                           FStar_Syntax_Syntax.binder_attrs = uu___4;_}::bt,
+                           FStar_Syntax_Syntax.binder_qual = uu___1;
+                           FStar_Syntax_Syntax.binder_positivity = uu___2;
+                           FStar_Syntax_Syntax.binder_attrs = uu___3;_}::bt,
                          val_b::vt) ->
-                          let uu___5 =
-                            let uu___6 =
-                              let uu___7 = has_auto_name body_bv in
-                              let uu___8 =
+                          let uu___4 =
+                            let uu___5 =
+                              let uu___6 = has_auto_name body_bv in
+                              let uu___7 =
                                 has_auto_name
                                   val_b.FStar_Syntax_Syntax.binder_bv in
-                              (uu___7, uu___8) in
-                            match uu___6 with
-                            | (true, uu___7) -> val_b
+                              (uu___6, uu___7) in
+                            match uu___5 with
+                            | (true, uu___6) -> val_b
                             | (false, true) ->
-                                let uu___7 =
-                                  let uu___8 =
+                                let uu___6 =
+                                  let uu___7 =
                                     val_b.FStar_Syntax_Syntax.binder_bv in
-                                  let uu___9 =
-                                    let uu___10 =
-                                      let uu___11 =
+                                  let uu___8 =
+                                    let uu___9 =
+                                      let uu___10 =
                                         FStar_Ident.string_of_id
                                           body_bv.FStar_Syntax_Syntax.ppname in
-                                      let uu___12 =
+                                      let uu___11 =
                                         FStar_Ident.range_of_id
                                           (val_b.FStar_Syntax_Syntax.binder_bv).FStar_Syntax_Syntax.ppname in
-                                      (uu___11, uu___12) in
-                                    FStar_Ident.mk_ident uu___10 in
+                                      (uu___10, uu___11) in
+                                    FStar_Ident.mk_ident uu___9 in
                                   {
-                                    FStar_Syntax_Syntax.ppname = uu___9;
+                                    FStar_Syntax_Syntax.ppname = uu___8;
                                     FStar_Syntax_Syntax.index =
-                                      (uu___8.FStar_Syntax_Syntax.index);
+                                      (uu___7.FStar_Syntax_Syntax.index);
                                     FStar_Syntax_Syntax.sort =
-                                      (uu___8.FStar_Syntax_Syntax.sort)
+                                      (uu___7.FStar_Syntax_Syntax.sort)
                                   } in
                                 {
-                                  FStar_Syntax_Syntax.binder_bv = uu___7;
+                                  FStar_Syntax_Syntax.binder_bv = uu___6;
                                   FStar_Syntax_Syntax.binder_qual =
                                     (val_b.FStar_Syntax_Syntax.binder_qual);
                                   FStar_Syntax_Syntax.binder_positivity =
@@ -874,14 +873,14 @@ let (tc_sig_let :
                                     (val_b.FStar_Syntax_Syntax.binder_attrs)
                                 }
                             | (false, false) -> val_b in
-                          let uu___6 = rename_binders bt vt in uu___5 ::
-                            uu___6 in
-                    let uu___2 =
-                      let uu___3 =
-                        let uu___4 = rename_binders def_bs val_bs in
-                        (uu___4, c) in
-                      FStar_Syntax_Syntax.Tm_arrow uu___3 in
-                    FStar_Syntax_Syntax.mk uu___2 r1
+                          let uu___5 = rename_binders bt vt in uu___4 ::
+                            uu___5 in
+                    let uu___1 =
+                      let uu___2 =
+                        let uu___3 = rename_binders def_bs val_bs in
+                        (uu___3, c) in
+                      FStar_Syntax_Syntax.Tm_arrow uu___2 in
+                    FStar_Syntax_Syntax.mk uu___1 r1
                 | uu___ -> typ1 in
               let uu___ =
                 rename_in_typ lb.FStar_Syntax_Syntax.lbdef
@@ -1239,8 +1238,6 @@ let (tc_sig_let :
                                                   }]), e2));
                                          FStar_Syntax_Syntax.pos =
                                            (e_lax.FStar_Syntax_Syntax.pos);
-                                         FStar_Syntax_Syntax.vars =
-                                           (e_lax.FStar_Syntax_Syntax.vars);
                                          FStar_Syntax_Syntax.hash_code =
                                            (e_lax.FStar_Syntax_Syntax.hash_code)
                                        }
@@ -1612,22 +1609,21 @@ let (tc_sig_let :
                                   FStar_Syntax_Syntax.n =
                                     FStar_Syntax_Syntax.Tm_let (lbs1, e2);
                                   FStar_Syntax_Syntax.pos = uu___5;
-                                  FStar_Syntax_Syntax.vars = uu___6;
-                                  FStar_Syntax_Syntax.hash_code = uu___7;_},
-                                uu___8, g) when
+                                  FStar_Syntax_Syntax.hash_code = uu___6;_},
+                                uu___7, g) when
                                  FStar_TypeChecker_Env.is_trivial g ->
                                  (FStar_Syntax_Util.check_mutual_universes
                                     (FStar_Pervasives_Native.snd lbs1);
                                   (let lbs2 =
-                                     let uu___10 =
+                                     let uu___9 =
                                        FStar_Compiler_Effect.op_Bar_Greater
                                          (FStar_Pervasives_Native.snd lbs1)
                                          (FStar_Compiler_List.map
                                             rename_parameters) in
                                      ((FStar_Pervasives_Native.fst lbs1),
-                                       uu___10) in
+                                       uu___9) in
                                    let lbs3 =
-                                     let uu___10 =
+                                     let uu___9 =
                                        match post_tau with
                                        | FStar_Pervasives_Native.Some tau ->
                                            FStar_Compiler_List.map
@@ -1637,17 +1633,17 @@ let (tc_sig_let :
                                        | FStar_Pervasives_Native.None ->
                                            FStar_Pervasives_Native.snd lbs2 in
                                      ((FStar_Pervasives_Native.fst lbs2),
-                                       uu___10) in
+                                       uu___9) in
                                    let quals1 =
                                      match e2.FStar_Syntax_Syntax.n with
                                      | FStar_Syntax_Syntax.Tm_meta
-                                         (uu___10,
+                                         (uu___9,
                                           FStar_Syntax_Syntax.Meta_desugared
                                           (FStar_Syntax_Syntax.Masked_effect))
                                          ->
                                          FStar_Syntax_Syntax.HasMaskedEffect
                                          :: quals
-                                     | uu___10 -> quals in
+                                     | uu___9 -> quals in
                                    ({
                                       FStar_Syntax_Syntax.sigel =
                                         (FStar_Syntax_Syntax.Sig_let
@@ -2365,8 +2361,7 @@ let (tc_decl' :
                           FStar_Syntax_Syntax.n =
                             FStar_Syntax_Syntax.Tm_unknown;
                           FStar_Syntax_Syntax.pos = uu___3;
-                          FStar_Syntax_Syntax.vars = uu___4;
-                          FStar_Syntax_Syntax.hash_code = uu___5;_} -> true
+                          FStar_Syntax_Syntax.hash_code = uu___4;_} -> true
                       | uu___3 -> false)
                  | uu___2 -> false in
                if is_unelaborated_dm4f

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_TcEffect.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_TcEffect.ml
@@ -4416,9 +4416,6 @@ let (tc_layered_eff_decl :
                                                       (uu___17.FStar_Syntax_Syntax.n);
                                                     FStar_Syntax_Syntax.pos =
                                                       uu___18;
-                                                    FStar_Syntax_Syntax.vars
-                                                      =
-                                                      (uu___17.FStar_Syntax_Syntax.vars);
                                                     FStar_Syntax_Syntax.hash_code
                                                       =
                                                       (uu___17.FStar_Syntax_Syntax.hash_code)
@@ -4611,9 +4608,6 @@ let (tc_layered_eff_decl :
                                                             (uu___19.FStar_Syntax_Syntax.n);
                                                           FStar_Syntax_Syntax.pos
                                                             = uu___20;
-                                                          FStar_Syntax_Syntax.vars
-                                                            =
-                                                            (uu___19.FStar_Syntax_Syntax.vars);
                                                           FStar_Syntax_Syntax.hash_code
                                                             =
                                                             (uu___19.FStar_Syntax_Syntax.hash_code)

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_TcInductive.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_TcInductive.ml
@@ -432,10 +432,8 @@ let (tc_data :
                                                            fv;
                                                          FStar_Syntax_Syntax.pos
                                                            = uu___9;
-                                                         FStar_Syntax_Syntax.vars
-                                                           = uu___10;
                                                          FStar_Syntax_Syntax.hash_code
-                                                           = uu___11;_},
+                                                           = uu___10;_},
                                                        tuvs)
                                                       when
                                                       FStar_Syntax_Syntax.fv_eq_lid
@@ -452,15 +450,15 @@ let (tc_data :
                                                           (fun g ->
                                                              fun u1 ->
                                                                fun u2 ->
-                                                                 let uu___12
+                                                                 let uu___11
                                                                    =
-                                                                   let uu___13
+                                                                   let uu___12
                                                                     =
                                                                     FStar_Syntax_Syntax.mk
                                                                     (FStar_Syntax_Syntax.Tm_type
                                                                     u1)
                                                                     FStar_Compiler_Range.dummyRange in
-                                                                   let uu___14
+                                                                   let uu___13
                                                                     =
                                                                     FStar_Syntax_Syntax.mk
                                                                     (FStar_Syntax_Syntax.Tm_type
@@ -469,10 +467,10 @@ let (tc_data :
                                                                     FStar_Compiler_Range.dummyRange in
                                                                    FStar_TypeChecker_Rel.teq
                                                                     env'1
-                                                                    uu___13
-                                                                    uu___14 in
+                                                                    uu___12
+                                                                    uu___13 in
                                                                  FStar_TypeChecker_Env.conj_guard
-                                                                   g uu___12)
+                                                                   g uu___11)
                                                           FStar_TypeChecker_Env.trivial_guard
                                                           tuvs _uvs1
                                                       else
@@ -1068,8 +1066,6 @@ let (get_optimized_haseq_axiom :
                        FStar_Syntax_Syntax.n = uu___2;
                        FStar_Syntax_Syntax.pos =
                          (fml.FStar_Syntax_Syntax.pos);
-                       FStar_Syntax_Syntax.vars =
-                         (fml.FStar_Syntax_Syntax.vars);
                        FStar_Syntax_Syntax.hash_code =
                          (fml.FStar_Syntax_Syntax.hash_code)
                      } in
@@ -1554,8 +1550,6 @@ let (unoptimized_haseq_ty :
                            FStar_Syntax_Syntax.n = uu___2;
                            FStar_Syntax_Syntax.pos =
                              (fml.FStar_Syntax_Syntax.pos);
-                           FStar_Syntax_Syntax.vars =
-                             (fml.FStar_Syntax_Syntax.vars);
                            FStar_Syntax_Syntax.hash_code =
                              (fml.FStar_Syntax_Syntax.hash_code)
                          } in

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_TcTerm.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_TcTerm.ml
@@ -381,9 +381,8 @@ let (maybe_warn_on_use :
                                FStar_Syntax_Syntax.Tm_constant
                                (FStar_Const.Const_string (s, uu___2));
                              FStar_Syntax_Syntax.pos = uu___3;
-                             FStar_Syntax_Syntax.vars = uu___4;
-                             FStar_Syntax_Syntax.hash_code = uu___5;_},
-                           uu___6)::[] ->
+                             FStar_Syntax_Syntax.hash_code = uu___4;_},
+                           uu___5)::[] ->
                             Prims.op_Hat m (Prims.op_Hat ": " s)
                         | uu___2 -> m in
                       (match head.FStar_Syntax_Syntax.n with
@@ -2501,7 +2500,30 @@ and (tc_maybe_toplevel_term :
                FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
                  (FStar_Const.Const_range_of);
                FStar_Syntax_Syntax.pos = uu___2;
-               FStar_Syntax_Syntax.vars = uu___3;
+               FStar_Syntax_Syntax.hash_code = uu___3;_},
+             a::hd::rest)
+            ->
+            let rest1 = hd :: rest in
+            let uu___4 = FStar_Syntax_Util.head_and_args top in
+            (match uu___4 with
+             | (unary_op, uu___5) ->
+                 let head =
+                   let uu___6 =
+                     FStar_Compiler_Range.union_ranges
+                       unary_op.FStar_Syntax_Syntax.pos
+                       (FStar_Pervasives_Native.fst a).FStar_Syntax_Syntax.pos in
+                   FStar_Syntax_Syntax.mk
+                     (FStar_Syntax_Syntax.Tm_app (unary_op, [a])) uu___6 in
+                 let t =
+                   FStar_Syntax_Syntax.mk
+                     (FStar_Syntax_Syntax.Tm_app (head, rest1))
+                     top.FStar_Syntax_Syntax.pos in
+                 tc_term env1 t)
+        | FStar_Syntax_Syntax.Tm_app
+            ({
+               FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
+                 (FStar_Const.Const_reify uu___2);
+               FStar_Syntax_Syntax.pos = uu___3;
                FStar_Syntax_Syntax.hash_code = uu___4;_},
              a::hd::rest)
             ->
@@ -2524,61 +2546,10 @@ and (tc_maybe_toplevel_term :
         | FStar_Syntax_Syntax.Tm_app
             ({
                FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
-                 (FStar_Const.Const_reify uu___2);
-               FStar_Syntax_Syntax.pos = uu___3;
-               FStar_Syntax_Syntax.vars = uu___4;
-               FStar_Syntax_Syntax.hash_code = uu___5;_},
-             a::hd::rest)
-            ->
-            let rest1 = hd :: rest in
-            let uu___6 = FStar_Syntax_Util.head_and_args top in
-            (match uu___6 with
-             | (unary_op, uu___7) ->
-                 let head =
-                   let uu___8 =
-                     FStar_Compiler_Range.union_ranges
-                       unary_op.FStar_Syntax_Syntax.pos
-                       (FStar_Pervasives_Native.fst a).FStar_Syntax_Syntax.pos in
-                   FStar_Syntax_Syntax.mk
-                     (FStar_Syntax_Syntax.Tm_app (unary_op, [a])) uu___8 in
-                 let t =
-                   FStar_Syntax_Syntax.mk
-                     (FStar_Syntax_Syntax.Tm_app (head, rest1))
-                     top.FStar_Syntax_Syntax.pos in
-                 tc_term env1 t)
-        | FStar_Syntax_Syntax.Tm_app
-            ({
-               FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
                  (FStar_Const.Const_reflect uu___2);
                FStar_Syntax_Syntax.pos = uu___3;
-               FStar_Syntax_Syntax.vars = uu___4;
-               FStar_Syntax_Syntax.hash_code = uu___5;_},
-             a::hd::rest)
-            ->
-            let rest1 = hd :: rest in
-            let uu___6 = FStar_Syntax_Util.head_and_args top in
-            (match uu___6 with
-             | (unary_op, uu___7) ->
-                 let head =
-                   let uu___8 =
-                     FStar_Compiler_Range.union_ranges
-                       unary_op.FStar_Syntax_Syntax.pos
-                       (FStar_Pervasives_Native.fst a).FStar_Syntax_Syntax.pos in
-                   FStar_Syntax_Syntax.mk
-                     (FStar_Syntax_Syntax.Tm_app (unary_op, [a])) uu___8 in
-                 let t =
-                   FStar_Syntax_Syntax.mk
-                     (FStar_Syntax_Syntax.Tm_app (head, rest1))
-                     top.FStar_Syntax_Syntax.pos in
-                 tc_term env1 t)
-        | FStar_Syntax_Syntax.Tm_app
-            ({
-               FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
-                 (FStar_Const.Const_set_range_of);
-               FStar_Syntax_Syntax.pos = uu___2;
-               FStar_Syntax_Syntax.vars = uu___3;
                FStar_Syntax_Syntax.hash_code = uu___4;_},
-             a1::a2::hd::rest)
+             a::hd::rest)
             ->
             let rest1 = hd :: rest in
             let uu___5 = FStar_Syntax_Util.head_and_args top in
@@ -2588,9 +2559,33 @@ and (tc_maybe_toplevel_term :
                    let uu___7 =
                      FStar_Compiler_Range.union_ranges
                        unary_op.FStar_Syntax_Syntax.pos
+                       (FStar_Pervasives_Native.fst a).FStar_Syntax_Syntax.pos in
+                   FStar_Syntax_Syntax.mk
+                     (FStar_Syntax_Syntax.Tm_app (unary_op, [a])) uu___7 in
+                 let t =
+                   FStar_Syntax_Syntax.mk
+                     (FStar_Syntax_Syntax.Tm_app (head, rest1))
+                     top.FStar_Syntax_Syntax.pos in
+                 tc_term env1 t)
+        | FStar_Syntax_Syntax.Tm_app
+            ({
+               FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
+                 (FStar_Const.Const_set_range_of);
+               FStar_Syntax_Syntax.pos = uu___2;
+               FStar_Syntax_Syntax.hash_code = uu___3;_},
+             a1::a2::hd::rest)
+            ->
+            let rest1 = hd :: rest in
+            let uu___4 = FStar_Syntax_Util.head_and_args top in
+            (match uu___4 with
+             | (unary_op, uu___5) ->
+                 let head =
+                   let uu___6 =
+                     FStar_Compiler_Range.union_ranges
+                       unary_op.FStar_Syntax_Syntax.pos
                        (FStar_Pervasives_Native.fst a1).FStar_Syntax_Syntax.pos in
                    FStar_Syntax_Syntax.mk
-                     (FStar_Syntax_Syntax.Tm_app (unary_op, [a1; a2])) uu___7 in
+                     (FStar_Syntax_Syntax.Tm_app (unary_op, [a1; a2])) uu___6 in
                  let t =
                    FStar_Syntax_Syntax.mk
                      (FStar_Syntax_Syntax.Tm_app (head, rest1))
@@ -2601,106 +2596,101 @@ and (tc_maybe_toplevel_term :
                FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
                  (FStar_Const.Const_range_of);
                FStar_Syntax_Syntax.pos = uu___2;
-               FStar_Syntax_Syntax.vars = uu___3;
-               FStar_Syntax_Syntax.hash_code = uu___4;_},
+               FStar_Syntax_Syntax.hash_code = uu___3;_},
              (e1, FStar_Pervasives_Native.None)::[])
             ->
-            let uu___5 =
-              let uu___6 =
-                let uu___7 = FStar_TypeChecker_Env.clear_expected_typ env1 in
+            let uu___4 =
+              let uu___5 =
+                let uu___6 = FStar_TypeChecker_Env.clear_expected_typ env1 in
                 FStar_Compiler_Effect.op_Less_Bar FStar_Pervasives_Native.fst
-                  uu___7 in
-              tc_term uu___6 e1 in
-            (match uu___5 with
+                  uu___6 in
+              tc_term uu___5 e1 in
+            (match uu___4 with
              | (e2, c, g) ->
-                 let uu___6 = FStar_Syntax_Util.head_and_args top in
-                 (match uu___6 with
-                  | (head, uu___7) ->
-                      let uu___8 =
+                 let uu___5 = FStar_Syntax_Util.head_and_args top in
+                 (match uu___5 with
+                  | (head, uu___6) ->
+                      let uu___7 =
                         FStar_Syntax_Syntax.mk
                           (FStar_Syntax_Syntax.Tm_app
                              (head, [(e2, FStar_Pervasives_Native.None)]))
                           top.FStar_Syntax_Syntax.pos in
-                      let uu___9 =
-                        let uu___10 =
-                          let uu___11 =
+                      let uu___8 =
+                        let uu___9 =
+                          let uu___10 =
                             FStar_Syntax_Syntax.tabbrev
                               FStar_Parser_Const.range_lid in
-                          FStar_Syntax_Syntax.mk_Total uu___11 in
+                          FStar_Syntax_Syntax.mk_Total uu___10 in
                         FStar_Compiler_Effect.op_Less_Bar
-                          FStar_TypeChecker_Common.lcomp_of_comp uu___10 in
-                      (uu___8, uu___9, g)))
+                          FStar_TypeChecker_Common.lcomp_of_comp uu___9 in
+                      (uu___7, uu___8, g)))
         | FStar_Syntax_Syntax.Tm_app
             ({
                FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
                  (FStar_Const.Const_set_range_of);
                FStar_Syntax_Syntax.pos = uu___2;
-               FStar_Syntax_Syntax.vars = uu___3;
-               FStar_Syntax_Syntax.hash_code = uu___4;_},
+               FStar_Syntax_Syntax.hash_code = uu___3;_},
              (t, FStar_Pervasives_Native.None)::(r,
                                                  FStar_Pervasives_Native.None)::[])
             ->
-            let uu___5 = FStar_Syntax_Util.head_and_args top in
-            (match uu___5 with
-             | (head, uu___6) ->
+            let uu___4 = FStar_Syntax_Util.head_and_args top in
+            (match uu___4 with
+             | (head, uu___5) ->
                  let env' =
-                   let uu___7 =
+                   let uu___6 =
                      FStar_Syntax_Syntax.tabbrev FStar_Parser_Const.range_lid in
-                   FStar_TypeChecker_Env.set_expected_typ env1 uu___7 in
-                 let uu___7 = tc_term env' r in
-                 (match uu___7 with
-                  | (er, uu___8, gr) ->
-                      let uu___9 = tc_term env1 t in
-                      (match uu___9 with
+                   FStar_TypeChecker_Env.set_expected_typ env1 uu___6 in
+                 let uu___6 = tc_term env' r in
+                 (match uu___6 with
+                  | (er, uu___7, gr) ->
+                      let uu___8 = tc_term env1 t in
+                      (match uu___8 with
                        | (t1, tt, gt) ->
                            let g = FStar_TypeChecker_Env.conj_guard gr gt in
-                           let uu___10 =
-                             let uu___11 =
-                               let uu___12 = FStar_Syntax_Syntax.as_arg t1 in
-                               let uu___13 =
-                                 let uu___14 = FStar_Syntax_Syntax.as_arg r in
-                                 [uu___14] in
-                               uu___12 :: uu___13 in
-                             FStar_Syntax_Syntax.mk_Tm_app head uu___11
+                           let uu___9 =
+                             let uu___10 =
+                               let uu___11 = FStar_Syntax_Syntax.as_arg t1 in
+                               let uu___12 =
+                                 let uu___13 = FStar_Syntax_Syntax.as_arg r in
+                                 [uu___13] in
+                               uu___11 :: uu___12 in
+                             FStar_Syntax_Syntax.mk_Tm_app head uu___10
                                top.FStar_Syntax_Syntax.pos in
-                           (uu___10, tt, g))))
+                           (uu___9, tt, g))))
         | FStar_Syntax_Syntax.Tm_app
             ({
                FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
                  (FStar_Const.Const_range_of);
                FStar_Syntax_Syntax.pos = uu___2;
-               FStar_Syntax_Syntax.vars = uu___3;
-               FStar_Syntax_Syntax.hash_code = uu___4;_},
-             uu___5)
+               FStar_Syntax_Syntax.hash_code = uu___3;_},
+             uu___4)
             ->
-            let uu___6 =
-              let uu___7 =
-                let uu___8 = FStar_Syntax_Print.term_to_string top in
-                FStar_Compiler_Util.format1 "Ill-applied constant %s" uu___8 in
-              (FStar_Errors_Codes.Fatal_IllAppliedConstant, uu___7) in
-            FStar_Errors.raise_error uu___6 e.FStar_Syntax_Syntax.pos
+            let uu___5 =
+              let uu___6 =
+                let uu___7 = FStar_Syntax_Print.term_to_string top in
+                FStar_Compiler_Util.format1 "Ill-applied constant %s" uu___7 in
+              (FStar_Errors_Codes.Fatal_IllAppliedConstant, uu___6) in
+            FStar_Errors.raise_error uu___5 e.FStar_Syntax_Syntax.pos
         | FStar_Syntax_Syntax.Tm_app
             ({
                FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
                  (FStar_Const.Const_set_range_of);
                FStar_Syntax_Syntax.pos = uu___2;
-               FStar_Syntax_Syntax.vars = uu___3;
-               FStar_Syntax_Syntax.hash_code = uu___4;_},
-             uu___5)
+               FStar_Syntax_Syntax.hash_code = uu___3;_},
+             uu___4)
             ->
-            let uu___6 =
-              let uu___7 =
-                let uu___8 = FStar_Syntax_Print.term_to_string top in
-                FStar_Compiler_Util.format1 "Ill-applied constant %s" uu___8 in
-              (FStar_Errors_Codes.Fatal_IllAppliedConstant, uu___7) in
-            FStar_Errors.raise_error uu___6 e.FStar_Syntax_Syntax.pos
+            let uu___5 =
+              let uu___6 =
+                let uu___7 = FStar_Syntax_Print.term_to_string top in
+                FStar_Compiler_Util.format1 "Ill-applied constant %s" uu___7 in
+              (FStar_Errors_Codes.Fatal_IllAppliedConstant, uu___6) in
+            FStar_Errors.raise_error uu___5 e.FStar_Syntax_Syntax.pos
         | FStar_Syntax_Syntax.Tm_app
             ({
                FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
                  (FStar_Const.Const_reify uu___2);
                FStar_Syntax_Syntax.pos = uu___3;
-               FStar_Syntax_Syntax.vars = uu___4;
-               FStar_Syntax_Syntax.hash_code = uu___5;_},
+               FStar_Syntax_Syntax.hash_code = uu___4;_},
              (e1, aqual)::[])
             ->
             (if FStar_Compiler_Option.isSome aqual
@@ -2709,39 +2699,39 @@ and (tc_maybe_toplevel_term :
                  (FStar_Errors_Codes.Warning_IrrelevantQualifierOnArgumentToReify,
                    "Qualifier on argument to reify is irrelevant and will be ignored")
              else ();
-             (let uu___7 = FStar_TypeChecker_Env.clear_expected_typ env1 in
-              match uu___7 with
-              | (env0, uu___8) ->
-                  let uu___9 = tc_term env0 e1 in
-                  (match uu___9 with
+             (let uu___6 = FStar_TypeChecker_Env.clear_expected_typ env1 in
+              match uu___6 with
+              | (env0, uu___7) ->
+                  let uu___8 = tc_term env0 e1 in
+                  (match uu___8 with
                    | (e2, c, g) ->
-                       let uu___10 =
-                         let uu___11 = FStar_TypeChecker_Common.lcomp_comp c in
-                         match uu___11 with
+                       let uu___9 =
+                         let uu___10 = FStar_TypeChecker_Common.lcomp_comp c in
+                         match uu___10 with
                          | (c1, g_c) ->
-                             let uu___12 =
+                             let uu___11 =
                                FStar_TypeChecker_Env.unfold_effect_abbrev
                                  env1 c1 in
-                             (uu___12, g_c) in
-                       (match uu___10 with
+                             (uu___11, g_c) in
+                       (match uu___9 with
                         | (c1, g_c) ->
-                            ((let uu___12 =
-                                let uu___13 =
+                            ((let uu___11 =
+                                let uu___12 =
                                   FStar_TypeChecker_Env.is_user_reifiable_effect
                                     env1 c1.FStar_Syntax_Syntax.effect_name in
-                                Prims.op_Negation uu___13 in
-                              if uu___12
+                                Prims.op_Negation uu___12 in
+                              if uu___11
                               then
-                                let uu___13 =
-                                  let uu___14 =
-                                    let uu___15 =
+                                let uu___12 =
+                                  let uu___13 =
+                                    let uu___14 =
                                       FStar_Ident.string_of_lid
                                         c1.FStar_Syntax_Syntax.effect_name in
                                     FStar_Compiler_Util.format1
-                                      "Effect %s cannot be reified" uu___15 in
+                                      "Effect %s cannot be reified" uu___14 in
                                   (FStar_Errors_Codes.Fatal_EffectCannotBeReified,
-                                    uu___14) in
-                                FStar_Errors.raise_error uu___13
+                                    uu___13) in
+                                FStar_Errors.raise_error uu___12
                                   e2.FStar_Syntax_Syntax.pos
                               else ());
                              (let u_c =
@@ -2752,19 +2742,19 @@ and (tc_maybe_toplevel_term :
                                   (FStar_Pervasives_Native.Some
                                      (c1.FStar_Syntax_Syntax.effect_name)) in
                               let repr =
-                                let uu___12 = FStar_Syntax_Syntax.mk_Comp c1 in
-                                FStar_TypeChecker_Env.reify_comp env1 uu___12
+                                let uu___11 = FStar_Syntax_Syntax.mk_Comp c1 in
+                                FStar_TypeChecker_Env.reify_comp env1 uu___11
                                   u_c in
                               let c2 =
-                                let uu___12 =
+                                let uu___11 =
                                   FStar_TypeChecker_Env.is_total_effect env1
                                     c1.FStar_Syntax_Syntax.effect_name in
-                                if uu___12
+                                if uu___11
                                 then
-                                  let uu___13 =
+                                  let uu___12 =
                                     FStar_Syntax_Syntax.mk_Total repr in
                                   FStar_Compiler_Effect.op_Bar_Greater
-                                    uu___13
+                                    uu___12
                                     FStar_TypeChecker_Common.lcomp_of_comp
                                 else
                                   (let ct =
@@ -2776,28 +2766,27 @@ and (tc_maybe_toplevel_term :
                                        FStar_Syntax_Syntax.effect_args = [];
                                        FStar_Syntax_Syntax.flags = []
                                      } in
-                                   let uu___14 =
+                                   let uu___13 =
                                      FStar_Syntax_Syntax.mk_Comp ct in
                                    FStar_Compiler_Effect.op_Bar_Greater
-                                     uu___14
+                                     uu___13
                                      FStar_TypeChecker_Common.lcomp_of_comp) in
-                              let uu___12 =
+                              let uu___11 =
                                 comp_check_expected_typ env1 e3 c2 in
-                              match uu___12 with
+                              match uu___11 with
                               | (e4, c3, g') ->
-                                  let uu___13 =
-                                    let uu___14 =
+                                  let uu___12 =
+                                    let uu___13 =
                                       FStar_TypeChecker_Env.conj_guard g_c g' in
                                     FStar_TypeChecker_Env.conj_guard g
-                                      uu___14 in
-                                  (e4, c3, uu___13)))))))
+                                      uu___13 in
+                                  (e4, c3, uu___12)))))))
         | FStar_Syntax_Syntax.Tm_app
             ({
                FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
                  (FStar_Const.Const_reflect l);
                FStar_Syntax_Syntax.pos = uu___2;
-               FStar_Syntax_Syntax.vars = uu___3;
-               FStar_Syntax_Syntax.hash_code = uu___4;_},
+               FStar_Syntax_Syntax.hash_code = uu___3;_},
              (e1, aqual)::[])
             ->
             (if FStar_Compiler_Option.isSome aqual
@@ -2806,50 +2795,50 @@ and (tc_maybe_toplevel_term :
                  (FStar_Errors_Codes.Warning_IrrelevantQualifierOnArgumentToReflect,
                    "Qualifier on argument to reflect is irrelevant and will be ignored")
              else ();
-             (let uu___7 =
-                let uu___8 =
+             (let uu___6 =
+                let uu___7 =
                   FStar_TypeChecker_Env.is_user_reflectable_effect env1 l in
-                Prims.op_Negation uu___8 in
-              if uu___7
+                Prims.op_Negation uu___7 in
+              if uu___6
               then
-                let uu___8 =
-                  let uu___9 =
-                    let uu___10 = FStar_Ident.string_of_lid l in
+                let uu___7 =
+                  let uu___8 =
+                    let uu___9 = FStar_Ident.string_of_lid l in
                     FStar_Compiler_Util.format1
-                      "Effect %s cannot be reflected" uu___10 in
-                  (FStar_Errors_Codes.Fatal_EffectCannotBeReified, uu___9) in
-                FStar_Errors.raise_error uu___8 e1.FStar_Syntax_Syntax.pos
+                      "Effect %s cannot be reflected" uu___9 in
+                  (FStar_Errors_Codes.Fatal_EffectCannotBeReified, uu___8) in
+                FStar_Errors.raise_error uu___7 e1.FStar_Syntax_Syntax.pos
               else ());
-             (let uu___7 = FStar_Syntax_Util.head_and_args top in
-              match uu___7 with
-              | (reflect_op, uu___8) ->
-                  let uu___9 = FStar_TypeChecker_Env.effect_decl_opt env1 l in
-                  (match uu___9 with
+             (let uu___6 = FStar_Syntax_Util.head_and_args top in
+              match uu___6 with
+              | (reflect_op, uu___7) ->
+                  let uu___8 = FStar_TypeChecker_Env.effect_decl_opt env1 l in
+                  (match uu___8 with
                    | FStar_Pervasives_Native.None ->
-                       let uu___10 =
-                         let uu___11 =
-                           let uu___12 = FStar_Ident.string_of_lid l in
+                       let uu___9 =
+                         let uu___10 =
+                           let uu___11 = FStar_Ident.string_of_lid l in
                            FStar_Compiler_Util.format1
-                             "Effect %s not found (for reflect)" uu___12 in
-                         (FStar_Errors_Codes.Fatal_EffectNotFound, uu___11) in
-                       FStar_Errors.raise_error uu___10
+                             "Effect %s not found (for reflect)" uu___11 in
+                         (FStar_Errors_Codes.Fatal_EffectNotFound, uu___10) in
+                       FStar_Errors.raise_error uu___9
                          e1.FStar_Syntax_Syntax.pos
                    | FStar_Pervasives_Native.Some (ed, qualifiers) ->
-                       let uu___10 =
+                       let uu___9 =
                          FStar_TypeChecker_Env.clear_expected_typ env1 in
-                       (match uu___10 with
-                        | (env_no_ex, uu___11) ->
-                            let uu___12 =
-                              let uu___13 = tc_tot_or_gtot_term env_no_ex e1 in
-                              match uu___13 with
+                       (match uu___9 with
+                        | (env_no_ex, uu___10) ->
+                            let uu___11 =
+                              let uu___12 = tc_tot_or_gtot_term env_no_ex e1 in
+                              match uu___12 with
                               | (e2, c, g) ->
-                                  ((let uu___15 =
-                                      let uu___16 =
+                                  ((let uu___14 =
+                                      let uu___15 =
                                         FStar_TypeChecker_Common.is_total_lcomp
                                           c in
                                       FStar_Compiler_Effect.op_Less_Bar
-                                        Prims.op_Negation uu___16 in
-                                    if uu___15
+                                        Prims.op_Negation uu___15 in
+                                    if uu___14
                                     then
                                       FStar_Errors.log_issue
                                         e2.FStar_Syntax_Syntax.pos
@@ -2857,26 +2846,26 @@ and (tc_maybe_toplevel_term :
                                           "Expected Tot, got a GTot computation")
                                     else ());
                                    (e2, c, g)) in
-                            (match uu___12 with
+                            (match uu___11 with
                              | (e2, c_e, g_e) ->
-                                 let uu___13 =
-                                   let uu___14 = FStar_Syntax_Util.type_u () in
-                                   match uu___14 with
+                                 let uu___12 =
+                                   let uu___13 = FStar_Syntax_Util.type_u () in
+                                   match uu___13 with
                                    | (a, u_a) ->
-                                       let uu___15 =
+                                       let uu___14 =
                                          FStar_TypeChecker_Util.new_implicit_var
                                            "tc_term reflect"
                                            e2.FStar_Syntax_Syntax.pos
                                            env_no_ex a in
-                                       (match uu___15 with
-                                        | (a_uvar, uu___16, g_a) ->
-                                            let uu___17 =
+                                       (match uu___14 with
+                                        | (a_uvar, uu___15, g_a) ->
+                                            let uu___16 =
                                               FStar_TypeChecker_Util.fresh_effect_repr_en
                                                 env_no_ex
                                                 e2.FStar_Syntax_Syntax.pos l
                                                 u_a a_uvar in
-                                            (uu___17, u_a, a_uvar, g_a)) in
-                                 (match uu___13 with
+                                            (uu___16, u_a, a_uvar, g_a)) in
+                                 (match uu___12 with
                                   | ((expected_repr_typ, g_repr), u_a, a,
                                      g_a) ->
                                       let g_eq =
@@ -2884,34 +2873,34 @@ and (tc_maybe_toplevel_term :
                                           c_e.FStar_TypeChecker_Common.res_typ
                                           expected_repr_typ in
                                       let eff_args =
-                                        let uu___14 =
-                                          let uu___15 =
+                                        let uu___13 =
+                                          let uu___14 =
                                             FStar_Syntax_Subst.compress
                                               expected_repr_typ in
-                                          uu___15.FStar_Syntax_Syntax.n in
-                                        match uu___14 with
+                                          uu___14.FStar_Syntax_Syntax.n in
+                                        match uu___13 with
                                         | FStar_Syntax_Syntax.Tm_app
-                                            (uu___15, uu___16::args) -> args
-                                        | uu___15 ->
-                                            let uu___16 =
-                                              let uu___17 =
-                                                let uu___18 =
+                                            (uu___14, uu___15::args) -> args
+                                        | uu___14 ->
+                                            let uu___15 =
+                                              let uu___16 =
+                                                let uu___17 =
                                                   FStar_Ident.string_of_lid l in
-                                                let uu___19 =
+                                                let uu___18 =
                                                   FStar_Syntax_Print.tag_of_term
                                                     expected_repr_typ in
-                                                let uu___20 =
+                                                let uu___19 =
                                                   FStar_Syntax_Print.term_to_string
                                                     expected_repr_typ in
                                                 FStar_Compiler_Util.format3
                                                   "Expected repr type for %s is not an application node (%s:%s)"
-                                                  uu___18 uu___19 uu___20 in
+                                                  uu___17 uu___18 uu___19 in
                                               (FStar_Errors_Codes.Fatal_UnexpectedEffect,
-                                                uu___17) in
-                                            FStar_Errors.raise_error uu___16
+                                                uu___16) in
+                                            FStar_Errors.raise_error uu___15
                                               top.FStar_Syntax_Syntax.pos in
                                       let c =
-                                        let uu___14 =
+                                        let uu___13 =
                                           FStar_Syntax_Syntax.mk_Comp
                                             {
                                               FStar_Syntax_Syntax.comp_univs
@@ -2926,16 +2915,16 @@ and (tc_maybe_toplevel_term :
                                               FStar_Syntax_Syntax.flags = []
                                             } in
                                         FStar_Compiler_Effect.op_Bar_Greater
-                                          uu___14
+                                          uu___13
                                           FStar_TypeChecker_Common.lcomp_of_comp in
                                       let e3 =
                                         FStar_Syntax_Syntax.mk
                                           (FStar_Syntax_Syntax.Tm_app
                                              (reflect_op, [(e2, aqual)]))
                                           top.FStar_Syntax_Syntax.pos in
-                                      let uu___14 =
+                                      let uu___13 =
                                         comp_check_expected_typ env1 e3 c in
-                                      (match uu___14 with
+                                      (match uu___13 with
                                        | (e4, c1, g') ->
                                            let e5 =
                                              FStar_Syntax_Syntax.mk
@@ -2945,10 +2934,10 @@ and (tc_maybe_toplevel_term :
                                                        ((c1.FStar_TypeChecker_Common.eff_name),
                                                          (c1.FStar_TypeChecker_Common.res_typ)))))
                                                e4.FStar_Syntax_Syntax.pos in
-                                           let uu___15 =
+                                           let uu___14 =
                                              FStar_TypeChecker_Env.conj_guards
                                                [g_e; g_repr; g_a; g_eq; g'] in
-                                           (e5, c1, uu___15))))))))
+                                           (e5, c1, uu___14))))))))
         | FStar_Syntax_Syntax.Tm_app
             ({
                FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar
@@ -2957,64 +2946,63 @@ and (tc_maybe_toplevel_term :
                    FStar_Syntax_Syntax.fv_qual = FStar_Pervasives_Native.Some
                      (FStar_Syntax_Syntax.Unresolved_constructor uc);_};
                FStar_Syntax_Syntax.pos = uu___4;
-               FStar_Syntax_Syntax.vars = uu___5;
-               FStar_Syntax_Syntax.hash_code = uu___6;_},
+               FStar_Syntax_Syntax.hash_code = uu___5;_},
              args)
             ->
-            let uu___7 =
-              let uu___8 =
+            let uu___6 =
+              let uu___7 =
                 if uc.FStar_Syntax_Syntax.uc_base_term
                 then
                   match args with
-                  | (b, uu___9)::rest ->
+                  | (b, uu___8)::rest ->
                       ((FStar_Pervasives_Native.Some b), rest)
-                  | uu___9 -> failwith "Impossible"
+                  | uu___8 -> failwith "Impossible"
                 else (FStar_Pervasives_Native.None, args) in
-              match uu___8 with
+              match uu___7 with
               | (base_term, fields) ->
-                  let uu___9 =
-                    let uu___10 =
+                  let uu___8 =
+                    let uu___9 =
                       FStar_Compiler_List.map FStar_Pervasives_Native.fst
                         fields in
                     FStar_Compiler_List.zip uc.FStar_Syntax_Syntax.uc_fields
-                      uu___10 in
-                  (base_term, uu___9) in
-            (match uu___7 with
+                      uu___9 in
+                  (base_term, uu___8) in
+            (match uu___6 with
              | (base_term, uc_fields) ->
-                 let uu___8 =
-                   let uu___9 = FStar_TypeChecker_Env.expected_typ env1 in
-                   match uu___9 with
-                   | FStar_Pervasives_Native.Some (t, uu___10) ->
-                       let uu___11 =
+                 let uu___7 =
+                   let uu___8 = FStar_TypeChecker_Env.expected_typ env1 in
+                   match uu___8 with
+                   | FStar_Pervasives_Native.Some (t, uu___9) ->
+                       let uu___10 =
                          FStar_TypeChecker_Util.find_record_or_dc_from_typ
                            env1 (FStar_Pervasives_Native.Some t) uc
                            top.FStar_Syntax_Syntax.pos in
-                       (uu___11,
+                       (uu___10,
                          (FStar_Pervasives_Native.Some
                             (FStar_Pervasives.Inl t)))
                    | FStar_Pervasives_Native.None ->
                        (match base_term with
                         | FStar_Pervasives_Native.Some e1 ->
-                            let uu___10 = tc_term env1 e1 in
-                            (match uu___10 with
-                             | (uu___11, lc, uu___12) ->
-                                 let uu___13 =
+                            let uu___9 = tc_term env1 e1 in
+                            (match uu___9 with
+                             | (uu___10, lc, uu___11) ->
+                                 let uu___12 =
                                    FStar_TypeChecker_Util.find_record_or_dc_from_typ
                                      env1
                                      (FStar_Pervasives_Native.Some
                                         (lc.FStar_TypeChecker_Common.res_typ))
                                      uc top.FStar_Syntax_Syntax.pos in
-                                 (uu___13,
+                                 (uu___12,
                                    (FStar_Pervasives_Native.Some
                                       (FStar_Pervasives.Inr
                                          (lc.FStar_TypeChecker_Common.res_typ)))))
                         | FStar_Pervasives_Native.None ->
-                            let uu___10 =
+                            let uu___9 =
                               FStar_TypeChecker_Util.find_record_or_dc_from_typ
                                 env1 FStar_Pervasives_Native.None uc
                                 top.FStar_Syntax_Syntax.pos in
-                            (uu___10, FStar_Pervasives_Native.None)) in
-                 (match uu___8 with
+                            (uu___9, FStar_Pervasives_Native.None)) in
+                 (match uu___7 with
                   | ((rdc, constrname, constructor), topt) ->
                       let rdc1 = rdc in
                       let constructor1 =
@@ -3031,10 +3019,10 @@ and (tc_maybe_toplevel_term :
                                  (constrname, i))
                           else FStar_Pervasives_Native.None in
                         let candidate =
-                          let uu___9 =
+                          let uu___8 =
                             FStar_Ident.set_lid_range projname
                               x.FStar_Syntax_Syntax.pos in
-                          FStar_Syntax_Syntax.fvar uu___9
+                          FStar_Syntax_Syntax.fvar uu___8
                             (FStar_Syntax_Syntax.Delta_equational_at_level
                                Prims.int_one) qual in
                         FStar_Syntax_Syntax.mk_Tm_app candidate
@@ -3046,9 +3034,9 @@ and (tc_maybe_toplevel_term :
                           (fun field_name ->
                              match base_term with
                              | FStar_Pervasives_Native.Some x ->
-                                 let uu___9 = mk_field_projector field_name x in
-                                 FStar_Pervasives_Native.Some uu___9
-                             | uu___9 -> FStar_Pervasives_Native.None)
+                                 let uu___8 = mk_field_projector field_name x in
+                                 FStar_Pervasives_Native.Some uu___8
+                             | uu___8 -> FStar_Pervasives_Native.None)
                           top.FStar_Syntax_Syntax.pos in
                       let args1 =
                         FStar_Compiler_List.map
@@ -3068,21 +3056,20 @@ and (tc_maybe_toplevel_term :
                    FStar_Syntax_Syntax.fv_qual = FStar_Pervasives_Native.Some
                      (FStar_Syntax_Syntax.Unresolved_projector candidate);_};
                FStar_Syntax_Syntax.pos = uu___4;
-               FStar_Syntax_Syntax.vars = uu___5;
-               FStar_Syntax_Syntax.hash_code = uu___6;_},
+               FStar_Syntax_Syntax.hash_code = uu___5;_},
              (e1, FStar_Pervasives_Native.None)::rest)
             ->
             let proceed_with choice =
               match choice with
               | FStar_Pervasives_Native.None ->
-                  let uu___7 =
-                    let uu___8 =
-                      let uu___9 = FStar_Ident.string_of_lid field_name in
+                  let uu___6 =
+                    let uu___7 =
+                      let uu___8 = FStar_Ident.string_of_lid field_name in
                       FStar_Compiler_Util.format1
-                        "Field name %s could not be resolved" uu___9 in
-                    (FStar_Errors_Codes.Fatal_IdentifierNotFound, uu___8) in
-                  let uu___8 = FStar_Ident.range_of_lid field_name in
-                  FStar_Errors.raise_error uu___7 uu___8
+                        "Field name %s could not be resolved" uu___8 in
+                    (FStar_Errors_Codes.Fatal_IdentifierNotFound, uu___7) in
+                  let uu___7 = FStar_Ident.range_of_lid field_name in
+                  FStar_Errors.raise_error uu___6 uu___7
               | FStar_Pervasives_Native.Some choice1 ->
                   let f = FStar_Syntax_Syntax.fv_to_tm choice1 in
                   let term =
@@ -3090,56 +3077,56 @@ and (tc_maybe_toplevel_term :
                       ((e1, FStar_Pervasives_Native.None) :: rest)
                       top.FStar_Syntax_Syntax.pos in
                   tc_term env1 term in
-            let uu___7 =
-              let uu___8 = FStar_TypeChecker_Env.clear_expected_typ env1 in
-              match uu___8 with | (env2, uu___9) -> tc_term env2 e1 in
-            (match uu___7 with
-             | (uu___8, lc, uu___9) ->
+            let uu___6 =
+              let uu___7 = FStar_TypeChecker_Env.clear_expected_typ env1 in
+              match uu___7 with | (env2, uu___8) -> tc_term env2 e1 in
+            (match uu___6 with
+             | (uu___7, lc, uu___8) ->
                  let t0 =
                    FStar_TypeChecker_Normalize.unfold_whnf'
                      [FStar_TypeChecker_Env.Unascribe;
                      FStar_TypeChecker_Env.Unmeta;
                      FStar_TypeChecker_Env.Unrefine] env1
                      lc.FStar_TypeChecker_Common.res_typ in
-                 let uu___10 = FStar_Syntax_Util.head_and_args t0 in
-                 (match uu___10 with
-                  | (thead, uu___11) ->
-                      ((let uu___13 =
+                 let uu___9 = FStar_Syntax_Util.head_and_args t0 in
+                 (match uu___9 with
+                  | (thead, uu___10) ->
+                      ((let uu___12 =
                           FStar_Compiler_Effect.op_Less_Bar
                             (FStar_TypeChecker_Env.debug env1)
                             (FStar_Options.Other "RFD") in
-                        if uu___13
+                        if uu___12
                         then
-                          let uu___14 =
+                          let uu___13 =
                             FStar_Syntax_Print.term_to_string
                               lc.FStar_TypeChecker_Common.res_typ in
-                          let uu___15 = FStar_Syntax_Print.term_to_string t0 in
-                          let uu___16 =
+                          let uu___14 = FStar_Syntax_Print.term_to_string t0 in
+                          let uu___15 =
                             FStar_Syntax_Print.term_to_string thead in
                           FStar_Compiler_Util.print3
                             "Got lc.res_typ=%s; t0 = %s; thead = %s\n"
-                            uu___14 uu___15 uu___16
+                            uu___13 uu___14 uu___15
                         else ());
-                       (let uu___13 =
-                          let uu___14 =
-                            let uu___15 = FStar_Syntax_Util.un_uinst thead in
-                            FStar_Syntax_Subst.compress uu___15 in
-                          uu___14.FStar_Syntax_Syntax.n in
-                        match uu___13 with
+                       (let uu___12 =
+                          let uu___13 =
+                            let uu___14 = FStar_Syntax_Util.un_uinst thead in
+                            FStar_Syntax_Subst.compress uu___14 in
+                          uu___13.FStar_Syntax_Syntax.n in
+                        match uu___12 with
                         | FStar_Syntax_Syntax.Tm_fvar type_name ->
-                            let uu___14 =
+                            let uu___13 =
                               FStar_TypeChecker_Util.try_lookup_record_type
                                 env1
                                 (type_name.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-                            (match uu___14 with
+                            (match uu___13 with
                              | FStar_Pervasives_Native.None ->
                                  proceed_with candidate
                              | FStar_Pervasives_Native.Some rdc ->
                                  let i =
                                    FStar_Compiler_List.tryFind
-                                     (fun uu___15 ->
-                                        match uu___15 with
-                                        | (i1, uu___16) ->
+                                     (fun uu___14 ->
+                                        match uu___14 with
+                                        | (i1, uu___15) ->
                                             FStar_TypeChecker_Util.field_name_matches
                                               field_name rdc i1)
                                      rdc.FStar_Syntax_DsEnv.fields in
@@ -3147,15 +3134,15 @@ and (tc_maybe_toplevel_term :
                                   | FStar_Pervasives_Native.None ->
                                       proceed_with candidate
                                   | FStar_Pervasives_Native.Some
-                                      (i1, uu___15) ->
+                                      (i1, uu___14) ->
                                       let constrname =
-                                        let uu___16 =
-                                          let uu___17 =
+                                        let uu___15 =
+                                          let uu___16 =
                                             FStar_Ident.ns_of_lid
                                               rdc.FStar_Syntax_DsEnv.typename in
-                                          FStar_Compiler_List.op_At uu___17
+                                          FStar_Compiler_List.op_At uu___16
                                             [rdc.FStar_Syntax_DsEnv.constrname] in
-                                        FStar_Ident.lid_of_ids uu___16 in
+                                        FStar_Ident.lid_of_ids uu___15 in
                                       let projname =
                                         FStar_Syntax_Util.mk_field_projector_name_from_ident
                                           constrname i1 in
@@ -3167,18 +3154,18 @@ and (tc_maybe_toplevel_term :
                                                (constrname, i1))
                                         else FStar_Pervasives_Native.None in
                                       let choice =
-                                        let uu___16 =
-                                          let uu___17 =
+                                        let uu___15 =
+                                          let uu___16 =
                                             FStar_Ident.range_of_lid
                                               field_name in
                                           FStar_Ident.set_lid_range projname
-                                            uu___17 in
-                                        FStar_Syntax_Syntax.lid_as_fv uu___16
+                                            uu___16 in
+                                        FStar_Syntax_Syntax.lid_as_fv uu___15
                                           (FStar_Syntax_Syntax.Delta_equational_at_level
                                              Prims.int_one) qual in
                                       proceed_with
                                         (FStar_Pervasives_Native.Some choice)))
-                        | uu___14 -> proceed_with candidate))))
+                        | uu___13 -> proceed_with candidate))))
         | FStar_Syntax_Syntax.Tm_app
             (head, (tau, FStar_Pervasives_Native.None)::[]) when
             (FStar_Syntax_Util.is_synth_by_tactic head) &&
@@ -3975,8 +3962,6 @@ and (tc_synth :
                                  FStar_Syntax_Syntax.n =
                                    (tau1.FStar_Syntax_Syntax.n);
                                  FStar_Syntax_Syntax.pos = rng;
-                                 FStar_Syntax_Syntax.vars =
-                                   (tau1.FStar_Syntax_Syntax.vars);
                                  FStar_Syntax_Syntax.hash_code =
                                    (tau1.FStar_Syntax_Syntax.hash_code)
                                } in
@@ -4262,17 +4247,16 @@ and (tc_value :
       | FStar_Syntax_Syntax.Tm_uinst
           ({ FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar fv;
              FStar_Syntax_Syntax.pos = uu___;
-             FStar_Syntax_Syntax.vars = uu___1;
-             FStar_Syntax_Syntax.hash_code = uu___2;_},
-           uu___3)
+             FStar_Syntax_Syntax.hash_code = uu___1;_},
+           uu___2)
           when
           (FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.synth_lid) &&
             (Prims.op_Negation env1.FStar_TypeChecker_Env.phase1)
           ->
-          let uu___4 = FStar_TypeChecker_Env.get_range env1 in
+          let uu___3 = FStar_TypeChecker_Env.get_range env1 in
           FStar_Errors.raise_error
             (FStar_Errors_Codes.Fatal_BadlyInstantiatedSynthByTactic,
-              "Badly instantiated synth_by_tactic") uu___4
+              "Badly instantiated synth_by_tactic") uu___3
       | FStar_Syntax_Syntax.Tm_fvar fv when
           (FStar_Syntax_Syntax.fv_eq_lid fv FStar_Parser_Const.synth_lid) &&
             (Prims.op_Negation env1.FStar_TypeChecker_Env.phase1)
@@ -4284,15 +4268,14 @@ and (tc_value :
       | FStar_Syntax_Syntax.Tm_uinst
           ({ FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar fv;
              FStar_Syntax_Syntax.pos = uu___;
-             FStar_Syntax_Syntax.vars = uu___1;
-             FStar_Syntax_Syntax.hash_code = uu___2;_},
+             FStar_Syntax_Syntax.hash_code = uu___1;_},
            us)
           ->
           let us1 = FStar_Compiler_List.map (tc_universe env1) us in
-          let uu___3 =
+          let uu___2 =
             FStar_TypeChecker_Env.lookup_lid env1
               (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-          (match uu___3 with
+          (match uu___2 with
            | ((us', t), range) ->
                let fv1 = FStar_Syntax_Syntax.set_range_of_fv fv range in
                (maybe_warn_on_use env1 fv1;
@@ -4300,54 +4283,54 @@ and (tc_value :
                   (FStar_Compiler_List.length us1) <>
                     (FStar_Compiler_List.length us')
                 then
-                  (let uu___6 =
-                     let uu___7 =
-                       let uu___8 = FStar_Syntax_Print.fv_to_string fv1 in
-                       let uu___9 =
+                  (let uu___5 =
+                     let uu___6 =
+                       let uu___7 = FStar_Syntax_Print.fv_to_string fv1 in
+                       let uu___8 =
                          FStar_Compiler_Util.string_of_int
                            (FStar_Compiler_List.length us1) in
-                       let uu___10 =
+                       let uu___9 =
                          FStar_Compiler_Util.string_of_int
                            (FStar_Compiler_List.length us') in
                        FStar_Compiler_Util.format3
                          "Unexpected number of universe instantiations for \"%s\" (%s vs %s)"
-                         uu___8 uu___9 uu___10 in
+                         uu___7 uu___8 uu___9 in
                      (FStar_Errors_Codes.Fatal_UnexpectedNumberOfUniverse,
-                       uu___7) in
-                   let uu___7 = FStar_TypeChecker_Env.get_range env1 in
-                   FStar_Errors.raise_error uu___6 uu___7)
+                       uu___6) in
+                   let uu___6 = FStar_TypeChecker_Env.get_range env1 in
+                   FStar_Errors.raise_error uu___5 uu___6)
                 else ();
                 FStar_Compiler_List.iter2
                   (fun ul ->
                      fun ur ->
                        match (ul, ur) with
-                       | (FStar_Syntax_Syntax.U_unif u'', uu___7) ->
+                       | (FStar_Syntax_Syntax.U_unif u'', uu___6) ->
                            FStar_Syntax_Unionfind.univ_change u'' ur
                        | (FStar_Syntax_Syntax.U_name n1,
                           FStar_Syntax_Syntax.U_name n2) when
                            FStar_Ident.ident_equals n1 n2 -> ()
-                       | uu___7 ->
-                           let uu___8 =
-                             let uu___9 =
-                               let uu___10 =
+                       | uu___6 ->
+                           let uu___7 =
+                             let uu___8 =
+                               let uu___9 =
                                  FStar_Syntax_Print.fv_to_string fv1 in
-                               let uu___11 =
+                               let uu___10 =
                                  FStar_Syntax_Print.univ_to_string ul in
-                               let uu___12 =
+                               let uu___11 =
                                  FStar_Syntax_Print.univ_to_string ur in
                                FStar_Compiler_Util.format3
                                  "Incompatible universe application for %s, expected %s got %s\n"
-                                 uu___10 uu___11 uu___12 in
+                                 uu___9 uu___10 uu___11 in
                              (FStar_Errors_Codes.Fatal_IncompatibleUniverse,
-                               uu___9) in
-                           let uu___9 = FStar_TypeChecker_Env.get_range env1 in
-                           FStar_Errors.raise_error uu___8 uu___9) us' us1;
+                               uu___8) in
+                           let uu___8 = FStar_TypeChecker_Env.get_range env1 in
+                           FStar_Errors.raise_error uu___7 uu___8) us' us1;
                 FStar_TypeChecker_Env.insert_fv_info env1 fv1 t;
                 (let e1 =
-                   let uu___8 =
+                   let uu___7 =
                      FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_fvar fv1)
                        e.FStar_Syntax_Syntax.pos in
-                   FStar_Syntax_Syntax.mk_Tm_uinst uu___8 us1 in
+                   FStar_Syntax_Syntax.mk_Tm_uinst uu___7 us1 in
                  check_instantiated_fvar env1 fv1.FStar_Syntax_Syntax.fv_name
                    fv1.FStar_Syntax_Syntax.fv_qual e1 t)))
       | FStar_Syntax_Syntax.Tm_uinst (uu___, us) ->
@@ -4420,8 +4403,6 @@ and (tc_value :
                                     (uu___5.FStar_Syntax_Syntax.n);
                                   FStar_Syntax_Syntax.pos =
                                     (top.FStar_Syntax_Syntax.pos);
-                                  FStar_Syntax_Syntax.vars =
-                                    (uu___5.FStar_Syntax_Syntax.vars);
                                   FStar_Syntax_Syntax.hash_code =
                                     (uu___5.FStar_Syntax_Syntax.hash_code)
                                 } in
@@ -4503,8 +4484,6 @@ and (tc_value :
                                           (uu___9.FStar_Syntax_Syntax.n);
                                         FStar_Syntax_Syntax.pos =
                                           (top.FStar_Syntax_Syntax.pos);
-                                        FStar_Syntax_Syntax.vars =
-                                          (uu___9.FStar_Syntax_Syntax.vars);
                                         FStar_Syntax_Syntax.hash_code =
                                           (uu___9.FStar_Syntax_Syntax.hash_code)
                                       } in
@@ -4536,7 +4515,6 @@ and (tc_value :
                       (FStar_Syntax_Syntax.Tm_abs
                          (bs1, body, FStar_Pervasives_Native.None));
                     FStar_Syntax_Syntax.pos = (top.FStar_Syntax_Syntax.pos);
-                    FStar_Syntax_Syntax.vars = (top.FStar_Syntax_Syntax.vars);
                     FStar_Syntax_Syntax.hash_code =
                       (top.FStar_Syntax_Syntax.hash_code)
                   } in
@@ -5057,20 +5035,19 @@ and (tc_abs_expected_function_typ :
                        FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_uvar
                          uu___1;
                        FStar_Syntax_Syntax.pos = uu___2;
-                       FStar_Syntax_Syntax.vars = uu___3;
-                       FStar_Syntax_Syntax.hash_code = uu___4;_},
-                     uu___5)
+                       FStar_Syntax_Syntax.hash_code = uu___3;_},
+                     uu___4)
                     ->
                     ((match env.FStar_TypeChecker_Env.letrecs with
                       | [] -> ()
-                      | uu___7 -> failwith "Impossible");
-                     (let uu___7 = tc_binders env bs in
-                      match uu___7 with
-                      | (bs1, envbody, g_env, uu___8) ->
-                          let uu___9 =
+                      | uu___6 -> failwith "Impossible");
+                     (let uu___6 = tc_binders env bs in
+                      match uu___6 with
+                      | (bs1, envbody, g_env, uu___7) ->
+                          let uu___8 =
                             FStar_TypeChecker_Env.clear_expected_typ envbody in
-                          (match uu___9 with
-                           | (envbody1, uu___10) ->
+                          (match uu___8 with
+                           | (envbody1, uu___9) ->
                                ((FStar_Pervasives_Native.Some t2), bs1, [],
                                  FStar_Pervasives_Native.None, envbody1,
                                  body, g_env))))
@@ -7505,90 +7482,89 @@ and (check_application_args :
                         FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_uvar
                           uu___2;
                         FStar_Syntax_Syntax.pos = uu___3;
-                        FStar_Syntax_Syntax.vars = uu___4;
-                        FStar_Syntax_Syntax.hash_code = uu___5;_},
-                      uu___6)
+                        FStar_Syntax_Syntax.hash_code = uu___4;_},
+                      uu___5)
                      ->
-                     let uu___7 =
+                     let uu___6 =
                        FStar_Compiler_List.fold_right
-                         (fun uu___8 ->
-                            fun uu___9 ->
-                              match uu___9 with
+                         (fun uu___7 ->
+                            fun uu___8 ->
+                              match uu___8 with
                               | (bs, guard1) ->
-                                  let uu___10 =
-                                    let uu___11 =
-                                      let uu___12 =
+                                  let uu___9 =
+                                    let uu___10 =
+                                      let uu___11 =
                                         FStar_Syntax_Util.type_u () in
                                       FStar_Compiler_Effect.op_Bar_Greater
-                                        uu___12 FStar_Pervasives_Native.fst in
+                                        uu___11 FStar_Pervasives_Native.fst in
                                     FStar_TypeChecker_Util.new_implicit_var
                                       "formal parameter"
-                                      tf.FStar_Syntax_Syntax.pos env uu___11 in
-                                  (match uu___10 with
-                                   | (t, uu___11, g) ->
-                                       let uu___12 =
-                                         let uu___13 =
+                                      tf.FStar_Syntax_Syntax.pos env uu___10 in
+                                  (match uu___9 with
+                                   | (t, uu___10, g) ->
+                                       let uu___11 =
+                                         let uu___12 =
                                            FStar_Syntax_Syntax.null_binder t in
-                                         uu___13 :: bs in
-                                       let uu___13 =
+                                         uu___12 :: bs in
+                                       let uu___12 =
                                          FStar_TypeChecker_Env.conj_guard g
                                            guard1 in
-                                       (uu___12, uu___13))) args ([], guard) in
-                     (match uu___7 with
+                                       (uu___11, uu___12))) args ([], guard) in
+                     (match uu___6 with
                       | (bs, guard1) ->
-                          let uu___8 =
-                            let uu___9 =
-                              let uu___10 =
-                                let uu___11 = FStar_Syntax_Util.type_u () in
-                                FStar_Compiler_Effect.op_Bar_Greater uu___11
+                          let uu___7 =
+                            let uu___8 =
+                              let uu___9 =
+                                let uu___10 = FStar_Syntax_Util.type_u () in
+                                FStar_Compiler_Effect.op_Bar_Greater uu___10
                                   FStar_Pervasives_Native.fst in
                               FStar_TypeChecker_Util.new_implicit_var
                                 "result type" tf.FStar_Syntax_Syntax.pos env
-                                uu___10 in
-                            match uu___9 with
-                            | (t, uu___10, g) ->
-                                let uu___11 = FStar_Options.ml_ish () in
-                                if uu___11
+                                uu___9 in
+                            match uu___8 with
+                            | (t, uu___9, g) ->
+                                let uu___10 = FStar_Options.ml_ish () in
+                                if uu___10
                                 then
-                                  let uu___12 = FStar_Syntax_Util.ml_comp t r in
-                                  let uu___13 =
+                                  let uu___11 = FStar_Syntax_Util.ml_comp t r in
+                                  let uu___12 =
                                     FStar_TypeChecker_Env.conj_guard guard1 g in
-                                  (uu___12, uu___13)
+                                  (uu___11, uu___12)
                                 else
-                                  (let uu___13 =
+                                  (let uu___12 =
                                      FStar_Syntax_Syntax.mk_Total t in
-                                   let uu___14 =
+                                   let uu___13 =
                                      FStar_TypeChecker_Env.conj_guard guard1
                                        g in
-                                   (uu___13, uu___14)) in
-                          (match uu___8 with
+                                   (uu___12, uu___13)) in
+                          (match uu___7 with
                            | (cres, guard2) ->
                                let bs_cres = FStar_Syntax_Util.arrow bs cres in
-                               ((let uu___10 =
+                               ((let uu___9 =
                                    FStar_Compiler_Effect.op_Less_Bar
                                      (FStar_TypeChecker_Env.debug env)
                                      FStar_Options.Extreme in
-                                 if uu___10
+                                 if uu___9
                                  then
-                                   let uu___11 =
+                                   let uu___10 =
                                      FStar_Syntax_Print.term_to_string head in
-                                   let uu___12 =
+                                   let uu___11 =
                                      FStar_Syntax_Print.term_to_string tf in
-                                   let uu___13 =
+                                   let uu___12 =
                                      FStar_Syntax_Print.term_to_string
                                        bs_cres in
                                    FStar_Compiler_Util.print3
                                      "Forcing the type of %s from %s to %s\n"
-                                     uu___11 uu___12 uu___13
+                                     uu___10 uu___11 uu___12
                                  else ());
                                 (let g =
-                                   let uu___10 =
+                                   let uu___9 =
                                      FStar_TypeChecker_Rel.teq env tf bs_cres in
                                    FStar_TypeChecker_Rel.solve_deferred_constraints
-                                     env uu___10 in
-                                 let uu___10 =
+                                     env uu___9 in
+                                 let uu___9 =
                                    FStar_TypeChecker_Env.conj_guard g guard2 in
-                                 check_function_app bs_cres uu___10))))
+                                 check_function_app bs_cres uu___9))))
                  | FStar_Syntax_Syntax.Tm_arrow (bs, c) ->
                      let uu___2 = FStar_Syntax_Subst.open_comp bs c in
                      (match uu___2 with
@@ -7741,8 +7717,7 @@ and (tc_pat :
                      ({
                         FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar f;
                         FStar_Syntax_Syntax.pos = uu___2;
-                        FStar_Syntax_Syntax.vars = uu___3;
-                        FStar_Syntax_Syntax.hash_code = uu___4;_},
+                        FStar_Syntax_Syntax.hash_code = uu___3;_},
                       us)
                      -> unfold_once t1 f us args
                  | FStar_Syntax_Syntax.Tm_fvar f -> unfold_once t1 f [] args
@@ -7824,30 +7799,29 @@ and (tc_pat :
                     FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar
                       uu___3;
                     FStar_Syntax_Syntax.pos = uu___4;
-                    FStar_Syntax_Syntax.vars = uu___5;
-                    FStar_Syntax_Syntax.hash_code = uu___6;_} ->
-                    let uu___7 = FStar_Syntax_Util.head_and_args pat_t2 in
-                    (match uu___7 with
+                    FStar_Syntax_Syntax.hash_code = uu___5;_} ->
+                    let uu___6 = FStar_Syntax_Util.head_and_args pat_t2 in
+                    (match uu___6 with
                      | (head_p, args_p) ->
-                         let uu___8 =
+                         let uu___7 =
                            FStar_TypeChecker_Rel.teq_nosmt_force env1 head_p
                              head_s in
-                         if uu___8
+                         if uu___7
                          then
-                           let uu___9 =
-                             let uu___10 = FStar_Syntax_Util.un_uinst head_p in
-                             uu___10.FStar_Syntax_Syntax.n in
-                           (match uu___9 with
+                           let uu___8 =
+                             let uu___9 = FStar_Syntax_Util.un_uinst head_p in
+                             uu___9.FStar_Syntax_Syntax.n in
+                           (match uu___8 with
                             | FStar_Syntax_Syntax.Tm_fvar f ->
-                                ((let uu___11 =
-                                    let uu___12 =
-                                      let uu___13 =
+                                ((let uu___10 =
+                                    let uu___11 =
+                                      let uu___12 =
                                         FStar_Syntax_Syntax.lid_of_fv f in
                                       FStar_TypeChecker_Env.is_type_constructor
-                                        env1 uu___13 in
+                                        env1 uu___12 in
                                     FStar_Compiler_Effect.op_Less_Bar
-                                      Prims.op_Negation uu___12 in
-                                  if uu___11
+                                      Prims.op_Negation uu___11 in
+                                  if uu___10
                                   then
                                     fail1
                                       "Pattern matching a non-inductive type"
@@ -7857,53 +7831,53 @@ and (tc_pat :
                                      (FStar_Compiler_List.length args_s)
                                  then fail1 ""
                                  else ();
-                                 (let uu___12 =
-                                    let uu___13 =
-                                      let uu___14 =
+                                 (let uu___11 =
+                                    let uu___12 =
+                                      let uu___13 =
                                         FStar_Syntax_Syntax.lid_of_fv f in
                                       FStar_TypeChecker_Env.num_inductive_ty_params
-                                        env1 uu___14 in
-                                    match uu___13 with
+                                        env1 uu___13 in
+                                    match uu___12 with
                                     | FStar_Pervasives_Native.None ->
                                         (args_p, args_s)
                                     | FStar_Pervasives_Native.Some n ->
-                                        let uu___14 =
+                                        let uu___13 =
                                           FStar_Compiler_Util.first_N n
                                             args_p in
-                                        (match uu___14 with
-                                         | (params_p, uu___15) ->
-                                             let uu___16 =
+                                        (match uu___13 with
+                                         | (params_p, uu___14) ->
+                                             let uu___15 =
                                                FStar_Compiler_Util.first_N n
                                                  args_s in
-                                             (match uu___16 with
-                                              | (params_s, uu___17) ->
+                                             (match uu___15 with
+                                              | (params_s, uu___16) ->
                                                   (params_p, params_s))) in
-                                  match uu___12 with
+                                  match uu___11 with
                                   | (params_p, params_s) ->
                                       FStar_Compiler_List.fold_left2
                                         (fun out ->
-                                           fun uu___13 ->
-                                             fun uu___14 ->
-                                               match (uu___13, uu___14) with
-                                               | ((p, uu___15), (s, uu___16))
+                                           fun uu___12 ->
+                                             fun uu___13 ->
+                                               match (uu___12, uu___13) with
+                                               | ((p, uu___14), (s, uu___15))
                                                    ->
-                                                   let uu___17 =
+                                                   let uu___16 =
                                                      FStar_TypeChecker_Rel.teq_nosmt
                                                        env1 p s in
-                                                   (match uu___17 with
+                                                   (match uu___16 with
                                                     | FStar_Pervasives_Native.None
                                                         ->
-                                                        let uu___18 =
-                                                          let uu___19 =
+                                                        let uu___17 =
+                                                          let uu___18 =
                                                             FStar_Syntax_Print.term_to_string
                                                               p in
-                                                          let uu___20 =
+                                                          let uu___19 =
                                                             FStar_Syntax_Print.term_to_string
                                                               s in
                                                           FStar_Compiler_Util.format2
                                                             "; parameter %s <> parameter %s"
-                                                            uu___19 uu___20 in
-                                                        fail1 uu___18
+                                                            uu___18 uu___19 in
+                                                        fail1 uu___17
                                                     | FStar_Pervasives_Native.Some
                                                         g ->
                                                         let g1 =
@@ -7913,17 +7887,17 @@ and (tc_pat :
                                                           g1 out))
                                         FStar_TypeChecker_Env.trivial_guard
                                         params_p params_s))
-                            | uu___10 ->
+                            | uu___9 ->
                                 fail1 "Pattern matching a non-inductive type")
                          else
-                           (let uu___10 =
-                              let uu___11 =
+                           (let uu___9 =
+                              let uu___10 =
                                 FStar_Syntax_Print.term_to_string head_p in
-                              let uu___12 =
+                              let uu___11 =
                                 FStar_Syntax_Print.term_to_string head_s in
                               FStar_Compiler_Util.format2
-                                "; head mismatch %s vs %s" uu___11 uu___12 in
-                            fail1 uu___10))
+                                "; head mismatch %s vs %s" uu___10 uu___11 in
+                            fail1 uu___9))
                 | uu___3 ->
                     let uu___4 =
                       FStar_TypeChecker_Rel.teq_nosmt env1 pat_t2 scrutinee_t in
@@ -7944,44 +7918,43 @@ and (tc_pat :
                       FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar
                         uu___1;
                       FStar_Syntax_Syntax.pos = uu___2;
-                      FStar_Syntax_Syntax.vars = uu___3;
-                      FStar_Syntax_Syntax.hash_code = uu___4;_},
-                    uu___5)
+                      FStar_Syntax_Syntax.hash_code = uu___3;_},
+                    uu___4)
                    ->
-                   let uu___6 =
+                   let uu___5 =
                      match head.FStar_Syntax_Syntax.n with
                      | FStar_Syntax_Syntax.Tm_uinst (head1, us) ->
-                         let uu___7 = head1.FStar_Syntax_Syntax.n in
-                         (match uu___7 with
+                         let uu___6 = head1.FStar_Syntax_Syntax.n in
+                         (match uu___6 with
                           | FStar_Syntax_Syntax.Tm_fvar f ->
                               let res =
                                 FStar_TypeChecker_Env.try_lookup_and_inst_lid
                                   env1 us
                                   (f.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
                               (match res with
-                               | FStar_Pervasives_Native.Some (t, uu___8)
+                               | FStar_Pervasives_Native.Some (t, uu___7)
                                    when
                                    FStar_TypeChecker_Env.is_datacon env1
                                      (f.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v
                                    -> (head1, (us, t))
-                               | uu___8 ->
-                                   let uu___9 =
-                                     let uu___10 =
+                               | uu___7 ->
+                                   let uu___8 =
+                                     let uu___9 =
                                        FStar_Ident.string_of_lid
                                          (f.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
                                      FStar_Compiler_Util.format1
                                        "Could not find constructor: %s"
-                                       uu___10 in
-                                   fail uu___9))
+                                       uu___9 in
+                                   fail uu___8))
                      | FStar_Syntax_Syntax.Tm_fvar f ->
-                         let uu___7 =
+                         let uu___6 =
                            FStar_TypeChecker_Env.lookup_datacon env1
                              (f.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-                         (head, uu___7) in
-                   (match uu___6 with
+                         (head, uu___6) in
+                   (match uu___5 with
                     | (head1, (us, t_f)) ->
-                        let uu___7 = FStar_Syntax_Util.arrow_formals t_f in
-                        (match uu___7 with
+                        let uu___6 = FStar_Syntax_Util.arrow_formals t_f in
+                        (match uu___6 with
                          | (formals, t) ->
                              let erasable =
                                FStar_TypeChecker_Env.non_informative env1 t in
@@ -7992,8 +7965,8 @@ and (tc_pat :
                                 fail
                                   "Pattern is not a fully-applied data constructor"
                               else ();
-                              (let rec aux uu___9 formals1 args1 =
-                                 match uu___9 with
+                              (let rec aux uu___8 formals1 args1 =
+                                 match uu___8 with
                                  | (subst, args_out, bvs, guard) ->
                                      (match (formals1, args1) with
                                       | ([], []) ->
@@ -8004,27 +7977,27 @@ and (tc_pat :
                                             FStar_Syntax_Syntax.mk_Tm_app
                                               head2 args_out
                                               e.FStar_Syntax_Syntax.pos in
-                                          let uu___10 =
+                                          let uu___9 =
                                             FStar_Syntax_Subst.subst subst t in
-                                          (pat_e, uu___10, bvs, guard,
+                                          (pat_e, uu___9, bvs, guard,
                                             erasable)
                                       | ({ FStar_Syntax_Syntax.binder_bv = f;
                                            FStar_Syntax_Syntax.binder_qual =
-                                             uu___10;
+                                             uu___9;
                                            FStar_Syntax_Syntax.binder_positivity
-                                             = uu___11;
+                                             = uu___10;
                                            FStar_Syntax_Syntax.binder_attrs =
-                                             uu___12;_}::formals2,
+                                             uu___11;_}::formals2,
                                          (a, imp_a)::args2) ->
                                           let t_f1 =
                                             FStar_Syntax_Subst.subst subst
                                               f.FStar_Syntax_Syntax.sort in
-                                          let uu___13 =
-                                            let uu___14 =
-                                              let uu___15 =
+                                          let uu___12 =
+                                            let uu___13 =
+                                              let uu___14 =
                                                 FStar_Syntax_Subst.compress a in
-                                              uu___15.FStar_Syntax_Syntax.n in
-                                            match uu___14 with
+                                              uu___14.FStar_Syntax_Syntax.n in
+                                            match uu___13 with
                                             | FStar_Syntax_Syntax.Tm_name x
                                                 ->
                                                 let x1 =
@@ -8050,51 +8023,51 @@ and (tc_pat :
                                                      bvs [x1]),
                                                   FStar_TypeChecker_Env.trivial_guard)
                                             | FStar_Syntax_Syntax.Tm_uvar
-                                                uu___15 ->
+                                                uu___14 ->
                                                 let use_eq = true in
                                                 let env2 =
                                                   FStar_TypeChecker_Env.set_expected_typ_maybe_eq
                                                     env1 t_f1 use_eq in
-                                                let uu___16 =
+                                                let uu___15 =
                                                   tc_tot_or_gtot_term_maybe_solve_deferred
                                                     env2 a "" false in
-                                                (match uu___16 with
-                                                 | (a1, uu___17, g) ->
+                                                (match uu___15 with
+                                                 | (a1, uu___16, g) ->
                                                      let subst1 =
                                                        (FStar_Syntax_Syntax.NT
                                                           (f, a1))
                                                        :: subst in
                                                      ((a1, imp_a), subst1,
                                                        bvs, g))
-                                            | uu___15 ->
+                                            | uu___14 ->
                                                 let a1 =
                                                   FStar_Syntax_Subst.subst
                                                     subst a in
                                                 let env2 =
                                                   FStar_TypeChecker_Env.set_expected_typ
                                                     env1 t_f1 in
-                                                let uu___16 =
+                                                let uu___15 =
                                                   tc_tot_or_gtot_term env2 a1 in
-                                                (match uu___16 with
-                                                 | (a2, uu___17, g) ->
+                                                (match uu___15 with
+                                                 | (a2, uu___16, g) ->
                                                      let subst1 =
                                                        (FStar_Syntax_Syntax.NT
                                                           (f, a2))
                                                        :: subst in
                                                      ((a2, imp_a), subst1,
                                                        bvs, g)) in
-                                          (match uu___13 with
+                                          (match uu___12 with
                                            | (a1, subst1, bvs1, g) ->
-                                               let uu___14 =
-                                                 let uu___15 =
+                                               let uu___13 =
+                                                 let uu___14 =
                                                    FStar_TypeChecker_Env.conj_guard
                                                      g guard in
                                                  (subst1,
                                                    (FStar_Compiler_List.op_At
                                                       args_out [a1]), bvs1,
-                                                   uu___15) in
-                                               aux uu___14 formals2 args2)
-                                      | uu___10 ->
+                                                   uu___14) in
+                                               aux uu___13 formals2 args2)
+                                      | uu___9 ->
                                           fail "Not a fully applied pattern") in
                                aux
                                  ([], [], [],
@@ -12302,49 +12275,48 @@ let rec (universe_of_aux :
       | FStar_Syntax_Syntax.Tm_uinst
           ({ FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar fv;
              FStar_Syntax_Syntax.pos = uu___1;
-             FStar_Syntax_Syntax.vars = uu___2;
-             FStar_Syntax_Syntax.hash_code = uu___3;_},
+             FStar_Syntax_Syntax.hash_code = uu___2;_},
            us)
           ->
-          let uu___4 =
+          let uu___3 =
             FStar_TypeChecker_Env.lookup_lid env
               (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-          (match uu___4 with
-           | ((us', t), uu___5) ->
+          (match uu___3 with
+           | ((us', t), uu___4) ->
                (if
                   (FStar_Compiler_List.length us) <>
                     (FStar_Compiler_List.length us')
                 then
-                  (let uu___7 = FStar_TypeChecker_Env.get_range env in
+                  (let uu___6 = FStar_TypeChecker_Env.get_range env in
                    FStar_Errors.raise_error
                      (FStar_Errors_Codes.Fatal_UnexpectedNumberOfUniverse,
-                       "Unexpected number of universe instantiations") uu___7)
+                       "Unexpected number of universe instantiations") uu___6)
                 else ();
                 FStar_Compiler_List.iter2
                   (fun ul ->
                      fun ur ->
                        match (ul, ur) with
-                       | (FStar_Syntax_Syntax.U_unif u'', uu___8) ->
+                       | (FStar_Syntax_Syntax.U_unif u'', uu___7) ->
                            FStar_Syntax_Unionfind.univ_change u'' ur
                        | (FStar_Syntax_Syntax.U_name n1,
                           FStar_Syntax_Syntax.U_name n2) when
                            FStar_Ident.ident_equals n1 n2 -> ()
-                       | uu___8 ->
-                           let uu___9 =
-                             let uu___10 =
-                               let uu___11 =
+                       | uu___7 ->
+                           let uu___8 =
+                             let uu___9 =
+                               let uu___10 =
                                  FStar_Syntax_Print.fv_to_string fv in
-                               let uu___12 =
+                               let uu___11 =
                                  FStar_Syntax_Print.univ_to_string ul in
-                               let uu___13 =
+                               let uu___12 =
                                  FStar_Syntax_Print.univ_to_string ur in
                                FStar_Compiler_Util.format3
                                  "Incompatible universe application for %s, expected %s got %s\n"
-                                 uu___11 uu___12 uu___13 in
+                                 uu___10 uu___11 uu___12 in
                              (FStar_Errors_Codes.Fatal_IncompatibleUniverse,
-                               uu___10) in
-                           let uu___10 = FStar_TypeChecker_Env.get_range env in
-                           FStar_Errors.raise_error uu___9 uu___10) us' us;
+                               uu___9) in
+                           let uu___9 = FStar_TypeChecker_Env.get_range env in
+                           FStar_Errors.raise_error uu___8 uu___9) us' us;
                 t))
       | FStar_Syntax_Syntax.Tm_uinst uu___1 ->
           failwith "Impossible: Tm_uinst's head must be an fvar"
@@ -12730,21 +12702,20 @@ let rec (__typeof_tot_or_gtot_term_fastpath :
                FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
                  (FStar_Const.Const_range_of);
                FStar_Syntax_Syntax.pos = uu___;
-               FStar_Syntax_Syntax.vars = uu___1;
-               FStar_Syntax_Syntax.hash_code = uu___2;_},
+               FStar_Syntax_Syntax.hash_code = uu___1;_},
              a::hd::rest)
             ->
             let rest1 = hd :: rest in
-            let uu___3 = FStar_Syntax_Util.head_and_args t1 in
-            (match uu___3 with
-             | (unary_op, uu___4) ->
+            let uu___2 = FStar_Syntax_Util.head_and_args t1 in
+            (match uu___2 with
+             | (unary_op, uu___3) ->
                  let head =
-                   let uu___5 =
+                   let uu___4 =
                      FStar_Compiler_Range.union_ranges
                        unary_op.FStar_Syntax_Syntax.pos
                        (FStar_Pervasives_Native.fst a).FStar_Syntax_Syntax.pos in
                    FStar_Syntax_Syntax.mk
-                     (FStar_Syntax_Syntax.Tm_app (unary_op, [a])) uu___5 in
+                     (FStar_Syntax_Syntax.Tm_app (unary_op, [a])) uu___4 in
                  let t2 =
                    FStar_Syntax_Syntax.mk
                      (FStar_Syntax_Syntax.Tm_app (head, rest1))
@@ -12755,21 +12726,20 @@ let rec (__typeof_tot_or_gtot_term_fastpath :
                FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
                  (FStar_Const.Const_set_range_of);
                FStar_Syntax_Syntax.pos = uu___;
-               FStar_Syntax_Syntax.vars = uu___1;
-               FStar_Syntax_Syntax.hash_code = uu___2;_},
+               FStar_Syntax_Syntax.hash_code = uu___1;_},
              a1::a2::hd::rest)
             ->
             let rest1 = hd :: rest in
-            let uu___3 = FStar_Syntax_Util.head_and_args t1 in
-            (match uu___3 with
-             | (unary_op, uu___4) ->
+            let uu___2 = FStar_Syntax_Util.head_and_args t1 in
+            (match uu___2 with
+             | (unary_op, uu___3) ->
                  let head =
-                   let uu___5 =
+                   let uu___4 =
                      FStar_Compiler_Range.union_ranges
                        unary_op.FStar_Syntax_Syntax.pos
                        (FStar_Pervasives_Native.fst a1).FStar_Syntax_Syntax.pos in
                    FStar_Syntax_Syntax.mk
-                     (FStar_Syntax_Syntax.Tm_app (unary_op, [a1; a2])) uu___5 in
+                     (FStar_Syntax_Syntax.Tm_app (unary_op, [a1; a2])) uu___4 in
                  let t2 =
                    FStar_Syntax_Syntax.mk
                      (FStar_Syntax_Syntax.Tm_app (head, rest1))
@@ -12780,18 +12750,16 @@ let rec (__typeof_tot_or_gtot_term_fastpath :
                FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
                  (FStar_Const.Const_range_of);
                FStar_Syntax_Syntax.pos = uu___;
-               FStar_Syntax_Syntax.vars = uu___1;
-               FStar_Syntax_Syntax.hash_code = uu___2;_},
-             uu___3::[])
+               FStar_Syntax_Syntax.hash_code = uu___1;_},
+             uu___2::[])
             -> FStar_Pervasives_Native.Some FStar_Syntax_Syntax.t_range
         | FStar_Syntax_Syntax.Tm_app
             ({
                FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_constant
                  (FStar_Const.Const_set_range_of);
                FStar_Syntax_Syntax.pos = uu___;
-               FStar_Syntax_Syntax.vars = uu___1;
-               FStar_Syntax_Syntax.hash_code = uu___2;_},
-             (t2, uu___3)::uu___4::[])
+               FStar_Syntax_Syntax.hash_code = uu___1;_},
+             (t2, uu___2)::uu___3::[])
             -> __typeof_tot_or_gtot_term_fastpath env t2 must_tot
         | FStar_Syntax_Syntax.Tm_app (hd, args) ->
             let t_hd = __typeof_tot_or_gtot_term_fastpath env hd must_tot in

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_Util.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_Util.ml
@@ -292,8 +292,6 @@ let (extract_let_rec_annotation :
                                     (FStar_Syntax_Syntax.Tm_meta (e'1, m));
                                   FStar_Syntax_Syntax.pos =
                                     (e3.FStar_Syntax_Syntax.pos);
-                                  FStar_Syntax_Syntax.vars =
-                                    (e3.FStar_Syntax_Syntax.vars);
                                   FStar_Syntax_Syntax.hash_code =
                                     (e3.FStar_Syntax_Syntax.hash_code)
                                 }, recheck))
@@ -324,8 +322,6 @@ let (extract_let_rec_annotation :
                                     FStar_Syntax_Syntax.n = uu___8;
                                     FStar_Syntax_Syntax.pos =
                                       (e3.FStar_Syntax_Syntax.pos);
-                                    FStar_Syntax_Syntax.vars =
-                                      (e3.FStar_Syntax_Syntax.vars);
                                     FStar_Syntax_Syntax.hash_code =
                                       (e3.FStar_Syntax_Syntax.hash_code)
                                   } in
@@ -359,8 +355,6 @@ let (extract_let_rec_annotation :
                                            use_eq), lopt));
                                   FStar_Syntax_Syntax.pos =
                                     (e3.FStar_Syntax_Syntax.pos);
-                                  FStar_Syntax_Syntax.vars =
-                                    (e3.FStar_Syntax_Syntax.vars);
                                   FStar_Syntax_Syntax.hash_code =
                                     (e3.FStar_Syntax_Syntax.hash_code)
                                 } in
@@ -393,8 +387,6 @@ let (extract_let_rec_annotation :
                                                   (body', m));
                                              FStar_Syntax_Syntax.pos =
                                                (body3.FStar_Syntax_Syntax.pos);
-                                             FStar_Syntax_Syntax.vars =
-                                               (body3.FStar_Syntax_Syntax.vars);
                                              FStar_Syntax_Syntax.hash_code =
                                                (body3.FStar_Syntax_Syntax.hash_code)
                                            } in
@@ -468,9 +460,6 @@ let (extract_let_rec_annotation :
                                                      FStar_Syntax_Syntax.pos
                                                        =
                                                        (body2.FStar_Syntax_Syntax.pos);
-                                                     FStar_Syntax_Syntax.vars
-                                                       =
-                                                       (body2.FStar_Syntax_Syntax.vars);
                                                      FStar_Syntax_Syntax.hash_code
                                                        =
                                                        (body2.FStar_Syntax_Syntax.hash_code)
@@ -5423,9 +5412,8 @@ let (weaken_result_typ :
                                   FStar_Syntax_Syntax.n =
                                     FStar_Syntax_Syntax.Tm_fvar fv;
                                   FStar_Syntax_Syntax.pos = uu___7;
-                                  FStar_Syntax_Syntax.vars = uu___8;
-                                  FStar_Syntax_Syntax.hash_code = uu___9;_},
-                                uu___10)
+                                  FStar_Syntax_Syntax.hash_code = uu___8;_},
+                                uu___9)
                                when
                                FStar_Syntax_Syntax.fv_eq_lid fv
                                  FStar_Parser_Const.true_lid

--- a/ocaml/fstar-tests/generated/FStar_Tests_Util.ml
+++ b/ocaml/fstar-tests/generated/FStar_Tests_Util.ml
@@ -168,19 +168,17 @@ let rec (term_eq' :
       | (FStar_Syntax_Syntax.Tm_app
          ({ FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar fv_eq_1;
             FStar_Syntax_Syntax.pos = uu___;
-            FStar_Syntax_Syntax.vars = uu___1;
-            FStar_Syntax_Syntax.hash_code = uu___2;_},
-          (uu___3, FStar_Pervasives_Native.Some
+            FStar_Syntax_Syntax.hash_code = uu___1;_},
+          (uu___2, FStar_Pervasives_Native.Some
            { FStar_Syntax_Syntax.aqual_implicit = true;
-             FStar_Syntax_Syntax.aqual_attributes = uu___4;_})::t12::t22::[]),
+             FStar_Syntax_Syntax.aqual_attributes = uu___3;_})::t12::t22::[]),
          FStar_Syntax_Syntax.Tm_app
          ({ FStar_Syntax_Syntax.n = FStar_Syntax_Syntax.Tm_fvar fv_eq_2;
-            FStar_Syntax_Syntax.pos = uu___5;
-            FStar_Syntax_Syntax.vars = uu___6;
-            FStar_Syntax_Syntax.hash_code = uu___7;_},
-          (uu___8, FStar_Pervasives_Native.Some
+            FStar_Syntax_Syntax.pos = uu___4;
+            FStar_Syntax_Syntax.hash_code = uu___5;_},
+          (uu___6, FStar_Pervasives_Native.Some
            { FStar_Syntax_Syntax.aqual_implicit = true;
-             FStar_Syntax_Syntax.aqual_attributes = uu___9;_})::s1::s2::[]))
+             FStar_Syntax_Syntax.aqual_attributes = uu___7;_})::s1::s2::[]))
           when
           (FStar_Syntax_Syntax.fv_eq_lid fv_eq_1 FStar_Parser_Const.eq2_lid)
             &&

--- a/src/syntax/FStar.Syntax.Syntax.fst
+++ b/src/syntax/FStar.Syntax.Syntax.fst
@@ -120,7 +120,6 @@ let list_of_freenames (fvs:freenames) = Util.set_elements fvs
 let mk (t:'a) r = {
     n=t;
     pos=r;
-    vars=Util.mk_ref None;
     hash_code=Util.mk_ref None;
 }
 

--- a/src/syntax/FStar.Syntax.Syntax.fsti
+++ b/src/syntax/FStar.Syntax.Syntax.fsti
@@ -324,7 +324,6 @@ and freenames = set bv
 and syntax 'a = {
     n:'a;
     pos:Range.range;
-    vars:memo free_vars;
     hash_code:memo FStar.Hash.hash_code
 }
 and bv = {


### PR DESCRIPTION
A look at a memory profile suggested that `Syntax.mk` was allocating much of the memory to. One particular overhead it has is creating a fresh memo reference for the free variables of the term, which are memoized at every node. This change removes that memoization, which does result in less memory being used. It also seems to be _faster_, see the graphs below:

![compact_time](https://user-images.githubusercontent.com/4195583/233515377-520e2cc0-b13a-4dc3-aaa2-47ba6e6b1890.png)
![compact_mem](https://user-images.githubusercontent.com/4195583/233515381-fc4432f7-589d-46f0-b567-0d91ef0afdd5.png)


This graph was obtained by setting OCaml's `Gc.max_overhead` to zero to trigger frequent heap compactions. With this setting it's not clear that the speed improvement would carry over to a normal setting, as less allocations means less GC and therefore a *lot* less compactions, which are expensive. But I re-ran the test without that setting, and it seems similar:


![nocompact_time](https://user-images.githubusercontent.com/4195583/233515386-deeba959-0c50-409d-8a9b-1daccc9bf0e2.png)
![nocompact_mem](https://user-images.githubusercontent.com/4195583/233515387-750da728-14ff-46ed-963c-d2acfc32bf98.png)

