### PR TITLE
Using a base image for CI jobs

### DIFF
--- a/.docker/base.Dockerfile
+++ b/.docker/base.Dockerfile
@@ -67,7 +67,8 @@ ENV DOTNET_ROOT /home/opam/dotnet
 RUN wget -nv https://download.visualstudio.microsoft.com/download/pr/cd0d0a4d-2a6a-4d0d-b42e-dfd3b880e222/008a93f83aba6d1acf75ded3d2cfba24/dotnet-sdk-6.0.400-linux-x64.tar.gz && \
     mkdir -p $DOTNET_ROOT && \
     tar xf dotnet-sdk-6.0.400-linux-x64.tar.gz -C $DOTNET_ROOT && \
-    echo 'export PATH=$PATH:$DOTNET_ROOT:$DOTNET_ROOT/tools' | tee --append $HOME/.profile $HOME/.bashrc $HOME/.bash_profile
+    echo 'export PATH=$PATH:$DOTNET_ROOT:$DOTNET_ROOT/tools' | tee --append $HOME/.profile $HOME/.bashrc $HOME/.bash_profile && \
+    rm -f dotnet-sdk*.tar.gz
 
 # Install OCaml
 ARG OCAML_VERSION=4.12.0
@@ -89,8 +90,9 @@ RUN mkdir $HOME/bin
 RUN echo 'export PATH=$HOME/bin:$PATH' | tee --append $HOME/.profile $HOME/.bashrc $HOME/.bash_profile
 
 # Install runlim
-RUN git clone https://github.com/arminbiere/runlim
+RUN git clone --depth 1 https://github.com/arminbiere/runlim
 RUN (cd runlim && ./configure.sh --prefix=$HOME/bin && make && make install)
+RUN rm -rf runlim
 
 WORKDIR $HOME
 

--- a/.docker/base.Dockerfile
+++ b/.docker/base.Dockerfile
@@ -1,0 +1,99 @@
+# This Dockerfile creates a base image suitable to start building F*.
+#
+# It is used by the CI job. It MAY miss some dependency, these are
+# anyway re-checked and installed if needed when running the CI job. We
+# only install them here to speed up that process.
+#
+# The ONLY file read by this dockerfile is fstar.opam in the root,
+# and it is copied into the home directory on the image. CI jobs
+# will NOT use this file.
+
+# We always try to build against the most current ubuntu image.
+FROM ubuntu:latest
+
+RUN apt-get update
+
+# Install editors, for the rare cases where we spin up a container to
+# see the status. Not a big deal to have them here, only installed
+# nightly and the files are shared by all subcontainers due to
+# overlayfs.
+RUN apt-get -y --no-install-recommends install vim emacs
+
+# Base dependencies: opam
+# CI dependencies: jq (to identify F* branch)
+# python3 (for interactive tests)
+# libicu (for .NET, cf. https://aka.ms/dotnet-missing-libicu )
+RUN apt-get install -y --no-install-recommends \
+      jq \
+      bc \
+      ca-certificates \
+      curl \
+      wget \
+      git \
+      gnupg \
+      sudo \
+      python3 \
+      python-is-python3 \
+      libicu70 \
+      opam
+
+# Create a new user and give them sudo rights
+# NOTE: we give them the name "opam" to keep compatibility with
+# derived hierarchical CI
+RUN useradd -d /home/opam opam
+RUN echo 'opam ALL=NOPASSWD: ALL' >> /etc/sudoers
+RUN mkdir /home/opam
+RUN chown opam:opam /home/opam
+USER opam
+ENV HOME /home/opam
+WORKDIR $HOME
+SHELL ["/bin/bash", "--login", "-c"]
+
+# Install GitHub CLI
+# From https://github.com/cli/cli/blob/trunk/docs/install_linux.md#debian-ubuntu-linux-raspberry-pi-os-apt
+# This is only used by the workflow that makes a release and publishes
+# it, but no harm in having it in the base.
+RUN { type -p curl >/dev/null || sudo apt-get install curl -y ; } \
+    && curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg \
+    && sudo chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
+    && sudo apt-get update \
+    && sudo apt-get install gh -y
+
+# CI dependencies: .NET Core
+# Repository install may incur some (transient?) failures (see for instance https://github.com/dotnet/sdk/issues/27082 )
+# So, we use manual install instead, from https://docs.microsoft.com/en-us/dotnet/core/install/linux-scripted-manual#manual-install
+ENV DOTNET_ROOT /home/opam/dotnet
+RUN wget -nv https://download.visualstudio.microsoft.com/download/pr/cd0d0a4d-2a6a-4d0d-b42e-dfd3b880e222/008a93f83aba6d1acf75ded3d2cfba24/dotnet-sdk-6.0.400-linux-x64.tar.gz && \
+    mkdir -p $DOTNET_ROOT && \
+    tar xf dotnet-sdk-6.0.400-linux-x64.tar.gz -C $DOTNET_ROOT && \
+    echo 'export PATH=$PATH:$DOTNET_ROOT:$DOTNET_ROOT/tools' | tee --append $HOME/.profile $HOME/.bashrc $HOME/.bash_profile
+
+# Install OCaml
+ARG OCAML_VERSION=4.12.0
+RUN opam init --compiler=$OCAML_VERSION --disable-sandboxing 
+RUN opam env --set-switch | tee --append $HOME/.profile $HOME/.bashrc $HOME/.bash_profile
+RUN opam option depext-run-installs=true
+ENV OPAMYES=1
+
+# F* dependencies. This is the only place where we read a file from
+# the F* repo.
+ADD fstar.opam $HOME/fstar.opam
+RUN opam install --confirm-level=unsafe-yes --deps-only $HOME/fstar.opam
+
+# Some karamel dependencies
+RUN opam install --confirm-level=unsafe-yes fix fileutils visitors camlp4 wasm ulex
+
+# Set up $HOME/bin. Note, binaries here take precedence over OPAM
+RUN mkdir $HOME/bin
+RUN echo 'export PATH=$HOME/bin:$PATH' | tee --append $HOME/.profile $HOME/.bashrc $HOME/.bash_profile
+
+# Install runlim
+RUN git clone https://github.com/arminbiere/runlim
+RUN (cd runlim && ./configure.sh --prefix=$HOME/bin && make && make install)
+
+WORKDIR $HOME
+
+# Configure the git user for hint refresh
+RUN git config --global user.name "Dzomo, the Everest Yak" && \
+    git config --global user.email "everbld@microsoft.com"

--- a/.docker/base.Dockerfile
+++ b/.docker/base.Dockerfile
@@ -35,7 +35,8 @@ RUN apt-get install -y --no-install-recommends \
       python3 \
       python-is-python3 \
       libicu70 \
-      opam
+      opam \
+      && apt-get clean -y
 
 # Create a new user and give them sudo rights
 # NOTE: we give them the name "opam" to keep compatibility with
@@ -80,10 +81,10 @@ ENV OPAMYES=1
 # F* dependencies. This is the only place where we read a file from
 # the F* repo.
 ADD fstar.opam $HOME/fstar.opam
-RUN opam install --confirm-level=unsafe-yes --deps-only $HOME/fstar.opam
+RUN opam install --confirm-level=unsafe-yes --deps-only $HOME/fstar.opam && opam clean
 
 # Some karamel dependencies
