### PR TITLE
fstar: gzip checked files

### DIFF
--- a/fstar.opam
+++ b/fstar.opam
@@ -10,6 +10,7 @@ depends: [
   "zarith"
   "stdint"
   "yojson"
+  "ezgzip"
   "dune" {build & >= "3.2.0"}
   "menhirLib"
   "pprint"

--- a/ocaml/fstar-lib/FStar_Zip.ml
+++ b/ocaml/fstar-lib/FStar_Zip.ml
@@ -1,0 +1,23 @@
+let zip = Ezgzip.compress
+let unzip s = Result.get_ok (Ezgzip.decompress s)
+
+let output_zipped_value (c : out_channel) (x:'a) : unit =
+  let str = Marshal.to_string x [] in
+  let zstr = zip str in
+  let zlen = String.length zstr in
+  let b = Bytes.create 8 in
+  (* save zlen *)
+  Bytes.set_int64_be b 0 (Int64.of_int zlen);
+  output c b 0 8;
+  (* save ztr *)
+  output_string c zstr
+
+let input_zipped_value (c : in_channel) : 'a =
+  (* read zlen *)
+  let lenbuf = Bytes.create 8 in
+  really_input c lenbuf 0 8;
+  let zlen = Int64.to_int (Bytes.get_int64_be lenbuf 0) in
+  (* read and decode *)
+  let zstr = really_input_string c zlen in
+  let str = unzip zstr in
+  Marshal.from_string str 0

--- a/ocaml/fstar-lib/dune
+++ b/ocaml/fstar-lib/dune
@@ -13,6 +13,7 @@
     pprint
     process
     sedlex
+    ezgzip
  )
  (modes native)
  (wrapped false)

--- a/ocaml/fstar-lib/generated/FStar_CheckedFiles.ml
+++ b/ocaml/fstar-lib/generated/FStar_CheckedFiles.ml
@@ -227,7 +227,8 @@ let (load_checked_file : Prims.string -> Prims.string -> cache_t) =
                checked_fn in
            add_and_return ((Invalid msg), (FStar_Pervasives.Inl msg))
          else
-           (let entry = FStar_Compiler_Util.load_value_from_file checked_fn in
+           (let entry =
+              FStar_Compiler_Util.load_zipped_value_from_file checked_fn in
             match entry with
             | FStar_Pervasives_Native.None ->
                 let msg =

--- a/ocaml/fstar-lib/generated/FStar_CheckedFiles.ml
+++ b/ocaml/fstar-lib/generated/FStar_CheckedFiles.ml
@@ -1,5 +1,5 @@
 open Prims
-let (cache_version_number : Prims.int) = (Prims.of_int (53))
+let (cache_version_number : Prims.int) = (Prims.of_int (54))
 type tc_result =
   {
   checked_module: FStar_Syntax_Syntax.modul ;

--- a/src/basic/FStar.Compiler.Util.fsti
+++ b/src/basic/FStar.Compiler.Util.fsti
@@ -383,6 +383,7 @@ val map_option: ('a -> 'b) -> option 'a -> option 'b
 
 val save_value_to_file: string -> 'a -> unit
 val load_value_from_file: string -> option 'a
+val load_zipped_value_from_file: string -> option 'a
 val save_2values_to_file: string -> 'a -> 'b -> unit
 val load_2values_from_file: string -> option ('a * 'b)
 val print_exn: exn -> string

--- a/src/basic/FStar.Zip.fsti
+++ b/src/basic/FStar.Zip.fsti
@@ -1,0 +1,8 @@
+module FStar.Zip
+
+open FStar.Compiler.Effect
+
+val zip : string -> string
+
+(* May raise an exception *)
+val unzip : string -> string

--- a/src/fstar/FStar.CheckedFiles.fst
+++ b/src/fstar/FStar.CheckedFiles.fst
@@ -40,7 +40,7 @@ module Dep     = FStar.Parser.Dep
  * detect when loading the cache that the version number is same
  * It needs to be kept in sync with prims.fst
  *)
-let cache_version_number = 53
+let cache_version_number = 54
 
 (*
  * Abbreviation for what we store in the checked files (stages as described below)

--- a/src/fstar/FStar.CheckedFiles.fst
+++ b/src/fstar/FStar.CheckedFiles.fst
@@ -208,7 +208,7 @@ let load_checked_file (fn:string) (checked_fn:string) :cache_t =
     if not (BU.file_exists checked_fn)
     then let msg = BU.format1 "checked file %s does not exist" checked_fn in
          add_and_return (Invalid msg, Inl msg)
-    else let entry :option checked_file_entry_stage1 = BU.load_value_from_file checked_fn in
+    else let entry :option checked_file_entry_stage1 = BU.load_zipped_value_from_file checked_fn in
          match entry with
          | None ->
            let msg = BU.format1 "checked file %s is corrupt" checked_fn in

--- a/ulib/prims.fst
+++ b/ulib/prims.fst
@@ -708,4 +708,4 @@ val string_of_int: int -> Tot string
 (** THIS IS MEANT TO BE KEPT IN SYNC WITH FStar.CheckedFiles.fs
     Incrementing this forces all .checked files to be invalidated *)
 irreducible
-let __cache_version_number__ = 53
+let __cache_version_number__ = 54


### PR DESCRIPTION
Add output_zipped_value as an analogue to output_value, which calls gzip
on the resulting marshaled string before writing to the channel. Idem
for input_value. Then use it to write compressed checked files.

This is not ideal, it would be better to just have a notion of a
compressed channel, but I couldn't find good support to do so in OCaml.
We could revisit it later, and perhaps use it to compress hint files
too.

The files reduce significantly, ~3x. Before
```
$ rm -f ulib/.cache/*.hints && du -ahx ulib/.cache/ | sort -h  | tail -n 20
1.4M	ulib/.cache/FStar.Pervasives.fsti.checked
1.6M	ulib/.cache/FStar.Math.Fermat.fst.checked
1.6M	ulib/.cache/FStar.Pervasives.fst.checked
1.6M	ulib/.cache/FStar.UInt128.fst.checked
1.7M	ulib/.cache/FStar.Pointer.Base.fsti.checked
1.7M	ulib/.cache/LowStar.Monotonic.Buffer.fsti.checked
1.8M	ulib/.cache/FStar.Seq.Properties.fst.checked
1.8M	ulib/.cache/FStar.Sequence.Base.fst.checked
1.8M	ulib/.cache/LowStar.BufferView.Down.fst.checked
1.9M	ulib/.cache/FStar.Matrix.fst.checked
1.9M	ulib/.cache/FStar.OrdSet.fst.checked
2.1M	ulib/.cache/LowStar.BufferView.fst.checked
2.2M	ulib/.cache/FStar.Buffer.fst.checked
3.0M	ulib/.cache/FStar.Pervasives.Native.fst.checked
3.2M	ulib/.cache/FStar.Tactics.CanonCommSemiring.fst.checked
3.7M	ulib/.cache/FStar.Reflection.Typing.fsti.checked
4.2M	ulib/.cache/FStar.Reflection.Typing.fst.checked
4.2M	ulib/.cache/LowStar.Monotonic.Buffer.fst.checked
4.7M	ulib/.cache/FStar.ModifiesGen.fst.checked
124M	ulib/.cache/
```
After:
```
$ rm -f ulib/.cache/*.hints && du -ahx ulib/.cache/ | sort -h  | tail -n 20
556K	ulib/.cache/FStar.UInt128.fst.checked
576K	ulib/.cache/FStar.Pointer.Base.fsti.checked
596K	ulib/.cache/LowStar.Monotonic.Buffer.fsti.checked
612K	ulib/.cache/FStar.Math.Lemmas.fst.checked
644K	ulib/.cache/FStar.Seq.Properties.fst.checked
652K	ulib/.cache/FStar.Sequence.Base.fst.checked
664K	ulib/.cache/FStar.Matrix.fst.checked
672K	ulib/.cache/LowStar.BufferView.fst.checked
688K	ulib/.cache/FStar.OrdSet.fst.checked
700K	ulib/.cache/FStar.Math.Fermat.fst.checked
732K	ulib/.cache/FStar.Pointer.Base.fst.hints
748K	ulib/.cache/FStar.ModifiesGen.fst.hints
772K	ulib/.cache/FStar.Buffer.fst.checked
812K	ulib/.cache/FStar.Pervasives.Native.fst.checked
1.1M	ulib/.cache/FStar.Reflection.Typing.fsti.checked
1.1M	ulib/.cache/FStar.Tactics.CanonCommSemiring.fst.checked
1.3M	ulib/.cache/FStar.Reflection.Typing.fst.checked
1.5M	ulib/.cache/LowStar.Monotonic.Buffer.fst.checked
1.6M	ulib/.cache/FStar.ModifiesGen.fst.checked
43M	ulib/.cache/
```

43M is about exactly what we get from making a compressed archive of all the old checked files together, which means we are not missing out too much out on repeated patterns or common structure (this won't be case for hints!).