### PR TITLE
Fixing the incremental parsing of syntax extension blobs

### DIFF
--- a/ocaml/fstar-lib/FStar_Parser_LexFStar.ml
+++ b/ocaml/fstar-lib/FStar_Parser_LexFStar.ml
@@ -446,8 +446,9 @@ match%sedlex lexbuf with
    let s = L.lexeme lexbuf in
    let name = BatString.lchop ~n:3 s in
    Buffer.clear blob_buffer;
+   let snap = Sedlexing.snapshot lexbuf in
    let pos = L.current_pos lexbuf in
-   uninterpreted_blob name pos blob_buffer lexbuf
+   uninterpreted_blob snap name pos blob_buffer lexbuf
  | "`%" -> BACKTICK_PERC
  | "`#" -> BACKTICK_HASH
  | "`@" -> BACKTICK_AT
@@ -637,19 +638,19 @@ match%sedlex lexbuf with
    comment inner buffer startpos lexbuf
  | _ -> assert false
 
-and uninterpreted_blob name pos buffer lexbuf =
+and uninterpreted_blob snap name pos buffer lexbuf =
 match %sedlex lexbuf with
  | "```" ->
-   BLOB(name, Buffer.contents buffer, pos)
+   BLOB(name, Buffer.contents buffer, pos, snap)
  | eof ->
    EOF
  | newline ->
    L.new_line lexbuf;
    Buffer.add_string buffer (L.lexeme lexbuf);
-   uninterpreted_blob name pos buffer lexbuf
+   uninterpreted_blob snap name pos buffer lexbuf
  | any ->
    Buffer.add_string buffer (L.lexeme lexbuf);
-   uninterpreted_blob name pos buffer lexbuf
+   uninterpreted_blob snap name pos buffer lexbuf
  | _ -> assert false
 
 and ignore_endline lexbuf =

--- a/ocaml/fstar-lib/FStar_Parser_Parse.mly
+++ b/ocaml/fstar-lib/FStar_Parser_Parse.mly
@@ -117,7 +117,7 @@ let parse_extension_blob (extension_name:string) (s:string) r : FStar_Parser_AST
 
 %token<string>  OPPREFIX OPINFIX0a OPINFIX0b OPINFIX0c OPINFIX0d OPINFIX1 OPINFIX2 OPINFIX3 OPINFIX4
 %token<string>  OP_MIXFIX_ASSIGNMENT OP_MIXFIX_ACCESS
-%token<string * string * Lexing.position>  BLOB
+%token<string * string * Lexing.position * FStar_Sedlexing.snap>  BLOB
 
 /* These are artificial */
 %token EOF
@@ -145,7 +145,7 @@ let parse_extension_blob (extension_name:string) (s:string) r : FStar_Parser_AST
 %start warn_error_list
 %start oneDeclOrEOF
 %type <FStar_Parser_AST.inputFragment> inputFragment
-%type <FStar_Parser_AST.decl option> oneDeclOrEOF
+%type <(FStar_Parser_AST.decl * FStar_Sedlexing.snap option) option> oneDeclOrEOF
 %type <FStar_Parser_AST.term> term
 %type <FStar_Ident.ident> lident
 %type <(FStar_Errors_Codes.error_flag * string) list> warn_error_list
@@ -160,37 +160,38 @@ inputFragment:
 
 oneDeclOrEOF:
   | EOF { None }
-  | d=idecl { Some d }
+  | ds=idecl { Some ds }
 
 idecl:
- | d=decl startOfNextDeclToken
-     { d }
+ | d=decl snap=startOfNextDeclToken
+     { d, snap }
 
 
 startOfNextDeclToken:
