### PR TITLE
Support for local state in meta programs

### DIFF
--- a/examples/native_tactics/LocalState.Test.fst
+++ b/examples/native_tactics/LocalState.Test.fst
@@ -1,0 +1,21 @@
+(*
+   Copyright 2008-2018 Microsoft Research
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*)
+module LocalState.Test
+open FStar.Tactics
+open LocalState
+
+let test () = assert (hasEq nat) by (t1 ())
+

--- a/examples/native_tactics/LocalState.fst
+++ b/examples/native_tactics/LocalState.fst
@@ -1,0 +1,52 @@
+(*
+   Copyright 2008-2018 Microsoft Research
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*)
+module LocalState
+
+open FStar.Tactics
+
+type st1 = {
+  x : int;
+  y : int;
+}
+
+type st2 = int -> int
+
+[@@ plugin]
+let t2 () : Tac unit = fail "always fail"
+
+[@@ plugin]
+let t1 (_:unit) : Tac unit =
+  let r1 = alloc {x = 1; y = 1} in
+  let r2 = alloc #st2 (fun x -> x + 1) in
+  let s1 = read r1 in
+  let s2 = read r2 in
+  let s = s1.x + s1.y + s2 1 in
+  if s <> 4 then fail "Expected 4"
+  else let _ = write r1 ({x = 2; y = 2}) in
+       let _ = write r2 (fun x -> x + 2) in
+       let s1 = read r1 in
+       let s2 = read r2 in
+       let s = s1.x + s1.y + s2 1 in
+       if s <> 7 then fail "Expected 7"
+       else try
+              let _ = write r1 ({x=3; y=3}) in
+              t2 ()
+            with
+              | _ ->
+                let s1 = read r1 in
+                let s = s1.x + s1.y in
+                if s <> 6 then fail "Expected 6"
+                else ()

--- a/examples/native_tactics/Makefile
+++ b/examples/native_tactics/Makefile
@@ -15,7 +15,8 @@ TAC_MODULES=Print\
     Embeddings\
     Plugins\
     Registers.List\
-    Sealed.Plugins
+    Sealed.Plugins \
+		LocalState
 
 # Tests for which the native tatics are declared and used in the same module
 ALL=Apply\

