### PR TITLE
Fix typo in vec example proof 

### DIFF
--- a/doc/book/part2/part2_vectors.rst
+++ b/doc/book/part2/part2_vectors.rst
@@ -226,7 +226,7 @@ to:
     unification algorithm implemented as part of its type inference
     procedure.
 
-  * Prove that ``(i - 1) < m``, which follows from ``i < m`` and ``n
+  * Prove that ``(i - 1) < m``, which follows from ``i < n`` and ``n
     == m + 1``.
 
   * Prove that the recursive call terminates, by proving that ``m <<


### PR DESCRIPTION
I believe it should be `i<n` not `i<m` so it's `i<n`=> `i < m+1` => `(i - 1) < m`