- | EOF    { () }
- | pragmaStartToken { () }
- | LBRACK_AT { () } (* Attribute start *)
- | LBRACK_AT_AT { () } (* Attribute start *) 
- | qualifier { () }
- | CLASS { () }
- | INSTANCE { () }
- | OPEN  { () }
- | FRIEND  { () }
- | INCLUDE  { () }
- | MODULE  { () }
- | TYPE  { () }
- | EFFECT  { () }
- | LET  { () }
- | VAL  { () }
- | SPLICE  { () }
- | SPLICET  { () }
- | EXCEPTION  { () }
- | NEW_EFFECT  { () }
- | LAYERED_EFFECT  { () }
- | SUB_EFFECT { () }
- | POLYMONADIC_BIND  { () }
- | POLYMONADIC_SUBCOMP  { () }
+ | EOF    { None }
+ | pragmaStartToken { None }
+ | LBRACK_AT { None } (* Attribute start *)
+ | LBRACK_AT_AT { None } (* Attribute start *) 
+ | qualifier { None }
+ | CLASS { None }
+ | INSTANCE { None }
+ | OPEN  { None }
+ | FRIEND  { None }
+ | INCLUDE  { None }
+ | MODULE  { None }
+ | TYPE  { None }
+ | EFFECT  { None }
+ | LET  { None }
+ | VAL  { None }
+ | SPLICE  { None }
+ | SPLICET  { None }
+ | EXCEPTION  { None }
+ | NEW_EFFECT  { None }
+ | LAYERED_EFFECT  { None }
+ | SUB_EFFECT { None }
+ | POLYMONADIC_BIND  { None }
+ | POLYMONADIC_SUBCOMP  { None }
+ | b=BLOB { let _, _, _, snap = b in Some snap }
  
  
 pragmaStartToken:
@@ -343,7 +344,7 @@ rawDecl:
       { Polymonadic_subcomp c }
   | blob=BLOB
       {
-        let ext_name, contents, pos = blob in
+        let ext_name, contents, pos, _ = blob in
         parse_extension_blob ext_name contents (rr (pos, pos))
       }
 

--- a/ocaml/fstar-lib/FStar_Parser_Parse.mly
+++ b/ocaml/fstar-lib/FStar_Parser_Parse.mly
@@ -52,8 +52,11 @@ let none_to_empty_list x =
   | None -> []
   | Some l -> l
 
-let parse_extension_blob (extension_name:string) (s:string) r : FStar_Parser_AST.decl' =
-    DeclSyntaxExtension (extension_name, s, r)
+let parse_extension_blob (extension_name:string)
+                         (s:string)
+                         (blob_range:range)
+                         (extension_syntax_start:range) : FStar_Parser_AST.decl' =
+    DeclSyntaxExtension (extension_name, s, blob_range, extension_syntax_start)
 %}
 
 %token <string> STRING
