### PR TITLE
Fixing the need to use --ide_id_info_off in Steel and Pulse

### DIFF
--- a/ocaml/fstar-lib/generated/FStar_Syntax_Compress.ml
+++ b/ocaml/fstar-lib/generated/FStar_Syntax_Compress.ml
@@ -94,6 +94,29 @@ let (deep_compress :
              let uu___3 = compress1_u allow_uvars in
              FStar_Syntax_Visit.visit_term_univs uu___2 uu___3 in
            uu___1 tm)
+let (deep_compress_if_no_uvars :
+  FStar_Syntax_Syntax.term ->
+    FStar_Syntax_Syntax.term FStar_Pervasives_Native.option)
+  =
+  fun tm ->
+    FStar_Errors.with_ctx "While deep-compressing a term"
+      (fun uu___ ->
+         try
+           (fun uu___1 ->
+              match () with
+              | () ->
+                  let uu___2 =
+                    let uu___3 =
+                      let uu___4 = compress1_t false in
+                      let uu___5 = compress1_u false in
+                      FStar_Syntax_Visit.visit_term_univs uu___4 uu___5 in
+                    uu___3 tm in
+                  FStar_Pervasives_Native.Some uu___2) ()
+         with
+         | FStar_Errors.Err
+             (FStar_Errors_Codes.Error_UnexpectedUnresolvedUvar, uu___2,
+              uu___3)
+             -> FStar_Pervasives_Native.None)
 let (deep_compress_se :
   Prims.bool -> FStar_Syntax_Syntax.sigelt -> FStar_Syntax_Syntax.sigelt) =
   fun allow_uvars ->

--- a/ocaml/fstar-lib/generated/FStar_Tactics_V2_Basic.ml
+++ b/ocaml/fstar-lib/generated/FStar_Tactics_V2_Basic.ml
@@ -6811,10 +6811,17 @@ let refl_typing_builtin_wrapper :
           ([issue], FStar_Pervasives_Native.None) in
     match uu___ with
     | (errs, r) ->