-RUN opam install --confirm-level=unsafe-yes fix fileutils visitors camlp4 wasm ulex
+RUN opam install --confirm-level=unsafe-yes fix fileutils visitors camlp4 wasm ulex && opam clean
 
 # Set up $HOME/bin. Note, binaries here take precedence over OPAM
 RUN mkdir $HOME/bin

--- a/.docker/build/build-standalone.sh
+++ b/.docker/build/build-standalone.sh
@@ -16,3 +16,13 @@ result_file="result.txt"
 status_file="status.txt"
 ORANGE_FILE="orange_file.txt"
 build_fstar $target
+
+# If RESOURCEMONITOR is defined, then make an rmon/ directory with
+# resource usage information
+echo "Saving runlim files into rmon/"
+if [ -n "$RESOURCEMONITOR" ]; then
+	mkdir -p rmon
+	.scripts/res_summary.sh > rmon/res_summary.txt
+	# Copy all .runlim files into a tar archive
+	find . -name '*.runlim' | tar czf rmon/rmon.tgz -T -
+fi

--- a/.docker/build/build_funs.sh
+++ b/.docker/build/build_funs.sh
@@ -119,11 +119,6 @@ function fstar_default_build () {
         echo " *** GIT DIFF: the files in the list above have a git diff"
         echo false >$status_file
     fi
-
-    # We should not generate hints when building on Windows
-    if [[ $localTarget == "uregressions-ulong" && "$OS" != "Windows_NT" ]]; then
-        .scripts/advance.sh refresh_fstar_hints || echo false >$status_file
-    fi
 }
 
 

