### PR TITLE
Introducing an `admit_termination` attribute

### DIFF
--- a/ocaml/fstar-lib/generated/FStar_Parser_Const.ml
+++ b/ocaml/fstar-lib/generated/FStar_Parser_Const.ml
@@ -321,6 +321,8 @@ let (binder_unused_attr : FStar_Ident.lident) = psconst "unused"
 let (no_auto_projectors_attr : FStar_Ident.lident) =
   psconst "no_auto_projectors"
 let (no_subtping_attr_lid : FStar_Ident.lident) = psconst "no_subtyping"
+let (admit_termination_lid : FStar_Ident.lident) =
+  psconst "admit_termination"
 let (attr_substitute_lid : FStar_Ident.lident) =
   p2l ["FStar"; "Pervasives"; "Substitute"]
 let (well_founded_relation_lid : FStar_Ident.lident) =

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_Tc.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_Tc.ml
@@ -950,14 +950,12 @@ let (tc_sig_let :
                                        r
                                    else ();
                                    (let uu___5 =
-                                      let uu___6 =
-                                        let uu___7 =
-                                          FStar_Parser_Const.effect_ALL_lid
-                                            () in
+                                      FStar_Syntax_Syntax.mk_lb
                                         ((FStar_Pervasives.Inr lbname), uvs,
-                                          uu___7, tval, def, [],
+                                          FStar_Parser_Const.effect_Tot_lid,
+                                          tval, def,
+                                          (lb.FStar_Syntax_Syntax.lbattrs),
                                           (lb.FStar_Syntax_Syntax.lbpos)) in
-                                      FStar_Syntax_Syntax.mk_lb uu___6 in
                                     (false, uu___5, quals_opt1))) in
                             (match uu___2 with
                              | (gen1, lb1, quals_opt1) ->

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_TcTerm.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_TcTerm.ml
@@ -10851,7 +10851,7 @@ and (build_let_rec_env :
     fun env ->
       fun lbs ->
         let env0 = env in
-        let termination_check_enabled lbname lbdef lbtyp =
+        let termination_check_enabled attrs lbname lbdef lbtyp =
           let uu___ = FStar_Options.ml_ish () in
           if uu___
           then FStar_Pervasives_Native.None
@@ -10893,21 +10893,38 @@ and (build_let_rec_env :
                        else ();
                        (let nformals = FStar_Compiler_List.length formals in
                         let uu___5 =
-                          let uu___6 =
-                            FStar_Compiler_Effect.op_Bar_Greater
-                              (FStar_Syntax_Util.comp_effect_name c)
-                              (FStar_TypeChecker_Env.lookup_effect_quals env) in
-                          FStar_Compiler_Effect.op_Bar_Greater uu___6
-                            (FStar_Compiler_List.contains
-                               FStar_Syntax_Syntax.TotalEffect) in
+                          FStar_Syntax_Util.has_attribute attrs
+                            FStar_Parser_Const.admit_termination_lid in
                         if uu___5
                         then
-                          let uu___6 =
-                            let uu___7 =
-                              FStar_Syntax_Util.abs actuals1 body body_lc in
-                            (nformals, uu___7) in
-                          FStar_Pervasives_Native.Some uu___6
-                        else FStar_Pervasives_Native.None)))) in
+                          ((let uu___7 =
+                              let uu___8 =
+                                let uu___9 =
+                                  FStar_Syntax_Print.lbname_to_string lbname in
+                                Prims.op_Hat "Admitting termination of "
+                                  uu___9 in
+                              (FStar_Errors_Codes.Warning_WarnOnUse, uu___8) in
+                            FStar_Errors.log_issue
+                              env.FStar_TypeChecker_Env.range uu___7);
+                           FStar_Pervasives_Native.None)
+                        else
+                          (let uu___7 =
+                             let uu___8 =
+                               FStar_Compiler_Effect.op_Bar_Greater
+                                 (FStar_Syntax_Util.comp_effect_name c)
+                                 (FStar_TypeChecker_Env.lookup_effect_quals
+                                    env) in
+                             FStar_Compiler_Effect.op_Bar_Greater uu___8
+                               (FStar_Compiler_List.contains
+                                  FStar_Syntax_Syntax.TotalEffect) in
+                           if uu___7
+                           then
+                             let uu___8 =
+                               let uu___9 =
+                                 FStar_Syntax_Util.abs actuals1 body body_lc in
+                               (nformals, uu___9) in
+                             FStar_Pervasives_Native.Some uu___8
+                           else FStar_Pervasives_Native.None))))) in
         let check_annot univ_vars t =
           let env01 = FStar_TypeChecker_Env.push_univ_vars env0 univ_vars in
           let uu___ =
