### PR TITLE
Restoring the old error handler in Errors.catch_errors_aux

### DIFF
--- a/ocaml/fstar-lib/generated/FStar_Tactics_Basic.ml
+++ b/ocaml/fstar-lib/generated/FStar_Tactics_Basic.ml
@@ -7162,7 +7162,25 @@ let refl_typing_builtin_wrapper :
   =
   fun f ->
     let tx = FStar_Syntax_Unionfind.new_transaction () in
-    let uu___ = FStar_Errors.catch_errors_and_ignore_rest f in
+    let uu___ =
+      try
+        (fun uu___1 ->
+           match () with | () -> FStar_Errors.catch_errors_and_ignore_rest f)
+          ()
+      with
+      | uu___1 ->
+          let issue =
+            let uu___2 = FStar_Compiler_Util.print_exn uu___1 in
+            let uu___3 = FStar_Errors.get_ctx () in
+            {
+              FStar_Errors.issue_msg = uu___2;
+              FStar_Errors.issue_level = FStar_Errors.EError;
+              FStar_Errors.issue_range = FStar_Pervasives_Native.None;
+              FStar_Errors.issue_number =
+                (FStar_Pervasives_Native.Some (Prims.of_int (17)));
+              FStar_Errors.issue_ctx = uu___3
+            } in
+          ([issue], FStar_Pervasives_Native.None) in
     match uu___ with
     | (errs, r) ->
         (FStar_Syntax_Unionfind.rollback tx;

--- a/src/tactics/FStar.Tactics.Basic.fst
+++ b/src/tactics/FStar.Tactics.Basic.fst
@@ -2272,7 +2272,18 @@ let dbg_refl (g:env) (msg:unit -> string) =
 let issues = list Errors.issue
 let refl_typing_builtin_wrapper (f:unit -> 'a) : tac (option 'a & issues) =
   let tx = UF.new_transaction () in
-  let errs, r = Errors.catch_errors_and_ignore_rest f in
+  let errs, r = 
+    try Errors.catch_errors_and_ignore_rest f
+    with exn -> //catch everything
+      let issue = FStar.Errors.({
+        issue_msg = BU.print_exn exn;
+        issue_level = EError;
+        issue_range = None;
+        issue_number = (Some 17);
+        issue_ctx = get_ctx ()
+      }) in
+      [issue], None
+  in
   UF.rollback tx;
   if List.length errs > 0
   then ret (None, errs)


### PR DESCRIPTION
FStar.Errors.catch_errors_aux is used to trap errors that can be raised in a function and to return back any issues rather than adding them to the default error handler. However, in case the error raised was a fatal error (e.g., Failure), then this function would not restore the original error handler, leading to very confusing behavior at the top-level, e.g., a tactic could fail saying issues were reported, but actually none would be reported. With Guido, we fixed this so that this function always finally restores the original error handler.

Additionally, in FStar.Tactics.Basic, in the functions that provide user-facing callbacks to the typechecker, we also trap fatal errors (e.g., violation of locally nameless convention) and return them to the caller as issues. 

This addresses problems as seen in https://github.com/FStarLang/steel/issues/17