--- a/.docker/build/build_funs.sh
+++ b/.docker/build/build_funs.sh
@@ -81,7 +81,7 @@ function fstar_default_build () {
     fi &
 
     # Build F*, along with fstarlib
-    if ! make -j $threads ci-utest-prelude; then
+    if ! make -j $threads ci-pre; then
         echo Warm-up failed
         echo Failure >$result_file
         return 1

--- a/.docker/build/build_funs.sh
+++ b/.docker/build/build_funs.sh
@@ -87,6 +87,10 @@ function fstar_default_build () {
         return 1
     fi
 
+    # Clean temporary build files, not needed and saves
+    # several hundred MB
+    make clean-buildfiles || true
+
     export_home FSTAR "$(pwd)"
 
     wait # for fetches above

--- a/.docker/standalone.Dockerfile
+++ b/.docker/standalone.Dockerfile
@@ -1,88 +1,16 @@
 # This Dockerfile should be run from the root FStar directory
 
-FROM ubuntu:22.04
+FROM fstar_ci_base
 
-# Base dependencies: opam
-# CI dependencies: jq (to identify F* branch)
-# python3 (for interactive tests)
-# libicu (for .NET, cf. https://aka.ms/dotnet-missing-libicu )
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
-      jq \
-      ca-certificates \
-      curl \
-      wget \
-      git \
-      gnupg \
-      sudo \
-      python3 \
-      python-is-python3 \
-      libicu70 \
-      opam
-
-# Create a new user and give them sudo rights
-# NOTE: we give them the name "opam" to keep compatibility with
-# derived hierarchical CI
-RUN useradd -d /home/opam opam
-RUN echo 'opam ALL=NOPASSWD: ALL' >> /etc/sudoers
-RUN mkdir /home/opam
-RUN chown opam:opam /home/opam
-USER opam
-ENV HOME /home/opam
-WORKDIR $HOME
-SHELL ["/bin/bash", "--login", "-c"]
-
-# Install GitHub CLI
-# From https://github.com/cli/cli/blob/trunk/docs/install_linux.md#debian-ubuntu-linux-raspberry-pi-os-apt
-RUN { type -p curl >/dev/null || sudo apt-get install curl -y ; } \
-    && curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg \
-    && sudo chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg \
-    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
-    && sudo apt-get update \
-    && sudo apt-get install gh -y
-
-# CI dependencies: .NET Core
-# Repository install may incur some (transient?) failures (see for instance https://github.com/dotnet/sdk/issues/27082 )
-# So, we use manual install instead, from https://docs.microsoft.com/en-us/dotnet/core/install/linux-scripted-manual#manual-install
-ENV DOTNET_ROOT /home/opam/dotnet
-RUN wget https://download.visualstudio.microsoft.com/download/pr/cd0d0a4d-2a6a-4d0d-b42e-dfd3b880e222/008a93f83aba6d1acf75ded3d2cfba24/dotnet-sdk-6.0.400-linux-x64.tar.gz && \
-    mkdir -p $DOTNET_ROOT && \
-    tar xf dotnet-sdk-6.0.400-linux-x64.tar.gz -C $DOTNET_ROOT && \
-    echo 'export PATH=$PATH:$DOTNET_ROOT:$DOTNET_ROOT/tools' | tee --append $HOME/.profile $HOME/.bashrc $HOME/.bash_profile
-
-# Install OCaml
-ARG OCAML_VERSION=4.12.0
-RUN opam init --compiler=$OCAML_VERSION --disable-sandboxing 
-RUN opam env --set-switch | tee --append $HOME/.profile $HOME/.bashrc $HOME/.bash_profile
-RUN opam option depext-run-installs=true
-ENV OPAMYES=1
-
-# FIXME: the `opam depext` command should be unnecessary with opam 2.1
-# RUN opam depext conf-gmp z3.4.8.5 conf-m4
-
+# Copy repo into image.
 ADD --chown=opam:opam ./ $HOME/FStar/
 
-# If CI_TEST_MIN_OPAM_DEPS is set, then for each package except ocaml,
-# when a lower bound constraint for its version number exists, replace
-# this constraint with an equality to install that lower version
-ARG CI_TEST_MIN_OPAM_DEPS=
-RUN if [[ -n "$CI_TEST_MIN_OPAM_DEPS" ]] ; then \
-  sed -i 's!>=!=!g' $HOME/FStar/fstar.opam && \
-  sed -i 's!"ocaml" {=!"ocaml" {>=!' $HOME/FStar/fstar.opam ; \
-fi
-
-# F* dependencies
-RUN opam install --confirm-level=unsafe-yes menhir # needed to bootstrap
-RUN opam install --confirm-level=unsafe-yes --deps-only $HOME/FStar/fstar.opam
-
-
-# Configure the git user for hint refresh
-RUN git config --global user.name "Dzomo, the Everest Yak" && \
-    git config --global user.email "everbld@microsoft.com"
-
-WORKDIR $HOME/FStar
+# Make sure opam dependencies are installed, the base image
+# may be stale.
+RUN opam install --confirm-level=unsafe-yes --deps-only ./fstar.opam
 
 # Run CI proper
+WORKDIR $HOME/FStar
 ARG CI_TARGET=uregressions
 ARG CI_THREADS=24
 ARG CI_BRANCH=master

--- a/.docker/standalone.Dockerfile
+++ b/.docker/standalone.Dockerfile
@@ -87,7 +87,7 @@ ARG CI_TARGET=uregressions
 ARG CI_THREADS=24
 ARG CI_BRANCH=master
 ARG CI_NO_KARAMEL=
-RUN --mount=type=secret,id=DZOMO_GITHUB_TOKEN eval $(opam env) && Z3_LICENSE="$(opam config expand '%{prefix}%')/.opam-switch/sources/z3.4.8.5/LICENSE.txt" CI_NO_KARAMEL=$CI_NO_KARAMEL DZOMO_GITHUB_TOKEN=$(sudo cat /run/secrets/DZOMO_GITHUB_TOKEN) .docker/build/build-standalone.sh $CI_TARGET $CI_THREADS $CI_BRANCH
+RUN eval $(opam env) && Z3_LICENSE="$(opam config expand '%{prefix}%')/.opam-switch/sources/z3.4.8.5/LICENSE.txt" CI_NO_KARAMEL=$CI_NO_KARAMEL .docker/build/build-standalone.sh $CI_TARGET $CI_THREADS $CI_BRANCH
 
 WORKDIR $HOME
 ENV FSTAR_HOME $HOME/FStar

--- a/.docker/standalone.Dockerfile
+++ b/.docker/standalone.Dockerfile
@@ -5,16 +5,13 @@ FROM fstar_ci_base
 # Copy repo into image.
 ADD --chown=opam:opam ./ $HOME/FStar/
 
-# Make sure opam dependencies are installed, the base image
-# may be stale.
-RUN opam install --confirm-level=unsafe-yes --deps-only ./fstar.opam
-
 # Run CI proper
 WORKDIR $HOME/FStar
 ARG CI_TARGET=uregressions
 ARG CI_THREADS=24
 ARG CI_BRANCH=master
 ARG CI_NO_KARAMEL=
+ARG RESOURCEMONITOR=
 RUN eval $(opam env) && Z3_LICENSE="$(opam config expand '%{prefix}%')/.opam-switch/sources/z3.4.8.5/LICENSE.txt" CI_NO_KARAMEL=$CI_NO_KARAMEL .docker/build/build-standalone.sh $CI_TARGET $CI_THREADS $CI_BRANCH
 
 WORKDIR $HOME

--- a/.docker/standalone.Dockerfile
+++ b/.docker/standalone.Dockerfile
@@ -10,7 +10,7 @@ WORKDIR $HOME/FStar
 
 # Make sure opam dependencies are installed, the base image
 # may be stale.
-RUN opam install --confirm-level=unsafe-yes --deps-only ./fstar.opam
+RUN opam install --confirm-level=unsafe-yes --deps-only ./fstar.opam && opam clean
 
 # Run CI proper
 ARG CI_TARGET=uregressions

--- a/.docker/standalone.Dockerfile
+++ b/.docker/standalone.Dockerfile
@@ -5,8 +5,14 @@ FROM fstar_ci_base
 # Copy repo into image.
 ADD --chown=opam:opam ./ $HOME/FStar/
 
-# Run CI proper
+# Go into repo
 WORKDIR $HOME/FStar
+
+# Make sure opam dependencies are installed, the base image
+# may be stale.
+RUN opam install --confirm-level=unsafe-yes --deps-only ./fstar.opam
+
+# Run CI proper
 ARG CI_TARGET=uregressions
 ARG CI_THREADS=24
 ARG CI_BRANCH=master

--- a/.github/workflows/linux-x64-rebuild-base.yaml
+++ b/.github/workflows/linux-x64-rebuild-base.yaml
@@ -1,0 +1,137 @@
+name: Rebuild base image
+on:
+  schedule:
+    # 2AM UTC
+    - cron: '0 2 * * *'
+  workflow_dispatch:
+    inputs:
+      force:
+        description: Update the base image even if running F* CI fails
+        required: true
+        type: boolean
+jobs:
+  build:
+    runs-on: [self-hosted, linux, X64]
+    defaults:
+      run:
+        # Setting the default shell to bash. This is not only more standard,
+        # but also makes sure that we run with -o pipefail, so we can safely
+        # pipe data (such as | tee LOG) without missing out on failures
+        # and getting false positives. If you want to change the default shell,
+        # keep in mind you need a way to handle this.
+        shell: bash
+
+    steps:
+      - name: Rebuild base image from scratch
+        run: |
+          TEMP_IMAGE_NAME=fstar:update-base-$GITHUB_RUN_ID-$GITHUB_RUN_ATTEMPT
+          CI_IMAGEBUILD_INITIAL_TIMESTAMP=$(date '+%s')
+          docker build --pull --no-cache -f .docker/base.Dockerfile -t ${TEMP_IMAGE_NAME} .
+          CI_IMAGEBUILD_FINAL_TIMESTAMP=$(date '+%s')
+          echo "TEMP_IMAGE_NAME=$TEMP_IMAGE_NAME" >> $GITHUB_ENV
+
+      - name: Check that F* CI passes
+        run: |
+          echo "CI_INITIAL_TIMESTAMP=$(date '+%s')" >> $GITHUB_ENV
+          ci_docker_image_tag=fstar:update-base-test-$GITHUB_RUN_ID-$GITHUB_RUN_ATTEMPT
+          echo "ci_docker_image_tag=$ci_docker_image_tag" >> $GITHUB_ENV
+
+          CI_TARGET=uregressions
+          docker build --no-cache -t $ci_docker_image_tag -f .docker/standalone.Dockerfile --build-arg CI_TARGET="$CI_TARGET" . |& tee BUILDLOG
+          ci_docker_status=$(docker run $ci_docker_image_tag /bin/bash -c 'cat $FSTAR_HOME/status.txt' || echo false)
+          $ci_docker_status
+
+      - name: Tag base image
+        if: ${{ success () || inputs.force }}
+        run: |
+          docker tag ${TEMP_IMAGE_NAME} fstar_ci_base
+
+      - name: Remove intermediate images
+        if: ${{ always() }}
+        run: |
+          docker rmi -f ${TEMP_IMAGE_NAME} || true
+          docker rmi -f ${ci_docker_image_tag} || true
+
+      - name: Compute elapsed time and status message
+        if: ${{ always() }}
+        run: |
+          CI_FINAL_TIMESTAMP=$(date '+%s')
+          CI_TIME_DIFF=$(( $CI_FINAL_TIMESTAMP - $CI_INITIAL_TIMESTAMP ))
+          echo "CI_TIME_DIFF_S=$(( $CI_TIME_DIFF % 60 ))" >> $GITHUB_ENV
+          echo "CI_TIME_DIFF_M=$(( ($CI_TIME_DIFF / 60) % 60 ))" >> $GITHUB_ENV
+          echo "CI_TIME_DIFF_H=$(( $CI_TIME_DIFF / 3600 ))" >> $GITHUB_ENV
+          case ${{ job.status }} in
+          (success)
+            if orange_contents="$(docker run $ci_docker_image_tag /bin/bash -c 'cat $FSTAR_HOME/orange_file.txt')" && [[ $orange_contents = '' ]] ; then
+              echo "CI_EMOJI=✅" >> $GITHUB_ENV
+            else
+              echo "CI_EMOJI=⚠" >> $GITHUB_ENV
+            fi
+            ;;
+          (cancelled)
+            echo "CI_EMOJI=⚠" >> $GITHUB_ENV
+            ;;
+          (*)
+            echo "CI_EMOJI=❌" >> $GITHUB_ENV
+            ;;
+          esac
+          echo "CI_COMMIT=$(echo ${{ github.event.head_commit.id || github.event.pull_request.head.sha }} | grep -o '^........')" >> $GITHUB_ENV
+          echo 'CI_STATUS='"$(docker run $ci_docker_image_tag /bin/bash -c 'cat $FSTAR_HOME/result.txt' || echo Failure)" >> $GITHUB_ENV
+          if [ -n "$CI_IMAGEBUILD_INITIALTIMESTAMP" ]; then
+            DIFF=$(( $CI_IMAGEBUILD_FINAL_TIMESTAMP - $CI_IMAGEBUILD_INITIAL_TIMESTAMP ))
+            SS=$(( $DIFF % 60 ))
+            MM=$(( ($DIFF / 60) % 60 ))
+            HH=$(( $DIFF / 3600 ))
+            CI_IMAGEBUILD_MSG=" (base image rebuilt in ${HH}h ${MM}m ${SS}s)"
+            echo "CI_IMAGEBUILD_MSG='$CI_IMAGEBUILD_MSG'" >> $GITHUB_ENV
+          fi
+
+      - name: Output build log error summary
+        if: ${{ always () }}
+        run: |
+          # Just outputs to the github snippet. Could be part of slack message.
+          # This command never triggers a failure
+          grep -C10 -Ew ' \*\*\* |\(Error' BUILDLOG || true
+
+      - name: Post to the Slack channel
+        if: ${{ always() && (github.event_name != 'workflow_dispatch') }}
+        id: slack
+        uses: slackapi/slack-github-action@v1.23.0
+        with:
+          channel-id: ${{ env.CI_SLACK_CHANNEL }}
+          payload: |
+            {
+              "blocks" : [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "Update F* base CI image\n<${{ github.event.head_commit.url || github.event.pull_request.html_url }}|${{ env.CI_COMMIT }}> on (${{ github.ref_name }}) by ${{ github.event.head_commit.author.username || github.event.pull_request.user.login }}"
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "plain_text",
+                    "text": ${{ toJSON(github.event.head_commit.message || github.event.pull_request.title) }}
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "${{ env.CI_EMOJI }} <https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}|${{ env.CI_STATUS }}>"
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "Duration: ${{ env.CI_TIME_DIFF_H }}h ${{ env.CI_TIME_DIFF_M }}min ${{ env.CI_TIME_DIFF_S }}s${{env.CI_IMAGEBUILD_MSG}}"
+                  }
+                }
+              ]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/.github/workflows/linux-x64.yaml
+++ b/.github/workflows/linux-x64.yaml
@@ -69,15 +69,13 @@ jobs:
         if: ${{ (github.event_name == 'workflow_dispatch') && inputs.ci_skip_image_tag }}
         run: |
           echo "CI_SKIP_IMAGE_TAG=1" >> $GITHUB_ENV
+
       - name: Build FStar and its dependencies
         run: |
           ci_docker_image_tag=fstar:local-run-$GITHUB_RUN_ID-$GITHUB_RUN_ATTEMPT
           echo "ci_docker_image_tag=$ci_docker_image_tag" >> $GITHUB_ENV
-          ci_docker_builder=builder_fstar_${GITHUB_RUN_ID}_${GITHUB_RUN_ATTEMPT}
-          echo "ci_docker_builder=$ci_docker_builder" >> $GITHUB_ENV
-          docker buildx create --name $ci_docker_builder --driver-opt env.BUILDKIT_STEP_LOG_MAX_SIZE=500000000
           if [[ -z $CI_TARGET ]] ; then CI_TARGET=uregressions ; fi
-          docker buildx build --builder $ci_docker_builder --pull --load --secret id=DZOMO_GITHUB_TOKEN -t $ci_docker_image_tag -f .docker/standalone.Dockerfile --build-arg CI_BRANCH=$GITHUB_REF_NAME --build-arg CI_TARGET="$CI_TARGET" $CI_DO_TEST_MIN_OPAM_DEPS $CI_DO_OCAML_VERSION $CI_DO_NO_KARAMEL . |& tee BUILDLOG
+          docker build -t $ci_docker_image_tag -f .docker/standalone.Dockerfile --build-arg CI_BRANCH=$GITHUB_REF_NAME --build-arg CI_TARGET="$CI_TARGET" $CI_DO_TEST_MIN_OPAM_DEPS $CI_DO_OCAML_VERSION $CI_DO_NO_KARAMEL . |& tee BUILDLOG
           ci_docker_status=$(docker run $ci_docker_image_tag /bin/bash -c 'cat $FSTAR_HOME/status.txt' || echo false)
           if $ci_docker_status && [[ -z "$CI_SKIP_IMAGE_TAG" ]] ; then
             if ! { echo $GITHUB_REF_NAME | grep '/' ; } ; then
@@ -86,11 +84,6 @@ jobs:
             docker tag $ci_docker_image_tag fstar:local-commit-$GITHUB_SHA
           fi
           $ci_docker_status
-
-      - name: Clean up temporary container
-        if: ${{ always() }}
-        run: |
-          docker buildx rm $ci_docker_builder
 
       - name: Pushed the generated hints
         if: ${{ (github.event_name == 'workflow_dispatch') && inputs.ci_refresh_hints }}

--- a/.github/workflows/linux-x64.yaml
+++ b/.github/workflows/linux-x64.yaml
@@ -30,6 +30,14 @@ on:
 jobs:
   build:
     runs-on: [self-hosted, linux, X64]
+    defaults:
+      run:
+        # Setting the default shell to bash. This is not only more standard,
+        # but also makes sure that we run with -o pipefail, so we can safely
+        # pipe data (such as | tee LOG) without missing out on failures
+        # and getting false positives. If you want to change the default shell,
+        # keep in mind you need a way to handle this.
+        shell: bash
     steps:
       - name: Record initial timestamp
         run: |

--- a/.github/workflows/linux-x64.yaml
+++ b/.github/workflows/linux-x64.yaml
@@ -185,11 +185,14 @@ jobs:
           fi
 
       - name: Output build log error summary
-        if: ${{ always () }}
+        if: ${{ failure () }}
         run: |
           # Just outputs to the github snippet. Could be part of slack message.
           # This command never triggers a failure
-          grep -C10 -Ew ' \*\*\* |\(Error' BUILDLOG || true
+          grep -C10 -Ew ' \*\*\* |\(Error' BUILDLOG > BUILDLOG_ERRORS || true
+          ERRORS_URL=$(.scripts/sprang BUILDLOG_ERRORS)
+          ERRORS_MSG=" <$ERRORS_URL|(Error summary)>"
+          echo "ERRORS_MSG=$ERRORS_MSG" >> $GITHUB_ENV
 
       - name: Post to the Slack channel
         if: ${{ always() && (github.event_name != 'workflow_dispatch') }}
@@ -218,7 +221,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "${{ env.CI_EMOJI }} <https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}|${{ env.CI_STATUS }}>"
+                    "text": "${{ env.CI_EMOJI }} <https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}|${{ env.CI_STATUS }}>${{ env.ERRORS_MSG}}"
                   }
                 },
                 {

--- a/.github/workflows/linux-x64.yaml
+++ b/.github/workflows/linux-x64.yaml
@@ -70,6 +70,13 @@ jobs:
         run: |
           echo "CI_SKIP_IMAGE_TAG=1" >> $GITHUB_ENV
 
+      - name: Make sure base image is present, or build it
+        run: |
+          if ! docker images | grep '^fstar_ci_base '; then
+            echo '*** REBUILDING fstar_ci_base image'
+            docker build -f .docker/base.Dockerfile -t fstar_ci_base .
+          fi
+
       - name: Build FStar and its dependencies
         run: |
           ci_docker_image_tag=fstar:local-run-$GITHUB_RUN_ID-$GITHUB_RUN_ATTEMPT

--- a/.github/workflows/linux-x64.yaml
+++ b/.github/workflows/linux-x64.yaml
@@ -43,7 +43,7 @@ jobs:
         run: |
           echo "CI_INITIAL_TIMESTAMP=$(date '+%s')" >> $GITHUB_ENV
       - name: Check out repo        
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Identify the notification channel
         run: |
           echo "CI_SLACK_CHANNEL=$(jq -c -r '.NotificationChannel' .docker/build/config.json)" >> $GITHUB_ENV
@@ -125,7 +125,7 @@ jobs:
       - name: Post to the Slack channel
         if: ${{ always() && (github.event_name != 'workflow_dispatch') }}
         id: slack
-        uses: slackapi/slack-github-action@v1.16.0
+        uses: slackapi/slack-github-action@v1.23.0
         with:
           channel-id: ${{ env.CI_SLACK_CHANNEL }}
           payload: |

--- a/.github/workflows/linux-x64.yaml
+++ b/.github/workflows/linux-x64.yaml
@@ -50,6 +50,7 @@ jobs:
       - name: Set the refresh hints flag
         if: ${{ (github.event_name == 'workflow_dispatch') && inputs.ci_refresh_hints }}
         run: |
+          # NOTE: this causes the build to record hints
           echo "CI_TARGET=uregressions-ulong" >> $GITHUB_ENV
       - name: Populate test min opam deps arg
         if: ${{ (github.event_name == 'workflow_dispatch') && inputs.ci_test_min_opam_deps }}
@@ -71,6 +72,7 @@ jobs:
       - name: Build FStar and its dependencies
         run: |
           ci_docker_image_tag=fstar:local-run-$GITHUB_RUN_ID-$GITHUB_RUN_ATTEMPT
+          echo "ci_docker_image_tag=$ci_docker_image_tag" >> $GITHUB_ENV
           ci_docker_builder=builder_fstar_${GITHUB_RUN_ID}_${GITHUB_RUN_ATTEMPT}
           echo "ci_docker_builder=$ci_docker_builder" >> $GITHUB_ENV
           docker buildx create --name $ci_docker_builder --driver-opt env.BUILDKIT_STEP_LOG_MAX_SIZE=500000000
@@ -84,12 +86,19 @@ jobs:
             docker tag $ci_docker_image_tag fstar:local-commit-$GITHUB_SHA
           fi
           $ci_docker_status
-        env:
-          DZOMO_GITHUB_TOKEN: ${{ secrets.DZOMO_GITHUB_TOKEN }}
+
       - name: Clean up temporary container
         if: ${{ always() }}
         run: |
           docker buildx rm $ci_docker_builder
+
+      - name: Pushed the generated hints
+        if: ${{ (github.event_name == 'workflow_dispatch') && inputs.ci_refresh_hints }}
+        run: |
+          docker run $ci_docker_image_tag export bash -c "env DZOMO_GITHUB_TOKEN=$DZOMO_GITHUB_TOKEN .scripts/advance.sh refresh_fstar_hints"
+        env:
+          DZOMO_GITHUB_TOKEN: ${{ secrets.DZOMO_GITHUB_TOKEN }}
+
       - name: Compute elapsed time and status message
         if: ${{ always() }}
         run: |

--- a/.github/workflows/linux-x64.yaml
+++ b/.github/workflows/linux-x64.yaml
@@ -74,7 +74,11 @@ jobs:
         run: |
           if ! docker images | grep '^fstar_ci_base '; then
             echo '*** REBUILDING fstar_ci_base image'
+            CI_IMAGEBUILD_INITIAL_TIMESTAMP=$(date '+%s')
             docker build -f .docker/base.Dockerfile -t fstar_ci_base .
+            CI_IMAGEBUILD_FINAL_TIMESTAMP=$(date '+%s')
+            echo "CI_IMAGEBUILD_INITIAL_TIMESTAMP='$CI_IMAGEBUILD_INITIAL_TIMESTAMP'" >> $GITHUB_ENV
+            echo "CI_IMAGEBUILD_FINAL_TIMESTAMP='$CI_IMAGEBUILD_FINAL_TIMESTAMP'" >> $GITHUB_ENV
           fi
 
       - name: Build FStar and its dependencies
@@ -124,6 +128,15 @@ jobs:
           esac
           echo "CI_COMMIT=$(echo ${{ github.event.head_commit.id || github.event.pull_request.head.sha }} | grep -o '^........')" >> $GITHUB_ENV
           echo 'CI_STATUS='"$(docker run fstar:local-run-$GITHUB_RUN_ID-$GITHUB_RUN_ATTEMPT /bin/bash -c 'cat $FSTAR_HOME/result.txt' || echo Failure)" >> $GITHUB_ENV
+          if [ -n "$CI_IMAGEBUILD_INITIALTIMESTAMP" ]; then
+            DIFF=$(( $CI_IMAGEBUILD_FINAL_TIMESTAMP - $CI_IMAGEBUILD_INITIAL_TIMESTAMP ))
+            SS=$(( $DIFF % 60 ))
+            MM=$(( ($DIFF / 60) % 60 ))
+            HH=$(( $DIFF / 3600 ))
+            CI_IMAGEBUILD_MSG=" (base image rebuilt in ${HH}h ${MM}m ${SS}s)"
+            echo "CI_IMAGEBUILD_MSG='$CI_IMAGEBUILD_MSG'" >> $GITHUB_ENV
+          fi
+
       - name: Output build log error summary
         if: ${{ always () }}
         run: |
@@ -165,7 +178,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "plain_text",
-                    "text": "Duration: ${{ env.CI_TIME_DIFF_H }}h ${{ env.CI_TIME_DIFF_M }}min ${{ env.CI_TIME_DIFF_S }}s"
+                    "text": "Duration: ${{ env.CI_TIME_DIFF_H }}h ${{ env.CI_TIME_DIFF_M }}min ${{ env.CI_TIME_DIFF_S }}s${{env.CI_IMAGEBUILD_MSG}}"
                   }
                 }
               ]