@@ -11053,6 +11070,7 @@ and (build_let_rec_env :
                                let uu___4 =
                                  let uu___5 =
                                    termination_check_enabled
+                                     lb.FStar_Syntax_Syntax.lbattrs
                                      lb.FStar_Syntax_Syntax.lbname lbdef
                                      lbtyp1 in
                                  match uu___5 with

--- a/src/parser/FStar.Parser.Const.fst
+++ b/src/parser/FStar.Parser.Const.fst
@@ -359,6 +359,7 @@ let binder_strictly_positive_attr = psconst "strictly_positive"
 let binder_unused_attr = psconst "unused"
 let no_auto_projectors_attr = psconst "no_auto_projectors"
 let no_subtping_attr_lid = psconst "no_subtyping"
+let admit_termination_lid = psconst "admit_termination"
 let attr_substitute_lid = p2l ["FStar"; "Pervasives"; "Substitute"]
 
 

--- a/src/tosyntax/FStar.ToSyntax.ToSyntax.fst
+++ b/src/tosyntax/FStar.ToSyntax.ToSyntax.fst
@@ -3493,7 +3493,7 @@ and desugar_decl_aux env (d: decl): (env_t * sigelts) =
       let d = { d with attrs = [] } in
       let errs, r = Errors.catch_errors (fun () ->
                       Options.with_saved_options (fun () ->
-                        desugar_decl_noattrs env d)) in
+                        desugar_decl_noattrs attrs env d)) in
       begin match errs, r with
       | [], Some (env, ses) ->
         (* Succeeded desugaring, carry on, but make a Sig_fail *)
@@ -3529,7 +3529,7 @@ and desugar_decl_aux env (d: decl): (env_t * sigelts) =
         end
       end
     | None ->
-      desugar_decl_noattrs env d
+      desugar_decl_noattrs attrs env d
   in
 
   let rec val_attrs (ses:list sigelt) : list S.term =
@@ -3549,7 +3549,7 @@ and desugar_decl env (d:decl) :(env_t * sigelts) =
   let env, ses = desugar_decl_aux env d in
   env, ses |> List.map generalize_annotated_univs
 
-and desugar_decl_noattrs env (d:decl) : (env_t * sigelts) =
+and desugar_decl_noattrs top_attrs env (d:decl) : (env_t * sigelts) =
   let trans_qual = trans_qual d.drange in
   match d.d with
   | Pragma p ->
@@ -3729,6 +3729,13 @@ and desugar_decl_noattrs env (d:decl) : (env_t * sigelts) =
                 fvs
                 ([], [])
           in
+          (* Propagate top-level attrs to each lb. The lb.lbattrs field should be empty,
+           * but just being safe here. *)
+          let lbs =
+            let (isrec, lbs0) = lbs in
+            let lbs0 = lbs0 |> List.map (fun lb -> { lb with lbattrs = lb.lbattrs @ val_attrs @ top_attrs }) in
+            (isrec, lbs0)
+          in
           // BU.print3 "Desugaring %s, val_quals are %s, val_attrs are %s\n"
           //   (List.map Print.fv_to_string fvs |> String.concat ", ")
           //   (Print.quals_to_string val_quals)
@@ -3745,19 +3752,11 @@ and desugar_decl_noattrs env (d:decl) : (env_t * sigelts) =
             then S.Logic::quals
             else quals in
           let names = fvs |> List.map (fun fv -> fv.fv_name.v) in
