### PR TITLE
Support for close combinator for indexed effects

### DIFF
--- a/ocaml/fstar-lib/generated/FStar_Syntax_Print.ml
+++ b/ocaml/fstar-lib/generated/FStar_Syntax_Print.ml
@@ -1336,13 +1336,28 @@ let (layered_eff_combinators_to_string :
             let uu___7 = to_str combs.FStar_Syntax_Syntax.l_subcomp in
             let uu___8 =
               let uu___9 = to_str combs.FStar_Syntax_Syntax.l_if_then_else in
-              [uu___9] in
+              let uu___10 =
+                let uu___11 =
+                  if
+                    FStar_Pervasives_Native.uu___is_None
+                      combs.FStar_Syntax_Syntax.l_close
+                  then ""
+                  else
+                    (let uu___13 =
+                       let uu___14 =
+                         FStar_Compiler_Effect.op_Bar_Greater
+                           combs.FStar_Syntax_Syntax.l_close
+                           FStar_Compiler_Util.must in
+                       FStar_Compiler_Effect.op_Bar_Greater uu___14 to_str2 in
+                     FStar_Compiler_Util.format1 "; l_close = %s\n" uu___13) in
+                [uu___11] in
+              uu___9 :: uu___10 in
             uu___7 :: uu___8 in
           uu___5 :: uu___6 in
         uu___3 :: uu___4 in
       uu___1 :: uu___2 in
     FStar_Compiler_Util.format
-      "{\n; l_repr = %s\n; l_return = %s\n; l_bind = %s\n; l_subcomp = %s\n; l_if_then_else = %s\n\n  }\n"
+      "{\n; l_repr = %s\n; l_return = %s\n; l_bind = %s\n; l_subcomp = %s\n; l_if_then_else = %s\n\n  %s\n  }\n"
       uu___
 let (eff_combinators_to_string :
   FStar_Syntax_Syntax.eff_combinators -> Prims.string) =

--- a/ocaml/fstar-lib/generated/FStar_Syntax_Syntax.ml
+++ b/ocaml/fstar-lib/generated/FStar_Syntax_Syntax.ml
@@ -1486,17 +1486,20 @@ type layered_eff_combinators =
   l_if_then_else:
     (tscheme * tscheme * indexed_effect_combinator_kind
       FStar_Pervasives_Native.option)
-    }
+    ;
+  l_close: (tscheme * tscheme) FStar_Pervasives_Native.option }
 let (__proj__Mklayered_eff_combinators__item__l_repr :
   layered_eff_combinators -> (tscheme * tscheme)) =
   fun projectee ->
     match projectee with
-    | { l_repr; l_return; l_bind; l_subcomp; l_if_then_else;_} -> l_repr
+    | { l_repr; l_return; l_bind; l_subcomp; l_if_then_else; l_close;_} ->
+        l_repr
 let (__proj__Mklayered_eff_combinators__item__l_return :
   layered_eff_combinators -> (tscheme * tscheme)) =
   fun projectee ->
     match projectee with