--- a/.github/workflows/linux-x64.yaml
+++ b/.github/workflows/linux-x64.yaml
@@ -160,7 +160,7 @@ jobs:
           echo "CI_TIME_DIFF_H=$(( $CI_TIME_DIFF / 3600 ))" >> $GITHUB_ENV
           case ${{ job.status }} in
           (success)
-            if orange_contents="$(docker run fstar:local-run-$GITHUB_RUN_ID-$GITHUB_RUN_ATTEMPT /bin/bash -c 'cat $FSTAR_HOME/orange_file.txt')" && [[ $orange_contents = '' ]] ; then
+            if orange_contents="$(docker run $ci_docker_image_tag /bin/bash -c 'cat $FSTAR_HOME/orange_file.txt')" && [[ $orange_contents = '' ]] ; then
               echo "CI_EMOJI=✅" >> $GITHUB_ENV
             else
               echo "CI_EMOJI=⚠" >> $GITHUB_ENV
@@ -174,7 +174,7 @@ jobs:
             ;;
           esac
           echo "CI_COMMIT=$(echo ${{ github.event.head_commit.id || github.event.pull_request.head.sha }} | grep -o '^........')" >> $GITHUB_ENV
-          echo 'CI_STATUS='"$(docker run fstar:local-run-$GITHUB_RUN_ID-$GITHUB_RUN_ATTEMPT /bin/bash -c 'cat $FSTAR_HOME/result.txt' || echo Failure)" >> $GITHUB_ENV
+          echo 'CI_STATUS='"$(docker run $ci_docker_image_tag /bin/bash -c 'cat $FSTAR_HOME/result.txt' || echo Failure)" >> $GITHUB_ENV
           if [ -n "$CI_IMAGEBUILD_INITIALTIMESTAMP" ]; then
             DIFF=$(( $CI_IMAGEBUILD_FINAL_TIMESTAMP - $CI_IMAGEBUILD_INITIAL_TIMESTAMP ))
             SS=$(( $DIFF % 60 ))