@@ -344,8 +347,13 @@ rawDecl:
       { Polymonadic_subcomp c }
   | blob=BLOB
       {
-        let ext_name, contents, pos, _ = blob in
-        parse_extension_blob ext_name contents (rr (pos, pos))
+        let ext_name, contents, pos, snap = blob in
+        (* blob_range is the full range of the blob, including the enclosing ``` *)
+        let blob_range = rr (snd snap, snd $loc) in
+        (* extension_syntax_start_range is where the extension syntax starts not incluing
+           the "```ident" prefix *)
+        let extension_syntax_start_range = (rr (pos, pos)) in
+        parse_extension_blob ext_name contents blob_range extension_syntax_start_range
       }
 
 

--- a/ocaml/fstar-lib/FStar_Parser_ParseIt.ml
+++ b/ocaml/fstar-lib/FStar_Parser_ParseIt.ml
@@ -248,7 +248,7 @@ let parse fn =
         in
         match d with
         | Inl None -> List.rev decls, None
-        | Inl (Some d) -> 
+        | Inl (Some (d, snap_opt)) -> 
           (* The parser may advance the lexer beyond the decls last token.
              E.g., in `let f x = 0 let g = 1`, we will have parsed the decl for `f`
                    but the lexer will have advanced to `let ^ g ...` since the
@@ -257,20 +257,16 @@ let parse fn =
                    requires such lookahead to complete a production.
           *)
           let end_pos =
-              rollback lexbuf;
-              current_pos lexbuf
+            let _ = 
+              match snap_opt with
+              | None -> 
+                rollback lexbuf
+              | Some p -> 
+                restore_snapshot lexbuf p
+            in
+            current_pos lexbuf
           in
           let raw_contents = contents_at d.drange in
-          (*
-          if FStar_Options.debug_any()
-          then (
-            FStar_Compiler_Util.print4 "Parsed decl@%s=%s\nRaw contents@%s=%s\n"
-              (FStar_Compiler_Range.string_of_def_range d.drange)
-              (FStar_Parser_AST.decl_to_string d)
-              (FStar_Compiler_Range.string_of_def_range raw_contents.range)
-              raw_contents.code
-          );
-          *)
           parse ((d, raw_contents)::decls)
         | Inr err -> List.rev decls, Some err
       in

--- a/ocaml/fstar-lib/FStar_Parser_ParseIt.ml
+++ b/ocaml/fstar-lib/FStar_Parser_ParseIt.ml
@@ -267,6 +267,11 @@ let parse fn =
             current_pos lexbuf
           in
           let raw_contents = contents_at d.drange in
+          if FStar_Options.debug_any()
+          then 
+            FStar_Compiler_Util.print2 "At range %s, got code\n%s\n"
+              (FStar_Compiler_Range.string_of_range raw_contents.range)
+              (raw_contents.code);
           parse ((d, raw_contents)::decls)
         | Inr err -> List.rev decls, Some err
       in

--- a/ocaml/fstar-lib/FStar_Sedlexing.ml
+++ b/ocaml/fstar-lib/FStar_Sedlexing.ml
@@ -72,6 +72,13 @@ let backtrack b =
   b.cur_p <- b.mark_p;
   b.mark_val
 
+type snap = int * pos
+
+let snapshot b = b.start, b.start_p
+let restore_snapshot b (cur, cur_p) =
+  b.cur <- cur;
+  b.cur_p <- cur_p
+
 let next b =
   if b.cur = b.len then None
   else

--- a/ocaml/fstar-lib/generated/FStar_Parser_AST.ml
+++ b/ocaml/fstar-lib/generated/FStar_Parser_AST.ml
@@ -810,7 +810,7 @@ type decl' =
   | Assume of (FStar_Ident.ident * term) 
   | Splice of (Prims.bool * FStar_Ident.ident Prims.list * term) 
   | DeclSyntaxExtension of (Prims.string * Prims.string *
-  FStar_Compiler_Range_Type.range) 
+  FStar_Compiler_Range_Type.range * FStar_Compiler_Range_Type.range) 
 and decl =
   {
   d: decl' ;
@@ -909,8 +909,10 @@ let (uu___is_DeclSyntaxExtension : decl' -> Prims.bool) =
   fun projectee ->
     match projectee with | DeclSyntaxExtension _0 -> true | uu___ -> false
 let (__proj__DeclSyntaxExtension__item___0 :
-  decl' -> (Prims.string * Prims.string * FStar_Compiler_Range_Type.range)) =
-  fun projectee -> match projectee with | DeclSyntaxExtension _0 -> _0
+  decl' ->
+    (Prims.string * Prims.string * FStar_Compiler_Range_Type.range *
+      FStar_Compiler_Range_Type.range))
+  = fun projectee -> match projectee with | DeclSyntaxExtension _0 -> _0
 let (__proj__Mkdecl__item__d : decl -> decl') =
   fun projectee -> match projectee with | { d; drange; quals; attrs;_} -> d
 let (__proj__Mkdecl__item__drange : decl -> FStar_Compiler_Range_Type.range)
@@ -1008,7 +1010,11 @@ let (mk_decl :
                match uu___ with
                | Qualifier q -> FStar_Pervasives_Native.Some q
                | uu___1 -> FStar_Pervasives_Native.None) decorations in
-        { d; drange = r; quals = qualifiers1; attrs = attributes_2 }
+        let range =
+          match d with
+          | DeclSyntaxExtension (uu___, uu___1, r1, uu___2) -> r1
+          | uu___ -> r in
+        { d; drange = range; quals = qualifiers1; attrs = attributes_2 }
 let (mk_binder_with_attrs :
   binder' ->
     FStar_Compiler_Range_Type.range ->
@@ -2439,7 +2445,7 @@ let (decl_to_string : decl -> Prims.string) =
     | SubEffect uu___ -> "sub_effect"
     | Pragma p ->
         let uu___ = string_of_pragma p in Prims.op_Hat "pragma #" uu___
-    | DeclSyntaxExtension (id, content, uu___) ->
+    | DeclSyntaxExtension (id, content, uu___, uu___1) ->
         Prims.op_Hat "```"
           (Prims.op_Hat id (Prims.op_Hat "\n" (Prims.op_Hat content "\n```")))
 let (modul_to_string : modul -> Prims.string) =

--- a/ocaml/fstar-lib/generated/FStar_Parser_AST.ml
+++ b/ocaml/fstar-lib/generated/FStar_Parser_AST.ml
@@ -2439,6 +2439,9 @@ let (decl_to_string : decl -> Prims.string) =
     | SubEffect uu___ -> "sub_effect"
     | Pragma p ->
         let uu___ = string_of_pragma p in Prims.op_Hat "pragma #" uu___
+    | DeclSyntaxExtension (id, content, uu___) ->
+        Prims.op_Hat "```"
+          (Prims.op_Hat id (Prims.op_Hat "\n" (Prims.op_Hat content "\n```")))
 let (modul_to_string : modul -> Prims.string) =
   fun m ->
     match m with

--- a/ocaml/fstar-lib/generated/FStar_ToSyntax_ToSyntax.ml
+++ b/ocaml/fstar-lib/generated/FStar_ToSyntax_ToSyntax.ml
@@ -9645,29 +9645,29 @@ and (desugar_decl_noattrs :
                 FStar_Syntax_Syntax.sigopts = FStar_Pervasives_Native.None
               } in
             let env1 = FStar_Syntax_DsEnv.push_sigelt env se in (env1, [se])
-        | FStar_Parser_AST.DeclSyntaxExtension (extension_name, code, range)
-            ->
+        | FStar_Parser_AST.DeclSyntaxExtension
+            (extension_name, code, uu___, range) ->
             let extension_parser =
               FStar_Parser_AST_Util.lookup_extension_parser extension_name in
             (match extension_parser with
              | FStar_Pervasives_Native.None ->
-                 let uu___ =
-                   let uu___1 =
+                 let uu___1 =
+                   let uu___2 =
                      FStar_Compiler_Util.format1
                        "Unknown syntax extension %s" extension_name in
-                   (FStar_Errors_Codes.Fatal_SyntaxError, uu___1) in
-                 FStar_Errors.raise_error uu___ range
+                   (FStar_Errors_Codes.Fatal_SyntaxError, uu___2) in
+                 FStar_Errors.raise_error uu___1 range
              | FStar_Pervasives_Native.Some parser ->
                  let opens =
-                   let uu___ =
+                   let uu___1 =
                      FStar_Syntax_DsEnv.open_modules_and_namespaces env in
-                   let uu___1 = FStar_Syntax_DsEnv.module_abbrevs env in
+                   let uu___2 = FStar_Syntax_DsEnv.module_abbrevs env in
                    {
-                     FStar_Parser_AST_Util.open_namespaces = uu___;
-                     FStar_Parser_AST_Util.module_abbreviations = uu___1
+                     FStar_Parser_AST_Util.open_namespaces = uu___1;
+                     FStar_Parser_AST_Util.module_abbreviations = uu___2
                    } in
-                 let uu___ = parser opens code range in
-                 (match uu___ with
+                 let uu___1 = parser opens code range in
+                 (match uu___1 with
                   | FStar_Pervasives.Inl error ->
                       FStar_Errors.raise_error
                         (FStar_Errors_Codes.Fatal_SyntaxError,

--- a/ocaml/fstar-tests/generated/FStar_Tests_Pars.ml
+++ b/ocaml/fstar-tests/generated/FStar_Tests_Pars.ml
@@ -641,7 +641,7 @@ let (parse_incremental_decls : unit -> unit) =
         {
           FStar_Parser_ParseIt.frag_fname = "Demo.fst";
           FStar_Parser_ParseIt.frag_text = source;
-          FStar_Parser_ParseIt.frag_line = Prims.int_zero;
+          FStar_Parser_ParseIt.frag_line = Prims.int_one;
           FStar_Parser_ParseIt.frag_col = Prims.int_zero
         } in
     let uu___1 = FStar_Parser_ParseIt.parse input in
@@ -650,12 +650,12 @@ let (parse_incremental_decls : unit -> unit) =
         ((match parse_err with
           | FStar_Pervasives_Native.None ->
               failwith
-                "Incremental parsing failed: Expected syntax error at (7,6), got no error"
+                "Incremental parsing failed: Expected syntax error at (8, 6), got no error"
           | FStar_Pervasives_Native.Some (uu___4, uu___5, rng) ->
               let p = FStar_Compiler_Range_Ops.start_of_range rng in
               let uu___6 =
                 (let uu___7 = FStar_Compiler_Range_Ops.line_of_pos p in
-                 uu___7 = (Prims.of_int (7))) &&
+                 uu___7 = (Prims.of_int (8))) &&
                   (let uu___7 = FStar_Compiler_Range_Ops.col_of_pos p in
                    uu___7 = (Prims.of_int (6))) in
               if uu___6
@@ -669,7 +669,7 @@ let (parse_incremental_decls : unit -> unit) =
                      let uu___11 = FStar_Compiler_Range_Ops.col_of_pos p in
                      FStar_Compiler_Util.string_of_int uu___11 in
                    FStar_Compiler_Util.format2
-                     "Incremental parsing failed: Expected syntax error at (7,6), got error at (%s, %s)"
+                     "Incremental parsing failed: Expected syntax error at (8, 6), got error at (%s, %s)"
                      uu___9 uu___10 in
                  failwith uu___8));
          (match decls with

--- a/ocaml/fstar-tests/generated/FStar_Tests_Pars.ml
+++ b/ocaml/fstar-tests/generated/FStar_Tests_Pars.ml
@@ -635,7 +635,7 @@ let (test_hashes : unit -> unit) =
 let (parse_incremental_decls : unit -> unit) =
   fun uu___ ->
     let source =
-      "module Demo\nlet f x = match x with | Some x -> true | None -> false\nlet test y = if Some? y then f y else true\nlet some junk )(" in
+      "module Demo\nlet f x = match x with | Some x -> true | None -> false\nlet test y = if Some? y then f y else true\n```pulse\nfn f() {}\n```\nlet something = more\nlet >< junk" in
     let input =
       FStar_Parser_ParseIt.Incremental
         {
@@ -650,14 +650,14 @@ let (parse_incremental_decls : unit -> unit) =
         ((match parse_err with
           | FStar_Pervasives_Native.None ->
               failwith
-                "Incremental parsing failed: Expected syntax error at (3,15), got no error"
+                "Incremental parsing failed: Expected syntax error at (7,6), got no error"
           | FStar_Pervasives_Native.Some (uu___4, uu___5, rng) ->
               let p = FStar_Compiler_Range_Ops.start_of_range rng in
               let uu___6 =
                 (let uu___7 = FStar_Compiler_Range_Ops.line_of_pos p in
-                 uu___7 = (Prims.of_int (3))) &&
+                 uu___7 = (Prims.of_int (7))) &&
                   (let uu___7 = FStar_Compiler_Range_Ops.col_of_pos p in
-                   uu___7 = (Prims.of_int (15))) in
+                   uu___7 = (Prims.of_int (6))) in
               if uu___6
               then ()
               else
@@ -669,18 +669,18 @@ let (parse_incremental_decls : unit -> unit) =
                      let uu___11 = FStar_Compiler_Range_Ops.col_of_pos p in
                      FStar_Compiler_Util.string_of_int uu___11 in
                    FStar_Compiler_Util.format2
-                     "Incremental parsing failed: Expected syntax error at (3,15), got error at (%s, %s)"
+                     "Incremental parsing failed: Expected syntax error at (7,6), got error at (%s, %s)"
                      uu___9 uu___10 in
                  failwith uu___8));
          (match decls with
-          | d0::d1::d2::[] -> ()
+          | d0::d1::d2::d3::d4::[] -> ()
           | uu___4 ->
               let uu___5 =
                 let uu___6 =
                   FStar_Compiler_Util.string_of_int
                     (FStar_Compiler_List.length decls) in
                 FStar_Compiler_Util.format1
-                  "Incremental parsing failed; expected 3 decls got %s\n"
+                  "Incremental parsing failed; expected 5 decls got %s\n"
                   uu___6 in
               failwith uu___5))
     | FStar_Parser_ParseIt.ParseError (code, message, range) ->

--- a/src/parser/FStar.Parser.AST.fst
+++ b/src/parser/FStar.Parser.AST.fst
@@ -44,7 +44,14 @@ let mk_decl d r decorations =
   ) in
   let attributes_ = Util.dflt [] attributes_ in
   let qualifiers = List.choose (function Qualifier q -> Some q | _ -> None) decorations in
-  { d=d; drange=r; quals=qualifiers; attrs=attributes_ }
+  (* for syntax extensions, take the range stored there rather than the callers
+     range, which may be inaccurate *)
+  let range = 
+    match d with
+    | DeclSyntaxExtension(_, _, r, _) -> r
+    | _ -> r
+  in
+  { d=d; drange=range; quals=qualifiers; attrs=attributes_ }
 
 let mk_binder_with_attrs b r l i attrs = {b=b; brange=r; blevel=l; aqual=i; battributes=attrs}
 let mk_binder b r l i = mk_binder_with_attrs b r l i []
@@ -736,7 +743,7 @@ let decl_to_string (d:decl) = match d.d with
              ^ (String.concat ";" <| List.map (fun i -> (string_of_id i)) ids) ^ "] (" ^ term_to_string t ^ ")"
   | SubEffect _ -> "sub_effect"
   | Pragma p -> "pragma #" ^ string_of_pragma p
-  | DeclSyntaxExtension (id, content, _) -> 
+  | DeclSyntaxExtension (id, content, _, _) -> 
     "```" ^ id ^ "\n" ^ content ^ "\n```"
 
 let modul_to_string (m:modul) = match m with

--- a/src/parser/FStar.Parser.AST.fst
+++ b/src/parser/FStar.Parser.AST.fst
@@ -736,6 +736,8 @@ let decl_to_string (d:decl) = match d.d with
              ^ (String.concat ";" <| List.map (fun i -> (string_of_id i)) ids) ^ "] (" ^ term_to_string t ^ ")"
   | SubEffect _ -> "sub_effect"
   | Pragma p -> "pragma #" ^ string_of_pragma p
+  | DeclSyntaxExtension (id, content, _) -> 
+    "```" ^ id ^ "\n" ^ content ^ "\n```"
 
 let modul_to_string (m:modul) = match m with
     | Module (_, decls)

--- a/src/parser/FStar.Parser.AST.fsti
+++ b/src/parser/FStar.Parser.AST.fsti
@@ -235,7 +235,9 @@ type decl' =
   | Pragma of pragma
   | Assume of ident * term
   | Splice of bool * list ident * term  (* bool is true for a typed splice *)
-  | DeclSyntaxExtension of string * string * range
+  (* The first range is the entire range of the blob.
+     The second range is the start point of the extension syntax itself *)
+  | DeclSyntaxExtension of string * string * range * range
 
 and decl = {
   d:decl';

--- a/src/tests/FStar.Tests.Pars.fst
+++ b/src/tests/FStar.Tests.Pars.fst
@@ -210,19 +210,19 @@ let parse_incremental_decls () =
   let open FStar.Parser.ParseIt in
   let input = Incremental { frag_fname = "Demo.fst";
                             frag_text = source;
-                            frag_line = 0;
+                            frag_line = 1;
                             frag_col = 0 } in
   let open FStar.Compiler.Range in
   match parse input with
   | IncrementalFragment (decls, _, parse_err) -> (
       let _ = match parse_err with
       | None -> 
-        failwith "Incremental parsing failed: Expected syntax error at (7,6), got no error"
+        failwith "Incremental parsing failed: Expected syntax error at (8, 6), got no error"
       | Some (_, _, rng) ->
         let p = start_of_range rng in
-        if line_of_pos p = 7 && col_of_pos p = 6
+        if line_of_pos p = 8 && col_of_pos p = 6
         then ()
-        else failwith (format2 "Incremental parsing failed: Expected syntax error at (7,6), got error at (%s, %s)"
+        else failwith (format2 "Incremental parsing failed: Expected syntax error at (8, 6), got error at (%s, %s)"
                                (string_of_int (line_of_pos p))
                                (string_of_int (col_of_pos p)))
       in

--- a/src/tests/FStar.Tests.Pars.fst
+++ b/src/tests/FStar.Tests.Pars.fst
@@ -201,7 +201,11 @@ let parse_incremental_decls () =
     "module Demo\n\
      let f x = match x with | Some x -> true | None -> false\n\
      let test y = if Some? y then f y else true\n\
-     let some junk )("
+     ```pulse\n\
+     fn f() {}\n\
+     ```\n\
+     let something = more\n\
+     let >< junk"
   in
   let open FStar.Parser.ParseIt in
   let input = Incremental { frag_fname = "Demo.fst";
@@ -213,18 +217,18 @@ let parse_incremental_decls () =
   | IncrementalFragment (decls, _, parse_err) -> (
       let _ = match parse_err with
       | None -> 
-        failwith "Incremental parsing failed: Expected syntax error at (3,15), got no error"
+        failwith "Incremental parsing failed: Expected syntax error at (7,6), got no error"
       | Some (_, _, rng) ->
         let p = start_of_range rng in
-        if line_of_pos p = 3 && col_of_pos p = 15
+        if line_of_pos p = 7 && col_of_pos p = 6
         then ()
-        else failwith (format2 "Incremental parsing failed: Expected syntax error at (3,15), got error at (%s, %s)"
+        else failwith (format2 "Incremental parsing failed: Expected syntax error at (7,6), got error at (%s, %s)"
                                (string_of_int (line_of_pos p))
                                (string_of_int (col_of_pos p)))
       in
       match decls with
-      | [d0;d1;d2] -> ()
-      | _ -> failwith (format1 "Incremental parsing failed; expected 3 decls got %s\n"
+      | [d0;d1;d2;d3;d4] -> ()
+      | _ -> failwith (format1 "Incremental parsing failed; expected 5 decls got %s\n"
                               (string_of_int (List.length decls)))
       )
       

--- a/src/tosyntax/FStar.ToSyntax.ToSyntax.fst
+++ b/src/tosyntax/FStar.ToSyntax.ToSyntax.fst
@@ -4056,7 +4056,7 @@ and desugar_decl_noattrs top_attrs env (d:decl) : (env_t * sigelts) =
     let env = push_sigelt env se in
     env, [se]
 
-  | DeclSyntaxExtension (extension_name, code, range) ->
+  | DeclSyntaxExtension (extension_name, code, _, range) ->
     let extension_parser = FStar.Parser.AST.Util.lookup_extension_parser extension_name in
     match extension_parser with
     | None ->


### PR DESCRIPTION
The incremental parsing of syntax extensions, as used by VSCode, was broken. This PR fixes it. 

There were three things:

1. The incremental parser uses the oneDeclOrEOF production, which parses a decl and then consumes one token for the start token of the next production or EOF. The BLOB token was missing from the list of start tokens of decls, so I added it.

2. After parsing oneDeclOrEOF, the incremental parser (in ParseIt.ml) calls FStar_Sedlexing.rollback to rewind the parser back to the point preceding the start token that it consumes. However, the rollback logic for BLOB is subtle, since from the perspective of the lexer, it is actually a composite of several tokens. Calling just rollback rewinds the lexer only to the point preceding the closing ` ` ` , which is incorrect. 

Instead, FStar_Sedlexing now provides a snapshot operation to take the current position of the lexer at the start of lexeme and a reset_snapshot that takes one of these snapshots and resets the lexer to that position. I used this instead of the mark/backtrack feature in Sedlexing, since this snapshot behavior relies less on imperative state.

So, when lexing a BLOB, the returned value includes this snapshot to the start of the BLOB and now ParseIt can reset the lexer back to the correct position.

3. Finally, the range associated with BLOB token is also wrong (since $loc only gives the location of the last atomic token, i.e., the closing ```). So, ranges for the BLOB are handled specially in FStar.Parser.AST.mk_decl.

With this, I'm able to get incremental checking to work correctly with extension syntax in vscode. 


