### PR TITLE
colorizing the output of --query_stats

### DIFF
--- a/ocaml/fstar-lib/FStar_Compiler_Util.ml
+++ b/ocaml/fstar-lib/FStar_Compiler_Util.ml
@@ -541,6 +541,11 @@ let colorize_cyan s =
   | Some true -> format3 "%s%s%s" "\x1b[36;1m" s "\x1b[0m"
   | _ -> s
 
+let colorize_green s =
+  match stdout_isatty () with
+  | Some true -> format3 "%s%s%s" "\x1b[32;1m" s "\x1b[0m"
+  | _ -> s
+
 let pr  = Printf.printf
 let spr = Printf.sprintf
 let fpr = Printf.fprintf

--- a/ocaml/fstar-lib/generated/FStar_SMTEncoding_Solver.ml
+++ b/ocaml/fstar-lib/generated/FStar_SMTEncoding_Solver.ml
@@ -890,11 +890,15 @@ let (query_info : query_settings -> FStar_SMTEncoding_Z3.z3result -> unit) =
               | FStar_Pervasives_Native.Some s -> Prims.op_Hat "@" s in
             let uu___2 =
               match z3result.FStar_SMTEncoding_Z3.z3result_status with
-              | FStar_SMTEncoding_Z3.UNSAT core -> ("succeeded", core)
+              | FStar_SMTEncoding_Z3.UNSAT core ->
+                  let uu___3 = FStar_Compiler_Util.colorize_green "succeeded" in
+                  (uu___3, core)
               | uu___3 ->
-                  ((Prims.op_Hat "failed {reason-unknown="
-                      (Prims.op_Hat status_string "}")),
-                    FStar_Pervasives_Native.None) in
+                  let uu___4 =
+                    FStar_Compiler_Util.colorize_red
+                      (Prims.op_Hat "failed {reason-unknown="
+                         (Prims.op_Hat status_string "}")) in
+                  (uu___4, FStar_Pervasives_Native.None) in
             (match uu___2 with
              | (tag, core) ->
                  let range =

--- a/src/basic/FStar.Compiler.Util.fsti
+++ b/src/basic/FStar.Compiler.Util.fsti
@@ -132,6 +132,7 @@ val colorize: string -> (string * string) -> string
 val colorize_bold: string -> string
 val colorize_red: string -> string
 val colorize_cyan: string -> string
+val colorize_green: string -> string
 
 
 type out_channel

--- a/src/smtencoding/FStar.SMTEncoding.Solver.fst
+++ b/src/smtencoding/FStar.SMTEncoding.Solver.fst
@@ -561,8 +561,8 @@ let query_info settings z3result =
             | Some s -> "@"^s
         in
         let tag, core = match z3result.z3result_status with
-         | UNSAT core -> "succeeded", core
-         | _ -> "failed {reason-unknown=" ^ status_string ^ "}", None
+         | UNSAT core -> BU.colorize_green "succeeded", core
+         | _ -> BU.colorize_red ("failed {reason-unknown=" ^ status_string ^ "}"), None
         in
         let range = "(" ^ (Range.string_of_range settings.query_range) ^ at_log_file ^ ")" in
         let used_hint_tag = if used_hint settings then " (with hint)" else "" in


### PR DESCRIPTION
This helps in telling whether a query-stats line is a success or a failure in a single glance.