--- a/.github/workflows/linux-x64.yaml
+++ b/.github/workflows/linux-x64.yaml
@@ -69,6 +69,10 @@ jobs:
         if: ${{ (github.event_name == 'workflow_dispatch') && inputs.ci_skip_image_tag }}
         run: |
           echo "CI_SKIP_IMAGE_TAG=1" >> $GITHUB_ENV
+      - name: Enable resource monitoring
+        if: ${{ vars.FSTAR_CI_RESOURCEMONITOR == '1' }}
+        run: |
+          echo "RESOURCEMONITOR=1" >> $GITHUB_ENV
 
       - name: Make sure base image is present, or build it
         run: |
@@ -81,12 +85,13 @@ jobs:
             echo "CI_IMAGEBUILD_FINAL_TIMESTAMP='$CI_IMAGEBUILD_FINAL_TIMESTAMP'" >> $GITHUB_ENV
           fi
 
+
       - name: Build FStar and its dependencies
         run: |
           ci_docker_image_tag=fstar:local-run-$GITHUB_RUN_ID-$GITHUB_RUN_ATTEMPT
           echo "ci_docker_image_tag=$ci_docker_image_tag" >> $GITHUB_ENV
           if [[ -z $CI_TARGET ]] ; then CI_TARGET=uregressions ; fi
