### PR TITLE
A different fix for #2894

### DIFF
--- a/ocaml/fstar-lib/generated/FStar_Compiler_Range_Type.ml
+++ b/ocaml/fstar-lib/generated/FStar_Compiler_Range_Type.ml
@@ -1,5 +1,5 @@
 open Prims
-type file_name = Prims.string[@@deriving yojson,show,yojson,show]
+type file_name = Prims.string[@@deriving yojson,show]
 type pos = {
   line: Prims.int ;
   col: Prims.int }[@@deriving yojson,show,yojson,show]

--- a/ocaml/fstar-lib/generated/FStar_Ident.ml
+++ b/ocaml/fstar-lib/generated/FStar_Ident.ml
@@ -9,8 +9,8 @@ let (__proj__Mkident__item__idText : ident -> Prims.string) =
 let (__proj__Mkident__item__idRange :
   ident -> FStar_Compiler_Range_Type.range) =
   fun projectee -> match projectee with | { idText; idRange;_} -> idRange
-type path = Prims.string Prims.list[@@deriving yojson,show,yojson,show]
-type ipath = ident Prims.list[@@deriving yojson,show,yojson,show]
+type path = Prims.string Prims.list[@@deriving yojson,show]
+type ipath = ident Prims.list[@@deriving yojson,show]
 type lident =
   {
   ns: ipath ;
@@ -95,7 +95,7 @@ let (lid_equals : lident -> lident -> Prims.bool) =
   fun l1 -> fun l2 -> l1.str = l2.str
 let (ident_equals : ident -> ident -> Prims.bool) =
   fun id1 -> fun id2 -> id1.idText = id2.idText
-type lid = lident[@@deriving yojson,show,yojson,show]
+type lid = lident[@@deriving yojson,show]
 let (range_of_lid : lident -> FStar_Compiler_Range_Type.range) =
   fun lid1 -> range_of_id lid1.ident
 let (set_lid_range : lident -> FStar_Compiler_Range_Type.range -> lident) =

--- a/ocaml/fstar-lib/generated/FStar_SMTEncoding_Encode.ml
+++ b/ocaml/fstar-lib/generated/FStar_SMTEncoding_Encode.ml
@@ -1798,36 +1798,19 @@ let (encode_free_var :
                                                  fv1
                                                  FStar_Parser_Const.unit_lid
                                            | uu___12 -> false) in
-                                    let is_arrow t =
-                                      let uu___9 =
-                                        let uu___10 =
-                                          let uu___11 =
-                                            FStar_TypeChecker_Normalize.unfold_whnf'
-                                              [FStar_TypeChecker_Env.EraseUniverses]
-                                              env.FStar_SMTEncoding_Env.tcenv
-                                              t in
-                                          FStar_Syntax_Util.unrefine uu___11 in
-                                        uu___10.FStar_Syntax_Syntax.n in
-                                      match uu___9 with
-                                      | FStar_Syntax_Syntax.Tm_arrow uu___10
-                                          -> true
-                                      | uu___10 -> false in
-                                    ((((let uu___9 = FStar_Ident.nsstr lid in
-                                        uu___9 <> "Prims") &&
-                                         (let uu___9 =
-                                            FStar_Compiler_Effect.op_Bar_Greater
-                                              quals
-                                              (FStar_Compiler_List.contains
-                                                 FStar_Syntax_Syntax.Logic) in
-                                          Prims.op_Negation uu___9))
-                                        &&
-                                        (let uu___9 = is_squash t_norm in
+                                    (((let uu___9 = FStar_Ident.nsstr lid in
+                                       uu___9 <> "Prims") &&
+                                        (let uu___9 =
+                                           FStar_Compiler_Effect.op_Bar_Greater
+                                             quals
+                                             (FStar_Compiler_List.contains
+                                                FStar_Syntax_Syntax.Logic) in
                                          Prims.op_Negation uu___9))
                                        &&
-                                       (let uu___9 = is_type t_norm in
+                                       (let uu___9 = is_squash t_norm in
                                         Prims.op_Negation uu___9))
                                       &&
-                                      (let uu___9 = is_arrow t_norm in
+                                      (let uu___9 = is_type t_norm in
                                        Prims.op_Negation uu___9) in
                                   let uu___8 =
                                     match vars with
@@ -2642,8 +2625,15 @@ let (encode_top_level_let :
                                                Let_rec_unencodeable
                                            else ());
                                           (let t_norm =
-                                             norm_before_encoding env1
-                                               lb.FStar_Syntax_Syntax.lbtyp in
+                                             if is_rec
+                                             then
+                                               FStar_TypeChecker_Normalize.unfold_whnf'
+                                                 [FStar_TypeChecker_Env.AllowUnboundUniverses]
+                                                 env1.FStar_SMTEncoding_Env.tcenv
+                                                 lb.FStar_Syntax_Syntax.lbtyp
+                                             else
+                                               norm_before_encoding env1
+                                                 lb.FStar_Syntax_Syntax.lbtyp in
                                            let uu___7 =
                                              let uu___8 =
                                                FStar_Compiler_Util.right

--- a/ocaml/fstar-lib/generated/FStar_SMTEncoding_Encode.ml
+++ b/ocaml/fstar-lib/generated/FStar_SMTEncoding_Encode.ml
@@ -1790,36 +1790,19 @@ let (encode_free_var :
                                                  fv1
                                                  FStar_Parser_Const.unit_lid
                                            | uu___12 -> false) in
-                                    let is_arrow t =
-                                      let uu___9 =
-                                        let uu___10 =
-                                          let uu___11 =
-                                            FStar_TypeChecker_Normalize.unfold_whnf'
-                                              [FStar_TypeChecker_Env.EraseUniverses]
-                                              env.FStar_SMTEncoding_Env.tcenv
-                                              t in
-                                          FStar_Syntax_Util.unrefine uu___11 in
-                                        uu___10.FStar_Syntax_Syntax.n in
-                                      match uu___9 with
-                                      | FStar_Syntax_Syntax.Tm_arrow uu___10
-                                          -> true
-                                      | uu___10 -> false in
-                                    ((((let uu___9 = FStar_Ident.nsstr lid in
-                                        uu___9 <> "Prims") &&
-                                         (let uu___9 =
-                                            FStar_Compiler_Effect.op_Bar_Greater
-                                              quals
-                                              (FStar_Compiler_List.contains
-                                                 FStar_Syntax_Syntax.Logic) in
-                                          Prims.op_Negation uu___9))
-                                        &&
-                                        (let uu___9 = is_squash t_norm in
+                                    (((let uu___9 = FStar_Ident.nsstr lid in
+                                       uu___9 <> "Prims") &&
+                                        (let uu___9 =
+                                           FStar_Compiler_Effect.op_Bar_Greater
+                                             quals
+                                             (FStar_Compiler_List.contains
+                                                FStar_Syntax_Syntax.Logic) in
                                          Prims.op_Negation uu___9))
                                        &&
-                                       (let uu___9 = is_type t_norm in
+                                       (let uu___9 = is_squash t_norm in
                                         Prims.op_Negation uu___9))
                                       &&
-                                      (let uu___9 = is_arrow t_norm in
+                                      (let uu___9 = is_type t_norm in
                                        Prims.op_Negation uu___9) in
                                   let uu___8 =
                                     match vars with
@@ -2632,8 +2615,15 @@ let (encode_top_level_let :
                                                Let_rec_unencodeable
                                            else ());
                                           (let t_norm =
-                                             norm_before_encoding env1
-                                               lb.FStar_Syntax_Syntax.lbtyp in
+                                             if is_rec
+                                             then
+                                               FStar_TypeChecker_Normalize.unfold_whnf'
+                                                 [FStar_TypeChecker_Env.AllowUnboundUniverses]
+                                                 env1.FStar_SMTEncoding_Env.tcenv
+                                                 lb.FStar_Syntax_Syntax.lbtyp
+                                             else
+                                               norm_before_encoding env1
+                                                 lb.FStar_Syntax_Syntax.lbtyp in
                                            let uu___7 =
                                              let uu___8 =
                                                FStar_Compiler_Util.right

--- a/ocaml/fstar-lib/generated/FStar_Syntax_Syntax.ml
+++ b/ocaml/fstar-lib/generated/FStar_Syntax_Syntax.ml
@@ -7,8 +7,8 @@ let __proj__Mkwithinfo_t__item__v : 'a . 'a withinfo_t -> 'a =
 let __proj__Mkwithinfo_t__item__p :
   'a . 'a withinfo_t -> FStar_Compiler_Range_Type.range =
   fun projectee -> match projectee with | { v; p;_} -> p
-type var = FStar_Ident.lident withinfo_t[@@deriving yojson,show,yojson,show]
-type sconst = FStar_Const.sconst[@@deriving yojson,show,yojson,show]
+type var = FStar_Ident.lident withinfo_t[@@deriving yojson,show]
+type sconst = FStar_Const.sconst[@@deriving yojson,show]
 type pragma =
   | SetOptions of Prims.string 
   | ResetOptions of Prims.string FStar_Pervasives_Native.option 
@@ -41,8 +41,14 @@ let (uu___is_RestartSolver : pragma -> Prims.bool) =
 let (uu___is_PrintEffectsGraph : pragma -> Prims.bool) =
   fun projectee ->
     match projectee with | PrintEffectsGraph -> true | uu___ -> false
-type 'a memo = 'a FStar_Pervasives_Native.option FStar_Compiler_Effect.ref
-[@@deriving yojson,show,yojson,show]
+type 'a memo =
+  (('a FStar_Pervasives_Native.option FStar_Compiler_Effect.ref)[@printer
+                                                                  fun fmt ->
+                                                                    fun _ ->
+                                                                    Format.pp_print_string
+                                                                    fmt
+                                                                    "None"])
+[@@deriving yojson,show]
 type emb_typ =
   | ET_abstract 
   | ET_fun of (emb_typ * emb_typ) 
@@ -102,13 +108,13 @@ let (__proj__U_unif__item___0 :
   = fun projectee -> match projectee with | U_unif _0 -> _0
 let (uu___is_U_unknown : universe -> Prims.bool) =
   fun projectee -> match projectee with | U_unknown -> true | uu___ -> false
-type univ_name = FStar_Ident.ident[@@deriving yojson,show,yojson,show]
+type univ_name = FStar_Ident.ident[@@deriving yojson,show]
 type universe_uvar =
   (universe FStar_Pervasives_Native.option FStar_Unionfind.p_uvar * version *
-    FStar_Compiler_Range_Type.range)[@@deriving yojson,show,yojson,show]
-type univ_names = univ_name Prims.list[@@deriving yojson,show,yojson,show]
-type universes = universe Prims.list[@@deriving yojson,show,yojson,show]
-type monad_name = FStar_Ident.lident[@@deriving yojson,show,yojson,show]
+    FStar_Compiler_Range_Type.range)[@@deriving yojson,show]
+type univ_names = univ_name Prims.list[@@deriving yojson,show]
+type universes = universe Prims.list[@@deriving yojson,show]
+type monad_name = FStar_Ident.lident[@@deriving yojson,show]
 type quote_kind =
   | Quote_static 
   | Quote_dynamic [@@deriving yojson,show]

--- a/ocaml/fstar-lib/generated/FStar_ToSyntax_ToSyntax.ml
+++ b/ocaml/fstar-lib/generated/FStar_ToSyntax_ToSyntax.ml
@@ -8606,9 +8606,7 @@ and (desugar_decl_aux :
                      (sigelt.FStar_Syntax_Syntax.sigquals);
                    FStar_Syntax_Syntax.sigmeta =
                      (sigelt.FStar_Syntax_Syntax.sigmeta);
-                   FStar_Syntax_Syntax.sigattrs =
-                     (FStar_Compiler_List.op_At
-                        sigelt.FStar_Syntax_Syntax.sigattrs attrs1);
+                   FStar_Syntax_Syntax.sigattrs = attrs1;
                    FStar_Syntax_Syntax.sigopts =
                      (sigelt.FStar_Syntax_Syntax.sigopts)
                  }) sigelts in

--- a/src/smtencoding/FStar.SMTEncoding.Encode.fst
+++ b/src/smtencoding/FStar.SMTEncoding.Encode.fst
@@ -435,24 +435,11 @@ let encode_free_var uninterpreted env fv tt t_norm quals :decls_t * env_t =
 
                     | _ -> false
                 in
-                let is_arrow t =
-                  match (U.unrefine (N.unfold_whnf' [EraseUniverses] env.tcenv t)).n with
-                  | Tm_arrow _ -> true
-                  | _ -> false
-                in
                 //Do not thunk ...
                 nsstr lid <> "Prims"  //things in prims
                 && not (quals |> List.contains Logic) //logic qualified terms
                 && not (is_squash t_norm) //ambient squashed properties
                 && not (is_type t_norm) // : Type terms, since ambient typing hypotheses for these are cheap
-                && not (is_arrow t_norm)
-                  (* Functions, also cheap. While we check below for
-                  an empty set of formal binders, this set may be empty if t_norm is an
-                  abbreviation of a function type. This can cause a crash if we saw
-                  a `val` with an abbreviation, and decide to thunk, and then
-                  check the `let` for it with explicit binders, and decide
-                  not to thunk, which will crash the encoding. So we unfold to check
-                  for arrows. See #2894. *)
               in
               let thunked, vars =
                  match vars with

--- a/src/tosyntax/FStar.ToSyntax.ToSyntax.fst
+++ b/src/tosyntax/FStar.ToSyntax.ToSyntax.fst
@@ -3594,10 +3594,7 @@ and desugar_decl_aux env (d: decl): (env_t * sigelts) =
     | _ -> []
   in
   let attrs = attrs @ val_attrs sigelts in
-  env,
-  List.map 
-    (fun sigelt -> { sigelt with sigattrs = sigelt.sigattrs@attrs })
-    sigelts
+  env, List.map (fun sigelt -> { sigelt with sigattrs = attrs }) sigelts
 
 and desugar_decl env (d:decl) :(env_t * sigelts) =
   let env, ses = desugar_decl_aux env d in


### PR DESCRIPTION
This is a different fix for #2894, the first one proved to be too disruptive in everest. This should gets us back to green in everest, except for a regression in KaRaMeL that's still being investigated.