### PR TITLE
Makefile: remove -T on install usage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ boot:
 	$(call msg, "DUNE BUILD")
 	$(Q)cd $(DUNE_SNAPSHOT) && dune build --profile release
 	$(call msg, "RAW INSTALL")
-	$(Q)install -T ocaml/_build/default/fstar/main.exe $(FSTAR_CURDIR)/bin/fstar.exe
+	$(Q)install ocaml/_build/default/fstar/main.exe $(FSTAR_CURDIR)/bin/fstar.exe
 
 .PHONY: install
 install:


### PR DESCRIPTION
It was a defensive flag anyway, and it breaks OSX