-          docker build -t $ci_docker_image_tag -f .docker/standalone.Dockerfile --build-arg CI_BRANCH=$GITHUB_REF_NAME --build-arg CI_TARGET="$CI_TARGET" $CI_DO_TEST_MIN_OPAM_DEPS $CI_DO_OCAML_VERSION $CI_DO_NO_KARAMEL . |& tee BUILDLOG
+          docker build -t $ci_docker_image_tag -f .docker/standalone.Dockerfile --build-arg CI_BRANCH=$GITHUB_REF_NAME --build-arg CI_TARGET="$CI_TARGET" --build-arg RESOURCEMONITOR=$RESOURCEMONITOR $CI_DO_TEST_MIN_OPAM_DEPS $CI_DO_OCAML_VERSION $CI_DO_NO_KARAMEL . |& tee BUILDLOG
           ci_docker_status=$(docker run $ci_docker_image_tag /bin/bash -c 'cat $FSTAR_HOME/status.txt' || echo false)
           if $ci_docker_status && [[ -z "$CI_SKIP_IMAGE_TAG" ]] ; then
             if ! { echo $GITHUB_REF_NAME | grep '/' ; } ; then
@@ -102,6 +107,48 @@ jobs:
           docker run $ci_docker_image_tag export bash -c "env DZOMO_GITHUB_TOKEN=$DZOMO_GITHUB_TOKEN .scripts/advance.sh refresh_fstar_hints"
         env:
           DZOMO_GITHUB_TOKEN: ${{ secrets.DZOMO_GITHUB_TOKEN }}
+
+      - name: Collect resource monitoring files and summary
+        if: ${{ always () && vars.FSTAR_CI_RESOURCEMONITOR == '1' }}
+        continue-on-error: true
+        run: |
+          # docker cp needs absolute path, obtain FSTAR_HOME
+          FSTAR_HOME=$(docker run $ci_docker_image_tag /bin/bash -c 'echo $FSTAR_HOME')
+          # We briefly kick up a container from the generated image, so
+          # we can extract files from it. No need to start it though.
+          temp_container=$(docker create $ci_docker_image_tag)
+          docker cp $temp_container:${FSTAR_HOME}/rmon/ rmon
+          docker rm -f $temp_container
+
+          # Also, read these bottom-line values into the environment so they
+          # can go into the Slack message.
+          FSTAR_CI_MEASURE_CPU=$(awk -F':' '/Total CPU/ { print $2 }' rmon/res_summary.txt)
+          FSTAR_CI_MEASURE_MEM=$(awk -F':' '/Total memory/ { print $2 }' rmon/res_summary.txt)
+          echo "FSTAR_CI_MEASURE_CPU=$FSTAR_CI_MEASURE_CPU" >> $GITHUB_ENV
+          echo "FSTAR_CI_MEASURE_MEM=$FSTAR_CI_MEASURE_MEM" >> $GITHUB_ENV
+
+          # Final goodie: upload the summary to sprunge.us and add a link in
+          # the Slack message for a 1-click report.
+          RMON_URL=$(.scripts/sprang rmon/res_summary.txt)
+          echo "RMON_URL=$RMON_URL" >> $GITHUB_ENV
+
+      - name: Save resource monitor summary as artifact
+        if: ${{ always () && vars.FSTAR_CI_RESOURCEMONITOR == '1' }}
+        continue-on-error: true
+        uses: actions/upload-artifact@v3
+        with:
+          name: Resource usage information (summary)
+          path: |
+            rmon/res_summary.txt
+
+      - name: Save resource monitor files as artifact
+        if: ${{ always () && vars.FSTAR_CI_RESOURCEMONITOR == '1' }}
+        continue-on-error: true
+        uses: actions/upload-artifact@v3
+        with:
+          name: Resource usage information (individual)
+          path: |
+            rmon/rmon.tgz
 
       - name: Compute elapsed time and status message
         if: ${{ always() }}
@@ -179,6 +226,13 @@ jobs:
                   "text": {
                     "type": "plain_text",
                     "text": "Duration: ${{ env.CI_TIME_DIFF_H }}h ${{ env.CI_TIME_DIFF_M }}min ${{ env.CI_TIME_DIFF_S }}s${{env.CI_IMAGEBUILD_MSG}}"
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "<${{env.RMON_URL}}|Resource summary>\nTotal CPU usage: ${{ env.FSTAR_CI_MEASURE_CPU }}\nTotal memory usage: ${{ env.FSTAR_CI_MEASURE_MEM }}"
                   }
                 }
               ]

--- a/.github/workflows/macos-build.yml
+++ b/.github/workflows/macos-build.yml
@@ -11,16 +11,16 @@ jobs:
 
     steps:
     - name: Checkout FStar
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         path: FStar
     - name: Checkout everest
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         repository: project-everest/everest
         path: FStar/.github/everest
     - name: Install .NET SDK
