### PR TITLE
A fix in the core typechecker

### DIFF
--- a/examples/tactics/eci19/ConstructiveLogic.fst
+++ b/examples/tactics/eci19/ConstructiveLogic.fst
@@ -14,13 +14,14 @@ commonly, however, the programmer needs to give the SMT solver some
 help in the form of new facts that it can use. We've seen examples of
 this when we call lemmas within a function body in order to make it
 verify. For instance, compare the following two examples (the first of
-which fails).
+which in the comments is known to be unstable).
 *)
 
-[@expect_failure]
+(*
 let modulo_add_fail (p:pos) (a b c : int)
   : Lemma (requires (b % p == c % p)) (ensures ((a + b) % p == (a + c) % p))
   = ()
+*)
 
 let modulo_add (p:pos) (a b c : int)
   : Lemma (requires (b % p == c % p)) (ensures ((a + b) % p == (a + c) % p))

--- a/examples/tactics/eci19/ConstructiveLogic.fst
+++ b/examples/tactics/eci19/ConstructiveLogic.fst
@@ -14,14 +14,13 @@ commonly, however, the programmer needs to give the SMT solver some
 help in the form of new facts that it can use. We've seen examples of
 this when we call lemmas within a function body in order to make it
 verify. For instance, compare the following two examples (the first of
-which in the comments is known to be unstable).
+which fails).
 *)
 
