### PR TITLE
Add missing case for `LetOperator`

### DIFF
--- a/.github/workflows/linux-x64-rebuild-base.yaml
+++ b/.github/workflows/linux-x64-rebuild-base.yaml
@@ -22,6 +22,9 @@ jobs:
         shell: bash
 
     steps:
+      - name: Check out repo
+        uses: actions/checkout@v3
+
       - name: Rebuild base image from scratch
         run: |
           TEMP_IMAGE_NAME=fstar:update-base-$GITHUB_RUN_ID-$GITHUB_RUN_ATTEMPT

--- a/ocaml/fstar-lib/generated/FStar_Parser_ToDocument.ml
+++ b/ocaml/fstar-lib/generated/FStar_Parser_ToDocument.ml
@@ -4678,6 +4678,8 @@ and (p_projectionLHS : FStar_Parser_AST.term -> FStar_Pprint.document) =
         let uu___1 = p_term false false e in soft_parens_with_nesting uu___1
     | FStar_Parser_AST.Let uu___ ->
         let uu___1 = p_term false false e in soft_parens_with_nesting uu___1
+    | FStar_Parser_AST.LetOperator uu___ ->
+        let uu___1 = p_term false false e in soft_parens_with_nesting uu___1
     | FStar_Parser_AST.LetOpen uu___ ->
         let uu___1 = p_term false false e in soft_parens_with_nesting uu___1
     | FStar_Parser_AST.LetOpenRecord uu___ ->

--- a/src/parser/FStar.Parser.ToDocument.fst
+++ b/src/parser/FStar.Parser.ToDocument.fst
@@ -2112,6 +2112,7 @@ and p_projectionLHS e = match e.tm with
   | Abs _       (* p_simpleTerm *)
   | App _       (* p_appTerm *)
   | Let _       (* p_noSeqTerm *)
+  | LetOperator _   (* p_noSeqTerm *)
   | LetOpen _   (* p_noSeqTerm *)
   | LetOpenRecord _ (* p_noSeqTerm *)
   | Seq _       (* p_term *)


### PR DESCRIPTION
While generating F* code from OCaml, I noticed a missed case in some pattern matching in `FStar.Parser.ToDocument`: while adding let operators, I missed the comment: https://github.com/FStarLang/FStar/blob/f781540098be4090ecca612fcb9cc1879aec6b62/src/parser/FStar.Parser.ToDocument.fst#L2103

This PR just adds a line to match `LetOperator` there.