-      uses: actions/setup-dotnet@v2
+      uses: actions/setup-dotnet@v3
       with:
         dotnet-version: '6.0.x'
     - name: Setup dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
     - name: Check out repo        
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Package and release FStar
       run: |
           ci_docker_image_tag=fstar-release:local-run-$GITHUB_RUN_ID-$GITHUB_RUN_ATTEMPT
@@ -33,11 +33,11 @@ jobs:
 
     steps:
     - name: Checkout FStar
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         path: FStar
     - name: Checkout everest
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         repository: project-everest/everest
         path: FStar/.github/everest
@@ -62,7 +62,7 @@ jobs:
 
     steps:
     - name: Check out repo        
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       
     - name: Package and release FStar
       shell: C:\cygwin64\bin\bash.exe --login '{0}'

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
     - name: Check out repo        
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       
     - name: Build a package
       shell: C:\cygwin64\bin\bash.exe --login '{0}'

--- a/.gitignore
+++ b/.gitignore
@@ -64,6 +64,7 @@ dump
 *.cmxa
 *.o
 fstar.install
+._fstar.install
 
 .depend
 .depend.rsp

--- a/.scripts/res_summary.sh
+++ b/.scripts/res_summary.sh
@@ -47,3 +47,15 @@ echo "Top 20 CPU time:"
 for fp in "${!cpu[@]}"; do
 	printf " %-80s %12s\n" "$fp" "${cpu[$fp]} s"
 done | sort -k2 -n -r  | head -n 20
+
+TOTMEM=0
+TOTCPU=0
+# Trying to do this in the loops above won't work as the command runs in
+# a subshell, with its own set of variables. Bash is fun :^).
+for fp in "${!mem[@]}"; do
+	TOTMEM=$(($TOTMEM + ${mem[$fp]}))
+	TOTCPU=$(echo $TOTCPU + ${cpu[$fp]} | bc)
+done
+
+echo "Total CPU: $TOTCPU seconds"
+echo "Total memory: $TOTMEM MB"

--- a/.scripts/sprang
+++ b/.scripts/sprang
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+function usage () {
+	cat << HERE
+$0
+
+DESCRIPTION
+  Upload data and fetch URL from the pastebin http://sprunge.us
+  Echoes back the URL where to find the paste
+
+USAGE
+  $0 filename.txt
+  $0 < filename.txt
+  piped_data | $0
+
+HERE
+	exit 1
+}
+
+case "$1" in
+	-h|--help)
+	    usage
+	    ;;
+esac
+
+cat "$@" | curl -F 'sprunge=<-' http://sprunge.us

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,7 @@
-.PHONY: all package clean boot 1 2 3 hints bench output install uninstall package
-
 include .common.mk
 
-all: dune
+.PHONY: all
+all: build-and-verify-ulib
 
 DUNE_SNAPSHOT ?= $(call maybe_cygwin_path,$(CURDIR)/ocaml)
 
@@ -14,9 +13,10 @@ PREFIX ?= /usr/local
 # supports Windows paths.
 FSTAR_CURDIR=$(call maybe_cygwin_path,$(CURDIR))
 
-.PHONY: dune dune-fstar verify-ulib
 FSTAR_BUILD_PROFILE ?= release
-dune-fstar:
+
+.PHONY: fstar
+fstar:
 	$(Q)cp version.txt $(DUNE_SNAPSHOT)/
 	@# Call Dune to build the snapshot.
 	@echo "  DUNE BUILD"
@@ -24,57 +24,59 @@ dune-fstar:
 	@echo "  DUNE INSTALL"
 	$(Q)cd $(DUNE_SNAPSHOT) && dune install --profile=$(FSTAR_BUILD_PROFILE) --prefix=$(FSTAR_CURDIR)
 
+.PHONY: verify-ulin
 verify-ulib:
-	+$(MAKE) -C ulib
+	+$(Q)$(MAKE) -C ulib
 
-dune: dune-fstar
-	+$(MAKE) verify-ulib
-
-.PHONY: clean-dune-snapshot
+.PHONY: build-and-verify-ulib
+build-and-verify-ulib: fstar
+	+$(Q)$(MAKE) verify-ulib
 
 # Removes all generated files (including the whole generated snapshot,
 # and .checked files), except the object files, so that the snapshot
 # can be rebuilt with an existing fstar.exe
