### PR TITLE
ci: performance monitoring

### DIFF
--- a/.docker/build/build-standalone.sh
+++ b/.docker/build/build-standalone.sh
@@ -16,3 +16,13 @@ result_file="result.txt"
 status_file="status.txt"
 ORANGE_FILE="orange_file.txt"
 build_fstar $target
+
+# If RESOURCEMONITOR is defined, then make an rmon/ directory with
+# resource usage information
+echo "Saving runlim files into rmon/"
+if [ -n "$RESOURCEMONITOR" ]; then
+	mkdir -p rmon
+	.scripts/res_summary.sh > rmon/res_summary.txt
+	# Copy all .runlim files into rmon preserving structure
+	find . -name '*.runlim' -not -path './rmon/*' -exec cp --parents {} rmon/ \;
+fi

--- a/.docker/standalone.Dockerfile
+++ b/.docker/standalone.Dockerfile
@@ -9,6 +9,7 @@ FROM ubuntu:22.04
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
       jq \
+      bc \
       ca-certificates \
       curl \
       wget \
@@ -79,6 +80,15 @@ RUN opam install --confirm-level=unsafe-yes --deps-only $HOME/FStar/fstar.opam
 # Configure the git user for hint refresh
 RUN git config --global user.name "Dzomo, the Everest Yak" && \
     git config --global user.email "everbld@microsoft.com"
+
+# Set up $HOME/bin
+RUN mkdir $HOME/bin
+RUN echo 'export PATH=$HOME/bin:$PATH' | tee --append $HOME/.profile $HOME/.bashrc $HOME/.bash_profile
+
+# Install runlim, if we are monitoring
+ARG RESOURCEMONITOR=
+RUN [ -z "$RESOURCEMONITOR" ] || git clone https://github.com/arminbiere/runlim
+RUN [ -z "$RESOURCEMONITOR" ] || (cd runlim && ./configure.sh --prefix=$HOME/bin && make && make install)
 
 WORKDIR $HOME/FStar
 

--- a/.github/workflows/linux-x64.yaml
+++ b/.github/workflows/linux-x64.yaml
@@ -35,7 +35,7 @@ jobs:
         run: |
           echo "CI_INITIAL_TIMESTAMP=$(date '+%s')" >> $GITHUB_ENV
       - name: Check out repo        
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Identify the notification channel
         run: |
           echo "CI_SLACK_CHANNEL=$(jq -c -r '.NotificationChannel' .docker/build/config.json)" >> $GITHUB_ENV
@@ -161,7 +161,7 @@ jobs:
       - name: Post to the Slack channel
         if: ${{ always() && (github.event_name != 'workflow_dispatch') }}
         id: slack
-        uses: slackapi/slack-github-action@v1.16.0
+        uses: slackapi/slack-github-action@v1.23.0
         with:
           channel-id: ${{ env.CI_SLACK_CHANNEL }}
           payload: |

--- a/.github/workflows/linux-x64.yaml
+++ b/.github/workflows/linux-x64.yaml
@@ -60,14 +60,20 @@ jobs:
         if: ${{ (github.event_name == 'workflow_dispatch') && inputs.ci_skip_image_tag }}
         run: |
           echo "CI_SKIP_IMAGE_TAG=1" >> $GITHUB_ENV
+      - name: Enable resource monitoring
+        if: ${{ vars.FSTAR_CI_RESOURCEMONITOR == '1' }}
+        run: |
+          echo "RESOURCEMONITOR=1'" >> $GITHUB_ENV
+
       - name: Build FStar and its dependencies
         run: |
           ci_docker_image_tag=fstar:local-run-$GITHUB_RUN_ID-$GITHUB_RUN_ATTEMPT
+          echo "ci_docker_image_tag=$ci_docker_image_tag" >> $GITHUB_ENV
           ci_docker_builder=builder_fstar_${GITHUB_RUN_ID}_${GITHUB_RUN_ATTEMPT}
           echo "ci_docker_builder=$ci_docker_builder" >> $GITHUB_ENV
           docker buildx create --name $ci_docker_builder --driver-opt env.BUILDKIT_STEP_LOG_MAX_SIZE=500000000
           if [[ -z $CI_TARGET ]] ; then CI_TARGET=uregressions ; fi
-          docker buildx build --builder $ci_docker_builder --pull --load --secret id=DZOMO_GITHUB_TOKEN -t $ci_docker_image_tag -f .docker/standalone.Dockerfile --build-arg CI_BRANCH=$GITHUB_REF_NAME --build-arg CI_TARGET="$CI_TARGET" $CI_DO_TEST_MIN_OPAM_DEPS $CI_DO_OCAML_VERSION $CI_DO_NO_KARAMEL . |& tee BUILDLOG
+          docker buildx build --builder $ci_docker_builder --pull --load --secret id=DZOMO_GITHUB_TOKEN -t $ci_docker_image_tag -f .docker/standalone.Dockerfile --build-arg CI_BRANCH=$GITHUB_REF_NAME --build-arg CI_TARGET="$CI_TARGET" --build-arg RESOURCEMONITOR=$RESOURCEMONITOR $CI_DO_TEST_MIN_OPAM_DEPS $CI_DO_OCAML_VERSION $CI_DO_NO_KARAMEL . |& tee BUILDLOG
           ci_docker_status=$(docker run $ci_docker_image_tag /bin/bash -c 'cat $FSTAR_HOME/status.txt' || echo false)
           if $ci_docker_status && [[ -z "$CI_SKIP_IMAGE_TAG" ]] ; then
             if ! { echo $GITHUB_REF_NAME | grep '/' ; } ; then
