### PR TITLE
Nix: fix build (menhir dependency) + update lock file

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,12 +1,15 @@
 {
   "nodes": {
     "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
       "locked": {
-        "lastModified": 1667395993,
-        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
+        "lastModified": 1681202837,
+        "narHash": "sha256-H+Rh19JDwRtpVPAWp64F+rlEtxUWBAQW28eAi3SRSzg=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
+        "rev": "cfacdce06f30d2b68473a46042957675eebb3401",
         "type": "github"
       },
       "original": {
@@ -16,11 +19,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1669140675,
-        "narHash": "sha256-npzfyfLECsJWgzK/M4gWhykP2DNAJTYjgY2BWkz/oEQ=",
+        "lastModified": 1684385584,
+        "narHash": "sha256-O7y0gK8OLIDqz+LaHJJyeu09IGiXlZIS3+JgEzGmmJA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "2788904d26dda6cfa1921c5abb7a2466ffe3cb8c",
+        "rev": "48a0fb7aab511df92a17cf239c37f2bd2ec9ae3a",
         "type": "github"
       },
       "original": {
@@ -33,6 +36,21 @@
       "inputs": {
         "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
       }
     }
   },

--- a/ocaml/default.nix
+++ b/ocaml/default.nix
@@ -16,7 +16,12 @@ buildDunePackage {
     patchShebangs fstar-lib/make_fstar_version.sh
   '';
 
-  nativeBuildInputs = [ installShellFiles makeWrapper removeReferencesTo ];
+  nativeBuildInputs = [
+    installShellFiles
+    makeWrapper
+    removeReferencesTo
+    menhir
+  ];
 
   buildInputs = [
     batteries

--- a/ocaml/default.nix
+++ b/ocaml/default.nix
@@ -25,7 +25,6 @@ buildDunePackage {
 
   buildInputs = [
     batteries
-    menhir
     menhirLib
     pprint
     ppx_deriving


### PR DESCRIPTION
Using latest version of nixpkgs (nixos-unstable), it is required to move menhir from buildInputs to nativeBuildInputs. Also, updating flake.lock. Thanks!