-clean-dune-snapshot: clean-intermediate
-	cd $(DUNE_SNAPSHOT) && { dune clean || true ; }
-	rm -rf $(DUNE_SNAPSHOT)/fstar-lib/generated/*
-	rm -rf $(DUNE_SNAPSHOT)/fstar-lib/dynamic/*
+.PHONY: clean-snapshot
+clean-snapshot: clean-intermediate
+	$(call msg, "CLEAN SNAPSHOT")
+	$(Q)cd $(DUNE_SNAPSHOT) && { dune clean || true ; }
+	$(Q)rm -rf $(DUNE_SNAPSHOT)/fstar-lib/generated/*
 
-.PHONY: dune-extract-all
-
-dune-extract-all:
-	+$(MAKE) -C src/ocaml-output dune-snapshot
+.PHONY: extract-all
+extract-all:
+	+$(Q)$(MAKE) -C src/ocaml-output dune-snapshot
 
 # This rule is not incremental, by design.
-dune-full-bootstrap:
-	+$(MAKE) dune-fstar
-	+$(MAKE) clean-dune-snapshot
-	+$(MAKE) dune-bootstrap
+.PHONY: full-bootstrap
+full-bootstrap:
+	+$(Q)$(MAKE) fstar
+	+$(Q)$(MAKE) clean-snapshot
+	+$(Q)$(MAKE) bootstrap
 
-.PHONY: dune-bootstrap
-dune-bootstrap:
-	+$(MAKE) dune-extract-all
-	+$(MAKE) dune
+.PHONY: bootstrap
+bootstrap:
+	+$(Q)$(MAKE) extract-all
+	+$(Q)$(MAKE) fstar
 
 .PHONY: boot
-
 boot:
-	+$(MAKE) dune-extract-all
+	+$(Q)$(MAKE) extract-all
 	$(Q)cp version.txt $(DUNE_SNAPSHOT)/
 	@# Call Dune to build the snapshot.
-	@echo "  DUNE BUILD"
+	$(call msg, "DUNE BUILD")
 	$(Q)cd $(DUNE_SNAPSHOT) && dune build --profile release
-	@echo "  RAW INSTALL"
+	$(call msg, "RAW INSTALL")
 	$(Q)cp ocaml/_build/default/fstar/main.exe $(FSTAR_CURDIR)/bin/fstar.exe
 
+.PHONY: install
 install:
-	$(Q)+$(MAKE) -C src/ocaml-output install
+	+$(Q)$(MAKE) -C src/ocaml-output install
 
 # The `uninstall` rule is only necessary for users who manually ran
 # `make install`. It is not needed if F* was installed with opam,
 # since `opam remove` can uninstall packages automatically with its
 # own way.
 
+.PHONY: uninstall
 uninstall:
 	rm -rf \
 	  $(PREFIX)/lib/fstar \
@@ -82,61 +84,75 @@ uninstall:
 	  $(PREFIX)/bin/fstar.exe \
 	  $(PREFIX)/share/fstar
 
+.PHONY: package
 package: all
-	$(Q)+$(MAKE) -C src/ocaml-output package
-
-.PHONY: clean-intermediate
+	+$(Q)$(MAKE) -C src/ocaml-output package
 
 # Removes everything created by `make all`. MUST NOT be used when
 # bootstrapping.
+.PHONY: clean
 clean: clean-intermediate
 	cd $(DUNE_SNAPSHOT) && { dune uninstall --prefix=$(FSTAR_CURDIR) || true ; } && { dune clean || true ; }
 
 # Removes all .checked files and other intermediate files
 # Does not remove the object files from the dune snapshot,
 # because otherwise dune can't uninstall properly
+.PHONY: clean-intermediate
 clean-intermediate:
-	$(Q)+$(MAKE) -C ulib clean
-	$(Q)+$(MAKE) -C src clean
+	+$(Q)$(MAKE) -C ulib clean
+	+$(Q)$(MAKE) -C src clean
 
 # Regenerate all hints for the standard library and regression test suite
+.PHONY: hints
 hints:
 	+$(Q)OTHERFLAGS=--record_hints $(MAKE) -C ulib/
 	+$(Q)OTHERFLAGS=--record_hints $(MAKE) ci-uregressions
 
+.PHONY: bench
 bench:
 	./bin/run_benchmark.sh
 
 # Regenerate and accept expected output tests. Should be manually
 # reviewed before checking in.
+.PHONY: output
 output:
-	$(Q)+$(MAKE) -C tests/error-messages accept
-	$(Q)+$(MAKE) -C tests/ide/emacs accept
-	$(Q)+$(MAKE) -C tests/bug-reports output-accept
+	+$(Q)$(MAKE) -C tests/error-messages accept
+	+$(Q)$(MAKE) -C tests/ide/emacs accept
+	+$(Q)$(MAKE) -C tests/bug-reports output-accept
 
-.PHONY: ci-utest-prelude
+.PHONY: ci
+ci:
+	+$(Q)$(MAKE) ci-pre
+	+$(Q)$(MAKE) ci-post
 
-ci-utest-prelude:
-	$(Q)+$(MAKE) dune-full-bootstrap FSTAR_BUILD_PROFILE=test
-	$(Q)+$(MAKE) -C src ocaml-unit-tests
-	$(Q)+$(MAKE) -C ulib ulib-in-fsharp    #build ulibfs
+.PHONY: ci-pre
+ci-pre:
+	+$(Q)$(MAKE) full-bootstrap FSTAR_BUILD_PROFILE=test
+	+$(Q)$(MAKE) -C src ocaml-unit-tests
+	+$(Q)$(MAKE) -C ulib ulib-in-fsharp    #build ulibfs
 
-.PHONY: ci-uregressions ci-uregressions-ulong
+.PHONY: ci-post
+ci-post: ci-uregressions
+	+if [ -n "${FSTAR_CI_UREGRESSIONS_ULONG}" ]; then $(MAKE) ci-uregressions-ulong; fi
 
+.PHONY: ci-uregressions
 ci-uregressions:
-	$(Q)+$(MAKE) -C src uregressions
+	+$(Q)$(MAKE) -C src uregressions
 
+.PHONY: ci-uregressions-ulong
 ci-uregressions-ulong:
-	$(Q)+$(MAKE) -C src uregressions-ulong
+	+$(Q)$(MAKE) -C src uregressions-ulong
 
 # Shortcuts:
 
-1: dune-fstar
+.PHONY: 1 2 3
+
+1: fstar
 
 2:
-	+$(MAKE) -C src ocaml
-	+$(MAKE) dune-fstar
+	+$(Q)$(MAKE) -C src ocaml
+	+$(Q)$(MAKE) fstar
 
 3:
-	+$(MAKE) 1
-	+$(MAKE) 2
+	+$(Q)$(MAKE) 1
+	+$(Q)$(MAKE) 2

--- a/Makefile
+++ b/Makefile
@@ -91,12 +91,24 @@ package: all
 # Removes everything created by `make all`. MUST NOT be used when
 # bootstrapping.
 .PHONY: clean
-clean: clean-intermediate
-	cd $(DUNE_SNAPSHOT) && { dune uninstall --prefix=$(FSTAR_CURDIR) || true ; } && { dune clean || true ; }
+clean: clean-intermediate clean-buildfiles
+	$(call msg, "CLEAN")
+	$(Q)cd $(DUNE_SNAPSHOT) && { dune uninstall --prefix=$(FSTAR_CURDIR) || true ; }
+
+# Clean temporary dune build files, while retaining all checked files
+# and installed files. Used to save space after building, particularly
+# after CI. Note we have to keep fstar.install or otherwise `dune
+# uninstall` cannot work.
+.PHONY: clean-buildfiles
+clean-buildfiles:
+	$(call msg, "CLEAN BUILDFILES")
+	$(Q)cp -f $(DUNE_SNAPSHOT)/_build/default/fstar.install ._fstar.install
+	$(Q)cd $(DUNE_SNAPSHOT) && { dune clean || true ; }
+	$(Q)mkdir -p $(DUNE_SNAPSHOT)/_build/default/
+	$(Q)cp -f ._fstar.install $(DUNE_SNAPSHOT)/_build/default/fstar.install
 
 # Removes all .checked files and other intermediate files
-# Does not remove the object files from the dune snapshot,
-# because otherwise dune can't uninstall properly
+# Does not remove the object files from the dune snapshot.
 .PHONY: clean-intermediate
 clean-intermediate:
 	+$(Q)$(MAKE) -C ulib clean

--- a/ulib/Makefile.verify
+++ b/ulib/Makefile.verify
@@ -1,6 +1,9 @@
 .PHONY: verify-core verify-extra
 
 # List the files that should be verified by verify-extra and verify-all
+# NOTE: Only use files that are extracted+linked into the library,
+# or they will anyway be verified when extracting it. Currently, legacy/
+# is the only subdirectory that does not go into fstar.lib.
 EXTRA=legacy/FStar.Pointer.Base.fst
 
 # List the files that should NOT be verified at all


### PR DESCRIPTION
This PR makes CI jobs (only the regular CI workflow on Linux; releases and others are unaffected) start from a base docker image instead of from scratch. This saves time as we don't have to install dependencies (which includes building Z3) on every push.

This change is rather annoying to make as there is no (to my knowledge) way of doing this kind of thing with buildx, especially if we need to avoid [this](https://github.com/moby/buildkit/pull/1754). So, this PR changes the workflow to not use buildx for normal CI jobs. Other workflows still can use it.

The main benefit we got from buildx is safely passing a secret while the image is being built, which we use for the github token so we can advance hints. I've worked around that by building the image without any such secret nor advancing hints, and using `docker run`, which runs a container from an image, after the fact (passing the secret) to push to github. This container is not published anywhere.

The base image is rebuilt nightly (2AM UTC) and, if F* CI passes on it, it is tagged. If CI fails we do not tag, so CI jobs can still run, but we get a notification in Slack so we can fix the base. This is intended to not block people when some upstream dependency breaks.

Note that this slightly relies on the fact that we run all CI jobs on the same machine. The image rebuilding workflow affects the state of the docker installation on the machine so it can be taken by other workflows. If we have more than one machine runner, we would have to run this job once for every machine. Perhaps a cron job is more appropriate.

This also supersedes #2919. However the numbers we are getting vary quite wildly, so maybe we should disable it for now.

I've been testing this on a local runner and CI time reduces by about 50%.