-          (*
-           * AR: we first desugar the term with no attributes and then add attributes in the end, see desugar_decl above
-           *     this used to be fine, because subsequent typechecker then works on terms that have attributes
-           *     however this doesn't work if we want access to the attributes during desugaring, e.g. when warning about deprecated defns.
-           *     for now, adding attrs to Sig_let to make progress on the deprecated warning, but perhaps we should add attrs to all terms
-           *)
-          let attrs = List.map (desugar_term env) d.attrs in
-          (* GM: Plus the val attrs, concatenated below *)
           let s = { sigel = Sig_let(lbs, names);
                     sigquals = quals;
                     sigrng = d.drange;
-                    sigmeta = default_sigmeta  ;
-                    sigattrs = val_attrs @ attrs;
+                    sigmeta = default_sigmeta;
+                    sigattrs = val_attrs @ top_attrs;
                     sigopts = None; } in
           let env = push_sigelt env s in
           env, [s]

--- a/src/typechecker/FStar.TypeChecker.Tc.fst
+++ b/src/typechecker/FStar.TypeChecker.Tc.fst
@@ -425,7 +425,7 @@ let tc_sig_let env r se lbs lids : list sigelt * list sigelt * Env.env =
               if lb.lbunivs <> [] && List.length lb.lbunivs <> List.length uvs
               then raise_error (Errors.Fatal_IncoherentInlineUniverse, ("Inline universes are incoherent with annotation from val declaration")) r;
               false, //explicit annotation provided; do not generalize
-              mk_lb (Inr lbname, uvs, PC.effect_ALL_lid(), tval, def, [], lb.lbpos),
+              mk_lb (Inr lbname, uvs, PC.effect_ALL_lid(), tval, def, lb.lbattrs, lb.lbpos),
               quals_opt
           in
           gen, lb::lbs, quals_opt)

--- a/src/typechecker/FStar.TypeChecker.Tc.fst
+++ b/src/typechecker/FStar.TypeChecker.Tc.fst
@@ -425,7 +425,7 @@ let tc_sig_let env r se lbs lids : list sigelt * list sigelt * Env.env =
               if lb.lbunivs <> [] && List.length lb.lbunivs <> List.length uvs
               then raise_error (Errors.Fatal_IncoherentInlineUniverse, ("Inline universes are incoherent with annotation from val declaration")) r;
               false, //explicit annotation provided; do not generalize
-              mk_lb (Inr lbname, uvs, PC.effect_ALL_lid(), tval, def, lb.lbattrs, lb.lbpos),
+              mk_lb (Inr lbname, uvs, PC.effect_Tot_lid, tval, def, lb.lbattrs, lb.lbpos),
               quals_opt
           in
           gen, lb::lbs, quals_opt)

--- a/tests/micro-benchmarks/AdmitTermination.fst
+++ b/tests/micro-benchmarks/AdmitTermination.fst
@@ -1,0 +1,20 @@
+module AdmitTermination
+
+// blah not used recursively, silence
+#set-options "--warn_error -328"
+
+[@@admit_termination]
+let rec blah () = ()
+and f (x:int) : int = f x
+
+[@@admit_termination]
+let rec g (x:int) : int = g x
+
+val h : int -> int
+[@@admit_termination]
+let rec h (x:int) : int = h x
+
+[@@admit_termination]
+val i : int -> int
+
+let rec i (x:int) : int = i x

--- a/tests/micro-benchmarks/AdmitTermination.fst
+++ b/tests/micro-benchmarks/AdmitTermination.fst
@@ -4,6 +4,14 @@ module AdmitTermination
 #set-options "--warn_error -328"
 
 [@@admit_termination]
+let rec f1 (x:nat) : nat = f1 x
+
+(* Even admitting termination, this is not type
+correct. *)
+[@@expect_failure [19]; admit_termination]
+let rec f2 (x:nat) : nat = f2 x - 1
+
+[@@admit_termination]
 let rec blah () = ()
 and f (x:int) : int = f x
 
@@ -18,3 +26,40 @@ let rec h (x:int) : int = h x
 val i : int -> int
 
 let rec i (x:int) : int = i x