-    | { l_repr; l_return; l_bind; l_subcomp; l_if_then_else;_} -> l_return
+    | { l_repr; l_return; l_bind; l_subcomp; l_if_then_else; l_close;_} ->
+        l_return
 let (__proj__Mklayered_eff_combinators__item__l_bind :
   layered_eff_combinators ->
     (tscheme * tscheme * indexed_effect_combinator_kind
@@ -1504,7 +1507,8 @@ let (__proj__Mklayered_eff_combinators__item__l_bind :
   =
   fun projectee ->
     match projectee with
-    | { l_repr; l_return; l_bind; l_subcomp; l_if_then_else;_} -> l_bind
+    | { l_repr; l_return; l_bind; l_subcomp; l_if_then_else; l_close;_} ->
+        l_bind
 let (__proj__Mklayered_eff_combinators__item__l_subcomp :
   layered_eff_combinators ->
     (tscheme * tscheme * indexed_effect_combinator_kind
@@ -1512,7 +1516,8 @@ let (__proj__Mklayered_eff_combinators__item__l_subcomp :
   =
   fun projectee ->
     match projectee with
-    | { l_repr; l_return; l_bind; l_subcomp; l_if_then_else;_} -> l_subcomp
+    | { l_repr; l_return; l_bind; l_subcomp; l_if_then_else; l_close;_} ->
+        l_subcomp
 let (__proj__Mklayered_eff_combinators__item__l_if_then_else :
   layered_eff_combinators ->
     (tscheme * tscheme * indexed_effect_combinator_kind
@@ -1520,8 +1525,16 @@ let (__proj__Mklayered_eff_combinators__item__l_if_then_else :
   =
   fun projectee ->
     match projectee with
-    | { l_repr; l_return; l_bind; l_subcomp; l_if_then_else;_} ->
+    | { l_repr; l_return; l_bind; l_subcomp; l_if_then_else; l_close;_} ->
         l_if_then_else
+let (__proj__Mklayered_eff_combinators__item__l_close :
+  layered_eff_combinators ->
+    (tscheme * tscheme) FStar_Pervasives_Native.option)
+  =
+  fun projectee ->
+    match projectee with
+    | { l_repr; l_return; l_bind; l_subcomp; l_if_then_else; l_close;_} ->
+        l_close
 type eff_combinators =
   | Primitive_eff of wp_eff_combinators 
   | DM4F_eff of wp_eff_combinators 

--- a/ocaml/fstar-lib/generated/FStar_Syntax_Util.ml
+++ b/ocaml/fstar-lib/generated/FStar_Syntax_Util.ml
@@ -4930,12 +4930,15 @@ let (apply_layered_eff_combinators :
       let uu___2 = map3 combs.FStar_Syntax_Syntax.l_bind in
       let uu___3 = map3 combs.FStar_Syntax_Syntax.l_subcomp in
       let uu___4 = map3 combs.FStar_Syntax_Syntax.l_if_then_else in
+      let uu___5 =
+        FStar_Compiler_Util.map_option map2 combs.FStar_Syntax_Syntax.l_close in
       {
         FStar_Syntax_Syntax.l_repr = uu___;
         FStar_Syntax_Syntax.l_return = uu___1;
         FStar_Syntax_Syntax.l_bind = uu___2;
         FStar_Syntax_Syntax.l_subcomp = uu___3;
-        FStar_Syntax_Syntax.l_if_then_else = uu___4
+        FStar_Syntax_Syntax.l_if_then_else = uu___4;
+        FStar_Syntax_Syntax.l_close = uu___5
       }
 let (apply_eff_combinators :
   (FStar_Syntax_Syntax.tscheme -> FStar_Syntax_Syntax.tscheme) ->
@@ -4954,6 +4957,30 @@ let (apply_eff_combinators :
       | FStar_Syntax_Syntax.Layered_eff combs1 ->
           let uu___ = apply_layered_eff_combinators f combs1 in
           FStar_Syntax_Syntax.Layered_eff uu___
+let (get_layered_close_combinator :
+  FStar_Syntax_Syntax.eff_decl ->
+    FStar_Syntax_Syntax.tscheme FStar_Pervasives_Native.option)
+  =
+  fun ed ->
+    match ed.FStar_Syntax_Syntax.combinators with
+    | FStar_Syntax_Syntax.Layered_eff
+        { FStar_Syntax_Syntax.l_repr = uu___;
+          FStar_Syntax_Syntax.l_return = uu___1;
+          FStar_Syntax_Syntax.l_bind = uu___2;
+          FStar_Syntax_Syntax.l_subcomp = uu___3;
+          FStar_Syntax_Syntax.l_if_then_else = uu___4;
+          FStar_Syntax_Syntax.l_close = FStar_Pervasives_Native.None;_}
+        -> FStar_Pervasives_Native.None
+    | FStar_Syntax_Syntax.Layered_eff
+        { FStar_Syntax_Syntax.l_repr = uu___;
+          FStar_Syntax_Syntax.l_return = uu___1;
+          FStar_Syntax_Syntax.l_bind = uu___2;
+          FStar_Syntax_Syntax.l_subcomp = uu___3;
+          FStar_Syntax_Syntax.l_if_then_else = uu___4;
+          FStar_Syntax_Syntax.l_close = FStar_Pervasives_Native.Some
+            (ts, uu___5);_}
+        -> FStar_Pervasives_Native.Some ts
+    | uu___ -> FStar_Pervasives_Native.None
 let (get_wp_close_combinator :
   FStar_Syntax_Syntax.eff_decl ->
     FStar_Syntax_Syntax.tscheme FStar_Pervasives_Native.option)

--- a/ocaml/fstar-lib/generated/FStar_Syntax_Visit.ml
+++ b/ocaml/fstar-lib/generated/FStar_Syntax_Visit.ml
@@ -558,12 +558,16 @@ let (on_sub_layered_eff_combinators :
       let uu___4 =
         on_tuple3 f_tscheme1 f_tscheme1 id
           lecs.FStar_Syntax_Syntax.l_if_then_else in
+      let uu___5 =
+        FStar_Compiler_Util.map_option (on_tuple2 f_tscheme1 f_tscheme1)
+          lecs.FStar_Syntax_Syntax.l_close in
       {
         FStar_Syntax_Syntax.l_repr = uu___;
         FStar_Syntax_Syntax.l_return = uu___1;
         FStar_Syntax_Syntax.l_bind = uu___2;
         FStar_Syntax_Syntax.l_subcomp = uu___3;
-        FStar_Syntax_Syntax.l_if_then_else = uu___4
+        FStar_Syntax_Syntax.l_if_then_else = uu___4;
+        FStar_Syntax_Syntax.l_close = uu___5
       }
 let (on_sub_combinators :
   vfs_t ->

--- a/ocaml/fstar-lib/generated/FStar_Tactics_Effect.ml
+++ b/ocaml/fstar-lib/generated/FStar_Tactics_Effect.ml
@@ -41,6 +41,7 @@ type ('a, 'wputhen, 'wpuelse, 'f, 'g, 'b) tac_if_then_else =
 let tac_subcomp :
   'a 'wpuf 'wpug . ('a, 'wpuf) tac_repr -> ('a, 'wpug) tac_repr =
   fun uu___ -> (fun f -> Obj.magic f) uu___
+type ('a, 'b, 'wpuf, 'f) tac_close = ('a, unit) tac_repr
 let __proj__TAC__item__return = tac_return
 let __proj__TAC__item__bind = tac_bind
 type ('a, 'wp, 'uuuuu, 'uuuuu1) lift_div_tac_wp = 'wp

--- a/ocaml/fstar-lib/generated/FStar_ToSyntax_ToSyntax.ml
+++ b/ocaml/fstar-lib/generated/FStar_ToSyntax_ToSyntax.ml
@@ -7669,7 +7669,7 @@ let rec (desugar_effect :
                               if is_layered
                               then
                                 FStar_Compiler_List.op_At rr_members
-                                  ["subcomp"; "if_then_else"]
+                                  ["subcomp"; "if_then_else"; "close"]
                               else
                                 FStar_Compiler_List.op_At rr_members
                                   ["return_wp";
@@ -7919,6 +7919,12 @@ let rec (desugar_effect :
                                                    name_of_eff_decl decl in
                                                  uu___6 = "if_then_else")
                                               eff_decls in
+                                          let has_close =
+                                            FStar_Compiler_List.existsb
+                                              (fun decl ->
+                                                 let uu___6 =
+                                                   name_of_eff_decl decl in
+                                                 uu___6 = "close") eff_decls in
                                           let to_comb uu___6 =
                                             match uu___6 with
                                             | (us, t) ->
@@ -8067,6 +8073,18 @@ let rec (desugar_effect :
                                                       (dummy_tscheme,
                                                         dummy_tscheme,
                                                         FStar_Pervasives_Native.None) in
+                                                  let uu___14 =
+                                                    if has_close
+                                                    then
+                                                      let uu___15 =
+                                                        let uu___16 =
+                                                          lookup "close" in
+                                                        (uu___16,
+                                                          dummy_tscheme) in
+                                                      FStar_Pervasives_Native.Some
+                                                        uu___15
+                                                    else
+                                                      FStar_Pervasives_Native.None in
                                                   {
                                                     FStar_Syntax_Syntax.l_repr
                                                       = uu___9;
@@ -8077,7 +8095,9 @@ let rec (desugar_effect :
                                                     FStar_Syntax_Syntax.l_subcomp
                                                       = uu___12;
                                                     FStar_Syntax_Syntax.l_if_then_else
-                                                      = uu___13
+                                                      = uu___13;
+                                                    FStar_Syntax_Syntax.l_close
+                                                      = uu___14
                                                   } in
                                                 FStar_Syntax_Syntax.Layered_eff
                                                   uu___8 in

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_TcEffect.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_TcEffect.ml
@@ -3413,6 +3413,221 @@ let (validate_indexed_effect_ite_shape :
                                          uu___6
                                      else ());
                                     (k1, kind)))))
+let (validate_indexed_effect_close_shape :
+  FStar_TypeChecker_Env.env ->
+    FStar_Ident.lident ->
+      FStar_Syntax_Syntax.tscheme ->
+        FStar_Syntax_Syntax.tscheme ->
+          FStar_Syntax_Syntax.univ_name ->
+            FStar_Syntax_Syntax.univ_name ->
+              FStar_Syntax_Syntax.term ->
+                Prims.int ->
+                  FStar_Compiler_Range_Type.range -> FStar_Syntax_Syntax.term)
+  =
+  fun env ->
+    fun eff_name ->
+      fun sig_ts ->
+        fun repr_ts ->
+          fun u_a ->
+            fun u_b ->
+              fun close_tm ->
+                fun num_effect_params ->
+                  fun r ->
+                    let close_name =
+                      let uu___ = FStar_Ident.string_of_lid eff_name in
+                      FStar_Compiler_Util.format1 "close_%s" uu___ in
+                    let b_b =
+                      let uu___ =
+                        let uu___1 =
+                          let uu___2 =
+                            FStar_Compiler_Effect.op_Bar_Greater u_b
+                              (fun uu___3 ->
+                                 FStar_Syntax_Syntax.U_name uu___3) in
+                          FStar_Compiler_Effect.op_Bar_Greater uu___2
+                            FStar_Syntax_Util.type_with_u in
+                        FStar_Compiler_Effect.op_Bar_Greater uu___1
+                          (FStar_Syntax_Syntax.gen_bv "b"
+                             FStar_Pervasives_Native.None) in
+                      FStar_Compiler_Effect.op_Bar_Greater uu___
+                        FStar_Syntax_Syntax.mk_binder in
+                    let uu___ =
+                      let uu___1 =
+                        let uu___2 =
+                          let uu___3 =
+                            FStar_TypeChecker_Env.inst_tscheme_with sig_ts
+                              [FStar_Syntax_Syntax.U_name u_a] in
+                          FStar_Compiler_Effect.op_Bar_Greater uu___3
+                            FStar_Pervasives_Native.snd in
+                        FStar_Compiler_Effect.op_Bar_Greater uu___2
+                          FStar_Syntax_Util.arrow_formals in
+                      FStar_Compiler_Effect.op_Bar_Greater uu___1
+                        FStar_Pervasives_Native.fst in
+                    match uu___ with
+                    | a_b::sig_bs ->
+                        let uu___1 =
+                          FStar_Compiler_List.splitAt num_effect_params
+                            sig_bs in
+                        (match uu___1 with
+                         | (eff_params_bs, sig_bs1) ->
+                             let bs =
+                               FStar_Compiler_List.map
+                                 (fun b ->
+                                    let x_b =
+                                      let uu___2 =
+                                        let uu___3 =
+                                          FStar_Syntax_Syntax.bv_to_name
+                                            b_b.FStar_Syntax_Syntax.binder_bv in
+                                        FStar_Syntax_Syntax.gen_bv "x"
+                                          FStar_Pervasives_Native.None uu___3 in
+                                      FStar_Compiler_Effect.op_Bar_Greater
+                                        uu___2 FStar_Syntax_Syntax.mk_binder in
+                                    let uu___2 =
+                                      let uu___3 =
+                                        b.FStar_Syntax_Syntax.binder_bv in
+                                      let uu___4 =
+                                        let uu___5 =
+                                          FStar_Syntax_Syntax.mk_Total
+                                            (b.FStar_Syntax_Syntax.binder_bv).FStar_Syntax_Syntax.sort in
+                                        FStar_Syntax_Util.arrow [x_b] uu___5 in
+                                      {
+                                        FStar_Syntax_Syntax.ppname =
+                                          (uu___3.FStar_Syntax_Syntax.ppname);
+                                        FStar_Syntax_Syntax.index =
+                                          (uu___3.FStar_Syntax_Syntax.index);
+                                        FStar_Syntax_Syntax.sort = uu___4
+                                      } in
+                                    {
+                                      FStar_Syntax_Syntax.binder_bv = uu___2;
+                                      FStar_Syntax_Syntax.binder_qual =
+                                        (b.FStar_Syntax_Syntax.binder_qual);
+                                      FStar_Syntax_Syntax.binder_positivity =
+                                        (b.FStar_Syntax_Syntax.binder_positivity);
+                                      FStar_Syntax_Syntax.binder_attrs =
+                                        (b.FStar_Syntax_Syntax.binder_attrs)
+                                    }) sig_bs1 in
+                             let f_b =
+                               let uu___2 =
+                                 FStar_TypeChecker_Env.inst_tscheme_with
+                                   repr_ts [FStar_Syntax_Syntax.U_name u_a] in
+                               match uu___2 with
+                               | (uu___3, repr_t) ->
+                                   let x_b =
+                                     let uu___4 =
+                                       let uu___5 =
+                                         FStar_Syntax_Syntax.bv_to_name
+                                           b_b.FStar_Syntax_Syntax.binder_bv in
+                                       FStar_Syntax_Syntax.gen_bv "x"
+                                         FStar_Pervasives_Native.None uu___5 in
+                                     FStar_Compiler_Effect.op_Bar_Greater
+                                       uu___4 FStar_Syntax_Syntax.mk_binder in
+                                   let is_args =
+                                     FStar_Compiler_List.map
+                                       (fun uu___4 ->
+                                          match uu___4 with
+                                          | {
+                                              FStar_Syntax_Syntax.binder_bv =
+                                                binder_bv;
+                                              FStar_Syntax_Syntax.binder_qual
+                                                = uu___5;
+                                              FStar_Syntax_Syntax.binder_positivity
+                                                = uu___6;
+                                              FStar_Syntax_Syntax.binder_attrs
+                                                = uu___7;_}
+                                              ->
+                                              let uu___8 =
+                                                let uu___9 =
+                                                  FStar_Syntax_Syntax.bv_to_name
+                                                    binder_bv in
+                                                let uu___10 =
+                                                  let uu___11 =
+                                                    let uu___12 =
+                                                      FStar_Compiler_Effect.op_Bar_Greater
+                                                        x_b.FStar_Syntax_Syntax.binder_bv
+                                                        FStar_Syntax_Syntax.bv_to_name in
+                                                    FStar_Compiler_Effect.op_Bar_Greater
+                                                      uu___12
+                                                      FStar_Syntax_Syntax.as_arg in
+                                                  [uu___11] in
+                                                FStar_Syntax_Syntax.mk_Tm_app
+                                                  uu___9 uu___10
+                                                  FStar_Compiler_Range_Type.dummyRange in
+                                              FStar_Compiler_Effect.op_Bar_Greater
+                                                uu___8
+                                                FStar_Syntax_Syntax.as_arg)
+                                       bs in
+                                   let repr_app =
+                                     let uu___4 =
+                                       let uu___5 =
+                                         let uu___6 =
+                                           FStar_Compiler_Effect.op_Bar_Greater
+                                             a_b.FStar_Syntax_Syntax.binder_bv
+                                             FStar_Syntax_Syntax.bv_to_name in
+                                         FStar_Compiler_Effect.op_Bar_Greater
+                                           uu___6 FStar_Syntax_Syntax.as_arg in
+                                       uu___5 :: is_args in
+                                     FStar_Syntax_Syntax.mk_Tm_app repr_t
+                                       uu___4
+                                       FStar_Compiler_Range_Type.dummyRange in
+                                   let f_sort =
+                                     let uu___4 =
+                                       FStar_Syntax_Syntax.mk_Total repr_app in
+                                     FStar_Syntax_Util.arrow [x_b] uu___4 in
+                                   let uu___4 =
+                                     FStar_Syntax_Syntax.gen_bv "f"
+                                       FStar_Pervasives_Native.None f_sort in
+                                   FStar_Compiler_Effect.op_Bar_Greater
+                                     uu___4 FStar_Syntax_Syntax.mk_binder in
+                             let uu___2 =
+                               let uu___3 =
+                                 FStar_TypeChecker_Env.push_binders env (a_b
+                                   :: b_b ::
+                                   (FStar_Compiler_List.op_At eff_params_bs
+                                      bs)) in
+                               let uu___4 =
+                                 FStar_Compiler_Effect.op_Bar_Greater
+                                   a_b.FStar_Syntax_Syntax.binder_bv
+                                   FStar_Syntax_Syntax.bv_to_name in
+                               FStar_TypeChecker_Util.fresh_effect_repr
+                                 uu___3 r eff_name sig_ts
+                                 (FStar_Pervasives_Native.Some repr_ts)
+                                 (FStar_Syntax_Syntax.U_name u_a) uu___4 in
+                             (match uu___2 with
+                              | (body_tm, g_body) ->
+                                  let k =
+                                    FStar_Syntax_Util.abs (a_b :: b_b ::
+                                      (FStar_Compiler_List.op_At
+                                         eff_params_bs
+                                         (FStar_Compiler_List.op_At bs [f_b])))
+                                      body_tm FStar_Pervasives_Native.None in
+                                  let g_eq =
+                                    let uu___3 =
+                                      FStar_TypeChecker_Rel.teq_nosmt env
+                                        close_tm k in
+                                    match uu___3 with
+                                    | FStar_Pervasives_Native.None ->
+                                        let uu___4 =
+                                          let uu___5 =
+                                            let uu___6 =
+                                              FStar_Syntax_Print.term_to_string
+                                                close_tm in
+                                            FStar_Compiler_Util.format2
+                                              "Unexpected term for %s (%s)\n"
+                                              close_name uu___6 in
+                                          (FStar_Errors_Codes.Fatal_UnexpectedEffect,
+                                            uu___5) in
+                                        FStar_Errors.raise_error uu___4 r
+                                    | FStar_Pervasives_Native.Some g -> g in
+                                  ((let uu___4 =
+                                      FStar_TypeChecker_Env.conj_guard g_body
+                                        g_eq in
+                                    FStar_TypeChecker_Rel.force_trivial_guard
+                                      env uu___4);
+                                   (let uu___4 =
+                                      FStar_Compiler_Effect.op_Bar_Greater k
+                                        (FStar_TypeChecker_Normalize.remove_uvar_solutions
+                                           env) in
+                                    FStar_Compiler_Effect.op_Bar_Greater
+                                      uu___4 FStar_Syntax_Subst.compress))))
 let (lift_combinator_kind :
   FStar_TypeChecker_Env.env ->
     FStar_Ident.lident ->
@@ -5251,7 +5466,75 @@ let (tc_layered_eff_decl :
                                                                     env1
                                                                     (g_b.FStar_Syntax_Syntax.binder_bv).FStar_Syntax_Syntax.sort
                                                                     ite_soundness_tac_attr))))));
-                                         (let tc_action env act =
+                                         (let close_ =
+                                            let ts_opt =
+                                              FStar_Compiler_Effect.op_Bar_Greater
+                                                ed
+                                                FStar_Syntax_Util.get_layered_close_combinator in
+                                            match ts_opt with
+                                            | FStar_Pervasives_Native.None ->
+                                                FStar_Pervasives_Native.None
+                                            | FStar_Pervasives_Native.Some
+                                                close_ts ->
+                                                let r =
+                                                  (FStar_Pervasives_Native.snd
+                                                     close_ts).FStar_Syntax_Syntax.pos in
+                                                let uu___14 =
+                                                  check_and_gen1 "close"
+                                                    (Prims.of_int (2))
+                                                    close_ts in
+                                                (match uu___14 with
+                                                 | (close_us, close_t,
+                                                    close_ty) ->
+                                                     let uu___15 =
+                                                       FStar_Syntax_Subst.open_univ_vars
+                                                         close_us close_t in
+                                                     (match uu___15 with
+                                                      | (us, t) ->
+                                                          let env =
+                                                            FStar_TypeChecker_Env.push_univ_vars
+                                                              env0 us in
+                                                          let k =
+                                                            let sig_ts =
+                                                              let uu___16 =
+                                                                signature in
+                                                              match uu___16
+                                                              with
+                                                              | (us1, t1,
+                                                                 uu___17) ->
+                                                                  (us1, t1) in
+                                                            let repr_ts =
+                                                              let uu___16 =
+                                                                repr in
+                                                              match uu___16
+                                                              with
+                                                              | (us1, t1,
+                                                                 uu___17) ->
+                                                                  (us1, t1) in
+                                                            let uu___16 = us in
+                                                            match uu___16
+                                                            with
+                                                            | u_a::u_b::[] ->
+                                                                validate_indexed_effect_close_shape
+                                                                  env
+                                                                  ed.FStar_Syntax_Syntax.mname
+                                                                  sig_ts
+                                                                  repr_ts u_a
+                                                                  u_b t
+                                                                  num_effect_params
+                                                                  r in
+                                                          let uu___16 =
+                                                            let uu___17 =
+                                                              FStar_Compiler_Effect.op_Bar_Greater
+                                                                k
+                                                                (FStar_Syntax_Subst.close_univ_vars
+                                                                   close_us) in
+                                                            (close_us,
+                                                              uu___17,
+                                                              close_ty) in
+                                                          FStar_Pervasives_Native.Some
+                                                            uu___16)) in
+                                          let tc_action env act =
                                             let env01 = env in
                                             let r =
                                               (act.FStar_Syntax_Syntax.action_defn).FStar_Syntax_Syntax.pos in
@@ -6189,7 +6472,17 @@ let (tc_layered_eff_decl :
                                                    =
                                                    (tschemes_of if_then_else
                                                       (FStar_Pervasives_Native.Some
-                                                         ite_kind))
+                                                         ite_kind));
+                                                 FStar_Syntax_Syntax.l_close
+                                                   =
+                                                   (match close_ with
+                                                    | FStar_Pervasives_Native.None
+                                                        ->
+                                                        FStar_Pervasives_Native.None
+                                                    | FStar_Pervasives_Native.Some
+                                                        (us, t, ty) ->
+                                                        FStar_Pervasives_Native.Some
+                                                          ((us, t), (us, ty)))
                                                } in
                                            let uu___15 =
                                              FStar_Compiler_List.map

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_TcEffect.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_TcEffect.ml
@@ -5543,25 +5543,44 @@ let (tc_layered_eff_decl :
                                                 | (us, close_tm, uu___15) ->
                                                     let r =
                                                       close_tm.FStar_Syntax_Syntax.pos in
-                                                    let uu___16 =
-                                                      FStar_Syntax_Subst.open_univ_vars
-                                                        us close_tm in
-                                                    (match uu___16 with
-                                                     | (us1, close_tm1) ->
-                                                         let uu___17 =
-                                                           FStar_Syntax_Util.abs_formals
-                                                             close_tm1 in
-                                                         (match uu___17 with
-                                                          | (close_bs,
-                                                             close_body,
-                                                             uu___18) ->
-                                                              let uu___19 =
-                                                                close_bs in
-                                                              (match uu___19
-                                                               with
-                                                               | a_b::b_b::close_bs1
-                                                                   ->
-                                                                   let uu___20
+                                                    ((let supported_subcomp =
+                                                        match subcomp_kind
+                                                        with
+                                                        | FStar_Syntax_Syntax.Substitutive_combinator
+                                                            l ->
+                                                            Prims.op_Negation
+                                                              (FStar_Compiler_List.contains
+                                                                 FStar_Syntax_Syntax.Ad_hoc_binder
+                                                                 l)
+                                                        | uu___17 -> false in
+                                                      if
+                                                        Prims.op_Negation
+                                                          supported_subcomp
+                                                      then
+                                                        FStar_Errors.raise_error
+                                                          (FStar_Errors_Codes.Fatal_UnexpectedEffect,
+                                                            "close combinator is only allowed for effects with substitutive subcomp")
+                                                          r
+                                                      else ());
+                                                     (let uu___17 =
+                                                        FStar_Syntax_Subst.open_univ_vars
+                                                          us close_tm in
+                                                      match uu___17 with
+                                                      | (us1, close_tm1) ->
+                                                          let uu___18 =
+                                                            FStar_Syntax_Util.abs_formals
+                                                              close_tm1 in
+                                                          (match uu___18 with
+                                                           | (close_bs,
+                                                              close_body,
+                                                              uu___19) ->
+                                                               let uu___20 =
+                                                                 close_bs in
+                                                               (match uu___20
+                                                                with
+                                                                | a_b::b_b::close_bs1
+                                                                    ->
+                                                                    let uu___21
                                                                     =
                                                                     FStar_Compiler_List.splitAt
                                                                     ((FStar_Compiler_List.length
@@ -5569,62 +5588,62 @@ let (tc_layered_eff_decl :
                                                                     -
                                                                     Prims.int_one)
                                                                     close_bs1 in
-                                                                   (match uu___20
+                                                                    (match uu___21
                                                                     with
                                                                     | 
                                                                     (is_bs,
-                                                                    uu___21)
+                                                                    uu___22)
                                                                     ->
                                                                     let x_bv
                                                                     =
-                                                                    let uu___22
+                                                                    let uu___23
                                                                     =
                                                                     FStar_Syntax_Syntax.bv_to_name
                                                                     b_b.FStar_Syntax_Syntax.binder_bv in
                                                                     FStar_Syntax_Syntax.gen_bv
                                                                     "x"
                                                                     FStar_Pervasives_Native.None
-                                                                    uu___22 in
+                                                                    uu___23 in
                                                                     let args1
                                                                     =
                                                                     FStar_Compiler_List.map
                                                                     (fun i_b
                                                                     ->
-                                                                    let uu___22
+                                                                    let uu___23
                                                                     =
                                                                     FStar_Syntax_Syntax.bv_to_name
                                                                     i_b.FStar_Syntax_Syntax.binder_bv in
-                                                                    let uu___23
-                                                                    =
                                                                     let uu___24
                                                                     =
                                                                     let uu___25
                                                                     =
+                                                                    let uu___26
+                                                                    =
                                                                     FStar_Syntax_Syntax.bv_to_name
                                                                     x_bv in
                                                                     FStar_Syntax_Syntax.as_arg
-                                                                    uu___25 in
-                                                                    [uu___24] in
+                                                                    uu___26 in
+                                                                    [uu___25] in
                                                                     FStar_Syntax_Syntax.mk_Tm_app
-                                                                    uu___22
-                                                                    uu___23 r)
+                                                                    uu___23
+                                                                    uu___24 r)
                                                                     is_bs in
                                                                     let args2
                                                                     =
-                                                                    let uu___22
-                                                                    =
                                                                     let uu___23
+                                                                    =
+                                                                    let uu___24
                                                                     =
                                                                     FStar_Syntax_Subst.compress
                                                                     close_body in
-                                                                    uu___23.FStar_Syntax_Syntax.n in
-                                                                    match uu___22
+                                                                    uu___24.FStar_Syntax_Syntax.n in
+                                                                    match uu___23
                                                                     with
                                                                     | 
                                                                     FStar_Syntax_Syntax.Tm_app
                                                                     {
                                                                     FStar_Syntax_Syntax.hd
-                                                                    = uu___23;
+                                                                    = uu___24;
                                                                     FStar_Syntax_Syntax.args
                                                                     = a::args;_}
                                                                     ->
@@ -5633,75 +5652,75 @@ let (tc_layered_eff_decl :
                                                                     (FStar_Compiler_List.map
                                                                     FStar_Pervasives_Native.fst)
                                                                     | 
-                                                                    uu___23
+                                                                    uu___24
                                                                     ->
                                                                     FStar_Errors.raise_error
                                                                     (FStar_Errors_Codes.Fatal_UnexpectedEffect,
                                                                     "close combinator body not a repr")
                                                                     r in
                                                                     let env =
-                                                                    let uu___22
-                                                                    =
-                                                                    let uu___23
-                                                                    =
-                                                                    let uu___24
-                                                                    =
-                                                                    FStar_Compiler_Effect.op_Bar_Greater
-                                                                    x_bv
-                                                                    FStar_Syntax_Syntax.mk_binder in
-                                                                    [uu___24] in
-                                                                    FStar_Compiler_List.op_At
-                                                                    (a_b ::
-                                                                    b_b ::
-                                                                    is_bs)
-                                                                    uu___23 in
-                                                                    FStar_TypeChecker_Env.push_binders
-                                                                    env0
-                                                                    uu___22 in
-                                                                    let subcomp_ts
-                                                                    =
-                                                                    let uu___22
-                                                                    =
-                                                                    stronger_repr in
-                                                                    match uu___22
-                                                                    with
-                                                                    | 
-                                                                    (us2,
-                                                                    uu___23,
-                                                                    t) ->
-                                                                    (us2, t) in
-                                                                    let uu___22
-                                                                    =
                                                                     let uu___23
                                                                     =
                                                                     let uu___24
                                                                     =
                                                                     let uu___25
                                                                     =
+                                                                    FStar_Compiler_Effect.op_Bar_Greater
+                                                                    x_bv
+                                                                    FStar_Syntax_Syntax.mk_binder in
+                                                                    [uu___25] in
+                                                                    FStar_Compiler_List.op_At
+                                                                    (a_b ::
+                                                                    b_b ::
+                                                                    is_bs)
+                                                                    uu___24 in
+                                                                    FStar_TypeChecker_Env.push_binders
+                                                                    env0
+                                                                    uu___23 in
+                                                                    let subcomp_ts
+                                                                    =
+                                                                    let uu___23
+                                                                    =
+                                                                    stronger_repr in
+                                                                    match uu___23
+                                                                    with
+                                                                    | 
+                                                                    (us2,
+                                                                    uu___24,
+                                                                    t) ->
+                                                                    (us2, t) in
+                                                                    let uu___23
+                                                                    =
+                                                                    let uu___24
+                                                                    =
+                                                                    let uu___25
+                                                                    =
+                                                                    let uu___26
+                                                                    =
                                                                     FStar_Compiler_List.hd
                                                                     us1 in
                                                                     FStar_Compiler_Effect.op_Bar_Greater
-                                                                    uu___25
-                                                                    (fun
                                                                     uu___26
+                                                                    (fun
+                                                                    uu___27
                                                                     ->
                                                                     FStar_Syntax_Syntax.U_name
-                                                                    uu___26) in
-                                                                    [uu___24] in
+                                                                    uu___27) in
+                                                                    [uu___25] in
                                                                     FStar_TypeChecker_Env.inst_tscheme_with
                                                                     subcomp_ts
-                                                                    uu___23 in
-                                                                    (match uu___22
+                                                                    uu___24 in
+                                                                    (match uu___23
                                                                     with
                                                                     | 
-                                                                    (uu___23,
+                                                                    (uu___24,
                                                                     subcomp_t)
                                                                     ->
-                                                                    let uu___24
+                                                                    let uu___25
                                                                     =
                                                                     FStar_Syntax_Util.arrow_formals_comp
                                                                     subcomp_t in
-                                                                    (match uu___24
+                                                                    (match uu___25
                                                                     with
                                                                     | 
                                                                     (a_b_subcomp::subcomp_bs,
@@ -5709,27 +5728,27 @@ let (tc_layered_eff_decl :
                                                                     ->
                                                                     let subcomp_substs
                                                                     =
-                                                                    let uu___25
-                                                                    =
                                                                     let uu___26
                                                                     =
                                                                     let uu___27
+                                                                    =
+                                                                    let uu___28
                                                                     =
                                                                     FStar_Compiler_Effect.op_Bar_Greater
                                                                     a_b.FStar_Syntax_Syntax.binder_bv
                                                                     FStar_Syntax_Syntax.bv_to_name in
                                                                     ((a_b_subcomp.FStar_Syntax_Syntax.binder_bv),
-                                                                    uu___27) in
+                                                                    uu___28) in
                                                                     FStar_Syntax_Syntax.NT
-                                                                    uu___26 in
-                                                                    [uu___25] in
-                                                                    let uu___25
+                                                                    uu___27 in
+                                                                    [uu___26] in
+                                                                    let uu___26
                                                                     =
                                                                     FStar_Compiler_List.splitAt
                                                                     (FStar_Compiler_List.length
                                                                     args1)
                                                                     subcomp_bs in
-                                                                    (match uu___25
+                                                                    (match uu___26
                                                                     with
                                                                     | 
                                                                     (subcomp_f_bs,
@@ -5737,7 +5756,7 @@ let (tc_layered_eff_decl :
                                                                     ->
                                                                     let subcomp_substs1
                                                                     =
-                                                                    let uu___26
+                                                                    let uu___27
                                                                     =
                                                                     FStar_Compiler_List.map2
                                                                     (fun b ->
@@ -5750,22 +5769,22 @@ let (tc_layered_eff_decl :
                                                                     args1 in
                                                                     FStar_Compiler_List.op_At
                                                                     subcomp_substs
-                                                                    uu___26 in
-                                                                    let uu___26
+                                                                    uu___27 in
+                                                                    let uu___27
                                                                     =
                                                                     FStar_Compiler_List.splitAt
                                                                     (FStar_Compiler_List.length
                                                                     args2)
                                                                     subcomp_bs1 in
-                                                                    (match uu___26
+                                                                    (match uu___27
                                                                     with
                                                                     | 
                                                                     (subcomp_g_bs,
-                                                                    uu___27)
+                                                                    uu___28)
                                                                     ->
                                                                     let subcomp_substs2
                                                                     =
-                                                                    let uu___28
+                                                                    let uu___29
                                                                     =
                                                                     FStar_Compiler_List.map2
                                                                     (fun b ->
@@ -5778,55 +5797,55 @@ let (tc_layered_eff_decl :
                                                                     args2 in
                                                                     FStar_Compiler_List.op_At
                                                                     subcomp_substs1
-                                                                    uu___28 in
+                                                                    uu___29 in
                                                                     let subcomp_c1
                                                                     =
-                                                                    let uu___28
+                                                                    let uu___29
                                                                     =
                                                                     FStar_Syntax_Subst.subst_comp
                                                                     subcomp_substs2
                                                                     subcomp_c in
                                                                     FStar_Compiler_Effect.op_Bar_Greater
-                                                                    uu___28
+                                                                    uu___29
                                                                     (FStar_TypeChecker_Env.unfold_effect_abbrev
                                                                     env) in
                                                                     let fml =
-                                                                    let uu___28
+                                                                    let uu___29
                                                                     =
                                                                     FStar_Compiler_List.hd
                                                                     subcomp_c1.FStar_Syntax_Syntax.comp_univs in
-                                                                    let uu___29
-                                                                    =
                                                                     let uu___30
+                                                                    =
+                                                                    let uu___31
                                                                     =
                                                                     FStar_Compiler_Effect.op_Bar_Greater
                                                                     subcomp_c1.FStar_Syntax_Syntax.effect_args
                                                                     FStar_Compiler_List.hd in
                                                                     FStar_Compiler_Effect.op_Bar_Greater
-                                                                    uu___30
+                                                                    uu___31
                                                                     FStar_Pervasives_Native.fst in
                                                                     FStar_TypeChecker_Env.pure_precondition_for_trivial_post
                                                                     env
-                                                                    uu___28
+                                                                    uu___29
                                                                     subcomp_c1.FStar_Syntax_Syntax.result_typ
-                                                                    uu___29 r in
-                                                                    let uu___28
-                                                                    =
+                                                                    uu___30 r in
                                                                     let uu___29
+                                                                    =
+                                                                    let uu___30
                                                                     =
                                                                     FStar_Compiler_Effect.op_Bar_Greater
                                                                     fml
                                                                     (fun
-                                                                    uu___30
+                                                                    uu___31
                                                                     ->
                                                                     FStar_TypeChecker_Common.NonTrivial
-                                                                    uu___30) in
+                                                                    uu___31) in
                                                                     FStar_Compiler_Effect.op_Bar_Greater
-                                                                    uu___29
+                                                                    uu___30
                                                                     FStar_TypeChecker_Env.guard_of_guard_formula in
                                                                     FStar_TypeChecker_Rel.force_trivial_guard
                                                                     env
-                                                                    uu___28))))))))));
+                                                                    uu___29)))))))))));
                                           (let tc_action env act =
                                              let env01 = env in
                                              let r =

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_TcEffect.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_TcEffect.ml
@@ -3577,20 +3577,19 @@ let (validate_indexed_effect_close_shape :
                                        FStar_Pervasives_Native.None f_sort in
                                    FStar_Compiler_Effect.op_Bar_Greater
                                      uu___4 FStar_Syntax_Syntax.mk_binder in
+                             let env1 =
+                               FStar_TypeChecker_Env.push_binders env (a_b ::
+                                 b_b ::
+                                 (FStar_Compiler_List.op_At eff_params_bs bs)) in
                              let uu___2 =
                                let uu___3 =
-                                 FStar_TypeChecker_Env.push_binders env (a_b
-                                   :: b_b ::
-                                   (FStar_Compiler_List.op_At eff_params_bs
-                                      bs)) in
-                               let uu___4 =
                                  FStar_Compiler_Effect.op_Bar_Greater
                                    a_b.FStar_Syntax_Syntax.binder_bv
                                    FStar_Syntax_Syntax.bv_to_name in
-                               FStar_TypeChecker_Util.fresh_effect_repr
-                                 uu___3 r eff_name sig_ts
+                               FStar_TypeChecker_Util.fresh_effect_repr env1
+                                 r eff_name sig_ts
                                  (FStar_Pervasives_Native.Some repr_ts)
-                                 (FStar_Syntax_Syntax.U_name u_a) uu___4 in
+                                 (FStar_Syntax_Syntax.U_name u_a) uu___3 in
                              (match uu___2 with
                               | (body_tm, g_body) ->
                                   let k =
@@ -3601,7 +3600,7 @@ let (validate_indexed_effect_close_shape :
                                       body_tm FStar_Pervasives_Native.None in
                                   let g_eq =
                                     let uu___3 =
-                                      FStar_TypeChecker_Rel.teq_nosmt env
+                                      FStar_TypeChecker_Rel.teq_nosmt env1
                                         close_tm k in
                                     match uu___3 with
                                     | FStar_Pervasives_Native.None ->
@@ -3621,11 +3620,11 @@ let (validate_indexed_effect_close_shape :
                                       FStar_TypeChecker_Env.conj_guard g_body
                                         g_eq in
                                     FStar_TypeChecker_Rel.force_trivial_guard
-                                      env uu___4);
+                                      env1 uu___4);
                                    (let uu___4 =
                                       FStar_Compiler_Effect.op_Bar_Greater k
                                         (FStar_TypeChecker_Normalize.remove_uvar_solutions
-                                           env) in
+                                           env1) in
                                     FStar_Compiler_Effect.op_Bar_Greater
                                       uu___4 FStar_Syntax_Subst.compress))))
 let (lift_combinator_kind :

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_TcEffect.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_TcEffect.ml
@@ -5533,349 +5533,648 @@ let (tc_layered_eff_decl :
                                                               close_ty) in
                                                           FStar_Pervasives_Native.Some
                                                             uu___16)) in
-                                          let tc_action env act =
-                                            let env01 = env in
-                                            let r =
-                                              (act.FStar_Syntax_Syntax.action_defn).FStar_Syntax_Syntax.pos in
-                                            if
-                                              (FStar_Compiler_List.length
-                                                 act.FStar_Syntax_Syntax.action_params)
-                                                <> Prims.int_zero
-                                            then
-                                              (let uu___15 =
-                                                 let uu___16 =
-                                                   let uu___17 =
-                                                     FStar_Ident.string_of_lid
-                                                       ed.FStar_Syntax_Syntax.mname in
-                                                   let uu___18 =
-                                                     FStar_Ident.string_of_lid
-                                                       act.FStar_Syntax_Syntax.action_name in
-                                                   let uu___19 =
-                                                     FStar_Syntax_Print.binders_to_string
-                                                       "; "
-                                                       act.FStar_Syntax_Syntax.action_params in
-                                                   FStar_Compiler_Util.format3
-                                                     "Action %s:%s has non-empty action params (%s)"
-                                                     uu___17 uu___18 uu___19 in
-                                                 (FStar_Errors_Codes.Fatal_MalformedActionDeclaration,
-                                                   uu___16) in
-                                               FStar_Errors.raise_error
-                                                 uu___15 r)
-                                            else ();
-                                            (let uu___15 =
-                                               let uu___16 =
-                                                 FStar_Syntax_Subst.univ_var_opening
-                                                   act.FStar_Syntax_Syntax.action_univs in
-                                               match uu___16 with
-                                               | (usubst, us) ->
-                                                   let uu___17 =
-                                                     FStar_TypeChecker_Env.push_univ_vars
-                                                       env us in
-                                                   let uu___18 =
-                                                     let uu___19 =
-                                                       FStar_Syntax_Subst.subst
-                                                         usubst
-                                                         act.FStar_Syntax_Syntax.action_defn in
-                                                     let uu___20 =
-                                                       FStar_Syntax_Subst.subst
-                                                         usubst
-                                                         act.FStar_Syntax_Syntax.action_typ in
-                                                     {
-                                                       FStar_Syntax_Syntax.action_name
-                                                         =
-                                                         (act.FStar_Syntax_Syntax.action_name);
-                                                       FStar_Syntax_Syntax.action_unqualified_name
-                                                         =
-                                                         (act.FStar_Syntax_Syntax.action_unqualified_name);
-                                                       FStar_Syntax_Syntax.action_univs
-                                                         = us;
-                                                       FStar_Syntax_Syntax.action_params
-                                                         =
-                                                         (act.FStar_Syntax_Syntax.action_params);
-                                                       FStar_Syntax_Syntax.action_defn
-                                                         = uu___19;
-                                                       FStar_Syntax_Syntax.action_typ
-                                                         = uu___20
-                                                     } in
-                                                   (uu___17, uu___18) in
-                                             match uu___15 with
-                                             | (env1, act1) ->
-                                                 let act_typ =
-                                                   let uu___16 =
-                                                     let uu___17 =
-                                                       FStar_Syntax_Subst.compress
-                                                         act1.FStar_Syntax_Syntax.action_typ in
-                                                     uu___17.FStar_Syntax_Syntax.n in
-                                                   match uu___16 with
-                                                   | FStar_Syntax_Syntax.Tm_arrow
-                                                       {
-                                                         FStar_Syntax_Syntax.bs1
-                                                           = bs;
-                                                         FStar_Syntax_Syntax.comp
-                                                           = c;_}
-                                                       ->
-                                                       let ct =
-                                                         FStar_TypeChecker_Env.comp_to_comp_typ
-                                                           env1 c in
-                                                       let uu___17 =
-                                                         FStar_Ident.lid_equals
-                                                           ct.FStar_Syntax_Syntax.effect_name
-                                                           ed.FStar_Syntax_Syntax.mname in
-                                                       if uu___17
-                                                       then
-                                                         let repr_ts =
-                                                           let uu___18 = repr in
-                                                           match uu___18 with
-                                                           | (us, t, uu___19)
-                                                               -> (us, t) in
-                                                         let repr1 =
-                                                           let uu___18 =
-                                                             FStar_TypeChecker_Env.inst_tscheme_with
-                                                               repr_ts
-                                                               ct.FStar_Syntax_Syntax.comp_univs in
-                                                           FStar_Compiler_Effect.op_Bar_Greater
-                                                             uu___18
-                                                             FStar_Pervasives_Native.snd in
-                                                         let repr2 =
-                                                           let uu___18 =
-                                                             let uu___19 =
-                                                               FStar_Syntax_Syntax.as_arg
-                                                                 ct.FStar_Syntax_Syntax.result_typ in
-                                                             uu___19 ::
-                                                               (ct.FStar_Syntax_Syntax.effect_args) in
-                                                           FStar_Syntax_Syntax.mk_Tm_app
-                                                             repr1 uu___18 r in
-                                                         let c1 =
-                                                           FStar_Syntax_Syntax.mk_Total
-                                                             repr2 in
-                                                         FStar_Syntax_Util.arrow
-                                                           bs c1
-                                                       else
-                                                         act1.FStar_Syntax_Syntax.action_typ
-                                                   | uu___17 ->
-                                                       act1.FStar_Syntax_Syntax.action_typ in
-                                                 let uu___16 =
-                                                   FStar_TypeChecker_TcTerm.tc_tot_or_gtot_term
-                                                     env1 act_typ in
-                                                 (match uu___16 with
-                                                  | (act_typ1, uu___17, g_t)
-                                                      ->
-                                                      let uu___18 =
-                                                        let uu___19 =
-                                                          let uu___20 =
-                                                            FStar_TypeChecker_Env.set_expected_typ
-                                                              env1 act_typ1 in
-                                                          {
-                                                            FStar_TypeChecker_Env.solver
-                                                              =
-                                                              (uu___20.FStar_TypeChecker_Env.solver);
-                                                            FStar_TypeChecker_Env.range
-                                                              =
-                                                              (uu___20.FStar_TypeChecker_Env.range);
-                                                            FStar_TypeChecker_Env.curmodule
-                                                              =
-                                                              (uu___20.FStar_TypeChecker_Env.curmodule);
-                                                            FStar_TypeChecker_Env.gamma
-                                                              =
-                                                              (uu___20.FStar_TypeChecker_Env.gamma);
-                                                            FStar_TypeChecker_Env.gamma_sig
-                                                              =
-                                                              (uu___20.FStar_TypeChecker_Env.gamma_sig);
-                                                            FStar_TypeChecker_Env.gamma_cache
-                                                              =
-                                                              (uu___20.FStar_TypeChecker_Env.gamma_cache);
-                                                            FStar_TypeChecker_Env.modules
-                                                              =
-                                                              (uu___20.FStar_TypeChecker_Env.modules);
-                                                            FStar_TypeChecker_Env.expected_typ
-                                                              =
-                                                              (uu___20.FStar_TypeChecker_Env.expected_typ);
-                                                            FStar_TypeChecker_Env.sigtab
-                                                              =
-                                                              (uu___20.FStar_TypeChecker_Env.sigtab);
-                                                            FStar_TypeChecker_Env.attrtab
-                                                              =
-                                                              (uu___20.FStar_TypeChecker_Env.attrtab);
-                                                            FStar_TypeChecker_Env.instantiate_imp
-                                                              = false;
-                                                            FStar_TypeChecker_Env.effects
-                                                              =
-                                                              (uu___20.FStar_TypeChecker_Env.effects);
-                                                            FStar_TypeChecker_Env.generalize
-                                                              =
-                                                              (uu___20.FStar_TypeChecker_Env.generalize);
-                                                            FStar_TypeChecker_Env.letrecs
-                                                              =
-                                                              (uu___20.FStar_TypeChecker_Env.letrecs);
-                                                            FStar_TypeChecker_Env.top_level
-                                                              =
-                                                              (uu___20.FStar_TypeChecker_Env.top_level);
-                                                            FStar_TypeChecker_Env.check_uvars
-                                                              =
-                                                              (uu___20.FStar_TypeChecker_Env.check_uvars);
-                                                            FStar_TypeChecker_Env.use_eq_strict
-                                                              =
-                                                              (uu___20.FStar_TypeChecker_Env.use_eq_strict);
-                                                            FStar_TypeChecker_Env.is_iface
-                                                              =
-                                                              (uu___20.FStar_TypeChecker_Env.is_iface);
-                                                            FStar_TypeChecker_Env.admit
-                                                              =
-                                                              (uu___20.FStar_TypeChecker_Env.admit);
-                                                            FStar_TypeChecker_Env.lax
-                                                              =
-                                                              (uu___20.FStar_TypeChecker_Env.lax);
-                                                            FStar_TypeChecker_Env.lax_universes
-                                                              =
-                                                              (uu___20.FStar_TypeChecker_Env.lax_universes);
-                                                            FStar_TypeChecker_Env.phase1
-                                                              =
-                                                              (uu___20.FStar_TypeChecker_Env.phase1);
-                                                            FStar_TypeChecker_Env.failhard
-                                                              =
-                                                              (uu___20.FStar_TypeChecker_Env.failhard);
-                                                            FStar_TypeChecker_Env.nosynth
-                                                              =
-                                                              (uu___20.FStar_TypeChecker_Env.nosynth);
-                                                            FStar_TypeChecker_Env.uvar_subtyping
-                                                              =
-                                                              (uu___20.FStar_TypeChecker_Env.uvar_subtyping);
-                                                            FStar_TypeChecker_Env.intactics
-                                                              =
-                                                              (uu___20.FStar_TypeChecker_Env.intactics);
-                                                            FStar_TypeChecker_Env.tc_term
-                                                              =
-                                                              (uu___20.FStar_TypeChecker_Env.tc_term);
-                                                            FStar_TypeChecker_Env.typeof_tot_or_gtot_term
-                                                              =
-                                                              (uu___20.FStar_TypeChecker_Env.typeof_tot_or_gtot_term);
-                                                            FStar_TypeChecker_Env.universe_of
-                                                              =
-                                                              (uu___20.FStar_TypeChecker_Env.universe_of);
-                                                            FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term
-                                                              =
-                                                              (uu___20.FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term);
-                                                            FStar_TypeChecker_Env.teq_nosmt_force
-                                                              =
-                                                              (uu___20.FStar_TypeChecker_Env.teq_nosmt_force);
-                                                            FStar_TypeChecker_Env.subtype_nosmt_force
-                                                              =
-                                                              (uu___20.FStar_TypeChecker_Env.subtype_nosmt_force);
-                                                            FStar_TypeChecker_Env.qtbl_name_and_index
-                                                              =
-                                                              (uu___20.FStar_TypeChecker_Env.qtbl_name_and_index);
-                                                            FStar_TypeChecker_Env.normalized_eff_names
-                                                              =
-                                                              (uu___20.FStar_TypeChecker_Env.normalized_eff_names);
-                                                            FStar_TypeChecker_Env.fv_delta_depths
-                                                              =
-                                                              (uu___20.FStar_TypeChecker_Env.fv_delta_depths);
-                                                            FStar_TypeChecker_Env.proof_ns
-                                                              =
-                                                              (uu___20.FStar_TypeChecker_Env.proof_ns);
-                                                            FStar_TypeChecker_Env.synth_hook
-                                                              =
-                                                              (uu___20.FStar_TypeChecker_Env.synth_hook);
-                                                            FStar_TypeChecker_Env.try_solve_implicits_hook
-                                                              =
-                                                              (uu___20.FStar_TypeChecker_Env.try_solve_implicits_hook);
-                                                            FStar_TypeChecker_Env.splice
-                                                              =
-                                                              (uu___20.FStar_TypeChecker_Env.splice);
-                                                            FStar_TypeChecker_Env.mpreprocess
-                                                              =
-                                                              (uu___20.FStar_TypeChecker_Env.mpreprocess);
-                                                            FStar_TypeChecker_Env.postprocess
-                                                              =
-                                                              (uu___20.FStar_TypeChecker_Env.postprocess);
-                                                            FStar_TypeChecker_Env.identifier_info
-                                                              =
-                                                              (uu___20.FStar_TypeChecker_Env.identifier_info);
-                                                            FStar_TypeChecker_Env.tc_hooks
-                                                              =
-                                                              (uu___20.FStar_TypeChecker_Env.tc_hooks);
-                                                            FStar_TypeChecker_Env.dsenv
-                                                              =
-                                                              (uu___20.FStar_TypeChecker_Env.dsenv);
-                                                            FStar_TypeChecker_Env.nbe
-                                                              =
-                                                              (uu___20.FStar_TypeChecker_Env.nbe);
-                                                            FStar_TypeChecker_Env.strict_args_tab
-                                                              =
-                                                              (uu___20.FStar_TypeChecker_Env.strict_args_tab);
-                                                            FStar_TypeChecker_Env.erasable_types_tab
-                                                              =
-                                                              (uu___20.FStar_TypeChecker_Env.erasable_types_tab);
-                                                            FStar_TypeChecker_Env.enable_defer_to_tac
-                                                              =
-                                                              (uu___20.FStar_TypeChecker_Env.enable_defer_to_tac);
-                                                            FStar_TypeChecker_Env.unif_allow_ref_guards
-                                                              =
-                                                              (uu___20.FStar_TypeChecker_Env.unif_allow_ref_guards);
-                                                            FStar_TypeChecker_Env.erase_erasable_args
-                                                              =
-                                                              (uu___20.FStar_TypeChecker_Env.erase_erasable_args);
-                                                            FStar_TypeChecker_Env.core_check
-                                                              =
-                                                              (uu___20.FStar_TypeChecker_Env.core_check)
-                                                          } in
-                                                        FStar_TypeChecker_TcTerm.tc_tot_or_gtot_term
-                                                          uu___19
-                                                          act1.FStar_Syntax_Syntax.action_defn in
-                                                      (match uu___18 with
-                                                       | (act_defn, uu___19,
-                                                          g_d) ->
-                                                           ((let uu___21 =
-                                                               FStar_Compiler_Effect.op_Less_Bar
-                                                                 (FStar_TypeChecker_Env.debug
-                                                                    env1)
-                                                                 (FStar_Options.Other
-                                                                    "LayeredEffectsTc") in
-                                                             if uu___21
-                                                             then
-                                                               let uu___22 =
-                                                                 FStar_Syntax_Print.term_to_string
-                                                                   act_defn in
-                                                               let uu___23 =
-                                                                 FStar_Syntax_Print.term_to_string
-                                                                   act_typ1 in
-                                                               FStar_Compiler_Util.print2
-                                                                 "Typechecked action definition: %s and action type: %s\n"
-                                                                 uu___22
-                                                                 uu___23
-                                                             else ());
-                                                            (let uu___21 =
-                                                               let act_typ2 =
-                                                                 FStar_TypeChecker_Normalize.normalize
-                                                                   [FStar_TypeChecker_Env.Beta]
-                                                                   env1
-                                                                   act_typ1 in
-                                                               let uu___22 =
-                                                                 let uu___23
-                                                                   =
-                                                                   FStar_Syntax_Subst.compress
-                                                                    act_typ2 in
-                                                                 uu___23.FStar_Syntax_Syntax.n in
-                                                               match uu___22
+                                          (match close_ with
+                                           | FStar_Pervasives_Native.None ->
+                                               ()
+                                           | FStar_Pervasives_Native.Some
+                                               close_1 ->
+                                               let uu___14 = close_1 in
+                                               (match uu___14 with
+                                                | (us, close_tm, uu___15) ->
+                                                    let r =
+                                                      close_tm.FStar_Syntax_Syntax.pos in
+                                                    let uu___16 =
+                                                      FStar_Syntax_Subst.open_univ_vars
+                                                        us close_tm in
+                                                    (match uu___16 with
+                                                     | (us1, close_tm1) ->
+                                                         let uu___17 =
+                                                           FStar_Syntax_Util.abs_formals
+                                                             close_tm1 in
+                                                         (match uu___17 with
+                                                          | (close_bs,
+                                                             close_body,
+                                                             uu___18) ->
+                                                              let uu___19 =
+                                                                close_bs in
+                                                              (match uu___19
                                                                with
-                                                               | FStar_Syntax_Syntax.Tm_arrow
-                                                                   {
+                                                               | a_b::b_b::close_bs1
+                                                                   ->
+                                                                   let uu___20
+                                                                    =
+                                                                    FStar_Compiler_List.splitAt
+                                                                    ((FStar_Compiler_List.length
+                                                                    close_bs1)
+                                                                    -
+                                                                    Prims.int_one)
+                                                                    close_bs1 in
+                                                                   (match uu___20
+                                                                    with
+                                                                    | 
+                                                                    (is_bs,
+                                                                    uu___21)
+                                                                    ->
+                                                                    let x_bv
+                                                                    =
+                                                                    let uu___22
+                                                                    =
+                                                                    FStar_Syntax_Syntax.bv_to_name
+                                                                    b_b.FStar_Syntax_Syntax.binder_bv in
+                                                                    FStar_Syntax_Syntax.gen_bv
+                                                                    "x"
+                                                                    FStar_Pervasives_Native.None
+                                                                    uu___22 in
+                                                                    let args1
+                                                                    =
+                                                                    FStar_Compiler_List.map
+                                                                    (fun i_b
+                                                                    ->
+                                                                    let uu___22
+                                                                    =
+                                                                    FStar_Syntax_Syntax.bv_to_name
+                                                                    i_b.FStar_Syntax_Syntax.binder_bv in
+                                                                    let uu___23
+                                                                    =
+                                                                    let uu___24
+                                                                    =
+                                                                    let uu___25
+                                                                    =
+                                                                    FStar_Syntax_Syntax.bv_to_name
+                                                                    x_bv in
+                                                                    FStar_Syntax_Syntax.as_arg
+                                                                    uu___25 in
+                                                                    [uu___24] in
+                                                                    FStar_Syntax_Syntax.mk_Tm_app
+                                                                    uu___22
+                                                                    uu___23 r)
+                                                                    is_bs in
+                                                                    let args2
+                                                                    =
+                                                                    let uu___22
+                                                                    =
+                                                                    let uu___23
+                                                                    =
+                                                                    FStar_Syntax_Subst.compress
+                                                                    close_body in
+                                                                    uu___23.FStar_Syntax_Syntax.n in
+                                                                    match uu___22
+                                                                    with
+                                                                    | 
+                                                                    FStar_Syntax_Syntax.Tm_app
+                                                                    {
+                                                                    FStar_Syntax_Syntax.hd
+                                                                    = uu___23;
+                                                                    FStar_Syntax_Syntax.args
+                                                                    = a::args;_}
+                                                                    ->
+                                                                    FStar_Compiler_Effect.op_Bar_Greater
+                                                                    args
+                                                                    (FStar_Compiler_List.map
+                                                                    FStar_Pervasives_Native.fst)
+                                                                    | 
+                                                                    uu___23
+                                                                    ->
+                                                                    FStar_Errors.raise_error
+                                                                    (FStar_Errors_Codes.Fatal_UnexpectedEffect,
+                                                                    "close combinator body not a repr")
+                                                                    r in
+                                                                    let env =
+                                                                    let uu___22
+                                                                    =
+                                                                    let uu___23
+                                                                    =
+                                                                    let uu___24
+                                                                    =
+                                                                    FStar_Compiler_Effect.op_Bar_Greater
+                                                                    x_bv
+                                                                    FStar_Syntax_Syntax.mk_binder in
+                                                                    [uu___24] in
+                                                                    FStar_Compiler_List.op_At
+                                                                    (a_b ::
+                                                                    b_b ::
+                                                                    is_bs)
+                                                                    uu___23 in
+                                                                    FStar_TypeChecker_Env.push_binders
+                                                                    env0
+                                                                    uu___22 in
+                                                                    let subcomp_ts
+                                                                    =
+                                                                    let uu___22
+                                                                    =
+                                                                    stronger_repr in
+                                                                    match uu___22
+                                                                    with
+                                                                    | 
+                                                                    (us2,
+                                                                    uu___23,
+                                                                    t) ->
+                                                                    (us2, t) in
+                                                                    let uu___22
+                                                                    =
+                                                                    let uu___23
+                                                                    =
+                                                                    let uu___24
+                                                                    =
+                                                                    let uu___25
+                                                                    =
+                                                                    FStar_Compiler_List.hd
+                                                                    us1 in
+                                                                    FStar_Compiler_Effect.op_Bar_Greater
+                                                                    uu___25
+                                                                    (fun
+                                                                    uu___26
+                                                                    ->
+                                                                    FStar_Syntax_Syntax.U_name
+                                                                    uu___26) in
+                                                                    [uu___24] in
+                                                                    FStar_TypeChecker_Env.inst_tscheme_with
+                                                                    subcomp_ts
+                                                                    uu___23 in
+                                                                    (match uu___22
+                                                                    with
+                                                                    | 
+                                                                    (uu___23,
+                                                                    subcomp_t)
+                                                                    ->
+                                                                    let uu___24
+                                                                    =
+                                                                    FStar_Syntax_Util.arrow_formals_comp
+                                                                    subcomp_t in
+                                                                    (match uu___24
+                                                                    with
+                                                                    | 
+                                                                    (a_b_subcomp::subcomp_bs,
+                                                                    subcomp_c)
+                                                                    ->
+                                                                    let subcomp_substs
+                                                                    =
+                                                                    let uu___25
+                                                                    =
+                                                                    let uu___26
+                                                                    =
+                                                                    let uu___27
+                                                                    =
+                                                                    FStar_Compiler_Effect.op_Bar_Greater
+                                                                    a_b.FStar_Syntax_Syntax.binder_bv
+                                                                    FStar_Syntax_Syntax.bv_to_name in
+                                                                    ((a_b_subcomp.FStar_Syntax_Syntax.binder_bv),
+                                                                    uu___27) in
+                                                                    FStar_Syntax_Syntax.NT
+                                                                    uu___26 in
+                                                                    [uu___25] in
+                                                                    let uu___25
+                                                                    =
+                                                                    FStar_Compiler_List.splitAt
+                                                                    (FStar_Compiler_List.length
+                                                                    args1)
+                                                                    subcomp_bs in
+                                                                    (match uu___25
+                                                                    with
+                                                                    | 
+                                                                    (subcomp_f_bs,
+                                                                    subcomp_bs1)
+                                                                    ->
+                                                                    let subcomp_substs1
+                                                                    =
+                                                                    let uu___26
+                                                                    =
+                                                                    FStar_Compiler_List.map2
+                                                                    (fun b ->
+                                                                    fun arg1
+                                                                    ->
+                                                                    FStar_Syntax_Syntax.NT
+                                                                    ((b.FStar_Syntax_Syntax.binder_bv),
+                                                                    arg1))
+                                                                    subcomp_f_bs
+                                                                    args1 in
+                                                                    FStar_Compiler_List.op_At
+                                                                    subcomp_substs
+                                                                    uu___26 in
+                                                                    let uu___26
+                                                                    =
+                                                                    FStar_Compiler_List.splitAt
+                                                                    (FStar_Compiler_List.length
+                                                                    args2)
+                                                                    subcomp_bs1 in
+                                                                    (match uu___26
+                                                                    with
+                                                                    | 
+                                                                    (subcomp_g_bs,
+                                                                    uu___27)
+                                                                    ->
+                                                                    let subcomp_substs2
+                                                                    =
+                                                                    let uu___28
+                                                                    =
+                                                                    FStar_Compiler_List.map2
+                                                                    (fun b ->
+                                                                    fun arg2
+                                                                    ->
+                                                                    FStar_Syntax_Syntax.NT
+                                                                    ((b.FStar_Syntax_Syntax.binder_bv),
+                                                                    arg2))
+                                                                    subcomp_g_bs
+                                                                    args2 in
+                                                                    FStar_Compiler_List.op_At
+                                                                    subcomp_substs1
+                                                                    uu___28 in
+                                                                    let subcomp_c1
+                                                                    =
+                                                                    let uu___28
+                                                                    =
+                                                                    FStar_Syntax_Subst.subst_comp
+                                                                    subcomp_substs2
+                                                                    subcomp_c in
+                                                                    FStar_Compiler_Effect.op_Bar_Greater
+                                                                    uu___28
+                                                                    (FStar_TypeChecker_Env.unfold_effect_abbrev
+                                                                    env) in
+                                                                    let fml =
+                                                                    let uu___28
+                                                                    =
+                                                                    FStar_Compiler_List.hd
+                                                                    subcomp_c1.FStar_Syntax_Syntax.comp_univs in
+                                                                    let uu___29
+                                                                    =
+                                                                    let uu___30
+                                                                    =
+                                                                    FStar_Compiler_Effect.op_Bar_Greater
+                                                                    subcomp_c1.FStar_Syntax_Syntax.effect_args
+                                                                    FStar_Compiler_List.hd in
+                                                                    FStar_Compiler_Effect.op_Bar_Greater
+                                                                    uu___30
+                                                                    FStar_Pervasives_Native.fst in
+                                                                    FStar_TypeChecker_Env.pure_precondition_for_trivial_post
+                                                                    env
+                                                                    uu___28
+                                                                    subcomp_c1.FStar_Syntax_Syntax.result_typ
+                                                                    uu___29 r in
+                                                                    let uu___28
+                                                                    =
+                                                                    let uu___29
+                                                                    =
+                                                                    FStar_Compiler_Effect.op_Bar_Greater
+                                                                    fml
+                                                                    (fun
+                                                                    uu___30
+                                                                    ->
+                                                                    FStar_TypeChecker_Common.NonTrivial
+                                                                    uu___30) in
+                                                                    FStar_Compiler_Effect.op_Bar_Greater
+                                                                    uu___29
+                                                                    FStar_TypeChecker_Env.guard_of_guard_formula in
+                                                                    FStar_TypeChecker_Rel.force_trivial_guard
+                                                                    env
+                                                                    uu___28))))))))));
+                                          (let tc_action env act =
+                                             let env01 = env in
+                                             let r =
+                                               (act.FStar_Syntax_Syntax.action_defn).FStar_Syntax_Syntax.pos in
+                                             if
+                                               (FStar_Compiler_List.length
+                                                  act.FStar_Syntax_Syntax.action_params)
+                                                 <> Prims.int_zero
+                                             then
+                                               (let uu___15 =
+                                                  let uu___16 =
+                                                    let uu___17 =
+                                                      FStar_Ident.string_of_lid
+                                                        ed.FStar_Syntax_Syntax.mname in
+                                                    let uu___18 =
+                                                      FStar_Ident.string_of_lid
+                                                        act.FStar_Syntax_Syntax.action_name in
+                                                    let uu___19 =
+                                                      FStar_Syntax_Print.binders_to_string
+                                                        "; "
+                                                        act.FStar_Syntax_Syntax.action_params in
+                                                    FStar_Compiler_Util.format3
+                                                      "Action %s:%s has non-empty action params (%s)"
+                                                      uu___17 uu___18 uu___19 in
+                                                  (FStar_Errors_Codes.Fatal_MalformedActionDeclaration,
+                                                    uu___16) in
+                                                FStar_Errors.raise_error
+                                                  uu___15 r)
+                                             else ();
+                                             (let uu___15 =
+                                                let uu___16 =
+                                                  FStar_Syntax_Subst.univ_var_opening
+                                                    act.FStar_Syntax_Syntax.action_univs in
+                                                match uu___16 with
+                                                | (usubst, us) ->
+                                                    let uu___17 =
+                                                      FStar_TypeChecker_Env.push_univ_vars
+                                                        env us in
+                                                    let uu___18 =
+                                                      let uu___19 =
+                                                        FStar_Syntax_Subst.subst
+                                                          usubst
+                                                          act.FStar_Syntax_Syntax.action_defn in
+                                                      let uu___20 =
+                                                        FStar_Syntax_Subst.subst
+                                                          usubst
+                                                          act.FStar_Syntax_Syntax.action_typ in
+                                                      {
+                                                        FStar_Syntax_Syntax.action_name
+                                                          =
+                                                          (act.FStar_Syntax_Syntax.action_name);
+                                                        FStar_Syntax_Syntax.action_unqualified_name
+                                                          =
+                                                          (act.FStar_Syntax_Syntax.action_unqualified_name);
+                                                        FStar_Syntax_Syntax.action_univs
+                                                          = us;
+                                                        FStar_Syntax_Syntax.action_params
+                                                          =
+                                                          (act.FStar_Syntax_Syntax.action_params);
+                                                        FStar_Syntax_Syntax.action_defn
+                                                          = uu___19;
+                                                        FStar_Syntax_Syntax.action_typ
+                                                          = uu___20
+                                                      } in
+                                                    (uu___17, uu___18) in
+                                              match uu___15 with
+                                              | (env1, act1) ->
+                                                  let act_typ =
+                                                    let uu___16 =
+                                                      let uu___17 =
+                                                        FStar_Syntax_Subst.compress
+                                                          act1.FStar_Syntax_Syntax.action_typ in
+                                                      uu___17.FStar_Syntax_Syntax.n in
+                                                    match uu___16 with
+                                                    | FStar_Syntax_Syntax.Tm_arrow
+                                                        {
+                                                          FStar_Syntax_Syntax.bs1
+                                                            = bs;
+                                                          FStar_Syntax_Syntax.comp
+                                                            = c;_}
+                                                        ->
+                                                        let ct =
+                                                          FStar_TypeChecker_Env.comp_to_comp_typ
+                                                            env1 c in
+                                                        let uu___17 =
+                                                          FStar_Ident.lid_equals
+                                                            ct.FStar_Syntax_Syntax.effect_name
+                                                            ed.FStar_Syntax_Syntax.mname in
+                                                        if uu___17
+                                                        then
+                                                          let repr_ts =
+                                                            let uu___18 =
+                                                              repr in
+                                                            match uu___18
+                                                            with
+                                                            | (us, t,
+                                                               uu___19) ->
+                                                                (us, t) in
+                                                          let repr1 =
+                                                            let uu___18 =
+                                                              FStar_TypeChecker_Env.inst_tscheme_with
+                                                                repr_ts
+                                                                ct.FStar_Syntax_Syntax.comp_univs in
+                                                            FStar_Compiler_Effect.op_Bar_Greater
+                                                              uu___18
+                                                              FStar_Pervasives_Native.snd in
+                                                          let repr2 =
+                                                            let uu___18 =
+                                                              let uu___19 =
+                                                                FStar_Syntax_Syntax.as_arg
+                                                                  ct.FStar_Syntax_Syntax.result_typ in
+                                                              uu___19 ::
+                                                                (ct.FStar_Syntax_Syntax.effect_args) in
+                                                            FStar_Syntax_Syntax.mk_Tm_app
+                                                              repr1 uu___18 r in
+                                                          let c1 =
+                                                            FStar_Syntax_Syntax.mk_Total
+                                                              repr2 in
+                                                          FStar_Syntax_Util.arrow
+                                                            bs c1
+                                                        else
+                                                          act1.FStar_Syntax_Syntax.action_typ
+                                                    | uu___17 ->
+                                                        act1.FStar_Syntax_Syntax.action_typ in
+                                                  let uu___16 =
+                                                    FStar_TypeChecker_TcTerm.tc_tot_or_gtot_term
+                                                      env1 act_typ in
+                                                  (match uu___16 with
+                                                   | (act_typ1, uu___17, g_t)
+                                                       ->
+                                                       let uu___18 =
+                                                         let uu___19 =
+                                                           let uu___20 =
+                                                             FStar_TypeChecker_Env.set_expected_typ
+                                                               env1 act_typ1 in
+                                                           {
+                                                             FStar_TypeChecker_Env.solver
+                                                               =
+                                                               (uu___20.FStar_TypeChecker_Env.solver);
+                                                             FStar_TypeChecker_Env.range
+                                                               =
+                                                               (uu___20.FStar_TypeChecker_Env.range);
+                                                             FStar_TypeChecker_Env.curmodule
+                                                               =
+                                                               (uu___20.FStar_TypeChecker_Env.curmodule);
+                                                             FStar_TypeChecker_Env.gamma
+                                                               =
+                                                               (uu___20.FStar_TypeChecker_Env.gamma);
+                                                             FStar_TypeChecker_Env.gamma_sig
+                                                               =
+                                                               (uu___20.FStar_TypeChecker_Env.gamma_sig);
+                                                             FStar_TypeChecker_Env.gamma_cache
+                                                               =
+                                                               (uu___20.FStar_TypeChecker_Env.gamma_cache);
+                                                             FStar_TypeChecker_Env.modules
+                                                               =
+                                                               (uu___20.FStar_TypeChecker_Env.modules);
+                                                             FStar_TypeChecker_Env.expected_typ
+                                                               =
+                                                               (uu___20.FStar_TypeChecker_Env.expected_typ);
+                                                             FStar_TypeChecker_Env.sigtab
+                                                               =
+                                                               (uu___20.FStar_TypeChecker_Env.sigtab);
+                                                             FStar_TypeChecker_Env.attrtab
+                                                               =
+                                                               (uu___20.FStar_TypeChecker_Env.attrtab);
+                                                             FStar_TypeChecker_Env.instantiate_imp
+                                                               = false;
+                                                             FStar_TypeChecker_Env.effects
+                                                               =
+                                                               (uu___20.FStar_TypeChecker_Env.effects);
+                                                             FStar_TypeChecker_Env.generalize
+                                                               =
+                                                               (uu___20.FStar_TypeChecker_Env.generalize);
+                                                             FStar_TypeChecker_Env.letrecs
+                                                               =
+                                                               (uu___20.FStar_TypeChecker_Env.letrecs);
+                                                             FStar_TypeChecker_Env.top_level
+                                                               =
+                                                               (uu___20.FStar_TypeChecker_Env.top_level);
+                                                             FStar_TypeChecker_Env.check_uvars
+                                                               =
+                                                               (uu___20.FStar_TypeChecker_Env.check_uvars);
+                                                             FStar_TypeChecker_Env.use_eq_strict
+                                                               =
+                                                               (uu___20.FStar_TypeChecker_Env.use_eq_strict);
+                                                             FStar_TypeChecker_Env.is_iface
+                                                               =
+                                                               (uu___20.FStar_TypeChecker_Env.is_iface);
+                                                             FStar_TypeChecker_Env.admit
+                                                               =
+                                                               (uu___20.FStar_TypeChecker_Env.admit);
+                                                             FStar_TypeChecker_Env.lax
+                                                               =
+                                                               (uu___20.FStar_TypeChecker_Env.lax);
+                                                             FStar_TypeChecker_Env.lax_universes
+                                                               =
+                                                               (uu___20.FStar_TypeChecker_Env.lax_universes);
+                                                             FStar_TypeChecker_Env.phase1
+                                                               =
+                                                               (uu___20.FStar_TypeChecker_Env.phase1);
+                                                             FStar_TypeChecker_Env.failhard
+                                                               =
+                                                               (uu___20.FStar_TypeChecker_Env.failhard);
+                                                             FStar_TypeChecker_Env.nosynth
+                                                               =
+                                                               (uu___20.FStar_TypeChecker_Env.nosynth);
+                                                             FStar_TypeChecker_Env.uvar_subtyping
+                                                               =
+                                                               (uu___20.FStar_TypeChecker_Env.uvar_subtyping);
+                                                             FStar_TypeChecker_Env.intactics
+                                                               =
+                                                               (uu___20.FStar_TypeChecker_Env.intactics);
+                                                             FStar_TypeChecker_Env.tc_term
+                                                               =
+                                                               (uu___20.FStar_TypeChecker_Env.tc_term);
+                                                             FStar_TypeChecker_Env.typeof_tot_or_gtot_term
+                                                               =
+                                                               (uu___20.FStar_TypeChecker_Env.typeof_tot_or_gtot_term);
+                                                             FStar_TypeChecker_Env.universe_of
+                                                               =
+                                                               (uu___20.FStar_TypeChecker_Env.universe_of);
+                                                             FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term
+                                                               =
+                                                               (uu___20.FStar_TypeChecker_Env.typeof_well_typed_tot_or_gtot_term);
+                                                             FStar_TypeChecker_Env.teq_nosmt_force
+                                                               =
+                                                               (uu___20.FStar_TypeChecker_Env.teq_nosmt_force);
+                                                             FStar_TypeChecker_Env.subtype_nosmt_force
+                                                               =
+                                                               (uu___20.FStar_TypeChecker_Env.subtype_nosmt_force);
+                                                             FStar_TypeChecker_Env.qtbl_name_and_index
+                                                               =
+                                                               (uu___20.FStar_TypeChecker_Env.qtbl_name_and_index);
+                                                             FStar_TypeChecker_Env.normalized_eff_names
+                                                               =
+                                                               (uu___20.FStar_TypeChecker_Env.normalized_eff_names);
+                                                             FStar_TypeChecker_Env.fv_delta_depths
+                                                               =
+                                                               (uu___20.FStar_TypeChecker_Env.fv_delta_depths);
+                                                             FStar_TypeChecker_Env.proof_ns
+                                                               =
+                                                               (uu___20.FStar_TypeChecker_Env.proof_ns);
+                                                             FStar_TypeChecker_Env.synth_hook
+                                                               =
+                                                               (uu___20.FStar_TypeChecker_Env.synth_hook);
+                                                             FStar_TypeChecker_Env.try_solve_implicits_hook
+                                                               =
+                                                               (uu___20.FStar_TypeChecker_Env.try_solve_implicits_hook);
+                                                             FStar_TypeChecker_Env.splice
+                                                               =
+                                                               (uu___20.FStar_TypeChecker_Env.splice);
+                                                             FStar_TypeChecker_Env.mpreprocess
+                                                               =
+                                                               (uu___20.FStar_TypeChecker_Env.mpreprocess);
+                                                             FStar_TypeChecker_Env.postprocess
+                                                               =
+                                                               (uu___20.FStar_TypeChecker_Env.postprocess);
+                                                             FStar_TypeChecker_Env.identifier_info
+                                                               =
+                                                               (uu___20.FStar_TypeChecker_Env.identifier_info);
+                                                             FStar_TypeChecker_Env.tc_hooks
+                                                               =
+                                                               (uu___20.FStar_TypeChecker_Env.tc_hooks);
+                                                             FStar_TypeChecker_Env.dsenv
+                                                               =
+                                                               (uu___20.FStar_TypeChecker_Env.dsenv);
+                                                             FStar_TypeChecker_Env.nbe
+                                                               =
+                                                               (uu___20.FStar_TypeChecker_Env.nbe);
+                                                             FStar_TypeChecker_Env.strict_args_tab
+                                                               =
+                                                               (uu___20.FStar_TypeChecker_Env.strict_args_tab);
+                                                             FStar_TypeChecker_Env.erasable_types_tab
+                                                               =
+                                                               (uu___20.FStar_TypeChecker_Env.erasable_types_tab);
+                                                             FStar_TypeChecker_Env.enable_defer_to_tac
+                                                               =
+                                                               (uu___20.FStar_TypeChecker_Env.enable_defer_to_tac);
+                                                             FStar_TypeChecker_Env.unif_allow_ref_guards
+                                                               =
+                                                               (uu___20.FStar_TypeChecker_Env.unif_allow_ref_guards);
+                                                             FStar_TypeChecker_Env.erase_erasable_args
+                                                               =
+                                                               (uu___20.FStar_TypeChecker_Env.erase_erasable_args);
+                                                             FStar_TypeChecker_Env.core_check
+                                                               =
+                                                               (uu___20.FStar_TypeChecker_Env.core_check)
+                                                           } in
+                                                         FStar_TypeChecker_TcTerm.tc_tot_or_gtot_term
+                                                           uu___19
+                                                           act1.FStar_Syntax_Syntax.action_defn in
+                                                       (match uu___18 with
+                                                        | (act_defn, uu___19,
+                                                           g_d) ->
+                                                            ((let uu___21 =
+                                                                FStar_Compiler_Effect.op_Less_Bar
+                                                                  (FStar_TypeChecker_Env.debug
+                                                                    env1)
+                                                                  (FStar_Options.Other
+                                                                    "LayeredEffectsTc") in
+                                                              if uu___21
+                                                              then
+                                                                let uu___22 =
+                                                                  FStar_Syntax_Print.term_to_string
+                                                                    act_defn in
+                                                                let uu___23 =
+                                                                  FStar_Syntax_Print.term_to_string
+                                                                    act_typ1 in
+                                                                FStar_Compiler_Util.print2
+                                                                  "Typechecked action definition: %s and action type: %s\n"
+                                                                  uu___22
+                                                                  uu___23
+                                                              else ());
+                                                             (let uu___21 =
+                                                                let act_typ2
+                                                                  =
+                                                                  FStar_TypeChecker_Normalize.normalize
+                                                                    [FStar_TypeChecker_Env.Beta]
+                                                                    env1
+                                                                    act_typ1 in
+                                                                let uu___22 =
+                                                                  let uu___23
+                                                                    =
+                                                                    FStar_Syntax_Subst.compress
+                                                                    act_typ2 in
+                                                                  uu___23.FStar_Syntax_Syntax.n in
+                                                                match uu___22
+                                                                with
+                                                                | FStar_Syntax_Syntax.Tm_arrow
+                                                                    {
                                                                     FStar_Syntax_Syntax.bs1
                                                                     = bs;
                                                                     FStar_Syntax_Syntax.comp
                                                                     = uu___23;_}
-                                                                   ->
-                                                                   let bs1 =
+                                                                    ->
+                                                                    let bs1 =
                                                                     FStar_Syntax_Subst.open_binders
                                                                     bs in
-                                                                   let env2 =
+                                                                    let env2
+                                                                    =
                                                                     FStar_TypeChecker_Env.push_binders
                                                                     env1 bs1 in
-                                                                   let uu___24
+                                                                    let uu___24
                                                                     =
                                                                     FStar_Syntax_Util.type_u
                                                                     () in
-                                                                   (match uu___24
+                                                                    (match uu___24
                                                                     with
                                                                     | 
                                                                     (t, u) ->
@@ -5929,8 +6228,8 @@ let (tc_layered_eff_decl :
                                                                     g g_tm in
                                                                     (uu___28,
                                                                     uu___29))))
-                                                               | uu___23 ->
-                                                                   let uu___24
+                                                                | uu___23 ->
+                                                                    let uu___24
                                                                     =
                                                                     let uu___25
                                                                     =
@@ -5953,20 +6252,21 @@ let (tc_layered_eff_decl :
                                                                     uu___28 in
                                                                     (FStar_Errors_Codes.Fatal_ActionMustHaveFunctionType,
                                                                     uu___25) in
-                                                                   FStar_Errors.raise_error
+                                                                    FStar_Errors.raise_error
                                                                     uu___24 r in
-                                                             match uu___21
-                                                             with
-                                                             | (k, g_k) ->
-                                                                 ((let uu___23
+                                                              match uu___21
+                                                              with
+                                                              | (k, g_k) ->
+                                                                  ((let uu___23
                                                                     =
                                                                     FStar_Compiler_Effect.op_Less_Bar
                                                                     (FStar_TypeChecker_Env.debug
                                                                     env1)
                                                                     (FStar_Options.Other
                                                                     "LayeredEffectsTc") in
-                                                                   if uu___23
-                                                                   then
+                                                                    if
+                                                                    uu___23
+                                                                    then
                                                                     let uu___24
                                                                     =
                                                                     FStar_Syntax_Print.term_to_string
@@ -5974,20 +6274,21 @@ let (tc_layered_eff_decl :
                                                                     FStar_Compiler_Util.print1
                                                                     "Expected action type: %s\n"
                                                                     uu___24
-                                                                   else ());
-                                                                  (let g =
+                                                                    else ());
+                                                                   (let g =
                                                                     FStar_TypeChecker_Rel.teq
                                                                     env1
                                                                     act_typ1
                                                                     k in
-                                                                   FStar_Compiler_List.iter
+                                                                    FStar_Compiler_List.iter
                                                                     (FStar_TypeChecker_Rel.force_trivial_guard
                                                                     env1)
                                                                     [g_t;
                                                                     g_d;
                                                                     g_k;
                                                                     g];
-                                                                   (let uu___25
+                                                                    (
+                                                                    let uu___25
                                                                     =
                                                                     FStar_Compiler_Effect.op_Less_Bar
                                                                     (FStar_TypeChecker_Env.debug
@@ -6005,7 +6306,8 @@ let (tc_layered_eff_decl :
                                                                     "Expected action type after unification: %s\n"
                                                                     uu___26
                                                                     else ());
-                                                                   (let act_typ2
+                                                                    (
+                                                                    let act_typ2
                                                                     =
                                                                     let err_msg
                                                                     t =
@@ -6297,222 +6599,226 @@ let (tc_layered_eff_decl :
                                                                     FStar_Errors.raise_error
                                                                     uu___30 r)) in
                                                                     act2))))))))) in
-                                          let extraction_mode =
-                                            let has_primitive_extraction =
-                                              FStar_Syntax_Util.has_attribute
-                                                ed.FStar_Syntax_Syntax.eff_attrs
-                                                FStar_Parser_Const.primitive_extraction_attr in
-                                            let is_reifiable =
-                                              FStar_Compiler_List.contains
-                                                FStar_Syntax_Syntax.Reifiable
-                                                quals in
-                                            if
-                                              has_primitive_extraction &&
-                                                is_reifiable
-                                            then
-                                              let uu___14 =
-                                                let uu___15 =
-                                                  let uu___16 =
-                                                    FStar_Ident.string_of_lid
-                                                      ed.FStar_Syntax_Syntax.mname in
-                                                  FStar_Compiler_Util.format1
-                                                    "Effect %s is declared to be both primitive extraction and reifiable"
-                                                    uu___16 in
-                                                (FStar_Errors_Codes.Fatal_UnexpectedEffect,
-                                                  uu___15) in
-                                              let uu___15 =
-                                                FStar_Ident.range_of_lid
-                                                  ed.FStar_Syntax_Syntax.mname in
-                                              FStar_Errors.raise_error
-                                                uu___14 uu___15
-                                            else
-                                              if has_primitive_extraction
-                                              then
-                                                FStar_Syntax_Syntax.Extract_primitive
-                                              else
-                                                (let uu___16 =
-                                                   let uu___17 =
-                                                     let uu___18 = signature in
-                                                     match uu___18 with
-                                                     | (us, t, uu___19) ->
-                                                         (us, t) in
-                                                   match uu___17 with
-                                                   | (us, t) ->
-                                                       let uu___18 =
-                                                         let uu___19 =
-                                                           FStar_Syntax_Subst.compress
-                                                             t in
-                                                         uu___19.FStar_Syntax_Syntax.n in
-                                                       (match uu___18 with
-                                                        | FStar_Syntax_Syntax.Tm_arrow
-                                                            {
-                                                              FStar_Syntax_Syntax.bs1
-                                                                = bs;
-                                                              FStar_Syntax_Syntax.comp
-                                                                = uu___19;_}
-                                                            ->
-                                                            let uu___20 =
-                                                              FStar_Syntax_Subst.open_binders
-                                                                bs in
-                                                            (match uu___20
-                                                             with
-                                                             | a_b::rest_bs
-                                                                 ->
-                                                                 (us, a_b,
-                                                                   rest_bs))
-                                                        | uu___19 ->
-                                                            failwith
-                                                              "Impossible!") in
-                                                 match uu___16 with
-                                                 | (us, a_b, rest_bs) ->
-                                                     let env =
-                                                       FStar_TypeChecker_Env.push_univ_vars
-                                                         env0 us in
-                                                     let env1 =
-                                                       FStar_TypeChecker_Env.push_binders
-                                                         env [a_b] in
-                                                     let uu___17 =
-                                                       FStar_Compiler_List.fold_left
-                                                         (fun uu___18 ->
-                                                            fun b ->
-                                                              match uu___18
+                                           let extraction_mode =
+                                             let has_primitive_extraction =
+                                               FStar_Syntax_Util.has_attribute
+                                                 ed.FStar_Syntax_Syntax.eff_attrs
+                                                 FStar_Parser_Const.primitive_extraction_attr in
+                                             let is_reifiable =
+                                               FStar_Compiler_List.contains
+                                                 FStar_Syntax_Syntax.Reifiable
+                                                 quals in
+                                             if
+                                               has_primitive_extraction &&
+                                                 is_reifiable
+                                             then
+                                               let uu___14 =
+                                                 let uu___15 =
+                                                   let uu___16 =
+                                                     FStar_Ident.string_of_lid
+                                                       ed.FStar_Syntax_Syntax.mname in
+                                                   FStar_Compiler_Util.format1
+                                                     "Effect %s is declared to be both primitive extraction and reifiable"
+                                                     uu___16 in
+                                                 (FStar_Errors_Codes.Fatal_UnexpectedEffect,
+                                                   uu___15) in
+                                               let uu___15 =
+                                                 FStar_Ident.range_of_lid
+                                                   ed.FStar_Syntax_Syntax.mname in
+                                               FStar_Errors.raise_error
+                                                 uu___14 uu___15
+                                             else
+                                               if has_primitive_extraction
+                                               then
+                                                 FStar_Syntax_Syntax.Extract_primitive
+                                               else
+                                                 (let uu___16 =
+                                                    let uu___17 =
+                                                      let uu___18 = signature in
+                                                      match uu___18 with
+                                                      | (us, t, uu___19) ->
+                                                          (us, t) in
+                                                    match uu___17 with
+                                                    | (us, t) ->
+                                                        let uu___18 =
+                                                          let uu___19 =
+                                                            FStar_Syntax_Subst.compress
+                                                              t in
+                                                          uu___19.FStar_Syntax_Syntax.n in
+                                                        (match uu___18 with
+                                                         | FStar_Syntax_Syntax.Tm_arrow
+                                                             {
+                                                               FStar_Syntax_Syntax.bs1
+                                                                 = bs;
+                                                               FStar_Syntax_Syntax.comp
+                                                                 = uu___19;_}
+                                                             ->
+                                                             let uu___20 =
+                                                               FStar_Syntax_Subst.open_binders
+                                                                 bs in
+                                                             (match uu___20
                                                               with
-                                                              | (env2, r) ->
-                                                                  let r1 =
+                                                              | a_b::rest_bs
+                                                                  ->
+                                                                  (us, a_b,
+                                                                    rest_bs))
+                                                         | uu___19 ->
+                                                             failwith
+                                                               "Impossible!") in
+                                                  match uu___16 with
+                                                  | (us, a_b, rest_bs) ->
+                                                      let env =
+                                                        FStar_TypeChecker_Env.push_univ_vars
+                                                          env0 us in
+                                                      let env1 =
+                                                        FStar_TypeChecker_Env.push_binders
+                                                          env [a_b] in
+                                                      let uu___17 =
+                                                        FStar_Compiler_List.fold_left
+                                                          (fun uu___18 ->
+                                                             fun b ->
+                                                               match uu___18
+                                                               with
+                                                               | (env2, r) ->
+                                                                   let r1 =
                                                                     r &&
                                                                     (FStar_TypeChecker_Normalize.non_info_norm
                                                                     env2
                                                                     (b.FStar_Syntax_Syntax.binder_bv).FStar_Syntax_Syntax.sort) in
-                                                                  let uu___19
+                                                                   let uu___19
                                                                     =
                                                                     FStar_TypeChecker_Env.push_binders
                                                                     env2 
                                                                     [b] in
-                                                                  (uu___19,
+                                                                   (uu___19,
                                                                     r1))
-                                                         (env1, true) rest_bs in
-                                                     (match uu___17 with
-                                                      | (uu___18, r) ->
-                                                          let uu___19 =
-                                                            (r &&
-                                                               (FStar_Syntax_Syntax.uu___is_Substitutive_combinator
-                                                                  bind_kind))
-                                                              &&
-                                                              (is_reifiable
-                                                                 ||
-                                                                 (FStar_Ident.lid_equals
+                                                          (env1, true)
+                                                          rest_bs in
+                                                      (match uu___17 with
+                                                       | (uu___18, r) ->
+                                                           let uu___19 =
+                                                             (r &&
+                                                                (FStar_Syntax_Syntax.uu___is_Substitutive_combinator
+                                                                   bind_kind))
+                                                               &&
+                                                               (is_reifiable
+                                                                  ||
+                                                                  (FStar_Ident.lid_equals
                                                                     ed.FStar_Syntax_Syntax.mname
                                                                     FStar_Parser_Const.effect_TAC_lid)) in
-                                                          if uu___19
-                                                          then
-                                                            FStar_Syntax_Syntax.Extract_reify
-                                                          else
-                                                            (let m =
-                                                               if
-                                                                 Prims.op_Negation
-                                                                   r
-                                                               then
-                                                                 "one or more effect indices are informative"
-                                                               else
-                                                                 if
-                                                                   Prims.op_Negation
+                                                           if uu___19
+                                                           then
+                                                             FStar_Syntax_Syntax.Extract_reify
+                                                           else
+                                                             (let m =
+                                                                if
+                                                                  Prims.op_Negation
+                                                                    r
+                                                                then
+                                                                  "one or more effect indices are informative"
+                                                                else
+                                                                  if
+                                                                    Prims.op_Negation
                                                                     (FStar_Syntax_Syntax.uu___is_Substitutive_combinator
                                                                     bind_kind)
-                                                                 then
-                                                                   "bind is not substitutive"
-                                                                 else
-                                                                   "the effect is not reifiable" in
-                                                             FStar_Syntax_Syntax.Extract_none
-                                                               m))) in
-                                          (let uu___15 =
-                                             FStar_Compiler_Effect.op_Less_Bar
-                                               (FStar_TypeChecker_Env.debug
-                                                  env0)
-                                               (FStar_Options.Other
-                                                  "LayeredEffectsTc") in
-                                           if uu___15
-                                           then
-                                             let uu___16 =
-                                               FStar_Ident.string_of_lid
-                                                 ed.FStar_Syntax_Syntax.mname in
-                                             let uu___17 =
-                                               FStar_Syntax_Print.eff_extraction_mode_to_string
-                                                 extraction_mode in
-                                             FStar_Compiler_Util.print2
-                                               "Effect %s has extraction mode %s\n"
-                                               uu___16 uu___17
-                                           else ());
-                                          (let tschemes_of uu___15 k =
-                                             match uu___15 with
-                                             | (us, t, ty) ->
-                                                 ((us, t), (us, ty), k) in
-                                           let tschemes_of2 uu___15 =
-                                             match uu___15 with
-                                             | (us, t, ty) ->
-                                                 ((us, t), (us, ty)) in
-                                           let combinators =
-                                             FStar_Syntax_Syntax.Layered_eff
-                                               {
-                                                 FStar_Syntax_Syntax.l_repr =
-                                                   (tschemes_of2 repr);
-                                                 FStar_Syntax_Syntax.l_return
-                                                   =
-                                                   (tschemes_of2 return_repr);
-                                                 FStar_Syntax_Syntax.l_bind =
-                                                   (tschemes_of bind_repr
-                                                      (FStar_Pervasives_Native.Some
-                                                         bind_kind));
-                                                 FStar_Syntax_Syntax.l_subcomp
-                                                   =
-                                                   (tschemes_of stronger_repr
-                                                      (FStar_Pervasives_Native.Some
-                                                         subcomp_kind));
-                                                 FStar_Syntax_Syntax.l_if_then_else
-                                                   =
-                                                   (tschemes_of if_then_else
-                                                      (FStar_Pervasives_Native.Some
-                                                         ite_kind));
-                                                 FStar_Syntax_Syntax.l_close
-                                                   =
-                                                   (match close_ with
-                                                    | FStar_Pervasives_Native.None
-                                                        ->
-                                                        FStar_Pervasives_Native.None
-                                                    | FStar_Pervasives_Native.Some
-                                                        (us, t, ty) ->
-                                                        FStar_Pervasives_Native.Some
-                                                          ((us, t), (us, ty)))
-                                               } in
-                                           let uu___15 =
-                                             FStar_Compiler_List.map
-                                               (tc_action env0)
-                                               ed.FStar_Syntax_Syntax.actions in
-                                           {
-                                             FStar_Syntax_Syntax.mname =
-                                               (ed.FStar_Syntax_Syntax.mname);
-                                             FStar_Syntax_Syntax.cattributes
-                                               =
-                                               (ed.FStar_Syntax_Syntax.cattributes);
-                                             FStar_Syntax_Syntax.univs =
-                                               (ed.FStar_Syntax_Syntax.univs);
-                                             FStar_Syntax_Syntax.binders =
-                                               (ed.FStar_Syntax_Syntax.binders);
-                                             FStar_Syntax_Syntax.signature =
-                                               (FStar_Syntax_Syntax.Layered_eff_sig
-                                                  (num_effect_params,
-                                                    (let uu___16 = signature in
-                                                     match uu___16 with
-                                                     | (us, t, uu___17) ->
-                                                         (us, t))));
-                                             FStar_Syntax_Syntax.combinators
-                                               = combinators;
-                                             FStar_Syntax_Syntax.actions =
-                                               uu___15;
-                                             FStar_Syntax_Syntax.eff_attrs =
-                                               (ed.FStar_Syntax_Syntax.eff_attrs);
-                                             FStar_Syntax_Syntax.extraction_mode
-                                               = extraction_mode
-                                           })))))))))))))
+                                                                  then
+                                                                    "bind is not substitutive"
+                                                                  else
+                                                                    "the effect is not reifiable" in
+                                                              FStar_Syntax_Syntax.Extract_none
+                                                                m))) in
+                                           (let uu___15 =
+                                              FStar_Compiler_Effect.op_Less_Bar
+                                                (FStar_TypeChecker_Env.debug
+                                                   env0)
+                                                (FStar_Options.Other
+                                                   "LayeredEffectsTc") in
+                                            if uu___15
+                                            then
+                                              let uu___16 =
+                                                FStar_Ident.string_of_lid
+                                                  ed.FStar_Syntax_Syntax.mname in
+                                              let uu___17 =
+                                                FStar_Syntax_Print.eff_extraction_mode_to_string
+                                                  extraction_mode in
+                                              FStar_Compiler_Util.print2
+                                                "Effect %s has extraction mode %s\n"
+                                                uu___16 uu___17
+                                            else ());
+                                           (let tschemes_of uu___15 k =
+                                              match uu___15 with
+                                              | (us, t, ty) ->
+                                                  ((us, t), (us, ty), k) in
+                                            let tschemes_of2 uu___15 =
+                                              match uu___15 with
+                                              | (us, t, ty) ->
+                                                  ((us, t), (us, ty)) in
+                                            let combinators =
+                                              FStar_Syntax_Syntax.Layered_eff
+                                                {
+                                                  FStar_Syntax_Syntax.l_repr
+                                                    = (tschemes_of2 repr);
+                                                  FStar_Syntax_Syntax.l_return
+                                                    =
+                                                    (tschemes_of2 return_repr);
+                                                  FStar_Syntax_Syntax.l_bind
+                                                    =
+                                                    (tschemes_of bind_repr
+                                                       (FStar_Pervasives_Native.Some
+                                                          bind_kind));
+                                                  FStar_Syntax_Syntax.l_subcomp
+                                                    =
+                                                    (tschemes_of
+                                                       stronger_repr
+                                                       (FStar_Pervasives_Native.Some
+                                                          subcomp_kind));
+                                                  FStar_Syntax_Syntax.l_if_then_else
+                                                    =
+                                                    (tschemes_of if_then_else
+                                                       (FStar_Pervasives_Native.Some
+                                                          ite_kind));
+                                                  FStar_Syntax_Syntax.l_close
+                                                    =
+                                                    (match close_ with
+                                                     | FStar_Pervasives_Native.None
+                                                         ->
+                                                         FStar_Pervasives_Native.None
+                                                     | FStar_Pervasives_Native.Some
+                                                         (us, t, ty) ->
+                                                         FStar_Pervasives_Native.Some
+                                                           ((us, t),
+                                                             (us, ty)))
+                                                } in
+                                            let uu___15 =
+                                              FStar_Compiler_List.map
+                                                (tc_action env0)
+                                                ed.FStar_Syntax_Syntax.actions in
+                                            {
+                                              FStar_Syntax_Syntax.mname =
+                                                (ed.FStar_Syntax_Syntax.mname);
+                                              FStar_Syntax_Syntax.cattributes
+                                                =
+                                                (ed.FStar_Syntax_Syntax.cattributes);
+                                              FStar_Syntax_Syntax.univs =
+                                                (ed.FStar_Syntax_Syntax.univs);
+                                              FStar_Syntax_Syntax.binders =
+                                                (ed.FStar_Syntax_Syntax.binders);
+                                              FStar_Syntax_Syntax.signature =
+                                                (FStar_Syntax_Syntax.Layered_eff_sig
+                                                   (num_effect_params,
+                                                     (let uu___16 = signature in
+                                                      match uu___16 with
+                                                      | (us, t, uu___17) ->
+                                                          (us, t))));
+                                              FStar_Syntax_Syntax.combinators
+                                                = combinators;
+                                              FStar_Syntax_Syntax.actions =
+                                                uu___15;
+                                              FStar_Syntax_Syntax.eff_attrs =
+                                                (ed.FStar_Syntax_Syntax.eff_attrs);
+                                              FStar_Syntax_Syntax.extraction_mode
+                                                = extraction_mode
+                                            }))))))))))))))
 let (tc_non_layered_eff_decl :
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.eff_decl ->

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_TcTerm.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_TcTerm.ml
@@ -9742,20 +9742,30 @@ and (tc_eqn :
                                                      g_branch in
                                                  (match uu___13 with
                                                   | (c1, g_branch1) ->
-                                                      let branch_has_layered_effect
+                                                      let close_branch_with_substitutions
                                                         =
-                                                        let uu___14 =
+                                                        let m =
                                                           FStar_Compiler_Effect.op_Bar_Greater
                                                             c1.FStar_TypeChecker_Common.eff_name
                                                             (FStar_TypeChecker_Env.norm_eff_name
                                                                env) in
-                                                        FStar_Compiler_Effect.op_Bar_Greater
-                                                          uu___14
-                                                          (FStar_TypeChecker_Env.is_layered_effect
-                                                             env) in
+                                                        (FStar_TypeChecker_Env.is_layered_effect
+                                                           env m)
+                                                          &&
+                                                          (let uu___14 =
+                                                             let uu___15 =
+                                                               FStar_Compiler_Effect.op_Bar_Greater
+                                                                 m
+                                                                 (FStar_TypeChecker_Env.get_effect_decl
+                                                                    env) in
+                                                             FStar_Compiler_Effect.op_Bar_Greater
+                                                               uu___15
+                                                               FStar_Syntax_Util.get_layered_close_combinator in
+                                                           FStar_Pervasives_Native.uu___is_None
+                                                             uu___14) in
                                                       let uu___14 =
                                                         if
-                                                          branch_has_layered_effect
+                                                          close_branch_with_substitutions
                                                         then
                                                           let c2 =
                                                             let uu___15 =
@@ -9870,7 +9880,7 @@ and (tc_eqn :
                                                                    c_weak
                                                                else c_weak in
                                                              if
-                                                               branch_has_layered_effect
+                                                               close_branch_with_substitutions
                                                              then
                                                                ((let uu___16
                                                                    =
@@ -10209,7 +10219,7 @@ and (tc_eqn :
                                                                     FStar_TypeChecker_Env.push_bv
                                                                     env
                                                                     scrutinee in
-                                                                    FStar_TypeChecker_Util.close_layered_lcomp
+                                                                    FStar_TypeChecker_Util.close_layered_lcomp_with_substitutions
                                                                     uu___19
                                                                     pat_bvs
                                                                     pat_bv_tms2 in
@@ -10218,13 +10228,38 @@ and (tc_eqn :
                                                                     uu___18)))
                                                              else
                                                                (let uu___16 =
-                                                                  FStar_TypeChecker_Env.push_bv
+                                                                  let uu___17
+                                                                    =
+                                                                    FStar_Compiler_Effect.op_Bar_Greater
+                                                                    c_weak1.FStar_TypeChecker_Common.eff_name
+                                                                    (FStar_TypeChecker_Env.norm_eff_name
+                                                                    env) in
+                                                                  FStar_Compiler_Effect.op_Bar_Greater
+                                                                    uu___17
+                                                                    (
+                                                                    FStar_TypeChecker_Env.is_layered_effect
+                                                                    env) in
+                                                                if uu___16
+                                                                then
+                                                                  let uu___17
+                                                                    =
+                                                                    FStar_TypeChecker_Env.push_bv
                                                                     env
                                                                     scrutinee in
-                                                                FStar_TypeChecker_Util.close_wp_lcomp
-                                                                  uu___16
-                                                                  pat_bvs
-                                                                  c_weak1) in
+                                                                  FStar_TypeChecker_Util.close_layered_lcomp_with_combinator
+                                                                    uu___17
+                                                                    pat_bvs
+                                                                    c_weak1
+                                                                else
+                                                                  (let uu___18
+                                                                    =
+                                                                    FStar_TypeChecker_Env.push_bv
+                                                                    env
+                                                                    scrutinee in
+                                                                   FStar_TypeChecker_Util.close_wp_lcomp
+                                                                    uu___18
+                                                                    pat_bvs
+                                                                    c_weak1)) in
                                                            let uu___15 =
                                                              FStar_TypeChecker_Env.close_guard
                                                                env binders

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_Util.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_Util.ml
@@ -1247,7 +1247,7 @@ let (substitutive_indexed_close_substs :
                                         [uu___5] in
                                       FStar_Compiler_List.op_At ss uu___4)
                            subst1 close_bs2 ct_args1)
-let (mk_indexed_close :
+let (close_layered_comp_with_combinator :
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.bv Prims.list ->
       FStar_Syntax_Syntax.comp -> FStar_Syntax_Syntax.comp)
@@ -1319,7 +1319,27 @@ let (mk_indexed_close :
             FStar_Syntax_Syntax.effect_args = effect_args;
             FStar_Syntax_Syntax.flags = (ct.FStar_Syntax_Syntax.flags)
           }
-let (close_layered_lcomp :
+let (close_layered_lcomp_with_combinator :
+  FStar_TypeChecker_Env.env ->
+    FStar_Syntax_Syntax.bv Prims.list ->
+      FStar_TypeChecker_Common.lcomp -> FStar_TypeChecker_Common.lcomp)
+  =
+  fun env ->
+    fun bvs ->
+      fun lc ->
+        let bs =
+          FStar_Compiler_Effect.op_Bar_Greater bvs
+            (FStar_Compiler_List.map FStar_Syntax_Syntax.mk_binder) in
+        FStar_Compiler_Effect.op_Bar_Greater lc
+          (FStar_TypeChecker_Common.apply_lcomp
+             (close_layered_comp_with_combinator env bvs)
+             (fun g ->
+                let uu___ =
+                  FStar_Compiler_Effect.op_Bar_Greater g
+                    (FStar_TypeChecker_Env.close_guard env bs) in
+                FStar_Compiler_Effect.op_Bar_Greater uu___
+                  (close_guard_implicits env false bs)))
+let (close_layered_lcomp_with_substitutions :
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.bv Prims.list ->
       FStar_Syntax_Syntax.term Prims.list ->

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_Util.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_Util.ml
@@ -1210,43 +1210,52 @@ let (substitutive_indexed_close_substs :
                           (match uu___3 with
                            | (ct_eff_params_args, ct_args1) ->
                                let uu___4 =
-                                 FStar_Compiler_List.map2
-                                   (fun b ->
-                                      fun uu___5 ->
-                                        match uu___5 with
-                                        | (arg, uu___6) ->
-                                            FStar_Syntax_Syntax.NT
-                                              ((b.FStar_Syntax_Syntax.binder_bv),
-                                                arg)) eff_params_bs
-                                   ct_eff_params_args in
+                                 let uu___5 =
+                                   FStar_Compiler_List.map2
+                                     (fun b ->
+                                        fun uu___6 ->
+                                          match uu___6 with
+                                          | (arg, uu___7) ->
+                                              FStar_Syntax_Syntax.NT
+                                                ((b.FStar_Syntax_Syntax.binder_bv),
+                                                  arg)) eff_params_bs
+                                     ct_eff_params_args in
+                                 FStar_Compiler_List.op_At subst uu___5 in
                                (close_bs2, uu___4, ct_args1)) in
                     (match uu___1 with
                      | (close_bs2, subst1, ct_args1) ->
-                         FStar_Compiler_List.fold_left2
-                           (fun ss ->
-                              fun b ->
-                                fun uu___2 ->
-                                  match uu___2 with
-                                  | (ct_arg, uu___3) ->
-                                      let uu___4 =
-                                        let uu___5 =
-                                          let uu___6 =
-                                            let uu___7 =
-                                              let uu___8 =
-                                                let uu___9 =
-                                                  FStar_Compiler_Effect.op_Bar_Greater
-                                                    b_bv
-                                                    FStar_Syntax_Syntax.mk_binder in
-                                                [uu___9] in
-                                              FStar_Syntax_Util.abs uu___8
-                                                ct_arg
-                                                FStar_Pervasives_Native.None in
-                                            ((b.FStar_Syntax_Syntax.binder_bv),
-                                              uu___7) in
-                                          FStar_Syntax_Syntax.NT uu___6 in
-                                        [uu___5] in
-                                      FStar_Compiler_List.op_At ss uu___4)
-                           subst1 close_bs2 ct_args1)
+                         let uu___2 =
+                           FStar_Compiler_List.splitAt
+                             ((FStar_Compiler_List.length close_bs2) -
+                                Prims.int_one) close_bs2 in
+                         (match uu___2 with
+                          | (close_bs3, uu___3) ->
+                              FStar_Compiler_List.fold_left2
+                                (fun ss ->
+                                   fun b ->
+                                     fun uu___4 ->
+                                       match uu___4 with
+                                       | (ct_arg, uu___5) ->
+                                           let uu___6 =
+                                             let uu___7 =
+                                               let uu___8 =
+                                                 let uu___9 =
+                                                   let uu___10 =
+                                                     let uu___11 =
+                                                       FStar_Compiler_Effect.op_Bar_Greater
+                                                         b_bv
+                                                         FStar_Syntax_Syntax.mk_binder in
+                                                     [uu___11] in
+                                                   FStar_Syntax_Util.abs
+                                                     uu___10 ct_arg
+                                                     FStar_Pervasives_Native.None in
+                                                 ((b.FStar_Syntax_Syntax.binder_bv),
+                                                   uu___9) in
+                                               FStar_Syntax_Syntax.NT uu___8 in
+                                             [uu___7] in
+                                           FStar_Compiler_List.op_At ss
+                                             uu___6) subst1 close_bs3
+                                ct_args1))
 let (close_layered_comp_with_combinator :
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.bv Prims.list ->

--- a/src/syntax/FStar.Syntax.Print.fst
+++ b/src/syntax/FStar.Syntax.Print.fst
@@ -658,12 +658,17 @@ let layered_eff_combinators_to_string combs =
   ; l_bind = %s\n\
   ; l_subcomp = %s\n\
   ; l_if_then_else = %s\n
+  %s
   }\n"
     [ to_str2 combs.l_repr;
       to_str2 combs.l_return;
       to_str  combs.l_bind;
       to_str  combs.l_subcomp;
-      to_str  combs.l_if_then_else ]
+      to_str  combs.l_if_then_else;
+
+      (if None? combs.l_close then ""
+       else U.format1 "; l_close = %s\n" (combs.l_close |> must |> to_str2));
+    ]
 
 let eff_combinators_to_string = function
   | Primitive_eff combs

--- a/src/syntax/FStar.Syntax.Syntax.fsti
+++ b/src/syntax/FStar.Syntax.Syntax.fsti
@@ -563,6 +563,7 @@ type layered_eff_combinators = {
   l_bind         : (tscheme * tscheme * option indexed_effect_combinator_kind);
   l_subcomp      : (tscheme * tscheme * option indexed_effect_combinator_kind);
   l_if_then_else : (tscheme * tscheme * option indexed_effect_combinator_kind);
+  l_close        : option (tscheme * tscheme)
 }
 
 type eff_combinators =

--- a/src/syntax/FStar.Syntax.Syntax.fsti
+++ b/src/syntax/FStar.Syntax.Syntax.fsti
@@ -556,6 +556,10 @@ type wp_eff_combinators = {
  *
  * Additionally, bind, subcomp, and if_then_else have a combinator kind,
  *   this is also set to None in desugaring and set during typechecking the effect
+ *
+ * The close combinator is optional
+ *   If it is not provided as part of the effect declaration,
+ *   the typechecker also does not synthesize it (unlike if-then-else and subcomp)
  *)
 type layered_eff_combinators = {
   l_repr         : (tscheme * tscheme);

--- a/src/syntax/FStar.Syntax.Util.fst
+++ b/src/syntax/FStar.Syntax.Util.fst
@@ -2388,13 +2388,20 @@ let apply_layered_eff_combinators (f:tscheme -> tscheme) (combs:layered_eff_comb
     l_return = map2 combs.l_return;
     l_bind = map3 combs.l_bind;
     l_subcomp = map3 combs.l_subcomp;
-    l_if_then_else = map3 combs.l_if_then_else }
+    l_if_then_else = map3 combs.l_if_then_else;
+    l_close = map_option map2 combs.l_close; }
 
 let apply_eff_combinators (f:tscheme -> tscheme) (combs:eff_combinators) : eff_combinators =
   match combs with
   | Primitive_eff combs -> Primitive_eff (apply_wp_eff_combinators f combs)
   | DM4F_eff combs -> DM4F_eff (apply_wp_eff_combinators f combs)
   | Layered_eff combs -> Layered_eff (apply_layered_eff_combinators f combs)
+
+let get_layered_close_combinator (ed:eff_decl) : option tscheme =
+  match ed.combinators with
+  | Layered_eff {l_close=None} -> None
+  | Layered_eff {l_close=Some (ts, _)} -> Some ts
+  | _ -> None
 
 let get_wp_close_combinator (ed:eff_decl) : option tscheme =
   match ed.combinators with

--- a/src/syntax/FStar.Syntax.Visit.fst
+++ b/src/syntax/FStar.Syntax.Visit.fst
@@ -282,11 +282,11 @@ let on_sub_wp_eff_combinators vfs (wpcs : wp_eff_combinators) : wp_eff_combinato
 let on_sub_layered_eff_combinators vfs (lecs : layered_eff_combinators) : layered_eff_combinators =
   let f_tscheme = f_tscheme vfs in
   {
-    l_repr         = on_tuple2  f_tscheme f_tscheme           lecs.l_repr;
-    l_return       = on_tuple2  f_tscheme f_tscheme           lecs.l_return;
-    l_bind         = on_tuple3  f_tscheme f_tscheme id        lecs.l_bind;
-    l_subcomp      = on_tuple3  f_tscheme f_tscheme id        lecs.l_subcomp;
-    l_if_then_else = on_tuple3  f_tscheme f_tscheme id        lecs.l_if_then_else;
+    l_repr         = on_tuple2  f_tscheme f_tscheme             lecs.l_repr;
+    l_return       = on_tuple2  f_tscheme f_tscheme             lecs.l_return;
+    l_bind         = on_tuple3  f_tscheme f_tscheme id          lecs.l_bind;
+    l_subcomp      = on_tuple3  f_tscheme f_tscheme id          lecs.l_subcomp;
+    l_if_then_else = on_tuple3  f_tscheme f_tscheme id          lecs.l_if_then_else;
     l_close        = map_option (on_tuple2 f_tscheme f_tscheme) lecs.l_close;
   }
 

--- a/src/syntax/FStar.Syntax.Visit.fst
+++ b/src/syntax/FStar.Syntax.Visit.fst
@@ -282,11 +282,12 @@ let on_sub_wp_eff_combinators vfs (wpcs : wp_eff_combinators) : wp_eff_combinato
 let on_sub_layered_eff_combinators vfs (lecs : layered_eff_combinators) : layered_eff_combinators =
   let f_tscheme = f_tscheme vfs in
   {
-    l_repr         = on_tuple2 f_tscheme f_tscheme    lecs.l_repr;
-    l_return       = on_tuple2 f_tscheme f_tscheme    lecs.l_return;
-    l_bind         = on_tuple3 f_tscheme f_tscheme id lecs.l_bind;
-    l_subcomp      = on_tuple3 f_tscheme f_tscheme id lecs.l_subcomp;
-    l_if_then_else = on_tuple3 f_tscheme f_tscheme id lecs.l_if_then_else;
+    l_repr         = on_tuple2  f_tscheme f_tscheme           lecs.l_repr;
+    l_return       = on_tuple2  f_tscheme f_tscheme           lecs.l_return;
+    l_bind         = on_tuple3  f_tscheme f_tscheme id        lecs.l_bind;
+    l_subcomp      = on_tuple3  f_tscheme f_tscheme id        lecs.l_subcomp;
+    l_if_then_else = on_tuple3  f_tscheme f_tscheme id        lecs.l_if_then_else;
+    l_close        = map_option (on_tuple2 f_tscheme f_tscheme) lecs.l_close;
   }
 
 let on_sub_combinators vfs (cbs : eff_combinators) : eff_combinators =

--- a/src/tosyntax/FStar.ToSyntax.ToSyntax.fst
+++ b/src/tosyntax/FStar.ToSyntax.ToSyntax.fst
@@ -3236,7 +3236,7 @@ let rec desugar_effect env d (quals: qualifiers) (is_layered:bool) eff_name eff_
          * AR: subcomp and if_then_else are optional
          *     but adding here so as not to count them as actions
          *)
-      else if is_layered then rr_members @ [ "subcomp"; "if_then_else" ]
+      else if is_layered then rr_members @ [ "subcomp"; "if_then_else"; "close" ]
         (* the first 3 are optional but must not be counted as actions *)
       else rr_members @ [
         "return_wp";
@@ -3327,6 +3327,7 @@ let rec desugar_effect env d (quals: qualifiers) (is_layered:bool) eff_name eff_
       else if is_layered then
         let has_subcomp = List.existsb (fun decl -> name_of_eff_decl decl = "subcomp") eff_decls in
         let has_if_then_else = List.existsb (fun decl -> name_of_eff_decl decl = "if_then_else") eff_decls in
+        let has_close = List.existsb (fun decl -> name_of_eff_decl decl = "close") eff_decls in
 
         //setting the second component to dummy_ts,
         //  and kind to None, typechecker fills them in
@@ -3377,6 +3378,9 @@ let rec desugar_effect env d (quals: qualifiers) (is_layered:bool) eff_name eff_
           l_if_then_else =
             if has_if_then_else then lookup "if_then_else" |> to_comb
             else dummy_tscheme, dummy_tscheme, None;
+          l_close =
+            if has_close then Some (lookup "close", dummy_tscheme)
+            else None;
         })
       else
         let rr = BU.for_some (function S.Reifiable | S.Reflectable _ -> true | _ -> false) qualifiers in

--- a/src/tosyntax/FStar.ToSyntax.ToSyntax.fst
+++ b/src/tosyntax/FStar.ToSyntax.ToSyntax.fst
@@ -3233,7 +3233,7 @@ let rec desugar_effect env d (quals: qualifiers) (is_layered:bool) eff_name eff_
       let rr_members = ["repr" ; "return" ; "bind"] in
       if for_free then rr_members
         (*
-         * AR: subcomp and if_then_else are optional
+         * AR: subcomp, if_then_else, and close are optional
          *     but adding here so as not to count them as actions
          *)
       else if is_layered then rr_members @ [ "subcomp"; "if_then_else"; "close" ]
@@ -3380,7 +3380,8 @@ let rec desugar_effect env d (quals: qualifiers) (is_layered:bool) eff_name eff_
             else dummy_tscheme, dummy_tscheme, None;
           l_close =
             if has_close then Some (lookup "close", dummy_tscheme)
-            else None;
+            else None;  // If close is not specified, leave it to None
+                        // The typechecker will also not fill it in
         })
       else
         let rr = BU.for_some (function S.Reifiable | S.Reflectable _ -> true | _ -> false) qualifiers in

--- a/src/typechecker/FStar.TypeChecker.TcEffect.fst
+++ b/src/typechecker/FStar.TypeChecker.TcEffect.fst
@@ -1677,49 +1677,49 @@ Errors.with_ctx (BU.format1 "While checking layered effect definition `%s`" (str
       in
       Some (close_us, k |> SS.close_univ_vars close_us, close_ty) in
     
-  // let _close_is_sound =
-  //   match close_ with
-  //   | None -> ()
-  //   | Some close_ ->
-  //     let us, close_tm, _ = close_ in
-  //     let r = close_tm.pos in
-  //     let us, close_tm = SS.open_univ_vars us close_tm in
-  //     let close_bs, close_body, _ = U.abs_formals close_tm in
-  //     let a_b::b_b::close_bs = close_bs in
-  //     let is_bs, _ = List.splitAt (List.length close_bs - 1) close_bs in
-  //     let x_bv = S.gen_bv "x" None (S.bv_to_name b_b.binder_bv) in
-  //     let args1 = List.map (fun i_b ->
-  //       S.mk_Tm_app (S.bv_to_name i_b.binder_bv) [S.as_arg (S.bv_to_name x_bv)] r
-  //     ) is_bs in
-  //     let args2 =
-  //       match (SS.compress close_body).n with
-  //       | Tm_app {args=a::args} -> args |> List.map fst
-  //       | _ -> raise_error (Errors.Fatal_UnexpectedEffect, "close combinator body not a repr") r in
+  let _close_is_sound =
+    match close_ with
+    | None -> ()
+    | Some close_ ->
+      let us, close_tm, _ = close_ in
+      let r = close_tm.pos in
+      let us, close_tm = SS.open_univ_vars us close_tm in
+      let close_bs, close_body, _ = U.abs_formals close_tm in
+      let a_b::b_b::close_bs = close_bs in
+      let is_bs, _ = List.splitAt (List.length close_bs - 1) close_bs in
+      let x_bv = S.gen_bv "x" None (S.bv_to_name b_b.binder_bv) in
+      let args1 = List.map (fun i_b ->
+        S.mk_Tm_app (S.bv_to_name i_b.binder_bv) [S.as_arg (S.bv_to_name x_bv)] r
+      ) is_bs in
+      let args2 =
+        match (SS.compress close_body).n with
+        | Tm_app {args=a::args} -> args |> List.map fst
+        | _ -> raise_error (Errors.Fatal_UnexpectedEffect, "close combinator body not a repr") r in
 
-  //     let env = Env.push_binders env0 ((a_b:b_b::is_bs)@[x_bv |> S.mk_binder]) in
-  //     let subcomp_ts =
-  //       let (us, _, t) = stronger_repr in
-  //       (us, t) in
-  //     let _, subcomp_t = Env.inst_tscheme_with subcomp_ts [List.hd us |> S.U_name] in
-  //     let a_b_subcomp::subcomp_bs, subcomp_c = U.arrow_formals_comp subcomp_t in
-  //     let subcomp_substs = [ NT (a_b_subcomp.binder_bv, a_b.binder_bv |> S.bv_to_name) ] in
-  //     let subcomp_f_bs, subcomp_bs = List.splitAt (List.length args1) subcomp_bs in
-  //     let subcomp_substs = subcomp_substs @ (List.map2 (fun b arg1 ->
-  //       NT (b.binder_bv, arg1)
-  //     ) subcomp_f_bs args1) in
-  //     let subcomp_g_bs, _ = List.splitAt (List.length args2) subcomp_bs in
-  //     let subcomp_substs = subcomp_substs @ (List.map2 (fun b arg2 ->
-  //       NT (b.binder_bv, arg2)
-  //     ) subcomp_g_bs args2) in
-  //     let subcomp_c = SS.subst_comp subcomp_substs subcomp_c |> Env.unfold_effect_abbrev env in
-  //     let fml = Env.pure_precondition_for_trivial_post
-  //       env
-  //       (List.hd subcomp_c.comp_univs)
-  //       subcomp_c.result_typ
-  //       (subcomp_c.effect_args |> List.hd |> fst)
-  //       r in
-  //     Rel.force_trivial_guard env (fml |> NonTrivial |> Env.guard_of_guard_formula)
-  // in
+      let env = Env.push_binders env0 ((a_b::b_b::is_bs)@[x_bv |> S.mk_binder]) in
+      let subcomp_ts =
+        let (us, _, t) = stronger_repr in
+        (us, t) in
+      let _, subcomp_t = Env.inst_tscheme_with subcomp_ts [List.hd us |> S.U_name] in
+      let a_b_subcomp::subcomp_bs, subcomp_c = U.arrow_formals_comp subcomp_t in
+      let subcomp_substs = [ NT (a_b_subcomp.binder_bv, a_b.binder_bv |> S.bv_to_name) ] in
+      let subcomp_f_bs, subcomp_bs = List.splitAt (List.length args1) subcomp_bs in
+      let subcomp_substs = subcomp_substs @ (List.map2 (fun b arg1 ->
+        NT (b.binder_bv, arg1)
+      ) subcomp_f_bs args1) in
+      let subcomp_g_bs, _ = List.splitAt (List.length args2) subcomp_bs in
+      let subcomp_substs = subcomp_substs @ (List.map2 (fun b arg2 ->
+        NT (b.binder_bv, arg2)
+      ) subcomp_g_bs args2) in
+      let subcomp_c = SS.subst_comp subcomp_substs subcomp_c |> Env.unfold_effect_abbrev env in
+      let fml = Env.pure_precondition_for_trivial_post
+        env
+        (List.hd subcomp_c.comp_univs)
+        subcomp_c.result_typ
+        (subcomp_c.effect_args |> List.hd |> fst)
+        r in
+      Rel.force_trivial_guard env (fml |> NonTrivial |> Env.guard_of_guard_formula)
+  in
 
   (*
    * Actions

--- a/src/typechecker/FStar.TypeChecker.TcEffect.fst
+++ b/src/typechecker/FStar.TypeChecker.TcEffect.fst
@@ -994,8 +994,9 @@ let validate_indexed_effect_close_shape (env:env)
     let repr_app = S.mk_Tm_app repr_t ((a_b.binder_bv |> S.bv_to_name |> S.as_arg)::is_args) Range.dummyRange in
     let f_sort = U.arrow [x_b] (S.mk_Total repr_app) in
     S.gen_bv "f" None f_sort |> S.mk_binder in
+  let env = Env.push_binders env (a_b::b_b::(eff_params_bs@bs)) in 
   let body_tm, g_body = TcUtil.fresh_effect_repr
-    (Env.push_binders env (a_b::b_b::(eff_params_bs@bs)))
+    env
     r
     eff_name
     sig_ts
@@ -1676,6 +1677,49 @@ Errors.with_ctx (BU.format1 "While checking layered effect definition `%s`" (str
       in
       Some (close_us, k |> SS.close_univ_vars close_us, close_ty) in
     
+  // let _close_is_sound =
+  //   match close_ with
+  //   | None -> ()
+  //   | Some close_ ->
+  //     let us, close_tm, _ = close_ in
+  //     let r = close_tm.pos in
+  //     let us, close_tm = SS.open_univ_vars us close_tm in
+  //     let close_bs, close_body, _ = U.abs_formals close_tm in
+  //     let a_b::b_b::close_bs = close_bs in
+  //     let is_bs, _ = List.splitAt (List.length close_bs - 1) close_bs in
+  //     let x_bv = S.gen_bv "x" None (S.bv_to_name b_b.binder_bv) in
+  //     let args1 = List.map (fun i_b ->
+  //       S.mk_Tm_app (S.bv_to_name i_b.binder_bv) [S.as_arg (S.bv_to_name x_bv)] r
+  //     ) is_bs in
+  //     let args2 =
+  //       match (SS.compress close_body).n with
+  //       | Tm_app {args=a::args} -> args |> List.map fst
+  //       | _ -> raise_error (Errors.Fatal_UnexpectedEffect, "close combinator body not a repr") r in
+
+  //     let env = Env.push_binders env0 ((a_b:b_b::is_bs)@[x_bv |> S.mk_binder]) in
+  //     let subcomp_ts =
+  //       let (us, _, t) = stronger_repr in
+  //       (us, t) in
+  //     let _, subcomp_t = Env.inst_tscheme_with subcomp_ts [List.hd us |> S.U_name] in
+  //     let a_b_subcomp::subcomp_bs, subcomp_c = U.arrow_formals_comp subcomp_t in
+  //     let subcomp_substs = [ NT (a_b_subcomp.binder_bv, a_b.binder_bv |> S.bv_to_name) ] in
+  //     let subcomp_f_bs, subcomp_bs = List.splitAt (List.length args1) subcomp_bs in
+  //     let subcomp_substs = subcomp_substs @ (List.map2 (fun b arg1 ->
+  //       NT (b.binder_bv, arg1)
+  //     ) subcomp_f_bs args1) in
+  //     let subcomp_g_bs, _ = List.splitAt (List.length args2) subcomp_bs in
+  //     let subcomp_substs = subcomp_substs @ (List.map2 (fun b arg2 ->
+  //       NT (b.binder_bv, arg2)
+  //     ) subcomp_g_bs args2) in
+  //     let subcomp_c = SS.subst_comp subcomp_substs subcomp_c |> Env.unfold_effect_abbrev env in
+  //     let fml = Env.pure_precondition_for_trivial_post
+  //       env
+  //       (List.hd subcomp_c.comp_univs)
+  //       subcomp_c.result_typ
+  //       (subcomp_c.effect_args |> List.hd |> fst)
+  //       r in
+  //     Rel.force_trivial_guard env (fml |> NonTrivial |> Env.guard_of_guard_formula)
+  // in
 
   (*
    * Actions

--- a/src/typechecker/FStar.TypeChecker.TcEffect.fst
+++ b/src/typechecker/FStar.TypeChecker.TcEffect.fst
@@ -960,6 +960,64 @@ let validate_indexed_effect_ite_shape (env:env)
 
   k, kind
 
+
+//
+// Validate the shape of an indexed effect close combinator
+//
+let validate_indexed_effect_close_shape (env:env)
+  (eff_name:lident)
+  (sig_ts:tscheme)
+  (repr_ts:tscheme)
+  (u_a:univ_name)
+  (u_b:univ_name)
+  (close_tm:term)
+  (num_effect_params:int)
+  (r:Range.range) : term =
+
+  let close_name = BU.format1 "close_%s" (string_of_lid eff_name) in
+
+  let b_b = u_b |> U_name |> U.type_with_u |> S.gen_bv "b" None |> S.mk_binder in
+
+  let a_b::sig_bs = Env.inst_tscheme_with sig_ts [U_name u_a] |> snd |> U.arrow_formals |> fst in
+  let eff_params_bs, sig_bs = List.splitAt num_effect_params sig_bs in
+  let bs = List.map (fun b ->
+    let x_b = S.gen_bv "x" None (S.bv_to_name b_b.binder_bv) |> S.mk_binder in
+    {b with binder_bv={b.binder_bv with sort=U.arrow [x_b] (S.mk_Total b.binder_bv.sort)}}
+  ) sig_bs in
+  let f_b =
+    let _, repr_t = Env.inst_tscheme_with repr_ts [U_name u_a] in
+    let x_b = S.gen_bv "x" None (S.bv_to_name b_b.binder_bv) |> S.mk_binder in
+    let is_args =
+      List.map (fun {binder_bv} ->
+                S.mk_Tm_app (S.bv_to_name binder_bv) [x_b.binder_bv |> S.bv_to_name |> S.as_arg] Range.dummyRange
+                |> S.as_arg) bs in
+    let repr_app = S.mk_Tm_app repr_t ((a_b.binder_bv |> S.bv_to_name |> S.as_arg)::is_args) Range.dummyRange in
+    let f_sort = U.arrow [x_b] (S.mk_Total repr_app) in
+    S.gen_bv "f" None f_sort |> S.mk_binder in
+  let body_tm, g_body = TcUtil.fresh_effect_repr
+    (Env.push_binders env (a_b::b_b::(eff_params_bs@bs)))
+    r
+    eff_name
+    sig_ts
+    (Some repr_ts)
+    (U_name u_a)
+    (a_b.binder_bv |> S.bv_to_name) in
+  
+  let k = U.abs (a_b::b_b::(eff_params_bs@bs@[f_b])) body_tm None in
+
+  let g_eq =
+    match Rel.teq_nosmt env close_tm k with
+    | None ->
+      raise_error (Errors.Fatal_UnexpectedEffect,
+                   BU.format2 "Unexpected term for %s (%s)\n"
+                     close_name
+                     (Print.term_to_string close_tm)) r
+    | Some g -> g in
+  
+  Rel.force_trivial_guard env (Env.conj_guard g_body g_eq);
+
+  k |> N.remove_uvar_solutions env |> SS.compress
+
 //
 // Check the kind of an indexed effect lift
 //
@@ -1601,6 +1659,23 @@ Errors.with_ctx (BU.format1 "While checking layered effect definition `%s`" (str
   )  //Errors.with_ctx
   in
 
+  let close_ =
+    let ts_opt = ed |> U.get_layered_close_combinator in
+    match ts_opt with
+    | None -> None
+    | Some close_ts ->
+      let r = (snd close_ts).pos in
+      let close_us, close_t, close_ty = check_and_gen "close" 2 close_ts in
+      let us, t = SS.open_univ_vars close_us close_t in
+      let env = Env.push_univ_vars env0 us in
+      let k =
+        let sig_ts = let us, t, _ = signature in (us, t) in
+        let repr_ts = let us, t, _ = repr in (us, t) in
+        let [u_a; u_b] = us in
+        validate_indexed_effect_close_shape env ed.mname sig_ts repr_ts u_a u_b t num_effect_params r
+      in
+      Some (close_us, k |> SS.close_univ_vars close_us, close_ty) in
+    
 
   (*
    * Actions
@@ -1785,6 +1860,9 @@ Errors.with_ctx (BU.format1 "While checking layered effect definition `%s`" (str
     l_bind = tschemes_of bind_repr (Some bind_kind);
     l_subcomp = tschemes_of stronger_repr (Some subcomp_kind);
     l_if_then_else = tschemes_of if_then_else (Some ite_kind);
+    l_close = (match close_ with
+               | None -> None
+               | Some (us, t, ty) -> Some ((us, t), (us, ty)));
   }) in
 
   { ed with

--- a/src/typechecker/FStar.TypeChecker.TcTerm.fst
+++ b/src/typechecker/FStar.TypeChecker.TcTerm.fst
@@ -3639,6 +3639,12 @@ and tc_eqn (scrutinee:bv) (env:Env.env) (ret_opt : option match_returns_ascripti
 
      //g_branch is trivial, its logical content is now incorporated within c
 
+     //
+     // Working towards closing the branches comp with the pattern variables
+     // For effects with close combinator defined, we will use that
+     // For other effects, we will close with substituting pattern variables with
+     //   corresponding projector expressions applied to the scrutinee
+     //
      let close_branch_with_substitutions =
        let m = c.eff_name |> Env.norm_eff_name env in
        Env.is_layered_effect env m &&

--- a/src/typechecker/FStar.TypeChecker.TcTerm.fst
+++ b/src/typechecker/FStar.TypeChecker.TcTerm.fst
@@ -3639,11 +3639,14 @@ and tc_eqn (scrutinee:bv) (env:Env.env) (ret_opt : option match_returns_ascripti
 
      //g_branch is trivial, its logical content is now incorporated within c
 
-     let branch_has_layered_effect = c.eff_name |> Env.norm_eff_name env |> Env.is_layered_effect env in
+     let close_branch_with_substitutions =
+       let m = c.eff_name |> Env.norm_eff_name env in
+       Env.is_layered_effect env m &&
+       None? (m |> Env.get_effect_decl env |> U.get_layered_close_combinator) in
 
      (* (b) *)
      let c_weak, g_when_weak =
-       if branch_has_layered_effect
+       if close_branch_with_substitutions
        then
          //branch_guard is a boolean, so b2t it
          let c = TcUtil.weaken_precondition pat_env c (NonTrivial (U.b2t branch_guard)) in
@@ -3682,7 +3685,7 @@ and tc_eqn (scrutinee:bv) (env:Env.env) (ret_opt : option match_returns_ascripti
             TcComm.is_pure_or_ghost_lcomp c_weak
          then TcUtil.maybe_assume_result_eq_pure_term env branch_exp c_weak
          else c_weak in
-       if branch_has_layered_effect
+       if close_branch_with_substitutions
        then
          let _ =
            if Env.debug env <| Options.Other "LayeredEffects"
@@ -3737,7 +3740,9 @@ and tc_eqn (scrutinee:bv) (env:Env.env) (ret_opt : option match_returns_ascripti
          |> TcComm.apply_lcomp (fun c -> c) (fun g -> match eqs with
                                                | None -> g
                                                | Some eqs -> TcComm.weaken_guard_formula g eqs)
-         |> TcUtil.close_layered_lcomp (Env.push_bv env scrutinee) pat_bvs pat_bv_tms
+         |> TcUtil.close_layered_lcomp_with_substitutions (Env.push_bv env scrutinee) pat_bvs pat_bv_tms
+       else if c_weak.eff_name |> Env.norm_eff_name env |> Env.is_layered_effect env
+       then TcUtil.close_layered_lcomp_with_combinator (Env.push_bv env scrutinee) pat_bvs c_weak
        else TcUtil.close_wp_lcomp (Env.push_bv env scrutinee) pat_bvs c_weak in
 
     c_weak.eff_name,

--- a/src/typechecker/FStar.TypeChecker.Util.fst
+++ b/src/typechecker/FStar.TypeChecker.Util.fst
@@ -692,6 +692,9 @@ let close_wp_lcomp env bvs (lc:lcomp) : lcomp =
 //
 // Apply substitutive close combinator for indexed effects
 //
+// The effect indices binders in the close combinator are arrows,
+//   so we abstract b_bv on the effect args for the substitutions
+//
 let substitutive_indexed_close_substs (env:env)
   (close_bs:binders)
   (a:typ)
@@ -722,6 +725,9 @@ let substitutive_indexed_close_substs (env:env)
     ss@[NT (b.binder_bv, U.abs [b_bv |> S.mk_binder] ct_arg None)]
   ) subst close_bs ct_args
 
+//
+// The caller ensures that the effect has the close combinator defined
+//
 let close_layered_comp_with_combinator (env:env) (bvs:list bv) (c:comp) : comp =
   let r = c.pos in
   
@@ -756,7 +762,7 @@ let close_layered_lcomp_with_combinator env bvs lc =
     (fun g -> g |> Env.close_guard env bs |> close_guard_implicits env false bs)
 
 (*
- * Closing of layered computations happens via substitution
+ * Closing of layered computations via substitution
  *)
 let close_layered_lcomp_with_substitutions env bvs tms (lc:lcomp) =
   let bs = bvs |> List.map S.mk_binder in

--- a/src/typechecker/FStar.TypeChecker.Util.fst
+++ b/src/typechecker/FStar.TypeChecker.Util.fst
@@ -713,9 +713,11 @@ let substitutive_indexed_close_substs (env:env)
     let eff_params_bs, close_bs = List.splitAt num_effect_params close_bs in
     let ct_eff_params_args, ct_args = List.splitAt num_effect_params ct_args in
     close_bs,
-    List.map2 (fun b (arg, _) -> NT (b.binder_bv, arg)) eff_params_bs ct_eff_params_args,
+    (subst@
+     List.map2 (fun b (arg, _) -> NT (b.binder_bv, arg)) eff_params_bs ct_eff_params_args),
     ct_args in
 
+  let close_bs, _ = List.splitAt (List.length close_bs - 1) close_bs in
   List.fold_left2 (fun ss b (ct_arg, _) ->
     ss@[NT (b.binder_bv, U.abs [b_bv |> S.mk_binder] ct_arg None)]
   ) subst close_bs ct_args

--- a/src/typechecker/FStar.TypeChecker.Util.fst
+++ b/src/typechecker/FStar.TypeChecker.Util.fst
@@ -689,6 +689,63 @@ let close_wp_lcomp env bvs (lc:lcomp) : lcomp =
     (close_wp_comp env bvs)
     (fun g -> g |> Env.close_guard env bs |> close_guard_implicits env false bs)
 
+//
+// Apply substitutive close combinator for indexed effects
+//
+let substitutive_indexed_close_substs (env:env)
+  (close_bs:binders)
+  (a:typ)
+  (b_bv:bv)
+  (ct_args:args)
+  (num_effect_params:int)
+  (r:Range.range)
+
+  : list subst_elt =
+  
+  let debug = Env.debug env <| Options.Other "LayeredEffectsApp" in
+
+  // go through the binders bs and aggregate substitutions
+  let close_bs, subst =
+    let a_b::b_b::close_bs = close_bs in
+    close_bs, [NT (a_b.binder_bv, a); NT (b_b.binder_bv, b_bv.sort)] in
+  
+  let close_bs, subst, ct_args =
+    let eff_params_bs, close_bs = List.splitAt num_effect_params close_bs in
+    let ct_eff_params_args, ct_args = List.splitAt num_effect_params ct_args in
+    close_bs,
+    List.map2 (fun b (arg, _) -> NT (b.binder_bv, arg)) eff_params_bs ct_eff_params_args,
+    ct_args in
+
+  List.fold_left2 (fun ss b (ct_arg, _) ->
+    ss@[NT (b.binder_bv, U.abs [b_bv |> S.mk_binder] ct_arg None)]
+  ) subst close_bs ct_args
+
+let mk_indexed_close (env:env) (bvs:list bv) (c:comp) : comp =
+  let r = c.pos in
+  
+  let env_bvs = Env.push_bvs env bvs in
+  let ct = Env.unfold_effect_abbrev env_bvs c in
+  let ed = Env.get_effect_decl env_bvs ct.effect_name in
+  let num_effect_params =
+    match ed.signature with
+    | Layered_eff_sig (n, _) -> n
+    | _ -> raise_error (Errors.Fatal_UnexpectedEffect,
+                        "mk_indexed_close called with a non-indexed effect") r in
+  let close_ts = U.get_layered_close_combinator ed |> must in
+  let effect_args = List.fold_right (fun x args ->
+    let u_a = List.hd ct.comp_univs in
+    let u_b = env.universe_of env_bvs x.sort in
+    let _, close_t = Env.inst_tscheme_with close_ts [u_a; u_b] in
+    let close_bs, close_body, _ = U.abs_formals close_t in
+    let ss = substitutive_indexed_close_substs
+      env_bvs close_bs ct.result_typ x args num_effect_params r in
+    match (SS.compress (SS.subst ss close_body)).n with
+    | Tm_app { args = _::args} -> args
+    | _ -> raise_error (Errors.Fatal_UnexpectedEffect,
+                        "Unexpected close combinator shape") r
+  ) bvs ct.effect_args in
+  S.mk_Comp {ct with effect_args}
+
 (*
  * Closing of layered computations happens via substitution
  *)

--- a/src/typechecker/FStar.TypeChecker.Util.fst
+++ b/src/typechecker/FStar.TypeChecker.Util.fst
@@ -720,7 +720,7 @@ let substitutive_indexed_close_substs (env:env)
     ss@[NT (b.binder_bv, U.abs [b_bv |> S.mk_binder] ct_arg None)]
   ) subst close_bs ct_args
 
-let mk_indexed_close (env:env) (bvs:list bv) (c:comp) : comp =
+let close_layered_comp_with_combinator (env:env) (bvs:list bv) (c:comp) : comp =
   let r = c.pos in
   
   let env_bvs = Env.push_bvs env bvs in
@@ -746,10 +746,17 @@ let mk_indexed_close (env:env) (bvs:list bv) (c:comp) : comp =
   ) bvs ct.effect_args in
   S.mk_Comp {ct with effect_args}
 
+let close_layered_lcomp_with_combinator env bvs lc =
+  let bs = bvs |> List.map S.mk_binder in
+  lc |>
+  TcComm.apply_lcomp
+    (close_layered_comp_with_combinator env bvs)
+    (fun g -> g |> Env.close_guard env bs |> close_guard_implicits env false bs)
+
 (*
  * Closing of layered computations happens via substitution
  *)
-let close_layered_lcomp env bvs tms (lc:lcomp) =
+let close_layered_lcomp_with_substitutions env bvs tms (lc:lcomp) =
   let bs = bvs |> List.map S.mk_binder in
   let substs = List.map2 (fun bv tm ->
     NT (bv, tm)

--- a/src/typechecker/FStar.TypeChecker.Util.fsti
+++ b/src/typechecker/FStar.TypeChecker.Util.fsti
@@ -102,8 +102,9 @@ val strengthen_precondition: (option (unit -> string) -> env -> term -> lcomp ->
 val weaken_guard: guard_formula -> guard_formula -> guard_formula
 val weaken_precondition: env -> lcomp -> guard_formula -> lcomp
 val maybe_assume_result_eq_pure_term: env -> term -> lcomp -> lcomp
+val close_layered_lcomp_with_combinator: env -> list bv -> lcomp -> lcomp
 val close_wp_lcomp: env -> list bv -> lcomp -> lcomp
-val close_layered_lcomp: env -> list bv -> list term -> lcomp -> lcomp
+val close_layered_lcomp_with_substitutions: env -> list bv -> list term -> lcomp -> lcomp
 val pure_or_ghost_pre_and_post: env -> comp -> (option typ * typ)
 
 //

--- a/ulib/FStar.Tactics.Effect.fsti
+++ b/ulib/FStar.Tactics.Effect.fsti
@@ -130,6 +130,12 @@ let tac_subcomp (a:Type)
          (ensures fun _ -> True)
   = f
 
+let tac_close (a b:Type)
+  (wp_f:b -> tac_wp_t a)
+  (f:(x:b -> tac_repr a (wp_f x))) =
+
+  tac_repr a (fun ps post -> forall (x:b). wp_f x ps post)
+
 /// default effect is Tac : meaning, unannotated TAC functions will be
 ///                         typed as Tac a
 ///
@@ -144,9 +150,9 @@ effect {
          return=tac_return;
          bind=tac_bind;
          if_then_else=tac_if_then_else;
-         subcomp=tac_subcomp }
+         subcomp=tac_subcomp;
+         close = tac_close }
 }
-
 
 (* Hoare variant *)
 effect TacH (a:Type) (pre : proofstate -> Tot Type0) (post : proofstate -> __result a -> Tot Type0) =


### PR DESCRIPTION
This PR adds support for a close combinator for indexed effects.

## Why

With some profiling of F* performance on the Pulse checker, we found that F* was creating huge VCs for relatively small `TAC` functions, resulting in high memory usage and typechecking time.

Adding general support for close combinators for indexed effects, and defining one for `TAC`, significantly improves the memory consumption and time taken by F* on Pulse checker---upto ~9x memory and ~19x time in some cases.

## What does close mean in the context?

Consider typechecking a `match` expression in F*:

```
match e1 with
| C x -> e
```

where `x` occurs free in `e`.

To typecheck the branch, F* opens `e` with `x` and computes a computation type `M a is` for it, where `is` are the effect indices. To compose the computation type with the rest of the function, F* has to ensure that `x` does not escape ... i.e. weaken `M a is` so that `x` does not occur free in the weakened type.

For the result type `a`, F* ensures this by just checking that `x` is not free in `a`, if it is, F* gives an error.

For the effect indices `is`, F* uses a closing mechanism.

## Closing in wp effects

For primitive wp effects, the effect definition defines a close combinator. For example, for the `PURE` effect, the combinator is defined as follows:

```
let close (a b:Type) (wp:b -> pure_wp a) : pure_wp a = fun post -> forall (x:b). wp x
```

When the branch has a primitive wp effect, F* uses such an associated close combinator to close the branch.

## Closing in indexed effects

For indexed effects, so far we were following a different approach. Instead of the effect defining a close combinator, we used projector functions applied to the scrutinee to substitute the pattern bound variables.

In the `match` expression above, for example, in the indices `is` we substitute `x` by `C? e`.

This design was chosen in part to ensure that effect writers provide as few combinators as possible to get the effect going.

## The problem

The following code in F*

```
let (| x, y, z |) = e in
e1
```
is simply a sugar for:

```
let r = e in
match r with
| MkTuple3 x y z -> e1
```
The Pulse checker code is heavily using dependent tuples and pattern matching like this.

When closing `x`, `y`, and `z` in this example, F* substitutes `x`, for example, by `MkTuple3?._1 r`. But this is not the whole story: it is actually `MkTuple3?._1 #t1 #t2 #t3 r`, where `t1`, `t2`, and `t3` are implicits for the type parameters. For dependent tuples, these implicits are lambda terms (for t2 and t3).

On inspecting the VCs, we found that the bulk of the VC was these projector expressions, with implicits repeated everywhere. This results in huge VCs, high memory consumption, and high cost of passes over the VC.

## Support for close combinators for indexed effects

To get around this problem, the PR adds support for custom close combinators for indexed effects, and defines one for `TAC`:

```
let tac_close (a b:Type) (wp_f:b -> tac_wp_t a) (f:(x:b -> tac_repr a (wp_f x))) =
  tac_repr a (fun ps post -> forall (x:b). wp_f x ps post)
```

So now the `MkTuple3` example above would result in a VC like `forall (x:t1) (y:t2) (z:t3). MkTuple3 #t1 #t2 #t3 x y z == r ==> ...` , and thus no duplication in the rest of the VC.

## Impact on the Pulse checker

For 3 of the slowest files, memory consumption and time taken (in MB and seconds resp.):

|                     | Memory before | Memory after | Time before | Time after |
|---------------------|---------------|--------------|-------------|------------|
| Pulse.Checker.Bind  | 6601          | 743          | 118.86      | 6.51       |
| Pulse.Checker.If    | 3062          | 774          | 48.66       | 7.28       |
| Pulse.Checker.While | 2332          | 838          | 40.91       | 9.10       |


The linear regression slope comparing times 0.27 and memory consumption 0.13.

(Using the runlim scripts and with admit smt queries.)

## Mechanics of the close combinator

The wiki page https://github.com/FStarLang/FStar/wiki/Indexed-effects describes how close combinators can be defined.

### Combinator shape

The shape of a close combinator looks like:

```
val close (a b:Type) (is:b -> is_t) (f:(x:a -> M a (is x)) : Type
```

and the body of the combinator is of the form `repr a js`, where `js` are the closed indices.

### Combinator soundness

F* checks the soundness of the combinator by checking that:

```
a:Type, b:Type, (is:b -> is_t), x:b |- subcomp (repr a (is x)) (repr a js)
```

I.e., `forall (x:b)`, the indices `js` are a weakening of `is x`, where the weakening is defined by the effect subcomp combinator.

### Applying the combinator

This is a small tweak in existing code for typechecking `match`. When the branch effect is a primitive wp effect, or an indexed effect with custom close combinator, then we use the combinator to close, else fallback to the substitution-based closing.