### PR TITLE
Fix typo in OCaml code for extracting elements of a pair

### DIFF
--- a/ocaml/fstar-lib/FStar_Pervasives_Native.ml
+++ b/ocaml/fstar-lib/FStar_Pervasives_Native.ml
@@ -17,8 +17,8 @@ type ('a,'b) tuple2 = 'a * 'b[@@deriving yojson,show]
 let fst = Stdlib.fst
 let snd = Stdlib.snd
 
-let __proj__Mktuple2__1 = fst
-let __proj__Mktuple2__2 = snd
+let __proj__Mktuple2__item___1 = fst
+let __proj__Mktuple2__item___2 = snd
 
 type ('a,'b,'c) tuple3 =
  'a* 'b* 'c


### PR DESCRIPTION
The projectors `._1` and `._2` for a pair are extracted in OCaml to `__proj__Mktuple2__item___1`, `__proj__Mktuple2__item___2`, but the file `FStar_Pervasives_Native.ml` defined them as `__proj__Mktuple2__1` and `__proj__Mktuple2__2`. This PR fixes this mismatch.