-(*
+[@expect_failure]
 let modulo_add_fail (p:pos) (a b c : int)
   : Lemma (requires (b % p == c % p)) (ensures ((a + b) % p == (a + c) % p))
   = ()
-*)
 
 let modulo_add (p:pos) (a b c : int)
   : Lemma (requires (b % p == c % p)) (ensures ((a + b) % p == (a + c) % p))

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_Core.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_Core.ml
@@ -4281,7 +4281,21 @@ let (check_term_top :
               (fun eff_te ->
                  match topt with
                  | FStar_Pervasives_Native.None ->
-                     return (FStar_Pervasives_Native.Some eff_te)
+                     if must_tot
+                     then
+                       let uu___1 = eff_te in
+                       (match uu___1 with
+                        | (eff, t) ->
+                            let uu___2 =
+                              (eff = E_GHOST) &&
+                                (let uu___3 = non_informative g1 t in
+                                 Prims.op_Negation uu___3) in
+                            if uu___2
+                            then fail "expected total effect, found ghost"
+                            else
+                              return
+                                (FStar_Pervasives_Native.Some (E_TOTAL, t)))
+                     else return (FStar_Pervasives_Native.Some eff_te)
                  | FStar_Pervasives_Native.Some t ->
                      let target_comp =
                        if

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_Core.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_Core.ml
@@ -1566,7 +1566,7 @@ let rec (check_relation :
                  let uu___1 = which_side_to_unfold t01 t11 in
                  maybe_unfold_side uu___1 t01 t11 in
                let emit_guard t01 t11 =
-                 let uu___1 = check' g t01 in
+                 let uu___1 = do_check g t01 in
                  op_let_Bang uu___1
                    (fun uu___2 ->
                       match uu___2 with
@@ -2607,7 +2607,7 @@ and (memo_check :
   fun g ->
     fun e ->
       let check_then_memo g1 e1 ctx =
-        let r = let uu___ = check' g1 e1 in uu___ ctx in
+        let r = let uu___ = do_check_and_promote g1 e1 in uu___ ctx in
         match r with
         | FStar_Pervasives.Inl (res, FStar_Pervasives_Native.None) ->
             (insert g1 e1 (res, FStar_Pervasives_Native.None); r)
@@ -2660,7 +2660,26 @@ and (check :
       fun e ->
         with_context msg (FStar_Pervasives_Native.Some (CtxTerm e))
           (fun uu___ -> memo_check g e)
-and (check' :
+and (do_check_and_promote :
+  env ->
+    FStar_Syntax_Syntax.term ->
+      (effect_label * FStar_Syntax_Syntax.typ) result)
+  =
+  fun g ->
+    fun e ->
+      let uu___ = do_check g e in
+      op_let_Bang uu___
+        (fun uu___1 ->
+           match uu___1 with
+           | (eff, t) ->
+               let eff1 =
+                 match eff with
+                 | E_TOTAL -> E_TOTAL
+                 | E_GHOST ->
+                     let uu___2 = non_informative g t in
+                     if uu___2 then E_TOTAL else E_GHOST in
+               return (eff1, t))
+and (do_check :
   env ->
     FStar_Syntax_Syntax.term ->
       (effect_label * FStar_Syntax_Syntax.typ) result)
@@ -2675,7 +2694,7 @@ and (check' :
               uu___1;
             FStar_Syntax_Syntax.ltyp = uu___2;
             FStar_Syntax_Syntax.rng = uu___3;_}
-          -> let uu___4 = FStar_Syntax_Util.unlazy e1 in check' g uu___4
+          -> let uu___4 = FStar_Syntax_Util.unlazy e1 in do_check g uu___4
       | FStar_Syntax_Syntax.Tm_lazy i ->
           return (E_TOTAL, (i.FStar_Syntax_Syntax.ltyp))
       | FStar_Syntax_Syntax.Tm_meta

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_Util.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_Util.ml
@@ -5425,6 +5425,31 @@ let (maybe_coerce_lc :
                    | (e1, lc1) ->
                        (e1, lc1, FStar_TypeChecker_Env.trivial_guard))
               | FStar_Pervasives_Native.None ->
+                  let strip_hide_or_reveal e1 hide_or_reveal =
+                    let uu___3 = FStar_Syntax_Util.leftmost_head_and_args e1 in
+                    match uu___3 with
+                    | (hd, args) ->
+                        let uu___4 =
+                          let uu___5 =
+                            let uu___6 = FStar_Syntax_Subst.compress hd in
+                            uu___6.FStar_Syntax_Syntax.n in
+                          (uu___5, args) in
+                        (match uu___4 with
+                         | (FStar_Syntax_Syntax.Tm_uinst (hd1, uu___5),
+                            (uu___6, aq_t)::(e2, aq_e)::[]) when
+                             (((FStar_Syntax_Util.is_fvar hide_or_reveal hd1)
+                                 &&
+                                 (FStar_Pervasives_Native.uu___is_Some aq_t))
+                                &&
+                                (FStar_Pervasives_Native.__proj__Some__item__v
+                                   aq_t).FStar_Syntax_Syntax.aqual_implicit)
+                               &&
+                               ((aq_e = FStar_Pervasives_Native.None) ||
+                                  (Prims.op_Negation
+                                     (FStar_Pervasives_Native.__proj__Some__item__v
+                                        aq_e).FStar_Syntax_Syntax.aqual_implicit))
+                             -> FStar_Pervasives_Native.Some e2
+                         | uu___5 -> FStar_Pervasives_Native.None) in
                   let uu___3 =
                     let uu___4 =
                       check_erased env lc.FStar_TypeChecker_Common.res_typ in
@@ -5447,7 +5472,14 @@ let (maybe_coerce_lc :
                               let uu___7 = FStar_Syntax_Syntax.mk_Total exp_t in
                               coerce_with env e lc FStar_Parser_Const.hide
                                 [u] uu___6 uu___7 in
-                            (match uu___5 with | (e1, lc1) -> (e1, lc1, g1)))
+                            (match uu___5 with
+                             | (e_hide, lc1) ->
+                                 let e_hide1 =
+                                   let uu___6 =
+                                     strip_hide_or_reveal e
+                                       FStar_Parser_Const.reveal in
+                                   FStar_Compiler_Util.dflt e_hide uu___6 in
+                                 (e_hide1, lc1, g1)))
                    | (Yes ty, No) ->
                        let u = env.FStar_TypeChecker_Env.universe_of env ty in
                        let uu___4 =
@@ -5458,8 +5490,14 @@ let (maybe_coerce_lc :
                          coerce_with env e lc FStar_Parser_Const.reveal 
                            [u] uu___5 uu___6 in
                        (match uu___4 with
-                        | (e1, lc1) ->
-                            (e1, lc1, FStar_TypeChecker_Env.trivial_guard))
+                        | (e_reveal, lc1) ->
+                            let e_reveal1 =
+                              let uu___5 =
+                                strip_hide_or_reveal e
+                                  FStar_Parser_Const.hide in
+                              FStar_Compiler_Util.dflt e_reveal uu___5 in
+                            (e_reveal1, lc1,
+                              FStar_TypeChecker_Env.trivial_guard))
                    | uu___4 -> (e, lc, FStar_TypeChecker_Env.trivial_guard))))
 let (weaken_result_typ :
   FStar_TypeChecker_Env.env ->

--- a/src/typechecker/FStar.TypeChecker.Core.fst
+++ b/src/typechecker/FStar.TypeChecker.Core.fst
@@ -1786,7 +1786,15 @@ let check_term_top g e topt (must_tot:bool) (gh:option guard_handler_t)
   = let g = initial_env g gh in
     let! eff_te = check "top" g e in
     match topt with
-    | None -> return (Some eff_te)
+    | None ->
+      // check expected effect
+      if must_tot
+      then let eff, t = eff_te in 
+           if eff = E_GHOST &&
+              not (non_informative g t)
+           then fail "expected total effect, found ghost"
+           else return (Some (E_TOTAL, t))
+      else return (Some eff_te)
     | Some t ->
       let target_comp =
         if must_tot || fst eff_te = E_TOTAL


### PR DESCRIPTION
Adding a missing check for expected effect in the case when the expected type is not set.

The fix failed some examples, where the core client wanted a total effect on non-informative types, but core computed a ghost effect (and the cases passed due to the missing check).

To fix those cases, the PR also adds eager promotion so that it computes a total effect in such cases.

The PR also contains a small optimization in inserting hide/reveal coercions. If the expression is `reveal e` (resp. `hide e`), and the context expects an erased (resp. non-erased) type, then instead of making the coercion return `hide (reveal e)` (resp. `reveal (hide e)`, we just return `e`.

The last optimization resulted in two failures, one each in `Steel.ST.Array` and `Steel.ST.HigherArray`. Since the coerced expression is a little different, two `rewrite` calls in the libraries (one in each file) had to be tweaked. In general, smt attribute saves us, but these cases were where the coercion was happening in the first argument of `pts_to` (see https://github.com/FStarLang/steel/pull/63).