-        (FStar_Syntax_Unionfind.rollback tx;
-         if (FStar_Compiler_List.length errs) > Prims.int_zero
-         then FStar_Tactics_Monad.ret (FStar_Pervasives_Native.None, errs)
-         else FStar_Tactics_Monad.ret (r, errs))
+        FStar_Tactics_Monad.op_let_Bang FStar_Tactics_Monad.get
+          (fun ps ->
+             FStar_TypeChecker_Env.promote_id_info
+               ps.FStar_Tactics_Types.main_context
+               (FStar_TypeChecker_Tc.compress_and_norm
+                  ps.FStar_Tactics_Types.main_context);
+             FStar_Syntax_Unionfind.rollback tx;
+             if (FStar_Compiler_List.length errs) > Prims.int_zero
+             then
+               FStar_Tactics_Monad.ret (FStar_Pervasives_Native.None, errs)
+             else FStar_Tactics_Monad.ret (r, errs))
 let (no_uvars_in_term : FStar_Syntax_Syntax.term -> Prims.bool) =
   fun t ->
     (let uu___ =

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_Common.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_Common.ml
@@ -323,7 +323,9 @@ let (print_identifier_info : identifier_info -> Prims.string) =
     let uu___2 = FStar_Syntax_Print.term_to_string info.identifier_ty in
     FStar_Compiler_Util.format3 "id info { %s, %s : %s}" uu___ uu___1 uu___2
 let (id_info__insert :
-  (FStar_Syntax_Syntax.typ -> FStar_Syntax_Syntax.typ) ->
+  (FStar_Syntax_Syntax.typ ->
+     FStar_Syntax_Syntax.typ FStar_Pervasives_Native.option)
+    ->
     (Prims.int * identifier_info) Prims.list FStar_Compiler_Util.pimap
       FStar_Compiler_Util.psmap ->
       identifier_info ->
@@ -341,30 +343,34 @@ let (id_info__insert :
           match info.identifier with
           | FStar_Pervasives.Inr uu___ -> ty_map info.identifier_ty
           | FStar_Pervasives.Inl x -> ty_map info.identifier_ty in
-        let info1 =
-          {
-            identifier = (info.identifier);
-            identifier_ty = id_ty;
-            identifier_range = use_range
-          } in
-        let fn = FStar_Compiler_Range_Ops.file_of_range use_range in
-        let start = FStar_Compiler_Range_Ops.start_of_range use_range in
-        let uu___ =
-          let uu___1 = FStar_Compiler_Range_Ops.line_of_pos start in
-          let uu___2 = FStar_Compiler_Range_Ops.col_of_pos start in
-          (uu___1, uu___2) in
-        match uu___ with
-        | (row, col) ->
-            let rows =
-              let uu___1 = FStar_Compiler_Util.pimap_empty () in
-              FStar_Compiler_Util.psmap_find_default db fn uu___1 in
-            let cols = FStar_Compiler_Util.pimap_find_default rows row [] in
-            let uu___1 =
-              let uu___2 = insert_col_info col info1 cols in
-              FStar_Compiler_Effect.op_Bar_Greater uu___2
-                (FStar_Compiler_Util.pimap_add rows row) in
-            FStar_Compiler_Effect.op_Bar_Greater uu___1
-              (FStar_Compiler_Util.psmap_add db fn)
+        match id_ty with
+        | FStar_Pervasives_Native.None -> db
+        | FStar_Pervasives_Native.Some id_ty1 ->
+            let info1 =
+              {
+                identifier = (info.identifier);
+                identifier_ty = id_ty1;
+                identifier_range = use_range
+              } in
+            let fn = FStar_Compiler_Range_Ops.file_of_range use_range in
+            let start = FStar_Compiler_Range_Ops.start_of_range use_range in
+            let uu___ =
+              let uu___1 = FStar_Compiler_Range_Ops.line_of_pos start in
+              let uu___2 = FStar_Compiler_Range_Ops.col_of_pos start in
+              (uu___1, uu___2) in
+            (match uu___ with
+             | (row, col) ->
+                 let rows =
+                   let uu___1 = FStar_Compiler_Util.pimap_empty () in
+                   FStar_Compiler_Util.psmap_find_default db fn uu___1 in
+                 let cols =
+                   FStar_Compiler_Util.pimap_find_default rows row [] in
+                 let uu___1 =
+                   let uu___2 = insert_col_info col info1 cols in
+                   FStar_Compiler_Effect.op_Bar_Greater uu___2
+                     (FStar_Compiler_Util.pimap_add rows row) in
+                 FStar_Compiler_Effect.op_Bar_Greater uu___1
+                   (FStar_Compiler_Util.psmap_add db fn))
 let (id_info_insert :
   id_info_table ->
     (FStar_Syntax_Syntax.bv, FStar_Syntax_Syntax.fv) FStar_Pervasives.either
@@ -417,7 +423,9 @@ let (id_info_toggle : id_info_table -> Prims.bool -> id_info_table) =
       }
 let (id_info_promote :
   id_info_table ->
-    (FStar_Syntax_Syntax.typ -> FStar_Syntax_Syntax.typ) -> id_info_table)
+    (FStar_Syntax_Syntax.typ ->
+       FStar_Syntax_Syntax.typ FStar_Pervasives_Native.option)
+      -> id_info_table)
   =
   fun table ->
     fun ty_map ->

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_Env.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_Env.ml
@@ -2361,7 +2361,11 @@ let (insert_fv_info :
           FStar_TypeChecker_Common.id_info_insert_fv uu___1 fv ty in
         FStar_Compiler_Effect.op_Colon_Equals env1.identifier_info uu___
 let (promote_id_info :
-  env -> (FStar_Syntax_Syntax.typ -> FStar_Syntax_Syntax.typ) -> unit) =
+  env ->
+    (FStar_Syntax_Syntax.typ ->
+       FStar_Syntax_Syntax.typ FStar_Pervasives_Native.option)
+      -> unit)
+  =
   fun env1 ->
     fun ty_map ->
       let uu___ =

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_Tc.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_Tc.ml
@@ -4618,6 +4618,28 @@ let (add_sigelt_to_env :
                   FStar_TypeChecker_Env.add_polymonadic_subcomp env1 m n
                     uu___3
               | uu___2 -> env1))
+let (compress_and_norm :
+  FStar_TypeChecker_Env.env ->
+    FStar_Syntax_Syntax.typ ->
+      FStar_Syntax_Syntax.typ FStar_Pervasives_Native.option)
+  =
+  fun env ->
+    fun t ->
+      let uu___ = FStar_Syntax_Compress.deep_compress_if_no_uvars t in
+      match uu___ with
+      | FStar_Pervasives_Native.None -> FStar_Pervasives_Native.None
+      | FStar_Pervasives_Native.Some t1 ->
+          let uu___1 =
+            FStar_TypeChecker_Normalize.normalize
+              [FStar_TypeChecker_Env.AllowUnboundUniverses;
+              FStar_TypeChecker_Env.CheckNoUvars;
+              FStar_TypeChecker_Env.Beta;
+              FStar_TypeChecker_Env.DoNotUnfoldPureLets;
+              FStar_TypeChecker_Env.CompressUvars;
+              FStar_TypeChecker_Env.Exclude FStar_TypeChecker_Env.Zeta;
+              FStar_TypeChecker_Env.Exclude FStar_TypeChecker_Env.Iota;
+              FStar_TypeChecker_Env.NoFullNorm] env t1 in
+          FStar_Pervasives_Native.Some uu___1
 let (tc_decls :
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.sigelt Prims.list ->
@@ -4695,38 +4717,8 @@ let (tc_decls :
                                    uu___9
                                else ());
                               FStar_TypeChecker_Normalize.elim_uvars env2 se1)) in