+
+let top1 () =
+  let rec blah () = ()
+  [@@admit_termination]
+  and f (x:int) : int = f x
+  in ()
+
+(* This admits the termination of blah, not of f! *)
+[@@expect_failure [19]]
+let top2 () =
+  [@@admit_termination]
+  let rec blah () = ()
+  and f (x:int) : int = f x
+  in ()
+
+(* Note that the admit_termination attribute applies to
+*calls* to the admitted binding, and not the definition
+of the binding. The difference is significant in mutual
+recursion, see ahead. *)
+
+(* Works: the body of f respects the termination argument
+for g. Since we admit the termination of f, the body of g
+has no obligation, and verifies. *)
+let top3 () =
+  [@@admit_termination]
+  let rec f (x:pos) : int = g (x-1)
+  and g (x:nat) : int = f (x+1)
+  in ()
+
+(* Fails: the body of g does not respect the termination
+argument for f, which is not admitted. *)
+[@@expect_failure [19]]
+let top4 () =
+  let rec f (x:pos) : int = g (x-1)
+  [@@admit_termination]
+  and g (x:nat) : int = f (x+1)
+  in ()

--- a/ulib/FStar.Pervasives.fst
+++ b/ulib/FStar.Pervasives.fst
@@ -182,4 +182,6 @@ let no_auto_projectors = ()
 
 let no_subtyping = ()
 
+let admit_termination = ()
+
 let singleton #_ x = x

--- a/ulib/FStar.Pervasives.fsti
+++ b/ulib/FStar.Pervasives.fsti
@@ -1163,6 +1163,8 @@ val no_auto_projectors : unit
 *)
 val no_subtyping : unit
 
+val admit_termination : unit
+
 (** Pure and ghost inner let bindings are now always inlined during
     the wp computation, if: the return type is not unit and the head
     symbol is not marked irreducible.


### PR DESCRIPTION
Currently, I don't think we have a good way of working on a total function while disregarding its termination. This can be useful when the termination is non-trivial (although perhaps evident to a human) so we want to postpone its proof, but without `admit`ing anything else in the function. (This is exactly my reason to add it, working on some big lemma over reflected syntax.)

This PR then introduces an attribute `admit_termination` that can be used to disable termination checking for a given letbinding, by not refining its domain with a precedes relation (as if it were in a non-total effect). So this works:
```f*
[@@admit_termination]
let rec f (x:nat) = f x
```
But this does not:
```f*
[@@expect_failure [19]; admit_termination]
let rec f2 (x:nat) : nat = f2 x - 1
// Subtyping check failed; expected type Prims.nat; got type Prims.int; The SMT solver could not prove the query.
```

The attribute can actually be attached to individual letbindings in a recursive group, not necessarily the entire group, see this:
```f*
let top1 () =
  let rec blah () = ()
  [@@admit_termination]
  and f (x:int) : int = f x
  in ()

(* This admits the termination of blah, not of f! *)
[@@expect_failure [19]]
let top2 () =
  [@@admit_termination]
  let rec blah () = ()
  and f (x:int) : int = f x
  in ()

(* Note that the admit_termination attribute applies to
*calls* to the admitted binding, and not the definition
of the binding. The difference is significant in mutual
recursion, see ahead. *)

(* Works: the body of f respects the termination argument
for g. Since we admit the termination of f, the body of g
has no obligation, and verifies. *)
let top3 () =
  [@@admit_termination]
  let rec f (x:pos) : int = g (x-1)
  and g (x:nat) : int = f (x+1)
  in ()

(* Fails: the body of g does not respect the termination
argument for f, which is not admitted. *)
[@@expect_failure [19]]
let top4 () =
  let rec f (x:pos) : int = g (x-1)
  [@@admit_termination]
  and g (x:nat) : int = f (x+1)
  in ()
```

However, we don't have surface syntax to attach attributes to top-level letbindings (only to the sigelt). And these attributes were not propagated to the letbindings--- this PR changes that. I took a look at adding syntax for attributes for bindings, but it's not clear what it should look like, since the sigelt can also have attributes.