### PR TITLE
Fixing order of `--warn_error`

### DIFF
--- a/ocaml/fstar-lib/generated/FStar_Errors.ml
+++ b/ocaml/fstar-lib/generated/FStar_Errors.ml
@@ -137,7 +137,8 @@ let (update_flags :
                   Invalid_warn_error_setting uu___4 in
                 FStar_Compiler_Effect.raise uu___3 in
           (match uu___1 with | (l1, h) -> (flag, (l1, h))) in
-    let error_range_settings = FStar_Compiler_List.map compute_range l in
+    let error_range_settings =
+      FStar_Compiler_List.map compute_range (FStar_Compiler_List.rev l) in
     let uu___ =
       FStar_Compiler_List.collect set_flag_for_range error_range_settings in
     FStar_Compiler_List.op_At uu___ FStar_Errors_Codes.default_settings

--- a/ocaml/fstar-lib/generated/FStar_Options.ml
+++ b/ocaml/fstar-lib/generated/FStar_Options.ml
@@ -1337,7 +1337,7 @@ let rec (specs_with_types :
               then option_warning_callback "__no_positivity"
               else ())), (Const (Bool true)))),
       "Don't check positivity of inductive types");
-    (FStar_Getopt.noshort, "warn_error", (Accumulated (SimpleStr "")),
+    (FStar_Getopt.noshort, "warn_error", (ReverseAccumulated (SimpleStr "")),
       "The [-warn_error] option follows the OCaml syntax, namely:\n\t\t- [r] is a range of warnings (either a number [n], or a range [n..n])\n\t\t- [-r] silences range [r]\n\t\t- [+r] enables range [r]\n\t\t- [@r] makes range [r] fatal.");
     (FStar_Getopt.noshort, "use_nbe", BoolStr,
       "Use normalization by evaluation as the default normalization strategy (default 'false')");

--- a/src/basic/FStar.Errors.fst
+++ b/src/basic/FStar.Errors.fst
@@ -96,7 +96,9 @@ let update_flags (l:list (error_flag * string))
      in
      flag, (l, h)
   in
-  let error_range_settings = List.map compute_range l in
+  // NOTE: Rev below so when we handle things like '@0..100-50'
+  // the -50 overrides the @0..100.
+  let error_range_settings = List.map compute_range (List.rev l) in
   List.collect set_flag_for_range error_range_settings
   @ default_settings
 

--- a/src/basic/FStar.Options.fst
+++ b/src/basic/FStar.Options.fst
@@ -1283,7 +1283,7 @@ let rec specs_with_types warn_unsafe : list (char * string * opt_type * string) 
 
         ( noshort,
         "warn_error",
-        Accumulated (SimpleStr ("")),
+        ReverseAccumulated (SimpleStr ("")),
         "The [-warn_error] option follows the OCaml syntax, namely:\n\t\t\
          - [r] is a range of warnings (either a number [n], or a range [n..n])\n\t\t\
          - [-r] silences range [r]\n\t\t\


### PR DESCRIPTION
The `--warn_error` option is accumulated by successive uses, with latter uses overriding the former, hence `--warn_error @1..100 --warn_error -50` will ignore error 50, but make 1..49 and 51..100 fatal.

However, combinations within a single `--warn_error` option use have the order reversed, the equivalent to the above is `--warn_error -50@1..100`.

This PR changes that, so the order within a single invocation is left-to-right as for separate invocations, and hence `--warn_error A --warn_error B` is the same as `--warn_error AB`. Earlier settings are overridden by latter ones (i.e. to the right, or more deeply nested within `#push-options`). 

Motivated by #2950