### PR TITLE
Allow a syntax extension to provide qualifiers and attributes on a decl

### DIFF
--- a/ocaml/fstar-lib/generated/FStar_Compiler_Range_Type.ml
+++ b/ocaml/fstar-lib/generated/FStar_Compiler_Range_Type.ml
@@ -1,5 +1,5 @@
 open Prims
-type file_name = Prims.string[@@deriving yojson,show]
+type file_name = Prims.string[@@deriving yojson,show,yojson,show]
 type pos = {
   line: Prims.int ;
   col: Prims.int }[@@deriving yojson,show,yojson,show]

--- a/ocaml/fstar-lib/generated/FStar_Ident.ml
+++ b/ocaml/fstar-lib/generated/FStar_Ident.ml
@@ -9,8 +9,8 @@ let (__proj__Mkident__item__idText : ident -> Prims.string) =
 let (__proj__Mkident__item__idRange :
   ident -> FStar_Compiler_Range_Type.range) =
   fun projectee -> match projectee with | { idText; idRange;_} -> idRange
-type path = Prims.string Prims.list[@@deriving yojson,show]
-type ipath = ident Prims.list[@@deriving yojson,show]
+type path = Prims.string Prims.list[@@deriving yojson,show,yojson,show]
+type ipath = ident Prims.list[@@deriving yojson,show,yojson,show]
 type lident =
   {
   ns: ipath ;
@@ -95,7 +95,7 @@ let (lid_equals : lident -> lident -> Prims.bool) =
   fun l1 -> fun l2 -> l1.str = l2.str
 let (ident_equals : ident -> ident -> Prims.bool) =
   fun id1 -> fun id2 -> id1.idText = id2.idText
-type lid = lident[@@deriving yojson,show]
+type lid = lident[@@deriving yojson,show,yojson,show]
 let (range_of_lid : lident -> FStar_Compiler_Range_Type.range) =
   fun lid1 -> range_of_id lid1.ident
 let (set_lid_range : lident -> FStar_Compiler_Range_Type.range -> lident) =

--- a/ocaml/fstar-lib/generated/FStar_Parser_AST_Util.ml
+++ b/ocaml/fstar-lib/generated/FStar_Parser_AST_Util.ml
@@ -1060,7 +1060,7 @@ type extension_parser =
   open_namespaces_and_abbreviations ->
     Prims.string ->
       FStar_Compiler_Range_Type.range ->
-        (error_message, FStar_Parser_AST.decl') FStar_Pervasives.either
+        (error_message, FStar_Parser_AST.decl) FStar_Pervasives.either
 let (extension_parser_table : extension_parser FStar_Compiler_Util.smap) =
   FStar_Compiler_Util.smap_create (Prims.of_int (20))
 let (register_extension_parser : Prims.string -> extension_parser -> unit) =

--- a/ocaml/fstar-lib/generated/FStar_Syntax_Syntax.ml
+++ b/ocaml/fstar-lib/generated/FStar_Syntax_Syntax.ml
@@ -7,8 +7,8 @@ let __proj__Mkwithinfo_t__item__v : 'a . 'a withinfo_t -> 'a =
 let __proj__Mkwithinfo_t__item__p :
   'a . 'a withinfo_t -> FStar_Compiler_Range_Type.range =
   fun projectee -> match projectee with | { v; p;_} -> p
-type var = FStar_Ident.lident withinfo_t[@@deriving yojson,show]
-type sconst = FStar_Const.sconst[@@deriving yojson,show]
+type var = FStar_Ident.lident withinfo_t[@@deriving yojson,show,yojson,show]
+type sconst = FStar_Const.sconst[@@deriving yojson,show,yojson,show]
 type pragma =
   | SetOptions of Prims.string 
   | ResetOptions of Prims.string FStar_Pervasives_Native.option 
@@ -41,14 +41,8 @@ let (uu___is_RestartSolver : pragma -> Prims.bool) =
 let (uu___is_PrintEffectsGraph : pragma -> Prims.bool) =
   fun projectee ->
     match projectee with | PrintEffectsGraph -> true | uu___ -> false
-type 'a memo =
-  (('a FStar_Pervasives_Native.option FStar_Compiler_Effect.ref)[@printer
-                                                                  fun fmt ->
-                                                                    fun _ ->
-                                                                    Format.pp_print_string
-                                                                    fmt
-                                                                    "None"])
-[@@deriving yojson,show]
+type 'a memo = 'a FStar_Pervasives_Native.option FStar_Compiler_Effect.ref
+[@@deriving yojson,show,yojson,show]
 type emb_typ =
   | ET_abstract 
   | ET_fun of (emb_typ * emb_typ) 
@@ -108,13 +102,13 @@ let (__proj__U_unif__item___0 :
   = fun projectee -> match projectee with | U_unif _0 -> _0
 let (uu___is_U_unknown : universe -> Prims.bool) =
   fun projectee -> match projectee with | U_unknown -> true | uu___ -> false
-type univ_name = FStar_Ident.ident[@@deriving yojson,show]
+type univ_name = FStar_Ident.ident[@@deriving yojson,show,yojson,show]
 type universe_uvar =
   (universe FStar_Pervasives_Native.option FStar_Unionfind.p_uvar * version *
-    FStar_Compiler_Range_Type.range)[@@deriving yojson,show]
-type univ_names = univ_name Prims.list[@@deriving yojson,show]
-type universes = universe Prims.list[@@deriving yojson,show]
-type monad_name = FStar_Ident.lident[@@deriving yojson,show]
+    FStar_Compiler_Range_Type.range)[@@deriving yojson,show,yojson,show]
+type univ_names = univ_name Prims.list[@@deriving yojson,show,yojson,show]
+type universes = universe Prims.list[@@deriving yojson,show,yojson,show]
+type monad_name = FStar_Ident.lident[@@deriving yojson,show,yojson,show]
 type quote_kind =
   | Quote_static 
   | Quote_dynamic [@@deriving yojson,show]

--- a/ocaml/fstar-lib/generated/FStar_ToSyntax_ToSyntax.ml
+++ b/ocaml/fstar-lib/generated/FStar_ToSyntax_ToSyntax.ml
@@ -8288,7 +8288,9 @@ and (desugar_decl_aux :
                      (sigelt.FStar_Syntax_Syntax.sigquals);
                    FStar_Syntax_Syntax.sigmeta =
                      (sigelt.FStar_Syntax_Syntax.sigmeta);
-                   FStar_Syntax_Syntax.sigattrs = attrs1;
+                   FStar_Syntax_Syntax.sigattrs =
+                     (FStar_Compiler_List.op_At
+                        sigelt.FStar_Syntax_Syntax.sigattrs attrs1);
                    FStar_Syntax_Syntax.sigopts =
                      (sigelt.FStar_Syntax_Syntax.sigopts)
                  }) sigelts in
@@ -9182,10 +9184,14 @@ and (desugar_decl_noattrs :
                       ids in
                   (is_typed, uu___2, t1) in
                 FStar_Syntax_Syntax.Sig_splice uu___1 in
+              let uu___1 =
+                FStar_Compiler_List.map
+                  (trans_qual1 FStar_Pervasives_Native.None)
+                  d.FStar_Parser_AST.quals in
               {
                 FStar_Syntax_Syntax.sigel = uu___;
                 FStar_Syntax_Syntax.sigrng = (d.FStar_Parser_AST.drange);
-                FStar_Syntax_Syntax.sigquals = [];
+                FStar_Syntax_Syntax.sigquals = uu___1;
                 FStar_Syntax_Syntax.sigmeta =
                   FStar_Syntax_Syntax.default_sigmeta;
                 FStar_Syntax_Syntax.sigattrs = [];
@@ -9221,13 +9227,19 @@ and (desugar_decl_noattrs :
                           (error.FStar_Parser_AST_Util.message))
                         error.FStar_Parser_AST_Util.range
                   | FStar_Pervasives.Inr d' ->
+                      let quals =
+                        FStar_Compiler_List.op_At d'.FStar_Parser_AST.quals
+                          d.FStar_Parser_AST.quals in
+                      let attrs =
+                        FStar_Compiler_List.op_At d'.FStar_Parser_AST.attrs
+                          d.FStar_Parser_AST.attrs in
                       desugar_decl_aux env
                         {
-                          FStar_Parser_AST.d = d';
+                          FStar_Parser_AST.d = (d'.FStar_Parser_AST.d);
                           FStar_Parser_AST.drange =
                             (d.FStar_Parser_AST.drange);
-                          FStar_Parser_AST.quals = (d.FStar_Parser_AST.quals);
-                          FStar_Parser_AST.attrs = (d.FStar_Parser_AST.attrs)
+                          FStar_Parser_AST.quals = quals;
+                          FStar_Parser_AST.attrs = attrs
                         }))
 let (desugar_decls :
   env_t ->

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_Tc.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_Tc.ml
@@ -3195,10 +3195,33 @@ let (tc_decl' :
                 (let ses =
                    env.FStar_TypeChecker_Env.splice env is_typed lids t
                      se2.FStar_Syntax_Syntax.sigrng in
+                 let ses1 =
+                   if is_typed
+                   then
+                     let sigquals =
+                       match se2.FStar_Syntax_Syntax.sigquals with
+                       | [] -> [FStar_Syntax_Syntax.Visible_default]
+                       | qs -> qs in
+                     FStar_Compiler_List.map
+                       (fun sp ->
+                          {
+                            FStar_Syntax_Syntax.sigel =
+                              (sp.FStar_Syntax_Syntax.sigel);
+                            FStar_Syntax_Syntax.sigrng =
+                              (sp.FStar_Syntax_Syntax.sigrng);
+                            FStar_Syntax_Syntax.sigquals = sigquals;
+                            FStar_Syntax_Syntax.sigmeta =
+                              (sp.FStar_Syntax_Syntax.sigmeta);
+                            FStar_Syntax_Syntax.sigattrs =
+                              (se2.FStar_Syntax_Syntax.sigattrs);
+                            FStar_Syntax_Syntax.sigopts =
+                              (sp.FStar_Syntax_Syntax.sigopts)
+                          }) ses
+                   else ses in
                  let dsenv =
                    FStar_Compiler_List.fold_left
                      FStar_Syntax_DsEnv.push_sigelt_force
-                     env.FStar_TypeChecker_Env.dsenv ses in
+                     env.FStar_TypeChecker_Env.dsenv ses1 in
                  let env1 =
                    {
                      FStar_TypeChecker_Env.solver =
@@ -3309,13 +3332,13 @@ let (tc_decl' :
                     let uu___5 =
                       let uu___6 =
                         FStar_Compiler_List.map
-                          FStar_Syntax_Print.sigelt_to_string ses in
+                          FStar_Syntax_Print.sigelt_to_string ses1 in
                       FStar_Compiler_Effect.op_Less_Bar
                         (FStar_String.concat "\n") uu___6 in
                     FStar_Compiler_Util.print1
                       "Splice returned sigelts {\n%s\n}\n" uu___5
                   else ());
-                 if is_typed then (ses, [], env1) else ([], ses, env1)))
+                 if is_typed then (ses1, [], env1) else ([], ses1, env1)))
            | FStar_Syntax_Syntax.Sig_let (lbs, lids) ->
                let uu___2 =
                  let uu___3 =
@@ -4496,7 +4519,7 @@ let (tc_decls :
                ([], env) ses) in
       match uu___ with
       | (ses1, env1) -> ((FStar_Compiler_List.rev_append ses1 []), env1)
-let (uu___917 : unit) =
+let (uu___923 : unit) =
   FStar_Compiler_Effect.op_Colon_Equals tc_decls_knot
     (FStar_Pervasives_Native.Some tc_decls)
 let (snapshot_context :

--- a/src/parser/FStar.Parser.AST.Util.fsti
+++ b/src/parser/FStar.Parser.AST.Util.fsti
@@ -41,7 +41,7 @@ type extension_parser =
    open_namespaces_and_abbreviations ->
    contents:string ->
    p:FStar.Compiler.Range.range ->
-   either error_message decl'
+   either error_message decl
 
 val register_extension_parser (extension_name:string) (parser:extension_parser) : unit
 val lookup_extension_parser (extension_name:string) : option extension_parser

--- a/src/tosyntax/FStar.ToSyntax.ToSyntax.fst
+++ b/src/tosyntax/FStar.ToSyntax.ToSyntax.fst
@@ -3545,7 +3545,10 @@ and desugar_decl_aux env (d: decl): (env_t * sigelts) =
     | _ -> []
   in
   let attrs = attrs @ val_attrs sigelts in
-  env, List.map (fun sigelt -> { sigelt with sigattrs = attrs }) sigelts
+  env,
+  List.map 
+    (fun sigelt -> { sigelt with sigattrs = sigelt.sigattrs@attrs })
+    sigelts
 
 and desugar_decl env (d:decl) :(env_t * sigelts) =
   let env, ses = desugar_decl_aux env d in
@@ -3996,7 +3999,7 @@ and desugar_decl_noattrs top_attrs env (d:decl) : (env_t * sigelts) =
   | Splice (is_typed, ids, t) ->
     let t = desugar_term env t in
     let se = { sigel = Sig_splice(is_typed, List.map (qualify env) ids, t);
-               sigquals = [];
+               sigquals = List.map (trans_qual None) d.quals;
                sigrng = d.drange;
                sigmeta = default_sigmeta;
                sigattrs = [];
@@ -4024,7 +4027,9 @@ and desugar_decl_noattrs top_attrs env (d:decl) : (env_t * sigelts) =
           (Errors.Fatal_SyntaxError, error.message)
           error.range
       | Inr d' ->
-        desugar_decl_aux env { d with d=d' }
+        let quals = d'.quals @ d.quals in
+        let attrs = d'.attrs @ d.attrs in
+        desugar_decl_aux env { d' with quals; attrs; drange=d.drange }
 
 let desugar_decls env decls =
   let env, sigelts =

--- a/src/typechecker/FStar.TypeChecker.Tc.fst
+++ b/src/typechecker/FStar.TypeChecker.Tc.fst
@@ -821,6 +821,18 @@ let tc_decl' env0 se: list sigelt * list sigelt * Env.env =
     // env.splice will check the tactic
 
     let ses = env.splice env is_typed lids t se.sigrng in
+    let ses = 
+      if is_typed
+      then let sigquals = 
+              match se.sigquals with
+              | [] -> [ S.Visible_default ]
+              | qs -> qs
+           in
+            List.map 
+              (fun sp -> { sp with sigquals = sigquals; sigattrs = se.sigattrs})
+              ses
+      else ses
+    in
     let dsenv = List.fold_left DsEnv.push_sigelt_force env.dsenv ses in
     let env = { env with dsenv = dsenv } in
 


### PR DESCRIPTION
extension_parser now returns a decl, rather than a decl'.

This allows the extension parser to add attributes (e.g., unintepreted_by_smt) and qualifiers (e.g., irreducible) on the decls it generates.

The typed hook for splices retains the attributes and qualifiers from the enclosing sigelt, if any.