--- a/examples/native_tactics/Simplifier.fst
+++ b/examples/native_tactics/Simplifier.fst
@@ -51,7 +51,7 @@ let op_Colon_Equals (#a:Type) (#rel:preorder a) (r:mref a rel) (v:a)
     (fun h0 x h1 -> rel (sel h0 r) v /\ h0 `contains` r /\
                  modifies_singleton r h0 h1 /\ equal_dom h0 h1 /\
                  sel h1 r == v)
-= write #a #rel r v
+= ST.write #a #rel r v
 
 let test1 (r: ref int) =
   (r := 0

--- a/examples/tactics/LocalState.fst
+++ b/examples/tactics/LocalState.fst
@@ -1,0 +1,52 @@
+(*
+   Copyright 2008-2018 Microsoft Research
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*)
+module LocalState
+
+open FStar.Tactics
+
+type st1 = {
+  x : int;
+  y : int;
+}
+
+type st2 = int -> int
+
+let t2 () : Tac unit = fail "always fail"
+
+let t1 (_:unit) : Tac unit =
+  let r1 = alloc {x = 1; y = 1} in
+  let r2 = alloc #st2 (fun x -> x + 1) in
+  let s1 = read r1 in
+  let s2 = read r2 in
+  let s = s1.x + s1.y + s2 1 in
+  if s <> 4 then fail "Expected 4"
+  else let _ = write r1 ({x = 2; y = 2}) in
+       let _ = write r2 (fun x -> x + 2) in
+       let s1 = read r1 in
+       let s2 = read r2 in
+       let s = s1.x + s1.y + s2 1 in
+       if s <> 7 then fail "Expected 7"
+       else try
+              let _ = write r1 ({x=3; y=3}) in
+              t2 ()
+            with
+              | _ ->
+                let s1 = read r1 in
+                let s = s1.x + s1.y in
+                if s <> 6 then fail "Expected 6"
+                else ()
+
+let _ = assert (hasEq nat) by (t1 ())

--- a/ocaml/fstar-lib/FStar_Tactics_Builtins.ml
+++ b/ocaml/fstar-lib/FStar_Tactics_Builtins.ml
@@ -180,6 +180,9 @@ let set_vconfig             = from_tac_1 B.set_vconfig
 let t_smt_sync              = from_tac_1 B.t_smt_sync
 let free_uvars              = from_tac_1 B.free_uvars
 
+let alloc (x:'a)             = from_tac_1 B.alloc x
+let read (r:'a tref)         = from_tac_1 B.read r
+let write (r:'a tref) (x:'a) = from_tac_2 B.write r x
 
 type ('env, 't0, 't1) subtyping_token = unit
 type ('env, 't0, 't1) equiv_token = unit

--- a/ocaml/fstar-lib/generated/FStar_CheckedFiles.ml
+++ b/ocaml/fstar-lib/generated/FStar_CheckedFiles.ml
@@ -1,5 +1,5 @@
 open Prims
-let (cache_version_number : Prims.int) = (Prims.of_int (56))
+let (cache_version_number : Prims.int) = (Prims.of_int (57))
 type tc_result =
   {
   checked_module: FStar_Syntax_Syntax.modul ;

--- a/ocaml/fstar-lib/generated/FStar_Main.ml
+++ b/ocaml/fstar-lib/generated/FStar_Main.ml
@@ -290,6 +290,8 @@ let (lazy_chooser :
           FStar_Syntax_Util.exp_string "((universe_uvar))"
       | FStar_Syntax_Syntax.Lazy_issue ->
           FStar_Syntax_Util.exp_string "((issue))"
+      | FStar_Syntax_Syntax.Lazy_tref ->
+          FStar_Syntax_Util.exp_string "((tref))"
 let (setup_hooks : unit -> unit) =
   fun uu___ ->
     FStar_Errors.set_parse_warn_error FStar_Parser_ParseIt.parse_warn_error;

--- a/ocaml/fstar-lib/generated/FStar_Parser_Const.ml
+++ b/ocaml/fstar-lib/generated/FStar_Parser_Const.ml
@@ -608,4 +608,6 @@ let (sealed_lid : FStar_Ident.lident) = p2l ["FStar"; "Sealed"; "sealed"]
 let (seal_lid : FStar_Ident.lident) = p2l ["FStar"; "Sealed"; "seal"]
 let (unseal_lid : FStar_Ident.lident) =
   p2l ["FStar"; "Tactics"; "Builtins"; "unseal"]
+let (tref_lid : FStar_Ident.lident) =
+  p2l ["FStar"; "Tactics"; "Types"; "tref"]
 let (issue_lid : FStar_Ident.lident) = p2l ["FStar"; "Issue"; "issue"]

--- a/ocaml/fstar-lib/generated/FStar_Syntax_Syntax.ml
+++ b/ocaml/fstar-lib/generated/FStar_Syntax_Syntax.ml
@@ -414,6 +414,7 @@ and lazy_kind =
   | Lazy_universe 
   | Lazy_universe_uvar 
   | Lazy_issue 
+  | Lazy_tref 
 and binding =
   | Binding_var of bv 
   | Binding_lid of (FStar_Ident.lident * (univ_names * term' syntax)) 
@@ -1061,6 +1062,8 @@ let (uu___is_Lazy_universe_uvar : lazy_kind -> Prims.bool) =
     match projectee with | Lazy_universe_uvar -> true | uu___ -> false
 let (uu___is_Lazy_issue : lazy_kind -> Prims.bool) =
   fun projectee -> match projectee with | Lazy_issue -> true | uu___ -> false
+let (uu___is_Lazy_tref : lazy_kind -> Prims.bool) =
+  fun projectee -> match projectee with | Lazy_tref -> true | uu___ -> false
 let (uu___is_Binding_var : binding -> Prims.bool) =
   fun projectee ->
     match projectee with | Binding_var _0 -> true | uu___ -> false

--- a/ocaml/fstar-lib/generated/FStar_Tactics_Basic.ml
+++ b/ocaml/fstar-lib/generated/FStar_Tactics_Basic.ml
@@ -7146,6 +7146,18 @@ let (free_uvars :
                        u.FStar_Syntax_Syntax.ctx_uvar_head in
                    FStar_BigInt.of_int_fs uu___2)) in
          FStar_Tactics_Monad.ret uvs)
+let alloc : 'a . 'a -> 'a FStar_Tactics_Types.tref FStar_Tactics_Monad.tac =
+  fun x ->
+    let uu___ = FStar_Compiler_Util.mk_ref x in FStar_Tactics_Monad.ret uu___
+let read : 'a . 'a FStar_Tactics_Types.tref -> 'a FStar_Tactics_Monad.tac =
+  fun r ->
+    let uu___ = FStar_Compiler_Effect.op_Bang r in
+    FStar_Tactics_Monad.ret uu___
+let write :
+  'a . 'a FStar_Tactics_Types.tref -> 'a -> unit FStar_Tactics_Monad.tac =
+  fun r ->
+    fun x ->
+      FStar_Compiler_Effect.op_Colon_Equals r x; FStar_Tactics_Monad.ret ()
 let (dbg_refl : env -> (unit -> Prims.string) -> unit) =
   fun g ->
     fun msg ->

--- a/ocaml/fstar-lib/generated/FStar_Tactics_Embedding.ml
+++ b/ocaml/fstar-lib/generated/FStar_Tactics_Embedding.ml
@@ -1046,10 +1046,18 @@ let e_tref_nbe :
             else ());
            FStar_Pervasives_Native.None) in
     let uu___1 =
+      let term_t =
+        let uu___2 =
+          FStar_Syntax_Syntax.lid_as_fv
+            FStar_Parser_Const.fstar_syntax_syntax_term
+            FStar_Pervasives_Native.None in
+        mkFV uu___2 [] [] in
       let uu___2 =
         FStar_Syntax_Syntax.lid_as_fv FStar_Parser_Const.tref_lid
           FStar_Pervasives_Native.None in
-      mkFV uu___2 [] [] in
+      let uu___3 =
+        let uu___4 = FStar_TypeChecker_NBETerm.as_arg term_t in [uu___4] in
+      mkFV uu___2 [FStar_Syntax_Syntax.U_zero] uu___3 in
     let uu___2 =
       let uu___3 =
         let uu___4 =

--- a/ocaml/fstar-lib/generated/FStar_Tactics_Embedding.ml
+++ b/ocaml/fstar-lib/generated/FStar_Tactics_Embedding.ml
@@ -937,6 +937,132 @@ let (e_tot_or_ghost_nbe :
     FStar_TypeChecker_NBETerm.typ = uu___;
     FStar_TypeChecker_NBETerm.emb_typ = uu___1
   }
+let (t_tref : FStar_Syntax_Syntax.term) =
+  let uu___ =
+    let uu___1 =
+      let uu___2 =
+        FStar_Syntax_Syntax.lid_as_fv FStar_Parser_Const.tref_lid
+          FStar_Pervasives_Native.None in
+      FStar_Compiler_Effect.op_Bar_Greater uu___2
+        FStar_Syntax_Syntax.fv_to_tm in
+    FStar_Compiler_Effect.op_Bar_Greater uu___1
+      (fun tm ->
+         FStar_Syntax_Syntax.mk_Tm_uinst tm [FStar_Syntax_Syntax.U_zero]) in
+  FStar_Compiler_Effect.op_Bar_Greater uu___
+    (fun head ->
+       let uu___1 =
+         let uu___2 = FStar_Syntax_Syntax.iarg FStar_Syntax_Syntax.t_term in
+         [uu___2] in
+       FStar_Syntax_Syntax.mk_Tm_app head uu___1
+         FStar_Compiler_Range_Type.dummyRange)
+let e_tref :
+  'a . unit -> 'a FStar_Tactics_Types.tref FStar_Syntax_Embeddings.embedding
+  =
+  fun uu___ ->
+    let em r rng _shadow _norm =
+      FStar_Syntax_Util.mk_lazy r t_tref FStar_Syntax_Syntax.Lazy_tref
+        (FStar_Pervasives_Native.Some rng) in
+    let un t0 w _norm =
+      let t = FStar_Syntax_Embeddings.unmeta_div_results t0 in
+      match t.FStar_Syntax_Syntax.n with
+      | FStar_Syntax_Syntax.Tm_lazy
+          { FStar_Syntax_Syntax.blob = blob;
+            FStar_Syntax_Syntax.lkind = FStar_Syntax_Syntax.Lazy_tref;
+            FStar_Syntax_Syntax.ltyp = uu___1;
+            FStar_Syntax_Syntax.rng = uu___2;_}
+          ->
+          let uu___3 = FStar_Compiler_Dyn.undyn blob in
+          FStar_Pervasives_Native.Some uu___3
+      | uu___1 ->
+          (if w
+           then
+             (let uu___3 =
+                let uu___4 =
+                  let uu___5 = FStar_Syntax_Print.term_to_string t0 in
+                  FStar_Compiler_Util.format1 "Not an embedded tref: %s"
+                    uu___5 in
+                (FStar_Errors_Codes.Warning_NotEmbedded, uu___4) in
+              FStar_Errors.log_issue t0.FStar_Syntax_Syntax.pos uu___3)
+           else ();
+           FStar_Pervasives_Native.None) in
+    let uu___1 =
+      let uu___2 =
+        let uu___3 =
+          FStar_Compiler_Effect.op_Bar_Greater FStar_Parser_Const.tref_lid
+            FStar_Ident.string_of_lid in
+        (uu___3, [FStar_Syntax_Syntax.ET_abstract]) in
+      FStar_Syntax_Syntax.ET_app uu___2 in
+    FStar_Syntax_Embeddings.mk_emb_full em un t_tref (fun i -> "tref") uu___1
+let e_tref_nbe :
+  'a .
+    unit -> 'a FStar_Tactics_Types.tref FStar_TypeChecker_NBETerm.embedding
+  =
+  fun uu___ ->
+    let embed_tref _cb r =
+      let li =
+        let uu___1 = FStar_Compiler_Dyn.mkdyn r in
+        {
+          FStar_Syntax_Syntax.blob = uu___1;
+          FStar_Syntax_Syntax.lkind = FStar_Syntax_Syntax.Lazy_tref;
+          FStar_Syntax_Syntax.ltyp = t_tref;
+          FStar_Syntax_Syntax.rng = FStar_Compiler_Range_Type.dummyRange
+        } in
+      let thunk =
+        FStar_Thunk.mk
+          (fun uu___1 ->
+             FStar_Compiler_Effect.op_Less_Bar FStar_TypeChecker_NBETerm.mk_t
+               (FStar_TypeChecker_NBETerm.Constant
+                  (FStar_TypeChecker_NBETerm.String
+                     ("(((tref.nbe)))", FStar_Compiler_Range_Type.dummyRange)))) in
+      FStar_TypeChecker_NBETerm.mk_t
+        (FStar_TypeChecker_NBETerm.Lazy ((FStar_Pervasives.Inl li), thunk)) in
+    let unembed_tref _cb t =
+      let uu___1 = FStar_TypeChecker_NBETerm.nbe_t_of_t t in
+      match uu___1 with
+      | FStar_TypeChecker_NBETerm.Lazy
+          (FStar_Pervasives.Inl
+           { FStar_Syntax_Syntax.blob = b;
+             FStar_Syntax_Syntax.lkind = FStar_Syntax_Syntax.Lazy_tref;
+             FStar_Syntax_Syntax.ltyp = uu___2;
+             FStar_Syntax_Syntax.rng = uu___3;_},
+           uu___4)
+          ->
+          let uu___5 = FStar_Compiler_Dyn.undyn b in
+          FStar_Compiler_Effect.op_Less_Bar
+            (fun uu___6 -> FStar_Pervasives_Native.Some uu___6) uu___5
+      | uu___2 ->
+          ((let uu___4 =
+              FStar_Compiler_Effect.op_Bang FStar_Options.debug_embedding in
+            if uu___4
+            then
+              let uu___5 =
+                let uu___6 =
+                  let uu___7 = FStar_TypeChecker_NBETerm.t_to_string t in
+                  FStar_Compiler_Util.format1
+                    "Not an embedded NBE tref: %s\n" uu___7 in
+                (FStar_Errors_Codes.Warning_NotEmbedded, uu___6) in
+              FStar_Errors.log_issue FStar_Compiler_Range_Type.dummyRange
+                uu___5
+            else ());
+           FStar_Pervasives_Native.None) in
+    let uu___1 =
+      let uu___2 =
+        FStar_Syntax_Syntax.lid_as_fv FStar_Parser_Const.tref_lid
+          FStar_Pervasives_Native.None in
+      mkFV uu___2 [] [] in
+    let uu___2 =
+      let uu___3 =
+        let uu___4 =
+          FStar_Compiler_Effect.op_Bar_Greater FStar_Parser_Const.tref_lid
+            FStar_Ident.string_of_lid in
+        (uu___4, [FStar_Syntax_Syntax.ET_abstract]) in
+      FStar_Syntax_Syntax.ET_app uu___3 in
+    {
+      FStar_TypeChecker_NBETerm.em = embed_tref;
+      FStar_TypeChecker_NBETerm.un = unembed_tref;
+      FStar_TypeChecker_NBETerm.typ = uu___1;
+      FStar_TypeChecker_NBETerm.emb_typ = uu___2
+    }
 let (e_guard_policy :
   FStar_Tactics_Types.guard_policy FStar_Syntax_Embeddings.embedding) =
   let embed_guard_policy rng p =

--- a/ocaml/fstar-lib/generated/FStar_Tactics_Interpreter.ml
+++ b/ocaml/fstar-lib/generated/FStar_Tactics_Interpreter.ml
@@ -1777,42 +1777,28 @@ let (uu___193 : unit) =
                                                                     =
                                                                     let uu___171
                                                                     =
+                                                                    FStar_Tactics_Embedding.e_tref
+                                                                    () in
                                                                     let uu___172
                                                                     =
-                                                                    FStar_Syntax_Embeddings.e_option
-                                                                    FStar_Syntax_Embeddings.e_unit in
-                                                                    let uu___173
-                                                                    =
-                                                                    FStar_Syntax_Embeddings.e_list
-                                                                    FStar_Syntax_Embeddings.e_issue in
-                                                                    FStar_Syntax_Embeddings.e_tuple2
-                                                                    uu___172
-                                                                    uu___173 in
-                                                                    let uu___172
-                                                                    =
-                                                                    let uu___173
-                                                                    =
-                                                                    FStar_TypeChecker_NBETerm.e_option
-                                                                    FStar_TypeChecker_NBETerm.e_unit in
-                                                                    let uu___174
-                                                                    =
-                                                                    FStar_TypeChecker_NBETerm.e_list
-                                                                    FStar_TypeChecker_NBETerm.e_issue in
-                                                                    FStar_TypeChecker_NBETerm.e_tuple2
+                                                                    FStar_Tactics_Embedding.e_tref_nbe
+                                                                    () in
+                                                                    FStar_Tactics_InterpFuns.mk_tac_step_2
+                                                                    Prims.int_one
+                                                                    "alloc"
+                                                                    (fun
                                                                     uu___173
-                                                                    uu___174 in
-                                                                    FStar_Tactics_InterpFuns.mk_tac_step_3
-                                                                    Prims.int_zero
-                                                                    "check_subtyping"
-                                                                    FStar_Tactics_Basic.refl_check_subtyping
-                                                                    FStar_Reflection_Embeddings.e_env
-                                                                    FStar_Reflection_Embeddings.e_term
-                                                                    FStar_Reflection_Embeddings.e_term
+                                                                    ->
+                                                                    FStar_Tactics_Basic.alloc)
+                                                                    FStar_Syntax_Embeddings.e_any
+                                                                    FStar_Syntax_Embeddings.e_any
                                                                     uu___171
-                                                                    FStar_Tactics_Basic.refl_check_subtyping
-                                                                    FStar_Reflection_NBEEmbeddings.e_env
-                                                                    FStar_Reflection_NBEEmbeddings.e_term
-                                                                    FStar_Reflection_NBEEmbeddings.e_term
+                                                                    (fun
+                                                                    uu___173
+                                                                    ->
+                                                                    FStar_Tactics_Basic.alloc)
+                                                                    FStar_TypeChecker_NBETerm.e_any
+                                                                    FStar_TypeChecker_NBETerm.e_any
                                                                     uu___172 in
                                                                     let uu___171
                                                                     =
@@ -1820,86 +1806,60 @@ let (uu___193 : unit) =
                                                                     =
                                                                     let uu___173
                                                                     =
+                                                                    FStar_Tactics_Embedding.e_tref
+                                                                    () in
                                                                     let uu___174
                                                                     =
-                                                                    FStar_Syntax_Embeddings.e_option
-                                                                    FStar_Syntax_Embeddings.e_unit in
-                                                                    let uu___175
-                                                                    =
-                                                                    FStar_Syntax_Embeddings.e_list
-                                                                    FStar_Syntax_Embeddings.e_issue in
-                                                                    FStar_Syntax_Embeddings.e_tuple2
-                                                                    uu___174
-                                                                    uu___175 in
-                                                                    let uu___174
-                                                                    =
-                                                                    let uu___175
-                                                                    =
-                                                                    FStar_TypeChecker_NBETerm.e_option
-                                                                    FStar_TypeChecker_NBETerm.e_unit in
-                                                                    let uu___176
-                                                                    =
-                                                                    FStar_TypeChecker_NBETerm.e_list
-                                                                    FStar_TypeChecker_NBETerm.e_issue in
-                                                                    FStar_TypeChecker_NBETerm.e_tuple2
+                                                                    FStar_Tactics_Embedding.e_tref_nbe
+                                                                    () in
+                                                                    FStar_Tactics_InterpFuns.mk_tac_step_2
+                                                                    Prims.int_one
+                                                                    "read"
+                                                                    (fun
                                                                     uu___175
-                                                                    uu___176 in
-                                                                    FStar_Tactics_InterpFuns.mk_tac_step_3
-                                                                    Prims.int_zero
-                                                                    "check_equiv"
-                                                                    FStar_Tactics_Basic.refl_check_equiv
-                                                                    FStar_Reflection_Embeddings.e_env
-                                                                    FStar_Reflection_Embeddings.e_term
-                                                                    FStar_Reflection_Embeddings.e_term
+                                                                    ->
+                                                                    FStar_Tactics_Basic.read)
+                                                                    FStar_Syntax_Embeddings.e_any
                                                                     uu___173
-                                                                    FStar_Tactics_Basic.refl_check_equiv
-                                                                    FStar_Reflection_NBEEmbeddings.e_env
-                                                                    FStar_Reflection_NBEEmbeddings.e_term
-                                                                    FStar_Reflection_NBEEmbeddings.e_term
-                                                                    uu___174 in
+                                                                    FStar_Syntax_Embeddings.e_any
+                                                                    (fun
+                                                                    uu___175
+                                                                    ->
+                                                                    FStar_Tactics_Basic.read)
+                                                                    FStar_TypeChecker_NBETerm.e_any
+                                                                    uu___174
+                                                                    FStar_TypeChecker_NBETerm.e_any in
                                                                     let uu___173
                                                                     =
                                                                     let uu___174
                                                                     =
                                                                     let uu___175
                                                                     =
+                                                                    FStar_Tactics_Embedding.e_tref
+                                                                    () in
                                                                     let uu___176
                                                                     =
-                                                                    FStar_Syntax_Embeddings.e_option
-                                                                    FStar_Reflection_Embeddings.e_term in
-                                                                    let uu___177
-                                                                    =
-                                                                    FStar_Syntax_Embeddings.e_list
-                                                                    FStar_Syntax_Embeddings.e_issue in
-                                                                    FStar_Syntax_Embeddings.e_tuple2
-                                                                    uu___176
-                                                                    uu___177 in
-                                                                    let uu___176
-                                                                    =
-                                                                    let uu___177
-                                                                    =
-                                                                    FStar_TypeChecker_NBETerm.e_option
-                                                                    FStar_Reflection_NBEEmbeddings.e_term in
-                                                                    let uu___178
-                                                                    =
-                                                                    FStar_TypeChecker_NBETerm.e_list
-                                                                    FStar_TypeChecker_NBETerm.e_issue in
-                                                                    FStar_TypeChecker_NBETerm.e_tuple2
-                                                                    uu___177
-                                                                    uu___178 in
+                                                                    FStar_Tactics_Embedding.e_tref_nbe
+                                                                    () in
                                                                     FStar_Tactics_InterpFuns.mk_tac_step_3
-                                                                    Prims.int_zero
-                                                                    "core_compute_term_type"
-                                                                    FStar_Tactics_Basic.refl_core_compute_term_type
-                                                                    FStar_Reflection_Embeddings.e_env
-                                                                    FStar_Reflection_Embeddings.e_term
-                                                                    FStar_Tactics_Embedding.e_tot_or_ghost
+                                                                    Prims.int_one
+                                                                    "write"
+                                                                    (fun
+                                                                    uu___177
+                                                                    ->
+                                                                    FStar_Tactics_Basic.write)
+                                                                    FStar_Syntax_Embeddings.e_any
                                                                     uu___175
-                                                                    FStar_Tactics_Basic.refl_core_compute_term_type
-                                                                    FStar_Reflection_NBEEmbeddings.e_env
-                                                                    FStar_Reflection_NBEEmbeddings.e_term
-                                                                    FStar_Tactics_Embedding.e_tot_or_ghost_nbe
-                                                                    uu___176 in
+                                                                    FStar_Syntax_Embeddings.e_any
+                                                                    FStar_Syntax_Embeddings.e_unit
+                                                                    (fun
+                                                                    uu___177
+                                                                    ->
+                                                                    FStar_Tactics_Basic.write)
+                                                                    FStar_TypeChecker_NBETerm.e_any
+                                                                    uu___176
+                                                                    FStar_TypeChecker_NBETerm.e_any
+                                                                    FStar_TypeChecker_NBETerm.e_unit in
                                                                     let uu___175
                                                                     =
                                                                     let uu___176
@@ -1930,20 +1890,18 @@ let (uu___193 : unit) =
                                                                     FStar_TypeChecker_NBETerm.e_tuple2
                                                                     uu___179
                                                                     uu___180 in
-                                                                    FStar_Tactics_InterpFuns.mk_tac_step_4
+                                                                    FStar_Tactics_InterpFuns.mk_tac_step_3
                                                                     Prims.int_zero
-                                                                    "core_check_term"
-                                                                    FStar_Tactics_Basic.refl_core_check_term
+                                                                    "check_subtyping"
+                                                                    FStar_Tactics_Basic.refl_check_subtyping
                                                                     FStar_Reflection_Embeddings.e_env
                                                                     FStar_Reflection_Embeddings.e_term
                                                                     FStar_Reflection_Embeddings.e_term
-                                                                    FStar_Tactics_Embedding.e_tot_or_ghost
                                                                     uu___177
-                                                                    FStar_Tactics_Basic.refl_core_check_term
+                                                                    FStar_Tactics_Basic.refl_check_subtyping
                                                                     FStar_Reflection_NBEEmbeddings.e_env
                                                                     FStar_Reflection_NBEEmbeddings.e_term
                                                                     FStar_Reflection_NBEEmbeddings.e_term
-                                                                    FStar_Tactics_Embedding.e_tot_or_ghost_nbe
                                                                     uu___178 in
                                                                     let uu___177
                                                                     =
@@ -1953,13 +1911,8 @@ let (uu___193 : unit) =
                                                                     =
                                                                     let uu___180
                                                                     =
-                                                                    let uu___181
-                                                                    =
-                                                                    FStar_Syntax_Embeddings.e_tuple2
-                                                                    FStar_Reflection_Embeddings.e_term
-                                                                    FStar_Reflection_Embeddings.e_term in
                                                                     FStar_Syntax_Embeddings.e_option
-                                                                    uu___181 in
+                                                                    FStar_Syntax_Embeddings.e_unit in
                                                                     let uu___181
                                                                     =
                                                                     FStar_Syntax_Embeddings.e_list
@@ -1971,13 +1924,8 @@ let (uu___193 : unit) =
                                                                     =
                                                                     let uu___181
                                                                     =
-                                                                    let uu___182
-                                                                    =
-                                                                    FStar_TypeChecker_NBETerm.e_tuple2
-                                                                    FStar_Reflection_NBEEmbeddings.e_term
-                                                                    FStar_Reflection_NBEEmbeddings.e_term in
                                                                     FStar_TypeChecker_NBETerm.e_option
-                                                                    uu___182 in
+                                                                    FStar_TypeChecker_NBETerm.e_unit in
                                                                     let uu___182
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.e_list
@@ -1987,16 +1935,16 @@ let (uu___193 : unit) =
                                                                     uu___182 in
                                                                     FStar_Tactics_InterpFuns.mk_tac_step_3
                                                                     Prims.int_zero
-                                                                    "tc_term"
-                                                                    FStar_Tactics_Basic.refl_tc_term
+                                                                    "check_equiv"
+                                                                    FStar_Tactics_Basic.refl_check_equiv
                                                                     FStar_Reflection_Embeddings.e_env
                                                                     FStar_Reflection_Embeddings.e_term
-                                                                    FStar_Tactics_Embedding.e_tot_or_ghost
+                                                                    FStar_Reflection_Embeddings.e_term
                                                                     uu___179
-                                                                    FStar_Tactics_Basic.refl_tc_term
+                                                                    FStar_Tactics_Basic.refl_check_equiv
                                                                     FStar_Reflection_NBEEmbeddings.e_env
                                                                     FStar_Reflection_NBEEmbeddings.e_term
-                                                                    FStar_Tactics_Embedding.e_tot_or_ghost_nbe
+                                                                    FStar_Reflection_NBEEmbeddings.e_term
                                                                     uu___180 in
                                                                     let uu___179
                                                                     =
@@ -2007,7 +1955,7 @@ let (uu___193 : unit) =
                                                                     let uu___182
                                                                     =
                                                                     FStar_Syntax_Embeddings.e_option
-                                                                    FStar_Reflection_Embeddings.e_universe in
+                                                                    FStar_Reflection_Embeddings.e_term in
                                                                     let uu___183
                                                                     =
                                                                     FStar_Syntax_Embeddings.e_list
@@ -2020,7 +1968,7 @@ let (uu___193 : unit) =
                                                                     let uu___183
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.e_option
-                                                                    FStar_Reflection_NBEEmbeddings.e_universe in
+                                                                    FStar_Reflection_NBEEmbeddings.e_term in
                                                                     let uu___184
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.e_list
@@ -2028,16 +1976,18 @@ let (uu___193 : unit) =
                                                                     FStar_TypeChecker_NBETerm.e_tuple2
                                                                     uu___183
                                                                     uu___184 in
-                                                                    FStar_Tactics_InterpFuns.mk_tac_step_2
+                                                                    FStar_Tactics_InterpFuns.mk_tac_step_3
                                                                     Prims.int_zero
-                                                                    "universe_of"
-                                                                    FStar_Tactics_Basic.refl_universe_of
+                                                                    "core_compute_term_type"
+                                                                    FStar_Tactics_Basic.refl_core_compute_term_type
                                                                     FStar_Reflection_Embeddings.e_env
                                                                     FStar_Reflection_Embeddings.e_term
+                                                                    FStar_Tactics_Embedding.e_tot_or_ghost
                                                                     uu___181
-                                                                    FStar_Tactics_Basic.refl_universe_of
+                                                                    FStar_Tactics_Basic.refl_core_compute_term_type
                                                                     FStar_Reflection_NBEEmbeddings.e_env
                                                                     FStar_Reflection_NBEEmbeddings.e_term
+                                                                    FStar_Tactics_Embedding.e_tot_or_ghost_nbe
                                                                     uu___182 in
                                                                     let uu___181
                                                                     =
@@ -2069,16 +2019,20 @@ let (uu___193 : unit) =
                                                                     FStar_TypeChecker_NBETerm.e_tuple2
                                                                     uu___185
                                                                     uu___186 in
-                                                                    FStar_Tactics_InterpFuns.mk_tac_step_2
+                                                                    FStar_Tactics_InterpFuns.mk_tac_step_4
                                                                     Prims.int_zero
-                                                                    "check_prop_validity"
-                                                                    FStar_Tactics_Basic.refl_check_prop_validity
+                                                                    "core_check_term"
+                                                                    FStar_Tactics_Basic.refl_core_check_term
                                                                     FStar_Reflection_Embeddings.e_env
                                                                     FStar_Reflection_Embeddings.e_term
+                                                                    FStar_Reflection_Embeddings.e_term
+                                                                    FStar_Tactics_Embedding.e_tot_or_ghost
                                                                     uu___183
-                                                                    FStar_Tactics_Basic.refl_check_prop_validity
+                                                                    FStar_Tactics_Basic.refl_core_check_term
                                                                     FStar_Reflection_NBEEmbeddings.e_env
                                                                     FStar_Reflection_NBEEmbeddings.e_term
+                                                                    FStar_Reflection_NBEEmbeddings.e_term
+                                                                    FStar_Tactics_Embedding.e_tot_or_ghost_nbe
                                                                     uu___184 in
                                                                     let uu___183
                                                                     =
@@ -2120,16 +2074,18 @@ let (uu___193 : unit) =
                                                                     FStar_TypeChecker_NBETerm.e_tuple2
                                                                     uu___187
                                                                     uu___188 in
-                                                                    FStar_Tactics_InterpFuns.mk_tac_step_2
+                                                                    FStar_Tactics_InterpFuns.mk_tac_step_3
                                                                     Prims.int_zero
-                                                                    "instantiate_implicits"
-                                                                    FStar_Tactics_Basic.refl_instantiate_implicits
+                                                                    "tc_term"
+                                                                    FStar_Tactics_Basic.refl_tc_term
                                                                     FStar_Reflection_Embeddings.e_env
                                                                     FStar_Reflection_Embeddings.e_term
+                                                                    FStar_Tactics_Embedding.e_tot_or_ghost
                                                                     uu___185
-                                                                    FStar_Tactics_Basic.refl_instantiate_implicits
+                                                                    FStar_Tactics_Basic.refl_tc_term
                                                                     FStar_Reflection_NBEEmbeddings.e_env
                                                                     FStar_Reflection_NBEEmbeddings.e_term
+                                                                    FStar_Tactics_Embedding.e_tot_or_ghost_nbe
                                                                     uu___186 in
                                                                     let uu___185
                                                                     =
@@ -2140,7 +2096,7 @@ let (uu___193 : unit) =
                                                                     let uu___188
                                                                     =
                                                                     FStar_Syntax_Embeddings.e_option
-                                                                    FStar_Tactics_Embedding.e_unfold_side in
+                                                                    FStar_Reflection_Embeddings.e_universe in
                                                                     let uu___189
                                                                     =
                                                                     FStar_Syntax_Embeddings.e_list
@@ -2153,7 +2109,7 @@ let (uu___193 : unit) =
                                                                     let uu___189
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.e_option
-                                                                    FStar_Tactics_Embedding.e_unfold_side_nbe in
+                                                                    FStar_Reflection_NBEEmbeddings.e_universe in
                                                                     let uu___190
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.e_list
@@ -2161,17 +2117,15 @@ let (uu___193 : unit) =
                                                                     FStar_TypeChecker_NBETerm.e_tuple2
                                                                     uu___189
                                                                     uu___190 in
-                                                                    FStar_Tactics_InterpFuns.mk_tac_step_3
+                                                                    FStar_Tactics_InterpFuns.mk_tac_step_2
                                                                     Prims.int_zero
-                                                                    "maybe_relate_after_unfolding"
-                                                                    FStar_Tactics_Basic.refl_maybe_relate_after_unfolding
+                                                                    "universe_of"
+                                                                    FStar_Tactics_Basic.refl_universe_of
                                                                     FStar_Reflection_Embeddings.e_env
                                                                     FStar_Reflection_Embeddings.e_term
-                                                                    FStar_Reflection_Embeddings.e_term
                                                                     uu___187
-                                                                    FStar_Tactics_Basic.refl_maybe_relate_after_unfolding
+                                                                    FStar_Tactics_Basic.refl_universe_of
                                                                     FStar_Reflection_NBEEmbeddings.e_env
-                                                                    FStar_Reflection_NBEEmbeddings.e_term
                                                                     FStar_Reflection_NBEEmbeddings.e_term
                                                                     uu___188 in
                                                                     let uu___187
@@ -2183,7 +2137,7 @@ let (uu___193 : unit) =
                                                                     let uu___190
                                                                     =
                                                                     FStar_Syntax_Embeddings.e_option
-                                                                    FStar_Reflection_Embeddings.e_term in
+                                                                    FStar_Syntax_Embeddings.e_unit in
                                                                     let uu___191
                                                                     =
                                                                     FStar_Syntax_Embeddings.e_list
@@ -2196,7 +2150,7 @@ let (uu___193 : unit) =
                                                                     let uu___191
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.e_option
-                                                                    FStar_Reflection_NBEEmbeddings.e_term in
+                                                                    FStar_TypeChecker_NBETerm.e_unit in
                                                                     let uu___194
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.e_list
@@ -2206,12 +2160,12 @@ let (uu___193 : unit) =
                                                                     uu___194 in
                                                                     FStar_Tactics_InterpFuns.mk_tac_step_2
                                                                     Prims.int_zero
-                                                                    "maybe_unfold_head"
-                                                                    FStar_Tactics_Basic.refl_maybe_unfold_head
+                                                                    "check_prop_validity"
+                                                                    FStar_Tactics_Basic.refl_check_prop_validity
                                                                     FStar_Reflection_Embeddings.e_env
                                                                     FStar_Reflection_Embeddings.e_term
                                                                     uu___189
-                                                                    FStar_Tactics_Basic.refl_maybe_unfold_head
+                                                                    FStar_Tactics_Basic.refl_check_prop_validity
                                                                     FStar_Reflection_NBEEmbeddings.e_env
                                                                     FStar_Reflection_NBEEmbeddings.e_term
                                                                     uu___190 in
@@ -2221,9 +2175,144 @@ let (uu___193 : unit) =
                                                                     =
                                                                     let uu___191
                                                                     =
+                                                                    let uu___194
+                                                                    =
+                                                                    let uu___195
+                                                                    =
+                                                                    FStar_Syntax_Embeddings.e_tuple2
+                                                                    FStar_Reflection_Embeddings.e_term
+                                                                    FStar_Reflection_Embeddings.e_term in
+                                                                    FStar_Syntax_Embeddings.e_option
+                                                                    uu___195 in
+                                                                    let uu___195
+                                                                    =
+                                                                    FStar_Syntax_Embeddings.e_list
+                                                                    FStar_Syntax_Embeddings.e_issue in
+                                                                    FStar_Syntax_Embeddings.e_tuple2
+                                                                    uu___194
+                                                                    uu___195 in
+                                                                    let uu___194
+                                                                    =
+                                                                    let uu___195
+                                                                    =
+                                                                    let uu___196
+                                                                    =
+                                                                    FStar_TypeChecker_NBETerm.e_tuple2
+                                                                    FStar_Reflection_NBEEmbeddings.e_term
+                                                                    FStar_Reflection_NBEEmbeddings.e_term in
+                                                                    FStar_TypeChecker_NBETerm.e_option
+                                                                    uu___196 in
+                                                                    let uu___196
+                                                                    =
+                                                                    FStar_TypeChecker_NBETerm.e_list
+                                                                    FStar_TypeChecker_NBETerm.e_issue in
+                                                                    FStar_TypeChecker_NBETerm.e_tuple2
+                                                                    uu___195
+                                                                    uu___196 in
+                                                                    FStar_Tactics_InterpFuns.mk_tac_step_2
+                                                                    Prims.int_zero
+                                                                    "instantiate_implicits"
+                                                                    FStar_Tactics_Basic.refl_instantiate_implicits
+                                                                    FStar_Reflection_Embeddings.e_env
+                                                                    FStar_Reflection_Embeddings.e_term
+                                                                    uu___191
+                                                                    FStar_Tactics_Basic.refl_instantiate_implicits
+                                                                    FStar_Reflection_NBEEmbeddings.e_env
+                                                                    FStar_Reflection_NBEEmbeddings.e_term
+                                                                    uu___194 in
+                                                                    let uu___191
+                                                                    =
+                                                                    let uu___194
+                                                                    =
+                                                                    let uu___195
+                                                                    =
+                                                                    let uu___196
+                                                                    =
+                                                                    FStar_Syntax_Embeddings.e_option
+                                                                    FStar_Tactics_Embedding.e_unfold_side in
+                                                                    let uu___197
+                                                                    =
+                                                                    FStar_Syntax_Embeddings.e_list
+                                                                    FStar_Syntax_Embeddings.e_issue in
+                                                                    FStar_Syntax_Embeddings.e_tuple2
+                                                                    uu___196
+                                                                    uu___197 in
+                                                                    let uu___196
+                                                                    =
+                                                                    let uu___197
+                                                                    =
+                                                                    FStar_TypeChecker_NBETerm.e_option
+                                                                    FStar_Tactics_Embedding.e_unfold_side_nbe in
+                                                                    let uu___198
+                                                                    =
+                                                                    FStar_TypeChecker_NBETerm.e_list
+                                                                    FStar_TypeChecker_NBETerm.e_issue in
+                                                                    FStar_TypeChecker_NBETerm.e_tuple2
+                                                                    uu___197
+                                                                    uu___198 in
+                                                                    FStar_Tactics_InterpFuns.mk_tac_step_3
+                                                                    Prims.int_zero
+                                                                    "maybe_relate_after_unfolding"
+                                                                    FStar_Tactics_Basic.refl_maybe_relate_after_unfolding
+                                                                    FStar_Reflection_Embeddings.e_env
+                                                                    FStar_Reflection_Embeddings.e_term
+                                                                    FStar_Reflection_Embeddings.e_term
+                                                                    uu___195
+                                                                    FStar_Tactics_Basic.refl_maybe_relate_after_unfolding
+                                                                    FStar_Reflection_NBEEmbeddings.e_env
+                                                                    FStar_Reflection_NBEEmbeddings.e_term
+                                                                    FStar_Reflection_NBEEmbeddings.e_term
+                                                                    uu___196 in
+                                                                    let uu___195
+                                                                    =
+                                                                    let uu___196
+                                                                    =
+                                                                    let uu___197
+                                                                    =
+                                                                    let uu___198
+                                                                    =
+                                                                    FStar_Syntax_Embeddings.e_option
+                                                                    FStar_Reflection_Embeddings.e_term in
+                                                                    let uu___199
+                                                                    =
+                                                                    FStar_Syntax_Embeddings.e_list
+                                                                    FStar_Syntax_Embeddings.e_issue in
+                                                                    FStar_Syntax_Embeddings.e_tuple2
+                                                                    uu___198
+                                                                    uu___199 in
+                                                                    let uu___198
+                                                                    =
+                                                                    let uu___199
+                                                                    =
+                                                                    FStar_TypeChecker_NBETerm.e_option
+                                                                    FStar_Reflection_NBEEmbeddings.e_term in
+                                                                    let uu___200
+                                                                    =
+                                                                    FStar_TypeChecker_NBETerm.e_list
+                                                                    FStar_TypeChecker_NBETerm.e_issue in
+                                                                    FStar_TypeChecker_NBETerm.e_tuple2
+                                                                    uu___199
+                                                                    uu___200 in
+                                                                    FStar_Tactics_InterpFuns.mk_tac_step_2
+                                                                    Prims.int_zero
+                                                                    "maybe_unfold_head"
+                                                                    FStar_Tactics_Basic.refl_maybe_unfold_head
+                                                                    FStar_Reflection_Embeddings.e_env
+                                                                    FStar_Reflection_Embeddings.e_term
+                                                                    uu___197
+                                                                    FStar_Tactics_Basic.refl_maybe_unfold_head
+                                                                    FStar_Reflection_NBEEmbeddings.e_env
+                                                                    FStar_Reflection_NBEEmbeddings.e_term
+                                                                    uu___198 in
+                                                                    let uu___197
+                                                                    =
+                                                                    let uu___198
+                                                                    =
+                                                                    let uu___199
+                                                                    =
                                                                     FStar_Syntax_Embeddings.e_list
                                                                     FStar_Syntax_Embeddings.e_string in
-                                                                    let uu___194
+                                                                    let uu___200
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.e_list
                                                                     FStar_TypeChecker_NBETerm.e_string in
@@ -2232,21 +2321,21 @@ let (uu___193 : unit) =
                                                                     "push_open_namespace"
                                                                     FStar_Tactics_Basic.push_open_namespace
                                                                     FStar_Reflection_Embeddings.e_env
-                                                                    uu___191
+                                                                    uu___199
                                                                     FStar_Reflection_Embeddings.e_env
                                                                     FStar_Tactics_Basic.push_open_namespace
                                                                     FStar_Reflection_NBEEmbeddings.e_env
-                                                                    uu___194
+                                                                    uu___200
                                                                     FStar_Reflection_NBEEmbeddings.e_env in
-                                                                    let uu___191
+                                                                    let uu___199
                                                                     =
-                                                                    let uu___194
+                                                                    let uu___200
                                                                     =
-                                                                    let uu___195
+                                                                    let uu___201
                                                                     =
                                                                     FStar_Syntax_Embeddings.e_list
                                                                     FStar_Syntax_Embeddings.e_string in
-                                                                    let uu___196
+                                                                    let uu___202
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.e_list
                                                                     FStar_TypeChecker_NBETerm.e_string in
@@ -2256,63 +2345,63 @@ let (uu___193 : unit) =
                                                                     FStar_Tactics_Basic.push_module_abbrev
                                                                     FStar_Reflection_Embeddings.e_env
                                                                     FStar_Syntax_Embeddings.e_string
-                                                                    uu___195
+                                                                    uu___201
                                                                     FStar_Reflection_Embeddings.e_env
                                                                     FStar_Tactics_Basic.push_module_abbrev
                                                                     FStar_Reflection_NBEEmbeddings.e_env
                                                                     FStar_TypeChecker_NBETerm.e_string
-                                                                    uu___196
+                                                                    uu___202
                                                                     FStar_Reflection_NBEEmbeddings.e_env in
-                                                                    let uu___195
+                                                                    let uu___201
                                                                     =
-                                                                    let uu___196
+                                                                    let uu___202
                                                                     =
-                                                                    let uu___197
+                                                                    let uu___203
                                                                     =
                                                                     FStar_Syntax_Embeddings.e_list
                                                                     FStar_Syntax_Embeddings.e_string in
-                                                                    let uu___198
+                                                                    let uu___204
                                                                     =
-                                                                    let uu___199
+                                                                    let uu___205
                                                                     =
                                                                     FStar_Syntax_Embeddings.e_either
                                                                     FStar_Reflection_Embeddings.e_bv
                                                                     FStar_Reflection_Embeddings.e_fv in
                                                                     FStar_Syntax_Embeddings.e_option
-                                                                    uu___199 in
-                                                                    let uu___199
+                                                                    uu___205 in
+                                                                    let uu___205
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.e_list
                                                                     FStar_TypeChecker_NBETerm.e_string in
-                                                                    let uu___200
+                                                                    let uu___206
                                                                     =
-                                                                    let uu___201
+                                                                    let uu___207
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.e_either
                                                                     FStar_Reflection_NBEEmbeddings.e_bv
                                                                     FStar_Reflection_NBEEmbeddings.e_fv in
                                                                     FStar_TypeChecker_NBETerm.e_option
-                                                                    uu___201 in
+                                                                    uu___207 in
                                                                     FStar_Tactics_InterpFuns.mk_tac_step_2
                                                                     Prims.int_zero
                                                                     "resolve_name"
                                                                     FStar_Tactics_Basic.resolve_name
                                                                     FStar_Reflection_Embeddings.e_env
-                                                                    uu___197
-                                                                    uu___198
+                                                                    uu___203
+                                                                    uu___204
                                                                     FStar_Tactics_Basic.resolve_name
                                                                     FStar_Reflection_NBEEmbeddings.e_env
-                                                                    uu___199
-                                                                    uu___200 in
-                                                                    let uu___197
+                                                                    uu___205
+                                                                    uu___206 in
+                                                                    let uu___203
                                                                     =
-                                                                    let uu___198
+                                                                    let uu___204
                                                                     =
-                                                                    let uu___199
+                                                                    let uu___205
                                                                     =
                                                                     FStar_Syntax_Embeddings.e_list
                                                                     FStar_Syntax_Embeddings.e_issue in
-                                                                    let uu___200
+                                                                    let uu___206
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.e_list
                                                                     FStar_TypeChecker_NBETerm.e_issue in
@@ -2325,7 +2414,7 @@ let (uu___193 : unit) =
                                                                     is;
                                                                     FStar_Tactics_Monad.ret
                                                                     ())
-                                                                    uu___199
+                                                                    uu___205
                                                                     FStar_Syntax_Embeddings.e_unit
                                                                     (fun is
                                                                     ->
@@ -2333,9 +2422,18 @@ let (uu___193 : unit) =
                                                                     is;
                                                                     FStar_Tactics_Monad.ret
                                                                     ())
-                                                                    uu___200
+                                                                    uu___206
                                                                     FStar_TypeChecker_NBETerm.e_unit in
-                                                                    [uu___198] in
+                                                                    [uu___204] in
+                                                                    uu___202
+                                                                    ::
+                                                                    uu___203 in
+                                                                    uu___200
+                                                                    ::
+                                                                    uu___201 in
+                                                                    uu___198
+                                                                    ::
+                                                                    uu___199 in
                                                                     uu___196
                                                                     ::
                                                                     uu___197 in

--- a/ocaml/fstar-lib/generated/FStar_Tactics_Types.ml
+++ b/ocaml/fstar-lib/generated/FStar_Tactics_Types.ml
@@ -484,3 +484,4 @@ let (uu___is_E_Total : tot_or_ghost -> Prims.bool) =
   fun projectee -> match projectee with | E_Total -> true | uu___ -> false
 let (uu___is_E_Ghost : tot_or_ghost -> Prims.bool) =
   fun projectee -> match projectee with | E_Ghost -> true | uu___ -> false
+type 'a tref = 'a FStar_Compiler_Effect.ref

--- a/src/fstar/FStar.CheckedFiles.fst
+++ b/src/fstar/FStar.CheckedFiles.fst
@@ -40,7 +40,7 @@ module Dep     = FStar.Parser.Dep
  * detect when loading the cache that the version number is same
  * It needs to be kept in sync with prims.fst
  *)
-let cache_version_number = 56
+let cache_version_number = 57
 
 (*
  * Abbreviation for what we store in the checked files (stages as described below)

--- a/src/fstar/FStar.Main.fst
+++ b/src/fstar/FStar.Main.fst
@@ -216,6 +216,7 @@ let lazy_chooser k i = match k with
     | FStar.Syntax.Syntax.Lazy_universe   -> FStar.Reflection.Embeddings.unfold_lazy_universe    i
     | FStar.Syntax.Syntax.Lazy_universe_uvar -> FStar.Syntax.Util.exp_string "((universe_uvar))"
     | FStar.Syntax.Syntax.Lazy_issue -> FStar.Syntax.Util.exp_string "((issue))"
+    | FStar.Syntax.Syntax.Lazy_tref -> FStar.Syntax.Util.exp_string "((tref))"
 
 // This is called directly by the Javascript port (it doesn't call Main)
 let setup_hooks () =

--- a/src/parser/FStar.Parser.Const.fst
+++ b/src/parser/FStar.Parser.Const.fst
@@ -554,5 +554,6 @@ let fext_on_dom_g_lid = fext_lid "on_dom_g"
 let sealed_lid      = p2l ["FStar"; "Sealed"; "sealed"]
 let seal_lid        = p2l ["FStar"; "Sealed"; "seal"]
 let unseal_lid      = p2l ["FStar"; "Tactics"; "Builtins"; "unseal"]
+let tref_lid        = p2l ["FStar"; "Tactics"; "Types"; "tref"]
 
 let issue_lid = p2l ["FStar"; "Issue"; "issue"]

--- a/src/syntax/FStar.Syntax.Embeddings.fsti
+++ b/src/syntax/FStar.Syntax.Embeddings.fsti
@@ -85,6 +85,21 @@ val id_norm_cb : norm_cb
 exception Embedding_failure
 exception Unembedding_failure
 
+//
+// AR/NS: 04/22/2022:
+//        In the case of metaprograms, we reduce divergent terms in
+//        the normalizer, therefore, the final result that we get
+//        may be wrapped in a Meta_monadic node (e.g. lift, app, etc.)
+//        Before unembedding the result of such a computation,
+//          we strip those meta nodes
+//        In case the term inside is not a result, unembedding would
+//          anyway fail
+//        And we strip down only DIV
+//        Can we get any other effect? Not today, since from the client
+//          code, we enforce terms to be normalized to be PURE
+//
+val unmeta_div_results (t:term) : term
+
 val embedding (a:Type0) : Type0
 val emb_typ_of: embedding 'a -> emb_typ
 val term_as_fv: term -> fv //partial!

--- a/src/syntax/FStar.Syntax.Syntax.fsti
+++ b/src/syntax/FStar.Syntax.Syntax.fsti
@@ -409,6 +409,7 @@ and lazy_kind =
   | Lazy_universe
   | Lazy_universe_uvar
   | Lazy_issue
+  | Lazy_tref
 and binding =
   | Binding_var      of bv
   | Binding_lid      of lident * (univ_names * typ)

--- a/src/tactics/FStar.Tactics.Basic.fst
+++ b/src/tactics/FStar.Tactics.Basic.fst
@@ -2262,6 +2262,12 @@ let free_uvars (tm : term) : tac (list Z.t)
     let uvs = Syntax.Free.uvars_uncached tm |> BU.set_elements |> List.map (fun u -> Z.of_int_fs (UF.uvar_id u.ctx_uvar_head)) in
     ret uvs
 
+let alloc (x:'a) : tac (tref 'a) = ret (BU.mk_ref x)
+let read (r:tref 'a) : tac 'a = ret (!r)
+let write (r:tref 'a) (x:'a) : tac unit =
+  r := x;
+  ret ()
+
 (***** Builtins used in the meta DSL framework *****)
 
 let dbg_refl (g:env) (msg:unit -> string) =

--- a/src/tactics/FStar.Tactics.Basic.fsti
+++ b/src/tactics/FStar.Tactics.Basic.fsti
@@ -36,6 +36,7 @@ module Range  = FStar.Compiler.Range
 module Z      = FStar.BigInt
 module TcComm = FStar.TypeChecker.Common
 module Core   = FStar.TypeChecker.Core
+module Types  = FStar.Tactics.Types
 
 (* Internal utilities *)
 val goal_typedness_deps : goal -> list ctx_uvar
@@ -122,7 +123,9 @@ val get_vconfig            : unit -> tac VConfig.vconfig
 val set_vconfig            : VConfig.vconfig -> tac unit
 val t_smt_sync             : VConfig.vconfig -> tac unit
 val free_uvars             : term -> tac (list Z.t)
-
+val alloc                  : 'a -> tac (tref 'a)
+val read                   : tref 'a -> tac 'a
+val write                  : tref 'a -> 'a -> tac unit
 
 (***** Callbacks for the meta DSL framework *****)
 let issues = list FStar.Errors.issue

--- a/src/tactics/FStar.Tactics.Embedding.fst
+++ b/src/tactics/FStar.Tactics.Embedding.fst
@@ -527,6 +527,59 @@ let e_tot_or_ghost_nbe  =
   ; NBETerm.typ = mkFV fstar_tactics_tot_or_ghost.fv [] []
   ; NBETerm.emb_typ = fv_as_emb_typ fstar_tactics_tot_or_ghost.fv }
 
+let t_tref = S.lid_as_fv PC.tref_lid None
+  |> S.fv_to_tm
+  |> (fun tm -> S.mk_Tm_uinst tm [U_zero])
+  |> (fun head -> S.mk_Tm_app head [S.iarg S.t_term] Range.dummyRange)
+
+let e_tref #a =
+  let em (r:tref a) (rng:Range.range) _shadow _norm : term = 
+    U.mk_lazy r t_tref Lazy_tref (Some rng)
+  in
+  let un (t0:term) (w:bool) _norm : option (tref a) =
+    let t = unmeta_div_results t0 in
+    match t.n with
+    | Tm_lazy { lkind = Lazy_tref; blob } -> Some (Dyn.undyn blob)
+    | _ ->
+      if w then
+      Err.log_issue t0.pos
+        (Err.Warning_NotEmbedded, (BU.format1 "Not an embedded tref: %s" (Print.term_to_string t0)));
+      None
+  in
+  mk_emb_full
+    em
+    un
+    t_tref
+    (fun i -> "tref")
+    (ET_app (PC.tref_lid |> Ident.string_of_lid, [ET_abstract]))
+
+let e_tref_nbe #a =
+  let embed_tref _cb (r:tref a) : NBETerm.t =
+    let li = { lkind = Lazy_tref
+             ; blob = FStar.Compiler.Dyn.mkdyn r
+             ; ltyp = t_tref
+             ; rng = Range.dummyRange }
+    in
+  let thunk = Thunk.mk (fun () -> NBETerm.mk_t <| NBETerm.Constant (NBETerm.String ("(((tref.nbe)))", Range.dummyRange))) in
+    NBETerm.mk_t (NBETerm.Lazy (Inl li, thunk))
+  in
+  let unembed_tref _cb (t:NBETerm.t) : option (tref a) =
+    match NBETerm.nbe_t_of_t t with
+    | NBETerm.Lazy (Inl {blob=b; lkind = Lazy_tref}, _) ->
+      Some <| FStar.Compiler.Dyn.undyn b
+    | _ ->
+      if !Options.debug_embedding then
+        Err.log_issue Range.dummyRange
+          (Err.Warning_NotEmbedded,
+           BU.format1 "Not an embedded NBE tref: %s\n"
+             (NBETerm.t_to_string t));
+      None
+  in
+  { NBETerm.em = embed_tref
+  ; NBETerm.un = unembed_tref
+  ; NBETerm.typ = mkFV (S.lid_as_fv PC.tref_lid None) [] []
+  ; NBETerm.emb_typ = ET_app (PC.tref_lid |> Ident.string_of_lid, [ET_abstract]) }
+
 let e_guard_policy =
     let embed_guard_policy (rng:Range.range) (p : guard_policy) : term =
         match p with

--- a/src/tactics/FStar.Tactics.Embedding.fst
+++ b/src/tactics/FStar.Tactics.Embedding.fst
@@ -577,7 +577,9 @@ let e_tref_nbe #a =
   in
   { NBETerm.em = embed_tref
   ; NBETerm.un = unembed_tref
-  ; NBETerm.typ = mkFV (S.lid_as_fv PC.tref_lid None) [] []
+  ; NBETerm.typ =
+    (let term_t = mkFV (S.lid_as_fv PC.fstar_syntax_syntax_term None) [] [] in
+      mkFV (S.lid_as_fv PC.tref_lid None) [U_zero] [NBETerm.as_arg term_t])
   ; NBETerm.emb_typ = ET_app (PC.tref_lid |> Ident.string_of_lid, [ET_abstract]) }
 
 let e_guard_policy =

--- a/src/tactics/FStar.Tactics.Embedding.fsti
+++ b/src/tactics/FStar.Tactics.Embedding.fsti
@@ -35,6 +35,7 @@ val e_ctrl_flag              : embedding ctrl_flag
 val e_guard_policy           : embedding guard_policy
 val e_unfold_side            : embedding Core.side
 val e_tot_or_ghost           : embedding tot_or_ghost
+val e_tref (#a:Type)         : embedding (tref a)
 
 val e_exn_nbe                : NBETerm.embedding exn
 val e_proofstate_nbe         : NBETerm.embedding proofstate
@@ -45,6 +46,7 @@ val e_ctrl_flag_nbe          : NBETerm.embedding ctrl_flag
 val e_guard_policy_nbe       : NBETerm.embedding guard_policy
 val e_unfold_side_nbe        : NBETerm.embedding Core.side
 val e_tot_or_ghost_nbe       : NBETerm.embedding tot_or_ghost
+val e_tref_nbe (#a:Type)     : NBETerm.embedding (tref a)
 
 val unfold_lazy_proofstate   : lazyinfo -> term
 val unfold_lazy_goal         : lazyinfo -> term

--- a/src/tactics/FStar.Tactics.Interpreter.fst
+++ b/src/tactics/FStar.Tactics.Interpreter.fst
@@ -595,6 +595,18 @@ let () =
         free_uvars RE.e_term (e_list e_int)
         free_uvars NRE.e_term (NBET.e_list NBET.e_int);
 
+      mk_tac_step_2 1 "alloc"
+        (fun _ -> alloc) e_any e_any (E.e_tref #S.term)
+        (fun _ -> alloc) NBET.e_any NBET.e_any (E.e_tref_nbe #NBET.t);
+      
+      mk_tac_step_2 1 "read"
+        (fun _ -> read) e_any (E.e_tref #S.term) e_any
+        (fun _ -> read) NBET.e_any (E.e_tref_nbe #NBET.t) NBET.e_any;
+      
+      mk_tac_step_3 1 "write"
+        (fun _ -> write) e_any (E.e_tref #S.term) e_any e_unit
+        (fun _ -> write) NBET.e_any (E.e_tref_nbe #NBET.t) NBET.e_any NBET.e_unit;
+
       // reflection typechecker callbacks (part of the DSL framework)
 
       mk_tac_step_3 0 "check_subtyping"

--- a/src/tactics/FStar.Tactics.Types.fsti
+++ b/src/tactics/FStar.Tactics.Types.fsti
@@ -127,3 +127,5 @@ type unfold_side =
 type tot_or_ghost =
   | E_Total
   | E_Ghost
+
+type tref (a:Type) = ref a

--- a/ulib/FStar.Tactics.Builtins.fsti
+++ b/ulib/FStar.Tactics.Builtins.fsti
@@ -452,6 +452,10 @@ a reflection primitive as it depends on the state of the UF graph. *)
 val free_uvars : term -> Tac (list int)
 
 
+val alloc (#a:Type) (x:a) : Tac (tref a)
+val read (#a:Type) (r:tref a) : Tac a
+val write (#a:Type) (r:tref a) (x:a) : Tac unit
+
 (***** APIs used in the meta DSL framework *****)
 
 (** Meta DSL framework is an experimental feature

--- a/ulib/FStar.Tactics.Builtins.fsti
+++ b/ulib/FStar.Tactics.Builtins.fsti
@@ -451,7 +451,11 @@ val t_smt_sync : vconfig -> Tac unit
 a reflection primitive as it depends on the state of the UF graph. *)
 val free_uvars : term -> Tac (list int)
 
-
+(** The following primitives provide support for local state
+    during execution of a tactic.
+    The local state is monotonic, it is not
+    reverted when the tactic backtracks (using catch e.g.)
+ *)
 val alloc (#a:Type) (x:a) : Tac (tref a)
 val read (#a:Type) (r:tref a) : Tac a
 val write (#a:Type) (r:tref a) (x:a) : Tac unit

--- a/ulib/FStar.Tactics.Types.fsti
+++ b/ulib/FStar.Tactics.Types.fsti
@@ -70,3 +70,5 @@ type unfold_side =
 type tot_or_ghost =
   | E_Total
   | E_Ghost
+
+val tref (a:Type) : Type0

--- a/ulib/prims.fst
+++ b/ulib/prims.fst
@@ -708,4 +708,4 @@ val string_of_int: int -> Tot string
 (** THIS IS MEANT TO BE KEPT IN SYNC WITH FStar.CheckedFiles.fs
     Incrementing this forces all .checked files to be invalidated *)
 irreducible
-let __cache_version_number__ = 56
+let __cache_version_number__ = 57


### PR DESCRIPTION
This PR adds support for local state in metaprograms. In particular, it adds three primitives:

```
(** The following primitives provide support for local state
    during execution of a tactic.
    The local state is monotonic, it is not
    reverted when the tactic backtracks (using catch e.g.)
 *)
val alloc (#a:Type) (x:a) : Tac (tref a)
val read (#a:Type) (r:tref a) : Tac a
val write (#a:Type) (r:tref a) (x:a) : Tac unit
```

That metaprograms can use these to maintain local state during execution.

Under the hoods we use native OCaml heap to allocate these references.