-                    ((let uu___8 =
-                        let uu___9 =
-                          let uu___10 =
-                            FStar_TypeChecker_Env.current_module env2 in
-                          FStar_Ident.string_of_lid uu___10 in
-                        FStar_Pervasives_Native.Some uu___9 in
-                      FStar_Profiling.profile
-                        (fun uu___9 ->
-                           FStar_TypeChecker_Env.promote_id_info env2
-                             (fun t ->
-                                (let uu___11 =
-                                   FStar_TypeChecker_Env.debug env2
-                                     (FStar_Options.Other "UF") in
-                                 if uu___11
-                                 then
-                                   let uu___12 =
-                                     FStar_Syntax_Print.term_to_string t in
-                                   FStar_Compiler_Util.print1
-                                     "check uvars %s\n" uu___12
-                                 else ());
-                                FStar_TypeChecker_Normalize.normalize
-                                  [FStar_TypeChecker_Env.AllowUnboundUniverses;
-                                  FStar_TypeChecker_Env.CheckNoUvars;
-                                  FStar_TypeChecker_Env.Beta;
-                                  FStar_TypeChecker_Env.DoNotUnfoldPureLets;
-                                  FStar_TypeChecker_Env.CompressUvars;
-                                  FStar_TypeChecker_Env.Exclude
-                                    FStar_TypeChecker_Env.Zeta;
-                                  FStar_TypeChecker_Env.Exclude
-                                    FStar_TypeChecker_Env.Iota;
-                                  FStar_TypeChecker_Env.NoFullNorm] env2 t))
-                        uu___8 "FStar.TypeChecker.Tc.chec_uvars");
+                    (FStar_TypeChecker_Env.promote_id_info env2
+                       (compress_and_norm env2);
                      (let ses'2 =
                         FStar_Compiler_Effect.op_Bar_Greater ses'1
                           (FStar_Compiler_List.map
@@ -4804,7 +4796,7 @@ let (tc_decls :
                ([], env) ses) in
       match uu___ with
       | (ses1, env1) -> ((FStar_Compiler_List.rev_append ses1 []), env1)
-let (uu___901 : unit) =
+let (uu___904 : unit) =
   FStar_Compiler_Effect.op_Colon_Equals tc_decls_knot
     (FStar_Pervasives_Native.Some tc_decls)
 let (snapshot_context :

--- a/src/syntax/FStar.Syntax.Compress.fst
+++ b/src/syntax/FStar.Syntax.Compress.fst
@@ -71,6 +71,17 @@ let deep_compress (allow_uvars:bool) (tm : term) : term =
       tm
   )
 
+let deep_compress_if_no_uvars (tm : term) : option term =
+  Err.with_ctx ("While deep-compressing a term") (fun () ->
+    try 
+      Some (Visit.visit_term_univs
+              (compress1_t false)
+              (compress1_u false)
+              tm)
+    with
+    | FStar.Errors.Err (Err.Error_UnexpectedUnresolvedUvar, _, _) -> None
+  )
+
 let deep_compress_se (allow_uvars:bool) (se : sigelt) : sigelt =
   Err.with_ctx (format1 "While deep-compressing %s" (Syntax.Print.sigelt_to_string_short se)) (fun () ->
     Visit.visit_sigelt

--- a/src/syntax/FStar.Syntax.Compress.fsti
+++ b/src/syntax/FStar.Syntax.Compress.fsti
@@ -8,4 +8,8 @@ if allow_uvars is false, it raises a hard error if an *unresolved* uvar
 solutions, as in compress. *)
 val deep_compress (allow_uvars: bool) (t:term) : term
 
+(* Similar to `deep_compress false t`, except instead of a hard error
+   this returns None in case an unresolved uvar is found. *)
+val deep_compress_if_no_uvars (t:term) : option term
+
 val deep_compress_se (allow_uvars: bool) (se:sigelt) : sigelt

--- a/src/tactics/FStar.Tactics.V2.Basic.fst
+++ b/src/tactics/FStar.Tactics.V2.Basic.fst
@@ -2101,6 +2101,8 @@ let refl_typing_builtin_wrapper (f:unit -> 'a) : tac (option 'a & issues) =
       }) in
       [issue], None
   in
+  let! ps = get in
+  Env.promote_id_info ps.main_context (FStar.TypeChecker.Tc.compress_and_norm ps.main_context);
   UF.rollback tx;
   if List.length errs > 0
   then ret (None, errs)

--- a/src/typechecker/FStar.TypeChecker.Common.fst
+++ b/src/typechecker/FStar.TypeChecker.Common.fst
@@ -112,23 +112,24 @@ let id_info__insert ty_map db info =
       | Inr _ ->
         ty_map info.identifier_ty
       | Inl x ->
-        // BU.print1 "id_info__insert: %s\n"
-        //           (print_identifier_info info);
         ty_map info.identifier_ty
     in
-    let info = { info with identifier_range = use_range;
-                           identifier_ty = id_ty } in
+    match id_ty with
+    | None -> db
+    | Some id_ty ->
+      let info = { info with identifier_range = use_range;
+                             identifier_ty = id_ty } in
 
-    let fn = file_of_range use_range in
-    let start = start_of_range use_range in
-    let row, col = line_of_pos start, col_of_pos start in
+      let fn = file_of_range use_range in
+      let start = start_of_range use_range in
+      let row, col = line_of_pos start, col_of_pos start in
 
-    let rows = BU.psmap_find_default db fn (BU.pimap_empty ()) in
-    let cols = BU.pimap_find_default rows row [] in
+      let rows = BU.psmap_find_default db fn (BU.pimap_empty ()) in
+      let cols = BU.pimap_find_default rows row [] in
 
-    insert_col_info col info cols
-    |> BU.pimap_add rows row
-    |> BU.psmap_add db fn
+      insert_col_info col info cols
+      |> BU.pimap_add rows row
+      |> BU.psmap_add db fn
 
 let id_info_insert table id ty range =
     let info = { identifier = id; identifier_ty = ty; identifier_range = range} in

--- a/src/typechecker/FStar.TypeChecker.Common.fsti
+++ b/src/typechecker/FStar.TypeChecker.Common.fsti
@@ -127,7 +127,7 @@ val id_info_table_empty : id_info_table
 val id_info_insert_bv : id_info_table -> bv -> typ -> id_info_table
 val id_info_insert_fv : id_info_table -> fv -> typ -> id_info_table
 val id_info_toggle    : id_info_table -> bool -> id_info_table
-val id_info_promote   : id_info_table -> (typ -> typ) -> id_info_table
+val id_info_promote   : id_info_table -> (typ -> option typ) -> id_info_table
 val id_info_at_pos    : id_info_table -> string -> int -> int -> option identifier_info
 
 // Reason, term and uvar, and (rough) position where it is introduced

--- a/src/typechecker/FStar.TypeChecker.Env.fsti
+++ b/src/typechecker/FStar.TypeChecker.Env.fsti
@@ -287,7 +287,7 @@ val get_range      : env -> Range.range
 val insert_bv_info : env -> bv -> typ -> unit
 val insert_fv_info : env -> fv -> typ -> unit
 val toggle_id_info : env -> bool -> unit
-val promote_id_info : env -> (typ -> typ) -> unit
+val promote_id_info : env -> (typ -> option typ) -> unit
 
 (* Querying identifiers *)
 val lid_exists             : env -> lident -> bool

--- a/src/typechecker/FStar.TypeChecker.Tc.fsti
+++ b/src/typechecker/FStar.TypeChecker.Tc.fsti
@@ -30,6 +30,7 @@ val push_context: env -> string -> env
 val snapshot_context: env -> string -> ((int * int * solver_depth_t * int) * env)
 val rollback_context: solver_t -> string -> option (int * int * solver_depth_t * int) -> env
 
+val compress_and_norm: env -> typ -> option typ
 val tc_decls: env -> list sigelt -> list sigelt * env
 val tc_partial_modul: env -> modul -> modul * env
 val tc_more_partial_modul: env -> modul -> list sigelt -> modul * list sigelt * env


### PR DESCRIPTION
Particularly in Steel and Pulse files, when using fstar-mode.el or with fstar-vscode-assistant, one would need to use --ide_id_info_off to avoid having F* crash when it enters types in the IDE's symbol lookup table. 

This has puzzled me for a long time and the need to use the flag is also annoying. 

## The problem

In some places we do `let tx = UF.new_transaction(); typecheck some stuff; UF.rollback tx`

Typechecking the stuff in between can add new symbols to the IDE id table and those symbols may mention uvars in the unionfind graph associated with tx.

But, when the tx is rolled back, those uvars are left dangling, although they are still in this table.

Later, when we complete checking the enclosing top-level declaration, we scan this table promoting all id info there (by normalizing all types in the id table and moving them to another sub-table), but there we encounter this dangling uvar and crash.

## The fix

The fix is in two parts.

1. First, the symbol table is just for info purposes and is not needed for correctness. So, rather than crashing if an unresolved uvar is found, I check if an unresolved uvar is present, and if so simply remove the entry from the table; Otherwise, normalize and move it as before. This should be a global defensive fix, but at the cost of losing information in the table.

2. In Pulse, this particular pattern of rolling back the UF graph happens at every callback to the typechecker. So, in FStar.Tactics.V2.Basic.refl_typing_builtin_wrapper I now promote entries in the symbol table at each callback *before* rolling back the UF graph. That allows us to keep useful symbol info.

If we wanted to retain all symbols in non-Pulse scenarios, we'd have to track down all uses of this transaction rollback pattern and apply a similar patch as in refl_typing_builtin_wrapper. 

## Evaluation

I have tested that Pulse files that were using this ide_id_info_off for use in the editor no longer need to do so.

I have also checked that some steel files that were using this option (e.g., OWGCounter) also no longer need to do so, @R1kM , you might be interested to check if this PR helps remove that option in other Steel developments.