### PR TITLE
Introducing a minimal devcontainer (for codespaces)

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,29 @@
+{
+  "name": "F* minimal devcontainer",
+  "build": {
+    "dockerfile": "minimal.Dockerfile"
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "FStarLang.fstar-vscode-assistant"
+      ]
+    }
+  },
+  "remoteEnv": {
+    "FSTAR_DEVCONTAINER": "minimal"
+    // ^ We just set this in case we ever need to distinguish
+    // we are running in a codespace.
+  },
+  // Runs only once when container is prepared
+  "onCreateCommand": {
+    "link_to_home_bin" : "ln -s $(realpath bin/fstar.exe) ~/bin/fstar.exe"
+  },
+  // Runs periodically and/or when content of repo changes
+  "updateContentCommand": {
+    "make": "bash -i .devcontainer/onUpdate.sh"
+  },
+  // These run only when the container is assigned to a user
+  "postCreateCommand": {
+  }
+}

--- a/.devcontainer/minimal.Dockerfile
+++ b/.devcontainer/minimal.Dockerfile
@@ -1,0 +1,65 @@
+FROM ubuntu:latest
+
+SHELL ["/bin/bash", "-c"]
+
+# Base dependencies: opam
+# CI dependencies: jq (to identify F* branch)
+# python3 (for interactive tests)
+# libicu (for .NET, cf. https://aka.ms/dotnet-missing-libicu )
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+      ca-certificates \
+      curl \
+      wget \
+      git \
+      gnupg \
+      sudo \
+      python3 \
+      python-is-python3 \
+      libicu70 \
+      libgmp-dev \
+      opam \
+    && apt-get clean -y
+# FIXME: libgmp-dev should be installed automatically by opam,
+# but it is not working, so just adding it above.
+
+# Create a new user and give them sudo rights
+ARG USER=vscode
+RUN useradd -d /home/$USER -s /bin/bash -m $USER
+RUN echo "$USER ALL=NOPASSWD: ALL" >> /etc/sudoers
+USER $USER
+ENV HOME /home/$USER
+WORKDIR $HOME
+RUN mkdir -p $HOME/bin
+
+# Make sure ~/bin is in the PATH
+RUN echo 'export PATH=$HOME/bin:$PATH' | tee --append $HOME/.profile $HOME/.bashrc $HOME/.bash_profile
+
+# Install dotnet
+ENV DOTNET_ROOT /home/$USER/dotnet
+RUN wget -nv https://download.visualstudio.microsoft.com/download/pr/cd0d0a4d-2a6a-4d0d-b42e-dfd3b880e222/008a93f83aba6d1acf75ded3d2cfba24/dotnet-sdk-6.0.400-linux-x64.tar.gz && \
+    mkdir -p $DOTNET_ROOT && \
+    tar xf dotnet-sdk-6.0.400-linux-x64.tar.gz -C $DOTNET_ROOT && \
+    echo 'export PATH=$PATH:$DOTNET_ROOT:$DOTNET_ROOT/tools' | tee --append $HOME/.profile $HOME/.bashrc $HOME/.bash_profile && \
+    rm -f dotnet-sdk*.tar.gz
+
+# Install OCaml
+ARG OCAML_VERSION=4.12.0
+RUN opam init --compiler=$OCAML_VERSION --disable-sandboxing
+RUN opam option depext-run-installs=true
+ENV OPAMYES=1
+RUN opam install --yes batteries zarith stdint yojson dune menhir menhirLib pprint sedlex ppxlib process ppx_deriving ppx_deriving_yojson
+
+# Get compiled Z3
+RUN wget -nv https://github.com/Z3Prover/z3/releases/download/Z3-4.8.5/z3-4.8.5-x64-ubuntu-16.04.zip \
+ && unzip z3-4.8.5-x64-ubuntu-16.04.zip \
+ && cp z3-4.8.5-x64-ubuntu-16.04/bin/z3 $HOME/bin/z3 \
+ && rm -r z3-4.8.5-*
+
+WORKDIR $HOME
+
+# Instrument .bashrc to set the opam switch. Note that this
+# just appends the *call* to eval $(opam env) in these files, so we
+# compute the new environments fter the fact. Calling opam env here
+# would perhaps thrash some variables set by the devcontainer infra.
+RUN echo 'eval $(opam env --set-switch)' | tee --append $HOME/.profile $HOME/.bashrc $HOME/.bash_profile

--- a/.devcontainer/onUpdate.sh
+++ b/.devcontainer/onUpdate.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+# Prebuild F* and library
+make -j$(nproc) ADMIT=1 |& tee .devcontainer_build.log

--- a/.gitignore
+++ b/.gitignore
@@ -98,3 +98,6 @@ nubuild.progress
 
 # Nuget packages
 nuget/
+
+# devcontainer temp files
+/.devcontainer_build.log

--- a/src/Makefile
+++ b/src/Makefile
@@ -8,6 +8,9 @@ MAKEFLAGS += --no-builtin-rules
 
 .PHONY: clean boot ocaml
 
+all:
+	$(error src/Makefile: Need to specify a rule)
+
 clean: clean-ocaml
 
 # --------------------------------------------------------------------


### PR DESCRIPTION
This PR adds the `.devcontainer` directory with a specification for how to create an F* devcontainer. This devcontainer is what's used to generate a 'codespace', which is just a devcontainer running on Github's servers.

The container is based on a Dockerfile that installs our usual dependencies, and will also run `make` as part of the creation process. Also, it automatically installs the F* vscode extension, so starting a codespace will give a usable F* out of the box.

The container can also be run locally within vscode by just using the "Reopen in container" command. VS Code will in fact automatically suggest that when opening the workspace.

I tried to base  this container on top of Github's codespace image (instead of a plain Ubuntu image), but I got different behaviors when running locally and on codespaces.. so I dropped that idea for now.

Note: when someone creates a codespace from the F* repo, the resource consumption (/ billing) runs on their tab. Having this file here should not use any resources from the FStarLang org.