@@ -78,6 +84,44 @@ jobs:
           $ci_docker_status
         env:
           DZOMO_GITHUB_TOKEN: ${{ secrets.DZOMO_GITHUB_TOKEN }}
+
+      - name: Collect resource monitoring files and summary
+        if: ${{ always () && vars.FSTAR_CI_RESOURCEMONITOR == '1' }}
+        continue-on-error: true
+        run: |
+          # docker cp needs absolute path, obtain FSTAR_HOME
+          FSTAR_HOME=$(docker run $ci_docker_image_tag /bin/bash -c 'echo $FSTAR_HOME')
+          # We briefly kick up a container from the generated image, so
+          # we can extract files from it. No need to start it though.
+          temp_container=$(docker create $ci_docker_image_tag)
+          docker cp $temp_container:${FSTAR_HOME}/rmon/ rmon
+          docker rm -f $temp_container
+
+          # Also, read these bottom-line values into the environment so they
+          # can go into the Slack message.
+          FSTAR_CI_MEASURE_CPU=$(awk -F':' '/Total CPU/ { print $2 }' rmon/res_summary.txt)
+          FSTAR_CI_MEASURE_MEM=$(awk -F':' '/Total memory/ { print $2 }' rmon/res_summary.txt)
+          echo "FSTAR_CI_MEASURE_CPU=$FSTAR_CI_MEASURE_CPU" >> $GITHUB_ENV
+          echo "FSTAR_CI_MEASURE_MEM=$FSTAR_CI_MEASURE_MEM" >> $GITHUB_ENV
+
+      - name: Save resource monitor summary as artifact
+        if: ${{ always () && vars.FSTAR_CI_RESOURCEMONITOR == '1' }}
+        continue-on-error: true
+        uses: actions/upload-artifact@v3
+        with:
+          name: Resource usage information (summary)
+          path: |
+            rmon/res_summary.txt
+
+      - name: Save resource monitor files as artifact
+        if: ${{ always () && vars.FSTAR_CI_RESOURCEMONITOR == '1' }}
+        continue-on-error: true
+        uses: actions/upload-artifact@v3
+        with:
+          name: Resource usage information (individual)
+          path: |
+            rmon/**/*.runlim
+
       - name: Clean up temporary container
         if: ${{ always() }}
         run: |
@@ -148,7 +192,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "plain_text",
-                    "text": "Duration: ${{ env.CI_TIME_DIFF_H }}h ${{ env.CI_TIME_DIFF_M }}min ${{ env.CI_TIME_DIFF_S }}s"
+                    "text": "Duration: ${{ env.CI_TIME_DIFF_H }}h ${{ env.CI_TIME_DIFF_M }}min ${{ env.CI_TIME_DIFF_S }}s\nTotal CPU usage: ${{ env.FSTAR_CI_MEASURE_CPU }}\nTotal memory usage: ${{ env.FSTAR_CI_MEASURE_MEM }}"
                   }
                 }
               ]

--- a/.scripts/res_summary.sh
+++ b/.scripts/res_summary.sh
@@ -47,3 +47,15 @@ echo "Top 20 CPU time:"
 for fp in "${!cpu[@]}"; do
 	printf " %-80s %12s\n" "$fp" "${cpu[$fp]} s"
 done | sort -k2 -n -r  | head -n 20
+
+TOTMEM=0
+TOTCPU=0
+# Trying to do this in the loops above won't work as the command runs in
+# a subshell, with its own set of variables. Bash is fun :^).
+for fp in "${!mem[@]}"; do
+	TOTMEM=$(($TOTMEM + ${mem[$fp]}))
+	TOTCPU=$(echo $TOTCPU + ${cpu[$fp]} | bc)
+done
+
+echo "Total CPU: $TOTCPU seconds"
+echo "Total memory: $TOTMEM MB"


### PR DESCRIPTION
This enables performance monitoring (as in building with `RESOURCEMONITOR=1`) for CI builds.

It is conditioned by the `FSTAR_CI_RESOURCEMONITOR` variable is set to `1` in the variables for the repository (Settings -> Secrets and variables -> Actions -> Variables). It is currently already enabled even without this PR.

In detail:

0) The workflow will pass the RESOURCEMONITOR=1 file to the Docker
   build command, this will cause our Makefiles to create .runlim
   files everywhere.
1) build-standalone.sh will, after running CI, create an `rmon/`
   directory and place relevant information there, including the summary
   generated by `.scripts/res_summary.sh` as well as all of the
   individual `.runlim` files ordered by path.
2) The workflow picks this directory up, and uploads two Github build
   artifacts, one with the summary and one with the tarball of all .runlim
   files.
3) Two lines added to the Slack message with total CPU and memory usage
   (to be seen how robust this measurement will be)

Github makes a .zip archive of an artifact when one tries to download it (even if it contains a single file), which is annoying, but I don't think there's an alternative currently.


--

See the github actions run for this PR for an example. One thing I didn't realize is that zipping all .runlim files can take some time, it took ~2.5 mins here! I imagine this can only be that the github upload-artifact action is super slow. Making a .tar.gz with all these files locally takes milliseconds, and even takes up half the size. I can upload a tarball instead, the only annoyance is that it will also be zipped.