### PR TITLE
Fix hardcoded dependences of a file

### DIFF
--- a/ocaml/fstar-lib/generated/FStar_Parser_Dep.ml
+++ b/ocaml/fstar-lib/generated/FStar_Parser_Dep.ml
@@ -901,7 +901,7 @@ let (hard_coded_dependencies :
     then []
     else
       (let uu___2 =
-         let uu___3 = lowercase_module_name full_filename in
+         let uu___3 = module_name_of_file full_filename in
          namespace_of_module uu___3 in
        match uu___2 with
        | FStar_Pervasives_Native.None ->

--- a/src/parser/FStar.Parser.Dep.fst
+++ b/src/parser/FStar.Parser.Dep.fst
@@ -513,7 +513,7 @@ let hard_coded_dependencies full_filename =
 
   (* The core libraries do not have any implicit dependencies *)
   if List.mem (module_name_of_file filename) (core_modules ()) then []
-  else match (namespace_of_module (lowercase_module_name full_filename)) with
+  else match namespace_of_module (module_name_of_file full_filename) with
        | None -> implicit_ns_deps @ implicit_module_deps
          (*
           * AR: we open FStar, and then ns


### PR DESCRIPTION
In FStar.Parser.Dep, the hardcoded dependences of a file include prims, pervasives etc. but also for a module with a qualified name, A.B.C, the dependences include opening the namespace A.B. 

However, FStar.Parser.Dep was lowercasing this name as a.b. Not sure why it was doing that.

In syntax extensions for modules with qualified names, we later try to open the namespace `a.b` but that doesn't exist.

So, FStar.Parser.Dep now does not lowercase that name and syntax extensions with namespaces work fine.