### PR TITLE
main.ml: only block signals on Posix systems

### DIFF
--- a/ocaml/fstar/main.ml
+++ b/ocaml/fstar/main.ml
@@ -4,7 +4,8 @@ let x =
          by defaults will terminate F*, and we won't get an exception
          or anything. So, block them, and instead rely on OCaml exceptions
          to detect this. *)
-      Unix.sigprocmask Unix.SIG_BLOCK [Sys.sigpipe];
+      if FStar_Platform.system = Posix then
+        ignore (Unix.sigprocmask Unix.SIG_BLOCK [Sys.sigpipe]);
 
       Printexc.record_backtrace true;
       Gc.set { (Gc.get()) with Gc.minor_heap_size = 1048576; Gc.major_heap_increment = 4194304; Gc.space_overhead = 150; };


### PR DESCRIPTION
The change to block signals unadvertedly broke F* on Windows, which would exit on startup with:

    Fatal error: exception (Invalid_argument "Unix.sigprocmask not implemented")