### PR TITLE
Some tweaks to how delta depths are handled in the typechecker

### DIFF
--- a/examples/metatheory/StlcCbvDbParSubst.fst
+++ b/examples/metatheory/StlcCbvDbParSubst.fst
@@ -251,16 +251,19 @@ let rec substitution_preserves_typing x #e #v #t_x #t #g h1 h2 =
                        context_invariance h1 g)
      else if y<x then context_invariance h2 g
      else             TyVar (y-1)
-  | TyLam t_y #e' h21 ->
-     (let h21' = typing_extensional h21 (extend_gen (x+1) t_x (extend t_y g)) in
-      typable_empty_closed h1;
-      subst_gen_elam x v t_y e';
-      TyLam t_y (substitution_preserves_typing (x+1) h1 h21'))
-  | TyApp h21 h22 ->
+  | TyLam #_ t_y #e' #t' h21 ->
+    let h21' = typing_extensional h21 (extend_gen (x+1) t_x (extend t_y g)) in
+    typable_empty_closed h1;
+    subst_gen_elam x v t_y e';
+    let h21' : (r:typing (extend_gen (x+1) t_x (extend t_y g)) e' t'{e' << e}) =
+      h21' in
+    TyLam t_y (substitution_preserves_typing (x+1) h1 h21')
+  | TyApp #_ #e1 #e2 #t11 #t12 h21 h22 ->
+    let h21 : (r:typing (extend_gen x t_x g) e1 (TArr t11 t12){e1 << e}) = h21 in
+    let h22 : (r:typing (extend_gen x t_x g) e2 t11{e2 << e}) = h22 in
     (TyApp (substitution_preserves_typing x h1 h21)
            (substitution_preserves_typing x h1 h22))
   | TyUnit -> TyUnit
-
 
 val extend_gen_0_aux : t:typ -> g:env -> y:var ->
                    Lemma (extend_gen 0 t g y = extend t g y)

--- a/ocaml/fstar-lib/generated/FStar_CheckedFiles.ml
+++ b/ocaml/fstar-lib/generated/FStar_CheckedFiles.ml
@@ -1,5 +1,5 @@
 open Prims
-let (cache_version_number : Prims.int) = (Prims.of_int (55))
+let (cache_version_number : Prims.int) = (Prims.of_int (56))
 type tc_result =
   {
   checked_module: FStar_Syntax_Syntax.modul ;

--- a/ocaml/fstar-lib/generated/FStar_Extraction_ML_Modul.ml
+++ b/ocaml/fstar-lib/generated/FStar_Extraction_ML_Modul.ml
@@ -64,8 +64,7 @@ let (always_fail :
       let lb =
         let uu___ =
           let uu___1 =
-            FStar_Syntax_Syntax.lid_as_fv lid
-              FStar_Syntax_Syntax.delta_constant FStar_Pervasives_Native.None in
+            FStar_Syntax_Syntax.lid_as_fv lid FStar_Pervasives_Native.None in
           FStar_Pervasives.Inr uu___1 in
         let uu___1 = FStar_Parser_Const.effect_ML_lid () in
         {
@@ -467,7 +466,6 @@ let (bundle_as_inductive_families :
                                  FStar_Compiler_List.op_At uu___5 uu___6 in
                                let fv =
                                  FStar_Syntax_Syntax.lid_as_fv l
-                                   FStar_Syntax_Syntax.delta_constant
                                    FStar_Pervasives_Native.None in
                                let uu___5 =
                                  FStar_Extraction_ML_UEnv.extend_type_name
@@ -922,7 +920,7 @@ let (extract_bundle_iface :
         let tys = (ml_tyvars, mlt) in
         let fvv =
           FStar_Syntax_Syntax.lid_as_fv ctor.dname
-            FStar_Syntax_Syntax.delta_constant FStar_Pervasives_Native.None in
+            FStar_Pervasives_Native.None in
         let uu___ = FStar_Extraction_ML_UEnv.extend_fv env1 fvv tys false in
         match uu___ with | (env2, uu___1, b) -> (env2, (fvv, b)) in
       let extract_one_family env1 ind =
@@ -1050,7 +1048,6 @@ let (extract_type_declaration :
                    | (bs, uu___3) ->
                        let fv =
                          FStar_Syntax_Syntax.lid_as_fv lid
-                           FStar_Syntax_Syntax.delta_constant
                            FStar_Pervasives_Native.None in
                        let lb =
                          let uu___4 =
@@ -1104,8 +1101,7 @@ let (extract_reifiable_effect :
     fun ed ->
       let extend_iface lid mlp exp exp_binding =
         let fv =
-          FStar_Syntax_Syntax.lid_as_fv lid
-            FStar_Syntax_Syntax.delta_equational FStar_Pervasives_Native.None in
+          FStar_Syntax_Syntax.lid_as_fv lid FStar_Pervasives_Native.None in
         let lb =
           {
             FStar_Extraction_ML_Syntax.mllb_name =
@@ -1583,9 +1579,7 @@ let (mark_sigelt_erased :
         (fun lid ->
            fun g1 ->
              let uu___1 =
-               FStar_Syntax_Syntax.lid_as_fv lid
-                 FStar_Syntax_Syntax.delta_constant
-                 FStar_Pervasives_Native.None in
+               FStar_Syntax_Syntax.lid_as_fv lid FStar_Pervasives_Native.None in
              FStar_Extraction_ML_UEnv.extend_erased_fv g1 uu___1)
         (FStar_Syntax_Util.lids_of_sigelt se) g
 let rec (extract_sigelt_iface :
@@ -1873,7 +1867,7 @@ let (extract_bundle :
         let tys = (ml_tyvars, mlt) in
         let fvv =
           FStar_Syntax_Syntax.lid_as_fv ctor.dname
-            FStar_Syntax_Syntax.delta_constant FStar_Pervasives_Native.None in
+            FStar_Pervasives_Native.None in
         let uu___ = FStar_Extraction_ML_UEnv.extend_fv env1 fvv tys false in
         match uu___ with
         | (env2, mls, uu___1) ->

--- a/ocaml/fstar-lib/generated/FStar_Extraction_ML_Modul.ml
+++ b/ocaml/fstar-lib/generated/FStar_Extraction_ML_Modul.ml
@@ -11,8 +11,7 @@ let (fail_exp :
         let uu___1 =
           let uu___2 =
             let uu___3 = FStar_Parser_Const.failwith_lid () in
-            FStar_Syntax_Syntax.fvar uu___3
-              FStar_Syntax_Syntax.delta_constant FStar_Pervasives_Native.None in
+            FStar_Syntax_Syntax.fvar uu___3 FStar_Pervasives_Native.None in
           let uu___3 =
             let uu___4 = FStar_Syntax_Syntax.iarg t in
             let uu___5 =

--- a/ocaml/fstar-lib/generated/FStar_Extraction_ML_Term.ml
+++ b/ocaml/fstar-lib/generated/FStar_Extraction_ML_Term.ml
@@ -2724,7 +2724,6 @@ and (term_as_mlexpr' :
              let uu___3 =
                let uu___4 = FStar_Parser_Const.failwith_lid () in
                FStar_Syntax_Syntax.lid_as_fv uu___4
-                 FStar_Syntax_Syntax.delta_constant
                  FStar_Pervasives_Native.None in
              FStar_Extraction_ML_UEnv.lookup_fv t.FStar_Syntax_Syntax.pos g
                uu___3 in
@@ -3065,7 +3064,6 @@ and (term_as_mlexpr' :
              let uu___7 =
                let uu___8 = FStar_Parser_Const.failwith_lid () in
                FStar_Syntax_Syntax.lid_as_fv uu___8
-                 FStar_Syntax_Syntax.delta_constant
                  FStar_Pervasives_Native.None in
              FStar_Extraction_ML_UEnv.lookup_fv t.FStar_Syntax_Syntax.pos g
                uu___7 in
@@ -4227,7 +4225,6 @@ and (term_as_mlexpr' :
                                      let uu___9 =
                                        FStar_Parser_Const.failwith_lid () in
                                      FStar_Syntax_Syntax.lid_as_fv uu___9
-                                       FStar_Syntax_Syntax.delta_constant
                                        FStar_Pervasives_Native.None in
                                    FStar_Extraction_ML_UEnv.lookup_fv
                                      t.FStar_Syntax_Syntax.pos g uu___8 in

--- a/ocaml/fstar-lib/generated/FStar_Extraction_ML_UEnv.ml
+++ b/ocaml/fstar-lib/generated/FStar_Extraction_ML_UEnv.ml
@@ -983,9 +983,7 @@ let (extend_with_monad_op_name :
               ed.FStar_Syntax_Syntax.mname uu___ in
           let uu___ =
             let uu___1 =
-              FStar_Syntax_Syntax.lid_as_fv lid
-                FStar_Syntax_Syntax.delta_constant
-                FStar_Pervasives_Native.None in
+              FStar_Syntax_Syntax.lid_as_fv lid FStar_Pervasives_Native.None in
             extend_fv g uu___1 ts false in
           match uu___ with
           | (g1, mlid, exp_b) ->
@@ -1016,9 +1014,7 @@ let (extend_with_action_name :
             FStar_Ident.lid_of_ids uu___ in
           let uu___ =
             let uu___1 =
-              FStar_Syntax_Syntax.lid_as_fv lid
-                FStar_Syntax_Syntax.delta_constant
-                FStar_Pervasives_Native.None in
+              FStar_Syntax_Syntax.lid_as_fv lid FStar_Pervasives_Native.None in
             extend_fv g uu___1 ts false in
           match uu___ with
           | (g1, mlid, exp_b) ->
@@ -1124,8 +1120,7 @@ let (new_uenv : FStar_TypeChecker_Env.env -> uenv) =
       let uu___1 =
         let uu___2 =
           let uu___3 = FStar_Parser_Const.failwith_lid () in
-          FStar_Syntax_Syntax.lid_as_fv uu___3
-            FStar_Syntax_Syntax.delta_constant FStar_Pervasives_Native.None in
+          FStar_Syntax_Syntax.lid_as_fv uu___3 FStar_Pervasives_Native.None in
         FStar_Pervasives.Inr uu___2 in
       extend_lb env uu___1 FStar_Syntax_Syntax.tun failwith_ty false in
     match uu___ with | (g, uu___1, uu___2) -> g

--- a/ocaml/fstar-lib/generated/FStar_Reflection_Basic.ml
+++ b/ocaml/fstar-lib/generated/FStar_Reflection_Basic.ml
@@ -73,9 +73,7 @@ let (pack_fv : Prims.string Prims.list -> FStar_Syntax_Syntax.fv) =
                    FStar_Pervasives_Native.Some FStar_Syntax_Syntax.Data_ctor
                  else FStar_Pervasives_Native.None))) in
       let uu___1 = FStar_Parser_Const.p2l ns in
-      FStar_Syntax_Syntax.lid_as_fv uu___1
-        (FStar_Syntax_Syntax.Delta_constant_at_level (Prims.of_int (999)))
-        quals in
+      FStar_Syntax_Syntax.lid_as_fv' uu___1 quals in
     let uu___ =
       FStar_Compiler_Effect.op_Bang
         FStar_TypeChecker_Normalize.reflection_env_hook in
@@ -88,9 +86,7 @@ let (pack_fv : Prims.string Prims.list -> FStar_Syntax_Syntax.fv) =
              (FStar_Pervasives.Inr (se, _us), _rng) ->
              let quals = FStar_Syntax_DsEnv.fv_qual_of_se se in
              let uu___1 = FStar_Parser_Const.p2l ns in
-             FStar_Syntax_Syntax.lid_as_fv uu___1
-               (FStar_Syntax_Syntax.Delta_constant_at_level
-                  (Prims.of_int (999))) quals
+             FStar_Syntax_Syntax.lid_as_fv' uu___1 quals
          | uu___1 -> fallback ())
 let rec last : 'a . 'a Prims.list -> 'a =
   fun l ->
@@ -644,9 +640,8 @@ let (lookup_attr :
                | FStar_Pervasives_Native.None -> []
                | FStar_Pervasives_Native.Some l ->
                    let uu___2 =
-                     FStar_Syntax_Syntax.lid_as_fv l
-                       (FStar_Syntax_Syntax.Delta_constant_at_level
-                          (Prims.of_int (999))) FStar_Pervasives_Native.None in
+                     FStar_Syntax_Syntax.lid_as_fv' l
+                       FStar_Pervasives_Native.None in
                    [uu___2]) ses
       | uu___1 -> []
 let (all_defs_in_env :
@@ -654,10 +649,8 @@ let (all_defs_in_env :
   fun env ->
     let uu___ = FStar_TypeChecker_Env.lidents env in
     FStar_Compiler_List.map
-      (fun l ->
-         FStar_Syntax_Syntax.lid_as_fv l
-           (FStar_Syntax_Syntax.Delta_constant_at_level (Prims.of_int (999)))
-           FStar_Pervasives_Native.None) uu___
+      (fun l -> FStar_Syntax_Syntax.lid_as_fv' l FStar_Pervasives_Native.None)
+      uu___
 let (defs_in_module :
   FStar_TypeChecker_Env.env ->
     FStar_Reflection_Data.name -> FStar_Syntax_Syntax.fv Prims.list)
@@ -676,9 +669,7 @@ let (defs_in_module :
            if ns = modul
            then
              let uu___1 =
-               FStar_Syntax_Syntax.lid_as_fv l
-                 (FStar_Syntax_Syntax.Delta_constant_at_level
-                    (Prims.of_int (999))) FStar_Pervasives_Native.None in
+               FStar_Syntax_Syntax.lid_as_fv' l FStar_Pervasives_Native.None in
              [uu___1]
            else []) uu___
 let (lookup_typ :

--- a/ocaml/fstar-lib/generated/FStar_Reflection_Basic.ml
+++ b/ocaml/fstar-lib/generated/FStar_Reflection_Basic.ml
@@ -73,7 +73,7 @@ let (pack_fv : Prims.string Prims.list -> FStar_Syntax_Syntax.fv) =
                    FStar_Pervasives_Native.Some FStar_Syntax_Syntax.Data_ctor
                  else FStar_Pervasives_Native.None))) in
       let uu___1 = FStar_Parser_Const.p2l ns in
-      FStar_Syntax_Syntax.lid_as_fv' uu___1 quals in
+      FStar_Syntax_Syntax.lid_as_fv uu___1 quals in
     let uu___ =
       FStar_Compiler_Effect.op_Bang
         FStar_TypeChecker_Normalize.reflection_env_hook in
@@ -86,7 +86,7 @@ let (pack_fv : Prims.string Prims.list -> FStar_Syntax_Syntax.fv) =
              (FStar_Pervasives.Inr (se, _us), _rng) ->
              let quals = FStar_Syntax_DsEnv.fv_qual_of_se se in
              let uu___1 = FStar_Parser_Const.p2l ns in
-             FStar_Syntax_Syntax.lid_as_fv' uu___1 quals
+             FStar_Syntax_Syntax.lid_as_fv uu___1 quals
          | uu___1 -> fallback ())
 let rec last : 'a . 'a Prims.list -> 'a =
   fun l ->
@@ -640,7 +640,7 @@ let (lookup_attr :
                | FStar_Pervasives_Native.None -> []
                | FStar_Pervasives_Native.Some l ->
                    let uu___2 =
-                     FStar_Syntax_Syntax.lid_as_fv' l
+                     FStar_Syntax_Syntax.lid_as_fv l
                        FStar_Pervasives_Native.None in
                    [uu___2]) ses
       | uu___1 -> []
@@ -649,7 +649,7 @@ let (all_defs_in_env :
   fun env ->
     let uu___ = FStar_TypeChecker_Env.lidents env in
     FStar_Compiler_List.map
-      (fun l -> FStar_Syntax_Syntax.lid_as_fv' l FStar_Pervasives_Native.None)
+      (fun l -> FStar_Syntax_Syntax.lid_as_fv l FStar_Pervasives_Native.None)
       uu___
 let (defs_in_module :
   FStar_TypeChecker_Env.env ->
@@ -669,7 +669,7 @@ let (defs_in_module :
            if ns = modul
            then
              let uu___1 =
-               FStar_Syntax_Syntax.lid_as_fv' l FStar_Pervasives_Native.None in
+               FStar_Syntax_Syntax.lid_as_fv l FStar_Pervasives_Native.None in
              [uu___1]
            else []) uu___
 let (lookup_typ :

--- a/ocaml/fstar-lib/generated/FStar_Reflection_Constants.ml
+++ b/ocaml/fstar-lib/generated/FStar_Reflection_Constants.ml
@@ -32,7 +32,7 @@ let (fstar_refl_data_const : Prims.string -> refl_constant) =
   fun s ->
     let lid = fstar_refl_data_lid s in
     let uu___ =
-      FStar_Syntax_Syntax.lid_as_fv lid FStar_Syntax_Syntax.delta_constant
+      FStar_Syntax_Syntax.lid_as_fv' lid
         (FStar_Pervasives_Native.Some FStar_Syntax_Syntax.Data_ctor) in
     let uu___1 = FStar_Syntax_Syntax.tdataconstr lid in
     { lid; fv = uu___; t = uu___1 }
@@ -60,13 +60,9 @@ let (mk_inspect_pack_pair : Prims.string -> (refl_constant * refl_constant))
     let inspect_lid = fstar_refl_builtins_lid (Prims.op_Hat "inspect" s) in
     let pack_lid = fstar_refl_builtins_lid (Prims.op_Hat "pack" s) in
     let inspect_fv =
-      FStar_Syntax_Syntax.lid_as_fv inspect_lid
-        (FStar_Syntax_Syntax.Delta_constant_at_level Prims.int_one)
-        FStar_Pervasives_Native.None in
+      FStar_Syntax_Syntax.lid_as_fv' inspect_lid FStar_Pervasives_Native.None in
     let pack_fv =
-      FStar_Syntax_Syntax.lid_as_fv pack_lid
-        (FStar_Syntax_Syntax.Delta_constant_at_level Prims.int_one)
-        FStar_Pervasives_Native.None in
+      FStar_Syntax_Syntax.lid_as_fv' pack_lid FStar_Pervasives_Native.None in
     let inspect =
       let uu___ = FStar_Syntax_Syntax.fv_to_tm inspect_fv in
       { lid = inspect_lid; fv = inspect_fv; t = uu___ } in
@@ -260,8 +256,7 @@ let (ref_Mk_bv : refl_constant) =
       (uu___1, uu___2) in
     FStar_Syntax_Syntax.Record_ctor uu___ in
   let fv =
-    FStar_Syntax_Syntax.lid_as_fv lid FStar_Syntax_Syntax.delta_constant
-      (FStar_Pervasives_Native.Some attr) in
+    FStar_Syntax_Syntax.lid_as_fv' lid (FStar_Pervasives_Native.Some attr) in
   let uu___ = FStar_Syntax_Syntax.fv_to_tm fv in { lid; fv; t = uu___ }
 let (ref_Mk_binder : refl_constant) =
   let lid = fstar_refl_data_lid "Mkbinder_view" in
@@ -291,8 +286,7 @@ let (ref_Mk_binder : refl_constant) =
       (uu___1, uu___2) in
     FStar_Syntax_Syntax.Record_ctor uu___ in
   let fv =
-    FStar_Syntax_Syntax.lid_as_fv lid FStar_Syntax_Syntax.delta_constant
-      (FStar_Pervasives_Native.Some attr) in
+    FStar_Syntax_Syntax.lid_as_fv' lid (FStar_Pervasives_Native.Some attr) in
   let uu___ = FStar_Syntax_Syntax.fv_to_tm fv in { lid; fv; t = uu___ }
 let (ref_Mk_lb : refl_constant) =
   let lid = fstar_refl_data_lid "Mklb_view" in
@@ -322,8 +316,7 @@ let (ref_Mk_lb : refl_constant) =
       (uu___1, uu___2) in
     FStar_Syntax_Syntax.Record_ctor uu___ in
   let fv =
-    FStar_Syntax_Syntax.lid_as_fv lid FStar_Syntax_Syntax.delta_constant
-      (FStar_Pervasives_Native.Some attr) in
+    FStar_Syntax_Syntax.lid_as_fv' lid (FStar_Pervasives_Native.Some attr) in
   let uu___ = FStar_Syntax_Syntax.fv_to_tm fv in { lid; fv; t = uu___ }
 let (ref_Q_Explicit : refl_constant) = fstar_refl_data_const "Q_Explicit"
 let (ref_Q_Implicit : refl_constant) = fstar_refl_data_const "Q_Implicit"
@@ -433,11 +426,11 @@ let (ord_Eq : FStar_Syntax_Syntax.term) =
 let (ord_Gt : FStar_Syntax_Syntax.term) =
   FStar_Syntax_Syntax.tdataconstr ord_Gt_lid
 let (ord_Lt_fv : FStar_Syntax_Syntax.fv) =
-  FStar_Syntax_Syntax.lid_as_fv ord_Lt_lid FStar_Syntax_Syntax.delta_constant
+  FStar_Syntax_Syntax.lid_as_fv' ord_Lt_lid
     (FStar_Pervasives_Native.Some FStar_Syntax_Syntax.Data_ctor)
 let (ord_Eq_fv : FStar_Syntax_Syntax.fv) =
-  FStar_Syntax_Syntax.lid_as_fv ord_Eq_lid FStar_Syntax_Syntax.delta_constant
+  FStar_Syntax_Syntax.lid_as_fv' ord_Eq_lid
     (FStar_Pervasives_Native.Some FStar_Syntax_Syntax.Data_ctor)
 let (ord_Gt_fv : FStar_Syntax_Syntax.fv) =
-  FStar_Syntax_Syntax.lid_as_fv ord_Gt_lid FStar_Syntax_Syntax.delta_constant
+  FStar_Syntax_Syntax.lid_as_fv' ord_Gt_lid
     (FStar_Pervasives_Native.Some FStar_Syntax_Syntax.Data_ctor)

--- a/ocaml/fstar-lib/generated/FStar_Reflection_Constants.ml
+++ b/ocaml/fstar-lib/generated/FStar_Reflection_Constants.ml
@@ -32,7 +32,7 @@ let (fstar_refl_data_const : Prims.string -> refl_constant) =
   fun s ->
     let lid = fstar_refl_data_lid s in
     let uu___ =
-      FStar_Syntax_Syntax.lid_as_fv' lid
+      FStar_Syntax_Syntax.lid_as_fv lid
         (FStar_Pervasives_Native.Some FStar_Syntax_Syntax.Data_ctor) in
     let uu___1 = FStar_Syntax_Syntax.tdataconstr lid in
     { lid; fv = uu___; t = uu___1 }
@@ -60,9 +60,9 @@ let (mk_inspect_pack_pair : Prims.string -> (refl_constant * refl_constant))
     let inspect_lid = fstar_refl_builtins_lid (Prims.op_Hat "inspect" s) in
     let pack_lid = fstar_refl_builtins_lid (Prims.op_Hat "pack" s) in
     let inspect_fv =
-      FStar_Syntax_Syntax.lid_as_fv' inspect_lid FStar_Pervasives_Native.None in
+      FStar_Syntax_Syntax.lid_as_fv inspect_lid FStar_Pervasives_Native.None in
     let pack_fv =
-      FStar_Syntax_Syntax.lid_as_fv' pack_lid FStar_Pervasives_Native.None in
+      FStar_Syntax_Syntax.lid_as_fv pack_lid FStar_Pervasives_Native.None in
     let inspect =
       let uu___ = FStar_Syntax_Syntax.fv_to_tm inspect_fv in
       { lid = inspect_lid; fv = inspect_fv; t = uu___ } in
@@ -256,7 +256,7 @@ let (ref_Mk_bv : refl_constant) =
       (uu___1, uu___2) in
     FStar_Syntax_Syntax.Record_ctor uu___ in
   let fv =
-    FStar_Syntax_Syntax.lid_as_fv' lid (FStar_Pervasives_Native.Some attr) in
+    FStar_Syntax_Syntax.lid_as_fv lid (FStar_Pervasives_Native.Some attr) in
   let uu___ = FStar_Syntax_Syntax.fv_to_tm fv in { lid; fv; t = uu___ }
 let (ref_Mk_binder : refl_constant) =
   let lid = fstar_refl_data_lid "Mkbinder_view" in
@@ -286,7 +286,7 @@ let (ref_Mk_binder : refl_constant) =
       (uu___1, uu___2) in
     FStar_Syntax_Syntax.Record_ctor uu___ in
   let fv =
-    FStar_Syntax_Syntax.lid_as_fv' lid (FStar_Pervasives_Native.Some attr) in
+    FStar_Syntax_Syntax.lid_as_fv lid (FStar_Pervasives_Native.Some attr) in
   let uu___ = FStar_Syntax_Syntax.fv_to_tm fv in { lid; fv; t = uu___ }
 let (ref_Mk_lb : refl_constant) =
   let lid = fstar_refl_data_lid "Mklb_view" in
@@ -316,7 +316,7 @@ let (ref_Mk_lb : refl_constant) =
       (uu___1, uu___2) in
     FStar_Syntax_Syntax.Record_ctor uu___ in
   let fv =
-    FStar_Syntax_Syntax.lid_as_fv' lid (FStar_Pervasives_Native.Some attr) in
+    FStar_Syntax_Syntax.lid_as_fv lid (FStar_Pervasives_Native.Some attr) in
   let uu___ = FStar_Syntax_Syntax.fv_to_tm fv in { lid; fv; t = uu___ }
 let (ref_Q_Explicit : refl_constant) = fstar_refl_data_const "Q_Explicit"
 let (ref_Q_Implicit : refl_constant) = fstar_refl_data_const "Q_Implicit"
@@ -426,11 +426,11 @@ let (ord_Eq : FStar_Syntax_Syntax.term) =
 let (ord_Gt : FStar_Syntax_Syntax.term) =
   FStar_Syntax_Syntax.tdataconstr ord_Gt_lid
 let (ord_Lt_fv : FStar_Syntax_Syntax.fv) =
-  FStar_Syntax_Syntax.lid_as_fv' ord_Lt_lid
+  FStar_Syntax_Syntax.lid_as_fv ord_Lt_lid
     (FStar_Pervasives_Native.Some FStar_Syntax_Syntax.Data_ctor)
 let (ord_Eq_fv : FStar_Syntax_Syntax.fv) =
-  FStar_Syntax_Syntax.lid_as_fv' ord_Eq_lid
+  FStar_Syntax_Syntax.lid_as_fv ord_Eq_lid
     (FStar_Pervasives_Native.Some FStar_Syntax_Syntax.Data_ctor)
 let (ord_Gt_fv : FStar_Syntax_Syntax.fv) =
-  FStar_Syntax_Syntax.lid_as_fv' ord_Gt_lid
+  FStar_Syntax_Syntax.lid_as_fv ord_Gt_lid
     (FStar_Pervasives_Native.Some FStar_Syntax_Syntax.Data_ctor)

--- a/ocaml/fstar-lib/generated/FStar_Reflection_NBEEmbeddings.ml
+++ b/ocaml/fstar-lib/generated/FStar_Reflection_NBEEmbeddings.ml
@@ -706,10 +706,10 @@ let (e_ident : FStar_Ident.ident FStar_TypeChecker_NBETerm.embedding) =
         FStar_Pervasives_Native.Some uu___1
     | FStar_Pervasives_Native.None -> FStar_Pervasives_Native.None in
   let range_fv =
-    FStar_Syntax_Syntax.lid_as_fv' FStar_Parser_Const.range_lid
+    FStar_Syntax_Syntax.lid_as_fv FStar_Parser_Const.range_lid
       FStar_Pervasives_Native.None in
   let string_fv =
-    FStar_Syntax_Syntax.lid_as_fv' FStar_Parser_Const.string_lid
+    FStar_Syntax_Syntax.lid_as_fv FStar_Parser_Const.string_lid
       FStar_Pervasives_Native.None in
   let et =
     let uu___ =
@@ -722,7 +722,7 @@ let (e_ident : FStar_Ident.ident FStar_TypeChecker_NBETerm.embedding) =
     FStar_Syntax_Syntax.ET_app uu___ in
   let uu___ =
     let uu___1 =
-      FStar_Syntax_Syntax.lid_as_fv' FStar_Parser_Const.lid_tuple2
+      FStar_Syntax_Syntax.lid_as_fv FStar_Parser_Const.lid_tuple2
         FStar_Pervasives_Native.None in
     let uu___2 =
       let uu___3 =
@@ -1833,7 +1833,7 @@ let (e_order : FStar_Order.order FStar_TypeChecker_NBETerm.embedding) =
           FStar_Errors.log_issue FStar_Compiler_Range_Type.dummyRange uu___2);
          FStar_Pervasives_Native.None) in
   let uu___ =
-    FStar_Syntax_Syntax.lid_as_fv' FStar_Parser_Const.order_lid
+    FStar_Syntax_Syntax.lid_as_fv FStar_Parser_Const.order_lid
       FStar_Pervasives_Native.None in
   mk_emb' embed_order unembed_order uu___
 let (e_sigelt :
@@ -2556,6 +2556,6 @@ let (e_vconfig : FStar_Order.order FStar_TypeChecker_NBETerm.embedding) =
   let emb cb o = failwith "emb vconfig NBE" in
   let unemb cb t = failwith "unemb vconfig NBE" in
   let uu___ =
-    FStar_Syntax_Syntax.lid_as_fv' FStar_Parser_Const.vconfig_lid
+    FStar_Syntax_Syntax.lid_as_fv FStar_Parser_Const.vconfig_lid
       FStar_Pervasives_Native.None in
   mk_emb' emb unemb uu___

--- a/ocaml/fstar-lib/generated/FStar_Reflection_NBEEmbeddings.ml
+++ b/ocaml/fstar-lib/generated/FStar_Reflection_NBEEmbeddings.ml
@@ -706,11 +706,11 @@ let (e_ident : FStar_Ident.ident FStar_TypeChecker_NBETerm.embedding) =
         FStar_Pervasives_Native.Some uu___1
     | FStar_Pervasives_Native.None -> FStar_Pervasives_Native.None in
   let range_fv =
-    FStar_Syntax_Syntax.lid_as_fv FStar_Parser_Const.range_lid
-      FStar_Syntax_Syntax.delta_constant FStar_Pervasives_Native.None in
+    FStar_Syntax_Syntax.lid_as_fv' FStar_Parser_Const.range_lid
+      FStar_Pervasives_Native.None in
   let string_fv =
-    FStar_Syntax_Syntax.lid_as_fv FStar_Parser_Const.string_lid
-      FStar_Syntax_Syntax.delta_constant FStar_Pervasives_Native.None in
+    FStar_Syntax_Syntax.lid_as_fv' FStar_Parser_Const.string_lid
+      FStar_Pervasives_Native.None in
   let et =
     let uu___ =
       let uu___1 = FStar_Ident.string_of_lid FStar_Parser_Const.lid_tuple2 in
@@ -722,8 +722,8 @@ let (e_ident : FStar_Ident.ident FStar_TypeChecker_NBETerm.embedding) =
     FStar_Syntax_Syntax.ET_app uu___ in
   let uu___ =
     let uu___1 =
-      FStar_Syntax_Syntax.lid_as_fv FStar_Parser_Const.lid_tuple2
-        FStar_Syntax_Syntax.delta_constant FStar_Pervasives_Native.None in
+      FStar_Syntax_Syntax.lid_as_fv' FStar_Parser_Const.lid_tuple2
+        FStar_Pervasives_Native.None in
     let uu___2 =
       let uu___3 =
         let uu___4 = mkFV range_fv [] [] in
@@ -1833,8 +1833,8 @@ let (e_order : FStar_Order.order FStar_TypeChecker_NBETerm.embedding) =
           FStar_Errors.log_issue FStar_Compiler_Range_Type.dummyRange uu___2);
          FStar_Pervasives_Native.None) in
   let uu___ =
-    FStar_Syntax_Syntax.lid_as_fv FStar_Parser_Const.order_lid
-      FStar_Syntax_Syntax.delta_constant FStar_Pervasives_Native.None in
+    FStar_Syntax_Syntax.lid_as_fv' FStar_Parser_Const.order_lid
+      FStar_Pervasives_Native.None in
   mk_emb' embed_order unembed_order uu___
 let (e_sigelt :
   FStar_Syntax_Syntax.sigelt FStar_TypeChecker_NBETerm.embedding) =
@@ -2556,6 +2556,6 @@ let (e_vconfig : FStar_Order.order FStar_TypeChecker_NBETerm.embedding) =
   let emb cb o = failwith "emb vconfig NBE" in
   let unemb cb t = failwith "unemb vconfig NBE" in
   let uu___ =
-    FStar_Syntax_Syntax.lid_as_fv FStar_Parser_Const.vconfig_lid
-      FStar_Syntax_Syntax.delta_constant FStar_Pervasives_Native.None in
+    FStar_Syntax_Syntax.lid_as_fv' FStar_Parser_Const.vconfig_lid
+      FStar_Pervasives_Native.None in
   mk_emb' emb unemb uu___

--- a/ocaml/fstar-lib/generated/FStar_SMTEncoding_Encode.ml
+++ b/ocaml/fstar-lib/generated/FStar_SMTEncoding_Encode.ml
@@ -4141,7 +4141,6 @@ and (encode_sigelt' :
            else
              (let fv =
                 FStar_Syntax_Syntax.lid_as_fv lid
-                  FStar_Syntax_Syntax.delta_constant
                   FStar_Pervasives_Native.None in
               let uu___3 =
                 let uu___4 =
@@ -7098,7 +7097,6 @@ let (encode_env_bindings :
                  let t_norm = norm_before_encoding env1 t in
                  let fv =
                    FStar_Syntax_Syntax.lid_as_fv x
-                     FStar_Syntax_Syntax.delta_constant
                      FStar_Pervasives_Native.None in
                  let uu___2 = encode_free_var false env1 fv t t_norm [] in
                  (match uu___2 with

--- a/ocaml/fstar-lib/generated/FStar_SMTEncoding_Encode.ml
+++ b/ocaml/fstar-lib/generated/FStar_SMTEncoding_Encode.ml
@@ -1798,36 +1798,19 @@ let (encode_free_var :
                                                  fv1
                                                  FStar_Parser_Const.unit_lid
                                            | uu___12 -> false) in
-                                    let is_arrow t =
-                                      let uu___9 =
-                                        let uu___10 =
-                                          let uu___11 =
-                                            FStar_TypeChecker_Normalize.unfold_whnf'
-                                              [FStar_TypeChecker_Env.EraseUniverses]
-                                              env.FStar_SMTEncoding_Env.tcenv
-                                              t in
-                                          FStar_Syntax_Util.unrefine uu___11 in
-                                        uu___10.FStar_Syntax_Syntax.n in
-                                      match uu___9 with
-                                      | FStar_Syntax_Syntax.Tm_arrow uu___10
-                                          -> true
-                                      | uu___10 -> false in
-                                    ((((let uu___9 = FStar_Ident.nsstr lid in
-                                        uu___9 <> "Prims") &&
-                                         (let uu___9 =
-                                            FStar_Compiler_Effect.op_Bar_Greater
-                                              quals
-                                              (FStar_Compiler_List.contains
-                                                 FStar_Syntax_Syntax.Logic) in
-                                          Prims.op_Negation uu___9))
-                                        &&
-                                        (let uu___9 = is_squash t_norm in
+                                    (((let uu___9 = FStar_Ident.nsstr lid in
+                                       uu___9 <> "Prims") &&
+                                        (let uu___9 =
+                                           FStar_Compiler_Effect.op_Bar_Greater
+                                             quals
+                                             (FStar_Compiler_List.contains
+                                                FStar_Syntax_Syntax.Logic) in
                                          Prims.op_Negation uu___9))
                                        &&
-                                       (let uu___9 = is_type t_norm in
+                                       (let uu___9 = is_squash t_norm in
                                         Prims.op_Negation uu___9))
                                       &&
-                                      (let uu___9 = is_arrow t_norm in
+                                      (let uu___9 = is_type t_norm in
                                        Prims.op_Negation uu___9) in
                                   let uu___8 =
                                     match vars with
@@ -2642,8 +2625,15 @@ let (encode_top_level_let :
                                                Let_rec_unencodeable
                                            else ());
                                           (let t_norm =
-                                             norm_before_encoding env1
-                                               lb.FStar_Syntax_Syntax.lbtyp in
+                                             if is_rec
+                                             then
+                                               FStar_TypeChecker_Normalize.unfold_whnf'
+                                                 [FStar_TypeChecker_Env.AllowUnboundUniverses]
+                                                 env1.FStar_SMTEncoding_Env.tcenv
+                                                 lb.FStar_Syntax_Syntax.lbtyp
+                                             else
+                                               norm_before_encoding env1
+                                                 lb.FStar_Syntax_Syntax.lbtyp in
                                            let uu___7 =
                                              let uu___8 =
                                                FStar_Compiler_Util.right

--- a/ocaml/fstar-lib/generated/FStar_SMTEncoding_Encode.ml
+++ b/ocaml/fstar-lib/generated/FStar_SMTEncoding_Encode.ml
@@ -4638,8 +4638,6 @@ and (encode_sigelt' :
                                        let uu___10 =
                                          let uu___11 =
                                            FStar_Syntax_Syntax.fvar t
-                                             (FStar_Syntax_Syntax.Delta_constant_at_level
-                                                Prims.int_zero)
                                              FStar_Pervasives_Native.None in
                                          let uu___12 =
                                            let uu___13 =

--- a/ocaml/fstar-lib/generated/FStar_SMTEncoding_EncodeTerm.ml
+++ b/ocaml/fstar-lib/generated/FStar_SMTEncoding_EncodeTerm.ml
@@ -220,7 +220,7 @@ let (trivial_post : FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term) =
     let uu___ = let uu___1 = FStar_Syntax_Syntax.null_binder t in [uu___1] in
     let uu___1 =
       FStar_Syntax_Syntax.fvar FStar_Parser_Const.true_lid
-        FStar_Syntax_Syntax.delta_constant FStar_Pervasives_Native.None in
+        FStar_Pervasives_Native.None in
     FStar_Syntax_Util.abs uu___ uu___1 FStar_Pervasives_Native.None
 let (mk_Apply :
   FStar_SMTEncoding_Term.term ->

--- a/ocaml/fstar-lib/generated/FStar_Syntax_DsEnv.ml
+++ b/ocaml/fstar-lib/generated/FStar_Syntax_DsEnv.ml
@@ -650,7 +650,7 @@ let (unmangleOpName :
                  let uu___3 =
                    let uu___4 = FStar_Ident.range_of_id id in
                    FStar_Ident.lid_of_path ["Prims"; y] uu___4 in
-                 FStar_Syntax_Syntax.fvar uu___3 dd dq in
+                 FStar_Syntax_Syntax.fvar_with_dd uu___3 dd dq in
                FStar_Pervasives_Native.Some uu___2
              else FStar_Pervasives_Native.None)
 type 'a cont_t =
@@ -1260,7 +1260,7 @@ let (try_lookup_name :
                      let uu___3 =
                        let uu___4 =
                          let uu___5 =
-                           FStar_Syntax_Syntax.fvar source_lid
+                           FStar_Syntax_Syntax.fvar_with_dd source_lid
                              FStar_Syntax_Syntax.delta_constant
                              FStar_Pervasives_Native.None in
                          (uu___5, (se.FStar_Syntax_Syntax.sigattrs)) in
@@ -1271,7 +1271,7 @@ let (try_lookup_name :
                        let uu___4 =
                          let uu___5 =
                            let uu___6 = fv_qual_of_se se in
-                           FStar_Syntax_Syntax.fvar source_lid
+                           FStar_Syntax_Syntax.fvar_with_dd source_lid
                              FStar_Syntax_Syntax.delta_constant uu___6 in
                          (uu___5, (se.FStar_Syntax_Syntax.sigattrs)) in
                        Term_name uu___4 in
@@ -1288,7 +1288,7 @@ let (try_lookup_name :
                              FStar_Compiler_Effect.op_Bar_Greater
                                fv.FStar_Syntax_Syntax.fv_delta
                                FStar_Compiler_Util.must in
-                           FStar_Syntax_Syntax.fvar source_lid uu___7
+                           FStar_Syntax_Syntax.fvar_with_dd source_lid uu___7
                              fv.FStar_Syntax_Syntax.fv_qual in
                          (uu___6, (se.FStar_Syntax_Syntax.sigattrs)) in
                        Term_name uu___5 in
@@ -1336,7 +1336,8 @@ let (try_lookup_name :
                               let uu___8 =
                                 let uu___9 =
                                   let uu___10 = fv_qual_of_se se in
-                                  FStar_Syntax_Syntax.fvar lid2 dd uu___10 in
+                                  FStar_Syntax_Syntax.fvar_with_dd lid2 dd
+                                    uu___10 in
                                 (uu___9, (se.FStar_Syntax_Syntax.sigattrs)) in
                               Term_name uu___8 in
                             FStar_Pervasives_Native.Some uu___7)
@@ -1361,7 +1362,7 @@ let (try_lookup_name :
                      let uu___3 =
                        let uu___4 =
                          let uu___5 =
-                           FStar_Syntax_Syntax.fvar source_lid
+                           FStar_Syntax_Syntax.fvar_with_dd source_lid
                              (FStar_Syntax_Syntax.Delta_constant_at_level
                                 Prims.int_one) FStar_Pervasives_Native.None in
                          (uu___5, []) in
@@ -1383,7 +1384,7 @@ let (try_lookup_name :
                         let uu___5 =
                           let uu___6 = FStar_Ident.range_of_lid lid in
                           FStar_Ident.set_lid_range l uu___6 in
-                        FStar_Syntax_Syntax.fvar uu___5 dd
+                        FStar_Syntax_Syntax.fvar_with_dd uu___5 dd
                           FStar_Pervasives_Native.None in
                       (uu___4, []) in
                     Term_name uu___3 in
@@ -1624,7 +1625,7 @@ let (try_lookup_let :
               let uu___10 =
                 FStar_Compiler_Effect.op_Bar_Greater
                   fv.FStar_Syntax_Syntax.fv_delta FStar_Compiler_Util.must in
-              FStar_Syntax_Syntax.fvar lid1 uu___10
+              FStar_Syntax_Syntax.fvar_with_dd lid1 uu___10
                 fv.FStar_Syntax_Syntax.fv_qual in
             FStar_Pervasives_Native.Some uu___9
         | uu___1 -> FStar_Pervasives_Native.None in

--- a/ocaml/fstar-lib/generated/FStar_Syntax_DsEnv.ml
+++ b/ocaml/fstar-lib/generated/FStar_Syntax_DsEnv.ml
@@ -1284,8 +1284,11 @@ let (try_lookup_name :
                      let uu___4 =
                        let uu___5 =
                          let uu___6 =
-                           FStar_Syntax_Syntax.fvar source_lid
-                             fv.FStar_Syntax_Syntax.fv_delta
+                           let uu___7 =
+                             FStar_Compiler_Effect.op_Bar_Greater
+                               fv.FStar_Syntax_Syntax.fv_delta
+                               FStar_Compiler_Util.must in
+                           FStar_Syntax_Syntax.fvar source_lid uu___7
                              fv.FStar_Syntax_Syntax.fv_qual in
                          (uu___6, (se.FStar_Syntax_Syntax.sigattrs)) in
                        Term_name uu___5 in
@@ -1618,7 +1621,10 @@ let (try_lookup_let :
            uu___8) ->
             let fv = lb_fv lbs lid1 in
             let uu___9 =
-              FStar_Syntax_Syntax.fvar lid1 fv.FStar_Syntax_Syntax.fv_delta
+              let uu___10 =
+                FStar_Compiler_Effect.op_Bar_Greater
+                  fv.FStar_Syntax_Syntax.fv_delta FStar_Compiler_Util.must in
+              FStar_Syntax_Syntax.fvar lid1 uu___10
                 fv.FStar_Syntax_Syntax.fv_qual in
             FStar_Pervasives_Native.Some uu___9
         | uu___1 -> FStar_Pervasives_Native.None in

--- a/ocaml/fstar-lib/generated/FStar_Syntax_DsEnv.ml
+++ b/ocaml/fstar-lib/generated/FStar_Syntax_DsEnv.ml
@@ -1868,7 +1868,7 @@ let (try_lookup_datacon :
             if uu___6
             then
               let uu___7 =
-                FStar_Syntax_Syntax.lid_as_fv lid1
+                FStar_Syntax_Syntax.lid_and_dd_as_fv lid1
                   FStar_Syntax_Syntax.delta_constant
                   FStar_Pervasives_Native.None in
               FStar_Pervasives_Native.Some uu___7
@@ -1883,7 +1883,7 @@ let (try_lookup_datacon :
            uu___6) ->
             let qual1 = fv_qual_of_se (FStar_Pervasives_Native.fst se) in
             let uu___7 =
-              FStar_Syntax_Syntax.lid_as_fv lid1
+              FStar_Syntax_Syntax.lid_and_dd_as_fv lid1
                 FStar_Syntax_Syntax.delta_constant qual1 in
             FStar_Pervasives_Native.Some uu___7
         | ({
@@ -1897,7 +1897,7 @@ let (try_lookup_datacon :
            uu___6) ->
             let qual1 = fv_qual_of_se (FStar_Pervasives_Native.fst se) in
             let uu___7 =
-              FStar_Syntax_Syntax.lid_as_fv lid1
+              FStar_Syntax_Syntax.lid_and_dd_as_fv lid1
                 FStar_Syntax_Syntax.delta_constant qual1 in
             FStar_Pervasives_Native.Some uu___7
         | uu___ -> FStar_Pervasives_Native.None in
@@ -3550,7 +3550,7 @@ let (resolve_name :
           let uu___1 = delta_depth_of_declaration in
           let uu___2 =
             let uu___3 =
-              FStar_Syntax_Syntax.lid_as_fv l
+              FStar_Syntax_Syntax.lid_and_dd_as_fv l
                 FStar_Syntax_Syntax.delta_constant
                 FStar_Pervasives_Native.None in
             FStar_Pervasives.Inr uu___3 in

--- a/ocaml/fstar-lib/generated/FStar_Syntax_Embeddings.ml
+++ b/ocaml/fstar-lib/generated/FStar_Syntax_Embeddings.ml
@@ -85,8 +85,7 @@ let (id_norm_cb : norm_cb) =
     | FStar_Pervasives.Inr x -> x
     | FStar_Pervasives.Inl l ->
         let uu___1 =
-          FStar_Syntax_Syntax.lid_and_dd_as_fv l
-            FStar_Syntax_Syntax.delta_equational FStar_Pervasives_Native.None in
+          FStar_Syntax_Syntax.lid_as_fv l FStar_Pervasives_Native.None in
         FStar_Syntax_Syntax.fv_to_tm uu___1
 exception Embedding_failure 
 let (uu___is_Embedding_failure : Prims.exn -> Prims.bool) =
@@ -628,8 +627,7 @@ let e_option :
                           FStar_Parser_Const.some_lid v in
                       let some_v_tm =
                         let uu___1 =
-                          FStar_Syntax_Syntax.lid_and_dd_as_fv some_v
-                            FStar_Syntax_Syntax.delta_equational
+                          FStar_Syntax_Syntax.lid_as_fv some_v
                             FStar_Pervasives_Native.None in
                         FStar_Syntax_Syntax.fv_to_tm uu___1 in
                       let uu___1 =
@@ -736,8 +734,7 @@ let e_tuple2 : 'a 'b . 'a embedding -> 'b embedding -> ('a * 'b) embedding =
                  FStar_Syntax_Util.mk_field_projector_name uu___1 uu___2 i in
                let proj_1_tm =
                  let uu___1 =
-                   FStar_Syntax_Syntax.lid_and_dd_as_fv proj_1
-                     FStar_Syntax_Syntax.delta_equational
+                   FStar_Syntax_Syntax.lid_as_fv proj_1
                      FStar_Pervasives_Native.None in
                  FStar_Syntax_Syntax.fv_to_tm uu___1 in
                let uu___1 =
@@ -870,8 +867,7 @@ let e_tuple3 :
                          uu___3 i in
                      let proj_i_tm =
                        let uu___2 =
-                         FStar_Syntax_Syntax.lid_and_dd_as_fv proj_i
-                           FStar_Syntax_Syntax.delta_equational
+                         FStar_Syntax_Syntax.lid_as_fv proj_i
                            FStar_Pervasives_Native.None in
                        FStar_Syntax_Syntax.fv_to_tm uu___2 in
                      let uu___2 =
@@ -1034,8 +1030,7 @@ let e_either :
                              FStar_Parser_Const.inl_lid v in
                          let some_v_tm =
                            let uu___1 =
-                             FStar_Syntax_Syntax.lid_and_dd_as_fv some_v
-                               FStar_Syntax_Syntax.delta_equational
+                             FStar_Syntax_Syntax.lid_as_fv some_v
                                FStar_Pervasives_Native.None in
                            FStar_Syntax_Syntax.fv_to_tm uu___1 in
                          let uu___1 =
@@ -1091,8 +1086,7 @@ let e_either :
                              FStar_Parser_Const.inr_lid v in
                          let some_v_tm =
                            let uu___1 =
-                             FStar_Syntax_Syntax.lid_and_dd_as_fv some_v
-                               FStar_Syntax_Syntax.delta_equational
+                             FStar_Syntax_Syntax.lid_as_fv some_v
                                FStar_Pervasives_Native.None in
                            FStar_Syntax_Syntax.fv_to_tm uu___1 in
                          let uu___1 =
@@ -1231,8 +1225,7 @@ let e_list : 'a . 'a embedding -> 'a Prims.list embedding =
                      FStar_Parser_Const.cons_lid fid in
                  let proj_tm =
                    let uu___1 =
-                     FStar_Syntax_Syntax.lid_and_dd_as_fv proj1
-                       FStar_Syntax_Syntax.delta_equational
+                     FStar_Syntax_Syntax.lid_as_fv proj1
                        FStar_Pervasives_Native.None in
                    FStar_Syntax_Syntax.fv_to_tm uu___1 in
                  let uu___1 =

--- a/ocaml/fstar-lib/generated/FStar_Syntax_Embeddings.ml
+++ b/ocaml/fstar-lib/generated/FStar_Syntax_Embeddings.ml
@@ -85,7 +85,7 @@ let (id_norm_cb : norm_cb) =
     | FStar_Pervasives.Inr x -> x
     | FStar_Pervasives.Inl l ->
         let uu___1 =
-          FStar_Syntax_Syntax.lid_as_fv l
+          FStar_Syntax_Syntax.lid_and_dd_as_fv l
             FStar_Syntax_Syntax.delta_equational FStar_Pervasives_Native.None in
         FStar_Syntax_Syntax.fv_to_tm uu___1
 exception Embedding_failure 
@@ -628,7 +628,7 @@ let e_option :
                           FStar_Parser_Const.some_lid v in
                       let some_v_tm =
                         let uu___1 =
-                          FStar_Syntax_Syntax.lid_as_fv some_v
+                          FStar_Syntax_Syntax.lid_and_dd_as_fv some_v
                             FStar_Syntax_Syntax.delta_equational
                             FStar_Pervasives_Native.None in
                         FStar_Syntax_Syntax.fv_to_tm uu___1 in
@@ -736,7 +736,7 @@ let e_tuple2 : 'a 'b . 'a embedding -> 'b embedding -> ('a * 'b) embedding =
                  FStar_Syntax_Util.mk_field_projector_name uu___1 uu___2 i in
                let proj_1_tm =
                  let uu___1 =
-                   FStar_Syntax_Syntax.lid_as_fv proj_1
+                   FStar_Syntax_Syntax.lid_and_dd_as_fv proj_1
                      FStar_Syntax_Syntax.delta_equational
                      FStar_Pervasives_Native.None in
                  FStar_Syntax_Syntax.fv_to_tm uu___1 in
@@ -870,7 +870,7 @@ let e_tuple3 :
                          uu___3 i in
                      let proj_i_tm =
                        let uu___2 =
-                         FStar_Syntax_Syntax.lid_as_fv proj_i
+                         FStar_Syntax_Syntax.lid_and_dd_as_fv proj_i
                            FStar_Syntax_Syntax.delta_equational
                            FStar_Pervasives_Native.None in
                        FStar_Syntax_Syntax.fv_to_tm uu___2 in
@@ -1034,7 +1034,7 @@ let e_either :
                              FStar_Parser_Const.inl_lid v in
                          let some_v_tm =
                            let uu___1 =
-                             FStar_Syntax_Syntax.lid_as_fv some_v
+                             FStar_Syntax_Syntax.lid_and_dd_as_fv some_v
                                FStar_Syntax_Syntax.delta_equational
                                FStar_Pervasives_Native.None in
                            FStar_Syntax_Syntax.fv_to_tm uu___1 in
@@ -1091,7 +1091,7 @@ let e_either :
                              FStar_Parser_Const.inr_lid v in
                          let some_v_tm =
                            let uu___1 =
-                             FStar_Syntax_Syntax.lid_as_fv some_v
+                             FStar_Syntax_Syntax.lid_and_dd_as_fv some_v
                                FStar_Syntax_Syntax.delta_equational
                                FStar_Pervasives_Native.None in
                            FStar_Syntax_Syntax.fv_to_tm uu___1 in
@@ -1231,7 +1231,7 @@ let e_list : 'a . 'a embedding -> 'a Prims.list embedding =
                      FStar_Parser_Const.cons_lid fid in
                  let proj_tm =
                    let uu___1 =
-                     FStar_Syntax_Syntax.lid_as_fv proj1
+                     FStar_Syntax_Syntax.lid_and_dd_as_fv proj1
                        FStar_Syntax_Syntax.delta_equational
                        FStar_Pervasives_Native.None in
                    FStar_Syntax_Syntax.fv_to_tm uu___1 in

--- a/ocaml/fstar-lib/generated/FStar_Syntax_Resugar.ml
+++ b/ocaml/fstar-lib/generated/FStar_Syntax_Resugar.ml
@@ -2814,7 +2814,7 @@ let (resugar_sigelt' :
                            FStar_Ident.ident_of_lid uu___7 in
                          [uu___6] in
                        FStar_Ident.lid_of_ids uu___5 in
-                     FStar_Syntax_Syntax.lid_as_fv uu___4
+                     FStar_Syntax_Syntax.lid_and_dd_as_fv uu___4
                        FStar_Syntax_Syntax.delta_constant
                        FStar_Pervasives_Native.None in
                    let lbs2 =

--- a/ocaml/fstar-lib/generated/FStar_Syntax_Resugar.ml
+++ b/ocaml/fstar-lib/generated/FStar_Syntax_Resugar.ml
@@ -2814,8 +2814,7 @@ let (resugar_sigelt' :
                            FStar_Ident.ident_of_lid uu___7 in
                          [uu___6] in
                        FStar_Ident.lid_of_ids uu___5 in
-                     FStar_Syntax_Syntax.lid_and_dd_as_fv uu___4
-                       FStar_Syntax_Syntax.delta_constant
+                     FStar_Syntax_Syntax.lid_as_fv uu___4
                        FStar_Pervasives_Native.None in
                    let lbs2 =
                      FStar_Compiler_List.map

--- a/ocaml/fstar-lib/generated/FStar_Syntax_Syntax.ml
+++ b/ocaml/fstar-lib/generated/FStar_Syntax_Syntax.ml
@@ -7,8 +7,8 @@ let __proj__Mkwithinfo_t__item__v : 'a . 'a withinfo_t -> 'a =
 let __proj__Mkwithinfo_t__item__p :
   'a . 'a withinfo_t -> FStar_Compiler_Range_Type.range =
   fun projectee -> match projectee with | { v; p;_} -> p
-type var = FStar_Ident.lident withinfo_t[@@deriving yojson,show,yojson,show]
-type sconst = FStar_Const.sconst[@@deriving yojson,show,yojson,show]
+type var = FStar_Ident.lident withinfo_t[@@deriving yojson,show]
+type sconst = FStar_Const.sconst[@@deriving yojson,show]
 type pragma =
   | SetOptions of Prims.string 
   | ResetOptions of Prims.string FStar_Pervasives_Native.option 
@@ -41,8 +41,14 @@ let (uu___is_RestartSolver : pragma -> Prims.bool) =
 let (uu___is_PrintEffectsGraph : pragma -> Prims.bool) =
   fun projectee ->
     match projectee with | PrintEffectsGraph -> true | uu___ -> false
-type 'a memo = 'a FStar_Pervasives_Native.option FStar_Compiler_Effect.ref
-[@@deriving yojson,show,yojson,show]
+type 'a memo =
+  (('a FStar_Pervasives_Native.option FStar_Compiler_Effect.ref)[@printer
+                                                                  fun fmt ->
+                                                                    fun _ ->
+                                                                    Format.pp_print_string
+                                                                    fmt
+                                                                    "None"])
+[@@deriving yojson,show]
 type emb_typ =
   | ET_abstract 
   | ET_fun of (emb_typ * emb_typ) 
@@ -102,13 +108,13 @@ let (__proj__U_unif__item___0 :
   = fun projectee -> match projectee with | U_unif _0 -> _0
 let (uu___is_U_unknown : universe -> Prims.bool) =
   fun projectee -> match projectee with | U_unknown -> true | uu___ -> false
-type univ_name = FStar_Ident.ident[@@deriving yojson,show,yojson,show]
+type univ_name = FStar_Ident.ident[@@deriving yojson,show]
 type universe_uvar =
   (universe FStar_Pervasives_Native.option FStar_Unionfind.p_uvar * version *
-    FStar_Compiler_Range_Type.range)[@@deriving yojson,show,yojson,show]
-type univ_names = univ_name Prims.list[@@deriving yojson,show,yojson,show]
-type universes = universe Prims.list[@@deriving yojson,show,yojson,show]
-type monad_name = FStar_Ident.lident[@@deriving yojson,show,yojson,show]
+    FStar_Compiler_Range_Type.range)[@@deriving yojson,show]
+type univ_names = univ_name Prims.list[@@deriving yojson,show]
+type universes = universe Prims.list[@@deriving yojson,show]
+type monad_name = FStar_Ident.lident[@@deriving yojson,show]
 type quote_kind =
   | Quote_static 
   | Quote_dynamic [@@deriving yojson,show]

--- a/ocaml/fstar-lib/generated/FStar_Syntax_Syntax.ml
+++ b/ocaml/fstar-lib/generated/FStar_Syntax_Syntax.ml
@@ -2464,7 +2464,7 @@ let (set_bv_range : bv -> FStar_Compiler_Range_Type.range -> bv) =
     fun r ->
       let uu___ = FStar_Ident.set_id_range r bv1.ppname in
       { ppname = uu___; index = (bv1.index); sort = (bv1.sort) }
-let (lid_as_fv :
+let (lid_and_dd_as_fv :
   FStar_Ident.lident ->
     delta_depth -> fv_qual FStar_Pervasives_Native.option -> fv)
   =
@@ -2478,7 +2478,7 @@ let (lid_as_fv :
           fv_delta = (FStar_Pervasives_Native.Some dd);
           fv_qual = dq
         }
-let (lid_as_fv' :
+let (lid_as_fv :
   FStar_Ident.lident -> fv_qual FStar_Pervasives_Native.option -> fv) =
   fun l ->
     fun dq ->
@@ -2498,7 +2498,8 @@ let (fvar :
     delta_depth -> fv_qual FStar_Pervasives_Native.option -> term)
   =
   fun l ->
-    fun dd -> fun dq -> let uu___ = lid_as_fv l dd dq in fv_to_tm uu___
+    fun dd ->
+      fun dq -> let uu___ = lid_and_dd_as_fv l dd dq in fv_to_tm uu___
 let (lid_of_fv : fv -> FStar_Ident.lid) = fun fv1 -> (fv1.fv_name).v
 let (range_of_fv : fv -> FStar_Compiler_Range_Type.range) =
   fun fv1 -> let uu___ = lid_of_fv fv1 in FStar_Ident.range_of_lid uu___
@@ -2556,7 +2557,7 @@ let (delta_constant : delta_depth) = Delta_constant_at_level Prims.int_zero
 let (delta_equational : delta_depth) =
   Delta_equational_at_level Prims.int_zero
 let (fvconst : FStar_Ident.lident -> fv) =
-  fun l -> lid_as_fv l delta_constant FStar_Pervasives_Native.None
+  fun l -> lid_and_dd_as_fv l delta_constant FStar_Pervasives_Native.None
 let (tconst : FStar_Ident.lident -> term) =
   fun l ->
     let uu___ = let uu___1 = fvconst l in Tm_fvar uu___1 in
@@ -2565,14 +2566,15 @@ let (tabbrev : FStar_Ident.lident -> term) =
   fun l ->
     let uu___ =
       let uu___1 =
-        lid_as_fv l (Delta_constant_at_level Prims.int_one)
+        lid_and_dd_as_fv l (Delta_constant_at_level Prims.int_one)
           FStar_Pervasives_Native.None in
       Tm_fvar uu___1 in
     mk uu___ FStar_Compiler_Range_Type.dummyRange
 let (tdataconstr : FStar_Ident.lident -> term) =
   fun l ->
     let uu___ =
-      lid_as_fv l delta_constant (FStar_Pervasives_Native.Some Data_ctor) in
+      lid_and_dd_as_fv l delta_constant
+        (FStar_Pervasives_Native.Some Data_ctor) in
     fv_to_tm uu___
 let (t_unit : term) = tconst FStar_Parser_Const.unit_lid
 let (t_bool : term) = tconst FStar_Parser_Const.bool_lid

--- a/ocaml/fstar-lib/generated/FStar_Syntax_Syntax.ml
+++ b/ocaml/fstar-lib/generated/FStar_Syntax_Syntax.ml
@@ -2499,13 +2499,16 @@ let (fv_to_tm : fv -> term) =
   fun fv1 ->
     let uu___ = FStar_Ident.range_of_lid (fv1.fv_name).v in
     mk (Tm_fvar fv1) uu___
-let (fvar :
+let (fvar_with_dd :
   FStar_Ident.lident ->
     delta_depth -> fv_qual FStar_Pervasives_Native.option -> term)
   =
   fun l ->
     fun dd ->
       fun dq -> let uu___ = lid_and_dd_as_fv l dd dq in fv_to_tm uu___
+let (fvar :
+  FStar_Ident.lident -> fv_qual FStar_Pervasives_Native.option -> term) =
+  fun l -> fun dq -> let uu___ = lid_as_fv l dq in fv_to_tm uu___
 let (lid_of_fv : fv -> FStar_Ident.lid) = fun fv1 -> (fv1.fv_name).v
 let (range_of_fv : fv -> FStar_Compiler_Range_Type.range) =
   fun fv1 -> let uu___ = lid_of_fv fv1 in FStar_Ident.range_of_lid uu___

--- a/ocaml/fstar-lib/generated/FStar_Syntax_Syntax.ml
+++ b/ocaml/fstar-lib/generated/FStar_Syntax_Syntax.ml
@@ -372,7 +372,7 @@ and bv = {
 and fv =
   {
   fv_name: var ;
-  fv_delta: delta_depth ;
+  fv_delta: delta_depth FStar_Pervasives_Native.option ;
   fv_qual: fv_qual FStar_Pervasives_Native.option }
 and free_vars =
   {
@@ -956,7 +956,8 @@ let (__proj__Mkfv__item__fv_name : fv -> var) =
   fun projectee ->
     match projectee with
     | { fv_name; fv_delta; fv_qual = fv_qual1;_} -> fv_name
-let (__proj__Mkfv__item__fv_delta : fv -> delta_depth) =
+let (__proj__Mkfv__item__fv_delta :
+  fv -> delta_depth FStar_Pervasives_Native.option) =
   fun projectee ->
     match projectee with
     | { fv_name; fv_delta; fv_qual = fv_qual1;_} -> fv_delta
@@ -2472,7 +2473,22 @@ let (lid_as_fv :
       fun dq ->
         let uu___ =
           let uu___1 = FStar_Ident.range_of_lid l in withinfo l uu___1 in
-        { fv_name = uu___; fv_delta = dd; fv_qual = dq }
+        {
+          fv_name = uu___;
+          fv_delta = (FStar_Pervasives_Native.Some dd);
+          fv_qual = dq
+        }
+let (lid_as_fv' :
+  FStar_Ident.lident -> fv_qual FStar_Pervasives_Native.option -> fv) =
+  fun l ->
+    fun dq ->
+      let uu___ =
+        let uu___1 = FStar_Ident.range_of_lid l in withinfo l uu___1 in
+      {
+        fv_name = uu___;
+        fv_delta = FStar_Pervasives_Native.None;
+        fv_qual = dq
+      }
 let (fv_to_tm : fv -> term) =
   fun fv1 ->
     let uu___ = FStar_Ident.range_of_lid (fv1.fv_name).v in

--- a/ocaml/fstar-lib/generated/FStar_Syntax_Util.ml
+++ b/ocaml/fstar-lib/generated/FStar_Syntax_Util.ml
@@ -3706,7 +3706,10 @@ let rec (delta_qualifier :
     | FStar_Syntax_Syntax.Tm_delayed uu___ -> failwith "Impossible"
     | FStar_Syntax_Syntax.Tm_lazy i ->
         let uu___ = unfold_lazy i in delta_qualifier uu___
-    | FStar_Syntax_Syntax.Tm_fvar fv -> fv.FStar_Syntax_Syntax.fv_delta
+    | FStar_Syntax_Syntax.Tm_fvar fv ->
+        (match fv.FStar_Syntax_Syntax.fv_delta with
+         | FStar_Pervasives_Native.Some d -> d
+         | FStar_Pervasives_Native.None -> FStar_Syntax_Syntax.delta_constant)
     | FStar_Syntax_Syntax.Tm_bvar uu___ ->
         FStar_Syntax_Syntax.delta_equational
     | FStar_Syntax_Syntax.Tm_name uu___ ->

--- a/ocaml/fstar-lib/generated/FStar_Syntax_Util.ml
+++ b/ocaml/fstar-lib/generated/FStar_Syntax_Util.ml
@@ -2420,16 +2420,16 @@ let (exp_string : Prims.string -> FStar_Syntax_Syntax.term) =
       FStar_Compiler_Range_Type.dummyRange
 let (fvar_const : FStar_Ident.lident -> FStar_Syntax_Syntax.term) =
   fun l ->
-    FStar_Syntax_Syntax.fvar l FStar_Syntax_Syntax.delta_constant
+    FStar_Syntax_Syntax.fvar_with_dd l FStar_Syntax_Syntax.delta_constant
       FStar_Pervasives_Native.None
 let (tand : FStar_Syntax_Syntax.term) = fvar_const FStar_Parser_Const.and_lid
 let (tor : FStar_Syntax_Syntax.term) = fvar_const FStar_Parser_Const.or_lid
 let (timp : FStar_Syntax_Syntax.term) =
-  FStar_Syntax_Syntax.fvar FStar_Parser_Const.imp_lid
+  FStar_Syntax_Syntax.fvar_with_dd FStar_Parser_Const.imp_lid
     (FStar_Syntax_Syntax.Delta_constant_at_level Prims.int_one)
     FStar_Pervasives_Native.None
 let (tiff : FStar_Syntax_Syntax.term) =
-  FStar_Syntax_Syntax.fvar FStar_Parser_Const.iff_lid
+  FStar_Syntax_Syntax.fvar_with_dd FStar_Parser_Const.iff_lid
     (FStar_Syntax_Syntax.Delta_constant_at_level (Prims.of_int (2)))
     FStar_Pervasives_Native.None
 let (t_bool : FStar_Syntax_Syntax.term) =
@@ -2457,7 +2457,6 @@ let (t_universe_uvar : FStar_Syntax_Syntax.term) =
   fvar_const FStar_Parser_Const.universe_uvar_lid
 let (t_dsl_tac_typ : FStar_Syntax_Syntax.term) =
   FStar_Syntax_Syntax.fvar FStar_Parser_Const.dsl_tac_typ_lid
-    (FStar_Syntax_Syntax.Delta_constant_at_level Prims.int_one)
     FStar_Pervasives_Native.None
 let (mk_conj_opt :
   FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax
@@ -2537,7 +2536,7 @@ let (mk_conj_l :
   fun phi ->
     match phi with
     | [] ->
-        FStar_Syntax_Syntax.fvar FStar_Parser_Const.true_lid
+        FStar_Syntax_Syntax.fvar_with_dd FStar_Parser_Const.true_lid
           FStar_Syntax_Syntax.delta_constant FStar_Pervasives_Native.None
     | hd::tl -> FStar_Compiler_List.fold_right mk_conj tl hd
 let (mk_disj :
@@ -2742,15 +2741,15 @@ let (mk_has_type :
           FStar_Syntax_Syntax.Tm_app uu___1 in
         FStar_Syntax_Syntax.mk uu___ FStar_Compiler_Range_Type.dummyRange
 let (tforall : FStar_Syntax_Syntax.term) =
-  FStar_Syntax_Syntax.fvar FStar_Parser_Const.forall_lid
+  FStar_Syntax_Syntax.fvar_with_dd FStar_Parser_Const.forall_lid
     (FStar_Syntax_Syntax.Delta_constant_at_level Prims.int_one)
     FStar_Pervasives_Native.None
 let (texists : FStar_Syntax_Syntax.term) =
-  FStar_Syntax_Syntax.fvar FStar_Parser_Const.exists_lid
+  FStar_Syntax_Syntax.fvar_with_dd FStar_Parser_Const.exists_lid
     (FStar_Syntax_Syntax.Delta_constant_at_level Prims.int_one)
     FStar_Pervasives_Native.None
 let (t_haseq : FStar_Syntax_Syntax.term) =
-  FStar_Syntax_Syntax.fvar FStar_Parser_Const.haseq_lid
+  FStar_Syntax_Syntax.fvar_with_dd FStar_Parser_Const.haseq_lid
     FStar_Syntax_Syntax.delta_constant FStar_Pervasives_Native.None
 let (decidable_eq : FStar_Syntax_Syntax.term) =
   fvar_const FStar_Parser_Const.op_Eq
@@ -3032,7 +3031,7 @@ let (mk_squash :
   fun u ->
     fun p ->
       let sq =
-        FStar_Syntax_Syntax.fvar FStar_Parser_Const.squash_lid
+        FStar_Syntax_Syntax.fvar_with_dd FStar_Parser_Const.squash_lid
           (FStar_Syntax_Syntax.Delta_constant_at_level Prims.int_one)
           FStar_Pervasives_Native.None in
       let uu___ = FStar_Syntax_Syntax.mk_Tm_uinst sq [u] in
@@ -3046,7 +3045,7 @@ let (mk_auto_squash :
   fun u ->
     fun p ->
       let sq =
-        FStar_Syntax_Syntax.fvar FStar_Parser_Const.auto_squash_lid
+        FStar_Syntax_Syntax.fvar_with_dd FStar_Parser_Const.auto_squash_lid
           (FStar_Syntax_Syntax.Delta_constant_at_level (Prims.of_int (2)))
           FStar_Pervasives_Native.None in
       let uu___ = FStar_Syntax_Syntax.mk_Tm_uinst sq [u] in
@@ -5120,9 +5119,7 @@ let (apply_reveal :
           let uu___ =
             FStar_Ident.set_lid_range FStar_Parser_Const.reveal
               v.FStar_Syntax_Syntax.pos in
-          FStar_Syntax_Syntax.fvar uu___
-            (FStar_Syntax_Syntax.Delta_constant_at_level Prims.int_one)
-            FStar_Pervasives_Native.None in
+          FStar_Syntax_Syntax.fvar uu___ FStar_Pervasives_Native.None in
         let uu___ = FStar_Syntax_Syntax.mk_Tm_uinst head [u] in
         let uu___1 =
           let uu___2 = FStar_Syntax_Syntax.iarg ty in

--- a/ocaml/fstar-lib/generated/FStar_Syntax_Util.ml
+++ b/ocaml/fstar-lib/generated/FStar_Syntax_Util.ml
@@ -2384,7 +2384,8 @@ let (attr_substitute : FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax)
   =
   let uu___ =
     let uu___1 =
-      FStar_Syntax_Syntax.lid_as_fv FStar_Parser_Const.attr_substitute_lid
+      FStar_Syntax_Syntax.lid_and_dd_as_fv
+        FStar_Parser_Const.attr_substitute_lid
         FStar_Syntax_Syntax.delta_constant FStar_Pervasives_Native.None in
     FStar_Syntax_Syntax.Tm_fvar uu___1 in
   FStar_Syntax_Syntax.mk uu___ FStar_Compiler_Range_Type.dummyRange
@@ -3626,7 +3627,8 @@ let (action_as_lb :
         let lb =
           let uu___ =
             let uu___1 =
-              FStar_Syntax_Syntax.lid_as_fv a.FStar_Syntax_Syntax.action_name
+              FStar_Syntax_Syntax.lid_and_dd_as_fv
+                a.FStar_Syntax_Syntax.action_name
                 FStar_Syntax_Syntax.delta_equational
                 FStar_Pervasives_Native.None in
             FStar_Pervasives.Inr uu___1 in
@@ -3802,7 +3804,7 @@ let (mk_list :
         let ctor l1 =
           let uu___ =
             let uu___1 =
-              FStar_Syntax_Syntax.lid_as_fv l1
+              FStar_Syntax_Syntax.lid_and_dd_as_fv l1
                 FStar_Syntax_Syntax.delta_constant
                 (FStar_Pervasives_Native.Some FStar_Syntax_Syntax.Data_ctor) in
             FStar_Syntax_Syntax.Tm_fvar uu___1 in
@@ -5248,7 +5250,7 @@ let (encode_positivity_attributes :
           else
             (let uu___2 =
                let uu___3 =
-                 FStar_Syntax_Syntax.lid_as_fv
+                 FStar_Syntax_Syntax.lid_and_dd_as_fv
                    FStar_Parser_Const.binder_strictly_positive_attr
                    (FStar_Syntax_Syntax.Delta_constant_at_level
                       Prims.int_zero) FStar_Pervasives_Native.None in
@@ -5261,7 +5263,7 @@ let (encode_positivity_attributes :
           else
             (let uu___2 =
                let uu___3 =
-                 FStar_Syntax_Syntax.lid_as_fv
+                 FStar_Syntax_Syntax.lid_and_dd_as_fv
                    FStar_Parser_Const.binder_unused_attr
                    (FStar_Syntax_Syntax.Delta_constant_at_level
                       Prims.int_zero) FStar_Pervasives_Native.None in

--- a/ocaml/fstar-lib/generated/FStar_Syntax_Util.ml
+++ b/ocaml/fstar-lib/generated/FStar_Syntax_Util.ml
@@ -2384,9 +2384,8 @@ let (attr_substitute : FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax)
   =
   let uu___ =
     let uu___1 =
-      FStar_Syntax_Syntax.lid_and_dd_as_fv
-        FStar_Parser_Const.attr_substitute_lid
-        FStar_Syntax_Syntax.delta_constant FStar_Pervasives_Native.None in
+      FStar_Syntax_Syntax.lid_as_fv FStar_Parser_Const.attr_substitute_lid
+        FStar_Pervasives_Native.None in
     FStar_Syntax_Syntax.Tm_fvar uu___1 in
   FStar_Syntax_Syntax.mk uu___ FStar_Compiler_Range_Type.dummyRange
 let (exp_true_bool : FStar_Syntax_Syntax.term) =
@@ -3803,8 +3802,7 @@ let (mk_list :
         let ctor l1 =
           let uu___ =
             let uu___1 =
-              FStar_Syntax_Syntax.lid_and_dd_as_fv l1
-                FStar_Syntax_Syntax.delta_constant
+              FStar_Syntax_Syntax.lid_as_fv l1
                 (FStar_Pervasives_Native.Some FStar_Syntax_Syntax.Data_ctor) in
             FStar_Syntax_Syntax.Tm_fvar uu___1 in
           FStar_Syntax_Syntax.mk uu___ rng in
@@ -5247,10 +5245,9 @@ let (encode_positivity_attributes :
           else
             (let uu___2 =
                let uu___3 =
-                 FStar_Syntax_Syntax.lid_and_dd_as_fv
+                 FStar_Syntax_Syntax.lid_as_fv
                    FStar_Parser_Const.binder_strictly_positive_attr
-                   (FStar_Syntax_Syntax.Delta_constant_at_level
-                      Prims.int_zero) FStar_Pervasives_Native.None in
+                   FStar_Pervasives_Native.None in
                FStar_Syntax_Syntax.fv_to_tm uu___3 in
              uu___2 :: attrs)
       | FStar_Pervasives_Native.Some (FStar_Syntax_Syntax.BinderUnused) ->
@@ -5260,10 +5257,9 @@ let (encode_positivity_attributes :
           else
             (let uu___2 =
                let uu___3 =
-                 FStar_Syntax_Syntax.lid_and_dd_as_fv
+                 FStar_Syntax_Syntax.lid_as_fv
                    FStar_Parser_Const.binder_unused_attr
-                   (FStar_Syntax_Syntax.Delta_constant_at_level
-                      Prims.int_zero) FStar_Pervasives_Native.None in
+                   FStar_Pervasives_Native.None in
                FStar_Syntax_Syntax.fv_to_tm uu___3 in
              uu___2 :: attrs)
 let (is_binder_strictly_positive : FStar_Syntax_Syntax.binder -> Prims.bool)

--- a/ocaml/fstar-lib/generated/FStar_Tactics_Basic.ml
+++ b/ocaml/fstar-lib/generated/FStar_Tactics_Basic.ml
@@ -5516,9 +5516,8 @@ let (t_destruct :
                                                                     = mut1;_}
                                                                     ->
                                                                     let fv1 =
-                                                                    FStar_Syntax_Syntax.lid_as_fv
+                                                                    FStar_Syntax_Syntax.lid_as_fv'
                                                                     c_lid
-                                                                    FStar_Syntax_Syntax.delta_constant
                                                                     (FStar_Pervasives_Native.Some
                                                                     FStar_Syntax_Syntax.Data_ctor) in
                                                                     let uu___20

--- a/ocaml/fstar-lib/generated/FStar_Tactics_Basic.ml
+++ b/ocaml/fstar-lib/generated/FStar_Tactics_Basic.ml
@@ -5516,7 +5516,7 @@ let (t_destruct :
                                                                     = mut1;_}
                                                                     ->
                                                                     let fv1 =
-                                                                    FStar_Syntax_Syntax.lid_as_fv'
+                                                                    FStar_Syntax_Syntax.lid_as_fv
                                                                     c_lid
                                                                     (FStar_Pervasives_Native.Some
                                                                     FStar_Syntax_Syntax.Data_ctor) in

--- a/ocaml/fstar-lib/generated/FStar_Tactics_Basic.ml
+++ b/ocaml/fstar-lib/generated/FStar_Tactics_Basic.ml
@@ -7281,6 +7281,13 @@ let (to_must_tot : FStar_Tactics_Types.tot_or_ghost -> Prims.bool) =
     match eff with
     | FStar_Tactics_Types.E_Total -> true
     | FStar_Tactics_Types.E_Ghost -> false
+let (refl_norm_type :
+  env -> FStar_Syntax_Syntax.typ -> FStar_Syntax_Syntax.typ) =
+  fun g ->
+    fun t ->
+      FStar_TypeChecker_Normalize.normalize
+        [FStar_TypeChecker_Env.Beta;
+        FStar_TypeChecker_Env.Exclude FStar_TypeChecker_Env.Zeta] g t
 let (refl_core_compute_term_type :
   env ->
     FStar_Syntax_Syntax.term ->
@@ -7322,14 +7329,15 @@ let (refl_core_compute_term_type :
                     must_tot gh in
                 match uu___3 with
                 | FStar_Pervasives.Inl t ->
+                    let t1 = refl_norm_type g t in
                     (dbg_refl g
                        (fun uu___5 ->
                           let uu___6 = FStar_Syntax_Print.term_to_string e in
-                          let uu___7 = FStar_Syntax_Print.term_to_string t in
+                          let uu___7 = FStar_Syntax_Print.term_to_string t1 in
                           FStar_Compiler_Util.format2
                             "refl_core_compute_term_type for %s computed type %s\n"
                             uu___6 uu___7);
-                     t)
+                     t1)
                 | FStar_Pervasives.Inr err ->
                     (dbg_refl g
                        (fun uu___5 ->
@@ -7685,16 +7693,17 @@ let (refl_tc_term :
                                g1 e2 must_tot gh in
                            match uu___6 with
                            | FStar_Pervasives.Inl t ->
+                               let t1 = refl_norm_type g1 t in
                                (dbg_refl g1
                                   (fun uu___8 ->
                                      let uu___9 =
                                        FStar_Syntax_Print.term_to_string e2 in
                                      let uu___10 =
-                                       FStar_Syntax_Print.term_to_string t in
+                                       FStar_Syntax_Print.term_to_string t1 in
                                      FStar_Compiler_Util.format2
                                        "refl_tc_term for %s computed type %s\n"
                                        uu___9 uu___10);
-                                (e2, t))
+                                (e2, t1))
                            | FStar_Pervasives.Inr err ->
                                (dbg_refl g1
                                   (fun uu___8 ->
@@ -7973,7 +7982,12 @@ let (refl_instantiate_implicits :
               | (e1, t, guard) ->
                   (FStar_TypeChecker_Rel.force_trivial_guard g1 guard;
                    (let e2 = FStar_Syntax_Compress.deep_compress false e1 in
-                    let t1 = FStar_Syntax_Compress.deep_compress false t in
+                    let t1 =
+                      let uu___6 =
+                        FStar_Compiler_Effect.op_Bar_Greater t
+                          (refl_norm_type g1) in
+                      FStar_Compiler_Effect.op_Bar_Greater uu___6
+                        (FStar_Syntax_Compress.deep_compress false) in
                     dbg_refl g1
                       (fun uu___7 ->
                          let uu___8 = FStar_Syntax_Print.term_to_string e2 in

--- a/ocaml/fstar-lib/generated/FStar_Tactics_Embedding.ml
+++ b/ocaml/fstar-lib/generated/FStar_Tactics_Embedding.ml
@@ -4,7 +4,7 @@ let (fstar_tactics_lid' : Prims.string Prims.list -> FStar_Ident.lid) =
   fun s -> FStar_Parser_Const.fstar_tactics_lid' s
 let (lid_as_tm : FStar_Ident.lident -> FStar_Syntax_Syntax.term) =
   fun l ->
-    let uu___ = FStar_Syntax_Syntax.lid_as_fv' l FStar_Pervasives_Native.None in
+    let uu___ = FStar_Syntax_Syntax.lid_as_fv l FStar_Pervasives_Native.None in
     FStar_Compiler_Effect.op_Bar_Greater uu___ FStar_Syntax_Syntax.fv_to_tm
 let (mk_tactic_lid_as_term : Prims.string -> FStar_Syntax_Syntax.term) =
   fun s -> let uu___ = fstar_tactics_lid' ["Effect"; s] in lid_as_tm uu___
@@ -23,7 +23,7 @@ let (__proj__Mktac_constant__item__t :
   fun projectee -> match projectee with | { lid; fv; t;_} -> t
 let (lid_as_data_fv : FStar_Ident.lident -> FStar_Syntax_Syntax.fv) =
   fun l ->
-    FStar_Syntax_Syntax.lid_as_fv' l
+    FStar_Syntax_Syntax.lid_as_fv l
       (FStar_Pervasives_Native.Some FStar_Syntax_Syntax.Data_ctor)
 let (lid_as_data_tm : FStar_Ident.lident -> FStar_Syntax_Syntax.term) =
   fun l -> let uu___ = lid_as_data_fv l in FStar_Syntax_Syntax.fv_to_tm uu___

--- a/ocaml/fstar-lib/generated/FStar_Tactics_Embedding.ml
+++ b/ocaml/fstar-lib/generated/FStar_Tactics_Embedding.ml
@@ -4,9 +4,7 @@ let (fstar_tactics_lid' : Prims.string Prims.list -> FStar_Ident.lid) =
   fun s -> FStar_Parser_Const.fstar_tactics_lid' s
 let (lid_as_tm : FStar_Ident.lident -> FStar_Syntax_Syntax.term) =
   fun l ->
-    let uu___ =
-      FStar_Syntax_Syntax.lid_as_fv l FStar_Syntax_Syntax.delta_constant
-        FStar_Pervasives_Native.None in
+    let uu___ = FStar_Syntax_Syntax.lid_as_fv' l FStar_Pervasives_Native.None in
     FStar_Compiler_Effect.op_Bar_Greater uu___ FStar_Syntax_Syntax.fv_to_tm
 let (mk_tactic_lid_as_term : Prims.string -> FStar_Syntax_Syntax.term) =
   fun s -> let uu___ = fstar_tactics_lid' ["Effect"; s] in lid_as_tm uu___
@@ -25,7 +23,7 @@ let (__proj__Mktac_constant__item__t :
   fun projectee -> match projectee with | { lid; fv; t;_} -> t
 let (lid_as_data_fv : FStar_Ident.lident -> FStar_Syntax_Syntax.fv) =
   fun l ->
-    FStar_Syntax_Syntax.lid_as_fv l FStar_Syntax_Syntax.delta_constant
+    FStar_Syntax_Syntax.lid_as_fv' l
       (FStar_Pervasives_Native.Some FStar_Syntax_Syntax.Data_ctor)
 let (lid_as_data_tm : FStar_Ident.lident -> FStar_Syntax_Syntax.term) =
   fun l -> let uu___ = lid_as_data_fv l in FStar_Syntax_Syntax.fv_to_tm uu___

--- a/ocaml/fstar-lib/generated/FStar_Tactics_Hooks.ml
+++ b/ocaml/fstar-lib/generated/FStar_Tactics_Hooks.ml
@@ -1677,9 +1677,8 @@ let (handle_smt_goal :
                      ->
                      let qn = FStar_TypeChecker_Env.lookup_qname env lid in
                      let fv =
-                       FStar_Syntax_Syntax.lid_as_fv lid
-                         (FStar_Syntax_Syntax.Delta_constant_at_level
-                            Prims.int_zero) FStar_Pervasives_Native.None in
+                       FStar_Syntax_Syntax.lid_as_fv' lid
+                         FStar_Pervasives_Native.None in
                      let dd =
                        let uu___3 =
                          FStar_TypeChecker_Env.delta_depth_of_qninfo fv qn in
@@ -1688,7 +1687,7 @@ let (handle_smt_goal :
                        | FStar_Pervasives_Native.None ->
                            failwith "Expected a dd" in
                      let uu___3 =
-                       FStar_Syntax_Syntax.lid_as_fv lid dd
+                       FStar_Syntax_Syntax.lid_as_fv' lid
                          FStar_Pervasives_Native.None in
                      FStar_Syntax_Syntax.fv_to_tm uu___3
                  | uu___2 -> failwith "Resolve_tac not found" in
@@ -1914,10 +1913,8 @@ let (splice :
                                        let uu___9 =
                                          let uu___10 =
                                            FStar_Compiler_List.hd lids in
-                                         FStar_Syntax_Syntax.lid_as_fv
+                                         FStar_Syntax_Syntax.lid_as_fv'
                                            uu___10
-                                           (FStar_Syntax_Syntax.Delta_constant_at_level
-                                              Prims.int_one)
                                            FStar_Pervasives_Native.None in
                                        FStar_Pervasives.Inr uu___9 in
                                      FStar_Syntax_Util.mk_letbinding uu___8
@@ -1944,13 +1941,114 @@ let (splice :
                                       }])
                              else
                                (let uu___8 =
-                                  FStar_Syntax_Embeddings.e_list
-                                    FStar_Reflection_Embeddings.e_sigelt in
-                                FStar_Tactics_Interpreter.run_tactic_on_ps
-                                  tau1.FStar_Syntax_Syntax.pos
-                                  tau1.FStar_Syntax_Syntax.pos false
-                                  FStar_Syntax_Embeddings.e_unit () uu___8
-                                  tau1 tactic_already_typed ps) in
+                                  let uu___9 =
+                                    FStar_Syntax_Embeddings.e_list
+                                      FStar_Reflection_Embeddings.e_sigelt in
+                                  FStar_Tactics_Interpreter.run_tactic_on_ps
+                                    tau1.FStar_Syntax_Syntax.pos
+                                    tau1.FStar_Syntax_Syntax.pos false
+                                    FStar_Syntax_Embeddings.e_unit () uu___9
+                                    tau1 tactic_already_typed ps in
+                                match uu___8 with
+                                | (gs, sigelts) ->
+                                    let set_lb_dd lb =
+                                      let uu___9 = lb in
+                                      match uu___9 with
+                                      | {
+                                          FStar_Syntax_Syntax.lbname =
+                                            FStar_Pervasives.Inr fv;
+                                          FStar_Syntax_Syntax.lbunivs =
+                                            uu___10;
+                                          FStar_Syntax_Syntax.lbtyp = uu___11;
+                                          FStar_Syntax_Syntax.lbeff = uu___12;
+                                          FStar_Syntax_Syntax.lbdef = lbdef;
+                                          FStar_Syntax_Syntax.lbattrs =
+                                            uu___13;
+                                          FStar_Syntax_Syntax.lbpos = uu___14;_}
+                                          ->
+                                          let uu___15 =
+                                            let uu___16 =
+                                              let uu___17 =
+                                                let uu___18 =
+                                                  FStar_Syntax_Util.incr_delta_qualifier
+                                                    lbdef in
+                                                FStar_Compiler_Effect.op_Bar_Greater
+                                                  uu___18
+                                                  (fun uu___19 ->
+                                                     FStar_Pervasives_Native.Some
+                                                       uu___19) in
+                                              {
+                                                FStar_Syntax_Syntax.fv_name =
+                                                  (fv.FStar_Syntax_Syntax.fv_name);
+                                                FStar_Syntax_Syntax.fv_delta
+                                                  = uu___17;
+                                                FStar_Syntax_Syntax.fv_qual =
+                                                  (fv.FStar_Syntax_Syntax.fv_qual)
+                                              } in
+                                            FStar_Pervasives.Inr uu___16 in
+                                          {
+                                            FStar_Syntax_Syntax.lbname =
+                                              uu___15;
+                                            FStar_Syntax_Syntax.lbunivs =
+                                              (lb.FStar_Syntax_Syntax.lbunivs);
+                                            FStar_Syntax_Syntax.lbtyp =
+                                              (lb.FStar_Syntax_Syntax.lbtyp);
+                                            FStar_Syntax_Syntax.lbeff =
+                                              (lb.FStar_Syntax_Syntax.lbeff);
+                                            FStar_Syntax_Syntax.lbdef =
+                                              (lb.FStar_Syntax_Syntax.lbdef);
+                                            FStar_Syntax_Syntax.lbattrs =
+                                              (lb.FStar_Syntax_Syntax.lbattrs);
+                                            FStar_Syntax_Syntax.lbpos =
+                                              (lb.FStar_Syntax_Syntax.lbpos)
+                                          } in
+                                    let sigelts1 =
+                                      FStar_Compiler_List.map
+                                        (fun se ->
+                                           match se.FStar_Syntax_Syntax.sigel
+                                           with
+                                           | FStar_Syntax_Syntax.Sig_let
+                                               {
+                                                 FStar_Syntax_Syntax.lbs1 =
+                                                   (is_rec, lbs);
+                                                 FStar_Syntax_Syntax.lids1 =
+                                                   lids1;_}
+                                               ->
+                                               let uu___9 =
+                                                 let uu___10 =
+                                                   let uu___11 =
+                                                     let uu___12 =
+                                                       FStar_Compiler_List.map
+                                                         set_lb_dd lbs in
+                                                     (is_rec, uu___12) in
+                                                   {
+                                                     FStar_Syntax_Syntax.lbs1
+                                                       = uu___11;
+                                                     FStar_Syntax_Syntax.lids1
+                                                       = lids1
+                                                   } in
+                                                 FStar_Syntax_Syntax.Sig_let
+                                                   uu___10 in
+                                               {
+                                                 FStar_Syntax_Syntax.sigel =
+                                                   uu___9;
+                                                 FStar_Syntax_Syntax.sigrng =
+                                                   (se.FStar_Syntax_Syntax.sigrng);
+                                                 FStar_Syntax_Syntax.sigquals
+                                                   =
+                                                   (se.FStar_Syntax_Syntax.sigquals);
+                                                 FStar_Syntax_Syntax.sigmeta
+                                                   =
+                                                   (se.FStar_Syntax_Syntax.sigmeta);
+                                                 FStar_Syntax_Syntax.sigattrs
+                                                   =
+                                                   (se.FStar_Syntax_Syntax.sigattrs);
+                                                 FStar_Syntax_Syntax.sigopts
+                                                   =
+                                                   (se.FStar_Syntax_Syntax.sigopts)
+                                               }
+                                           | uu___9 -> se) sigelts in
+                                    (gs, sigelts1)) in
                            match uu___6 with
                            | (gs, sigelts) ->
                                ((let uu___8 =

--- a/ocaml/fstar-lib/generated/FStar_Tactics_Hooks.ml
+++ b/ocaml/fstar-lib/generated/FStar_Tactics_Hooks.ml
@@ -1677,7 +1677,7 @@ let (handle_smt_goal :
                      ->
                      let qn = FStar_TypeChecker_Env.lookup_qname env lid in
                      let fv =
-                       FStar_Syntax_Syntax.lid_as_fv' lid
+                       FStar_Syntax_Syntax.lid_as_fv lid
                          FStar_Pervasives_Native.None in
                      let dd =
                        let uu___3 =
@@ -1687,7 +1687,7 @@ let (handle_smt_goal :
                        | FStar_Pervasives_Native.None ->
                            failwith "Expected a dd" in
                      let uu___3 =
-                       FStar_Syntax_Syntax.lid_as_fv' lid
+                       FStar_Syntax_Syntax.lid_as_fv lid
                          FStar_Pervasives_Native.None in
                      FStar_Syntax_Syntax.fv_to_tm uu___3
                  | uu___2 -> failwith "Resolve_tac not found" in
@@ -1913,7 +1913,7 @@ let (splice :
                                        let uu___9 =
                                          let uu___10 =
                                            FStar_Compiler_List.hd lids in
-                                         FStar_Syntax_Syntax.lid_as_fv'
+                                         FStar_Syntax_Syntax.lid_as_fv
                                            uu___10
                                            FStar_Pervasives_Native.None in
                                        FStar_Pervasives.Inr uu___9 in
@@ -1950,107 +1950,97 @@ let (splice :
                                     FStar_Syntax_Embeddings.e_unit () uu___9
                                     tau1 tactic_already_typed ps in
                                 match uu___8 with
-                                | (gs, sigelts) ->
-                                    let set_lb_dd lb =
-                                      let uu___9 = lb in
-                                      match uu___9 with
-                                      | {
-                                          FStar_Syntax_Syntax.lbname =
-                                            FStar_Pervasives.Inr fv;
-                                          FStar_Syntax_Syntax.lbunivs =
-                                            uu___10;
-                                          FStar_Syntax_Syntax.lbtyp = uu___11;
-                                          FStar_Syntax_Syntax.lbeff = uu___12;
-                                          FStar_Syntax_Syntax.lbdef = lbdef;
-                                          FStar_Syntax_Syntax.lbattrs =
-                                            uu___13;
-                                          FStar_Syntax_Syntax.lbpos = uu___14;_}
-                                          ->
-                                          let uu___15 =
-                                            let uu___16 =
-                                              let uu___17 =
-                                                let uu___18 =
-                                                  FStar_Syntax_Util.incr_delta_qualifier
-                                                    lbdef in
-                                                FStar_Compiler_Effect.op_Bar_Greater
-                                                  uu___18
-                                                  (fun uu___19 ->
-                                                     FStar_Pervasives_Native.Some
-                                                       uu___19) in
-                                              {
-                                                FStar_Syntax_Syntax.fv_name =
-                                                  (fv.FStar_Syntax_Syntax.fv_name);
-                                                FStar_Syntax_Syntax.fv_delta
-                                                  = uu___17;
-                                                FStar_Syntax_Syntax.fv_qual =
-                                                  (fv.FStar_Syntax_Syntax.fv_qual)
-                                              } in
-                                            FStar_Pervasives.Inr uu___16 in
-                                          {
-                                            FStar_Syntax_Syntax.lbname =
-                                              uu___15;
-                                            FStar_Syntax_Syntax.lbunivs =
-                                              (lb.FStar_Syntax_Syntax.lbunivs);
-                                            FStar_Syntax_Syntax.lbtyp =
-                                              (lb.FStar_Syntax_Syntax.lbtyp);
-                                            FStar_Syntax_Syntax.lbeff =
-                                              (lb.FStar_Syntax_Syntax.lbeff);
-                                            FStar_Syntax_Syntax.lbdef =
-                                              (lb.FStar_Syntax_Syntax.lbdef);
-                                            FStar_Syntax_Syntax.lbattrs =
-                                              (lb.FStar_Syntax_Syntax.lbattrs);
-                                            FStar_Syntax_Syntax.lbpos =
-                                              (lb.FStar_Syntax_Syntax.lbpos)
-                                          } in
-                                    let sigelts1 =
-                                      FStar_Compiler_List.map
-                                        (fun se ->
-                                           match se.FStar_Syntax_Syntax.sigel
-                                           with
-                                           | FStar_Syntax_Syntax.Sig_let
-                                               {
-                                                 FStar_Syntax_Syntax.lbs1 =
-                                                   (is_rec, lbs);
-                                                 FStar_Syntax_Syntax.lids1 =
-                                                   lids1;_}
-                                               ->
-                                               let uu___9 =
-                                                 let uu___10 =
-                                                   let uu___11 =
-                                                     let uu___12 =
-                                                       FStar_Compiler_List.map
-                                                         set_lb_dd lbs in
-                                                     (is_rec, uu___12) in
-                                                   {
-                                                     FStar_Syntax_Syntax.lbs1
-                                                       = uu___11;
-                                                     FStar_Syntax_Syntax.lids1
-                                                       = lids1
-                                                   } in
-                                                 FStar_Syntax_Syntax.Sig_let
-                                                   uu___10 in
-                                               {
-                                                 FStar_Syntax_Syntax.sigel =
-                                                   uu___9;
-                                                 FStar_Syntax_Syntax.sigrng =
-                                                   (se.FStar_Syntax_Syntax.sigrng);
-                                                 FStar_Syntax_Syntax.sigquals
-                                                   =
-                                                   (se.FStar_Syntax_Syntax.sigquals);
-                                                 FStar_Syntax_Syntax.sigmeta
-                                                   =
-                                                   (se.FStar_Syntax_Syntax.sigmeta);
-                                                 FStar_Syntax_Syntax.sigattrs
-                                                   =
-                                                   (se.FStar_Syntax_Syntax.sigattrs);
-                                                 FStar_Syntax_Syntax.sigopts
-                                                   =
-                                                   (se.FStar_Syntax_Syntax.sigopts)
-                                               }
-                                           | uu___9 -> se) sigelts in
-                                    (gs, sigelts1)) in
+                                | (gs, sigelts) -> (gs, sigelts)) in
                            match uu___6 with
                            | (gs, sigelts) ->
+                               let set_lb_dd lb =
+                                 let uu___7 = lb in
+                                 match uu___7 with
+                                 | {
+                                     FStar_Syntax_Syntax.lbname =
+                                       FStar_Pervasives.Inr fv;
+                                     FStar_Syntax_Syntax.lbunivs = uu___8;
+                                     FStar_Syntax_Syntax.lbtyp = uu___9;
+                                     FStar_Syntax_Syntax.lbeff = uu___10;
+                                     FStar_Syntax_Syntax.lbdef = lbdef;
+                                     FStar_Syntax_Syntax.lbattrs = uu___11;
+                                     FStar_Syntax_Syntax.lbpos = uu___12;_}
+                                     ->
+                                     let uu___13 =
+                                       let uu___14 =
+                                         let uu___15 =
+                                           let uu___16 =
+                                             FStar_Syntax_Util.incr_delta_qualifier
+                                               lbdef in
+                                           FStar_Compiler_Effect.op_Bar_Greater
+                                             uu___16
+                                             (fun uu___17 ->
+                                                FStar_Pervasives_Native.Some
+                                                  uu___17) in
+                                         {
+                                           FStar_Syntax_Syntax.fv_name =
+                                             (fv.FStar_Syntax_Syntax.fv_name);
+                                           FStar_Syntax_Syntax.fv_delta =
+                                             uu___15;
+                                           FStar_Syntax_Syntax.fv_qual =
+                                             (fv.FStar_Syntax_Syntax.fv_qual)
+                                         } in
+                                       FStar_Pervasives.Inr uu___14 in
+                                     {
+                                       FStar_Syntax_Syntax.lbname = uu___13;
+                                       FStar_Syntax_Syntax.lbunivs =
+                                         (lb.FStar_Syntax_Syntax.lbunivs);
+                                       FStar_Syntax_Syntax.lbtyp =
+                                         (lb.FStar_Syntax_Syntax.lbtyp);
+                                       FStar_Syntax_Syntax.lbeff =
+                                         (lb.FStar_Syntax_Syntax.lbeff);
+                                       FStar_Syntax_Syntax.lbdef =
+                                         (lb.FStar_Syntax_Syntax.lbdef);
+                                       FStar_Syntax_Syntax.lbattrs =
+                                         (lb.FStar_Syntax_Syntax.lbattrs);
+                                       FStar_Syntax_Syntax.lbpos =
+                                         (lb.FStar_Syntax_Syntax.lbpos)
+                                     } in
+                               let sigelts1 =
+                                 FStar_Compiler_List.map
+                                   (fun se ->
+                                      match se.FStar_Syntax_Syntax.sigel with
+                                      | FStar_Syntax_Syntax.Sig_let
+                                          {
+                                            FStar_Syntax_Syntax.lbs1 =
+                                              (is_rec, lbs);
+                                            FStar_Syntax_Syntax.lids1 = lids1;_}
+                                          ->
+                                          let uu___7 =
+                                            let uu___8 =
+                                              let uu___9 =
+                                                let uu___10 =
+                                                  FStar_Compiler_List.map
+                                                    set_lb_dd lbs in
+                                                (is_rec, uu___10) in
+                                              {
+                                                FStar_Syntax_Syntax.lbs1 =
+                                                  uu___9;
+                                                FStar_Syntax_Syntax.lids1 =
+                                                  lids1
+                                              } in
+                                            FStar_Syntax_Syntax.Sig_let
+                                              uu___8 in
+                                          {
+                                            FStar_Syntax_Syntax.sigel =
+                                              uu___7;
+                                            FStar_Syntax_Syntax.sigrng =
+                                              (se.FStar_Syntax_Syntax.sigrng);
+                                            FStar_Syntax_Syntax.sigquals =
+                                              (se.FStar_Syntax_Syntax.sigquals);
+                                            FStar_Syntax_Syntax.sigmeta =
+                                              (se.FStar_Syntax_Syntax.sigmeta);
+                                            FStar_Syntax_Syntax.sigattrs =
+                                              (se.FStar_Syntax_Syntax.sigattrs);
+                                            FStar_Syntax_Syntax.sigopts =
+                                              (se.FStar_Syntax_Syntax.sigopts)
+                                          }
+                                      | uu___7 -> se) sigelts in
                                ((let uu___8 =
                                    FStar_Compiler_List.existsML
                                      (fun g1 ->
@@ -2073,7 +2063,8 @@ let (splice :
                                  else ());
                                 (let lids' =
                                    FStar_Compiler_List.collect
-                                     FStar_Syntax_Util.lids_of_sigelt sigelts in
+                                     FStar_Syntax_Util.lids_of_sigelt
+                                     sigelts1 in
                                  FStar_Compiler_List.iter
                                    (fun lid ->
                                       let uu___9 =
@@ -2112,14 +2103,14 @@ let (splice :
                                     let uu___11 =
                                       (FStar_Common.string_of_list ())
                                         FStar_Syntax_Print.sigelt_to_string
-                                        sigelts in
+                                        sigelts1 in
                                     FStar_Compiler_Util.print1
                                       "splice: got decls = {\n\n%s\n\n}\n"
                                       uu___11
                                   else ());
-                                 (let sigelts1 =
+                                 (let sigelts2 =
                                     FStar_Compiler_Effect.op_Bar_Greater
-                                      sigelts
+                                      sigelts1
                                       (FStar_Compiler_List.map
                                          (fun se ->
                                             (match se.FStar_Syntax_Syntax.sigel
@@ -2171,7 +2162,7 @@ let (splice :
                                   then ()
                                   else
                                     FStar_Compiler_Effect.op_Bar_Greater
-                                      sigelts1
+                                      sigelts2
                                       (FStar_Compiler_List.iter
                                          (fun se ->
                                             FStar_Compiler_Effect.op_Bar_Greater
@@ -2199,7 +2190,7 @@ let (splice :
                                                       FStar_Errors.raise_error
                                                         uu___13 rng
                                                     else ()))));
-                                  (match () with | () -> sigelts1)))))))))
+                                  (match () with | () -> sigelts2)))))))))
 let (mpreprocess :
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.term ->

--- a/ocaml/fstar-lib/generated/FStar_Tactics_Hooks.ml
+++ b/ocaml/fstar-lib/generated/FStar_Tactics_Hooks.ml
@@ -1492,7 +1492,7 @@ let (synthesize :
              if env.FStar_TypeChecker_Env.nosynth
              then
                let uu___1 =
-                 FStar_TypeChecker_Util.fvar_const env
+                 FStar_TypeChecker_Util.fvar_env env
                    FStar_Parser_Const.magic_lid in
                let uu___2 =
                  let uu___3 =
@@ -1941,67 +1941,64 @@ let (splice :
                                       }])
                              else
                                (let uu___8 =
-                                  let uu___9 =
-                                    FStar_Syntax_Embeddings.e_list
-                                      FStar_Reflection_Embeddings.e_sigelt in
-                                  FStar_Tactics_Interpreter.run_tactic_on_ps
-                                    tau1.FStar_Syntax_Syntax.pos
-                                    tau1.FStar_Syntax_Syntax.pos false
-                                    FStar_Syntax_Embeddings.e_unit () uu___9
-                                    tau1 tactic_already_typed ps in
-                                match uu___8 with
-                                | (gs, sigelts) -> (gs, sigelts)) in
+                                  FStar_Syntax_Embeddings.e_list
+                                    FStar_Reflection_Embeddings.e_sigelt in
+                                FStar_Tactics_Interpreter.run_tactic_on_ps
+                                  tau1.FStar_Syntax_Syntax.pos
+                                  tau1.FStar_Syntax_Syntax.pos false
+                                  FStar_Syntax_Embeddings.e_unit () uu___8
+                                  tau1 tactic_already_typed ps) in
                            match uu___6 with
                            | (gs, sigelts) ->
-                               let set_lb_dd lb =
-                                 let uu___7 = lb in
-                                 match uu___7 with
-                                 | {
-                                     FStar_Syntax_Syntax.lbname =
-                                       FStar_Pervasives.Inr fv;
-                                     FStar_Syntax_Syntax.lbunivs = uu___8;
-                                     FStar_Syntax_Syntax.lbtyp = uu___9;
-                                     FStar_Syntax_Syntax.lbeff = uu___10;
-                                     FStar_Syntax_Syntax.lbdef = lbdef;
-                                     FStar_Syntax_Syntax.lbattrs = uu___11;
-                                     FStar_Syntax_Syntax.lbpos = uu___12;_}
-                                     ->
-                                     let uu___13 =
-                                       let uu___14 =
-                                         let uu___15 =
-                                           let uu___16 =
-                                             FStar_Syntax_Util.incr_delta_qualifier
-                                               lbdef in
-                                           FStar_Compiler_Effect.op_Bar_Greater
-                                             uu___16
-                                             (fun uu___17 ->
-                                                FStar_Pervasives_Native.Some
-                                                  uu___17) in
-                                         {
-                                           FStar_Syntax_Syntax.fv_name =
-                                             (fv.FStar_Syntax_Syntax.fv_name);
-                                           FStar_Syntax_Syntax.fv_delta =
-                                             uu___15;
-                                           FStar_Syntax_Syntax.fv_qual =
-                                             (fv.FStar_Syntax_Syntax.fv_qual)
-                                         } in
-                                       FStar_Pervasives.Inr uu___14 in
-                                     {
-                                       FStar_Syntax_Syntax.lbname = uu___13;
-                                       FStar_Syntax_Syntax.lbunivs =
-                                         (lb.FStar_Syntax_Syntax.lbunivs);
-                                       FStar_Syntax_Syntax.lbtyp =
-                                         (lb.FStar_Syntax_Syntax.lbtyp);
-                                       FStar_Syntax_Syntax.lbeff =
-                                         (lb.FStar_Syntax_Syntax.lbeff);
-                                       FStar_Syntax_Syntax.lbdef =
-                                         (lb.FStar_Syntax_Syntax.lbdef);
-                                       FStar_Syntax_Syntax.lbattrs =
-                                         (lb.FStar_Syntax_Syntax.lbattrs);
-                                       FStar_Syntax_Syntax.lbpos =
-                                         (lb.FStar_Syntax_Syntax.lbpos)
-                                     } in
                                let sigelts1 =
+                                 let set_lb_dd lb =
+                                   let uu___7 = lb in
+                                   match uu___7 with
+                                   | {
+                                       FStar_Syntax_Syntax.lbname =
+                                         FStar_Pervasives.Inr fv;
+                                       FStar_Syntax_Syntax.lbunivs = uu___8;
+                                       FStar_Syntax_Syntax.lbtyp = uu___9;
+                                       FStar_Syntax_Syntax.lbeff = uu___10;
+                                       FStar_Syntax_Syntax.lbdef = lbdef;
+                                       FStar_Syntax_Syntax.lbattrs = uu___11;
+                                       FStar_Syntax_Syntax.lbpos = uu___12;_}
+                                       ->
+                                       let uu___13 =
+                                         let uu___14 =
+                                           let uu___15 =
+                                             let uu___16 =
+                                               FStar_Syntax_Util.incr_delta_qualifier
+                                                 lbdef in
+                                             FStar_Compiler_Effect.op_Bar_Greater
+                                               uu___16
+                                               (fun uu___17 ->
+                                                  FStar_Pervasives_Native.Some
+                                                    uu___17) in
+                                           {
+                                             FStar_Syntax_Syntax.fv_name =
+                                               (fv.FStar_Syntax_Syntax.fv_name);
+                                             FStar_Syntax_Syntax.fv_delta =
+                                               uu___15;
+                                             FStar_Syntax_Syntax.fv_qual =
+                                               (fv.FStar_Syntax_Syntax.fv_qual)
+                                           } in
+                                         FStar_Pervasives.Inr uu___14 in
+                                       {
+                                         FStar_Syntax_Syntax.lbname = uu___13;
+                                         FStar_Syntax_Syntax.lbunivs =
+                                           (lb.FStar_Syntax_Syntax.lbunivs);
+                                         FStar_Syntax_Syntax.lbtyp =
+                                           (lb.FStar_Syntax_Syntax.lbtyp);
+                                         FStar_Syntax_Syntax.lbeff =
+                                           (lb.FStar_Syntax_Syntax.lbeff);
+                                         FStar_Syntax_Syntax.lbdef =
+                                           (lb.FStar_Syntax_Syntax.lbdef);
+                                         FStar_Syntax_Syntax.lbattrs =
+                                           (lb.FStar_Syntax_Syntax.lbattrs);
+                                         FStar_Syntax_Syntax.lbpos =
+                                           (lb.FStar_Syntax_Syntax.lbpos)
+                                       } in
                                  FStar_Compiler_List.map
                                    (fun se ->
                                       match se.FStar_Syntax_Syntax.sigel with

--- a/ocaml/fstar-lib/generated/FStar_ToSyntax_ToSyntax.ml
+++ b/ocaml/fstar-lib/generated/FStar_ToSyntax_ToSyntax.ml
@@ -2331,7 +2331,8 @@ and (desugar_machine_integer :
                            let private_fv =
                              let uu___3 =
                                FStar_Syntax_Util.incr_delta_depth
-                                 fv.FStar_Syntax_Syntax.fv_delta in
+                                 (FStar_Pervasives_Native.__proj__Some__item__v
+                                    fv.FStar_Syntax_Syntax.fv_delta) in
                              FStar_Syntax_Syntax.lid_as_fv private_lid uu___3
                                fv.FStar_Syntax_Syntax.fv_qual in
                            {

--- a/ocaml/fstar-lib/generated/FStar_ToSyntax_ToSyntax.ml
+++ b/ocaml/fstar-lib/generated/FStar_ToSyntax_ToSyntax.ml
@@ -8611,9 +8611,7 @@ and (desugar_decl_aux :
                      (sigelt.FStar_Syntax_Syntax.sigquals);
                    FStar_Syntax_Syntax.sigmeta =
                      (sigelt.FStar_Syntax_Syntax.sigmeta);
-                   FStar_Syntax_Syntax.sigattrs =
-                     (FStar_Compiler_List.op_At
-                        sigelt.FStar_Syntax_Syntax.sigattrs attrs1);
+                   FStar_Syntax_Syntax.sigattrs = attrs1;
                    FStar_Syntax_Syntax.sigopts =
                      (sigelt.FStar_Syntax_Syntax.sigopts)
                  }) sigelts in

--- a/ocaml/fstar-lib/generated/FStar_ToSyntax_ToSyntax.ml
+++ b/ocaml/fstar-lib/generated/FStar_ToSyntax_ToSyntax.ml
@@ -336,7 +336,7 @@ let (op_as_term :
               let uu___2 =
                 let uu___3 = FStar_Ident.range_of_id op in
                 FStar_Ident.set_lid_range l uu___3 in
-              FStar_Syntax_Syntax.lid_as_fv uu___2 dd
+              FStar_Syntax_Syntax.lid_and_dd_as_fv uu___2 dd
                 FStar_Pervasives_Native.None in
             FStar_Compiler_Effect.op_Bar_Greater uu___1
               FStar_Syntax_Syntax.fv_to_tm in
@@ -955,7 +955,7 @@ let (mk_ref_read :
       let uu___ =
         let uu___1 =
           let uu___2 =
-            FStar_Syntax_Syntax.lid_as_fv FStar_Parser_Const.sread_lid
+            FStar_Syntax_Syntax.lid_and_dd_as_fv FStar_Parser_Const.sread_lid
               FStar_Syntax_Syntax.delta_constant FStar_Pervasives_Native.None in
           FStar_Syntax_Syntax.fv_to_tm uu___2 in
         let uu___2 =
@@ -976,7 +976,8 @@ let (mk_ref_alloc :
       let uu___ =
         let uu___1 =
           let uu___2 =
-            FStar_Syntax_Syntax.lid_as_fv FStar_Parser_Const.salloc_lid
+            FStar_Syntax_Syntax.lid_and_dd_as_fv
+              FStar_Parser_Const.salloc_lid
               FStar_Syntax_Syntax.delta_constant FStar_Pervasives_Native.None in
           FStar_Syntax_Syntax.fv_to_tm uu___2 in
         let uu___2 =
@@ -1001,7 +1002,8 @@ let (mk_ref_assign :
           let uu___ =
             let uu___1 =
               let uu___2 =
-                FStar_Syntax_Syntax.lid_as_fv FStar_Parser_Const.swrite_lid
+                FStar_Syntax_Syntax.lid_and_dd_as_fv
+                  FStar_Parser_Const.swrite_lid
                   FStar_Syntax_Syntax.delta_constant
                   FStar_Pervasives_Native.None in
               FStar_Syntax_Syntax.fv_to_tm uu___2 in
@@ -1932,7 +1934,7 @@ let rec (desugar_data_pat :
                        let uu___3 =
                          let uu___4 =
                            let uu___5 =
-                             FStar_Syntax_Syntax.lid_as_fv
+                             FStar_Syntax_Syntax.lid_and_dd_as_fv
                                FStar_Parser_Const.nil_lid
                                FStar_Syntax_Syntax.delta_constant
                                (FStar_Pervasives_Native.Some
@@ -1950,7 +1952,7 @@ let rec (desugar_data_pat :
                             let uu___2 =
                               let uu___3 =
                                 let uu___4 =
-                                  FStar_Syntax_Syntax.lid_as_fv
+                                  FStar_Syntax_Syntax.lid_and_dd_as_fv
                                     FStar_Parser_Const.cons_lid
                                     FStar_Syntax_Syntax.delta_constant
                                     (FStar_Pervasives_Native.Some
@@ -2044,7 +2046,7 @@ let rec (desugar_data_pat :
                                let lid =
                                  FStar_Ident.lid_of_path ["__dummy__"]
                                    p1.FStar_Parser_AST.prange in
-                               FStar_Syntax_Syntax.lid_as_fv lid
+                               FStar_Syntax_Syntax.lid_and_dd_as_fv lid
                                  FStar_Syntax_Syntax.delta_constant
                                  (FStar_Pervasives_Native.Some
                                     (FStar_Syntax_Syntax.Unresolved_constructor
@@ -2333,8 +2335,8 @@ and (desugar_machine_integer :
                                FStar_Syntax_Util.incr_delta_depth
                                  (FStar_Pervasives_Native.__proj__Some__item__v
                                     fv.FStar_Syntax_Syntax.fv_delta) in
-                             FStar_Syntax_Syntax.lid_as_fv private_lid uu___3
-                               fv.FStar_Syntax_Syntax.fv_qual in
+                             FStar_Syntax_Syntax.lid_and_dd_as_fv private_lid
+                               uu___3 fv.FStar_Syntax_Syntax.fv_qual in
                            {
                              FStar_Syntax_Syntax.n =
                                (FStar_Syntax_Syntax.Tm_fvar private_fv);
@@ -3152,7 +3154,7 @@ and (desugar_term_maybe_top :
                                                   FStar_Parser_Const.mk_tuple_data_lid
                                                     (Prims.of_int (2))
                                                     top.FStar_Parser_AST.range in
-                                                FStar_Syntax_Syntax.lid_as_fv
+                                                FStar_Syntax_Syntax.lid_and_dd_as_fv
                                                   uu___8
                                                   FStar_Syntax_Syntax.delta_constant
                                                   (FStar_Pervasives_Native.Some
@@ -3216,7 +3218,7 @@ and (desugar_term_maybe_top :
                                                        (FStar_Compiler_List.length
                                                           args))
                                                     top.FStar_Parser_AST.range in
-                                                FStar_Syntax_Syntax.lid_as_fv
+                                                FStar_Syntax_Syntax.lid_and_dd_as_fv
                                                   uu___9
                                                   FStar_Syntax_Syntax.delta_constant
                                                   (FStar_Pervasives_Native.Some
@@ -3667,8 +3669,8 @@ and (desugar_term_maybe_top :
                                      let uu___7 =
                                        FStar_Syntax_Util.incr_delta_qualifier
                                          body1 in
-                                     FStar_Syntax_Syntax.lid_as_fv l uu___7
-                                       FStar_Pervasives_Native.None in
+                                     FStar_Syntax_Syntax.lid_and_dd_as_fv l
+                                       uu___7 FStar_Pervasives_Native.None in
                                    FStar_Pervasives.Inr uu___6 in
                              let body2 =
                                if is_rec
@@ -3799,8 +3801,8 @@ and (desugar_term_maybe_top :
                                        let uu___7 =
                                          FStar_Syntax_Util.incr_delta_qualifier
                                            t11 in
-                                       FStar_Syntax_Syntax.lid_as_fv l uu___7
-                                         FStar_Pervasives_Native.None in
+                                       FStar_Syntax_Syntax.lid_and_dd_as_fv l
+                                         uu___7 FStar_Pervasives_Native.None in
                                      let uu___7 =
                                        let uu___8 =
                                          let uu___9 =
@@ -3934,7 +3936,8 @@ and (desugar_term_maybe_top :
             let t_bool =
               let uu___1 =
                 let uu___2 =
-                  FStar_Syntax_Syntax.lid_as_fv FStar_Parser_Const.bool_lid
+                  FStar_Syntax_Syntax.lid_and_dd_as_fv
+                    FStar_Parser_Const.bool_lid
                     FStar_Syntax_Syntax.delta_constant
                     FStar_Pervasives_Native.None in
                 FStar_Syntax_Syntax.Tm_fvar uu___2 in
@@ -4266,7 +4269,7 @@ and (desugar_term_maybe_top :
                          let uu___3 =
                            FStar_Ident.set_lid_range projname
                              top.FStar_Parser_AST.range in
-                         FStar_Syntax_Syntax.lid_as_fv uu___3
+                         FStar_Syntax_Syntax.lid_and_dd_as_fv uu___3
                            (FStar_Syntax_Syntax.Delta_equational_at_level
                               Prims.int_one) qual in
                        let qual1 =
@@ -4553,7 +4556,7 @@ and (desugar_term_maybe_top :
                  let mk_forall_intro t p2 pf =
                    let head =
                      let uu___2 =
-                       FStar_Syntax_Syntax.lid_as_fv
+                       FStar_Syntax_Syntax.lid_and_dd_as_fv
                          FStar_Parser_Const.forall_intro_lid
                          FStar_Syntax_Syntax.delta_equational
                          FStar_Pervasives_Native.None in
@@ -4597,7 +4600,7 @@ and (desugar_term_maybe_top :
                  let mk_exists_intro t p2 v e2 =
                    let head =
                      let uu___2 =
-                       FStar_Syntax_Syntax.lid_as_fv
+                       FStar_Syntax_Syntax.lid_and_dd_as_fv
                          FStar_Parser_Const.exists_intro_lid
                          FStar_Syntax_Syntax.delta_equational
                          FStar_Pervasives_Native.None in
@@ -4652,7 +4655,7 @@ and (desugar_term_maybe_top :
                  let e1 = desugar_term env' e in
                  let head =
                    let uu___2 =
-                     FStar_Syntax_Syntax.lid_as_fv
+                     FStar_Syntax_Syntax.lid_and_dd_as_fv
                        FStar_Parser_Const.implies_intro_lid
                        FStar_Syntax_Syntax.delta_equational
                        FStar_Pervasives_Native.None in
@@ -4685,7 +4688,7 @@ and (desugar_term_maybe_top :
               else FStar_Parser_Const.or_intro_right_lid in
             let head =
               let uu___1 =
-                FStar_Syntax_Syntax.lid_as_fv lid
+                FStar_Syntax_Syntax.lid_and_dd_as_fv lid
                   FStar_Syntax_Syntax.delta_equational
                   FStar_Pervasives_Native.None in
               FStar_Syntax_Syntax.fv_to_tm uu___1 in
@@ -4712,7 +4715,7 @@ and (desugar_term_maybe_top :
             let e21 = desugar_term env e2 in
             let head =
               let uu___1 =
-                FStar_Syntax_Syntax.lid_as_fv
+                FStar_Syntax_Syntax.lid_and_dd_as_fv
                   FStar_Parser_Const.and_intro_lid
                   FStar_Syntax_Syntax.delta_equational
                   FStar_Pervasives_Native.None in
@@ -4747,7 +4750,7 @@ and (desugar_term_maybe_top :
                  let mk_forall_elim a p2 v t =
                    let head =
                      let uu___2 =
-                       FStar_Syntax_Syntax.lid_as_fv
+                       FStar_Syntax_Syntax.lid_and_dd_as_fv
                          FStar_Parser_Const.forall_elim_lid
                          FStar_Syntax_Syntax.delta_equational
                          FStar_Pervasives_Native.None in
@@ -4813,7 +4816,7 @@ and (desugar_term_maybe_top :
                             let x = b.FStar_Syntax_Syntax.binder_bv in
                             let head =
                               let uu___3 =
-                                FStar_Syntax_Syntax.lid_as_fv
+                                FStar_Syntax_Syntax.lid_and_dd_as_fv
                                   FStar_Parser_Const.exists_lid
                                   FStar_Syntax_Syntax.delta_equational
                                   FStar_Pervasives_Native.None in
@@ -4841,7 +4844,7 @@ and (desugar_term_maybe_top :
                       let mk_exists_elim t x_p s_ex_p f r =
                         let head =
                           let uu___3 =
-                            FStar_Syntax_Syntax.lid_as_fv
+                            FStar_Syntax_Syntax.lid_and_dd_as_fv
                               FStar_Parser_Const.exists_elim_lid
                               FStar_Syntax_Syntax.delta_equational
                               FStar_Pervasives_Native.None in
@@ -4921,7 +4924,7 @@ and (desugar_term_maybe_top :
             let e1 = desugar_term env e in
             let head =
               let uu___1 =
-                FStar_Syntax_Syntax.lid_as_fv
+                FStar_Syntax_Syntax.lid_and_dd_as_fv
                   FStar_Parser_Const.implies_elim_lid
                   FStar_Syntax_Syntax.delta_equational
                   FStar_Pervasives_Native.None in
@@ -4956,7 +4959,7 @@ and (desugar_term_maybe_top :
                       let e21 = desugar_term env_y e2 in
                       let head =
                         let uu___3 =
-                          FStar_Syntax_Syntax.lid_as_fv
+                          FStar_Syntax_Syntax.lid_and_dd_as_fv
                             FStar_Parser_Const.or_elim_lid
                             FStar_Syntax_Syntax.delta_equational
                             FStar_Pervasives_Native.None in
@@ -5008,7 +5011,7 @@ and (desugar_term_maybe_top :
                  let e1 = desugar_term env' e in
                  let head =
                    let uu___2 =
-                     FStar_Syntax_Syntax.lid_as_fv
+                     FStar_Syntax_Syntax.lid_and_dd_as_fv
                        FStar_Parser_Const.and_elim_lid
                        FStar_Syntax_Syntax.delta_equational
                        FStar_Pervasives_Native.None in
@@ -6212,8 +6215,9 @@ let (mk_indexed_projector_names :
                              let lb =
                                let uu___2 =
                                  let uu___3 =
-                                   FStar_Syntax_Syntax.lid_as_fv field_name
-                                     dd FStar_Pervasives_Native.None in
+                                   FStar_Syntax_Syntax.lid_and_dd_as_fv
+                                     field_name dd
+                                     FStar_Pervasives_Native.None in
                                  FStar_Pervasives.Inr uu___3 in
                                {
                                  FStar_Syntax_Syntax.lbname = uu___2;
@@ -6339,7 +6343,7 @@ let (mk_typ_abbrev :
                       let lb =
                         let uu___ =
                           let uu___1 =
-                            FStar_Syntax_Syntax.lid_as_fv lid dd
+                            FStar_Syntax_Syntax.lid_and_dd_as_fv lid dd
                               FStar_Pervasives_Native.None in
                           FStar_Pervasives.Inr uu___1 in
                         let uu___1 =

--- a/ocaml/fstar-lib/generated/FStar_ToSyntax_ToSyntax.ml
+++ b/ocaml/fstar-lib/generated/FStar_ToSyntax_ToSyntax.ml
@@ -2661,7 +2661,7 @@ and (desugar_term_maybe_top :
               let uu___2 =
                 FStar_Ident.set_lid_range FStar_Parser_Const.true_lid
                   top.FStar_Parser_AST.range in
-              FStar_Syntax_Syntax.fvar uu___2
+              FStar_Syntax_Syntax.fvar_with_dd uu___2
                 FStar_Syntax_Syntax.delta_constant
                 FStar_Pervasives_Native.None in
             (uu___1, noaqs)
@@ -2671,7 +2671,7 @@ and (desugar_term_maybe_top :
               let uu___2 =
                 FStar_Ident.set_lid_range FStar_Parser_Const.false_lid
                   top.FStar_Parser_AST.range in
-              FStar_Syntax_Syntax.fvar uu___2
+              FStar_Syntax_Syntax.fvar_with_dd uu___2
                 FStar_Syntax_Syntax.delta_constant
                 FStar_Pervasives_Native.None in
             (uu___1, noaqs)
@@ -2687,7 +2687,7 @@ and (desugar_term_maybe_top :
              | FStar_Pervasives_Native.Some ed ->
                  let lid = FStar_Syntax_Util.dm4f_lid ed txt in
                  let uu___2 =
-                   FStar_Syntax_Syntax.fvar lid
+                   FStar_Syntax_Syntax.fvar_with_dd lid
                      (FStar_Syntax_Syntax.Delta_constant_at_level
                         Prims.int_one) FStar_Pervasives_Native.None in
                  (uu___2, noaqs)
@@ -4168,7 +4168,7 @@ and (desugar_term_maybe_top :
                         let lid =
                           FStar_Ident.lid_of_path ["__dummy__"]
                             top.FStar_Parser_AST.range in
-                        FStar_Syntax_Syntax.fvar lid
+                        FStar_Syntax_Syntax.fvar_with_dd lid
                           FStar_Syntax_Syntax.delta_constant
                           (FStar_Pervasives_Native.Some
                              (FStar_Syntax_Syntax.Unresolved_constructor uc)) in
@@ -4244,7 +4244,7 @@ and (desugar_term_maybe_top :
                      FStar_Syntax_DsEnv.try_lookup_dc_by_field_name env f in
                    match uu___2 with
                    | FStar_Pervasives_Native.None ->
-                       FStar_Syntax_Syntax.fvar f
+                       FStar_Syntax_Syntax.fvar_with_dd f
                          (FStar_Syntax_Syntax.Delta_equational_at_level
                             Prims.int_one)
                          (FStar_Pervasives_Native.Some
@@ -4278,7 +4278,7 @@ and (desugar_term_maybe_top :
                        let f1 =
                          let uu___3 = qualify_field_names constrname [f] in
                          FStar_Compiler_List.hd uu___3 in
-                       FStar_Syntax_Syntax.fvar f1
+                       FStar_Syntax_Syntax.fvar_with_dd f1
                          (FStar_Syntax_Syntax.Delta_equational_at_level
                             Prims.int_one)
                          (FStar_Pervasives_Native.Some qual1) in
@@ -5660,7 +5660,7 @@ and (desugar_comp :
                                                       FStar_Ident.set_lid_range
                                                         FStar_Parser_Const.pattern_lid
                                                         pat.FStar_Syntax_Syntax.pos in
-                                                    FStar_Syntax_Syntax.fvar
+                                                    FStar_Syntax_Syntax.fvar_with_dd
                                                       uu___10
                                                       FStar_Syntax_Syntax.delta_constant
                                                       FStar_Pervasives_Native.None in
@@ -5804,7 +5804,7 @@ and (desugar_formula :
                        let uu___5 =
                          FStar_Ident.set_lid_range q
                            b.FStar_Parser_AST.brange in
-                       FStar_Syntax_Syntax.fvar uu___5
+                       FStar_Syntax_Syntax.fvar_with_dd uu___5
                          (FStar_Syntax_Syntax.Delta_constant_at_level
                             Prims.int_one) FStar_Pervasives_Native.None in
                      let uu___5 =
@@ -8916,7 +8916,7 @@ and (desugar_decl_noattrs :
                        | FStar_Syntax_Syntax.Sig_inductive_typ uu___2 ->
                            let uu___3 =
                              let uu___4 =
-                               FStar_Syntax_Syntax.fvar
+                               FStar_Syntax_Syntax.fvar_with_dd
                                  FStar_Parser_Const.tcclass_lid
                                  FStar_Syntax_Syntax.delta_constant
                                  FStar_Pervasives_Native.None in

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_Cfg.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_Cfg.ml
@@ -2178,8 +2178,7 @@ let (built_in_primitive_steps : primitive_step FStar_Compiler_Util.psmap) =
     let name l =
       let uu___ =
         let uu___1 =
-          FStar_Syntax_Syntax.lid_as_fv l FStar_Syntax_Syntax.delta_constant
-            FStar_Pervasives_Native.None in
+          FStar_Syntax_Syntax.lid_as_fv' l FStar_Pervasives_Native.None in
         FStar_Syntax_Syntax.Tm_fvar uu___1 in
       FStar_Syntax_Syntax.mk uu___ rng in
     let char_t = name FStar_Parser_Const.char_lid in
@@ -2581,9 +2580,7 @@ let (built_in_primitive_steps : primitive_step FStar_Compiler_Util.psmap) =
                                   FStar_Compiler_Effect.op_Bar_Greater
                                     uu___24
                                     (fun l ->
-                                       FStar_Syntax_Syntax.lid_as_fv l
-                                         (FStar_Syntax_Syntax.Delta_constant_at_level
-                                            Prims.int_zero)
+                                       FStar_Syntax_Syntax.lid_as_fv' l
                                          FStar_Pervasives_Native.None) in
                                 let uu___24 =
                                   FStar_TypeChecker_NBETerm.unary_op
@@ -3734,9 +3731,8 @@ let (built_in_primitive_steps : primitive_step FStar_Compiler_Util.psmap) =
                              let uu___6 =
                                let uu___7 =
                                  let uu___8 =
-                                   FStar_Syntax_Syntax.lid_as_fv
+                                   FStar_Syntax_Syntax.lid_as_fv'
                                      FStar_Parser_Const.immutable_array_of_list_lid
-                                     FStar_Syntax_Syntax.delta_constant
                                      FStar_Pervasives_Native.None in
                                  let uu___9 =
                                    let uu___10 =

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_Cfg.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_Cfg.ml
@@ -2178,7 +2178,7 @@ let (built_in_primitive_steps : primitive_step FStar_Compiler_Util.psmap) =
     let name l =
       let uu___ =
         let uu___1 =
-          FStar_Syntax_Syntax.lid_as_fv' l FStar_Pervasives_Native.None in
+          FStar_Syntax_Syntax.lid_as_fv l FStar_Pervasives_Native.None in
         FStar_Syntax_Syntax.Tm_fvar uu___1 in
       FStar_Syntax_Syntax.mk uu___ rng in
     let char_t = name FStar_Parser_Const.char_lid in
@@ -2580,7 +2580,7 @@ let (built_in_primitive_steps : primitive_step FStar_Compiler_Util.psmap) =
                                   FStar_Compiler_Effect.op_Bar_Greater
                                     uu___24
                                     (fun l ->
-                                       FStar_Syntax_Syntax.lid_as_fv' l
+                                       FStar_Syntax_Syntax.lid_as_fv l
                                          FStar_Pervasives_Native.None) in
                                 let uu___24 =
                                   FStar_TypeChecker_NBETerm.unary_op
@@ -3731,7 +3731,7 @@ let (built_in_primitive_steps : primitive_step FStar_Compiler_Util.psmap) =
                              let uu___6 =
                                let uu___7 =
                                  let uu___8 =
-                                   FStar_Syntax_Syntax.lid_as_fv'
+                                   FStar_Syntax_Syntax.lid_as_fv
                                      FStar_Parser_Const.immutable_array_of_list_lid
                                      FStar_Pervasives_Native.None in
                                  let uu___9 =

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_Core.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_Core.ml
@@ -3534,7 +3534,6 @@ and (check_comp :
                  let uu___1 =
                    FStar_Syntax_Syntax.fvar
                      ct.FStar_Syntax_Syntax.effect_name
-                     FStar_Syntax_Syntax.delta_constant
                      FStar_Pervasives_Native.None in
                  FStar_Syntax_Syntax.mk_Tm_uinst uu___1 [u] in
                let uu___1 =

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_DMFF.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_DMFF.ml
@@ -1141,7 +1141,7 @@ let (gen_wps_for_free :
                                 FStar_Syntax_Util.mk_app k_tm uu___5 in
                               let guard_free =
                                 let uu___5 =
-                                  FStar_Syntax_Syntax.lid_as_fv
+                                  FStar_Syntax_Syntax.lid_and_dd_as_fv
                                     FStar_Parser_Const.guard_free
                                     FStar_Syntax_Syntax.delta_constant
                                     FStar_Pervasives_Native.None in
@@ -4394,7 +4394,7 @@ let (cps_and_elaborate :
                                                      uu___17
                                                  else ());
                                                 (let uu___16 =
-                                                   FStar_Syntax_Syntax.lid_as_fv
+                                                   FStar_Syntax_Syntax.lid_and_dd_as_fv
                                                      l'
                                                      FStar_Syntax_Syntax.delta_equational
                                                      FStar_Pervasives_Native.None in

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_DMFF.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_DMFF.ml
@@ -15,6 +15,59 @@ let (__proj__Mkenv__item__tc_const :
   env -> FStar_Const.sconst -> FStar_Syntax_Syntax.typ) =
   fun projectee ->
     match projectee with | { tcenv; subst; tc_const;_} -> tc_const
+let (d : Prims.string -> unit) =
+  fun s -> FStar_Compiler_Util.print1 "\027[01;36m%s\027[00m\n" s
+let (mk_toplevel_definition :
+  FStar_TypeChecker_Env.env_t ->
+    FStar_Ident.lident ->
+      FStar_Syntax_Syntax.term ->
+        (FStar_Syntax_Syntax.sigelt * FStar_Syntax_Syntax.term))
+  =
+  fun env1 ->
+    fun lident ->
+      fun def ->
+        (let uu___1 =
+           FStar_TypeChecker_Env.debug env1 (FStar_Options.Other "ED") in
+         if uu___1
+         then
+           ((let uu___3 = FStar_Ident.string_of_lid lident in d uu___3);
+            (let uu___3 = FStar_Ident.string_of_lid lident in
+             let uu___4 = FStar_Syntax_Print.term_to_string def in
+             FStar_Compiler_Util.print2
+               "Registering top-level definition: %s\n%s\n" uu___3 uu___4))
+         else ());
+        (let fv =
+           let uu___1 = FStar_Syntax_Util.incr_delta_qualifier def in
+           FStar_Syntax_Syntax.lid_and_dd_as_fv lident uu___1
+             FStar_Pervasives_Native.None in
+         let lbname = FStar_Pervasives.Inr fv in
+         let lb =
+           (false,
+             [FStar_Syntax_Util.mk_letbinding lbname []
+                FStar_Syntax_Syntax.tun FStar_Parser_Const.effect_Tot_lid def
+                [] FStar_Compiler_Range_Type.dummyRange]) in
+         let sig_ctx =
+           FStar_Syntax_Syntax.mk_sigelt
+             (FStar_Syntax_Syntax.Sig_let
+                {
+                  FStar_Syntax_Syntax.lbs1 = lb;
+                  FStar_Syntax_Syntax.lids1 = [lident]
+                }) in
+         let uu___1 =
+           FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_fvar fv)
+             FStar_Compiler_Range_Type.dummyRange in
+         ({
+            FStar_Syntax_Syntax.sigel = (sig_ctx.FStar_Syntax_Syntax.sigel);
+            FStar_Syntax_Syntax.sigrng = (sig_ctx.FStar_Syntax_Syntax.sigrng);
+            FStar_Syntax_Syntax.sigquals =
+              [FStar_Syntax_Syntax.Unfold_for_unification_and_vcgen];
+            FStar_Syntax_Syntax.sigmeta =
+              (sig_ctx.FStar_Syntax_Syntax.sigmeta);
+            FStar_Syntax_Syntax.sigattrs =
+              (sig_ctx.FStar_Syntax_Syntax.sigattrs);
+            FStar_Syntax_Syntax.sigopts =
+              (sig_ctx.FStar_Syntax_Syntax.sigopts)
+          }, uu___1))
 let (empty :
   FStar_TypeChecker_Env.env ->
     (FStar_Const.sconst -> FStar_Syntax_Syntax.typ) -> env)
@@ -46,12 +99,12 @@ let (gen_wps_for_free :
                 FStar_Syntax_Syntax.index = (a.FStar_Syntax_Syntax.index);
                 FStar_Syntax_Syntax.sort = uu___
               } in
-            let d s = FStar_Compiler_Util.print1 "\027[01;36m%s\027[00m\n" s in
+            let d1 s = FStar_Compiler_Util.print1 "\027[01;36m%s\027[00m\n" s in
             (let uu___1 =
                FStar_TypeChecker_Env.debug env1 (FStar_Options.Other "ED") in
              if uu___1
              then
-               (d "Elaborating extra WP combinators";
+               (d1 "Elaborating extra WP combinators";
                 (let uu___3 = FStar_Syntax_Print.term_to_string wp_a1 in
                  FStar_Compiler_Util.print1 "wp_a is: %s\n" uu___3))
              else ());
@@ -103,16 +156,14 @@ let (gen_wps_for_free :
                   let uu___4 =
                     FStar_Syntax_Print.binders_to_string ", " gamma in
                   FStar_Compiler_Util.format1 "Gamma is %s\n" uu___4 in
-                d uu___3
+                d1 uu___3
               else ());
              (let unknown = FStar_Syntax_Syntax.tun in
               let mk x =
                 FStar_Syntax_Syntax.mk x FStar_Compiler_Range_Type.dummyRange in
               let sigelts = FStar_Compiler_Util.mk_ref [] in
               let register env2 lident def =
-                let uu___2 =
-                  FStar_TypeChecker_Util.mk_toplevel_definition env2 lident
-                    def in
+                let uu___2 = mk_toplevel_definition env2 lident def in
                 match uu___2 with
                 | (sigelt, fv) ->
                     let sigelt1 =
@@ -1280,7 +1331,7 @@ let (gen_wps_for_free :
                   ((let uu___4 =
                       FStar_TypeChecker_Env.debug env2
                         (FStar_Options.Other "ED") in
-                    if uu___4 then d "End Dijkstra monads for free" else ());
+                    if uu___4 then d1 "End Dijkstra monads for free" else ());
                    (let c = FStar_Syntax_Subst.close binders in
                     let ed_combs =
                       match ed.FStar_Syntax_Syntax.combinators with
@@ -4408,8 +4459,8 @@ let (cps_and_elaborate :
                                                    FStar_Syntax_Util.abs
                                                      effect_binders1 item
                                                      FStar_Pervasives_Native.None in
-                                                 FStar_TypeChecker_Util.mk_toplevel_definition
-                                                   env2 uu___16 uu___17 in
+                                                 mk_toplevel_definition env2
+                                                   uu___16 uu___17 in
                                                (match uu___15 with
                                                 | (sigelt, fv) ->
                                                     let sigelt1 =

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_DMFF.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_DMFF.ml
@@ -605,7 +605,8 @@ let (gen_wps_for_free :
                       FStar_Compiler_List.op_At binders uu___4 in
                     let uu___4 =
                       let l_ite =
-                        FStar_Syntax_Syntax.fvar FStar_Parser_Const.ite_lid
+                        FStar_Syntax_Syntax.fvar_with_dd
+                          FStar_Parser_Const.ite_lid
                           (FStar_Syntax_Syntax.Delta_constant_at_level
                              (Prims.of_int (2))) FStar_Pervasives_Native.None in
                       let uu___5 =
@@ -982,7 +983,7 @@ let (gen_wps_for_free :
                                     FStar_Compiler_Range_Type.dummyRange in
                                 FStar_TypeChecker_Env.lookup_projector env2
                                   uu___5 i in
-                              FStar_Syntax_Syntax.fvar uu___4
+                              FStar_Syntax_Syntax.fvar_with_dd uu___4
                                 (FStar_Syntax_Syntax.Delta_constant_at_level
                                    Prims.int_one)
                                 FStar_Pervasives_Native.None in

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_DeferredImplicits.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_DeferredImplicits.ml
@@ -348,7 +348,7 @@ let solve_goals_with_tac :
                      ->
                      let qn = FStar_TypeChecker_Env.lookup_qname env lid in
                      let fv =
-                       FStar_Syntax_Syntax.lid_as_fv' lid
+                       FStar_Syntax_Syntax.lid_as_fv lid
                          FStar_Pervasives_Native.None in
                      let dd =
                        let uu___3 =
@@ -359,7 +359,7 @@ let solve_goals_with_tac :
                            failwith "Expected a dd" in
                      let term =
                        let uu___3 =
-                         FStar_Syntax_Syntax.lid_as_fv' lid
+                         FStar_Syntax_Syntax.lid_as_fv lid
                            FStar_Pervasives_Native.None in
                        FStar_Syntax_Syntax.fv_to_tm uu___3 in
                      term

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_DeferredImplicits.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_DeferredImplicits.ml
@@ -348,9 +348,8 @@ let solve_goals_with_tac :
                      ->
                      let qn = FStar_TypeChecker_Env.lookup_qname env lid in
                      let fv =
-                       FStar_Syntax_Syntax.lid_as_fv lid
-                         (FStar_Syntax_Syntax.Delta_constant_at_level
-                            Prims.int_zero) FStar_Pervasives_Native.None in
+                       FStar_Syntax_Syntax.lid_as_fv' lid
+                         FStar_Pervasives_Native.None in
                      let dd =
                        let uu___3 =
                          FStar_TypeChecker_Env.delta_depth_of_qninfo fv qn in
@@ -360,7 +359,7 @@ let solve_goals_with_tac :
                            failwith "Expected a dd" in
                      let term =
                        let uu___3 =
-                         FStar_Syntax_Syntax.lid_as_fv lid dd
+                         FStar_Syntax_Syntax.lid_as_fv' lid
                            FStar_Pervasives_Native.None in
                        FStar_Syntax_Syntax.fv_to_tm uu___3 in
                      term

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_Env.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_Env.ml
@@ -3480,9 +3480,7 @@ let (delta_depth_of_qninfo_lid :
                       FStar_Compiler_Util.right lb.FStar_Syntax_Syntax.lbname in
                     let uu___4 = FStar_Syntax_Syntax.fv_eq_lid fv lid in
                     if uu___4
-                    then
-                      FStar_Pervasives_Native.Some
-                        (fv.FStar_Syntax_Syntax.fv_delta)
+                    then fv.FStar_Syntax_Syntax.fv_delta
                     else FStar_Pervasives_Native.None)
            | FStar_Syntax_Syntax.Sig_fail uu___2 ->
                failwith "impossible: delta_depth_of_qninfo"
@@ -3565,18 +3563,26 @@ let (delta_depth_of_qninfo :
   fun fv ->
     fun qn ->
       let lid = (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-      let uu___ = is_prims_dd_lid lid in
+      let uu___ =
+        (is_prims_dd_lid lid) &&
+          (FStar_Pervasives_Native.uu___is_Some
+             fv.FStar_Syntax_Syntax.fv_delta) in
       if uu___
-      then FStar_Pervasives_Native.Some (fv.FStar_Syntax_Syntax.fv_delta)
+      then fv.FStar_Syntax_Syntax.fv_delta
       else delta_depth_of_qninfo_lid lid qn
 let (delta_depth_of_fv :
   env -> FStar_Syntax_Syntax.fv -> FStar_Syntax_Syntax.delta_depth) =
   fun env1 ->
     fun fv ->
       let lid = (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-      let uu___ = is_prims_dd_lid lid in
+      let uu___ =
+        (is_prims_dd_lid lid) &&
+          (FStar_Pervasives_Native.uu___is_Some
+             fv.FStar_Syntax_Syntax.fv_delta) in
       if uu___
-      then fv.FStar_Syntax_Syntax.fv_delta
+      then
+        FStar_Pervasives_Native.__proj__Some__item__v
+          fv.FStar_Syntax_Syntax.fv_delta
       else
         (let uu___2 =
            let uu___3 = FStar_Ident.string_of_lid lid in
@@ -3606,14 +3612,20 @@ let (delta_depth_of_fv :
                      failwith uu___6
                  | FStar_Pervasives_Native.Some d ->
                      ((let uu___7 =
-                         (d <> fv.FStar_Syntax_Syntax.fv_delta) &&
-                           (FStar_Options.debug_any ()) in
+                         ((FStar_Pervasives_Native.uu___is_Some
+                             fv.FStar_Syntax_Syntax.fv_delta)
+                            &&
+                            (d <>
+                               (FStar_Pervasives_Native.__proj__Some__item__v
+                                  fv.FStar_Syntax_Syntax.fv_delta)))
+                           && (FStar_Options.debug_any ()) in
                        if uu___7
                        then
                          let uu___8 = FStar_Syntax_Print.fv_to_string fv in
                          let uu___9 =
                            FStar_Syntax_Print.delta_depth_to_string
-                             fv.FStar_Syntax_Syntax.fv_delta in
+                             (FStar_Pervasives_Native.__proj__Some__item__v
+                                fv.FStar_Syntax_Syntax.fv_delta) in
                          let uu___10 =
                            FStar_Syntax_Print.delta_depth_to_string d in
                          FStar_Compiler_Util.print3
@@ -3920,8 +3932,7 @@ let (is_erasable_effect : env -> FStar_Ident.lident -> Prims.bool) =
         (fun l1 ->
            (FStar_Ident.lid_equals l1 FStar_Parser_Const.effect_GHOST_lid) ||
              (let uu___1 =
-                FStar_Syntax_Syntax.lid_as_fv l1
-                  (FStar_Syntax_Syntax.Delta_constant_at_level Prims.int_zero)
+                FStar_Syntax_Syntax.lid_as_fv' l1
                   FStar_Pervasives_Native.None in
               FStar_Compiler_Effect.op_Bar_Greater uu___1
                 (fv_has_erasable_attr env1)))
@@ -4149,13 +4160,15 @@ let (is_interpreted : env -> FStar_Syntax_Syntax.term -> Prims.bool) =
         uu___1.FStar_Syntax_Syntax.n in
       match uu___ with
       | FStar_Syntax_Syntax.Tm_fvar fv ->
-          (match fv.FStar_Syntax_Syntax.fv_delta with
-           | FStar_Syntax_Syntax.Delta_equational_at_level uu___1 -> true
-           | uu___1 -> false) ||
-            (FStar_Compiler_Util.for_some
-               (FStar_Ident.lid_equals
-                  (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v)
-               interpreted_symbols)
+          (FStar_Compiler_Util.for_some
+             (FStar_Ident.lid_equals
+                (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v)
+             interpreted_symbols)
+            ||
+            (let uu___1 = delta_depth_of_fv env1 fv in
+             (match uu___1 with
+              | FStar_Syntax_Syntax.Delta_equational_at_level uu___2 -> true
+              | uu___2 -> false))
       | uu___1 -> false
 let (is_irreducible : env -> FStar_Ident.lident -> Prims.bool) =
   fun env1 ->

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_Env.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_Env.ml
@@ -3502,6 +3502,62 @@ let (delta_depth_of_qninfo_lid :
                FStar_Pervasives_Native.None
            | FStar_Syntax_Syntax.Sig_polymonadic_subcomp uu___2 ->
                FStar_Pervasives_Native.None)
+let (prims_dd_lids : FStar_Ident.lident Prims.list) =
+  [FStar_Parser_Const.and_lid;
+  FStar_Parser_Const.or_lid;
+  FStar_Parser_Const.imp_lid;
+  FStar_Parser_Const.iff_lid;
+  FStar_Parser_Const.true_lid;
+  FStar_Parser_Const.false_lid;
+  FStar_Parser_Const.not_lid;
+  FStar_Parser_Const.b2t_lid;
+  FStar_Parser_Const.eq2_lid;
+  FStar_Parser_Const.eq3_lid;
+  FStar_Parser_Const.op_Eq;
+  FStar_Parser_Const.op_LT;
+  FStar_Parser_Const.op_LTE;
+  FStar_Parser_Const.op_GT;
+  FStar_Parser_Const.op_GTE;
+  FStar_Parser_Const.forall_lid;
+  FStar_Parser_Const.exists_lid;
+  FStar_Parser_Const.haseq_lid;
+  FStar_Parser_Const.op_And;
+  FStar_Parser_Const.op_Or;
+  FStar_Parser_Const.op_Negation]
+let (is_prims_dd_lid : FStar_Ident.lident -> Prims.bool) =
+  fun l ->
+    FStar_Compiler_List.existsb (fun l0 -> FStar_Ident.lid_equals l l0)
+      prims_dd_lids
+let (prims_delta_depths :
+  FStar_Syntax_Syntax.delta_depth FStar_Compiler_Util.smap) =
+  let m = FStar_Compiler_Util.smap_create (Prims.of_int (20)) in
+  let d0 = FStar_Syntax_Syntax.Delta_constant_at_level Prims.int_zero in
+  let d1 = FStar_Syntax_Syntax.Delta_constant_at_level Prims.int_one in
+  let d2 = FStar_Syntax_Syntax.Delta_constant_at_level (Prims.of_int (2)) in
+  let deq0 = FStar_Syntax_Syntax.Delta_equational_at_level Prims.int_zero in
+  let l =
+    [("l_and", d0);
+    ("l_Forall", d1);
+    ("l_imp", d1);
+    ("l_iff", d2);
+    ("l_not", d2);
+    ("b2t", d1);
+    ("l_True", d0);
+    ("l_Exists", d1);
+    ("l_or", d1);
+    ("eq2", d0);
+    ("op_Equality", deq0);
+    ("op_Addition", deq0);
+    ("op_LessThanOrEqual", deq0);
+    ("pow2", deq0);
+    ("precedes", d0);
+    ("op_LessThan", deq0);
+    ("op_disEquality", deq0);
+    ("op_Division", deq0)] in
+  FStar_Compiler_List.iter
+    (fun uu___1 ->
+       match uu___1 with | (s, d) -> FStar_Compiler_Util.smap_add m s d) l;
+  m
 let (delta_depth_of_qninfo :
   FStar_Syntax_Syntax.fv ->
     qninfo -> FStar_Syntax_Syntax.delta_depth FStar_Pervasives_Native.option)
@@ -3509,7 +3565,7 @@ let (delta_depth_of_qninfo :
   fun fv ->
     fun qn ->
       let lid = (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-      let uu___ = let uu___1 = FStar_Ident.nsstr lid in uu___1 = "Prims" in
+      let uu___ = is_prims_dd_lid lid in
       if uu___
       then FStar_Pervasives_Native.Some (fv.FStar_Syntax_Syntax.fv_delta)
       else delta_depth_of_qninfo_lid lid qn
@@ -3518,7 +3574,7 @@ let (delta_depth_of_fv :
   fun env1 ->
     fun fv ->
       let lid = (fv.FStar_Syntax_Syntax.fv_name).FStar_Syntax_Syntax.v in
-      let uu___ = let uu___1 = FStar_Ident.nsstr lid in uu___1 = "Prims" in
+      let uu___ = is_prims_dd_lid lid in
       if uu___
       then fv.FStar_Syntax_Syntax.fv_delta
       else

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_Env.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_Env.ml
@@ -3526,36 +3526,6 @@ let (is_prims_dd_lid : FStar_Ident.lident -> Prims.bool) =
   fun l ->
     FStar_Compiler_List.existsb (fun l0 -> FStar_Ident.lid_equals l l0)
       prims_dd_lids
-let (prims_delta_depths :
-  FStar_Syntax_Syntax.delta_depth FStar_Compiler_Util.smap) =
-  let m = FStar_Compiler_Util.smap_create (Prims.of_int (20)) in
-  let d0 = FStar_Syntax_Syntax.Delta_constant_at_level Prims.int_zero in
-  let d1 = FStar_Syntax_Syntax.Delta_constant_at_level Prims.int_one in
-  let d2 = FStar_Syntax_Syntax.Delta_constant_at_level (Prims.of_int (2)) in
-  let deq0 = FStar_Syntax_Syntax.Delta_equational_at_level Prims.int_zero in
-  let l =
-    [("l_and", d0);
-    ("l_Forall", d1);
-    ("l_imp", d1);
-    ("l_iff", d2);
-    ("l_not", d2);
-    ("b2t", d1);
-    ("l_True", d0);
-    ("l_Exists", d1);
-    ("l_or", d1);
-    ("eq2", d0);
-    ("op_Equality", deq0);
-    ("op_Addition", deq0);
-    ("op_LessThanOrEqual", deq0);
-    ("pow2", deq0);
-    ("precedes", d0);
-    ("op_LessThan", deq0);
-    ("op_disEquality", deq0);
-    ("op_Division", deq0)] in
-  FStar_Compiler_List.iter
-    (fun uu___1 ->
-       match uu___1 with | (s, d) -> FStar_Compiler_Util.smap_add m s d) l;
-  m
 let (delta_depth_of_qninfo :
   FStar_Syntax_Syntax.fv ->
     qninfo -> FStar_Syntax_Syntax.delta_depth FStar_Pervasives_Native.option)
@@ -3581,8 +3551,8 @@ let (delta_depth_of_fv :
              fv.FStar_Syntax_Syntax.fv_delta) in
       if uu___
       then
-        FStar_Pervasives_Native.__proj__Some__item__v
-          fv.FStar_Syntax_Syntax.fv_delta
+        FStar_Compiler_Effect.op_Bar_Greater fv.FStar_Syntax_Syntax.fv_delta
+          FStar_Compiler_Util.must
       else
         (let uu___2 =
            let uu___3 = FStar_Ident.string_of_lid lid in
@@ -3932,8 +3902,7 @@ let (is_erasable_effect : env -> FStar_Ident.lident -> Prims.bool) =
         (fun l1 ->
            (FStar_Ident.lid_equals l1 FStar_Parser_Const.effect_GHOST_lid) ||
              (let uu___1 =
-                FStar_Syntax_Syntax.lid_as_fv' l1
-                  FStar_Pervasives_Native.None in
+                FStar_Syntax_Syntax.lid_as_fv l1 FStar_Pervasives_Native.None in
               FStar_Compiler_Effect.op_Bar_Greater uu___1
                 (fv_has_erasable_attr env1)))
 let rec (non_informative : env -> FStar_Syntax_Syntax.typ -> Prims.bool) =

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_Env.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_Env.ml
@@ -6949,7 +6949,7 @@ let (fvar_of_nonqual_lid :
         | FStar_Pervasives_Native.None ->
             failwith "Unexpected no delta_depth"
         | FStar_Pervasives_Native.Some dd1 -> dd1 in
-      FStar_Syntax_Syntax.fvar lid dd FStar_Pervasives_Native.None
+      FStar_Syntax_Syntax.fvar lid FStar_Pervasives_Native.None
 let (split_smt_query :
   env ->
     FStar_Syntax_Syntax.term ->

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_NBETerm.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_NBETerm.ml
@@ -776,7 +776,7 @@ let (lid_as_constr :
     fun us ->
       fun args1 ->
         let uu___ =
-          FStar_Syntax_Syntax.lid_as_fv l FStar_Syntax_Syntax.delta_constant
+          FStar_Syntax_Syntax.lid_as_fv' l
             (FStar_Pervasives_Native.Some FStar_Syntax_Syntax.Data_ctor) in
         mkConstruct uu___ us args1
 let (lid_as_typ :
@@ -786,8 +786,7 @@ let (lid_as_typ :
     fun us ->
       fun args1 ->
         let uu___ =
-          FStar_Syntax_Syntax.lid_as_fv l FStar_Syntax_Syntax.delta_constant
-            FStar_Pervasives_Native.None in
+          FStar_Syntax_Syntax.lid_as_fv' l FStar_Pervasives_Native.None in
         mkFV uu___ us args1
 let (as_iarg : t -> arg) =
   fun a ->
@@ -1344,53 +1343,53 @@ let (e_norm_step : FStar_Syntax_Embeddings.norm_step embedding) =
     match n with
     | FStar_Syntax_Embeddings.Simpl ->
         let uu___ =
-          FStar_Syntax_Syntax.lid_as_fv FStar_Parser_Const.steps_simpl
-            FStar_Syntax_Syntax.delta_constant FStar_Pervasives_Native.None in
+          FStar_Syntax_Syntax.lid_as_fv' FStar_Parser_Const.steps_simpl
+            FStar_Pervasives_Native.None in
         mkFV uu___ [] []
     | FStar_Syntax_Embeddings.Weak ->
         let uu___ =
-          FStar_Syntax_Syntax.lid_as_fv FStar_Parser_Const.steps_weak
-            FStar_Syntax_Syntax.delta_constant FStar_Pervasives_Native.None in
+          FStar_Syntax_Syntax.lid_as_fv' FStar_Parser_Const.steps_weak
+            FStar_Pervasives_Native.None in
         mkFV uu___ [] []
     | FStar_Syntax_Embeddings.HNF ->
         let uu___ =
-          FStar_Syntax_Syntax.lid_as_fv FStar_Parser_Const.steps_hnf
-            FStar_Syntax_Syntax.delta_constant FStar_Pervasives_Native.None in
+          FStar_Syntax_Syntax.lid_as_fv' FStar_Parser_Const.steps_hnf
+            FStar_Pervasives_Native.None in
         mkFV uu___ [] []
     | FStar_Syntax_Embeddings.Primops ->
         let uu___ =
-          FStar_Syntax_Syntax.lid_as_fv FStar_Parser_Const.steps_primops
-            FStar_Syntax_Syntax.delta_constant FStar_Pervasives_Native.None in
+          FStar_Syntax_Syntax.lid_as_fv' FStar_Parser_Const.steps_primops
+            FStar_Pervasives_Native.None in
         mkFV uu___ [] []
     | FStar_Syntax_Embeddings.Delta ->
         let uu___ =
-          FStar_Syntax_Syntax.lid_as_fv FStar_Parser_Const.steps_delta
-            FStar_Syntax_Syntax.delta_constant FStar_Pervasives_Native.None in
+          FStar_Syntax_Syntax.lid_as_fv' FStar_Parser_Const.steps_delta
+            FStar_Pervasives_Native.None in
         mkFV uu___ [] []
     | FStar_Syntax_Embeddings.Zeta ->
         let uu___ =
-          FStar_Syntax_Syntax.lid_as_fv FStar_Parser_Const.steps_zeta
-            FStar_Syntax_Syntax.delta_constant FStar_Pervasives_Native.None in
+          FStar_Syntax_Syntax.lid_as_fv' FStar_Parser_Const.steps_zeta
+            FStar_Pervasives_Native.None in
         mkFV uu___ [] []
     | FStar_Syntax_Embeddings.Iota ->
         let uu___ =
-          FStar_Syntax_Syntax.lid_as_fv FStar_Parser_Const.steps_iota
-            FStar_Syntax_Syntax.delta_constant FStar_Pervasives_Native.None in
+          FStar_Syntax_Syntax.lid_as_fv' FStar_Parser_Const.steps_iota
+            FStar_Pervasives_Native.None in
         mkFV uu___ [] []
     | FStar_Syntax_Embeddings.Reify ->
         let uu___ =
-          FStar_Syntax_Syntax.lid_as_fv FStar_Parser_Const.steps_reify
-            FStar_Syntax_Syntax.delta_constant FStar_Pervasives_Native.None in
+          FStar_Syntax_Syntax.lid_as_fv' FStar_Parser_Const.steps_reify
+            FStar_Pervasives_Native.None in
         mkFV uu___ [] []
     | FStar_Syntax_Embeddings.NBE ->
         let uu___ =
-          FStar_Syntax_Syntax.lid_as_fv FStar_Parser_Const.steps_nbe
-            FStar_Syntax_Syntax.delta_constant FStar_Pervasives_Native.None in
+          FStar_Syntax_Syntax.lid_as_fv' FStar_Parser_Const.steps_nbe
+            FStar_Pervasives_Native.None in
         mkFV uu___ [] []
     | FStar_Syntax_Embeddings.UnfoldOnly l ->
         let uu___ =
-          FStar_Syntax_Syntax.lid_as_fv FStar_Parser_Const.steps_unfoldonly
-            FStar_Syntax_Syntax.delta_constant FStar_Pervasives_Native.None in
+          FStar_Syntax_Syntax.lid_as_fv' FStar_Parser_Const.steps_unfoldonly
+            FStar_Pervasives_Native.None in
         let uu___1 =
           let uu___2 =
             let uu___3 = let uu___4 = e_list e_string in embed uu___4 cb l in
@@ -1399,8 +1398,8 @@ let (e_norm_step : FStar_Syntax_Embeddings.norm_step embedding) =
         mkFV uu___ [] uu___1
     | FStar_Syntax_Embeddings.UnfoldFully l ->
         let uu___ =
-          FStar_Syntax_Syntax.lid_as_fv FStar_Parser_Const.steps_unfoldfully
-            FStar_Syntax_Syntax.delta_constant FStar_Pervasives_Native.None in
+          FStar_Syntax_Syntax.lid_as_fv' FStar_Parser_Const.steps_unfoldfully
+            FStar_Pervasives_Native.None in
         let uu___1 =
           let uu___2 =
             let uu___3 = let uu___4 = e_list e_string in embed uu___4 cb l in
@@ -1409,8 +1408,8 @@ let (e_norm_step : FStar_Syntax_Embeddings.norm_step embedding) =
         mkFV uu___ [] uu___1
     | FStar_Syntax_Embeddings.UnfoldAttr l ->
         let uu___ =
-          FStar_Syntax_Syntax.lid_as_fv FStar_Parser_Const.steps_unfoldattr
-            FStar_Syntax_Syntax.delta_constant FStar_Pervasives_Native.None in
+          FStar_Syntax_Syntax.lid_as_fv' FStar_Parser_Const.steps_unfoldattr
+            FStar_Pervasives_Native.None in
         let uu___1 =
           let uu___2 =
             let uu___3 = let uu___4 = e_list e_string in embed uu___4 cb l in
@@ -1419,8 +1418,8 @@ let (e_norm_step : FStar_Syntax_Embeddings.norm_step embedding) =
         mkFV uu___ [] uu___1
     | FStar_Syntax_Embeddings.UnfoldQual l ->
         let uu___ =
-          FStar_Syntax_Syntax.lid_as_fv FStar_Parser_Const.steps_unfoldqual
-            FStar_Syntax_Syntax.delta_constant FStar_Pervasives_Native.None in
+          FStar_Syntax_Syntax.lid_as_fv' FStar_Parser_Const.steps_unfoldqual
+            FStar_Pervasives_Native.None in
         let uu___1 =
           let uu___2 =
             let uu___3 = let uu___4 = e_list e_string in embed uu___4 cb l in
@@ -1429,9 +1428,9 @@ let (e_norm_step : FStar_Syntax_Embeddings.norm_step embedding) =
         mkFV uu___ [] uu___1
     | FStar_Syntax_Embeddings.UnfoldNamespace l ->
         let uu___ =
-          FStar_Syntax_Syntax.lid_as_fv
+          FStar_Syntax_Syntax.lid_as_fv'
             FStar_Parser_Const.steps_unfoldnamespace
-            FStar_Syntax_Syntax.delta_constant FStar_Pervasives_Native.None in
+            FStar_Pervasives_Native.None in
         let uu___1 =
           let uu___2 =
             let uu___3 = let uu___4 = e_list e_string in embed uu___4 cb l in
@@ -1440,13 +1439,13 @@ let (e_norm_step : FStar_Syntax_Embeddings.norm_step embedding) =
         mkFV uu___ [] uu___1
     | FStar_Syntax_Embeddings.ZetaFull ->
         let uu___ =
-          FStar_Syntax_Syntax.lid_as_fv FStar_Parser_Const.steps_zeta_full
-            FStar_Syntax_Syntax.delta_constant FStar_Pervasives_Native.None in
+          FStar_Syntax_Syntax.lid_as_fv' FStar_Parser_Const.steps_zeta_full
+            FStar_Pervasives_Native.None in
         mkFV uu___ [] []
     | FStar_Syntax_Embeddings.Unascribe ->
         let uu___ =
-          FStar_Syntax_Syntax.lid_as_fv FStar_Parser_Const.steps_unascribe
-            FStar_Syntax_Syntax.delta_constant FStar_Pervasives_Native.None in
+          FStar_Syntax_Syntax.lid_as_fv' FStar_Parser_Const.steps_unascribe
+            FStar_Pervasives_Native.None in
         mkFV uu___ [] [] in
   let un cb t0 =
     match t0.nbe_t with
@@ -1540,8 +1539,8 @@ let (e_norm_step : FStar_Syntax_Embeddings.norm_step embedding) =
          FStar_Pervasives_Native.None) in
   let uu___ =
     let uu___1 =
-      FStar_Syntax_Syntax.lid_as_fv FStar_Parser_Const.norm_step_lid
-        FStar_Syntax_Syntax.delta_constant FStar_Pervasives_Native.None in
+      FStar_Syntax_Syntax.lid_as_fv' FStar_Parser_Const.norm_step_lid
+        FStar_Pervasives_Native.None in
     mkFV uu___1 [] [] in
   let uu___1 =
     FStar_Syntax_Embeddings.emb_typ_of FStar_Syntax_Embeddings.e_norm_step in

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_NBETerm.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_NBETerm.ml
@@ -776,7 +776,7 @@ let (lid_as_constr :
     fun us ->
       fun args1 ->
         let uu___ =
-          FStar_Syntax_Syntax.lid_as_fv' l
+          FStar_Syntax_Syntax.lid_as_fv l
             (FStar_Pervasives_Native.Some FStar_Syntax_Syntax.Data_ctor) in
         mkConstruct uu___ us args1
 let (lid_as_typ :
@@ -786,7 +786,7 @@ let (lid_as_typ :
     fun us ->
       fun args1 ->
         let uu___ =
-          FStar_Syntax_Syntax.lid_as_fv' l FStar_Pervasives_Native.None in
+          FStar_Syntax_Syntax.lid_as_fv l FStar_Pervasives_Native.None in
         mkFV uu___ us args1
 let (as_iarg : t -> arg) =
   fun a ->
@@ -1343,52 +1343,52 @@ let (e_norm_step : FStar_Syntax_Embeddings.norm_step embedding) =
     match n with
     | FStar_Syntax_Embeddings.Simpl ->
         let uu___ =
-          FStar_Syntax_Syntax.lid_as_fv' FStar_Parser_Const.steps_simpl
+          FStar_Syntax_Syntax.lid_as_fv FStar_Parser_Const.steps_simpl
             FStar_Pervasives_Native.None in
         mkFV uu___ [] []
     | FStar_Syntax_Embeddings.Weak ->
         let uu___ =
-          FStar_Syntax_Syntax.lid_as_fv' FStar_Parser_Const.steps_weak
+          FStar_Syntax_Syntax.lid_as_fv FStar_Parser_Const.steps_weak
             FStar_Pervasives_Native.None in
         mkFV uu___ [] []
     | FStar_Syntax_Embeddings.HNF ->
         let uu___ =
-          FStar_Syntax_Syntax.lid_as_fv' FStar_Parser_Const.steps_hnf
+          FStar_Syntax_Syntax.lid_as_fv FStar_Parser_Const.steps_hnf
             FStar_Pervasives_Native.None in
         mkFV uu___ [] []
     | FStar_Syntax_Embeddings.Primops ->
         let uu___ =
-          FStar_Syntax_Syntax.lid_as_fv' FStar_Parser_Const.steps_primops
+          FStar_Syntax_Syntax.lid_as_fv FStar_Parser_Const.steps_primops
             FStar_Pervasives_Native.None in
         mkFV uu___ [] []
     | FStar_Syntax_Embeddings.Delta ->
         let uu___ =
-          FStar_Syntax_Syntax.lid_as_fv' FStar_Parser_Const.steps_delta
+          FStar_Syntax_Syntax.lid_as_fv FStar_Parser_Const.steps_delta
             FStar_Pervasives_Native.None in
         mkFV uu___ [] []
     | FStar_Syntax_Embeddings.Zeta ->
         let uu___ =
-          FStar_Syntax_Syntax.lid_as_fv' FStar_Parser_Const.steps_zeta
+          FStar_Syntax_Syntax.lid_as_fv FStar_Parser_Const.steps_zeta
             FStar_Pervasives_Native.None in
         mkFV uu___ [] []
     | FStar_Syntax_Embeddings.Iota ->
         let uu___ =
-          FStar_Syntax_Syntax.lid_as_fv' FStar_Parser_Const.steps_iota
+          FStar_Syntax_Syntax.lid_as_fv FStar_Parser_Const.steps_iota
             FStar_Pervasives_Native.None in
         mkFV uu___ [] []
     | FStar_Syntax_Embeddings.Reify ->
         let uu___ =
-          FStar_Syntax_Syntax.lid_as_fv' FStar_Parser_Const.steps_reify
+          FStar_Syntax_Syntax.lid_as_fv FStar_Parser_Const.steps_reify
             FStar_Pervasives_Native.None in
         mkFV uu___ [] []
     | FStar_Syntax_Embeddings.NBE ->
         let uu___ =
-          FStar_Syntax_Syntax.lid_as_fv' FStar_Parser_Const.steps_nbe
+          FStar_Syntax_Syntax.lid_as_fv FStar_Parser_Const.steps_nbe
             FStar_Pervasives_Native.None in
         mkFV uu___ [] []
     | FStar_Syntax_Embeddings.UnfoldOnly l ->
         let uu___ =
-          FStar_Syntax_Syntax.lid_as_fv' FStar_Parser_Const.steps_unfoldonly
+          FStar_Syntax_Syntax.lid_as_fv FStar_Parser_Const.steps_unfoldonly
             FStar_Pervasives_Native.None in
         let uu___1 =
           let uu___2 =
@@ -1398,7 +1398,7 @@ let (e_norm_step : FStar_Syntax_Embeddings.norm_step embedding) =
         mkFV uu___ [] uu___1
     | FStar_Syntax_Embeddings.UnfoldFully l ->
         let uu___ =
-          FStar_Syntax_Syntax.lid_as_fv' FStar_Parser_Const.steps_unfoldfully
+          FStar_Syntax_Syntax.lid_as_fv FStar_Parser_Const.steps_unfoldfully
             FStar_Pervasives_Native.None in
         let uu___1 =
           let uu___2 =
@@ -1408,7 +1408,7 @@ let (e_norm_step : FStar_Syntax_Embeddings.norm_step embedding) =
         mkFV uu___ [] uu___1
     | FStar_Syntax_Embeddings.UnfoldAttr l ->
         let uu___ =
-          FStar_Syntax_Syntax.lid_as_fv' FStar_Parser_Const.steps_unfoldattr
+          FStar_Syntax_Syntax.lid_as_fv FStar_Parser_Const.steps_unfoldattr
             FStar_Pervasives_Native.None in
         let uu___1 =
           let uu___2 =
@@ -1418,7 +1418,7 @@ let (e_norm_step : FStar_Syntax_Embeddings.norm_step embedding) =
         mkFV uu___ [] uu___1
     | FStar_Syntax_Embeddings.UnfoldQual l ->
         let uu___ =
-          FStar_Syntax_Syntax.lid_as_fv' FStar_Parser_Const.steps_unfoldqual
+          FStar_Syntax_Syntax.lid_as_fv FStar_Parser_Const.steps_unfoldqual
             FStar_Pervasives_Native.None in
         let uu___1 =
           let uu___2 =
@@ -1428,7 +1428,7 @@ let (e_norm_step : FStar_Syntax_Embeddings.norm_step embedding) =
         mkFV uu___ [] uu___1
     | FStar_Syntax_Embeddings.UnfoldNamespace l ->
         let uu___ =
-          FStar_Syntax_Syntax.lid_as_fv'
+          FStar_Syntax_Syntax.lid_as_fv
             FStar_Parser_Const.steps_unfoldnamespace
             FStar_Pervasives_Native.None in
         let uu___1 =
@@ -1439,12 +1439,12 @@ let (e_norm_step : FStar_Syntax_Embeddings.norm_step embedding) =
         mkFV uu___ [] uu___1
     | FStar_Syntax_Embeddings.ZetaFull ->
         let uu___ =
-          FStar_Syntax_Syntax.lid_as_fv' FStar_Parser_Const.steps_zeta_full
+          FStar_Syntax_Syntax.lid_as_fv FStar_Parser_Const.steps_zeta_full
             FStar_Pervasives_Native.None in
         mkFV uu___ [] []
     | FStar_Syntax_Embeddings.Unascribe ->
         let uu___ =
-          FStar_Syntax_Syntax.lid_as_fv' FStar_Parser_Const.steps_unascribe
+          FStar_Syntax_Syntax.lid_as_fv FStar_Parser_Const.steps_unascribe
             FStar_Pervasives_Native.None in
         mkFV uu___ [] [] in
   let un cb t0 =
@@ -1539,7 +1539,7 @@ let (e_norm_step : FStar_Syntax_Embeddings.norm_step embedding) =
          FStar_Pervasives_Native.None) in
   let uu___ =
     let uu___1 =
-      FStar_Syntax_Syntax.lid_as_fv' FStar_Parser_Const.norm_step_lid
+      FStar_Syntax_Syntax.lid_as_fv FStar_Parser_Const.norm_step_lid
         FStar_Pervasives_Native.None in
     mkFV uu___1 [] [] in
   let uu___1 =

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_Normalize.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_Normalize.ml
@@ -1999,8 +1999,10 @@ let (should_unfold :
               (fun uu___2 ->
                  let uu___3 = FStar_Syntax_Print.fv_to_string fv in
                  let uu___4 =
-                   FStar_Syntax_Print.delta_depth_to_string
-                     fv.FStar_Syntax_Syntax.fv_delta in
+                   let uu___5 =
+                     FStar_TypeChecker_Env.delta_depth_of_fv
+                       cfg.FStar_TypeChecker_Cfg.tcenv fv in
+                   FStar_Syntax_Print.delta_depth_to_string uu___5 in
                  let uu___5 =
                    (FStar_Common.string_of_list ())
                      FStar_TypeChecker_Env.string_of_delta_level
@@ -5900,8 +5902,7 @@ and (norm_cb : FStar_TypeChecker_Cfg.cfg -> FStar_Syntax_Embeddings.norm_cb)
            | FStar_Pervasives_Native.Some t -> t
            | FStar_Pervasives_Native.None ->
                let uu___2 =
-                 FStar_Syntax_Syntax.lid_as_fv l
-                   FStar_Syntax_Syntax.delta_constant
+                 FStar_Syntax_Syntax.lid_as_fv' l
                    FStar_Pervasives_Native.None in
                FStar_Syntax_Syntax.fv_to_tm uu___2)
 and (maybe_simplify_aux :

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_Normalize.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_Normalize.ml
@@ -5902,8 +5902,7 @@ and (norm_cb : FStar_TypeChecker_Cfg.cfg -> FStar_Syntax_Embeddings.norm_cb)
            | FStar_Pervasives_Native.Some t -> t
            | FStar_Pervasives_Native.None ->
                let uu___2 =
-                 FStar_Syntax_Syntax.lid_as_fv' l
-                   FStar_Pervasives_Native.None in
+                 FStar_Syntax_Syntax.lid_as_fv l FStar_Pervasives_Native.None in
                FStar_Syntax_Syntax.fv_to_tm uu___2)
 and (maybe_simplify_aux :
   FStar_TypeChecker_Cfg.cfg ->

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_TcEffect.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_TcEffect.ml
@@ -5216,7 +5216,7 @@ let (tc_layered_eff_decl :
                                                                     =
                                                                     let uu___21
                                                                     =
-                                                                    FStar_Syntax_Syntax.lid_as_fv'
+                                                                    FStar_Syntax_Syntax.lid_as_fv
                                                                     FStar_Parser_Const.not_lid
                                                                     FStar_Pervasives_Native.None in
                                                                     FStar_Compiler_Effect.op_Bar_Greater

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_TcEffect.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_TcEffect.ml
@@ -5216,9 +5216,8 @@ let (tc_layered_eff_decl :
                                                                     =
                                                                     let uu___21
                                                                     =
-                                                                    FStar_Syntax_Syntax.lid_as_fv
+                                                                    FStar_Syntax_Syntax.lid_as_fv'
                                                                     FStar_Parser_Const.not_lid
-                                                                    FStar_Syntax_Syntax.delta_constant
                                                                     FStar_Pervasives_Native.None in
                                                                     FStar_Compiler_Effect.op_Bar_Greater
                                                                     uu___21

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_TcInductive.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_TcInductive.ml
@@ -1136,7 +1136,6 @@ let (get_optimized_haseq_axiom :
                    let ind =
                      let uu___2 =
                        FStar_Syntax_Syntax.fvar lid
-                         FStar_Syntax_Syntax.delta_constant
                          FStar_Pervasives_Native.None in
                      let uu___3 =
                        FStar_Compiler_List.map
@@ -1683,7 +1682,6 @@ let (unoptimized_haseq_ty :
                        let ind =
                          let uu___2 =
                            FStar_Syntax_Syntax.fvar lid
-                             FStar_Syntax_Syntax.delta_constant
                              FStar_Pervasives_Native.None in
                          let uu___3 =
                            FStar_Compiler_List.map
@@ -2372,7 +2370,7 @@ let (mk_discriminator_and_indexed_projectors :
                                  let disc_fvar =
                                    let uu___1 =
                                      FStar_Ident.set_lid_range disc_name p in
-                                   FStar_Syntax_Syntax.fvar uu___1
+                                   FStar_Syntax_Syntax.fvar_with_dd uu___1
                                      (FStar_Syntax_Syntax.Delta_equational_at_level
                                         Prims.int_one)
                                      FStar_Pervasives_Native.None in

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_TcInductive.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_TcInductive.ml
@@ -2344,8 +2344,7 @@ let (mk_discriminator_and_indexed_projectors :
                                 let uu___1 =
                                   let uu___2 =
                                     let uu___3 =
-                                      FStar_Syntax_Syntax.lid_as_fv tc
-                                        FStar_Syntax_Syntax.delta_constant
+                                      FStar_Syntax_Syntax.lid_as_fv' tc
                                         FStar_Pervasives_Native.None in
                                     FStar_Syntax_Syntax.fv_to_tm uu___3 in
                                   (uu___2, inst_univs) in
@@ -2582,9 +2581,8 @@ let (mk_discriminator_and_indexed_projectors :
                                            let uu___5 =
                                              let uu___6 =
                                                let uu___7 =
-                                                 FStar_Syntax_Syntax.lid_as_fv
+                                                 FStar_Syntax_Syntax.lid_as_fv'
                                                    lid
-                                                   FStar_Syntax_Syntax.delta_constant
                                                    (FStar_Pervasives_Native.Some
                                                       fvq) in
                                                (uu___7,
@@ -2732,10 +2730,8 @@ let (mk_discriminator_and_indexed_projectors :
                                           let field_proj_tm =
                                             let uu___4 =
                                               let uu___5 =
-                                                FStar_Syntax_Syntax.lid_as_fv
+                                                FStar_Syntax_Syntax.lid_as_fv'
                                                   field_name
-                                                  (FStar_Syntax_Syntax.Delta_equational_at_level
-                                                     Prims.int_one)
                                                   FStar_Pervasives_Native.None in
                                               FStar_Syntax_Syntax.fv_to_tm
                                                 uu___5 in
@@ -2946,9 +2942,8 @@ let (mk_discriminator_and_indexed_projectors :
                                                     let uu___8 =
                                                       let uu___9 =
                                                         let uu___10 =
-                                                          FStar_Syntax_Syntax.lid_as_fv
+                                                          FStar_Syntax_Syntax.lid_as_fv'
                                                             lid
-                                                            FStar_Syntax_Syntax.delta_constant
                                                             (FStar_Pervasives_Native.Some
                                                                fvq) in
                                                         (uu___10,

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_TcInductive.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_TcInductive.ml
@@ -179,7 +179,7 @@ let (tc_tycon :
                                           match uu___7 with
                                           | (tps5, k5) ->
                                               let fv_tc =
-                                                FStar_Syntax_Syntax.lid_as_fv
+                                                FStar_Syntax_Syntax.lid_and_dd_as_fv
                                                   tc
                                                   FStar_Syntax_Syntax.delta_constant
                                                   FStar_Pervasives_Native.None in
@@ -2344,7 +2344,7 @@ let (mk_discriminator_and_indexed_projectors :
                                 let uu___1 =
                                   let uu___2 =
                                     let uu___3 =
-                                      FStar_Syntax_Syntax.lid_as_fv' tc
+                                      FStar_Syntax_Syntax.lid_as_fv tc
                                         FStar_Pervasives_Native.None in
                                     FStar_Syntax_Syntax.fv_to_tm uu___3 in
                                   (uu___2, inst_univs) in
@@ -2581,7 +2581,7 @@ let (mk_discriminator_and_indexed_projectors :
                                            let uu___5 =
                                              let uu___6 =
                                                let uu___7 =
-                                                 FStar_Syntax_Syntax.lid_as_fv'
+                                                 FStar_Syntax_Syntax.lid_as_fv
                                                    lid
                                                    (FStar_Pervasives_Native.Some
                                                       fvq) in
@@ -2646,7 +2646,7 @@ let (mk_discriminator_and_indexed_projectors :
                                   let lb =
                                     let uu___3 =
                                       let uu___4 =
-                                        FStar_Syntax_Syntax.lid_as_fv
+                                        FStar_Syntax_Syntax.lid_and_dd_as_fv
                                           discriminator_name dd
                                           FStar_Pervasives_Native.None in
                                       FStar_Pervasives.Inr uu___4 in
@@ -2730,7 +2730,7 @@ let (mk_discriminator_and_indexed_projectors :
                                           let field_proj_tm =
                                             let uu___4 =
                                               let uu___5 =
-                                                FStar_Syntax_Syntax.lid_as_fv'
+                                                FStar_Syntax_Syntax.lid_as_fv
                                                   field_name
                                                   FStar_Pervasives_Native.None in
                                               FStar_Syntax_Syntax.fv_to_tm
@@ -2942,7 +2942,7 @@ let (mk_discriminator_and_indexed_projectors :
                                                     let uu___8 =
                                                       let uu___9 =
                                                         let uu___10 =
-                                                          FStar_Syntax_Syntax.lid_as_fv'
+                                                          FStar_Syntax_Syntax.lid_as_fv
                                                             lid
                                                             (FStar_Pervasives_Native.Some
                                                                fvq) in
@@ -3054,7 +3054,7 @@ let (mk_discriminator_and_indexed_projectors :
                                                 let lb =
                                                   let uu___7 =
                                                     let uu___8 =
-                                                      FStar_Syntax_Syntax.lid_as_fv
+                                                      FStar_Syntax_Syntax.lid_and_dd_as_fv
                                                         field_name dd
                                                         FStar_Pervasives_Native.None in
                                                     FStar_Pervasives.Inr

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_TcInductive.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_TcInductive.ml
@@ -179,9 +179,8 @@ let (tc_tycon :
                                           match uu___7 with
                                           | (tps5, k5) ->
                                               let fv_tc =
-                                                FStar_Syntax_Syntax.lid_and_dd_as_fv
+                                                FStar_Syntax_Syntax.lid_as_fv
                                                   tc
-                                                  FStar_Syntax_Syntax.delta_constant
                                                   FStar_Pervasives_Native.None in
                                               let uu___8 =
                                                 FStar_Syntax_Subst.open_univ_vars

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_TcTerm.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_TcTerm.ml
@@ -3332,8 +3332,8 @@ and (tc_maybe_toplevel_term :
                                               field_name in
                                           FStar_Ident.set_lid_range projname
                                             uu___17 in
-                                        FStar_Syntax_Syntax.lid_as_fv'
-                                          uu___16 qual in
+                                        FStar_Syntax_Syntax.lid_as_fv uu___16
+                                          qual in
                                       proceed_with
                                         (FStar_Pervasives_Native.Some choice)))
                         | uu___14 -> proceed_with candidate))))

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_TcTerm.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_TcTerm.ml
@@ -1205,7 +1205,7 @@ let (guard_letrecs :
                    FStar_Compiler_Effect.op_Bar_Greater uu___3
                      (fun uu___4 -> FStar_Syntax_Syntax.Decreases_lex uu___4)) in
             let precedes_t =
-              FStar_TypeChecker_Util.fvar_const env1
+              FStar_TypeChecker_Util.fvar_env env1
                 FStar_Parser_Const.precedes_lid in
             let rec mk_precedes_lex env2 l l_prev =
               let rec aux l1 l_prev1 =
@@ -3189,9 +3189,7 @@ and (tc_maybe_toplevel_term :
                           let uu___9 =
                             FStar_Ident.set_lid_range projname
                               x.FStar_Syntax_Syntax.pos in
-                          FStar_Syntax_Syntax.fvar_with_dd uu___9
-                            (FStar_Syntax_Syntax.Delta_equational_at_level
-                               Prims.int_one) qual in
+                          FStar_Syntax_Syntax.fvar uu___9 qual in
                         FStar_Syntax_Syntax.mk_Tm_app candidate
                           [(x, FStar_Pervasives_Native.None)]
                           x.FStar_Syntax_Syntax.pos in
@@ -8923,10 +8921,8 @@ and (tc_pat :
                                                 let uu___9 =
                                                   let uu___10 =
                                                     let uu___11 =
-                                                      FStar_Syntax_Syntax.fvar_with_dd
+                                                      FStar_Syntax_Syntax.fvar
                                                         disc_tm
-                                                        (FStar_Syntax_Syntax.Delta_constant_at_level
-                                                           Prims.int_one)
                                                         FStar_Pervasives_Native.None in
                                                     mk_disc_t uu___11 in
                                                   FStar_Compiler_List.map
@@ -9270,10 +9266,8 @@ and (tc_eqn :
                                                               -> []
                                                           | uu___14 ->
                                                               let disc =
-                                                                FStar_Syntax_Syntax.fvar_with_dd
+                                                                FStar_Syntax_Syntax.fvar
                                                                   discriminator
-                                                                  (FStar_Syntax_Syntax.Delta_equational_at_level
-                                                                    Prims.int_one)
                                                                   FStar_Pervasives_Native.None in
                                                               let uu___15 =
                                                                 let uu___16 =
@@ -9521,10 +9515,8 @@ and (tc_eqn :
                                                                     FStar_Ident.set_lid_range
                                                                     projector
                                                                     f.FStar_Syntax_Syntax.p in
-                                                                    FStar_Syntax_Syntax.fvar_with_dd
+                                                                    FStar_Syntax_Syntax.fvar
                                                                     uu___23
-                                                                    (FStar_Syntax_Syntax.Delta_equational_at_level
-                                                                    Prims.int_one)
                                                                     FStar_Pervasives_Native.None in
                                                                     let uu___23
                                                                     =

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_TcTerm.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_TcTerm.ml
@@ -3189,7 +3189,7 @@ and (tc_maybe_toplevel_term :
                           let uu___9 =
                             FStar_Ident.set_lid_range projname
                               x.FStar_Syntax_Syntax.pos in
-                          FStar_Syntax_Syntax.fvar uu___9
+                          FStar_Syntax_Syntax.fvar_with_dd uu___9
                             (FStar_Syntax_Syntax.Delta_equational_at_level
                                Prims.int_one) qual in
                         FStar_Syntax_Syntax.mk_Tm_app candidate
@@ -4873,7 +4873,7 @@ and (tc_comp :
       | FStar_Syntax_Syntax.Comp c1 ->
           let head =
             FStar_Syntax_Syntax.fvar c1.FStar_Syntax_Syntax.effect_name
-              FStar_Syntax_Syntax.delta_constant FStar_Pervasives_Native.None in
+              FStar_Pervasives_Native.None in
           let head1 =
             match c1.FStar_Syntax_Syntax.comp_univs with
             | [] -> head
@@ -8526,7 +8526,6 @@ and (tc_pat :
           (let id t1 =
              let uu___1 =
                FStar_Syntax_Syntax.fvar FStar_Parser_Const.id_lid
-                 (FStar_Syntax_Syntax.Delta_constant_at_level Prims.int_one)
                  FStar_Pervasives_Native.None in
              let uu___2 =
                let uu___3 = FStar_Syntax_Syntax.iarg t1 in [uu___3] in
@@ -8924,7 +8923,7 @@ and (tc_pat :
                                                 let uu___9 =
                                                   let uu___10 =
                                                     let uu___11 =
-                                                      FStar_Syntax_Syntax.fvar
+                                                      FStar_Syntax_Syntax.fvar_with_dd
                                                         disc_tm
                                                         (FStar_Syntax_Syntax.Delta_constant_at_level
                                                            Prims.int_one)
@@ -9271,7 +9270,7 @@ and (tc_eqn :
                                                               -> []
                                                           | uu___14 ->
                                                               let disc =
-                                                                FStar_Syntax_Syntax.fvar
+                                                                FStar_Syntax_Syntax.fvar_with_dd
                                                                   discriminator
                                                                   (FStar_Syntax_Syntax.Delta_equational_at_level
                                                                     Prims.int_one)
@@ -9522,7 +9521,7 @@ and (tc_eqn :
                                                                     FStar_Ident.set_lid_range
                                                                     projector
                                                                     f.FStar_Syntax_Syntax.p in
-                                                                    FStar_Syntax_Syntax.fvar
+                                                                    FStar_Syntax_Syntax.fvar_with_dd
                                                                     uu___23
                                                                     (FStar_Syntax_Syntax.Delta_equational_at_level
                                                                     Prims.int_one)

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_TcTerm.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_TcTerm.ml
@@ -3332,9 +3332,8 @@ and (tc_maybe_toplevel_term :
                                               field_name in
                                           FStar_Ident.set_lid_range projname
                                             uu___17 in
-                                        FStar_Syntax_Syntax.lid_as_fv uu___16
-                                          (FStar_Syntax_Syntax.Delta_equational_at_level
-                                             Prims.int_one) qual in
+                                        FStar_Syntax_Syntax.lid_as_fv'
+                                          uu___16 qual in
                                       proceed_with
                                         (FStar_Pervasives_Native.Some choice)))
                         | uu___14 -> proceed_with candidate))))

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_Util.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_Util.ml
@@ -2605,10 +2605,9 @@ let (strengthen_comp :
               (let r = FStar_TypeChecker_Env.get_range env in
                let pure_assert_wp =
                  let uu___2 =
-                   FStar_Syntax_Syntax.lid_as_fv
+                   FStar_Syntax_Syntax.lid_as_fv'
                      FStar_Parser_Const.pure_assert_wp_lid
-                     (FStar_Syntax_Syntax.Delta_constant_at_level
-                        Prims.int_one) FStar_Pervasives_Native.None in
+                     FStar_Pervasives_Native.None in
                  FStar_Syntax_Syntax.fv_to_tm uu___2 in
                let pure_assert_wp1 =
                  let uu___2 =
@@ -2722,9 +2721,8 @@ let (weaken_comp :
           (let ct = FStar_TypeChecker_Env.unfold_effect_abbrev env c in
            let pure_assume_wp =
              let uu___2 =
-               FStar_Syntax_Syntax.lid_as_fv
+               FStar_Syntax_Syntax.lid_as_fv'
                  FStar_Parser_Const.pure_assume_wp_lid
-                 (FStar_Syntax_Syntax.Delta_constant_at_level Prims.int_one)
                  FStar_Pervasives_Native.None in
              FStar_Syntax_Syntax.fv_to_tm uu___2 in
            let pure_assume_wp1 =
@@ -8381,8 +8379,7 @@ let (find_record_or_dc_from_typ :
                   FStar_Syntax_Syntax.Record_ctor uu___1 in
                 FStar_Pervasives_Native.Some uu___
               else FStar_Pervasives_Native.None in
-            FStar_Syntax_Syntax.lid_as_fv constrname
-              FStar_Syntax_Syntax.delta_constant qual in
+            FStar_Syntax_Syntax.lid_as_fv' constrname qual in
           (rdc, constrname, constructor)
 let (field_name_matches :
   FStar_Ident.lident ->

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_Util.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_Util.ml
@@ -2605,7 +2605,7 @@ let (strengthen_comp :
               (let r = FStar_TypeChecker_Env.get_range env in
                let pure_assert_wp =
                  let uu___2 =
-                   FStar_Syntax_Syntax.lid_as_fv'
+                   FStar_Syntax_Syntax.lid_as_fv
                      FStar_Parser_Const.pure_assert_wp_lid
                      FStar_Pervasives_Native.None in
                  FStar_Syntax_Syntax.fv_to_tm uu___2 in
@@ -2721,7 +2721,7 @@ let (weaken_comp :
           (let ct = FStar_TypeChecker_Env.unfold_effect_abbrev env c in
            let pure_assume_wp =
              let uu___2 =
-               FStar_Syntax_Syntax.lid_as_fv'
+               FStar_Syntax_Syntax.lid_as_fv
                  FStar_Parser_Const.pure_assume_wp_lid
                  FStar_Pervasives_Native.None in
              FStar_Syntax_Syntax.fv_to_tm uu___2 in
@@ -6644,7 +6644,7 @@ let (mk_toplevel_definition :
          else ());
         (let fv =
            let uu___1 = FStar_Syntax_Util.incr_delta_qualifier def in
-           FStar_Syntax_Syntax.lid_as_fv lident uu___1
+           FStar_Syntax_Syntax.lid_and_dd_as_fv lident uu___1
              FStar_Pervasives_Native.None in
          let lbname = FStar_Pervasives.Inr fv in
          let lb =
@@ -8379,7 +8379,7 @@ let (find_record_or_dc_from_typ :
                   FStar_Syntax_Syntax.Record_ctor uu___1 in
                 FStar_Pervasives_Native.Some uu___
               else FStar_Pervasives_Native.None in
-            FStar_Syntax_Syntax.lid_as_fv' constrname qual in
+            FStar_Syntax_Syntax.lid_as_fv constrname qual in
           (rdc, constrname, constructor)
 let (field_name_matches :
   FStar_Ident.lident ->

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_Util.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_Util.ml
@@ -3655,7 +3655,7 @@ let (maybe_return_e2_and_bind :
                                 uu___5 e2 lc21
                             else lc21) in
                        bind r env e1opt lc11 (x, lc22))
-let (fvar_const :
+let (fvar_env :
   FStar_TypeChecker_Env.env -> FStar_Ident.lident -> FStar_Syntax_Syntax.term)
   =
   fun env ->
@@ -4274,7 +4274,7 @@ let (comp_pure_wp_false :
         let wp =
           let uu___ =
             let uu___1 = FStar_Syntax_Syntax.mk_binder post in [uu___1] in
-          let uu___1 = fvar_const env FStar_Parser_Const.false_lid in
+          let uu___1 = fvar_env env FStar_Parser_Const.false_lid in
           FStar_Syntax_Util.abs uu___ uu___1
             (FStar_Pervasives_Native.Some
                (FStar_Syntax_Util.mk_residual_comp
@@ -5130,7 +5130,7 @@ let (maybe_coerce_lc :
                   (let mk_erased u t =
                      let uu___3 =
                        let uu___4 =
-                         fvar_const env FStar_Parser_Const.erased_lid in
+                         fvar_env env FStar_Parser_Const.erased_lid in
                        FStar_Syntax_Syntax.mk_Tm_uinst uu___4 [u] in
                      let uu___4 =
                        let uu___5 = FStar_Syntax_Syntax.as_arg t in [uu___5] in
@@ -5779,8 +5779,7 @@ let (pure_or_ghost_pre_and_post :
                                   let uu___11 =
                                     FStar_Ident.set_lid_range
                                       FStar_Parser_Const.as_requires r in
-                                  FStar_Syntax_Syntax.fvar_with_dd uu___11
-                                    FStar_Syntax_Syntax.delta_equational
+                                  FStar_Syntax_Syntax.fvar uu___11
                                     FStar_Pervasives_Native.None in
                                 FStar_Syntax_Syntax.mk_Tm_uinst uu___10 us_r in
                               let as_ens =
@@ -5788,8 +5787,7 @@ let (pure_or_ghost_pre_and_post :
                                   let uu___11 =
                                     FStar_Ident.set_lid_range
                                       FStar_Parser_Const.as_ensures r in
-                                  FStar_Syntax_Syntax.fvar_with_dd uu___11
-                                    FStar_Syntax_Syntax.delta_equational
+                                  FStar_Syntax_Syntax.fvar uu___11
                                     FStar_Pervasives_Native.None in
                                 FStar_Syntax_Syntax.mk_Tm_uinst uu___10 us_e in
                               let req =
@@ -6619,59 +6617,6 @@ let (maybe_add_implicit_binders :
                                    })) in
                          FStar_Compiler_List.op_At imps1 bs)
                 | uu___4 -> bs))
-let (d : Prims.string -> unit) =
-  fun s -> FStar_Compiler_Util.print1 "\027[01;36m%s\027[00m\n" s
-let (mk_toplevel_definition :
-  FStar_TypeChecker_Env.env ->
-    FStar_Ident.lident ->
-      FStar_Syntax_Syntax.term ->
-        (FStar_Syntax_Syntax.sigelt * FStar_Syntax_Syntax.term))
-  =
-  fun env ->
-    fun lident ->
-      fun def ->
-        (let uu___1 =
-           FStar_TypeChecker_Env.debug env (FStar_Options.Other "ED") in
-         if uu___1
-         then
-           ((let uu___3 = FStar_Ident.string_of_lid lident in d uu___3);
-            (let uu___3 = FStar_Ident.string_of_lid lident in
-             let uu___4 = FStar_Syntax_Print.term_to_string def in
-             FStar_Compiler_Util.print2
-               "Registering top-level definition: %s\n%s\n" uu___3 uu___4))
-         else ());
-        (let fv =
-           let uu___1 = FStar_Syntax_Util.incr_delta_qualifier def in
-           FStar_Syntax_Syntax.lid_and_dd_as_fv lident uu___1
-             FStar_Pervasives_Native.None in
-         let lbname = FStar_Pervasives.Inr fv in
-         let lb =
-           (false,
-             [FStar_Syntax_Util.mk_letbinding lbname []
-                FStar_Syntax_Syntax.tun FStar_Parser_Const.effect_Tot_lid def
-                [] FStar_Compiler_Range_Type.dummyRange]) in
-         let sig_ctx =
-           FStar_Syntax_Syntax.mk_sigelt
-             (FStar_Syntax_Syntax.Sig_let
-                {
-                  FStar_Syntax_Syntax.lbs1 = lb;
-                  FStar_Syntax_Syntax.lids1 = [lident]
-                }) in
-         let uu___1 =
-           FStar_Syntax_Syntax.mk (FStar_Syntax_Syntax.Tm_fvar fv)
-             FStar_Compiler_Range_Type.dummyRange in
-         ({
-            FStar_Syntax_Syntax.sigel = (sig_ctx.FStar_Syntax_Syntax.sigel);
-            FStar_Syntax_Syntax.sigrng = (sig_ctx.FStar_Syntax_Syntax.sigrng);
-            FStar_Syntax_Syntax.sigquals =
-              [FStar_Syntax_Syntax.Unfold_for_unification_and_vcgen];
-            FStar_Syntax_Syntax.sigmeta =
-              (sig_ctx.FStar_Syntax_Syntax.sigmeta);
-            FStar_Syntax_Syntax.sigattrs =
-              (sig_ctx.FStar_Syntax_Syntax.sigattrs);
-            FStar_Syntax_Syntax.sigopts =
-              (sig_ctx.FStar_Syntax_Syntax.sigopts)
-          }, uu___1))
 let (check_sigelt_quals :
   FStar_TypeChecker_Env.env -> FStar_Syntax_Syntax.sigelt -> unit) =
   fun env ->

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_Util.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_Util.ml
@@ -3663,8 +3663,7 @@ let (fvar_const :
       let uu___ =
         let uu___1 = FStar_TypeChecker_Env.get_range env in
         FStar_Ident.set_lid_range lid uu___1 in
-      FStar_Syntax_Syntax.fvar uu___ FStar_Syntax_Syntax.delta_constant
-        FStar_Pervasives_Native.None
+      FStar_Syntax_Syntax.fvar uu___ FStar_Pervasives_Native.None
 let (substitutive_indexed_ite_substs :
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.indexed_effect_combinator_kind ->
@@ -4890,8 +4889,7 @@ let (coerce_with :
                             FStar_Ident.set_lid_range f
                               e.FStar_Syntax_Syntax.pos in
                           FStar_Syntax_Syntax.fvar uu___3
-                            (FStar_Syntax_Syntax.Delta_constant_at_level
-                               Prims.int_one) FStar_Pervasives_Native.None in
+                            FStar_Pervasives_Native.None in
                         let coercion1 =
                           FStar_Syntax_Syntax.mk_Tm_uinst coercion us in
                         let e1 =
@@ -5781,7 +5779,7 @@ let (pure_or_ghost_pre_and_post :
                                   let uu___11 =
                                     FStar_Ident.set_lid_range
                                       FStar_Parser_Const.as_requires r in
-                                  FStar_Syntax_Syntax.fvar uu___11
+                                  FStar_Syntax_Syntax.fvar_with_dd uu___11
                                     FStar_Syntax_Syntax.delta_equational
                                     FStar_Pervasives_Native.None in
                                 FStar_Syntax_Syntax.mk_Tm_uinst uu___10 us_r in
@@ -5790,7 +5788,7 @@ let (pure_or_ghost_pre_and_post :
                                   let uu___11 =
                                     FStar_Ident.set_lid_range
                                       FStar_Parser_Const.as_ensures r in
-                                  FStar_Syntax_Syntax.fvar uu___11
+                                  FStar_Syntax_Syntax.fvar_with_dd uu___11
                                     FStar_Syntax_Syntax.delta_equational
                                     FStar_Pervasives_Native.None in
                                 FStar_Syntax_Syntax.mk_Tm_uinst uu___10 us_e in

--- a/ocaml/fstar-tests/generated/FStar_Tests_Norm.ml
+++ b/ocaml/fstar-tests/generated/FStar_Tests_Norm.ml
@@ -78,13 +78,11 @@ let (lid : Prims.string -> FStar_Ident.lident) =
     FStar_Ident.lid_of_path ["Test"; x] FStar_Compiler_Range_Type.dummyRange
 let (znat_l : FStar_Syntax_Syntax.fv) =
   let uu___ = lid "Z" in
-  FStar_Syntax_Syntax.lid_and_dd_as_fv uu___
-    FStar_Syntax_Syntax.delta_constant
+  FStar_Syntax_Syntax.lid_as_fv uu___
     (FStar_Pervasives_Native.Some FStar_Syntax_Syntax.Data_ctor)
 let (snat_l : FStar_Syntax_Syntax.fv) =
   let uu___ = lid "S" in
-  FStar_Syntax_Syntax.lid_and_dd_as_fv uu___
-    FStar_Syntax_Syntax.delta_constant
+  FStar_Syntax_Syntax.lid_as_fv uu___
     (FStar_Pervasives_Native.Some FStar_Syntax_Syntax.Data_ctor)
 let (tm_fv :
   FStar_Syntax_Syntax.fv ->
@@ -113,8 +111,7 @@ let pat : 'uuuuu . 'uuuuu -> 'uuuuu FStar_Syntax_Syntax.withinfo_t =
 let (snat_type : FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax) =
   let uu___ =
     let uu___1 = lid "snat" in
-    FStar_Syntax_Syntax.lid_and_dd_as_fv uu___1
-      FStar_Syntax_Syntax.delta_constant FStar_Pervasives_Native.None in
+    FStar_Syntax_Syntax.lid_as_fv uu___1 FStar_Pervasives_Native.None in
   tm_fv uu___
 let (mk_match :
   FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->

--- a/ocaml/fstar-tests/generated/FStar_Tests_Norm.ml
+++ b/ocaml/fstar-tests/generated/FStar_Tests_Norm.ml
@@ -78,11 +78,13 @@ let (lid : Prims.string -> FStar_Ident.lident) =
     FStar_Ident.lid_of_path ["Test"; x] FStar_Compiler_Range_Type.dummyRange
 let (znat_l : FStar_Syntax_Syntax.fv) =
   let uu___ = lid "Z" in
-  FStar_Syntax_Syntax.lid_as_fv uu___ FStar_Syntax_Syntax.delta_constant
+  FStar_Syntax_Syntax.lid_and_dd_as_fv uu___
+    FStar_Syntax_Syntax.delta_constant
     (FStar_Pervasives_Native.Some FStar_Syntax_Syntax.Data_ctor)
 let (snat_l : FStar_Syntax_Syntax.fv) =
   let uu___ = lid "S" in
-  FStar_Syntax_Syntax.lid_as_fv uu___ FStar_Syntax_Syntax.delta_constant
+  FStar_Syntax_Syntax.lid_and_dd_as_fv uu___
+    FStar_Syntax_Syntax.delta_constant
     (FStar_Pervasives_Native.Some FStar_Syntax_Syntax.Data_ctor)
 let (tm_fv :
   FStar_Syntax_Syntax.fv ->
@@ -111,8 +113,8 @@ let pat : 'uuuuu . 'uuuuu -> 'uuuuu FStar_Syntax_Syntax.withinfo_t =
 let (snat_type : FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax) =
   let uu___ =
     let uu___1 = lid "snat" in
-    FStar_Syntax_Syntax.lid_as_fv uu___1 FStar_Syntax_Syntax.delta_constant
-      FStar_Pervasives_Native.None in
+    FStar_Syntax_Syntax.lid_and_dd_as_fv uu___1
+      FStar_Syntax_Syntax.delta_constant FStar_Pervasives_Native.None in
   tm_fv uu___
 let (mk_match :
   FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->

--- a/src/extraction/FStar.Extraction.ML.Modul.fst
+++ b/src/extraction/FStar.Extraction.ML.Modul.fst
@@ -69,7 +69,7 @@ let always_fail lid t =
             U.abs bs (fail_exp lid t) None
     in
     let lb = {
-        lbname=Inr (S.lid_as_fv lid delta_constant None);
+        lbname=Inr (S.lid_as_fv lid None);
         lbunivs=[];
         lbtyp=t;
         lbeff=PC.effect_ML_lid();
@@ -207,7 +207,7 @@ let bundle_as_inductive_families env ses quals
                         [{dname=d; dtyp=t}]
                     | _ -> []) in
                 let metadata = extract_metadata se.sigattrs @ List.choose flag_of_qual quals in
-                let fv = S.lid_as_fv l delta_constant None in
+                let fv = S.lid_as_fv l None in
                 let _, env = UEnv.extend_type_name env fv in
                 env, [{   ifv = fv
                         ; iname=l
@@ -434,7 +434,7 @@ let extract_bundle_iface env se
                     (Util.udelta_unfold env_iparams)
                     (Term.term_as_mlty env_iparams ctor.dtyp) in
         let tys = (ml_tyvars, mlt) in
-        let fvv = lid_as_fv ctor.dname delta_constant None in
+        let fvv = lid_as_fv ctor.dname None in
         let env, _, b = extend_fv env fvv tys false in
         env, (fvv, b)
     in
@@ -488,7 +488,7 @@ let extract_type_declaration (g:uenv) is_interface_val lid quals attrs univs t
       then let g = UEnv.extend_with_tydef_declaration g lid in
            g, empty_iface, []
       else let bs, _ = U.arrow_formals t in
-           let fv = S.lid_as_fv lid delta_constant None in
+           let fv = S.lid_as_fv lid None in
            let lb = {
                lbname = Inr fv;
                lbunivs = univs;
@@ -513,7 +513,7 @@ let extract_reifiable_effect g ed
     * iface
     * list mlmodule1 =
     let extend_iface lid mlp exp exp_binding =
-        let fv = (S.lid_as_fv lid delta_equational None) in
+        let fv = (S.lid_as_fv lid None) in
         let lb = {
             mllb_name=snd mlp;
             mllb_tysc=None;
@@ -718,7 +718,7 @@ let karamel_fixup_qual (se:sigelt) : sigelt =
 let mark_sigelt_erased (se:sigelt) (g:uenv) : uenv =
   debug g (fun u -> BU.print1 ">>>> NOT extracting %s \n" (Print.sigelt_to_string_short se));
   // Cheating with delta levels and qualifiers below, but we don't ever use them.
-  List.fold_right (fun lid g -> extend_erased_fv g (S.lid_as_fv lid delta_constant None))
+  List.fold_right (fun lid g -> extend_erased_fv g (S.lid_as_fv lid None))
                   (U.lids_of_sigelt se) g
 
 (*  The top-level extraction of a sigelt to an interface *)
@@ -866,7 +866,7 @@ let extract_bundle env se =
               []
         in
         let tys = (ml_tyvars, mlt) in
-        let fvv = lid_as_fv ctor.dname delta_constant None in
+        let fvv = lid_as_fv ctor.dname None in
         let env, mls, _ = extend_fv env fvv tys false in
         env,
         (mls, List.zip names (argTypes mlt)) in

--- a/src/extraction/FStar.Extraction.ML.Modul.fst
+++ b/src/extraction/FStar.Extraction.ML.Modul.fst
@@ -50,7 +50,7 @@ type env_t = UEnv.uenv
 
 (*This approach assumes that failwith already exists in scope. This might be problematic, see below.*)
 let fail_exp (lid:lident) (t:typ) =
-    mk (Tm_app {hd=S.fvar (PC.failwith_lid()) delta_constant None; //NS delta: wrong
+    mk (Tm_app {hd=S.fvar (PC.failwith_lid()) None; //NS delta: wrong
                 args=[ S.iarg t
                      ; S.as_arg <|
                        mk (Tm_constant

--- a/src/extraction/FStar.Extraction.ML.Modul.fst
+++ b/src/extraction/FStar.Extraction.ML.Modul.fst
@@ -50,7 +50,7 @@ type env_t = UEnv.uenv
 
 (*This approach assumes that failwith already exists in scope. This might be problematic, see below.*)
 let fail_exp (lid:lident) (t:typ) =
-    mk (Tm_app {hd=S.fvar (PC.failwith_lid()) None; //NS delta: wrong
+    mk (Tm_app {hd=S.fvar (PC.failwith_lid()) None;
                 args=[ S.iarg t
                      ; S.as_arg <|
                        mk (Tm_constant

--- a/src/extraction/FStar.Extraction.ML.Term.fst
+++ b/src/extraction/FStar.Extraction.ML.Term.fst
@@ -1357,7 +1357,7 @@ and term_as_mlexpr' (g:uenv) (top:term) : (mlexpr * e_tag * mlty) =
           ml_unit, E_PURE, ml_unit_ty
 
         | Tm_quoted (qt, { qkind = Quote_dynamic }) ->
-          let ({exp_b_expr=fw}) = UEnv.lookup_fv t.pos g (S.lid_as_fv (PC.failwith_lid()) delta_constant None) in
+          let ({exp_b_expr=fw}) = UEnv.lookup_fv t.pos g (S.lid_as_fv (PC.failwith_lid()) None) in
           with_ty ml_int_ty <| MLE_App(fw, [with_ty ml_string_ty <| MLE_Const (MLC_String "Cannot evaluate open quotation at runtime")]),
           E_PURE,
           ml_int_ty
@@ -1513,7 +1513,7 @@ and term_as_mlexpr' (g:uenv) (top:term) : (mlexpr * e_tag * mlty) =
           term_as_mlexpr g t
 
         | Tm_app {hd={n=Tm_constant (Const_reflect _)}} ->
-            let ({exp_b_expr=fw}) = UEnv.lookup_fv t.pos g (S.lid_as_fv (PC.failwith_lid()) delta_constant None) in
+            let ({exp_b_expr=fw}) = UEnv.lookup_fv t.pos g (S.lid_as_fv (PC.failwith_lid()) None) in
             with_ty ml_int_ty <| MLE_App(fw, [with_ty ml_string_ty <| MLE_Const (MLC_String "Extraction of reflect is not supported")]),
             E_PURE,
             ml_int_ty
@@ -1949,7 +1949,7 @@ and term_as_mlexpr' (g:uenv) (top:term) : (mlexpr * e_tag * mlty) =
                            with_ty t_e <| MLE_Coerce (e, t_e, MLTY_Top)) in
              begin match mlbranches with
                 | [] ->
-                    let ({exp_b_expr=fw}) = UEnv.lookup_fv t.pos g (S.lid_as_fv (PC.failwith_lid()) delta_constant None) in
+                    let ({exp_b_expr=fw}) = UEnv.lookup_fv t.pos g (S.lid_as_fv (PC.failwith_lid()) None) in
                     with_ty ml_int_ty <| MLE_App(fw, [with_ty ml_string_ty <| MLE_Const (MLC_String "unreachable")]),
                     E_PURE,
                     ml_int_ty

--- a/src/extraction/FStar.Extraction.ML.UEnv.fst
+++ b/src/extraction/FStar.Extraction.ML.UEnv.fst
@@ -533,7 +533,7 @@ let extend_with_monad_op_name g (ed:Syntax.eff_decl) nm ts =
     (* Extract bind and return of effects as (unqualified) projectors of that effect, *)
     (* same as for actions. However, extracted code should not make explicit use of them. *)
     let lid = U.mk_field_projector_name_from_ident ed.mname (id_of_text nm) in
-    let g, mlid, exp_b = extend_fv g (lid_as_fv lid delta_constant None) ts false in
+    let g, mlid, exp_b = extend_fv g (lid_as_fv lid None) ts false in
     let mlp = mlns_of_lid lid, mlid in
     mlp, lid, exp_b, g
 
@@ -543,7 +543,7 @@ let extend_with_action_name g (ed:Syntax.eff_decl) (a:Syntax.action) ts =
     let nm = string_of_id (ident_of_lid a.action_name) in
     let module_name = ns_of_lid ed.mname in
     let lid = Ident.lid_of_ids (module_name@[Ident.id_of_text nm]) in
-    let g, mlid, exp_b = extend_fv g (lid_as_fv lid delta_constant None) ts false in
+    let g, mlid, exp_b = extend_fv g (lid_as_fv lid None) ts false in
     let mlp = mlns_of_lid lid, mlid in
     mlp, lid, exp_b, g
 
@@ -617,6 +617,6 @@ let new_uenv (e:TypeChecker.Env.env)
     let a = "'a" in
     let failwith_ty = ([a], MLTY_Fun(MLTY_Named([], (["Prims"], "string")), E_IMPURE, MLTY_Var a)) in
     let g, _, _ =
-        extend_lb env (Inr (lid_as_fv (Const.failwith_lid()) delta_constant None)) tun failwith_ty false
+        extend_lb env (Inr (lid_as_fv (Const.failwith_lid()) None)) tun failwith_ty false
     in
     g

--- a/src/fstar/FStar.CheckedFiles.fst
+++ b/src/fstar/FStar.CheckedFiles.fst
@@ -40,7 +40,7 @@ module Dep     = FStar.Parser.Dep
  * detect when loading the cache that the version number is same
  * It needs to be kept in sync with prims.fst
  *)
-let cache_version_number = 55
+let cache_version_number = 56
 
 (*
  * Abbreviation for what we store in the checked files (stages as described below)

--- a/src/reflection/FStar.Reflection.Basic.fst
+++ b/src/reflection/FStar.Reflection.Basic.fst
@@ -119,7 +119,7 @@ let pack_fv (ns:list string) : fv =
             None
         in
         // FIXME: Get a proper delta depth
-        lid_as_fv' (PC.p2l ns) quals
+        lid_as_fv (PC.p2l ns) quals
     in
     match !N.reflection_env_hook with
     | None -> fallback ()
@@ -129,7 +129,7 @@ let pack_fv (ns:list string) : fv =
      | Some (Inr (se, _us), _rng) ->
          let quals = DsEnv.fv_qual_of_se se in
          // FIXME: Get a proper delta depth
-         lid_as_fv' (PC.p2l ns) quals
+         lid_as_fv (PC.p2l ns) quals
      | _ ->
          fallback ()
 
@@ -458,11 +458,11 @@ let lookup_attr (attr:term) (env:Env.env) : list fv =
         List.concatMap (fun se -> match U.lid_of_sigelt se with
                                   | None -> []
                                   // FIXME: Get a proper delta depth
-                                  | Some l -> [S.lid_as_fv' l None]) ses
+                                  | Some l -> [S.lid_as_fv l None]) ses
     | _ -> []
 
 let all_defs_in_env (env:Env.env) : list fv =
-    List.map (fun l -> S.lid_as_fv' l None) (Env.lidents env) // |> take 10
+    List.map (fun l -> S.lid_as_fv l None) (Env.lidents env) // |> take 10
 
 let defs_in_module (env:Env.env) (modul:name) : list fv =
     List.concatMap
@@ -470,7 +470,7 @@ let defs_in_module (env:Env.env) (modul:name) : list fv =
                 (* must succeed, ids_of_lid always returns a non-empty list *)
                 let ns = Ident.ids_of_lid l |> init |> List.map Ident.string_of_id in
                 if ns = modul
-                then [S.lid_as_fv' l None]
+                then [S.lid_as_fv l None]
                 else [])
         (Env.lidents env)
 

--- a/src/reflection/FStar.Reflection.Basic.fst
+++ b/src/reflection/FStar.Reflection.Basic.fst
@@ -118,7 +118,6 @@ let pack_fv (ns:list string) : fv =
             if Ident.lid_equals lid PC.none_lid then Some Data_ctor else
             None
         in
-        // FIXME: Get a proper delta depth
         lid_as_fv (PC.p2l ns) quals
     in
     match !N.reflection_env_hook with
@@ -128,7 +127,6 @@ let pack_fv (ns:list string) : fv =
      match qninfo with
      | Some (Inr (se, _us), _rng) ->
          let quals = DsEnv.fv_qual_of_se se in
-         // FIXME: Get a proper delta depth
          lid_as_fv (PC.p2l ns) quals
      | _ ->
          fallback ()
@@ -457,7 +455,6 @@ let lookup_attr (attr:term) (env:Env.env) : list fv =
         let ses = Env.lookup_attr env (Ident.string_of_lid (lid_of_fv fv)) in
         List.concatMap (fun se -> match U.lid_of_sigelt se with
                                   | None -> []
-                                  // FIXME: Get a proper delta depth
                                   | Some l -> [S.lid_as_fv l None]) ses
     | _ -> []
 

--- a/src/reflection/FStar.Reflection.Basic.fst
+++ b/src/reflection/FStar.Reflection.Basic.fst
@@ -119,7 +119,7 @@ let pack_fv (ns:list string) : fv =
             None
         in
         // FIXME: Get a proper delta depth
-        lid_as_fv (PC.p2l ns) (Delta_constant_at_level 999) quals
+        lid_as_fv' (PC.p2l ns) quals
     in
     match !N.reflection_env_hook with
     | None -> fallback ()
@@ -129,7 +129,7 @@ let pack_fv (ns:list string) : fv =
      | Some (Inr (se, _us), _rng) ->
          let quals = DsEnv.fv_qual_of_se se in
          // FIXME: Get a proper delta depth
-         lid_as_fv (PC.p2l ns) (Delta_constant_at_level 999) quals
+         lid_as_fv' (PC.p2l ns) quals
      | _ ->
          fallback ()
 
@@ -458,11 +458,11 @@ let lookup_attr (attr:term) (env:Env.env) : list fv =
         List.concatMap (fun se -> match U.lid_of_sigelt se with
                                   | None -> []
                                   // FIXME: Get a proper delta depth
-                                  | Some l -> [S.lid_as_fv l (S.Delta_constant_at_level 999) None]) ses
+                                  | Some l -> [S.lid_as_fv' l None]) ses
     | _ -> []
 
 let all_defs_in_env (env:Env.env) : list fv =
-    List.map (fun l -> S.lid_as_fv l (S.Delta_constant_at_level 999) None) (Env.lidents env) // |> take 10
+    List.map (fun l -> S.lid_as_fv' l None) (Env.lidents env) // |> take 10
 
 let defs_in_module (env:Env.env) (modul:name) : list fv =
     List.concatMap
@@ -470,7 +470,7 @@ let defs_in_module (env:Env.env) (modul:name) : list fv =
                 (* must succeed, ids_of_lid always returns a non-empty list *)
                 let ns = Ident.ids_of_lid l |> init |> List.map Ident.string_of_id in
                 if ns = modul
-                then [S.lid_as_fv l (S.Delta_constant_at_level 999) None]
+                then [S.lid_as_fv' l None]
                 else [])
         (Env.lidents env)
 

--- a/src/reflection/FStar.Reflection.Constants.fst
+++ b/src/reflection/FStar.Reflection.Constants.fst
@@ -53,7 +53,7 @@ let fstar_refl_data_lid      s = fstar_refl_lid ["Data";      s]
 let fstar_refl_data_const s =
     let lid = fstar_refl_data_lid s in
     { lid = lid
-    ; fv  = lid_as_fv' lid (Some Data_ctor)
+    ; fv  = lid_as_fv lid (Some Data_ctor)
     ; t   = tdataconstr lid
     }
 
@@ -67,8 +67,8 @@ let mk_refl_data_lid_as_fv     (s:string) = fvconst (fstar_refl_data_lid s)
 let mk_inspect_pack_pair s =
     let inspect_lid = fstar_refl_builtins_lid ("inspect" ^ s) in
     let pack_lid    = fstar_refl_builtins_lid ("pack" ^ s) in
-    let inspect_fv  = lid_as_fv' inspect_lid None in
-    let pack_fv     = lid_as_fv' pack_lid    None in
+    let inspect_fv  = lid_as_fv inspect_lid None in
+    let pack_fv     = lid_as_fv pack_lid    None in
     let inspect     = { lid = inspect_lid ; fv = inspect_fv ; t = fv_to_tm inspect_fv } in
     let pack        = { lid = pack_lid    ; fv = pack_fv    ; t = fv_to_tm pack_fv } in
     (inspect, pack)
@@ -143,7 +143,7 @@ let ref_Mk_bv =
     let attr = Record_ctor (fstar_refl_data_lid "bv_view", [
                                 Ident.mk_ident ("bv_ppname", Range.dummyRange);
                                 Ident.mk_ident ("bv_index" , Range.dummyRange)]) in
-    let fv = lid_as_fv' lid (Some attr) in
+    let fv = lid_as_fv lid (Some attr) in
     { lid = lid
     ; fv  = fv
     ; t   = fv_to_tm fv
@@ -156,7 +156,7 @@ let ref_Mk_binder =
                             Ident.mk_ident ("binder_qual", Range.dummyRange);
                             Ident.mk_ident ("binder_attrs", Range.dummyRange);
                             Ident.mk_ident ("binder_sort"  , Range.dummyRange)]) in
-  let fv = lid_as_fv' lid (Some attr) in
+  let fv = lid_as_fv lid (Some attr) in
   { lid = lid;
     fv = fv;
     t = fv_to_tm fv }
@@ -169,7 +169,7 @@ let ref_Mk_lb =
                                 Ident.mk_ident ("lb_typ" , Range.dummyRange);
                                 Ident.mk_ident ("lb_def" , Range.dummyRange)
                                 ]) in
-    let fv = lid_as_fv' lid (Some attr) in
+    let fv = lid_as_fv lid (Some attr) in
     { lid = lid
     ; fv  = fv
     ; t   = fv_to_tm fv
@@ -275,6 +275,6 @@ let ord_Gt_lid = Ident.lid_of_path (["FStar"; "Order"; "Gt"]) Range.dummyRange
 let ord_Lt = tdataconstr ord_Lt_lid
 let ord_Eq = tdataconstr ord_Eq_lid
 let ord_Gt = tdataconstr ord_Gt_lid
-let ord_Lt_fv = lid_as_fv' ord_Lt_lid (Some Data_ctor)
-let ord_Eq_fv = lid_as_fv' ord_Eq_lid (Some Data_ctor)
-let ord_Gt_fv = lid_as_fv' ord_Gt_lid (Some Data_ctor)
+let ord_Lt_fv = lid_as_fv ord_Lt_lid (Some Data_ctor)
+let ord_Eq_fv = lid_as_fv ord_Eq_lid (Some Data_ctor)
+let ord_Gt_fv = lid_as_fv ord_Gt_lid (Some Data_ctor)

--- a/src/reflection/FStar.Reflection.Constants.fst
+++ b/src/reflection/FStar.Reflection.Constants.fst
@@ -53,7 +53,7 @@ let fstar_refl_data_lid      s = fstar_refl_lid ["Data";      s]
 let fstar_refl_data_const s =
     let lid = fstar_refl_data_lid s in
     { lid = lid
-    ; fv  = lid_as_fv lid delta_constant (Some Data_ctor)
+    ; fv  = lid_as_fv' lid (Some Data_ctor)
     ; t   = tdataconstr lid
     }
 
@@ -67,8 +67,8 @@ let mk_refl_data_lid_as_fv     (s:string) = fvconst (fstar_refl_data_lid s)
 let mk_inspect_pack_pair s =
     let inspect_lid = fstar_refl_builtins_lid ("inspect" ^ s) in
     let pack_lid    = fstar_refl_builtins_lid ("pack" ^ s) in
-    let inspect_fv  = lid_as_fv inspect_lid (Delta_constant_at_level 1) None in
-    let pack_fv     = lid_as_fv pack_lid    (Delta_constant_at_level 1) None in
+    let inspect_fv  = lid_as_fv' inspect_lid None in
+    let pack_fv     = lid_as_fv' pack_lid    None in
     let inspect     = { lid = inspect_lid ; fv = inspect_fv ; t = fv_to_tm inspect_fv } in
     let pack        = { lid = pack_lid    ; fv = pack_fv    ; t = fv_to_tm pack_fv } in
     (inspect, pack)
@@ -143,7 +143,7 @@ let ref_Mk_bv =
     let attr = Record_ctor (fstar_refl_data_lid "bv_view", [
                                 Ident.mk_ident ("bv_ppname", Range.dummyRange);
                                 Ident.mk_ident ("bv_index" , Range.dummyRange)]) in
-    let fv = lid_as_fv lid delta_constant (Some attr) in
+    let fv = lid_as_fv' lid (Some attr) in
     { lid = lid
     ; fv  = fv
     ; t   = fv_to_tm fv
@@ -156,7 +156,7 @@ let ref_Mk_binder =
                             Ident.mk_ident ("binder_qual", Range.dummyRange);
                             Ident.mk_ident ("binder_attrs", Range.dummyRange);
                             Ident.mk_ident ("binder_sort"  , Range.dummyRange)]) in
-  let fv = lid_as_fv lid delta_constant (Some attr) in
+  let fv = lid_as_fv' lid (Some attr) in
   { lid = lid;
     fv = fv;
     t = fv_to_tm fv }
@@ -169,7 +169,7 @@ let ref_Mk_lb =
                                 Ident.mk_ident ("lb_typ" , Range.dummyRange);
                                 Ident.mk_ident ("lb_def" , Range.dummyRange)
                                 ]) in
-    let fv = lid_as_fv lid delta_constant (Some attr) in
+    let fv = lid_as_fv' lid (Some attr) in
     { lid = lid
     ; fv  = fv
     ; t   = fv_to_tm fv
@@ -275,6 +275,6 @@ let ord_Gt_lid = Ident.lid_of_path (["FStar"; "Order"; "Gt"]) Range.dummyRange
 let ord_Lt = tdataconstr ord_Lt_lid
 let ord_Eq = tdataconstr ord_Eq_lid
 let ord_Gt = tdataconstr ord_Gt_lid
-let ord_Lt_fv = lid_as_fv ord_Lt_lid delta_constant (Some Data_ctor)
-let ord_Eq_fv = lid_as_fv ord_Eq_lid delta_constant (Some Data_ctor)
-let ord_Gt_fv = lid_as_fv ord_Gt_lid delta_constant (Some Data_ctor)
+let ord_Lt_fv = lid_as_fv' ord_Lt_lid (Some Data_ctor)
+let ord_Eq_fv = lid_as_fv' ord_Eq_lid (Some Data_ctor)
+let ord_Gt_fv = lid_as_fv' ord_Gt_lid (Some Data_ctor)

--- a/src/reflection/FStar.Reflection.NBEEmbeddings.fst
+++ b/src/reflection/FStar.Reflection.NBEEmbeddings.fst
@@ -342,14 +342,14 @@ let e_ident : embedding I.ident =
         | Some (rng, s) -> Some (I.mk_ident (s, rng))
         | None -> None
     in
-    let range_fv = (lid_as_fv' PC.range_lid  None) in
-    let string_fv = (lid_as_fv' PC.string_lid None) in
+    let range_fv = (lid_as_fv PC.range_lid  None) in
+    let string_fv = (lid_as_fv PC.string_lid None) in
     let et =
       ET_app (FStar.Ident.string_of_lid PC.lid_tuple2,
               [fv_as_emb_typ range_fv;
                fv_as_emb_typ string_fv])
     in
-    mk_emb embed_ident unembed_ident (mkFV (lid_as_fv' PC.lid_tuple2 None)
+    mk_emb embed_ident unembed_ident (mkFV (lid_as_fv PC.lid_tuple2 None)
                                            [U_zero;U_zero]
                                            [as_arg (mkFV range_fv [] []);
                                             as_arg (mkFV string_fv [] [])]) et
@@ -697,7 +697,7 @@ let e_order =
             Err.log_issue Range.dummyRange (Err.Warning_NotEmbedded, (BU.format1 "Not an embedded order: %s" (t_to_string t)));
             None
     in
-    mk_emb' embed_order unembed_order (lid_as_fv' PC.order_lid None)
+    mk_emb' embed_order unembed_order (lid_as_fv PC.order_lid None)
 
 let e_sigelt =
     let embed_sigelt cb (se:sigelt) : t =
@@ -957,4 +957,4 @@ let e_vconfig =
     let unemb cb (t:t) : option order =
       failwith "unemb vconfig NBE"
     in
-    mk_emb' emb unemb (lid_as_fv' PC.vconfig_lid None)
+    mk_emb' emb unemb (lid_as_fv PC.vconfig_lid None)

--- a/src/reflection/FStar.Reflection.NBEEmbeddings.fst
+++ b/src/reflection/FStar.Reflection.NBEEmbeddings.fst
@@ -342,14 +342,14 @@ let e_ident : embedding I.ident =
         | Some (rng, s) -> Some (I.mk_ident (s, rng))
         | None -> None
     in
-    let range_fv = (lid_as_fv PC.range_lid  delta_constant None) in
-    let string_fv = (lid_as_fv PC.string_lid delta_constant None) in
+    let range_fv = (lid_as_fv' PC.range_lid  None) in
+    let string_fv = (lid_as_fv' PC.string_lid None) in
     let et =
       ET_app (FStar.Ident.string_of_lid PC.lid_tuple2,
               [fv_as_emb_typ range_fv;
                fv_as_emb_typ string_fv])
     in
-    mk_emb embed_ident unembed_ident (mkFV (lid_as_fv PC.lid_tuple2 delta_constant None)
+    mk_emb embed_ident unembed_ident (mkFV (lid_as_fv' PC.lid_tuple2 None)
                                            [U_zero;U_zero]
                                            [as_arg (mkFV range_fv [] []);
                                             as_arg (mkFV string_fv [] [])]) et
@@ -697,7 +697,7 @@ let e_order =
             Err.log_issue Range.dummyRange (Err.Warning_NotEmbedded, (BU.format1 "Not an embedded order: %s" (t_to_string t)));
             None
     in
-    mk_emb' embed_order unembed_order (lid_as_fv PC.order_lid delta_constant None)
+    mk_emb' embed_order unembed_order (lid_as_fv' PC.order_lid None)
 
 let e_sigelt =
     let embed_sigelt cb (se:sigelt) : t =
@@ -957,4 +957,4 @@ let e_vconfig =
     let unemb cb (t:t) : option order =
       failwith "unemb vconfig NBE"
     in
-    mk_emb' emb unemb (lid_as_fv PC.vconfig_lid delta_constant None)
+    mk_emb' emb unemb (lid_as_fv' PC.vconfig_lid None)

--- a/src/smtencoding/FStar.SMTEncoding.Encode.fst
+++ b/src/smtencoding/FStar.SMTEncoding.Encode.fst
@@ -1120,7 +1120,7 @@ and encode_sigelt' (env:env_t) (se:sigelt) : (decls_t * env_t) =
             | _ -> false)) in
         if will_encode_definition
         then [], env //nothing to do at the declaration; wait to encode the definition
-        else let fv = S.lid_as_fv lid delta_constant None in
+        else let fv = S.lid_as_fv lid None in
              let decls, env =
                encode_top_level_val
                  (se.sigattrs |> BU.for_some is_uninterpreted_by_smt)
@@ -1755,7 +1755,7 @@ let encode_env_bindings (env:env_t) (bindings:list S.binding) : (decls_t * env_t
 
         | S.Binding_lid(x, (_, t)) ->
             let t_norm = norm_before_encoding env t in
-            let fv = S.lid_as_fv x delta_constant None in
+            let fv = S.lid_as_fv x None in
 //            Printf.printf "Encoding %s at type %s\n" (Print.lid_to_string x) (Print.term_to_string t);
             let g, env' = encode_free_var false env fv t t_norm [] in
             i+1, decls@g, env'

--- a/src/smtencoding/FStar.SMTEncoding.Encode.fst
+++ b/src/smtencoding/FStar.SMTEncoding.Encode.fst
@@ -1250,7 +1250,7 @@ and encode_sigelt' (env:env_t) (se:sigelt) : (decls_t * env_t) =
                TcTerm.level_of_type
                  env_tps
                  (S.mk_Tm_app
-                   (S.fvar t (Delta_constant_at_level 0) None)
+                   (S.fvar t None)
                    (snd (U.args_of_binders tps))
                    (Ident.range_of_lid t))
                  k

--- a/src/smtencoding/FStar.SMTEncoding.EncodeTerm.fst
+++ b/src/smtencoding/FStar.SMTEncoding.EncodeTerm.fst
@@ -134,7 +134,7 @@ let maybe_whnf env t =
 
 let trivial_post t : Syntax.term =
     U.abs [null_binder t]
-             (Syntax.fvar Const.true_lid delta_constant None)
+             (Syntax.fvar Const.true_lid None)
              None
 
 let mk_Apply e (vars:fvs) =

--- a/src/syntax/FStar.Syntax.DsEnv.fst
+++ b/src/syntax/FStar.Syntax.DsEnv.fst
@@ -767,12 +767,12 @@ let try_lookup_datacon env (lid:lident) =
       match se with
       | ({ sigel = Sig_declare_typ _; sigquals = quals }, _) ->
         if quals |> BU.for_some (function Assumption -> true | _ -> false)
-        then Some (lid_as_fv lid delta_constant None)
+        then Some (lid_and_dd_as_fv lid delta_constant None)
         else None
       | ({ sigel = Sig_splice _ }, _) (* A spliced datacon *)
       | ({ sigel = Sig_datacon _ }, _) ->
          let qual = fv_qual_of_se (fst se) in
-         Some (lid_as_fv lid delta_constant qual)
+         Some (lid_and_dd_as_fv lid delta_constant qual)
       | _ -> None in
   resolve_in_open_namespaces' env lid (fun _ -> None) (fun _ -> None) k_global_def
 
@@ -1372,4 +1372,4 @@ let resolve_name (e:env) (name:lident)
     )
     | Some (Eff_name(se, l)) ->
       let _ =  delta_depth_of_declaration in
-      Some (Inr (S.lid_as_fv l delta_constant None))
+      Some (Inr (S.lid_and_dd_as_fv l delta_constant None))

--- a/src/syntax/FStar.Syntax.DsEnv.fst
+++ b/src/syntax/FStar.Syntax.DsEnv.fst
@@ -178,7 +178,7 @@ let unmangleMap = [("op_ColonColon", "Cons", delta_constant, Some Data_ctor);
 let unmangleOpName (id:ident) : option term =
   find_map unmangleMap (fun (x,y,dd,dq) ->
     if string_of_id id = x
-    then Some (S.fvar (lid_of_path ["Prims"; y] (range_of_id id)) dd dq) //NS delta ok
+    then Some (S.fvar_with_dd (lid_of_path ["Prims"; y] (range_of_id id)) dd dq) //NS delta ok
     else None)
 
 type cont_t 'a =
@@ -528,11 +528,11 @@ let try_lookup_name any_val exclude_interf env (lid:lident) : option foundname =
       | (_, true) when exclude_interf -> None
       | (se, _) ->
         begin match se.sigel with
-          | Sig_inductive_typ _ ->   Some (Term_name(S.fvar source_lid delta_constant None, se.sigattrs)) //NS delta: ok
-          | Sig_datacon _ ->         Some (Term_name(S.fvar source_lid delta_constant (fv_qual_of_se se), se.sigattrs)) //NS delta: ok
+          | Sig_inductive_typ _ ->   Some (Term_name (S.fvar_with_dd source_lid delta_constant None, se.sigattrs)) //NS delta: ok
+          | Sig_datacon _ ->         Some (Term_name (S.fvar_with_dd source_lid delta_constant (fv_qual_of_se se), se.sigattrs)) //NS delta: ok
           | Sig_let {lbs=(_, lbs)} ->
             let fv = lb_fv lbs source_lid in
-            Some (Term_name(S.fvar source_lid (fv.fv_delta |> must) fv.fv_qual, se.sigattrs))
+            Some (Term_name(S.fvar_with_dd source_lid (fv.fv_delta |> must) fv.fv_qual, se.sigattrs))
           | Sig_declare_typ {lid} ->
             let quals = se.sigquals in
             if any_val //only in scope in an interface (any_val is true) or if the val is assumed
@@ -544,14 +544,14 @@ let try_lookup_name any_val exclude_interf env (lid:lident) : option foundname =
                         let refl_const = S.mk (Tm_constant (FStar.Const.Const_reflect refl_monad)) occurrence_range in
                         Some (Term_name (refl_const, se.sigattrs))
                  | _ ->
-                   Some (Term_name(fvar lid dd (fv_qual_of_se se), se.sigattrs)) //NS delta: ok
+                   Some (Term_name(fvar_with_dd lid dd (fv_qual_of_se se), se.sigattrs)) //NS delta: ok
                  end
             else None
           | Sig_new_effect(ne) -> Some (Eff_name(se, set_lid_range ne.mname (range_of_lid source_lid)))
           | Sig_effect_abbrev _ ->   Some (Eff_name(se, source_lid))
           | Sig_splice {lids; tac=t} ->
                 // TODO: This depth is probably wrong
-                Some (Term_name (S.fvar source_lid (Delta_constant_at_level 1) None, [])) //NS delta: wrong
+                Some (Term_name (S.fvar_with_dd source_lid (Delta_constant_at_level 1) None, [])) //NS delta: wrong
           | _ -> None
         end in
 
@@ -560,7 +560,7 @@ let try_lookup_name any_val exclude_interf env (lid:lident) : option foundname =
 
   let k_rec_binding (id, l, dd, used_marker) =
     used_marker := true;
-    Some (Term_name(S.fvar (set_lid_range l (range_of_lid lid)) dd None, [])) //NS delta: ok
+    Some (Term_name(S.fvar_with_dd (set_lid_range l (range_of_lid lid)) dd None, [])) //NS delta: ok
   in
 
   let found_unmangled = match ns_of_lid lid with
@@ -638,7 +638,7 @@ let try_lookup_let env (lid:lident) =
   let k_global_def lid = function
       | ({ sigel = Sig_let {lbs=(_, lbs)} }, _) ->
         let fv = lb_fv lbs lid in
-        Some (fvar lid (fv.fv_delta |> must) fv.fv_qual) //NS delta: ok
+        Some (fvar_with_dd lid (fv.fv_delta |> must) fv.fv_qual) //NS delta: ok
       | _ -> None in
   resolve_in_open_namespaces' env lid (fun _ -> None) (fun _ -> None) k_global_def
 

--- a/src/syntax/FStar.Syntax.DsEnv.fst
+++ b/src/syntax/FStar.Syntax.DsEnv.fst
@@ -532,7 +532,7 @@ let try_lookup_name any_val exclude_interf env (lid:lident) : option foundname =
           | Sig_datacon _ ->         Some (Term_name(S.fvar source_lid delta_constant (fv_qual_of_se se), se.sigattrs)) //NS delta: ok
           | Sig_let {lbs=(_, lbs)} ->
             let fv = lb_fv lbs source_lid in
-            Some (Term_name(S.fvar source_lid fv.fv_delta fv.fv_qual, se.sigattrs))
+            Some (Term_name(S.fvar source_lid (fv.fv_delta |> must) fv.fv_qual, se.sigattrs))
           | Sig_declare_typ {lid} ->
             let quals = se.sigquals in
             if any_val //only in scope in an interface (any_val is true) or if the val is assumed
@@ -638,7 +638,7 @@ let try_lookup_let env (lid:lident) =
   let k_global_def lid = function
       | ({ sigel = Sig_let {lbs=(_, lbs)} }, _) ->
         let fv = lb_fv lbs lid in
-        Some (fvar lid fv.fv_delta fv.fv_qual) //NS delta: ok
+        Some (fvar lid (fv.fv_delta |> must) fv.fv_qual) //NS delta: ok
       | _ -> None in
   resolve_in_open_namespaces' env lid (fun _ -> None) (fun _ -> None) k_global_def
 

--- a/src/syntax/FStar.Syntax.DsEnv.fst
+++ b/src/syntax/FStar.Syntax.DsEnv.fst
@@ -532,7 +532,7 @@ let try_lookup_name any_val exclude_interf env (lid:lident) : option foundname =
           | Sig_datacon _ ->         Some (Term_name (S.fvar_with_dd source_lid delta_constant (fv_qual_of_se se), se.sigattrs)) //NS delta: ok
           | Sig_let {lbs=(_, lbs)} ->
             let fv = lb_fv lbs source_lid in
-            Some (Term_name(S.fvar_with_dd source_lid (fv.fv_delta |> must) fv.fv_qual, se.sigattrs))
+            Some (Term_name (S.fvar_with_dd source_lid (fv.fv_delta |> must) fv.fv_qual, se.sigattrs))
           | Sig_declare_typ {lid} ->
             let quals = se.sigquals in
             if any_val //only in scope in an interface (any_val is true) or if the val is assumed

--- a/src/syntax/FStar.Syntax.Embeddings.fst
+++ b/src/syntax/FStar.Syntax.Embeddings.fst
@@ -112,7 +112,7 @@ otherwise since reduction is blocked.)
 
 let id_norm_cb : norm_cb = function
     | Inr x -> x
-    | Inl l -> S.fv_to_tm (S.lid_and_dd_as_fv l delta_equational None)
+    | Inl l -> S.fv_to_tm (S.lid_as_fv l None)
 exception Embedding_failure
 exception Unembedding_failure
 
@@ -418,7 +418,7 @@ let e_option (ea : embedding 'a) =
                   let shadow_a = map_shadow shadow (fun t ->
                     let v = Ident.mk_ident ("v", rng) in
                     let some_v = U.mk_field_projector_name_from_ident PC.some_lid v in
-                    let some_v_tm = S.fv_to_tm (lid_and_dd_as_fv some_v delta_equational None) in
+                    let some_v_tm = S.fv_to_tm (lid_as_fv some_v None) in
                     S.mk_Tm_app (S.mk_Tm_uinst some_v_tm [U_zero])
                                 [S.iarg (type_of ea); S.as_arg t]
                                 rng)
@@ -470,7 +470,7 @@ let e_tuple2 (ea:embedding 'a) (eb:embedding 'b) =
             (fun () ->
                 let proj i ab =
                     let proj_1 = U.mk_field_projector_name (PC.mk_tuple_data_lid 2 rng) (S.null_bv S.tun) i in
-                    let proj_1_tm = S.fv_to_tm (lid_and_dd_as_fv proj_1 delta_equational None) in
+                    let proj_1_tm = S.fv_to_tm (lid_as_fv proj_1 None) in
                     S.mk_Tm_app (S.mk_Tm_uinst proj_1_tm [U_zero])
                                 [S.iarg (type_of ea);
                                  S.iarg (type_of eb);
@@ -530,7 +530,7 @@ let e_tuple3 (ea:embedding 'a) (eb:embedding 'b) (ec:embedding 'c) =
             (fun () ->
                 let proj i abc =
                     let proj_i = U.mk_field_projector_name (PC.mk_tuple_data_lid 3 rng) (S.null_bv S.tun) i in
-                    let proj_i_tm = S.fv_to_tm (lid_and_dd_as_fv proj_i delta_equational None) in
+                    let proj_i_tm = S.fv_to_tm (lid_as_fv proj_i None) in
                     S.mk_Tm_app (S.mk_Tm_uinst proj_i_tm [U_zero])
                                 [S.iarg (type_of ea);
                                  S.iarg (type_of eb);
@@ -601,7 +601,7 @@ let e_either (ea:embedding 'a) (eb:embedding 'b) =
                 let shadow_a = map_shadow shadow (fun t ->
                   let v = Ident.mk_ident ("v", rng) in
                   let some_v = U.mk_field_projector_name_from_ident PC.inl_lid v in
-                  let some_v_tm = S.fv_to_tm (lid_and_dd_as_fv some_v delta_equational None) in
+                  let some_v_tm = S.fv_to_tm (lid_as_fv some_v None) in
                   S.mk_Tm_app (S.mk_Tm_uinst some_v_tm [U_zero])
                               [S.iarg (type_of ea); S.iarg (type_of eb); S.as_arg t]
                               rng)
@@ -616,7 +616,7 @@ let e_either (ea:embedding 'a) (eb:embedding 'b) =
                 let shadow_b = map_shadow shadow (fun t ->
                   let v = Ident.mk_ident ("v", rng) in
                   let some_v = U.mk_field_projector_name_from_ident PC.inr_lid v in
-                  let some_v_tm = S.fv_to_tm (lid_and_dd_as_fv some_v delta_equational None) in
+                  let some_v_tm = S.fv_to_tm (lid_as_fv some_v None) in
                   S.mk_Tm_app (S.mk_Tm_uinst some_v_tm [U_zero])
                               [S.iarg (type_of ea); S.iarg (type_of eb); S.as_arg t]
                               rng)
@@ -685,7 +685,7 @@ let e_list (ea:embedding 'a) =
                   let proj f cons_tm =
                     let fid = Ident.mk_ident (f, rng) in
                     let proj = U.mk_field_projector_name_from_ident PC.cons_lid fid in
-                    let proj_tm = S.fv_to_tm (lid_and_dd_as_fv proj delta_equational None) in
+                    let proj_tm = S.fv_to_tm (lid_as_fv proj None) in
                     S.mk_Tm_app (S.mk_Tm_uinst proj_tm [U_zero])
                                 [S.iarg (type_of ea);
                                  S.as_arg cons_tm]

--- a/src/syntax/FStar.Syntax.Embeddings.fst
+++ b/src/syntax/FStar.Syntax.Embeddings.fst
@@ -112,7 +112,7 @@ otherwise since reduction is blocked.)
 
 let id_norm_cb : norm_cb = function
     | Inr x -> x
-    | Inl l -> S.fv_to_tm (S.lid_as_fv l delta_equational None)
+    | Inl l -> S.fv_to_tm (S.lid_and_dd_as_fv l delta_equational None)
 exception Embedding_failure
 exception Unembedding_failure
 
@@ -418,7 +418,7 @@ let e_option (ea : embedding 'a) =
                   let shadow_a = map_shadow shadow (fun t ->
                     let v = Ident.mk_ident ("v", rng) in
                     let some_v = U.mk_field_projector_name_from_ident PC.some_lid v in
-                    let some_v_tm = S.fv_to_tm (lid_as_fv some_v delta_equational None) in
+                    let some_v_tm = S.fv_to_tm (lid_and_dd_as_fv some_v delta_equational None) in
                     S.mk_Tm_app (S.mk_Tm_uinst some_v_tm [U_zero])
                                 [S.iarg (type_of ea); S.as_arg t]
                                 rng)
@@ -470,7 +470,7 @@ let e_tuple2 (ea:embedding 'a) (eb:embedding 'b) =
             (fun () ->
                 let proj i ab =
                     let proj_1 = U.mk_field_projector_name (PC.mk_tuple_data_lid 2 rng) (S.null_bv S.tun) i in
-                    let proj_1_tm = S.fv_to_tm (lid_as_fv proj_1 delta_equational None) in
+                    let proj_1_tm = S.fv_to_tm (lid_and_dd_as_fv proj_1 delta_equational None) in
                     S.mk_Tm_app (S.mk_Tm_uinst proj_1_tm [U_zero])
                                 [S.iarg (type_of ea);
                                  S.iarg (type_of eb);
@@ -530,7 +530,7 @@ let e_tuple3 (ea:embedding 'a) (eb:embedding 'b) (ec:embedding 'c) =
             (fun () ->
                 let proj i abc =
                     let proj_i = U.mk_field_projector_name (PC.mk_tuple_data_lid 3 rng) (S.null_bv S.tun) i in
-                    let proj_i_tm = S.fv_to_tm (lid_as_fv proj_i delta_equational None) in
+                    let proj_i_tm = S.fv_to_tm (lid_and_dd_as_fv proj_i delta_equational None) in
                     S.mk_Tm_app (S.mk_Tm_uinst proj_i_tm [U_zero])
                                 [S.iarg (type_of ea);
                                  S.iarg (type_of eb);
@@ -601,7 +601,7 @@ let e_either (ea:embedding 'a) (eb:embedding 'b) =
                 let shadow_a = map_shadow shadow (fun t ->
                   let v = Ident.mk_ident ("v", rng) in
                   let some_v = U.mk_field_projector_name_from_ident PC.inl_lid v in
-                  let some_v_tm = S.fv_to_tm (lid_as_fv some_v delta_equational None) in
+                  let some_v_tm = S.fv_to_tm (lid_and_dd_as_fv some_v delta_equational None) in
                   S.mk_Tm_app (S.mk_Tm_uinst some_v_tm [U_zero])
                               [S.iarg (type_of ea); S.iarg (type_of eb); S.as_arg t]
                               rng)
@@ -616,7 +616,7 @@ let e_either (ea:embedding 'a) (eb:embedding 'b) =
                 let shadow_b = map_shadow shadow (fun t ->
                   let v = Ident.mk_ident ("v", rng) in
                   let some_v = U.mk_field_projector_name_from_ident PC.inr_lid v in
-                  let some_v_tm = S.fv_to_tm (lid_as_fv some_v delta_equational None) in
+                  let some_v_tm = S.fv_to_tm (lid_and_dd_as_fv some_v delta_equational None) in
                   S.mk_Tm_app (S.mk_Tm_uinst some_v_tm [U_zero])
                               [S.iarg (type_of ea); S.iarg (type_of eb); S.as_arg t]
                               rng)
@@ -685,7 +685,7 @@ let e_list (ea:embedding 'a) =
                   let proj f cons_tm =
                     let fid = Ident.mk_ident (f, rng) in
                     let proj = U.mk_field_projector_name_from_ident PC.cons_lid fid in
-                    let proj_tm = S.fv_to_tm (lid_as_fv proj delta_equational None) in
+                    let proj_tm = S.fv_to_tm (lid_and_dd_as_fv proj delta_equational None) in
                     S.mk_Tm_app (S.mk_Tm_uinst proj_tm [U_zero])
                                 [S.iarg (type_of ea);
                                  S.as_arg cons_tm]

--- a/src/syntax/FStar.Syntax.Resugar.fst
+++ b/src/syntax/FStar.Syntax.Resugar.fst
@@ -1383,7 +1383,7 @@ let resugar_sigelt' env se : option A.decl =
       (* This function turns each resolved top-level lid being defined into an
        * ident without a path, so it gets printed correctly. *)
       let nopath_lbs ((is_rec, lbs) : letbindings) : letbindings =
-        let nopath fv = lid_as_fv (lid_of_ids [ident_of_lid (lid_of_fv fv)]) delta_constant None in
+        let nopath fv = lid_and_dd_as_fv (lid_of_ids [ident_of_lid (lid_of_fv fv)]) delta_constant None in
         let lbs = List.map (fun lb ->  { lb with lbname = Inr (nopath <| right lb.lbname)} ) lbs in
         (is_rec, lbs)
       in

--- a/src/syntax/FStar.Syntax.Resugar.fst
+++ b/src/syntax/FStar.Syntax.Resugar.fst
@@ -1383,7 +1383,7 @@ let resugar_sigelt' env se : option A.decl =
       (* This function turns each resolved top-level lid being defined into an
        * ident without a path, so it gets printed correctly. *)
       let nopath_lbs ((is_rec, lbs) : letbindings) : letbindings =
-        let nopath fv = lid_and_dd_as_fv (lid_of_ids [ident_of_lid (lid_of_fv fv)]) delta_constant None in
+        let nopath fv = lid_as_fv (lid_of_ids [ident_of_lid (lid_of_fv fv)]) None in
         let lbs = List.map (fun lb ->  { lb with lbname = Inr (nopath <| right lb.lbname)} ) lbs in
         (is_rec, lbs)
       in

--- a/src/syntax/FStar.Syntax.Syntax.fst
+++ b/src/syntax/FStar.Syntax.Syntax.fst
@@ -257,7 +257,12 @@ let set_bv_range bv r = {bv with ppname = set_id_range r bv.ppname}
 
 let lid_as_fv l dd dq : fv = {
     fv_name=withinfo l (range_of_lid l);
-    fv_delta=dd;
+    fv_delta=Some dd;
+    fv_qual =dq;
+}
+let lid_as_fv' l dq : fv = {
+    fv_name=withinfo l (range_of_lid l);
+    fv_delta=None;
     fv_qual =dq;
 }
 let fv_to_tm (fv:fv) : term = mk (Tm_fvar fv) (range_of_lid fv.fv_name.v)

--- a/src/syntax/FStar.Syntax.Syntax.fst
+++ b/src/syntax/FStar.Syntax.Syntax.fst
@@ -266,7 +266,8 @@ let lid_as_fv l dq : fv = {
     fv_qual =dq;
 }
 let fv_to_tm (fv:fv) : term = mk (Tm_fvar fv) (range_of_lid fv.fv_name.v)
-let fvar l dd dq =  fv_to_tm (lid_and_dd_as_fv l dd dq)
+let fvar_with_dd l dd dq =  fv_to_tm (lid_and_dd_as_fv l dd dq)
+let fvar l dq = fv_to_tm (lid_as_fv l dq)
 let lid_of_fv (fv:fv) = fv.fv_name.v
 let range_of_fv (fv:fv) = range_of_lid (lid_of_fv fv)
 let set_range_of_fv (fv:fv) (r:Range.range) =

--- a/src/syntax/FStar.Syntax.Syntax.fst
+++ b/src/syntax/FStar.Syntax.Syntax.fst
@@ -255,18 +255,18 @@ let fv_eq_lid fv lid = lid_equals fv.fv_name.v lid
 
 let set_bv_range bv r = {bv with ppname = set_id_range r bv.ppname}
 
-let lid_as_fv l dd dq : fv = {
+let lid_and_dd_as_fv l dd dq : fv = {
     fv_name=withinfo l (range_of_lid l);
     fv_delta=Some dd;
     fv_qual =dq;
 }
-let lid_as_fv' l dq : fv = {
+let lid_as_fv l dq : fv = {
     fv_name=withinfo l (range_of_lid l);
     fv_delta=None;
     fv_qual =dq;
 }
 let fv_to_tm (fv:fv) : term = mk (Tm_fvar fv) (range_of_lid fv.fv_name.v)
-let fvar l dd dq =  fv_to_tm (lid_as_fv l dd dq)
+let fvar l dd dq =  fv_to_tm (lid_and_dd_as_fv l dd dq)
 let lid_of_fv (fv:fv) = fv.fv_name.v
 let range_of_fv (fv:fv) = range_of_lid (lid_of_fv fv)
 let set_range_of_fv (fv:fv) (r:Range.range) =
@@ -302,10 +302,10 @@ let rec eq_pat (p1 : pat) (p2 : pat) : bool =
 ///////////////////////////////////////////////////////////////////////
 let delta_constant = Delta_constant_at_level 0
 let delta_equational = Delta_equational_at_level 0
-let fvconst l = lid_as_fv l delta_constant None
+let fvconst l = lid_and_dd_as_fv l delta_constant None
 let tconst l = mk (Tm_fvar (fvconst l)) Range.dummyRange
-let tabbrev l = mk (Tm_fvar(lid_as_fv l (Delta_constant_at_level 1) None)) Range.dummyRange
-let tdataconstr l = fv_to_tm (lid_as_fv l delta_constant (Some Data_ctor))
+let tabbrev l = mk (Tm_fvar(lid_and_dd_as_fv l (Delta_constant_at_level 1) None)) Range.dummyRange
+let tdataconstr l = fv_to_tm (lid_and_dd_as_fv l delta_constant (Some Data_ctor))
 let t_unit      = tconst PC.unit_lid
 let t_bool      = tconst PC.bool_lid
 let t_int       = tconst PC.int_lid

--- a/src/syntax/FStar.Syntax.Syntax.fsti
+++ b/src/syntax/FStar.Syntax.Syntax.fsti
@@ -813,7 +813,8 @@ val new_univ_name    : option range -> univ_name
 val lid_and_dd_as_fv : lident -> delta_depth -> option fv_qual -> fv
 val lid_as_fv        : lident -> option fv_qual -> fv
 val fv_to_tm         : fv -> term
-val fvar             : lident -> delta_depth -> option fv_qual -> term
+val fvar_with_dd     : lident -> delta_depth -> option fv_qual -> term
+val fvar             : lident -> option fv_qual -> term
 val fv_eq            : fv -> fv -> bool
 val fv_eq_lid        : fv -> lident -> bool
 val range_of_fv      : fv -> range

--- a/src/syntax/FStar.Syntax.Syntax.fsti
+++ b/src/syntax/FStar.Syntax.Syntax.fsti
@@ -804,21 +804,21 @@ val as_aqual_implicit:    bool -> aqual
 val is_top_level:   list letbinding -> bool
 
 (* gensym *)
-val freshen_bv:     bv -> bv
-val freshen_binder:  binder -> binder
-val gen_bv:         string -> option Range.range -> typ -> bv
-val gen_bv':        ident -> option Range.range -> typ -> bv
-val new_bv:         option range -> typ -> bv
-val new_univ_name:  option range -> univ_name
-val lid_as_fv:      lident -> delta_depth -> option fv_qual -> fv
-val lid_as_fv':     lident -> option fv_qual -> fv
-val fv_to_tm:       fv -> term
-val fvar:           lident -> delta_depth -> option fv_qual -> term
-val fv_eq:          fv -> fv -> bool
-val fv_eq_lid:      fv -> lident -> bool
-val range_of_fv:    fv -> range
-val lid_of_fv:      fv -> lid
-val set_range_of_fv:fv -> range -> fv
+val freshen_bv       : bv -> bv
+val freshen_binder   : binder -> binder
+val gen_bv           : string -> option Range.range -> typ -> bv
+val gen_bv'          : ident -> option Range.range -> typ -> bv
+val new_bv           : option range -> typ -> bv
+val new_univ_name    : option range -> univ_name
+val lid_and_dd_as_fv : lident -> delta_depth -> option fv_qual -> fv
+val lid_as_fv        : lident -> option fv_qual -> fv
+val fv_to_tm         : fv -> term
+val fvar             : lident -> delta_depth -> option fv_qual -> term
+val fv_eq            : fv -> fv -> bool
+val fv_eq_lid        : fv -> lident -> bool
+val range_of_fv      : fv -> range
+val lid_of_fv        : fv -> lid
+val set_range_of_fv  : fv -> range -> fv
 
 (* attributes *)
 val has_simple_attribute: list term -> string -> bool

--- a/src/syntax/FStar.Syntax.Syntax.fsti
+++ b/src/syntax/FStar.Syntax.Syntax.fsti
@@ -202,13 +202,13 @@ and pat' =
   | Pat_dot_term of option term                                  (* dot patterns: determined by other elements in the pattern *)
                                                                  (* the option term is the optionally resolved pat dot term *)
 and letbinding = {  //let f : forall u1..un. M t = e
-    lbname :lbname;          //f
-    lbunivs:list univ_name; //u1..un
-    lbtyp  :typ;             //t
-    lbeff  :lident;          //M
-    lbdef  :term;            //e
-    lbattrs:list attribute; //attrs
-    lbpos  :range;           //original position of 'e'
+    lbname :lbname;          // f
+    lbunivs:list univ_name;  // u1..un
+    lbtyp  :typ;             // t
+    lbeff  :lident;          // M
+    lbdef  :term;            // e
+    lbattrs:list attribute;  // attrs
+    lbpos  :range;           // original position of 'e'
 }
 and antiquotations = int * list term
 and quoteinfo = {
@@ -363,7 +363,7 @@ and bv = {
 }
 and fv = {
     fv_name :var;
-    fv_delta:delta_depth;
+    fv_delta:option delta_depth;
     fv_qual :option fv_qual
 }
 and free_vars = {
@@ -811,6 +811,7 @@ val gen_bv':        ident -> option Range.range -> typ -> bv
 val new_bv:         option range -> typ -> bv
 val new_univ_name:  option range -> univ_name
 val lid_as_fv:      lident -> delta_depth -> option fv_qual -> fv
+val lid_as_fv':     lident -> option fv_qual -> fv
 val fv_to_tm:       fv -> term
 val fvar:           lident -> delta_depth -> option fv_qual -> term
 val fv_eq:          fv -> fv -> bool

--- a/src/syntax/FStar.Syntax.Util.fst
+++ b/src/syntax/FStar.Syntax.Util.fst
@@ -1287,11 +1287,11 @@ let exp_int s : term = mk (Tm_constant (Const_int (s,None))) dummyRange
 let exp_char c : term = mk (Tm_constant (Const_char c)) dummyRange
 let exp_string s : term = mk (Tm_constant (Const_string (s, dummyRange))) dummyRange
 
-let fvar_const l = fvar l delta_constant None
+let fvar_const l = fvar_with_dd l delta_constant None
 let tand    = fvar_const PC.and_lid
 let tor     = fvar_const PC.or_lid
-let timp    = fvar PC.imp_lid (Delta_constant_at_level 1) None //NS delta: wrong? level 2
-let tiff    = fvar PC.iff_lid (Delta_constant_at_level 2) None //NS delta: wrong? level 3
+let timp    = fvar_with_dd PC.imp_lid (Delta_constant_at_level 1) None //NS delta: wrong? level 2
+let tiff    = fvar_with_dd PC.iff_lid (Delta_constant_at_level 2) None //NS delta: wrong? level 3
 let t_bool  = fvar_const PC.bool_lid
 let b2t_v   = fvar_const PC.b2t_lid
 let t_not   = fvar_const PC.not_lid
@@ -1307,7 +1307,7 @@ let rename_let_attr = fvar_const PC.rename_let_attr
 let t_ctx_uvar_and_sust = fvar_const PC.ctx_uvar_and_subst_lid
 let t_universe_uvar     = fvar_const PC.universe_uvar_lid
 
-let t_dsl_tac_typ = fvar PC.dsl_tac_typ_lid (Delta_constant_at_level 1) None
+let t_dsl_tac_typ = fvar PC.dsl_tac_typ_lid None
 
 
 let mk_conj_opt phi1 phi2 = match phi1 with
@@ -1317,7 +1317,7 @@ let mk_binop op_t phi1 phi2 = mk (Tm_app {hd=op_t; args=[as_arg phi1; as_arg phi
 let mk_neg phi = mk (Tm_app {hd=t_not; args=[as_arg phi]}) phi.pos
 let mk_conj phi1 phi2 = mk_binop tand phi1 phi2
 let mk_conj_l phi = match phi with
-    | [] -> fvar PC.true_lid delta_constant None //NS delta: wrong, see a t_true
+    | [] -> fvar_with_dd PC.true_lid delta_constant None //NS delta: wrong, see a t_true
     | hd::tl -> List.fold_right mk_conj tl hd
 let mk_disj phi1 phi2 = mk_binop tor phi1 phi2
 let mk_disj_l phi = match phi with
@@ -1362,9 +1362,9 @@ let mk_has_type t x t' =
     let t_has_type = mk (Tm_uinst(t_has_type, [U_zero; U_zero])) dummyRange in
     mk (Tm_app {hd=t_has_type; args=[iarg t; as_arg x; as_arg t']}) dummyRange
 
-let tforall  = fvar PC.forall_lid (Delta_constant_at_level 1) None //NS delta: wrong level 2
-let texists  = fvar PC.exists_lid (Delta_constant_at_level 1) None //NS delta: wrong level 2
-let t_haseq   = fvar PC.haseq_lid delta_constant None //NS delta: wrong Delta_abstract (Delta_constant_at_level 0)?
+let tforall  = fvar_with_dd PC.forall_lid (Delta_constant_at_level 1) None //NS delta: wrong level 2
+let texists  = fvar_with_dd PC.exists_lid (Delta_constant_at_level 1) None //NS delta: wrong level 2
+let t_haseq   = fvar_with_dd PC.haseq_lid delta_constant None //NS delta: wrong Delta_abstract (Delta_constant_at_level 0)?
 
 let decidable_eq = fvar_const PC.op_Eq
 let mk_decidable_eq t e1 e2 =
@@ -1438,11 +1438,11 @@ let if_then_else b t1 t2 =
 // Operations on squashed and other irrelevant/sub-singleton types
 //////////////////////////////////////////////////////////////////////////////////////
 let mk_squash u p =
-    let sq = fvar PC.squash_lid (Delta_constant_at_level 1) None in //NS delta: ok
+    let sq = fvar_with_dd PC.squash_lid (Delta_constant_at_level 1) None in //NS delta: ok
     mk_app (mk_Tm_uinst sq [u]) [as_arg p]
 
 let mk_auto_squash u p =
-    let sq = fvar PC.auto_squash_lid (Delta_constant_at_level 2) None in //NS delta: ok
+    let sq = fvar_with_dd PC.auto_squash_lid (Delta_constant_at_level 2) None in //NS delta: ok
     mk_app (mk_Tm_uinst sq [u]) [as_arg p]
 
 let un_squash t =
@@ -2453,9 +2453,7 @@ let is_erased_head (t:term) : option (universe & term) =
     None
 
 let apply_reveal (u:universe) (ty:term) (v:term) =
-  let head = fvar (Ident.set_lid_range PC.reveal v.pos)
-                  (Delta_constant_at_level 1)
-                   None in
+  let head = fvar (Ident.set_lid_range PC.reveal v.pos) None in
   mk_Tm_app (mk_Tm_uinst head [u])
             [iarg ty; as_arg v]
             v.pos

--- a/src/syntax/FStar.Syntax.Util.fst
+++ b/src/syntax/FStar.Syntax.Util.fst
@@ -1733,7 +1733,9 @@ let rec delta_qualifier t =
     match t.n with
         | Tm_delayed _ -> failwith "Impossible"
         | Tm_lazy i -> delta_qualifier (unfold_lazy i)
-        | Tm_fvar fv -> fv.fv_delta
+        | Tm_fvar fv -> (match fv.fv_delta with
+                         | Some d -> d
+                         | None -> delta_constant)
         | Tm_bvar _
         | Tm_name _
         | Tm_match _

--- a/src/syntax/FStar.Syntax.Util.fst
+++ b/src/syntax/FStar.Syntax.Util.fst
@@ -1274,9 +1274,9 @@ let attr_eq a a' =
    | _ -> false
 
 let attr_substitute =
-    mk (Tm_fvar (lid_as_fv PC.attr_substitute_lid
-                           delta_constant
-                           None))
+    mk (Tm_fvar (lid_and_dd_as_fv PC.attr_substitute_lid
+                                  delta_constant
+                                  None))
        Range.dummyRange
 
 let exp_true_bool : term = mk (Tm_constant (Const_bool true)) dummyRange
@@ -1701,7 +1701,7 @@ let action_as_lb eff_lid a pos =
   let lb =
     close_univs_and_mk_letbinding None
       (* Actions are set to Delta_constant since they need an explicit reify to be unfolded *)
-      (Inr (lid_as_fv a.action_name delta_equational None))
+      (Inr (lid_and_dd_as_fv a.action_name delta_equational None))
       a.action_univs
       (arrow a.action_params (mk_Total a.action_typ))
       PC.effect_Tot_lid
@@ -1775,7 +1775,7 @@ let dm4f_lid ed name : lident =
     lid_of_path p' Range.dummyRange
 
 let mk_list (typ:term) (rng:range) (l:list term) : term =
-    let ctor l = mk (Tm_fvar (lid_as_fv l delta_constant (Some Data_ctor))) rng in
+    let ctor l = mk (Tm_fvar (lid_and_dd_as_fv l delta_constant (Some Data_ctor))) rng in
     let cons args pos = mk_Tm_app (mk_Tm_uinst (ctor PC.cons_lid) [U_zero]) args pos in
     let nil  args pos = mk_Tm_app (mk_Tm_uinst (ctor PC.nil_lid)  [U_zero]) args pos in
     List.fold_right (fun t a -> cons [iarg typ; as_arg t; as_arg a] t.pos) l (nil [iarg typ] rng)
@@ -2532,12 +2532,12 @@ let encode_positivity_attributes (pqual:option positivity_qualifier) (attrs:list
   | Some BinderStrictlyPositive ->
     if contains_strictly_positive_attribute attrs
     then attrs
-    else FStar.Syntax.Syntax.fv_to_tm (lid_as_fv PC.binder_strictly_positive_attr (Delta_constant_at_level 0) None)
+    else FStar.Syntax.Syntax.fv_to_tm (lid_and_dd_as_fv PC.binder_strictly_positive_attr (Delta_constant_at_level 0) None)
          :: attrs
   | Some BinderUnused ->
     if contains_unused_attribute attrs
     then attrs
-    else FStar.Syntax.Syntax.fv_to_tm (lid_as_fv PC.binder_unused_attr (Delta_constant_at_level 0) None)
+    else FStar.Syntax.Syntax.fv_to_tm (lid_and_dd_as_fv PC.binder_unused_attr (Delta_constant_at_level 0) None)
          :: attrs
 
 let is_binder_strictly_positive (b:binder) =

--- a/src/syntax/FStar.Syntax.Util.fst
+++ b/src/syntax/FStar.Syntax.Util.fst
@@ -1274,10 +1274,7 @@ let attr_eq a a' =
    | _ -> false
 
 let attr_substitute =
-    mk (Tm_fvar (lid_and_dd_as_fv PC.attr_substitute_lid
-                                  delta_constant
-                                  None))
-       Range.dummyRange
+  mk (Tm_fvar (lid_as_fv PC.attr_substitute_lid None)) Range.dummyRange
 
 let exp_true_bool : term = mk (Tm_constant (Const_bool true)) dummyRange
 let exp_false_bool : term = mk (Tm_constant (Const_bool false)) dummyRange
@@ -1700,7 +1697,6 @@ let destruct_typ_as_formula f : option connective =
 let action_as_lb eff_lid a pos =
   let lb =
     close_univs_and_mk_letbinding None
-      (* Actions are set to Delta_constant since they need an explicit reify to be unfolded *)
       (Inr (lid_and_dd_as_fv a.action_name delta_equational None))
       a.action_univs
       (arrow a.action_params (mk_Total a.action_typ))
@@ -1775,7 +1771,7 @@ let dm4f_lid ed name : lident =
     lid_of_path p' Range.dummyRange
 
 let mk_list (typ:term) (rng:range) (l:list term) : term =
-    let ctor l = mk (Tm_fvar (lid_and_dd_as_fv l delta_constant (Some Data_ctor))) rng in
+    let ctor l = mk (Tm_fvar (lid_as_fv l (Some Data_ctor))) rng in
     let cons args pos = mk_Tm_app (mk_Tm_uinst (ctor PC.cons_lid) [U_zero]) args pos in
     let nil  args pos = mk_Tm_app (mk_Tm_uinst (ctor PC.nil_lid)  [U_zero]) args pos in
     List.fold_right (fun t a -> cons [iarg typ; as_arg t; as_arg a] t.pos) l (nil [iarg typ] rng)
@@ -2530,12 +2526,12 @@ let encode_positivity_attributes (pqual:option positivity_qualifier) (attrs:list
   | Some BinderStrictlyPositive ->
     if contains_strictly_positive_attribute attrs
     then attrs
-    else FStar.Syntax.Syntax.fv_to_tm (lid_and_dd_as_fv PC.binder_strictly_positive_attr (Delta_constant_at_level 0) None)
+    else FStar.Syntax.Syntax.fv_to_tm (lid_as_fv PC.binder_strictly_positive_attr None)
          :: attrs
   | Some BinderUnused ->
     if contains_unused_attribute attrs
     then attrs
-    else FStar.Syntax.Syntax.fv_to_tm (lid_and_dd_as_fv PC.binder_unused_attr (Delta_constant_at_level 0) None)
+    else FStar.Syntax.Syntax.fv_to_tm (lid_as_fv PC.binder_unused_attr None)
          :: attrs
 
 let is_binder_strictly_positive (b:binder) =

--- a/src/tactics/FStar.Tactics.Basic.fst
+++ b/src/tactics/FStar.Tactics.Basic.fst
@@ -1791,7 +1791,7 @@ let t_destruct (s_tm : term) : tac (list (fv * Z.t)) = wrap_err "destruct" <| (
                     | Sig_datacon {us=c_us; t=c_ty; num_ty_params=nparam; mutuals=mut} ->
                         (* BU.print2 "ty of %s = %s\n" (Ident.string_of_lid c_lid) *)
                         (*                             (Print.term_to_string c_ty); *)
-                        let fv = S.lid_as_fv' c_lid (Some Data_ctor) in
+                        let fv = S.lid_as_fv c_lid (Some Data_ctor) in
 
 
                         failwhen (List.length a_us <> List.length c_us) "t_us don't match?" ;!

--- a/src/tactics/FStar.Tactics.Basic.fst
+++ b/src/tactics/FStar.Tactics.Basic.fst
@@ -1791,7 +1791,7 @@ let t_destruct (s_tm : term) : tac (list (fv * Z.t)) = wrap_err "destruct" <| (
                     | Sig_datacon {us=c_us; t=c_ty; num_ty_params=nparam; mutuals=mut} ->
                         (* BU.print2 "ty of %s = %s\n" (Ident.string_of_lid c_lid) *)
                         (*                             (Print.term_to_string c_ty); *)
-                        let fv = S.lid_as_fv c_lid S.delta_constant (Some Data_ctor) in
+                        let fv = S.lid_as_fv' c_lid (Some Data_ctor) in
 
 
                         failwhen (List.length a_us <> List.length c_us) "t_us don't match?" ;!

--- a/src/tactics/FStar.Tactics.Basic.fst
+++ b/src/tactics/FStar.Tactics.Basic.fst
@@ -2328,6 +2328,9 @@ let to_must_tot (eff:tot_or_ghost) : bool =
   | E_Total -> true
   | E_Ghost -> false
 
+let refl_norm_type (g:env) (t:typ) : typ =
+  N.normalize [Env.Beta; Env.Exclude Zeta] g t
+
 let refl_core_compute_term_type (g:env) (e:term) (eff:tot_or_ghost) : tac (option typ) =
   if no_uvars_in_g g &&
      no_uvars_in_term e
@@ -2341,6 +2344,7 @@ let refl_core_compute_term_type (g:env) (e:term) (eff:tot_or_ghost) : tac (optio
            true in
          match Core.compute_term_type_handle_guards g e must_tot gh with
          | Inl t ->
+           let t = refl_norm_type g t in
            dbg_refl g (fun _ ->
              BU.format2 "refl_core_compute_term_type for %s computed type %s\n"
                (Print.term_to_string e)
@@ -2413,6 +2417,7 @@ let refl_tc_term (g:env) (e:term) (eff:tot_or_ghost) : tac (option (term & typ))
         true in
      match Core.compute_term_type_handle_guards g e must_tot gh with
      | Inl t ->
+        let t = refl_norm_type g t in
         dbg_refl g (fun _ ->
           BU.format2 "refl_tc_term for %s computed type %s\n"
             (Print.term_to_string e)
@@ -2486,7 +2491,7 @@ let refl_instantiate_implicits (g:env) (e:term) : tac (option (term & typ)) =
     let e, t, guard = g.typeof_tot_or_gtot_term g e must_tot in
     Rel.force_trivial_guard g guard;
     let e = SC.deep_compress false e in
-    let t = SC.deep_compress false t in
+    let t = t |> refl_norm_type g |> SC.deep_compress false in
     dbg_refl g (fun _ ->
       BU.format2 "} finished tc with e = %s and t = %s\n"
         (Print.term_to_string e)

--- a/src/tactics/FStar.Tactics.Embedding.fst
+++ b/src/tactics/FStar.Tactics.Embedding.fst
@@ -50,7 +50,7 @@ open FStar.Reflection.Data
 type name = bv
 
 let fstar_tactics_lid' s = PC.fstar_tactics_lid' s
-let lid_as_tm l = S.lid_as_fv' l None |> S.fv_to_tm
+let lid_as_tm l = S.lid_as_fv l None |> S.fv_to_tm
 let mk_tactic_lid_as_term (s:string) = lid_as_tm (fstar_tactics_lid' ["Effect"; s])
 
 
@@ -60,7 +60,7 @@ type tac_constant = {
   t   : term;
 }
 
-let lid_as_data_fv l = S.lid_as_fv' l (Some Data_ctor)
+let lid_as_data_fv l = S.lid_as_fv l (Some Data_ctor)
 let lid_as_data_tm l = S.fv_to_tm (lid_as_data_fv l)
 
 let fstar_tactics_data ns =

--- a/src/tactics/FStar.Tactics.Embedding.fst
+++ b/src/tactics/FStar.Tactics.Embedding.fst
@@ -50,7 +50,7 @@ open FStar.Reflection.Data
 type name = bv
 
 let fstar_tactics_lid' s = PC.fstar_tactics_lid' s
-let lid_as_tm l = S.lid_as_fv l delta_constant None |> S.fv_to_tm
+let lid_as_tm l = S.lid_as_fv' l None |> S.fv_to_tm
 let mk_tactic_lid_as_term (s:string) = lid_as_tm (fstar_tactics_lid' ["Effect"; s])
 
 
@@ -60,7 +60,7 @@ type tac_constant = {
   t   : term;
 }
 
-let lid_as_data_fv l = S.lid_as_fv l delta_constant (Some Data_ctor)
+let lid_as_data_fv l = S.lid_as_fv' l (Some Data_ctor)
 let lid_as_data_tm l = S.fv_to_tm (lid_as_data_fv l)
 
 let fstar_tactics_data ns =

--- a/src/tactics/FStar.Tactics.Hooks.fst
+++ b/src/tactics/FStar.Tactics.Hooks.fst
@@ -780,13 +780,13 @@ let handle_smt_goal env goal =
         match tac.sigel with
         | Sig_let {lids=[lid]} ->
           let qn = Env.lookup_qname env lid in
-          let fv = S.lid_as_fv' lid None in
+          let fv = S.lid_as_fv lid None in
           let dd =
             match Env.delta_depth_of_qninfo fv qn with
             | Some dd -> dd
             | None -> failwith "Expected a dd"
           in
-          S.fv_to_tm (S.lid_as_fv' lid None)
+          S.fv_to_tm (S.lid_as_fv lid None)
         | _ -> failwith "Resolve_tac not found"
       in
 
@@ -838,7 +838,7 @@ let splice (env:Env.env) (is_typed:bool) (lids:list Ident.lident) (tau:term) (rn
           ps in
 
         let lb = U.mk_letbinding
-          (Inr (S.lid_as_fv' (List.hd lids) None))
+          (Inr (S.lid_as_fv (List.hd lids) None))
           []  // no universe polymorphism yet
           t
           PC.effect_Tot_lid  // only Tot top-level effect so far
@@ -858,6 +858,9 @@ let splice (env:Env.env) (is_typed:bool) (lids:list Ident.lident) (tau:term) (rn
         let gs, sigelts = run_tactic_on_ps tau.pos tau.pos false
           e_unit ()
           (e_list RE.e_sigelt) tau tactic_already_typed ps in
+        gs, sigelts
+      in
+
         let set_lb_dd lb =
           let {lbname=Inr fv; lbdef} = lb in
           {lb with lbname=Inr {fv with fv_delta=U.incr_delta_qualifier lbdef
@@ -869,8 +872,6 @@ let splice (env:Env.env) (is_typed:bool) (lids:list Ident.lident) (tau:term) (rn
             {se with sigel=Sig_let {lbs=(is_rec, List.map set_lb_dd lbs); lids}}
           | _ -> se
         ) sigelts in
-        gs, sigelts
-      in
 
     // Check that all goals left are irrelevant. We don't need to check their
     // validity, as we will typecheck the witness independently.

--- a/src/tests/FStar.Tests.Norm.fst
+++ b/src/tests/FStar.Tests.Norm.fst
@@ -61,13 +61,13 @@ let mk_let x e e' : term =
                            dummyRange
 
 let lid x = lid_of_path ["Test"; x] dummyRange
-let znat_l = S.lid_and_dd_as_fv (lid "Z") delta_constant (Some Data_ctor)
-let snat_l = S.lid_and_dd_as_fv (lid "S") delta_constant (Some Data_ctor)
+let znat_l = S.lid_as_fv (lid "Z") (Some Data_ctor)
+let snat_l = S.lid_as_fv (lid "S") (Some Data_ctor)
 let tm_fv fv = mk (Tm_fvar fv) dummyRange
 let znat : term = tm_fv znat_l
 let snat s      = mk (Tm_app {hd=tm_fv snat_l; args=[as_arg s]}) dummyRange
 let pat p = withinfo p dummyRange
-let snat_type = tm_fv (S.lid_and_dd_as_fv (lid "snat") delta_constant None)
+let snat_type = tm_fv (S.lid_as_fv (lid "snat") None)
 open FStar.Syntax.Subst
 module SS=FStar.Syntax.Subst
 let mk_match h branches =

--- a/src/tests/FStar.Tests.Norm.fst
+++ b/src/tests/FStar.Tests.Norm.fst
@@ -61,13 +61,13 @@ let mk_let x e e' : term =
                            dummyRange
 
 let lid x = lid_of_path ["Test"; x] dummyRange
-let znat_l = S.lid_as_fv (lid "Z") delta_constant (Some Data_ctor)
-let snat_l = S.lid_as_fv (lid "S") delta_constant (Some Data_ctor)
+let znat_l = S.lid_and_dd_as_fv (lid "Z") delta_constant (Some Data_ctor)
+let snat_l = S.lid_and_dd_as_fv (lid "S") delta_constant (Some Data_ctor)
 let tm_fv fv = mk (Tm_fvar fv) dummyRange
 let znat : term = tm_fv znat_l
 let snat s      = mk (Tm_app {hd=tm_fv snat_l; args=[as_arg s]}) dummyRange
 let pat p = withinfo p dummyRange
-let snat_type = tm_fv (S.lid_as_fv (lid "snat") delta_constant None)
+let snat_type = tm_fv (S.lid_and_dd_as_fv (lid "snat") delta_constant None)
 open FStar.Syntax.Subst
 module SS=FStar.Syntax.Subst
 let mk_match h branches =

--- a/src/tosyntax/FStar.ToSyntax.ToSyntax.fst
+++ b/src/tosyntax/FStar.ToSyntax.ToSyntax.fst
@@ -1096,7 +1096,7 @@ and desugar_machine_integer env repr (signedness, width) range =
       begin match intro_term.n with
         | Tm_fvar fv ->
           let private_lid = lid_of_path (path_of_text private_intro_nm) range in
-          let private_fv = S.lid_as_fv private_lid (U.incr_delta_depth fv.fv_delta) fv.fv_qual in
+          let private_fv = S.lid_as_fv private_lid (U.incr_delta_depth (Some?.v fv.fv_delta)) fv.fv_qual in
           {intro_term with n=Tm_fvar private_fv}
         | _ ->
           failwith ("Unexpected non-fvar for " ^ intro_nm)

--- a/src/tosyntax/FStar.ToSyntax.ToSyntax.fst
+++ b/src/tosyntax/FStar.ToSyntax.ToSyntax.fst
@@ -1226,10 +1226,10 @@ and desugar_term_maybe_top (top_level:bool) (env:env_t) (top:term) : S.term * an
     | Name lid when string_of_lid lid = "Effect" ->
         mk (Tm_constant Const_effect), noaqs
     | Name lid when string_of_lid lid = "True"   ->
-        S.fvar (Ident.set_lid_range Const.true_lid top.range) delta_constant None, //NS delta: wrong, but maybe intentionally so
+        S.fvar_with_dd (Ident.set_lid_range Const.true_lid top.range) delta_constant None, //NS delta: wrong, but maybe intentionally so
                              noaqs
     | Name lid when string_of_lid lid = "False"   ->
-        S.fvar (Ident.set_lid_range Const.false_lid top.range) delta_constant None, //NS delta: wrong, but maybe intentionally so
+        S.fvar_with_dd (Ident.set_lid_range Const.false_lid top.range) delta_constant None, //NS delta: wrong, but maybe intentionally so
                               noaqs
     | Projector (eff_name, id)
       when is_special_effect_combinator (string_of_id id) && Env.is_effect_name env eff_name ->
@@ -1239,7 +1239,7 @@ and desugar_term_maybe_top (top_level:bool) (env:env_t) (top:term) : S.term * an
       begin match try_lookup_effect_defn env eff_name with
         | Some ed ->
           let lid = U.dm4f_lid ed txt in
-          S.fvar lid (Delta_constant_at_level 1) None, noaqs
+          S.fvar_with_dd lid (Delta_constant_at_level 1) None, noaqs
         | None ->
           failwith (BU.format2 "Member %s of effect %s is not accessible \
                                 (using an effect abbreviation instead of the original effect ?)"
@@ -1830,7 +1830,7 @@ and desugar_term_maybe_top (top_level:bool) (env:env_t) (top:term) : S.term * an
       in
       let head =
           let lid = lid_of_path ["__dummy__"] top.range in
-          S.fvar lid
+          S.fvar_with_dd lid
                  delta_constant
                  (Some (Unresolved_constructor uc))
       in
@@ -1866,7 +1866,7 @@ and desugar_term_maybe_top (top_level:bool) (env:env_t) (top:term) : S.term * an
       let head =
         match try_lookup_dc_by_field_name env f with
         | None ->
-          S.fvar f (Delta_equational_at_level 1) (Some (Unresolved_projector None))
+          S.fvar_with_dd f (Delta_equational_at_level 1) (Some (Unresolved_projector None))
 
         | Some (constrname, is_rec) ->
           let projname = mk_field_projector_name_from_ident constrname (ident_of_lid f) in
@@ -1874,7 +1874,7 @@ and desugar_term_maybe_top (top_level:bool) (env:env_t) (top:term) : S.term * an
           let candidate_projector = S.lid_and_dd_as_fv (Ident.set_lid_range projname top.range) (Delta_equational_at_level 1) qual in //NS delta: ok, projector
           let qual = Unresolved_projector (Some candidate_projector) in
           let f = List.hd (qualify_field_names constrname [f]) in
-          S.fvar f (Delta_equational_at_level 1) (Some qual)
+          S.fvar_with_dd f (Delta_equational_at_level 1) (Some qual)
       in
       //The fvar at the head of the term just records the fieldname that the user wrote
       //and in TcTerm, we use that field name combined with type info to disambiguate
@@ -2540,7 +2540,7 @@ and desugar_comp r (allow_type_promotion:bool) env t =
               | Tm_fvar fv when S.fv_eq_lid fv Const.nil_lid ->
                 let nil = S.mk_Tm_uinst pat [U_zero] in
                 let pattern =
-                  S.fvar (Ident.set_lid_range Const.pattern_lid pat.pos) delta_constant None //NS delta: incorrect, should be Delta_abstract (Delta_constant_at_level 1)?
+                  S.fvar_with_dd (Ident.set_lid_range Const.pattern_lid pat.pos) delta_constant None //NS delta: incorrect, should be Delta_abstract (Delta_constant_at_level 1)?
                 in
                 S.mk_Tm_app nil [(pattern, S.as_aqual_implicit true)] pat.pos
               | _ -> pat
@@ -2586,7 +2586,7 @@ and desugar_formula env (f:term) : S.term =
         let body = desugar_formula env body in
         let body = with_pats env pats body in
         let body = setpos <| no_annot_abs [S.mk_binder a] body in
-        mk <| Tm_app {hd=S.fvar (set_lid_range q b.brange) (Delta_constant_at_level 1) None;  //NS delta: wrong?  Delta_constant_at_level 2?
+        mk <| Tm_app {hd=S.fvar_with_dd (set_lid_range q b.brange) (Delta_constant_at_level 1) None;  //NS delta: wrong?  Delta_constant_at_level 2?
                       args=[as_arg body]}
 
       | _ -> failwith "impossible" in
@@ -3738,7 +3738,7 @@ and desugar_decl_noattrs top_attrs env (d:decl) : (env_t * sigelts) =
                  { se with sigel = Sig_bundle {ses; lids} }
 
                | Sig_inductive_typ _ ->
-                 { se with sigattrs = S.fvar FStar.Parser.Const.tcclass_lid S.delta_constant None :: se.sigattrs }
+                 { se with sigattrs = S.fvar_with_dd FStar.Parser.Const.tcclass_lid S.delta_constant None :: se.sigattrs }
 
                | _ -> se
              in

--- a/src/typechecker/FStar.TypeChecker.Cfg.fst
+++ b/src/typechecker/FStar.TypeChecker.Cfg.fst
@@ -380,7 +380,7 @@ let built_in_primitive_steps : prim_step_set =
                  | _ -> None
     in
     let list_of_string' rng (s:string) : term =
-        let name l = mk (Tm_fvar (lid_as_fv' l None)) rng in
+        let name l = mk (Tm_fvar (lid_as_fv l None)) rng in
         let char_t = name PC.char_lid in
         let charterm c = mk (Tm_constant (Const_char c)) rng in
         U.mk_list char_t rng <| List.map charterm (list_of_string s)
@@ -649,7 +649,7 @@ let built_in_primitive_steps : prim_step_set =
          (let u32_int_to_t =
             ["FStar"; "UInt32"; "uint_to_t"]
             |> PC.p2l
-            |> (fun l -> S.lid_as_fv' l None) in
+            |> (fun l -> S.lid_as_fv l None) in
           PC.char_u32_of_char,
              1,
              0,
@@ -1126,7 +1126,7 @@ let built_in_primitive_steps : prim_step_set =
                NBETerm.mk_t <|
                NBETerm.Lazy (Inr (blob, emb_typ EMB.(emb_typ_of e_any)),
                              Thunk.mk (fun _ ->
-                               NBETerm.mk_t <| NBETerm.FV (S.lid_as_fv' PC.immutable_array_of_list_lid None,
+                               NBETerm.mk_t <| NBETerm.FV (S.lid_as_fv PC.immutable_array_of_list_lid None,
                                                           universes,
                                                           [NBETerm.as_arg l]))))
              (fun  universes elt_t (l, lst) ->

--- a/src/typechecker/FStar.TypeChecker.Cfg.fst
+++ b/src/typechecker/FStar.TypeChecker.Cfg.fst
@@ -380,7 +380,7 @@ let built_in_primitive_steps : prim_step_set =
                  | _ -> None
     in
     let list_of_string' rng (s:string) : term =
-        let name l = mk (Tm_fvar (lid_as_fv l delta_constant None)) rng in
+        let name l = mk (Tm_fvar (lid_as_fv' l None)) rng in
         let char_t = name PC.char_lid in
         let charterm c = mk (Tm_constant (Const_char c)) rng in
         U.mk_list char_t rng <| List.map charterm (list_of_string s)
@@ -649,7 +649,7 @@ let built_in_primitive_steps : prim_step_set =
          (let u32_int_to_t =
             ["FStar"; "UInt32"; "uint_to_t"]
             |> PC.p2l
-            |> (fun l -> S.lid_as_fv l (S.Delta_constant_at_level 0) None) in
+            |> (fun l -> S.lid_as_fv' l None) in
           PC.char_u32_of_char,
              1,
              0,
@@ -1126,7 +1126,7 @@ let built_in_primitive_steps : prim_step_set =
                NBETerm.mk_t <|
                NBETerm.Lazy (Inr (blob, emb_typ EMB.(emb_typ_of e_any)),
                              Thunk.mk (fun _ ->
-                               NBETerm.mk_t <| NBETerm.FV (S.lid_as_fv PC.immutable_array_of_list_lid S.delta_constant None,
+                               NBETerm.mk_t <| NBETerm.FV (S.lid_as_fv' PC.immutable_array_of_list_lid None,
                                                           universes,
                                                           [NBETerm.as_arg l]))))
              (fun  universes elt_t (l, lst) ->

--- a/src/typechecker/FStar.TypeChecker.Core.fst
+++ b/src/typechecker/FStar.TypeChecker.Core.fst
@@ -1532,7 +1532,7 @@ and check_comp (g:env) (c:comp)
       then fail "Unexpected/missing universe instantitation in comp"
       else let u = List.hd ct.comp_univs in
            let effect_app_tm =
-             let head = S.mk_Tm_uinst (S.fvar ct.effect_name delta_constant None) [u] in
+             let head = S.mk_Tm_uinst (S.fvar ct.effect_name None) [u] in
              S.mk_Tm_app head ((as_arg ct.result_typ)::ct.effect_args) ct.result_typ.pos in
            let! _, t = check "effectful comp" g effect_app_tm in
            with_context "comp fully applied" None (fun _ -> check_subtype g None t S.teff);!

--- a/src/typechecker/FStar.TypeChecker.DMFF.fst
+++ b/src/typechecker/FStar.TypeChecker.DMFF.fst
@@ -276,7 +276,7 @@ let gen_wps_for_free
     let result_comp = (mk_Total ((U.arrow [ S.null_binder wp_a; S.null_binder wp_a ] (mk_Total wp_a)))) in
     let c = S.gen_bv "c" None U.ktype in
     U.abs (binders @ S.binders_of_list [ a; c ]) (
-      let l_ite = fvar PC.ite_lid (S.Delta_constant_at_level 2) None in
+      let l_ite = fvar_with_dd PC.ite_lid (S.Delta_constant_at_level 2) None in
       U.ascribe (
         U.mk_app c_lift2 (List.map S.as_arg [
           U.mk_app l_ite [S.as_arg (S.bv_to_name c)]
@@ -377,7 +377,7 @@ let gen_wps_for_free
         | Tm_app {hd=head; args} when is_tuple_constructor (SS.compress head) ->
           let project i tuple =
             (* TODO : I guess a projector shouldn't be handled as a constant... *)
-            let projector = S.fvar (Env.lookup_projector env (PC.mk_tuple_data_lid (List.length args) Range.dummyRange) i) (S.Delta_constant_at_level 1) None in
+            let projector = S.fvar_with_dd (Env.lookup_projector env (PC.mk_tuple_data_lid (List.length args) Range.dummyRange) i) (S.Delta_constant_at_level 1) None in
             mk_app projector [tuple, None]
           in
           let (rel0,rels) =

--- a/src/typechecker/FStar.TypeChecker.DMFF.fst
+++ b/src/typechecker/FStar.TypeChecker.DMFF.fst
@@ -1,5 +1,5 @@
 (*
-11;rgb:ffff/ffff/ffffCopyright 2008-2014 Nikhil Swamy and Microsoft Research
+  Copyright 2008-2014 Nikhil Swamy and Microsoft Research
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -414,7 +414,7 @@ let gen_wps_for_free
         match U.destruct_typ_as_formula eq with
         | Some (QAll (binders, [], body)) ->
           let k_app = U.mk_app k_tm (args_of_binders binders) in
-          let guard_free =  S.fv_to_tm (S.lid_as_fv PC.guard_free delta_constant None) in
+          let guard_free =  S.fv_to_tm (S.lid_and_dd_as_fv PC.guard_free delta_constant None) in
           let pat = U.mk_app guard_free [as_arg k_app] in
           let pattern_guarded_body =
             mk (Tm_meta {tm=body; meta=Meta_pattern(binders_to_names binders, [[as_arg pat]])}) in
@@ -1511,7 +1511,7 @@ let cps_and_elaborate (env:FStar.TypeChecker.Env.env) (ed:S.eff_decl)
     match (SS.compress bind_wp).n with
     | Tm_abs {bs=binders; body; rc_opt=what} ->
         // TODO: figure out how to deal with ranges
-        //let r = S.lid_as_fv PC.range_lid (S.Delta_constant_at_level 1) None in
+        //let r = S.lid_and_dd_as_fv PC.range_lid (S.Delta_constant_at_level 1) None in
         U.abs binders body what
     | _ ->
         raise_error (Errors.Fatal_UnexpectedBindShape, "unexpected shape for bind")
@@ -1538,7 +1538,7 @@ let cps_and_elaborate (env:FStar.TypeChecker.Env.env) (ed:S.eff_decl)
       if Options.debug_any () then
           BU.print1 "DM4F: Applying override %s\n" (string_of_lid l');
       // TODO: GM: get exact delta depth, needs a change of interfaces
-      fv_to_tm (lid_as_fv l' delta_equational None)
+      fv_to_tm (lid_and_dd_as_fv l' delta_equational None)
       end
     | None ->
       let sigelt, fv = TcUtil.mk_toplevel_definition env (mk_lid name) (U.abs effect_binders item None) in

--- a/src/typechecker/FStar.TypeChecker.DeferredImplicits.fst
+++ b/src/typechecker/FStar.TypeChecker.DeferredImplicits.fst
@@ -214,13 +214,13 @@ let solve_goals_with_tac env g (deferred_goals:implicits) (tac:sigelt) =
       match tac.sigel with
       | Sig_let {lids=[lid]} ->
         let qn = Env.lookup_qname env lid in
-        let fv = S.lid_as_fv lid (Delta_constant_at_level 0) None in
+        let fv = S.lid_as_fv' lid None in
         let dd =
           match Env.delta_depth_of_qninfo fv qn with
           | Some dd -> dd
           | None -> failwith "Expected a dd"
         in
-        let term = S.fv_to_tm (S.lid_as_fv lid dd None) in
+        let term = S.fv_to_tm (S.lid_as_fv' lid None) in
         term
       | _ -> failwith "Resolve_tac not found"
     in

--- a/src/typechecker/FStar.TypeChecker.DeferredImplicits.fst
+++ b/src/typechecker/FStar.TypeChecker.DeferredImplicits.fst
@@ -214,13 +214,13 @@ let solve_goals_with_tac env g (deferred_goals:implicits) (tac:sigelt) =
       match tac.sigel with
       | Sig_let {lids=[lid]} ->
         let qn = Env.lookup_qname env lid in
-        let fv = S.lid_as_fv' lid None in
+        let fv = S.lid_as_fv lid None in
         let dd =
           match Env.delta_depth_of_qninfo fv qn with
           | Some dd -> dd
           | None -> failwith "Expected a dd"
         in
-        let term = S.fv_to_tm (S.lid_as_fv' lid None) in
+        let term = S.fv_to_tm (S.lid_as_fv lid None) in
         term
       | _ -> failwith "Resolve_tac not found"
     in

--- a/src/typechecker/FStar.TypeChecker.Env.fst
+++ b/src/typechecker/FStar.TypeChecker.Env.fst
@@ -1985,7 +1985,7 @@ let fvar_of_nonqual_lid env lid =
         | None -> failwith "Unexpected no delta_depth"
         | Some dd -> dd
     in
-    fvar lid dd None
+    fvar lid None
 
 let split_smt_query (e:env) (q:term) 
   : option (list (env & term))

--- a/src/typechecker/FStar.TypeChecker.Env.fst
+++ b/src/typechecker/FStar.TypeChecker.Env.fst
@@ -901,7 +901,7 @@ let is_erasable_effect env l =
   l
   |> norm_eff_name env
   |> (fun l -> lid_equals l Const.effect_GHOST_lid ||
-           S.lid_as_fv' l None
+           S.lid_as_fv l None
            |> fv_has_erasable_attr env)
 
 let rec non_informative env t =

--- a/src/typechecker/FStar.TypeChecker.Env.fst
+++ b/src/typechecker/FStar.TypeChecker.Env.fst
@@ -690,7 +690,7 @@ let delta_depth_of_qninfo_lid lid (qn:qninfo) : option delta_depth =
           BU.find_map lbs (fun lb ->
               let fv = right lb.lbname in
               if fv_eq_lid fv lid
-              then Some fv.fv_delta
+              then fv.fv_delta
               else None)
 
       | Sig_fail _
@@ -706,6 +706,13 @@ let delta_depth_of_qninfo_lid lid (qn:qninfo) : option delta_depth =
       | Sig_polymonadic_subcomp _ -> None
 
 
+//
+// For the following prims symbols,
+//   delta depth is handled specially
+// Instead of looking it up in the env,
+//   we  return as is set in the input fv.fv_delta
+// No principled reason, for backward compatibility
+//
 let prims_dd_lids = [
   Const.and_lid;
   Const.or_lid;
@@ -733,61 +740,16 @@ let prims_dd_lids = [
 let is_prims_dd_lid (l:lident) =
   List.existsb (fun l0 -> lid_equals l l0) prims_dd_lids
 
-let prims_delta_depths : BU.smap delta_depth =
-  let m = BU.smap_create 20 in
-  let d0 = Delta_constant_at_level 0 in
-  let d1 = Delta_constant_at_level 1 in
-  let d2 = Delta_constant_at_level 2 in
-  let deq0 = Delta_equational_at_level 0 in
-  let l = [
-    ("l_and", d0);
-    ("l_Forall", d1);
-    ("l_imp", d1);
-    ("l_iff", d2);
-    ("l_not", d2);
-    ("b2t", d1);
-    ("l_True", d0);
-    ("l_Exists", d1);
-    ("l_or", d1);
-    ("eq2", d0);
-    ("op_Equality", deq0);
-    ("op_Addition", deq0);
-    ("op_LessThanOrEqual", deq0);
-    ("pow2", deq0);
-    ("precedes", d0);
-    ("op_LessThan", deq0);
-    ("op_disEquality", deq0);
-    ("op_Division", deq0);
-
-  ] in
-  List.iter (fun (s, d) -> BU.smap_add m s d) l;
-  m
-
 let delta_depth_of_qninfo (fv:fv) (qn:qninfo) : option delta_depth =
-    let lid = fv.fv_name.v in
-    if is_prims_dd_lid lid then Some fv.fv_delta //NS delta: too many special cases in existing code
-    else delta_depth_of_qninfo_lid lid qn
+  let lid = fv.fv_name.v in
+  if is_prims_dd_lid lid && Some? fv.fv_delta
+  then fv.fv_delta //NS delta: too many special cases in existing code
+  else delta_depth_of_qninfo_lid lid qn
 
 let delta_depth_of_fv env fv =
   let lid = fv.fv_name.v in
-  // let res =
-  //   (string_of_lid lid) |> BU.smap_try_find env.fv_delta_depths |> (fun d_opt ->
-  //     if d_opt |> is_some then d_opt |> must
-  //     else match delta_depth_of_qninfo_lid fv.fv_name.v (lookup_qname env fv.fv_name.v) with
-  //          | None -> failwith (BU.format1 "Delta depth not found for %s" (FStar.Syntax.Print.fv_to_string fv))
-  //          | Some d -> d) in
-  if is_prims_dd_lid lid then begin
-    // if res <> fv.fv_delta &&
-    //    ((lid |> ident_of_lid |> string_of_id) |> BU.smap_try_find prims_delta_depths |> (fun d_opt ->
-    //       match d_opt with
-    //       | None -> BU.print1 "%s not in map!\n" (string_of_lid lid); true
-    //       | Some dm -> dm <> fv.fv_delta))
-    // then BU.print3 "\n\nWARNING: fv %s, fv.fv_delta %s, env delta %s\n\n"
-    //        (Print.fv_to_string fv)
-    //        (Print.delta_depth_to_string fv.fv_delta)
-    //        (Print.delta_depth_to_string res);
-    fv.fv_delta //NS delta: too many special cases in existing code for prims; FIXME!
-  end
+  if is_prims_dd_lid lid && Some? fv.fv_delta
+  then fv.fv_delta |> must
   else
     //try cache
     (string_of_lid lid) |> BU.smap_try_find env.fv_delta_depths |> (fun d_opt ->
@@ -796,11 +758,11 @@ let delta_depth_of_fv env fv =
         match delta_depth_of_qninfo fv (lookup_qname env fv.fv_name.v) with
         | None -> failwith (BU.format1 "Delta depth not found for %s" (FStar.Syntax.Print.fv_to_string fv))
         | Some d ->
-          if d <> fv.fv_delta
+          if Some? fv.fv_delta && d <> Some?.v fv.fv_delta
           && Options.debug_any()
           then BU.print3 "WARNING WARNING WARNING fv=%s, delta_depth=%s, env.delta_depth=%s\n"
                          (Print.fv_to_string fv)
-                         (Print.delta_depth_to_string fv.fv_delta)
+                         (Print.delta_depth_to_string (Some?.v fv.fv_delta))
                          (Print.delta_depth_to_string d);
           BU.smap_add env.fv_delta_depths (string_of_lid lid) d;
           d)
@@ -939,7 +901,7 @@ let is_erasable_effect env l =
   l
   |> norm_eff_name env
   |> (fun l -> lid_equals l Const.effect_GHOST_lid ||
-           S.lid_as_fv l (Delta_constant_at_level 0) None
+           S.lid_as_fv' l None
            |> fv_has_erasable_attr env)
 
 let rec non_informative env t =
@@ -1032,10 +994,10 @@ let is_interpreted =
     fun (env:env) head ->
         match (U.un_uinst head).n with
         | Tm_fvar fv ->
-            (match fv.fv_delta with
+          BU.for_some (Ident.lid_equals fv.fv_name.v) interpreted_symbols ||
+            (match delta_depth_of_fv env fv with
              | Delta_equational_at_level _ -> true
-             | _ -> false) ||
-            BU.for_some (Ident.lid_equals fv.fv_name.v) interpreted_symbols
+             | _ -> false)
         | _ -> false
 
 let is_irreducible env l =

--- a/src/typechecker/FStar.TypeChecker.Env.fst
+++ b/src/typechecker/FStar.TypeChecker.Env.fst
@@ -706,14 +706,88 @@ let delta_depth_of_qninfo_lid lid (qn:qninfo) : option delta_depth =
       | Sig_polymonadic_subcomp _ -> None
 
 
+let prims_dd_lids = [
+  Const.and_lid;
+  Const.or_lid;
+  Const.imp_lid;
+  Const.iff_lid;
+  Const.true_lid;
+  Const.false_lid;
+  Const.not_lid;
+  Const.b2t_lid;
+  Const.eq2_lid;
+  Const.eq3_lid;
+  Const.op_Eq;
+  Const.op_LT;
+  Const.op_LTE;
+  Const.op_GT;
+  Const.op_GTE;
+  Const.forall_lid;
+  Const.exists_lid;
+  Const.haseq_lid;
+  Const.op_And;
+  Const.op_Or;
+  Const.op_Negation;
+]
+
+let is_prims_dd_lid (l:lident) =
+  List.existsb (fun l0 -> lid_equals l l0) prims_dd_lids
+
+let prims_delta_depths : BU.smap delta_depth =
+  let m = BU.smap_create 20 in
+  let d0 = Delta_constant_at_level 0 in
+  let d1 = Delta_constant_at_level 1 in
+  let d2 = Delta_constant_at_level 2 in
+  let deq0 = Delta_equational_at_level 0 in
+  let l = [
+    ("l_and", d0);
+    ("l_Forall", d1);
+    ("l_imp", d1);
+    ("l_iff", d2);
+    ("l_not", d2);
+    ("b2t", d1);
+    ("l_True", d0);
+    ("l_Exists", d1);
+    ("l_or", d1);
+    ("eq2", d0);
+    ("op_Equality", deq0);
+    ("op_Addition", deq0);
+    ("op_LessThanOrEqual", deq0);
+    ("pow2", deq0);
+    ("precedes", d0);
+    ("op_LessThan", deq0);
+    ("op_disEquality", deq0);
+    ("op_Division", deq0);
+
+  ] in
+  List.iter (fun (s, d) -> BU.smap_add m s d) l;
+  m
+
 let delta_depth_of_qninfo (fv:fv) (qn:qninfo) : option delta_depth =
     let lid = fv.fv_name.v in
-    if nsstr lid = "Prims" then Some fv.fv_delta //NS delta: too many special cases in existing code
+    if is_prims_dd_lid lid then Some fv.fv_delta //NS delta: too many special cases in existing code
     else delta_depth_of_qninfo_lid lid qn
 
 let delta_depth_of_fv env fv =
   let lid = fv.fv_name.v in
-  if nsstr lid = "Prims" then fv.fv_delta //NS delta: too many special cases in existing code for prims; FIXME!
+  // let res =
+  //   (string_of_lid lid) |> BU.smap_try_find env.fv_delta_depths |> (fun d_opt ->
+  //     if d_opt |> is_some then d_opt |> must
+  //     else match delta_depth_of_qninfo_lid fv.fv_name.v (lookup_qname env fv.fv_name.v) with
+  //          | None -> failwith (BU.format1 "Delta depth not found for %s" (FStar.Syntax.Print.fv_to_string fv))
+  //          | Some d -> d) in
+  if is_prims_dd_lid lid then begin
+    // if res <> fv.fv_delta &&
+    //    ((lid |> ident_of_lid |> string_of_id) |> BU.smap_try_find prims_delta_depths |> (fun d_opt ->
+    //       match d_opt with
+    //       | None -> BU.print1 "%s not in map!\n" (string_of_lid lid); true
+    //       | Some dm -> dm <> fv.fv_delta))
+    // then BU.print3 "\n\nWARNING: fv %s, fv.fv_delta %s, env delta %s\n\n"
+    //        (Print.fv_to_string fv)
+    //        (Print.delta_depth_to_string fv.fv_delta)
+    //        (Print.delta_depth_to_string res);
+    fv.fv_delta //NS delta: too many special cases in existing code for prims; FIXME!
+  end
   else
     //try cache
     (string_of_lid lid) |> BU.smap_try_find env.fv_delta_depths |> (fun d_opt ->

--- a/src/typechecker/FStar.TypeChecker.NBETerm.fst
+++ b/src/typechecker/FStar.TypeChecker.NBETerm.fst
@@ -234,10 +234,10 @@ let embed_as (ea:embedding 'a)
           ea.emb_typ
 
 let lid_as_constr (l:lident) (us:list universe) (args:args) : t =
-    mkConstruct (lid_as_fv' l (Some Data_ctor)) us args
+    mkConstruct (lid_as_fv l (Some Data_ctor)) us args
 
 let lid_as_typ (l:lident) (us:list universe) (args:args) : t =
-    mkFV (lid_as_fv' l None) us args
+    mkFV (lid_as_fv l None) us args
 
 let as_iarg (a:t) : arg = (a, S.as_aqual_implicit true)
 let as_arg (a:t) : arg = (a, None)
@@ -523,32 +523,32 @@ let e_arrow (ea:embedding 'a) (eb:embedding 'b) : embedding ('a -> 'b) =
 let e_norm_step =
     let em cb (n:SE.norm_step) : t =
         match n with
-        | SE.Simpl   -> mkFV (lid_as_fv' PC.steps_simpl     None) [] []
-        | SE.Weak    -> mkFV (lid_as_fv' PC.steps_weak      None) [] []
-        | SE.HNF     -> mkFV (lid_as_fv' PC.steps_hnf       None) [] []
-        | SE.Primops -> mkFV (lid_as_fv' PC.steps_primops   None) [] []
-        | SE.Delta   -> mkFV (lid_as_fv' PC.steps_delta     None) [] []
-        | SE.Zeta    -> mkFV (lid_as_fv' PC.steps_zeta      None) [] []
-        | SE.Iota    -> mkFV (lid_as_fv' PC.steps_iota      None) [] []
-        | SE.Reify   -> mkFV (lid_as_fv' PC.steps_reify     None) [] []
-        | SE.NBE     -> mkFV (lid_as_fv' PC.steps_nbe       None) [] []
+        | SE.Simpl   -> mkFV (lid_as_fv PC.steps_simpl     None) [] []
+        | SE.Weak    -> mkFV (lid_as_fv PC.steps_weak      None) [] []
+        | SE.HNF     -> mkFV (lid_as_fv PC.steps_hnf       None) [] []
+        | SE.Primops -> mkFV (lid_as_fv PC.steps_primops   None) [] []
+        | SE.Delta   -> mkFV (lid_as_fv PC.steps_delta     None) [] []
+        | SE.Zeta    -> mkFV (lid_as_fv PC.steps_zeta      None) [] []
+        | SE.Iota    -> mkFV (lid_as_fv PC.steps_iota      None) [] []
+        | SE.Reify   -> mkFV (lid_as_fv PC.steps_reify     None) [] []
+        | SE.NBE     -> mkFV (lid_as_fv PC.steps_nbe       None) [] []
         | SE.UnfoldOnly l ->
-                     mkFV (lid_as_fv' PC.steps_unfoldonly None)
+                     mkFV (lid_as_fv PC.steps_unfoldonly None)
                           [] [as_arg (embed (e_list e_string) cb l)]
         | SE.UnfoldFully l ->
-                     mkFV (lid_as_fv' PC.steps_unfoldfully None)
+                     mkFV (lid_as_fv PC.steps_unfoldfully None)
                           [] [as_arg (embed (e_list e_string) cb l)]
         | SE.UnfoldAttr l ->
-                     mkFV (lid_as_fv' PC.steps_unfoldattr None)
+                     mkFV (lid_as_fv PC.steps_unfoldattr None)
                           [] [as_arg (embed (e_list e_string) cb l)]
         | SE.UnfoldQual l ->
-                     mkFV (lid_as_fv' PC.steps_unfoldqual None)
+                     mkFV (lid_as_fv PC.steps_unfoldqual None)
                           [] [as_arg (embed (e_list e_string) cb l)]
         | SE.UnfoldNamespace l ->
-                     mkFV (lid_as_fv' PC.steps_unfoldnamespace None)
+                     mkFV (lid_as_fv PC.steps_unfoldnamespace None)
                           [] [as_arg (embed (e_list e_string) cb l)]
-        | SE.ZetaFull -> mkFV (lid_as_fv' PC.steps_zeta_full None) [] []
-        | SE.Unascribe -> mkFV (lid_as_fv' PC.steps_unascribe None) [] []
+        | SE.ZetaFull -> mkFV (lid_as_fv PC.steps_zeta_full None) [] []
+        | SE.Unascribe -> mkFV (lid_as_fv PC.steps_unascribe None) [] []
     in
     let un cb (t0:t) : option SE.norm_step =
         match t0.nbe_t with
@@ -593,7 +593,7 @@ let e_norm_step =
             Errors.log_issue Range.dummyRange (Errors.Warning_NotEmbedded, (BU.format1 "Not an embedded norm_step: %s" (t_to_string t0)));
             None
     in
-    mk_emb em un (mkFV (lid_as_fv' PC.norm_step_lid None) [] []) (SE.emb_typ_of SE.e_norm_step)
+    mk_emb em un (mkFV (lid_as_fv PC.norm_step_lid None) [] []) (SE.emb_typ_of SE.e_norm_step)
 
 // Embedding a sealed term. This just calls the embedding for a but also
 // adds a `seal` marker to the result. The unembedding removes it.

--- a/src/typechecker/FStar.TypeChecker.NBETerm.fst
+++ b/src/typechecker/FStar.TypeChecker.NBETerm.fst
@@ -234,10 +234,10 @@ let embed_as (ea:embedding 'a)
           ea.emb_typ
 
 let lid_as_constr (l:lident) (us:list universe) (args:args) : t =
-    mkConstruct (lid_as_fv l S.delta_constant (Some Data_ctor)) us args
+    mkConstruct (lid_as_fv' l (Some Data_ctor)) us args
 
 let lid_as_typ (l:lident) (us:list universe) (args:args) : t =
-    mkFV (lid_as_fv l S.delta_constant None) us args
+    mkFV (lid_as_fv' l None) us args
 
 let as_iarg (a:t) : arg = (a, S.as_aqual_implicit true)
 let as_arg (a:t) : arg = (a, None)
@@ -523,32 +523,32 @@ let e_arrow (ea:embedding 'a) (eb:embedding 'b) : embedding ('a -> 'b) =
 let e_norm_step =
     let em cb (n:SE.norm_step) : t =
         match n with
-        | SE.Simpl   -> mkFV (lid_as_fv PC.steps_simpl     S.delta_constant None) [] []
-        | SE.Weak    -> mkFV (lid_as_fv PC.steps_weak      S.delta_constant None) [] []
-        | SE.HNF     -> mkFV (lid_as_fv PC.steps_hnf       S.delta_constant None) [] []
-        | SE.Primops -> mkFV (lid_as_fv PC.steps_primops   S.delta_constant None) [] []
-        | SE.Delta   -> mkFV (lid_as_fv PC.steps_delta     S.delta_constant None) [] []
-        | SE.Zeta    -> mkFV (lid_as_fv PC.steps_zeta      S.delta_constant None) [] []
-        | SE.Iota    -> mkFV (lid_as_fv PC.steps_iota      S.delta_constant None) [] []
-        | SE.Reify   -> mkFV (lid_as_fv PC.steps_reify     S.delta_constant None) [] []
-        | SE.NBE     -> mkFV (lid_as_fv PC.steps_nbe       S.delta_constant None) [] []
+        | SE.Simpl   -> mkFV (lid_as_fv' PC.steps_simpl     None) [] []
+        | SE.Weak    -> mkFV (lid_as_fv' PC.steps_weak      None) [] []
+        | SE.HNF     -> mkFV (lid_as_fv' PC.steps_hnf       None) [] []
+        | SE.Primops -> mkFV (lid_as_fv' PC.steps_primops   None) [] []
+        | SE.Delta   -> mkFV (lid_as_fv' PC.steps_delta     None) [] []
+        | SE.Zeta    -> mkFV (lid_as_fv' PC.steps_zeta      None) [] []
+        | SE.Iota    -> mkFV (lid_as_fv' PC.steps_iota      None) [] []
+        | SE.Reify   -> mkFV (lid_as_fv' PC.steps_reify     None) [] []
+        | SE.NBE     -> mkFV (lid_as_fv' PC.steps_nbe       None) [] []
         | SE.UnfoldOnly l ->
-                     mkFV (lid_as_fv PC.steps_unfoldonly S.delta_constant None)
+                     mkFV (lid_as_fv' PC.steps_unfoldonly None)
                           [] [as_arg (embed (e_list e_string) cb l)]
         | SE.UnfoldFully l ->
-                     mkFV (lid_as_fv PC.steps_unfoldfully S.delta_constant None)
+                     mkFV (lid_as_fv' PC.steps_unfoldfully None)
                           [] [as_arg (embed (e_list e_string) cb l)]
         | SE.UnfoldAttr l ->
-                     mkFV (lid_as_fv PC.steps_unfoldattr S.delta_constant None)
+                     mkFV (lid_as_fv' PC.steps_unfoldattr None)
                           [] [as_arg (embed (e_list e_string) cb l)]
         | SE.UnfoldQual l ->
-                     mkFV (lid_as_fv PC.steps_unfoldqual S.delta_constant None)
+                     mkFV (lid_as_fv' PC.steps_unfoldqual None)
                           [] [as_arg (embed (e_list e_string) cb l)]
         | SE.UnfoldNamespace l ->
-                     mkFV (lid_as_fv PC.steps_unfoldnamespace S.delta_constant None)
+                     mkFV (lid_as_fv' PC.steps_unfoldnamespace None)
                           [] [as_arg (embed (e_list e_string) cb l)]
-        | SE.ZetaFull -> mkFV (lid_as_fv PC.steps_zeta_full S.delta_constant None) [] []
-        | SE.Unascribe -> mkFV (lid_as_fv PC.steps_unascribe S.delta_constant None) [] []
+        | SE.ZetaFull -> mkFV (lid_as_fv' PC.steps_zeta_full None) [] []
+        | SE.Unascribe -> mkFV (lid_as_fv' PC.steps_unascribe None) [] []
     in
     let un cb (t0:t) : option SE.norm_step =
         match t0.nbe_t with
@@ -593,7 +593,7 @@ let e_norm_step =
             Errors.log_issue Range.dummyRange (Errors.Warning_NotEmbedded, (BU.format1 "Not an embedded norm_step: %s" (t_to_string t0)));
             None
     in
-    mk_emb em un (mkFV (lid_as_fv PC.norm_step_lid delta_constant None) [] []) (SE.emb_typ_of SE.e_norm_step)
+    mk_emb em un (mkFV (lid_as_fv' PC.norm_step_lid None) [] []) (SE.emb_typ_of SE.e_norm_step)
 
 // Embedding a sealed term. This just calls the embedding for a but also
 // adds a `seal` marker to the result. The unembedding removes it.

--- a/src/typechecker/FStar.TypeChecker.Normalize.fst
+++ b/src/typechecker/FStar.TypeChecker.Normalize.fst
@@ -2217,7 +2217,7 @@ and norm_cb cfg : EMB.norm_cb = function
             FStar.Syntax.DsEnv.try_lookup_lid cfg.tcenv.dsenv l
         with
         | Some t -> t
-        | None -> S.fv_to_tm (S.lid_as_fv' l None)
+        | None -> S.fv_to_tm (S.lid_as_fv l None)
 
 
 (*******************************************************************)

--- a/src/typechecker/FStar.TypeChecker.Normalize.fst
+++ b/src/typechecker/FStar.TypeChecker.Normalize.fst
@@ -899,7 +899,7 @@ let should_unfold cfg should_reify fv qninfo : should_unfold_res =
     let default_unfolding () =
         log_unfolding cfg (fun () -> BU.print3 "should_unfold: Reached a %s with delta_depth = %s\n >> Our delta_level is %s\n"
                                                (Print.fv_to_string fv)
-                                               (Print.delta_depth_to_string fv.fv_delta)
+                                               (Print.delta_depth_to_string (Env.delta_depth_of_fv cfg.tcenv fv))
                                                (FStar.Common.string_of_list Env.string_of_delta_level cfg.delta_level));
         yesno <| (cfg.delta_level |> BU.for_some (function
              | NoDelta -> false
@@ -2217,7 +2217,7 @@ and norm_cb cfg : EMB.norm_cb = function
             FStar.Syntax.DsEnv.try_lookup_lid cfg.tcenv.dsenv l
         with
         | Some t -> t
-        | None -> S.fv_to_tm (S.lid_as_fv l delta_constant None)
+        | None -> S.fv_to_tm (S.lid_as_fv' l None)
 
 
 (*******************************************************************)

--- a/src/typechecker/FStar.TypeChecker.TcEffect.fst
+++ b/src/typechecker/FStar.TypeChecker.TcEffect.fst
@@ -1591,7 +1591,7 @@ Errors.with_ctx (BU.format1 "While checking layered effect definition `%s`" (str
 
     let _check_else =
       let not_p = S.mk_Tm_app
-        (S.lid_as_fv' PC.not_lid None |> S.fv_to_tm)
+        (S.lid_as_fv PC.not_lid None |> S.fv_to_tm)
         [p_t |> U.b2t |> S.as_arg]
         r in
       let env = Env.push_bv env (S.new_bv None not_p) in

--- a/src/typechecker/FStar.TypeChecker.TcEffect.fst
+++ b/src/typechecker/FStar.TypeChecker.TcEffect.fst
@@ -1591,7 +1591,7 @@ Errors.with_ctx (BU.format1 "While checking layered effect definition `%s`" (str
 
     let _check_else =
       let not_p = S.mk_Tm_app
-        (S.lid_as_fv PC.not_lid S.delta_constant None |> S.fv_to_tm)
+        (S.lid_as_fv' PC.not_lid None |> S.fv_to_tm)
         [p_t |> U.b2t |> S.as_arg]
         r in
       let env = Env.push_bv env (S.new_bv None not_p) in

--- a/src/typechecker/FStar.TypeChecker.TcInductive.fst
+++ b/src/typechecker/FStar.TypeChecker.TcInductive.fst
@@ -357,7 +357,7 @@ let get_optimized_haseq_axiom (en:env) (ty:sigelt) (usubst:list subst_elt) (us:u
   //open the ibs binders
   let ibs = SS.open_binders ibs in
   //term for unapplied inductive type, making a Tm_uinst, otherwise there are unresolved universe variables, may be that's fine ?
-  let ind = mk_Tm_uinst (S.fvar lid delta_constant None) (List.map (fun u -> U_name u) us) in
+  let ind = mk_Tm_uinst (S.fvar lid None) (List.map (fun u -> U_name u) us) in
   //apply the bs parameters, bv_to_name ok ? also note that we are copying the qualifiers from the binder, so that implicits remain implicits
   let ind = mk_Tm_app ind (List.map U.arg_of_non_null_binder bs) Range.dummyRange in
   //apply the ibs parameters, bv_to_name ok ? also note that we are copying the qualifiers from the binder, so that implicits remain implicits
@@ -586,7 +586,7 @@ let unoptimized_haseq_ty (all_datas_in_the_bundle:list sigelt) (mutuals:list lid
   //open the ibs binders
   let ibs = SS.open_binders ibs in
   //term for unapplied inductive type, making a Tm_uinst, otherwise there are unresolved universe variables, may be that's fine ?
-  let ind = mk_Tm_uinst (S.fvar lid delta_constant None) (List.map (fun u -> U_name u) us) in
+  let ind = mk_Tm_uinst (S.fvar lid None) (List.map (fun u -> U_name u) us) in
   //apply the bs parameters, bv_to_name ok ? also note that we are copying the qualifiers from the binder, so that implicits remain implicits
   let ind = mk_Tm_app ind (List.map U.arg_of_non_null_binder bs) Range.dummyRange in
   //apply the ibs parameters, bv_to_name ok ? also note that we are copying the qualifiers from the binder, so that implicits remain implicits
@@ -899,7 +899,7 @@ let mk_discriminator_and_indexed_projectors iquals                   (* Qualifie
         else let disc_name = U.mk_discriminator lid in
              let x = S.new_bv (Some p) arg_typ in
              let sort =
-                 let disc_fvar = S.fvar (Ident.set_lid_range disc_name p) (Delta_equational_at_level 1) None in
+                 let disc_fvar = S.fvar_with_dd (Ident.set_lid_range disc_name p) (Delta_equational_at_level 1) None in
                  U.refine x (U.b2t (S.mk_Tm_app (S.mk_Tm_uinst disc_fvar inst_univs) [as_arg <| S.bv_to_name x] p))
              in
              S.mk_binder ({projectee arg_typ with sort = sort})

--- a/src/typechecker/FStar.TypeChecker.TcInductive.fst
+++ b/src/typechecker/FStar.TypeChecker.TcInductive.fst
@@ -95,7 +95,7 @@ let tc_tycon (env:env_t)     (* environment that contains all mutually defined t
          let tps = SS.close_binders tps in
          let k = SS.close tps k in
          let tps, k = SS.subst_binders usubst tps, SS.subst (SS.shift_subst (List.length tps) usubst) k in
-         let fv_tc = S.lid_and_dd_as_fv tc delta_constant None in
+         let fv_tc = S.lid_as_fv tc None in
          let (uvs, t_tc) = SS.open_univ_vars uvs t_tc in
          Env.push_let_binding env0 (Inr fv_tc) (uvs, t_tc),
          { s with sigel = Sig_inductive_typ {lid=tc;

--- a/src/typechecker/FStar.TypeChecker.TcInductive.fst
+++ b/src/typechecker/FStar.TypeChecker.TcInductive.fst
@@ -95,7 +95,7 @@ let tc_tycon (env:env_t)     (* environment that contains all mutually defined t
          let tps = SS.close_binders tps in
          let k = SS.close tps k in
          let tps, k = SS.subst_binders usubst tps, SS.subst (SS.shift_subst (List.length tps) usubst) k in
-         let fv_tc = S.lid_as_fv tc delta_constant None in
+         let fv_tc = S.lid_and_dd_as_fv tc delta_constant None in
          let (uvs, t_tc) = SS.open_univ_vars uvs t_tc in
          Env.push_let_binding env0 (Inr fv_tc) (uvs, t_tc),
          { s with sigel = Sig_inductive_typ {lid=tc;
@@ -888,7 +888,7 @@ let mk_discriminator_and_indexed_projectors iquals                   (* Qualifie
     let inst_univs = List.map (fun u -> U_name u) uvs in
     let tps = inductive_tps in //List.map2 (fun (x,_) (_,imp) -> ({x,imp)) implicit_tps inductive_tps in
     let arg_typ =
-        let inst_tc = S.mk (Tm_uinst (S.fv_to_tm (S.lid_as_fv' tc None), inst_univs)) p in
+        let inst_tc = S.mk (Tm_uinst (S.fv_to_tm (S.lid_as_fv tc None), inst_univs)) p in
         let args = tps@indices |> List.map U.arg_of_non_null_binder in
         S.mk_Tm_app inst_tc args p
     in
@@ -967,7 +967,7 @@ let mk_discriminator_and_indexed_projectors iquals                   (* Qualifie
                             then pos (Pat_dot_term None), b
                             else pos (Pat_var (S.gen_bv (string_of_id x.ppname) None tun)), b)
                         in
-                        let pat_true = pos (S.Pat_cons (S.lid_as_fv' lid (Some fvq), None, arg_pats)), None, U.exp_true_bool in
+                        let pat_true = pos (S.Pat_cons (S.lid_as_fv lid (Some fvq), None, arg_pats)), None, U.exp_true_bool in
                         let pat_false = pos (Pat_var (S.new_bv None tun)), None, U.exp_false_bool in
                         let arg_exp = S.bv_to_name unrefined_arg_binder.binder_bv in
                         mk (Tm_match {scrutinee=arg_exp;
@@ -979,7 +979,7 @@ let mk_discriminator_and_indexed_projectors iquals                   (* Qualifie
                 let imp = U.abs binders body None in
                 let lbtyp = if no_decl then t else tun in
                 let lb = U.mk_letbinding
-                            (Inr (S.lid_as_fv discriminator_name dd None))
+                            (Inr (S.lid_and_dd_as_fv discriminator_name dd None))
                             uvs
                             lbtyp
                             C.effect_Tot_lid
@@ -1007,7 +1007,7 @@ let mk_discriminator_and_indexed_projectors iquals                   (* Qualifie
 
     let subst = fields |> List.mapi (fun i ({binder_bv=a}) ->
             let field_name = U.mk_field_projector_name lid a i in
-            let field_proj_tm = mk_Tm_uinst (S.fv_to_tm (S.lid_as_fv' field_name None)) inst_univs in
+            let field_proj_tm = mk_Tm_uinst (S.fv_to_tm (S.lid_as_fv field_name None)) inst_univs in
             let proj = mk_Tm_app field_proj_tm [arg] p in
             NT(a, proj))
     in
@@ -1063,7 +1063,7 @@ let mk_discriminator_and_indexed_projectors iquals                   (* Qualifie
                   then pos (Pat_dot_term None), b
                   else pos (Pat_var (S.gen_bv (string_of_id x.ppname) None tun)), b)
               in
-              let pat = pos (S.Pat_cons (S.lid_as_fv' lid (Some fvq), None, arg_pats)), None, S.bv_to_name projection in
+              let pat = pos (S.Pat_cons (S.lid_as_fv lid (Some fvq), None, arg_pats)), None, S.bv_to_name projection in
               let body =
                 let return_bv = S.gen_bv "proj_ret" (Some p) S.tun in
                 let result_typ = result_comp
@@ -1082,7 +1082,7 @@ let mk_discriminator_and_indexed_projectors iquals                   (* Qualifie
               let dd = Delta_equational_at_level 1 in
               let lbtyp = if no_decl then t else tun in
               let lb = {
-                  lbname=Inr (S.lid_as_fv field_name dd None);
+                  lbname=Inr (S.lid_and_dd_as_fv field_name dd None);
                   lbunivs=uvs;
                   lbtyp=lbtyp;
                   lbeff=C.effect_Tot_lid;

--- a/src/typechecker/FStar.TypeChecker.TcInductive.fst
+++ b/src/typechecker/FStar.TypeChecker.TcInductive.fst
@@ -888,7 +888,7 @@ let mk_discriminator_and_indexed_projectors iquals                   (* Qualifie
     let inst_univs = List.map (fun u -> U_name u) uvs in
     let tps = inductive_tps in //List.map2 (fun (x,_) (_,imp) -> ({x,imp)) implicit_tps inductive_tps in
     let arg_typ =
-        let inst_tc = S.mk (Tm_uinst (S.fv_to_tm (S.lid_as_fv tc delta_constant None), inst_univs)) p in
+        let inst_tc = S.mk (Tm_uinst (S.fv_to_tm (S.lid_as_fv' tc None), inst_univs)) p in
         let args = tps@indices |> List.map U.arg_of_non_null_binder in
         S.mk_Tm_app inst_tc args p
     in
@@ -967,7 +967,7 @@ let mk_discriminator_and_indexed_projectors iquals                   (* Qualifie
                             then pos (Pat_dot_term None), b
                             else pos (Pat_var (S.gen_bv (string_of_id x.ppname) None tun)), b)
                         in
-                        let pat_true = pos (S.Pat_cons (S.lid_as_fv lid delta_constant (Some fvq), None, arg_pats)), None, U.exp_true_bool in
+                        let pat_true = pos (S.Pat_cons (S.lid_as_fv' lid (Some fvq), None, arg_pats)), None, U.exp_true_bool in
                         let pat_false = pos (Pat_var (S.new_bv None tun)), None, U.exp_false_bool in
                         let arg_exp = S.bv_to_name unrefined_arg_binder.binder_bv in
                         mk (Tm_match {scrutinee=arg_exp;
@@ -1007,7 +1007,7 @@ let mk_discriminator_and_indexed_projectors iquals                   (* Qualifie
 
     let subst = fields |> List.mapi (fun i ({binder_bv=a}) ->
             let field_name = U.mk_field_projector_name lid a i in
-            let field_proj_tm = mk_Tm_uinst (S.fv_to_tm (S.lid_as_fv field_name (Delta_equational_at_level 1) None)) inst_univs in
+            let field_proj_tm = mk_Tm_uinst (S.fv_to_tm (S.lid_as_fv' field_name None)) inst_univs in
             let proj = mk_Tm_app field_proj_tm [arg] p in
             NT(a, proj))
     in
@@ -1063,7 +1063,7 @@ let mk_discriminator_and_indexed_projectors iquals                   (* Qualifie
                   then pos (Pat_dot_term None), b
                   else pos (Pat_var (S.gen_bv (string_of_id x.ppname) None tun)), b)
               in
-              let pat = pos (S.Pat_cons (S.lid_as_fv lid delta_constant (Some fvq), None, arg_pats)), None, S.bv_to_name projection in
+              let pat = pos (S.Pat_cons (S.lid_as_fv' lid (Some fvq), None, arg_pats)), None, S.bv_to_name projection in
               let body =
                 let return_bv = S.gen_bv "proj_ret" (Some p) S.tun in
                 let result_typ = result_comp

--- a/src/typechecker/FStar.TypeChecker.TcTerm.fst
+++ b/src/typechecker/FStar.TypeChecker.TcTerm.fst
@@ -493,7 +493,7 @@ let guard_letrecs env actuals expected_c : list (lbname*typ*univ_names) =
                 | _ -> bs |> filter_types_and_functions |> Decreases_lex
       in
 
-      let precedes_t = TcUtil.fvar_const env Const.precedes_lid in
+      let precedes_t = TcUtil.fvar_env env Const.precedes_lid in
       let rec mk_precedes_lex env l l_prev : term =
         (*
          * AR: aux assumes that l and l_prev have the same lengths
@@ -1114,7 +1114,7 @@ and tc_maybe_toplevel_term env (e:term) : term                  (* type-checked 
     let mk_field_projector i x =
         let projname = mk_field_projector_name_from_ident constrname i in
         let qual = if rdc.is_record then Some (Record_projector (constrname, i)) else None in
-        let candidate = S.fvar_with_dd (Ident.set_lid_range projname x.pos) (Delta_equational_at_level 1) qual in
+        let candidate = S.fvar (Ident.set_lid_range projname x.pos) qual in
         S.mk_Tm_app candidate [(x, None)] x.pos
     in
     let fields =
@@ -3290,7 +3290,7 @@ and tc_pat env (pat_t:typ) (p0:pat) :
                 let g' = Env.close_guard env (bvs |> List.map S.mk_binder) g' in
                 let tms_p =
                   let disc_tm = TcUtil.get_field_projector_name env (S.lid_of_fv fv) i in
-                  tms_p |> List.map (mk_disc_t (S.fvar_with_dd disc_tm (S.Delta_constant_at_level 1) None)) in
+                  tms_p |> List.map (mk_disc_t (S.fvar disc_tm None)) in
                 bvs@bvs_p, tms@tms_p, pats@[(p,b)], NT(x, e_p)::subst, Env.conj_guard g g', erasable || erasable_p, i+1)
               ([], [], [], [], Env.conj_guard g0 g1, erasable, 0)
               sub_pats
@@ -3479,7 +3479,7 @@ and tc_eqn (scrutinee:bv) (env:Env.env) (ret_opt : option match_returns_ascripti
                     match Env.try_lookup_lid env discriminator with
                         | None -> []  // We don't use the discriminator if we are typechecking it
                         | _ ->
-                            let disc = S.fvar_with_dd discriminator (Delta_equational_at_level 1) None in
+                            let disc = S.fvar discriminator None in
                             [mk_Tm_app disc [as_arg scrutinee_tm] scrutinee_tm.pos]
                 else []
             in
@@ -3546,7 +3546,7 @@ and tc_eqn (scrutinee:bv) (env:Env.env) (ret_opt : option match_returns_ascripti
                                 | None ->
                                   None //no projector, e.g., because we are actually typechecking the projector itself
                                 | _ ->
-                                  let proj = S.fvar_with_dd (Ident.set_lid_range projector f.p) (Delta_equational_at_level 1) None in
+                                  let proj = S.fvar (Ident.set_lid_range projector f.p) None in
                                   Some (mk_Tm_app proj [as_arg (force_scrutinee())] f.p)
                             in
                             build_branch_guard scrutinee_tm pi ei) |>

--- a/src/typechecker/FStar.TypeChecker.TcTerm.fst
+++ b/src/typechecker/FStar.TypeChecker.TcTerm.fst
@@ -1114,7 +1114,7 @@ and tc_maybe_toplevel_term env (e:term) : term                  (* type-checked 
     let mk_field_projector i x =
         let projname = mk_field_projector_name_from_ident constrname i in
         let qual = if rdc.is_record then Some (Record_projector (constrname, i)) else None in
-        let candidate = S.fvar (Ident.set_lid_range projname x.pos) (Delta_equational_at_level 1) qual in
+        let candidate = S.fvar_with_dd (Ident.set_lid_range projname x.pos) (Delta_equational_at_level 1) qual in
         S.mk_Tm_app candidate [(x, None)] x.pos
     in
     let fields =
@@ -1832,7 +1832,7 @@ and tc_comp env c : comp                                      (* checked version
       mk_GTotal t, u, g
 
     | Comp c ->
-      let head = S.fvar c.effect_name delta_constant None in
+      let head = S.fvar c.effect_name None in
       let head = match c.comp_univs with
          | [] -> head
          | us -> S.mk (Tm_uinst(head, us)) c0.pos in
@@ -3097,7 +3097,7 @@ and tc_pat env (pat_t:typ) (p0:pat) :
         then BU.print2 "Checking pattern %s at type %s\n" (Print.pat_to_string p) (Print.term_to_string t);
 
         let id t = mk_Tm_app
-          (S.fvar Const.id_lid (S.Delta_constant_at_level 1) None)
+          (S.fvar Const.id_lid None)
           [S.iarg t]
           t.pos
         in
@@ -3290,7 +3290,7 @@ and tc_pat env (pat_t:typ) (p0:pat) :
                 let g' = Env.close_guard env (bvs |> List.map S.mk_binder) g' in
                 let tms_p =
                   let disc_tm = TcUtil.get_field_projector_name env (S.lid_of_fv fv) i in
-                  tms_p |> List.map (mk_disc_t (S.fvar disc_tm (S.Delta_constant_at_level 1) None)) in
+                  tms_p |> List.map (mk_disc_t (S.fvar_with_dd disc_tm (S.Delta_constant_at_level 1) None)) in
                 bvs@bvs_p, tms@tms_p, pats@[(p,b)], NT(x, e_p)::subst, Env.conj_guard g g', erasable || erasable_p, i+1)
               ([], [], [], [], Env.conj_guard g0 g1, erasable, 0)
               sub_pats
@@ -3479,7 +3479,7 @@ and tc_eqn (scrutinee:bv) (env:Env.env) (ret_opt : option match_returns_ascripti
                     match Env.try_lookup_lid env discriminator with
                         | None -> []  // We don't use the discriminator if we are typechecking it
                         | _ ->
-                            let disc = S.fvar discriminator (Delta_equational_at_level 1) None in
+                            let disc = S.fvar_with_dd discriminator (Delta_equational_at_level 1) None in
                             [mk_Tm_app disc [as_arg scrutinee_tm] scrutinee_tm.pos]
                 else []
             in
@@ -3546,7 +3546,7 @@ and tc_eqn (scrutinee:bv) (env:Env.env) (ret_opt : option match_returns_ascripti
                                 | None ->
                                   None //no projector, e.g., because we are actually typechecking the projector itself
                                 | _ ->
-                                  let proj = S.fvar (Ident.set_lid_range projector f.p) (Delta_equational_at_level 1) None in
+                                  let proj = S.fvar_with_dd (Ident.set_lid_range projector f.p) (Delta_equational_at_level 1) None in
                                   Some (mk_Tm_app proj [as_arg (force_scrutinee())] f.p)
                             in
                             build_branch_guard scrutinee_tm pi ei) |>

--- a/src/typechecker/FStar.TypeChecker.TcTerm.fst
+++ b/src/typechecker/FStar.TypeChecker.TcTerm.fst
@@ -1178,7 +1178,7 @@ and tc_maybe_toplevel_term env (e:term) : term                  (* type-checked 
           let projname = mk_field_projector_name_from_ident constrname i in
           let qual = if rdc.is_record then Some (Record_projector (constrname, i)) else None in
           let choice =
-            S.lid_as_fv'
+            S.lid_as_fv
               (Ident.set_lid_range projname (Ident.range_of_lid field_name))
               qual
           in

--- a/src/typechecker/FStar.TypeChecker.TcTerm.fst
+++ b/src/typechecker/FStar.TypeChecker.TcTerm.fst
@@ -1178,9 +1178,8 @@ and tc_maybe_toplevel_term env (e:term) : term                  (* type-checked 
           let projname = mk_field_projector_name_from_ident constrname i in
           let qual = if rdc.is_record then Some (Record_projector (constrname, i)) else None in
           let choice =
-            S.lid_as_fv
+            S.lid_as_fv'
               (Ident.set_lid_range projname (Ident.range_of_lid field_name))
-              (Delta_equational_at_level 1)
               qual
           in
           proceed_with (Some choice)

--- a/src/typechecker/FStar.TypeChecker.Util.fst
+++ b/src/typechecker/FStar.TypeChecker.Util.fst
@@ -1231,7 +1231,7 @@ let strengthen_comp env (reason:option (unit -> string)) (c:comp) (f:formula) fl
           * its type is p:Type -> pure_wp unit
           *  and it is not universe polymorphic
           *)
-         let pure_assert_wp = S.fv_to_tm (S.lid_as_fv C.pure_assert_wp_lid (Delta_constant_at_level 1) None) in
+         let pure_assert_wp = S.fv_to_tm (S.lid_as_fv' C.pure_assert_wp_lid None) in
 
          (* apply it to f, after decorating f with the reason *)
          let pure_assert_wp = mk_Tm_app
@@ -1294,7 +1294,7 @@ let weaken_comp env (c:comp) (formula:term) : comp * guard_t =
         * its type is p:Type -> pure_wp unit
         *  and it is not universe polymorphic
         *)
-       let pure_assume_wp = S.fv_to_tm (S.lid_as_fv C.pure_assume_wp_lid (Delta_constant_at_level 1) None) in
+       let pure_assume_wp = S.fv_to_tm (S.lid_as_fv' C.pure_assume_wp_lid None) in
 
        (* apply it to f, after decorating f with the reason *)
        let pure_assume_wp = mk_Tm_app
@@ -3661,7 +3661,7 @@ let find_record_or_dc_from_typ env (t:option typ) (uc:unresolved_constructor) rn
             then (Some (Record_ctor(rdc.typename, rdc.fields |> List.map fst)))
           else None
         in
-        S.lid_as_fv constrname delta_constant qual
+        S.lid_as_fv' constrname qual
     in
     rdc, constrname, constructor
 

--- a/src/typechecker/FStar.TypeChecker.Util.fst
+++ b/src/typechecker/FStar.TypeChecker.Util.fst
@@ -1231,7 +1231,7 @@ let strengthen_comp env (reason:option (unit -> string)) (c:comp) (f:formula) fl
           * its type is p:Type -> pure_wp unit
           *  and it is not universe polymorphic
           *)
-         let pure_assert_wp = S.fv_to_tm (S.lid_as_fv' C.pure_assert_wp_lid None) in
+         let pure_assert_wp = S.fv_to_tm (S.lid_as_fv C.pure_assert_wp_lid None) in
 
          (* apply it to f, after decorating f with the reason *)
          let pure_assert_wp = mk_Tm_app
@@ -1294,7 +1294,7 @@ let weaken_comp env (c:comp) (formula:term) : comp * guard_t =
         * its type is p:Type -> pure_wp unit
         *  and it is not universe polymorphic
         *)
-       let pure_assume_wp = S.fv_to_tm (S.lid_as_fv' C.pure_assume_wp_lid None) in
+       let pure_assume_wp = S.fv_to_tm (S.lid_as_fv C.pure_assume_wp_lid None) in
 
        (* apply it to f, after decorating f with the reason *)
        let pure_assume_wp = mk_Tm_app
@@ -2990,7 +2990,7 @@ let mk_toplevel_definition (env: env_t) lident (def: term): sigelt * term =
     BU.print2 "Registering top-level definition: %s\n%s\n" (string_of_lid lident) (Print.term_to_string def)
   end;
   // Allocate a new top-level name.
-  let fv = S.lid_as_fv lident (U.incr_delta_qualifier def) None in
+  let fv = S.lid_and_dd_as_fv lident (U.incr_delta_qualifier def) None in
   let lbname: lbname = Inr fv in
   let lb: letbindings =
     // the effect label will be recomputed correctly
@@ -3661,7 +3661,7 @@ let find_record_or_dc_from_typ env (t:option typ) (uc:unresolved_constructor) rn
             then (Some (Record_ctor(rdc.typename, rdc.fields |> List.map fst)))
           else None
         in
-        S.lid_as_fv' constrname qual
+        S.lid_as_fv constrname qual
     in
     rdc, constrname, constructor
 

--- a/src/typechecker/FStar.TypeChecker.Util.fst
+++ b/src/typechecker/FStar.TypeChecker.Util.fst
@@ -1726,7 +1726,7 @@ let maybe_return_e2_and_bind
         else lc2 in //the resulting computation is still pure/ghost and inlineable; no need to insert a return
    bind r env e1opt lc1 (x, lc2)
 
-let fvar_const env lid =  S.fvar (Ident.set_lid_range lid (Env.get_range env)) delta_constant None
+let fvar_const env lid =  S.fvar (Ident.set_lid_range lid (Env.get_range env)) None
 
 //
 // Apply substitutive ite combinator for indexed effects
@@ -2232,7 +2232,7 @@ let coerce_with (env:Env.env)
             BU.print1 "Coercing with %s!\n" (Ident.string_of_lid f);
         let lc2 = TcComm.lcomp_of_comp <| mkcomp ty in
         let lc_res = bind e.pos env (Some e) lc (None, lc2) in
-        let coercion = S.fvar (Ident.set_lid_range f e.pos) (Delta_constant_at_level 1) None in
+        let coercion = S.fvar (Ident.set_lid_range f e.pos) None in
         let coercion = S.mk_Tm_uinst coercion us in
 
         //
@@ -2581,8 +2581,8 @@ let pure_or_ghost_pre_and_post env comp =
                               let us_r, _ = fst <| Env.lookup_lid env C.as_requires in
                               let us_e, _ = fst <| Env.lookup_lid env C.as_ensures in
                               let r = ct.result_typ.pos in
-                              let as_req = S.mk_Tm_uinst (S.fvar (Ident.set_lid_range C.as_requires r) delta_equational None) us_r in
-                              let as_ens = S.mk_Tm_uinst (S.fvar (Ident.set_lid_range C.as_ensures r) delta_equational None) us_e in
+                              let as_req = S.mk_Tm_uinst (S.fvar_with_dd (Ident.set_lid_range C.as_requires r) delta_equational None) us_r in
+                              let as_ens = S.mk_Tm_uinst (S.fvar_with_dd (Ident.set_lid_range C.as_ensures r) delta_equational None) us_e in
                               let req = mk_Tm_app as_req [(ct.result_typ, S.as_aqual_implicit true); S.as_arg wp] ct.result_typ.pos in
                               let ens = mk_Tm_app as_ens [(ct.result_typ, S.as_aqual_implicit true); S.as_arg wp] ct.result_typ.pos in
                               Some (norm req), norm (mk_post_type ct.result_typ ens)

--- a/src/typechecker/FStar.TypeChecker.Util.fsti
+++ b/src/typechecker/FStar.TypeChecker.Util.fsti
@@ -137,8 +137,7 @@ val label_guard: Range.range -> string -> guard_t -> guard_t
 val short_circuit: term -> args -> guard_formula
 val short_circuit_head: term -> bool
 val maybe_add_implicit_binders: env -> binders -> binders
-val fvar_const: env -> lident -> term
-val mk_toplevel_definition: env -> lident -> term -> sigelt * term
+val fvar_env: env -> lident -> term
 val norm_reify: env -> steps -> term -> term
 val remove_reify: term -> term
 

--- a/ucontrib/CoreCrypto/ml/.depend
+++ b/ucontrib/CoreCrypto/ml/.depend
@@ -1,9 +1,0 @@
-CoreCrypto.cmo : ../../../ucontrib/Platform/ml/platform.cmo CoreCrypto.cmi
-CoreCrypto.cmx : ../../../ucontrib/Platform/ml/platform.cmx CoreCrypto.cmi
-CoreCrypto.cmi : ../../../ucontrib/Platform/ml/platform.cmo
-DHDB.cmo : ../../../ucontrib/Platform/ml/platform.cmo db/DB.cmi \
-    CoreCrypto.cmi
-DHDB.cmx : ../../../ucontrib/Platform/ml/platform.cmx db/DB.cmx \
-    CoreCrypto.cmx
-Tests.cmo : ../../../ucontrib/Platform/ml/platform.cmo CoreCrypto.cmi
-Tests.cmx : ../../../ucontrib/Platform/ml/platform.cmx CoreCrypto.cmx

--- a/ulib/FStar.Tactics.Builtins.fsti
+++ b/ulib/FStar.Tactics.Builtins.fsti
@@ -472,12 +472,21 @@ val check_subtyping (g:env) (t0 t1:typ)
 val check_equiv (g:env) (t0 t1:typ)
   : Tac (option (equiv_token g t0 t1))
 
+//
+// Compute the type of e using the core typechecker
+//
 val core_compute_term_type (g:env) (e:term) (eff:tot_or_ghost)
   : Tac (option (t:typ{typing_token g e (eff, t)}))
 
+//
+// Check that e:t using the core typechecker
+//
 val core_check_term (g:env) (e:term) (t:typ) (eff:tot_or_ghost)
   : Tac (option (typing_token g e (eff, t)))
 
+//
+// Instantiate the implicits in e and compute its type
+//
 val tc_term (g:env) (e:term) (eff:tot_or_ghost)
   : Tac (option (r:(term & typ){typing_token g (fst r) (eff, snd r)}))
 
@@ -491,6 +500,15 @@ type prop_validity_token (g:env) (t:term) =
 val check_prop_validity (g:env) (t:term)
   : Tac (option (prop_validity_token g t))
 
+//
+// Instantiate implicits in t
+//
+// When the return value is Some (t', ty),
+//   t' is the elaborated t, and ty is its type
+//
+// This API does not return a proof for typing of t'
+//   The client may follow it up with another call to core_check_term get the proof
+//
 val instantiate_implicits (g:env) (t:term)
   : Tac (option (term & typ))
 

--- a/ulib/prims.fst
+++ b/ulib/prims.fst
@@ -708,4 +708,4 @@ val string_of_int: int -> Tot string
 (** THIS IS MEANT TO BE KEPT IN SYNC WITH FStar.CheckedFiles.fs
     Incrementing this forces all .checked files to be invalidated *)
 irreducible
-let __cache_version_number__ = 55
+let __cache_version_number__ = 56


### PR DESCRIPTION
We have two ways to get delta depths for an fv in the typechecker: (1) there is a fv_delta field in fv, and (2) Env provides an API to get delta depth of an fv. This fv_delta currently is set by all the code, whenever an fv is created via lid_as_fv or fvar API in Syntax. This is quite delicate since one has to be careful in setting the delta depth. It is possible to enquire it in Env, but in some cases the Env may not be there. E.g., in the reflection API (though there seems to be some access to top-level env even there). The reflection API, e.g., was just setting the delta depth to 999 resulting in strange errors.

Ideally, instead of associating delta depths with each fv instance, we would like to migrate to using the Env API, doing away with fv_delta altogether.

However, for logical symbols in prims, the proofs (and the typechecker) is tuned to whatever delta depths are set in fv_delta. 

So this PR tries to make the situation a little better; though it doesn't go all the way. Concretely:

* In Env, instead of special casing the use of fv_delta for all prims symbols, do it only for logical connectives.
* Make fv_delta an option.
* The default lid_as_fv and fvar APIs in syntax now do not require the delta depth argument; they set fv_delta to None.
* Two new APIs lid_and_dd_as_fv and fvar_with_dd, which can be used to create fv with a delta depth.
* Minimize the uses to these two special APIs. Their use is restricted only to Syntax, ToSyntax, and other places where we are actually creating the sigs.

One STLC proof had a regression, which I fixed by explaining the proof. But otherwise no regressions in Everest.