### PR TITLE
Fix extraction of character constants

### DIFF
--- a/ocaml/fstar-lib/generated/FStar_Extraction_Krml.ml
+++ b/ocaml/fstar-lib/generated/FStar_Extraction_Krml.ml
@@ -2674,7 +2674,7 @@ and (translate_constant : FStar_Extraction_ML_Syntax.mlconstant -> expr) =
     | FStar_Extraction_ML_Syntax.MLC_Char c1 ->
         let i = FStar_Compiler_Util.int_of_char c1 in
         let s = FStar_Compiler_Util.string_of_int i in
-        let c2 = EConstant (UInt32, s) in
+        let c2 = EConstant (CInt, s) in
         let char_of_int = EQualified (["FStar"; "Char"], "char_of_int") in
         EApp (char_of_int, [c2])
     | FStar_Extraction_ML_Syntax.MLC_Int

--- a/src/extraction/FStar.Extraction.Krml.fst
+++ b/src/extraction/FStar.Extraction.Krml.fst
@@ -1094,7 +1094,7 @@ and translate_constant c: expr =
   | MLC_Char c ->
       let i = BU.int_of_char c in
       let s = BU.string_of_int i in
-      let c = EConstant (UInt32, s) in
+      let c = EConstant (CInt, s) in
       let char_of_int = EQualified (["FStar"; "Char"], "char_of_int") in
       EApp(char_of_int, [c])
   | MLC_Int (s, Some (sg, wd)) ->


### PR DESCRIPTION
The extraction of character constants to krml is ill-typed, since it generates an application of FStar.Char.char_of_int (of type int -> char) to an Int32 constant.