### PR TITLE
Simplifying subtype_of queries to avoid needless VCs related to proving that a term is a prop

### DIFF
--- a/ocaml/fstar-lib/generated/FStar_Parser_Const.ml
+++ b/ocaml/fstar-lib/generated/FStar_Parser_Const.ml
@@ -147,6 +147,7 @@ let (op_Modulus : FStar_Ident.lident) = pconst "op_Modulus"
 let (op_And : FStar_Ident.lident) = pconst "op_AmpAmp"
 let (op_Or : FStar_Ident.lident) = pconst "op_BarBar"
 let (op_Negation : FStar_Ident.lident) = pconst "op_Negation"
+let (subtype_of_lid : FStar_Ident.lident) = pconst "subtype_of"
 let (real_const : Prims.string -> FStar_Ident.lident) =
   fun s -> p2l ["FStar"; "Real"; s]
 let (real_op_LT : FStar_Ident.lident) = real_const "op_Less_Dot"

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_Normalize.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_Normalize.ml
@@ -6670,21 +6670,53 @@ and (maybe_simplify_aux :
                                                  else tm1)
                                               else
                                                 (let uu___29 =
-                                                   FStar_Syntax_Util.is_auto_squash
-                                                     tm1 in
-                                                 match uu___29 with
-                                                 | FStar_Pervasives_Native.Some
-                                                     (FStar_Syntax_Syntax.U_zero,
-                                                      t)
-                                                     when
-                                                     FStar_Syntax_Util.is_sub_singleton
-                                                       t
-                                                     -> t
-                                                 | uu___30 ->
-                                                     let uu___31 =
-                                                       norm_cb cfg in
-                                                     reduce_equality uu___31
-                                                       cfg env1 tm1)))))))))
+                                                   FStar_Syntax_Syntax.fv_eq_lid
+                                                     fv
+                                                     FStar_Parser_Const.subtype_of_lid in
+                                                 if uu___29
+                                                 then
+                                                   let is_unit ty =
+                                                     let uu___30 =
+                                                       let uu___31 =
+                                                         FStar_Syntax_Subst.compress
+                                                           ty in
+                                                       uu___31.FStar_Syntax_Syntax.n in
+                                                     match uu___30 with
+                                                     | FStar_Syntax_Syntax.Tm_fvar
+                                                         fv1 ->
+                                                         FStar_Syntax_Syntax.fv_eq_lid
+                                                           fv1
+                                                           FStar_Parser_Const.unit_lid
+                                                     | uu___31 -> false in
+                                                   match args with
+                                                   | (t, uu___30)::(ty,
+                                                                    uu___31)::[]
+                                                       when
+                                                       (is_unit ty) &&
+                                                         (FStar_Syntax_Util.is_sub_singleton
+                                                            t)
+                                                       ->
+                                                       w
+                                                         FStar_Syntax_Util.t_true
+                                                   | uu___30 -> tm1
+                                                 else
+                                                   (let uu___31 =
+                                                      FStar_Syntax_Util.is_auto_squash
+                                                        tm1 in
+                                                    match uu___31 with
+                                                    | FStar_Pervasives_Native.Some
+                                                        (FStar_Syntax_Syntax.U_zero,
+                                                         t)
+                                                        when
+                                                        FStar_Syntax_Util.is_sub_singleton
+                                                          t
+                                                        -> t
+                                                    | uu___32 ->
+                                                        let uu___33 =
+                                                          norm_cb cfg in
+                                                        reduce_equality
+                                                          uu___33 cfg env1
+                                                          tm1))))))))))
                   | FStar_Syntax_Syntax.Tm_app
                       {
                         FStar_Syntax_Syntax.hd =
@@ -7112,21 +7144,53 @@ and (maybe_simplify_aux :
                                                  else tm1)
                                               else
                                                 (let uu___25 =
-                                                   FStar_Syntax_Util.is_auto_squash
-                                                     tm1 in
-                                                 match uu___25 with
-                                                 | FStar_Pervasives_Native.Some
-                                                     (FStar_Syntax_Syntax.U_zero,
-                                                      t)
-                                                     when
-                                                     FStar_Syntax_Util.is_sub_singleton
-                                                       t
-                                                     -> t
-                                                 | uu___26 ->
-                                                     let uu___27 =
-                                                       norm_cb cfg in
-                                                     reduce_equality uu___27
-                                                       cfg env1 tm1)))))))))
+                                                   FStar_Syntax_Syntax.fv_eq_lid
+                                                     fv
+                                                     FStar_Parser_Const.subtype_of_lid in
+                                                 if uu___25
+                                                 then
+                                                   let is_unit ty =
+                                                     let uu___26 =
+                                                       let uu___27 =
+                                                         FStar_Syntax_Subst.compress
+                                                           ty in
+                                                       uu___27.FStar_Syntax_Syntax.n in
+                                                     match uu___26 with
+                                                     | FStar_Syntax_Syntax.Tm_fvar
+                                                         fv1 ->
+                                                         FStar_Syntax_Syntax.fv_eq_lid
+                                                           fv1
+                                                           FStar_Parser_Const.unit_lid
+                                                     | uu___27 -> false in
+                                                   match args with
+                                                   | (t, uu___26)::(ty,
+                                                                    uu___27)::[]
+                                                       when
+                                                       (is_unit ty) &&
+                                                         (FStar_Syntax_Util.is_sub_singleton
+                                                            t)
+                                                       ->
+                                                       w
+                                                         FStar_Syntax_Util.t_true
+                                                   | uu___26 -> tm1
+                                                 else
+                                                   (let uu___27 =
+                                                      FStar_Syntax_Util.is_auto_squash
+                                                        tm1 in
+                                                    match uu___27 with
+                                                    | FStar_Pervasives_Native.Some
+                                                        (FStar_Syntax_Syntax.U_zero,
+                                                         t)
+                                                        when
+                                                        FStar_Syntax_Util.is_sub_singleton
+                                                          t
+                                                        -> t
+                                                    | uu___28 ->
+                                                        let uu___29 =
+                                                          norm_cb cfg in
+                                                        reduce_equality
+                                                          uu___29 cfg env1
+                                                          tm1))))))))))
                   | FStar_Syntax_Syntax.Tm_refine
                       { FStar_Syntax_Syntax.b = bv;
                         FStar_Syntax_Syntax.phi = t;_}

