### PR TITLE
Unifier tweaks

### DIFF
--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_Rel.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_Rel.ml
@@ -10176,26 +10176,29 @@ and (solve_t' : tprob -> worklist -> solution) =
                       uu___11
                   else ());
                  (let equal t11 t21 =
-                    (let uu___10 = FStar_Syntax_Util.eq_tm t11 t21 in
-                     uu___10 = FStar_Syntax_Util.Equal) ||
-                      (let steps =
-                         [FStar_TypeChecker_Env.UnfoldUntil
-                            FStar_Syntax_Syntax.delta_constant;
-                         FStar_TypeChecker_Env.Primops;
-                         FStar_TypeChecker_Env.Beta;
-                         FStar_TypeChecker_Env.Eager_unfolding;
-                         FStar_TypeChecker_Env.Iota] in
-                       let env = p_env wl orig in
-                       let t12 =
-                         norm_with_steps
-                           "FStar.TypeChecker.Rel.norm_with_steps.2" steps
-                           env t11 in
-                       let t22 =
-                         norm_with_steps
-                           "FStar.TypeChecker.Rel.norm_with_steps.3" steps
-                           env t21 in
-                       let uu___10 = FStar_Syntax_Util.eq_tm t12 t22 in
-                       uu___10 = FStar_Syntax_Util.Equal) in
+                    let r = FStar_Syntax_Util.eq_tm t11 t21 in
+                    match r with
+                    | FStar_Syntax_Util.Equal -> true
+                    | FStar_Syntax_Util.NotEqual -> false
+                    | FStar_Syntax_Util.Unknown ->
+                        let steps =
+                          [FStar_TypeChecker_Env.UnfoldUntil
+                             FStar_Syntax_Syntax.delta_constant;
+                          FStar_TypeChecker_Env.Primops;
+                          FStar_TypeChecker_Env.Beta;
+                          FStar_TypeChecker_Env.Eager_unfolding;
+                          FStar_TypeChecker_Env.Iota] in
+                        let env = p_env wl orig in
+                        let t12 =
+                          norm_with_steps
+                            "FStar.TypeChecker.Rel.norm_with_steps.2" steps
+                            env t11 in
+                        let t22 =
+                          norm_with_steps
+                            "FStar.TypeChecker.Rel.norm_with_steps.3" steps
+                            env t21 in
+                        let uu___10 = FStar_Syntax_Util.eq_tm t12 t22 in
+                        uu___10 = FStar_Syntax_Util.Equal in
                   let uu___10 =
                     ((FStar_TypeChecker_Env.is_interpreted wl.tcenv head1) ||
                        (FStar_TypeChecker_Env.is_interpreted wl.tcenv head2))
@@ -10309,26 +10312,29 @@ and (solve_t' : tprob -> worklist -> solution) =
                       uu___11
                   else ());
                  (let equal t11 t21 =
-                    (let uu___10 = FStar_Syntax_Util.eq_tm t11 t21 in
-                     uu___10 = FStar_Syntax_Util.Equal) ||
-                      (let steps =
-                         [FStar_TypeChecker_Env.UnfoldUntil
-                            FStar_Syntax_Syntax.delta_constant;
-                         FStar_TypeChecker_Env.Primops;
-                         FStar_TypeChecker_Env.Beta;
-                         FStar_TypeChecker_Env.Eager_unfolding;
-                         FStar_TypeChecker_Env.Iota] in
-                       let env = p_env wl orig in
-                       let t12 =
-                         norm_with_steps
-                           "FStar.TypeChecker.Rel.norm_with_steps.2" steps
-                           env t11 in
-                       let t22 =
-                         norm_with_steps
-                           "FStar.TypeChecker.Rel.norm_with_steps.3" steps
-                           env t21 in
-                       let uu___10 = FStar_Syntax_Util.eq_tm t12 t22 in
-                       uu___10 = FStar_Syntax_Util.Equal) in
+                    let r = FStar_Syntax_Util.eq_tm t11 t21 in
+                    match r with
+                    | FStar_Syntax_Util.Equal -> true
+                    | FStar_Syntax_Util.NotEqual -> false
+                    | FStar_Syntax_Util.Unknown ->
+                        let steps =
+                          [FStar_TypeChecker_Env.UnfoldUntil
+                             FStar_Syntax_Syntax.delta_constant;
+                          FStar_TypeChecker_Env.Primops;
+                          FStar_TypeChecker_Env.Beta;
+                          FStar_TypeChecker_Env.Eager_unfolding;
+                          FStar_TypeChecker_Env.Iota] in
+                        let env = p_env wl orig in
+                        let t12 =
+                          norm_with_steps
+                            "FStar.TypeChecker.Rel.norm_with_steps.2" steps
+                            env t11 in
+                        let t22 =
+                          norm_with_steps
+                            "FStar.TypeChecker.Rel.norm_with_steps.3" steps
+                            env t21 in
+                        let uu___10 = FStar_Syntax_Util.eq_tm t12 t22 in
+                        uu___10 = FStar_Syntax_Util.Equal in
                   let uu___10 =
                     ((FStar_TypeChecker_Env.is_interpreted wl.tcenv head1) ||
                        (FStar_TypeChecker_Env.is_interpreted wl.tcenv head2))
@@ -10442,26 +10448,29 @@ and (solve_t' : tprob -> worklist -> solution) =
                       uu___11
                   else ());
                  (let equal t11 t21 =
-                    (let uu___10 = FStar_Syntax_Util.eq_tm t11 t21 in
-                     uu___10 = FStar_Syntax_Util.Equal) ||
-                      (let steps =
-                         [FStar_TypeChecker_Env.UnfoldUntil
-                            FStar_Syntax_Syntax.delta_constant;
-                         FStar_TypeChecker_Env.Primops;
-                         FStar_TypeChecker_Env.Beta;
-                         FStar_TypeChecker_Env.Eager_unfolding;
-                         FStar_TypeChecker_Env.Iota] in
-                       let env = p_env wl orig in
-                       let t12 =
-                         norm_with_steps
-                           "FStar.TypeChecker.Rel.norm_with_steps.2" steps
-                           env t11 in
-                       let t22 =
-                         norm_with_steps
-                           "FStar.TypeChecker.Rel.norm_with_steps.3" steps
-                           env t21 in
-                       let uu___10 = FStar_Syntax_Util.eq_tm t12 t22 in
-                       uu___10 = FStar_Syntax_Util.Equal) in
+                    let r = FStar_Syntax_Util.eq_tm t11 t21 in
+                    match r with
+                    | FStar_Syntax_Util.Equal -> true
+                    | FStar_Syntax_Util.NotEqual -> false
+                    | FStar_Syntax_Util.Unknown ->
+                        let steps =
+                          [FStar_TypeChecker_Env.UnfoldUntil
+                             FStar_Syntax_Syntax.delta_constant;
+                          FStar_TypeChecker_Env.Primops;
+                          FStar_TypeChecker_Env.Beta;
+                          FStar_TypeChecker_Env.Eager_unfolding;
+                          FStar_TypeChecker_Env.Iota] in
+                        let env = p_env wl orig in
+                        let t12 =
+                          norm_with_steps
+                            "FStar.TypeChecker.Rel.norm_with_steps.2" steps
+                            env t11 in
+                        let t22 =
+                          norm_with_steps
+                            "FStar.TypeChecker.Rel.norm_with_steps.3" steps
+                            env t21 in
+                        let uu___10 = FStar_Syntax_Util.eq_tm t12 t22 in
+                        uu___10 = FStar_Syntax_Util.Equal in
                   let uu___10 =
                     ((FStar_TypeChecker_Env.is_interpreted wl.tcenv head1) ||
                        (FStar_TypeChecker_Env.is_interpreted wl.tcenv head2))
@@ -10575,26 +10584,29 @@ and (solve_t' : tprob -> worklist -> solution) =
                       uu___11
                   else ());
                  (let equal t11 t21 =
-                    (let uu___10 = FStar_Syntax_Util.eq_tm t11 t21 in
-                     uu___10 = FStar_Syntax_Util.Equal) ||
-                      (let steps =
-                         [FStar_TypeChecker_Env.UnfoldUntil
-                            FStar_Syntax_Syntax.delta_constant;
-                         FStar_TypeChecker_Env.Primops;
-                         FStar_TypeChecker_Env.Beta;
-                         FStar_TypeChecker_Env.Eager_unfolding;
-                         FStar_TypeChecker_Env.Iota] in
-                       let env = p_env wl orig in
-                       let t12 =
-                         norm_with_steps
-                           "FStar.TypeChecker.Rel.norm_with_steps.2" steps
-                           env t11 in
-                       let t22 =
-                         norm_with_steps
-                           "FStar.TypeChecker.Rel.norm_with_steps.3" steps
-                           env t21 in
-                       let uu___10 = FStar_Syntax_Util.eq_tm t12 t22 in
-                       uu___10 = FStar_Syntax_Util.Equal) in
+                    let r = FStar_Syntax_Util.eq_tm t11 t21 in
+                    match r with
+                    | FStar_Syntax_Util.Equal -> true
+                    | FStar_Syntax_Util.NotEqual -> false
+                    | FStar_Syntax_Util.Unknown ->
+                        let steps =
+                          [FStar_TypeChecker_Env.UnfoldUntil
+                             FStar_Syntax_Syntax.delta_constant;
+                          FStar_TypeChecker_Env.Primops;
+                          FStar_TypeChecker_Env.Beta;
+                          FStar_TypeChecker_Env.Eager_unfolding;
+                          FStar_TypeChecker_Env.Iota] in
+                        let env = p_env wl orig in
+                        let t12 =
+                          norm_with_steps
+                            "FStar.TypeChecker.Rel.norm_with_steps.2" steps
+                            env t11 in
+                        let t22 =
+                          norm_with_steps
+                            "FStar.TypeChecker.Rel.norm_with_steps.3" steps
+                            env t21 in
+                        let uu___10 = FStar_Syntax_Util.eq_tm t12 t22 in
+                        uu___10 = FStar_Syntax_Util.Equal in
                   let uu___10 =
                     ((FStar_TypeChecker_Env.is_interpreted wl.tcenv head1) ||
                        (FStar_TypeChecker_Env.is_interpreted wl.tcenv head2))
@@ -10708,26 +10720,29 @@ and (solve_t' : tprob -> worklist -> solution) =
                       uu___11
                   else ());
                  (let equal t11 t21 =
-                    (let uu___10 = FStar_Syntax_Util.eq_tm t11 t21 in
-                     uu___10 = FStar_Syntax_Util.Equal) ||
-                      (let steps =
-                         [FStar_TypeChecker_Env.UnfoldUntil
-                            FStar_Syntax_Syntax.delta_constant;
-                         FStar_TypeChecker_Env.Primops;
-                         FStar_TypeChecker_Env.Beta;
-                         FStar_TypeChecker_Env.Eager_unfolding;
-                         FStar_TypeChecker_Env.Iota] in
-                       let env = p_env wl orig in
-                       let t12 =
-                         norm_with_steps
-                           "FStar.TypeChecker.Rel.norm_with_steps.2" steps
-                           env t11 in
-                       let t22 =
-                         norm_with_steps
-                           "FStar.TypeChecker.Rel.norm_with_steps.3" steps
-                           env t21 in
-                       let uu___10 = FStar_Syntax_Util.eq_tm t12 t22 in
-                       uu___10 = FStar_Syntax_Util.Equal) in
+                    let r = FStar_Syntax_Util.eq_tm t11 t21 in
+                    match r with
+                    | FStar_Syntax_Util.Equal -> true
+                    | FStar_Syntax_Util.NotEqual -> false
+                    | FStar_Syntax_Util.Unknown ->
+                        let steps =
+                          [FStar_TypeChecker_Env.UnfoldUntil
+                             FStar_Syntax_Syntax.delta_constant;
+                          FStar_TypeChecker_Env.Primops;
+                          FStar_TypeChecker_Env.Beta;
+                          FStar_TypeChecker_Env.Eager_unfolding;
+                          FStar_TypeChecker_Env.Iota] in
+                        let env = p_env wl orig in
+                        let t12 =
+                          norm_with_steps
+                            "FStar.TypeChecker.Rel.norm_with_steps.2" steps
+                            env t11 in
+                        let t22 =
+                          norm_with_steps
+                            "FStar.TypeChecker.Rel.norm_with_steps.3" steps
+                            env t21 in
+                        let uu___10 = FStar_Syntax_Util.eq_tm t12 t22 in
+                        uu___10 = FStar_Syntax_Util.Equal in
                   let uu___10 =
                     ((FStar_TypeChecker_Env.is_interpreted wl.tcenv head1) ||
                        (FStar_TypeChecker_Env.is_interpreted wl.tcenv head2))
@@ -10841,26 +10856,29 @@ and (solve_t' : tprob -> worklist -> solution) =
                       uu___11
                   else ());
                  (let equal t11 t21 =
-                    (let uu___10 = FStar_Syntax_Util.eq_tm t11 t21 in
-                     uu___10 = FStar_Syntax_Util.Equal) ||
-                      (let steps =
-                         [FStar_TypeChecker_Env.UnfoldUntil
-                            FStar_Syntax_Syntax.delta_constant;
-                         FStar_TypeChecker_Env.Primops;
-                         FStar_TypeChecker_Env.Beta;
-                         FStar_TypeChecker_Env.Eager_unfolding;
-                         FStar_TypeChecker_Env.Iota] in
-                       let env = p_env wl orig in
-                       let t12 =
-                         norm_with_steps
-                           "FStar.TypeChecker.Rel.norm_with_steps.2" steps
-                           env t11 in
-                       let t22 =
-                         norm_with_steps
-                           "FStar.TypeChecker.Rel.norm_with_steps.3" steps
-                           env t21 in
-                       let uu___10 = FStar_Syntax_Util.eq_tm t12 t22 in
-                       uu___10 = FStar_Syntax_Util.Equal) in
+                    let r = FStar_Syntax_Util.eq_tm t11 t21 in
+                    match r with
+                    | FStar_Syntax_Util.Equal -> true
+                    | FStar_Syntax_Util.NotEqual -> false
+                    | FStar_Syntax_Util.Unknown ->
+                        let steps =
+                          [FStar_TypeChecker_Env.UnfoldUntil
+                             FStar_Syntax_Syntax.delta_constant;
+                          FStar_TypeChecker_Env.Primops;
+                          FStar_TypeChecker_Env.Beta;
+                          FStar_TypeChecker_Env.Eager_unfolding;
+                          FStar_TypeChecker_Env.Iota] in
+                        let env = p_env wl orig in
+                        let t12 =
+                          norm_with_steps
+                            "FStar.TypeChecker.Rel.norm_with_steps.2" steps
+                            env t11 in
+                        let t22 =
+                          norm_with_steps
+                            "FStar.TypeChecker.Rel.norm_with_steps.3" steps
+                            env t21 in
+                        let uu___10 = FStar_Syntax_Util.eq_tm t12 t22 in
+                        uu___10 = FStar_Syntax_Util.Equal in
                   let uu___10 =
                     ((FStar_TypeChecker_Env.is_interpreted wl.tcenv head1) ||
                        (FStar_TypeChecker_Env.is_interpreted wl.tcenv head2))
@@ -10974,26 +10992,29 @@ and (solve_t' : tprob -> worklist -> solution) =
                       uu___11
                   else ());
                  (let equal t11 t21 =
-                    (let uu___10 = FStar_Syntax_Util.eq_tm t11 t21 in
-                     uu___10 = FStar_Syntax_Util.Equal) ||
-                      (let steps =
-                         [FStar_TypeChecker_Env.UnfoldUntil
-                            FStar_Syntax_Syntax.delta_constant;
-                         FStar_TypeChecker_Env.Primops;
-                         FStar_TypeChecker_Env.Beta;
-                         FStar_TypeChecker_Env.Eager_unfolding;
-                         FStar_TypeChecker_Env.Iota] in
-                       let env = p_env wl orig in
-                       let t12 =
-                         norm_with_steps
-                           "FStar.TypeChecker.Rel.norm_with_steps.2" steps
-                           env t11 in
-                       let t22 =
-                         norm_with_steps
-                           "FStar.TypeChecker.Rel.norm_with_steps.3" steps
-                           env t21 in
-                       let uu___10 = FStar_Syntax_Util.eq_tm t12 t22 in
-                       uu___10 = FStar_Syntax_Util.Equal) in
+                    let r = FStar_Syntax_Util.eq_tm t11 t21 in
+                    match r with
+                    | FStar_Syntax_Util.Equal -> true
+                    | FStar_Syntax_Util.NotEqual -> false
+                    | FStar_Syntax_Util.Unknown ->
+                        let steps =
+                          [FStar_TypeChecker_Env.UnfoldUntil
+                             FStar_Syntax_Syntax.delta_constant;
+                          FStar_TypeChecker_Env.Primops;
+                          FStar_TypeChecker_Env.Beta;
+                          FStar_TypeChecker_Env.Eager_unfolding;
+                          FStar_TypeChecker_Env.Iota] in
+                        let env = p_env wl orig in
+                        let t12 =
+                          norm_with_steps
+                            "FStar.TypeChecker.Rel.norm_with_steps.2" steps
+                            env t11 in
+                        let t22 =
+                          norm_with_steps
+                            "FStar.TypeChecker.Rel.norm_with_steps.3" steps
+                            env t21 in
+                        let uu___10 = FStar_Syntax_Util.eq_tm t12 t22 in
+                        uu___10 = FStar_Syntax_Util.Equal in
                   let uu___10 =
                     ((FStar_TypeChecker_Env.is_interpreted wl.tcenv head1) ||
                        (FStar_TypeChecker_Env.is_interpreted wl.tcenv head2))
@@ -11107,26 +11128,29 @@ and (solve_t' : tprob -> worklist -> solution) =
                       uu___11
                   else ());
                  (let equal t11 t21 =
-                    (let uu___10 = FStar_Syntax_Util.eq_tm t11 t21 in
-                     uu___10 = FStar_Syntax_Util.Equal) ||
-                      (let steps =
-                         [FStar_TypeChecker_Env.UnfoldUntil
-                            FStar_Syntax_Syntax.delta_constant;
-                         FStar_TypeChecker_Env.Primops;
-                         FStar_TypeChecker_Env.Beta;
-                         FStar_TypeChecker_Env.Eager_unfolding;
-                         FStar_TypeChecker_Env.Iota] in
-                       let env = p_env wl orig in
-                       let t12 =
-                         norm_with_steps
-                           "FStar.TypeChecker.Rel.norm_with_steps.2" steps
-                           env t11 in
-                       let t22 =
-                         norm_with_steps
-                           "FStar.TypeChecker.Rel.norm_with_steps.3" steps
-                           env t21 in
-                       let uu___10 = FStar_Syntax_Util.eq_tm t12 t22 in
-                       uu___10 = FStar_Syntax_Util.Equal) in
+                    let r = FStar_Syntax_Util.eq_tm t11 t21 in
+                    match r with
+                    | FStar_Syntax_Util.Equal -> true
+                    | FStar_Syntax_Util.NotEqual -> false
+                    | FStar_Syntax_Util.Unknown ->
+                        let steps =
+                          [FStar_TypeChecker_Env.UnfoldUntil
+                             FStar_Syntax_Syntax.delta_constant;
+                          FStar_TypeChecker_Env.Primops;
+                          FStar_TypeChecker_Env.Beta;
+                          FStar_TypeChecker_Env.Eager_unfolding;
+                          FStar_TypeChecker_Env.Iota] in
+                        let env = p_env wl orig in
+                        let t12 =
+                          norm_with_steps
+                            "FStar.TypeChecker.Rel.norm_with_steps.2" steps
+                            env t11 in
+                        let t22 =
+                          norm_with_steps
+                            "FStar.TypeChecker.Rel.norm_with_steps.3" steps
+                            env t21 in
+                        let uu___10 = FStar_Syntax_Util.eq_tm t12 t22 in
+                        uu___10 = FStar_Syntax_Util.Equal in
                   let uu___10 =
                     ((FStar_TypeChecker_Env.is_interpreted wl.tcenv head1) ||
                        (FStar_TypeChecker_Env.is_interpreted wl.tcenv head2))
@@ -11240,26 +11264,29 @@ and (solve_t' : tprob -> worklist -> solution) =
                       uu___11
                   else ());
                  (let equal t11 t21 =
-                    (let uu___10 = FStar_Syntax_Util.eq_tm t11 t21 in
-                     uu___10 = FStar_Syntax_Util.Equal) ||
-                      (let steps =
-                         [FStar_TypeChecker_Env.UnfoldUntil
-                            FStar_Syntax_Syntax.delta_constant;
-                         FStar_TypeChecker_Env.Primops;
-                         FStar_TypeChecker_Env.Beta;
-                         FStar_TypeChecker_Env.Eager_unfolding;
-                         FStar_TypeChecker_Env.Iota] in
-                       let env = p_env wl orig in
-                       let t12 =
-                         norm_with_steps
-                           "FStar.TypeChecker.Rel.norm_with_steps.2" steps
-                           env t11 in
-                       let t22 =
-                         norm_with_steps
-                           "FStar.TypeChecker.Rel.norm_with_steps.3" steps
-                           env t21 in
-                       let uu___10 = FStar_Syntax_Util.eq_tm t12 t22 in
-                       uu___10 = FStar_Syntax_Util.Equal) in
+                    let r = FStar_Syntax_Util.eq_tm t11 t21 in
+                    match r with
+                    | FStar_Syntax_Util.Equal -> true
+                    | FStar_Syntax_Util.NotEqual -> false
+                    | FStar_Syntax_Util.Unknown ->
+                        let steps =
+                          [FStar_TypeChecker_Env.UnfoldUntil
+                             FStar_Syntax_Syntax.delta_constant;
+                          FStar_TypeChecker_Env.Primops;
+                          FStar_TypeChecker_Env.Beta;
+                          FStar_TypeChecker_Env.Eager_unfolding;
+                          FStar_TypeChecker_Env.Iota] in
+                        let env = p_env wl orig in
+                        let t12 =
+                          norm_with_steps
+                            "FStar.TypeChecker.Rel.norm_with_steps.2" steps
+                            env t11 in
+                        let t22 =
+                          norm_with_steps
+                            "FStar.TypeChecker.Rel.norm_with_steps.3" steps
+                            env t21 in
+                        let uu___10 = FStar_Syntax_Util.eq_tm t12 t22 in
+                        uu___10 = FStar_Syntax_Util.Equal in
                   let uu___10 =
                     ((FStar_TypeChecker_Env.is_interpreted wl.tcenv head1) ||
                        (FStar_TypeChecker_Env.is_interpreted wl.tcenv head2))
@@ -11373,26 +11400,29 @@ and (solve_t' : tprob -> worklist -> solution) =
                       uu___11
                   else ());
                  (let equal t11 t21 =
-                    (let uu___10 = FStar_Syntax_Util.eq_tm t11 t21 in
-                     uu___10 = FStar_Syntax_Util.Equal) ||
-                      (let steps =
-                         [FStar_TypeChecker_Env.UnfoldUntil
-                            FStar_Syntax_Syntax.delta_constant;
-                         FStar_TypeChecker_Env.Primops;
-                         FStar_TypeChecker_Env.Beta;
-                         FStar_TypeChecker_Env.Eager_unfolding;
-                         FStar_TypeChecker_Env.Iota] in
-                       let env = p_env wl orig in
-                       let t12 =
-                         norm_with_steps
-                           "FStar.TypeChecker.Rel.norm_with_steps.2" steps
-                           env t11 in
-                       let t22 =
-                         norm_with_steps
-                           "FStar.TypeChecker.Rel.norm_with_steps.3" steps
-                           env t21 in
-                       let uu___10 = FStar_Syntax_Util.eq_tm t12 t22 in
-                       uu___10 = FStar_Syntax_Util.Equal) in
+                    let r = FStar_Syntax_Util.eq_tm t11 t21 in
+                    match r with
+                    | FStar_Syntax_Util.Equal -> true
+                    | FStar_Syntax_Util.NotEqual -> false
+                    | FStar_Syntax_Util.Unknown ->
+                        let steps =
+                          [FStar_TypeChecker_Env.UnfoldUntil
+                             FStar_Syntax_Syntax.delta_constant;
+                          FStar_TypeChecker_Env.Primops;
+                          FStar_TypeChecker_Env.Beta;
+                          FStar_TypeChecker_Env.Eager_unfolding;
+                          FStar_TypeChecker_Env.Iota] in
+                        let env = p_env wl orig in
+                        let t12 =
+                          norm_with_steps
+                            "FStar.TypeChecker.Rel.norm_with_steps.2" steps
+                            env t11 in
+                        let t22 =
+                          norm_with_steps
+                            "FStar.TypeChecker.Rel.norm_with_steps.3" steps
+                            env t21 in
+                        let uu___10 = FStar_Syntax_Util.eq_tm t12 t22 in
+                        uu___10 = FStar_Syntax_Util.Equal in
                   let uu___10 =
                     ((FStar_TypeChecker_Env.is_interpreted wl.tcenv head1) ||
                        (FStar_TypeChecker_Env.is_interpreted wl.tcenv head2))
@@ -11506,26 +11536,29 @@ and (solve_t' : tprob -> worklist -> solution) =
                       uu___11
                   else ());
                  (let equal t11 t21 =
-                    (let uu___10 = FStar_Syntax_Util.eq_tm t11 t21 in
-                     uu___10 = FStar_Syntax_Util.Equal) ||
-                      (let steps =
-                         [FStar_TypeChecker_Env.UnfoldUntil
-                            FStar_Syntax_Syntax.delta_constant;
-                         FStar_TypeChecker_Env.Primops;
-                         FStar_TypeChecker_Env.Beta;
-                         FStar_TypeChecker_Env.Eager_unfolding;
-                         FStar_TypeChecker_Env.Iota] in
-                       let env = p_env wl orig in
-                       let t12 =
-                         norm_with_steps
-                           "FStar.TypeChecker.Rel.norm_with_steps.2" steps
-                           env t11 in
-                       let t22 =
-                         norm_with_steps
-                           "FStar.TypeChecker.Rel.norm_with_steps.3" steps
-                           env t21 in
-                       let uu___10 = FStar_Syntax_Util.eq_tm t12 t22 in
-                       uu___10 = FStar_Syntax_Util.Equal) in
+                    let r = FStar_Syntax_Util.eq_tm t11 t21 in
+                    match r with
+                    | FStar_Syntax_Util.Equal -> true
+                    | FStar_Syntax_Util.NotEqual -> false
+                    | FStar_Syntax_Util.Unknown ->
+                        let steps =
+                          [FStar_TypeChecker_Env.UnfoldUntil
+                             FStar_Syntax_Syntax.delta_constant;
+                          FStar_TypeChecker_Env.Primops;
+                          FStar_TypeChecker_Env.Beta;
+                          FStar_TypeChecker_Env.Eager_unfolding;
+                          FStar_TypeChecker_Env.Iota] in
+                        let env = p_env wl orig in
+                        let t12 =
+                          norm_with_steps
+                            "FStar.TypeChecker.Rel.norm_with_steps.2" steps
+                            env t11 in
+                        let t22 =
+                          norm_with_steps
+                            "FStar.TypeChecker.Rel.norm_with_steps.3" steps
+                            env t21 in
+                        let uu___10 = FStar_Syntax_Util.eq_tm t12 t22 in
+                        uu___10 = FStar_Syntax_Util.Equal in
                   let uu___10 =
                     ((FStar_TypeChecker_Env.is_interpreted wl.tcenv head1) ||
                        (FStar_TypeChecker_Env.is_interpreted wl.tcenv head2))
@@ -11639,26 +11672,29 @@ and (solve_t' : tprob -> worklist -> solution) =
                       uu___11
                   else ());
                  (let equal t11 t21 =
-                    (let uu___10 = FStar_Syntax_Util.eq_tm t11 t21 in
-                     uu___10 = FStar_Syntax_Util.Equal) ||
-                      (let steps =
-                         [FStar_TypeChecker_Env.UnfoldUntil
-                            FStar_Syntax_Syntax.delta_constant;
-                         FStar_TypeChecker_Env.Primops;
-                         FStar_TypeChecker_Env.Beta;
-                         FStar_TypeChecker_Env.Eager_unfolding;
-                         FStar_TypeChecker_Env.Iota] in
-                       let env = p_env wl orig in
-                       let t12 =
-                         norm_with_steps
-                           "FStar.TypeChecker.Rel.norm_with_steps.2" steps
-                           env t11 in
-                       let t22 =
-                         norm_with_steps
-                           "FStar.TypeChecker.Rel.norm_with_steps.3" steps
-                           env t21 in
-                       let uu___10 = FStar_Syntax_Util.eq_tm t12 t22 in
-                       uu___10 = FStar_Syntax_Util.Equal) in
+                    let r = FStar_Syntax_Util.eq_tm t11 t21 in
+                    match r with
+                    | FStar_Syntax_Util.Equal -> true
+                    | FStar_Syntax_Util.NotEqual -> false
+                    | FStar_Syntax_Util.Unknown ->
+                        let steps =
+                          [FStar_TypeChecker_Env.UnfoldUntil
+                             FStar_Syntax_Syntax.delta_constant;
+                          FStar_TypeChecker_Env.Primops;
+                          FStar_TypeChecker_Env.Beta;
+                          FStar_TypeChecker_Env.Eager_unfolding;
+                          FStar_TypeChecker_Env.Iota] in
+                        let env = p_env wl orig in
+                        let t12 =
+                          norm_with_steps
+                            "FStar.TypeChecker.Rel.norm_with_steps.2" steps
+                            env t11 in
+                        let t22 =
+                          norm_with_steps
+                            "FStar.TypeChecker.Rel.norm_with_steps.3" steps
+                            env t21 in
+                        let uu___10 = FStar_Syntax_Util.eq_tm t12 t22 in
+                        uu___10 = FStar_Syntax_Util.Equal in
                   let uu___10 =
                     ((FStar_TypeChecker_Env.is_interpreted wl.tcenv head1) ||
                        (FStar_TypeChecker_Env.is_interpreted wl.tcenv head2))

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_Tc.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_Tc.ml
@@ -4715,9 +4715,7 @@ let (tc_decls :
          | (uu___2, env1) ->
              let r =
                let uu___3 =
-                 let uu___4 =
-                   let uu___5 = FStar_TypeChecker_Env.current_module env1 in
-                   FStar_Ident.string_of_lid uu___5 in
+                 let uu___4 = FStar_Syntax_Print.sigelt_to_string_short se in
                  FStar_Pervasives_Native.Some uu___4 in
                FStar_Profiling.profile
                  (fun uu___4 -> process_one_decl acc se) uu___3

--- a/src/typechecker/FStar.TypeChecker.Rel.fst
+++ b/src/typechecker/FStar.TypeChecker.Rel.fst
@@ -4146,9 +4146,15 @@ and solve_t' (problem:tprob) (wl:worklist) : solution =
                 (string_of_bool (Env.is_interpreted wl.tcenv head2));
                 (string_of_bool (no_free_uvars t2))]
          in
-         let equal t1 t2 =
-            (U.eq_tm t1 t2 = U.Equal) ||
-            (let steps = [
+         let equal t1 t2 : bool =
+          (* Try comparing the terms as they are. If we get Equal or NotEqual,
+             we are done. If we get an Unknown, attempt some normalization. *)
+           let r = U.eq_tm t1 t2 in
+           match r with
+           | U.Equal -> true
+           | U.NotEqual -> false
+           | U.Unknown ->
+             let steps = [
                Env.UnfoldUntil delta_constant;
                Env.Primops;
                Env.Beta;
@@ -4157,7 +4163,7 @@ and solve_t' (problem:tprob) (wl:worklist) : solution =
              let env = p_env wl orig in
              let t1 = norm_with_steps "FStar.TypeChecker.Rel.norm_with_steps.2" steps env t1 in
              let t2 = norm_with_steps "FStar.TypeChecker.Rel.norm_with_steps.3" steps env t2 in
-             U.eq_tm t1 t2 = U.Equal)
+             U.eq_tm t1 t2 = U.Equal
          in
          if (Env.is_interpreted wl.tcenv head1 || Env.is_interpreted wl.tcenv head2) //we have something like (+ x1 x2) =?= (- y1 y2)
            && problem.relation = EQ

--- a/src/typechecker/FStar.TypeChecker.Tc.fst
+++ b/src/typechecker/FStar.TypeChecker.Tc.fst
@@ -1075,7 +1075,7 @@ let tc_decls env ses =
     let r =
       Profiling.profile
                  (fun () -> process_one_decl acc se)
-                 (Some (Ident.string_of_lid (Env.current_module env)))
+                 (Some (Print.sigelt_to_string_short se))
                  "FStar.TypeChecker.Tc.process_one_decl"
       // ^ See a special case for this phase in FStar.Options. --timing
       // enables it.


### PR DESCRIPTION
The interesting commit is the second one, that slightly changes some
unfolding logic in the unifier. I think I wrote this originally,
and made the mistake of thinking that `||` was short-circuiting :).

I'll run an everest comparison and post it here before merging.

This call is anyway problematic as this full normalization can be excessively
expensive, I'm working on finding a better way to do this instead of
full normalization. In one F* example in an external development,
adding `Weak` to the set of flags is the difference between a runtime
of 30mins and 0.5 seconds. Separate PR to come soon probably.

- tc: print sigelt (in short form) for --timing/--profile
- tc: rel: slightly improving norm call, short-circuit
- snap