--- a/src/parser/FStar.Parser.Const.fst
+++ b/src/parser/FStar.Parser.Const.fst
@@ -182,6 +182,7 @@ let op_Modulus         = pconst "op_Modulus"
 let op_And             = pconst "op_AmpAmp"
 let op_Or              = pconst "op_BarBar"
 let op_Negation        = pconst "op_Negation"
+let subtype_of_lid     = pconst "subtype_of"
 
 let real_const  s        = p2l ["FStar";"Real";s]
 let real_op_LT           = real_const "op_Less_Dot"

--- a/src/typechecker/FStar.TypeChecker.Normalize.fst
+++ b/src/typechecker/FStar.TypeChecker.Normalize.fst
@@ -2532,6 +2532,19 @@ and maybe_simplify_aux (cfg:cfg) (env:env) (stack:stack) (tm:term) : term =
             | _ -> tm
         else tm
       end
+      else if S.fv_eq_lid fv PC.subtype_of_lid
+      then begin
+        let is_unit ty = 
+          match (SS.compress ty).n with
+          | Tm_fvar fv -> S.fv_eq_lid fv PC.unit_lid
+          | _ -> false
+        in
+        match args with
+        | [(t, _); (ty, _)]
+          when is_unit ty && U.is_sub_singleton t ->
+          w U.t_true
+        | _ -> tm
+      end
       else begin
            match U.is_auto_squash tm with
            | Some (U_zero, t)


### PR DESCRIPTION
Simplifies `subtype_of t unit` to `True` when `t` is a sub-singleton