### PR TITLE
Adding opens and abbrevs to sigelts

### DIFF
--- a/ocaml/fstar-lib/generated/FStar_CheckedFiles.ml
+++ b/ocaml/fstar-lib/generated/FStar_CheckedFiles.ml
@@ -1,5 +1,5 @@
 open Prims
-let (cache_version_number : Prims.int) = (Prims.of_int (57))
+let (cache_version_number : Prims.int) = (Prims.of_int (58))
 type tc_result =
   {
   checked_module: FStar_Syntax_Syntax.modul ;

--- a/ocaml/fstar-lib/generated/FStar_Extraction_ML_Modul.ml
+++ b/ocaml/fstar-lib/generated/FStar_Extraction_ML_Modul.ml
@@ -972,11 +972,12 @@ let (extract_bundle_iface :
                FStar_Syntax_Syntax.sigquals = uu___5;
                FStar_Syntax_Syntax.sigmeta = uu___6;
                FStar_Syntax_Syntax.sigattrs = uu___7;
-               FStar_Syntax_Syntax.sigopts = uu___8;_}::[];
-           FStar_Syntax_Syntax.lids = uu___9;_},
+               FStar_Syntax_Syntax.sigopens_and_abbrevs = uu___8;
+               FStar_Syntax_Syntax.sigopts = uu___9;_}::[];
+           FStar_Syntax_Syntax.lids = uu___10;_},
          (FStar_Syntax_Syntax.ExceptionConstructor)::[]) ->
-          let uu___10 = extract_ctor env [] env { dname = l; dtyp = t } in
-          (match uu___10 with
+          let uu___11 = extract_ctor env [] env { dname = l; dtyp = t } in
+          (match uu___11 with
            | (env1, ctor) -> (env1, (iface_of_bindings [ctor])))
       | (FStar_Syntax_Syntax.Sig_bundle
          { FStar_Syntax_Syntax.ses = ses; FStar_Syntax_Syntax.lids = uu___;_},
@@ -1409,6 +1410,8 @@ let (split_let_rec_types_and_terms :
                                 (se.FStar_Syntax_Syntax.sigmeta);
                               FStar_Syntax_Syntax.sigattrs =
                                 (se.FStar_Syntax_Syntax.sigattrs);
+                              FStar_Syntax_Syntax.sigopens_and_abbrevs =
+                                (se.FStar_Syntax_Syntax.sigopens_and_abbrevs);
                               FStar_Syntax_Syntax.sigopts =
                                 (se.FStar_Syntax_Syntax.sigopts)
                             } in
@@ -1442,6 +1445,8 @@ let (split_let_rec_types_and_terms :
                   (se.FStar_Syntax_Syntax.sigmeta);
                 FStar_Syntax_Syntax.sigattrs =
                   (se.FStar_Syntax_Syntax.sigattrs);
+                FStar_Syntax_Syntax.sigopens_and_abbrevs =
+                  (se.FStar_Syntax_Syntax.sigopens_and_abbrevs);
                 FStar_Syntax_Syntax.sigopts =
                   (se.FStar_Syntax_Syntax.sigopts)
               } in
@@ -1560,6 +1565,8 @@ let (karamel_fixup_qual :
           (se.FStar_Syntax_Syntax.sigquals));
         FStar_Syntax_Syntax.sigmeta = (se.FStar_Syntax_Syntax.sigmeta);
         FStar_Syntax_Syntax.sigattrs = (se.FStar_Syntax_Syntax.sigattrs);
+        FStar_Syntax_Syntax.sigopens_and_abbrevs =
+          (se.FStar_Syntax_Syntax.sigopens_and_abbrevs);
         FStar_Syntax_Syntax.sigopts = (se.FStar_Syntax_Syntax.sigopts)
       }
     else se
@@ -1980,11 +1987,12 @@ let (extract_bundle :
                FStar_Syntax_Syntax.sigquals = uu___5;
                FStar_Syntax_Syntax.sigmeta = uu___6;
                FStar_Syntax_Syntax.sigattrs = uu___7;
-               FStar_Syntax_Syntax.sigopts = uu___8;_}::[];
-           FStar_Syntax_Syntax.lids = uu___9;_},
+               FStar_Syntax_Syntax.sigopens_and_abbrevs = uu___8;
+               FStar_Syntax_Syntax.sigopts = uu___9;_}::[];
+           FStar_Syntax_Syntax.lids = uu___10;_},
          (FStar_Syntax_Syntax.ExceptionConstructor)::[]) ->
-          let uu___10 = extract_ctor env [] env { dname = l; dtyp = t } in
-          (match uu___10 with
+          let uu___11 = extract_ctor env [] env { dname = l; dtyp = t } in
+          (match uu___11 with
            | (env1, ctor) ->
                (env1, [FStar_Extraction_ML_Syntax.MLM_Exn ctor]))
       | (FStar_Syntax_Syntax.Sig_bundle
@@ -2662,6 +2670,8 @@ let rec (extract_sig :
                            (se1.FStar_Syntax_Syntax.sigmeta);
                          FStar_Syntax_Syntax.sigattrs =
                            (se1.FStar_Syntax_Syntax.sigattrs);
+                         FStar_Syntax_Syntax.sigopens_and_abbrevs =
+                           (se1.FStar_Syntax_Syntax.sigopens_and_abbrevs);
                          FStar_Syntax_Syntax.sigopts =
                            (se1.FStar_Syntax_Syntax.sigopts)
                        } in

--- a/ocaml/fstar-lib/generated/FStar_Interactive_Ide.ml
+++ b/ocaml/fstar-lib/generated/FStar_Interactive_Ide.ml
@@ -2177,7 +2177,8 @@ let run_with_parsed_and_tc_term :
                   FStar_Syntax_Syntax.sigquals = uu___8;
                   FStar_Syntax_Syntax.sigmeta = uu___9;
                   FStar_Syntax_Syntax.sigattrs = uu___10;
-                  FStar_Syntax_Syntax.sigopts = uu___11;_}::[] ->
+                  FStar_Syntax_Syntax.sigopens_and_abbrevs = uu___11;
+                  FStar_Syntax_Syntax.sigopts = uu___12;_}::[] ->
                   FStar_Pervasives_Native.Some (univs, def)
               | uu___ -> FStar_Pervasives_Native.None in
             let parse frag =

--- a/ocaml/fstar-lib/generated/FStar_Interactive_PushHelper.ml
+++ b/ocaml/fstar-lib/generated/FStar_Interactive_PushHelper.ml
@@ -7,8 +7,8 @@ type either_replst =
     FStar_Interactive_Ide_Types.repl_state) FStar_Pervasives.either
 type name_tracking_event =
   | NTAlias of (FStar_Ident.lid * FStar_Ident.ident * FStar_Ident.lid) 
-  | NTOpen of (FStar_Ident.lid * FStar_Syntax_DsEnv.open_module_or_namespace)
-  
+  | NTOpen of (FStar_Ident.lid *
+  FStar_Syntax_Syntax.open_module_or_namespace) 
   | NTInclude of (FStar_Ident.lid * FStar_Ident.lid) 
   | NTBinding of (FStar_Syntax_Syntax.binding,
   FStar_TypeChecker_Env.sig_binding) FStar_Pervasives.either 
@@ -22,7 +22,7 @@ let (uu___is_NTOpen : name_tracking_event -> Prims.bool) =
   fun projectee -> match projectee with | NTOpen _0 -> true | uu___ -> false
 let (__proj__NTOpen__item___0 :
   name_tracking_event ->
-    (FStar_Ident.lid * FStar_Syntax_DsEnv.open_module_or_namespace))
+    (FStar_Ident.lid * FStar_Syntax_Syntax.open_module_or_namespace))
   = fun projectee -> match projectee with | NTOpen _0 -> _0
 let (uu___is_NTInclude : name_tracking_event -> Prims.bool) =
   fun projectee ->
@@ -427,7 +427,7 @@ let (update_names_from_event :
             then
               let uu___1 = query_of_lid included in
               FStar_Interactive_CompletionTable.register_open table
-                (kind = FStar_Syntax_DsEnv.Open_module) [] uu___1
+                (kind = FStar_Syntax_Syntax.Open_module) [] uu___1
             else table
         | NTInclude (host, included) ->
             let uu___ =

--- a/ocaml/fstar-lib/generated/FStar_Reflection_V1_Builtins.ml
+++ b/ocaml/fstar-lib/generated/FStar_Reflection_V1_Builtins.ml
@@ -701,6 +701,8 @@ let (set_sigelt_attrs :
         FStar_Syntax_Syntax.sigquals = (se.FStar_Syntax_Syntax.sigquals);
         FStar_Syntax_Syntax.sigmeta = (se.FStar_Syntax_Syntax.sigmeta);
         FStar_Syntax_Syntax.sigattrs = attrs;
+        FStar_Syntax_Syntax.sigopens_and_abbrevs =
+          (se.FStar_Syntax_Syntax.sigopens_and_abbrevs);
         FStar_Syntax_Syntax.sigopts = (se.FStar_Syntax_Syntax.sigopts)
       }
 let (inspect_ident : FStar_Ident.ident -> FStar_Reflection_V1_Data.ident) =
@@ -818,6 +820,8 @@ let (set_sigelt_quals :
         FStar_Syntax_Syntax.sigquals = uu___;
         FStar_Syntax_Syntax.sigmeta = (se.FStar_Syntax_Syntax.sigmeta);
         FStar_Syntax_Syntax.sigattrs = (se.FStar_Syntax_Syntax.sigattrs);
+        FStar_Syntax_Syntax.sigopens_and_abbrevs =
+          (se.FStar_Syntax_Syntax.sigopens_and_abbrevs);
         FStar_Syntax_Syntax.sigopts = (se.FStar_Syntax_Syntax.sigopts)
       }
 let (sigelt_opts :
@@ -895,14 +899,15 @@ let (inspect_sigelt :
                           FStar_Syntax_Syntax.sigquals = uu___8;
                           FStar_Syntax_Syntax.sigmeta = uu___9;
                           FStar_Syntax_Syntax.sigattrs = uu___10;
-                          FStar_Syntax_Syntax.sigopts = uu___11;_}
+                          FStar_Syntax_Syntax.sigopens_and_abbrevs = uu___11;
+                          FStar_Syntax_Syntax.sigopts = uu___12;_}
                         ->
                         let cty1 = FStar_Syntax_Subst.subst s cty in
-                        let uu___12 =
-                          let uu___13 = get_env () in
-                          FStar_TypeChecker_Normalize.get_n_binders uu___13
+                        let uu___13 =
+                          let uu___14 = get_env () in
+                          FStar_TypeChecker_Normalize.get_n_binders uu___14
                             nparam cty1 in
-                        (match uu___12 with
+                        (match uu___13 with
                          | (param_ctor_bs, c) ->
                              (if
                                 (FStar_Compiler_List.length param_ctor_bs) <>
@@ -911,11 +916,11 @@ let (inspect_sigelt :
                                 failwith
                                   "impossible: inspect_sigelt: could not obtain sufficient ctor param binders"
                               else ();
-                              (let uu___15 =
-                                 let uu___16 =
+                              (let uu___16 =
+                                 let uu___17 =
                                    FStar_Syntax_Util.is_total_comp c in
-                                 Prims.op_Negation uu___16 in
-                               if uu___15
+                                 Prims.op_Negation uu___17 in
+                               if uu___16
                                then
                                  failwith
                                    "impossible: inspect_sigelt: removed parameters and got an effectful comp"
@@ -925,18 +930,18 @@ let (inspect_sigelt :
                                  FStar_Compiler_List.map2
                                    (fun b1 ->
                                       fun b2 ->
-                                        let uu___15 =
-                                          let uu___16 =
+                                        let uu___16 =
+                                          let uu___17 =
                                             FStar_Syntax_Syntax.bv_to_name
                                               b2.FStar_Syntax_Syntax.binder_bv in
                                           ((b1.FStar_Syntax_Syntax.binder_bv),
-                                            uu___16) in
-                                        FStar_Syntax_Syntax.NT uu___15)
+                                            uu___17) in
+                                        FStar_Syntax_Syntax.NT uu___16)
                                    param_ctor_bs param_bs2 in
                                let cty3 = FStar_Syntax_Subst.subst s' cty2 in
                                let cty4 = FStar_Syntax_Util.remove_inacc cty3 in
-                               let uu___15 = FStar_Ident.path_of_lid lid1 in
-                               (uu___15, cty4))))
+                               let uu___16 = FStar_Ident.path_of_lid lid1 in
+                               (uu___16, cty4))))
                     | uu___5 ->
                         failwith
                           "impossible: inspect_sigelt: did not find ctor" in
@@ -1078,6 +1083,8 @@ let (pack_sigelt :
               (se.FStar_Syntax_Syntax.sigquals));
             FStar_Syntax_Syntax.sigmeta = (se.FStar_Syntax_Syntax.sigmeta);
             FStar_Syntax_Syntax.sigattrs = (se.FStar_Syntax_Syntax.sigattrs);
+            FStar_Syntax_Syntax.sigopens_and_abbrevs =
+              (se.FStar_Syntax_Syntax.sigopens_and_abbrevs);
             FStar_Syntax_Syntax.sigopts = (se.FStar_Syntax_Syntax.sigopts)
           }))
     | FStar_Reflection_V1_Data.Sg_Val (nm, us_names, ty) ->

--- a/ocaml/fstar-lib/generated/FStar_Reflection_V2_Builtins.ml
+++ b/ocaml/fstar-lib/generated/FStar_Reflection_V2_Builtins.ml
@@ -679,6 +679,8 @@ let (set_sigelt_attrs :
         FStar_Syntax_Syntax.sigquals = (se.FStar_Syntax_Syntax.sigquals);
         FStar_Syntax_Syntax.sigmeta = (se.FStar_Syntax_Syntax.sigmeta);
         FStar_Syntax_Syntax.sigattrs = attrs;
+        FStar_Syntax_Syntax.sigopens_and_abbrevs =
+          (se.FStar_Syntax_Syntax.sigopens_and_abbrevs);
         FStar_Syntax_Syntax.sigopts = (se.FStar_Syntax_Syntax.sigopts)
       }
 let (rd_to_syntax_qual :
@@ -782,6 +784,8 @@ let (set_sigelt_quals :
         FStar_Syntax_Syntax.sigquals = uu___;
         FStar_Syntax_Syntax.sigmeta = (se.FStar_Syntax_Syntax.sigmeta);
         FStar_Syntax_Syntax.sigattrs = (se.FStar_Syntax_Syntax.sigattrs);
+        FStar_Syntax_Syntax.sigopens_and_abbrevs =
+          (se.FStar_Syntax_Syntax.sigopens_and_abbrevs);
         FStar_Syntax_Syntax.sigopts = (se.FStar_Syntax_Syntax.sigopts)
       }
 let (sigelt_opts :
@@ -829,8 +833,9 @@ let (inspect_sigelt :
                 FStar_Syntax_Syntax.sigquals = uu___6;
                 FStar_Syntax_Syntax.sigmeta = uu___7;
                 FStar_Syntax_Syntax.sigattrs = uu___8;
-                FStar_Syntax_Syntax.sigopts = uu___9;_}
-              -> let uu___10 = FStar_Ident.path_of_lid lid1 in (uu___10, cty)
+                FStar_Syntax_Syntax.sigopens_and_abbrevs = uu___9;
+                FStar_Syntax_Syntax.sigopts = uu___10;_}
+              -> let uu___11 = FStar_Ident.path_of_lid lid1 in (uu___11, cty)
           | uu___3 ->
               failwith "impossible: inspect_sigelt: did not find ctor" in
         let uu___2 =
@@ -947,6 +952,8 @@ let (pack_sigelt :
               (se.FStar_Syntax_Syntax.sigquals));
             FStar_Syntax_Syntax.sigmeta = (se.FStar_Syntax_Syntax.sigmeta);
             FStar_Syntax_Syntax.sigattrs = (se.FStar_Syntax_Syntax.sigattrs);
+            FStar_Syntax_Syntax.sigopens_and_abbrevs =
+              (se.FStar_Syntax_Syntax.sigopens_and_abbrevs);
             FStar_Syntax_Syntax.sigopts = (se.FStar_Syntax_Syntax.sigopts)
           }))
     | FStar_Reflection_V2_Data.Sg_Val (nm, us_names, ty) ->

--- a/ocaml/fstar-lib/generated/FStar_SMTEncoding_Encode.ml
+++ b/ocaml/fstar-lib/generated/FStar_SMTEncoding_Encode.ml
@@ -4272,6 +4272,8 @@ and (encode_sigelt' :
                             (se.FStar_Syntax_Syntax.sigmeta);
                           FStar_Syntax_Syntax.sigattrs =
                             (se.FStar_Syntax_Syntax.sigattrs);
+                          FStar_Syntax_Syntax.sigopens_and_abbrevs =
+                            (se.FStar_Syntax_Syntax.sigopens_and_abbrevs);
                           FStar_Syntax_Syntax.sigopts =
                             (se.FStar_Syntax_Syntax.sigopts)
                         } in
@@ -4456,6 +4458,8 @@ and (encode_sigelt' :
                       (se.FStar_Syntax_Syntax.sigmeta);
                     FStar_Syntax_Syntax.sigattrs =
                       (se.FStar_Syntax_Syntax.sigattrs);
+                    FStar_Syntax_Syntax.sigopens_and_abbrevs =
+                      (se.FStar_Syntax_Syntax.sigopens_and_abbrevs);
                     FStar_Syntax_Syntax.sigopts =
                       (se.FStar_Syntax_Syntax.sigopts)
                   } in

--- a/ocaml/fstar-lib/generated/FStar_Syntax_MutRecTy.ml
+++ b/ocaml/fstar-lib/generated/FStar_Syntax_MutRecTy.ml
@@ -59,6 +59,7 @@ let (disentangle_abbrevs_from_bundle :
                  FStar_Syntax_Syntax.sigmeta =
                    FStar_Syntax_Syntax.default_sigmeta;
                  FStar_Syntax_Syntax.sigattrs = sigattrs1;
+                 FStar_Syntax_Syntax.sigopens_and_abbrevs = [];
                  FStar_Syntax_Syntax.sigopts = FStar_Pervasives_Native.None
                }, [])
           | uu___ ->
@@ -165,7 +166,8 @@ let (disentangle_abbrevs_from_bundle :
                           FStar_Syntax_Syntax.sigquals = uu___10;
                           FStar_Syntax_Syntax.sigmeta = uu___11;
                           FStar_Syntax_Syntax.sigattrs = uu___12;
-                          FStar_Syntax_Syntax.sigopts = uu___13;_}
+                          FStar_Syntax_Syntax.sigopens_and_abbrevs = uu___13;
+                          FStar_Syntax_Syntax.sigopts = uu___14;_}
                         -> FStar_Pervasives_Native.Some tm
                     | uu___1 -> FStar_Pervasives_Native.None in
                   let uu___1 =
@@ -278,6 +280,9 @@ let (disentangle_abbrevs_from_bundle :
                                           (x.FStar_Syntax_Syntax.sigmeta);
                                         FStar_Syntax_Syntax.sigattrs =
                                           (x.FStar_Syntax_Syntax.sigattrs);
+                                        FStar_Syntax_Syntax.sigopens_and_abbrevs
+                                          =
+                                          (x.FStar_Syntax_Syntax.sigopens_and_abbrevs);
                                         FStar_Syntax_Syntax.sigopts =
                                           (x.FStar_Syntax_Syntax.sigopts)
                                       } :: uu___6 in
@@ -379,6 +384,8 @@ let (disentangle_abbrevs_from_bundle :
                            (x.FStar_Syntax_Syntax.sigmeta);
                          FStar_Syntax_Syntax.sigattrs =
                            (x.FStar_Syntax_Syntax.sigattrs);
+                         FStar_Syntax_Syntax.sigopens_and_abbrevs =
+                           (x.FStar_Syntax_Syntax.sigopens_and_abbrevs);
                          FStar_Syntax_Syntax.sigopts =
                            (x.FStar_Syntax_Syntax.sigopts)
                        }]
@@ -411,6 +418,8 @@ let (disentangle_abbrevs_from_bundle :
                            (x.FStar_Syntax_Syntax.sigmeta);
                          FStar_Syntax_Syntax.sigattrs =
                            (x.FStar_Syntax_Syntax.sigattrs);
+                         FStar_Syntax_Syntax.sigopens_and_abbrevs =
+                           (x.FStar_Syntax_Syntax.sigopens_and_abbrevs);
                          FStar_Syntax_Syntax.sigopts =
                            (x.FStar_Syntax_Syntax.sigopts)
                        }]
@@ -434,6 +443,7 @@ let (disentangle_abbrevs_from_bundle :
                   FStar_Syntax_Syntax.sigmeta =
                     FStar_Syntax_Syntax.default_sigmeta;
                   FStar_Syntax_Syntax.sigattrs = sigattrs1;
+                  FStar_Syntax_Syntax.sigopens_and_abbrevs = [];
                   FStar_Syntax_Syntax.sigopts = FStar_Pervasives_Native.None
                 } in
               (new_bundle, unfolded_type_abbrevs)

--- a/ocaml/fstar-lib/generated/FStar_Syntax_Syntax.ml
+++ b/ocaml/fstar-lib/generated/FStar_Syntax_Syntax.ml
@@ -1666,6 +1666,17 @@ let (__proj__Mksig_metadata__item__sigmeta_admit :
     match projectee with
     | { sigmeta_active; sigmeta_fact_db_ids; sigmeta_admit;_} ->
         sigmeta_admit
+type open_kind =
+  | Open_module 
+  | Open_namespace 
+let (uu___is_Open_module : open_kind -> Prims.bool) =
+  fun projectee ->
+    match projectee with | Open_module -> true | uu___ -> false
+let (uu___is_Open_namespace : open_kind -> Prims.bool) =
+  fun projectee ->
+    match projectee with | Open_namespace -> true | uu___ -> false
+type open_module_or_namespace = (FStar_Ident.lident * open_kind)
+type module_abbrev = (FStar_Ident.ident * FStar_Ident.lident)
 type sigelt'__Sig_inductive_typ__payload =
   {
   lid: FStar_Ident.lident ;
@@ -1755,6 +1766,10 @@ and sigelt =
   sigquals: qualifier Prims.list ;
   sigmeta: sig_metadata ;
   sigattrs: attribute Prims.list ;
+  sigopens_and_abbrevs:
+    (open_module_or_namespace, module_abbrev) FStar_Pervasives.either
+      Prims.list
+    ;
   sigopts: FStar_VConfig.vconfig FStar_Pervasives_Native.option }
 let (__proj__Mksigelt'__Sig_inductive_typ__payload__item__lid :
   sigelt'__Sig_inductive_typ__payload -> FStar_Ident.lident) =
@@ -2061,29 +2076,44 @@ let (__proj__Sig_fail__item___0 : sigelt' -> sigelt'__Sig_fail__payload) =
 let (__proj__Mksigelt__item__sigel : sigelt -> sigelt') =
   fun projectee ->
     match projectee with
-    | { sigel; sigrng; sigquals; sigmeta; sigattrs; sigopts;_} -> sigel
+    | { sigel; sigrng; sigquals; sigmeta; sigattrs; sigopens_and_abbrevs;
+        sigopts;_} -> sigel
 let (__proj__Mksigelt__item__sigrng :
   sigelt -> FStar_Compiler_Range_Type.range) =
   fun projectee ->
     match projectee with
-    | { sigel; sigrng; sigquals; sigmeta; sigattrs; sigopts;_} -> sigrng
+    | { sigel; sigrng; sigquals; sigmeta; sigattrs; sigopens_and_abbrevs;
+        sigopts;_} -> sigrng
 let (__proj__Mksigelt__item__sigquals : sigelt -> qualifier Prims.list) =
   fun projectee ->
     match projectee with
-    | { sigel; sigrng; sigquals; sigmeta; sigattrs; sigopts;_} -> sigquals
+    | { sigel; sigrng; sigquals; sigmeta; sigattrs; sigopens_and_abbrevs;
+        sigopts;_} -> sigquals
 let (__proj__Mksigelt__item__sigmeta : sigelt -> sig_metadata) =
   fun projectee ->
     match projectee with
-    | { sigel; sigrng; sigquals; sigmeta; sigattrs; sigopts;_} -> sigmeta
+    | { sigel; sigrng; sigquals; sigmeta; sigattrs; sigopens_and_abbrevs;
+        sigopts;_} -> sigmeta
 let (__proj__Mksigelt__item__sigattrs : sigelt -> attribute Prims.list) =
   fun projectee ->
     match projectee with
-    | { sigel; sigrng; sigquals; sigmeta; sigattrs; sigopts;_} -> sigattrs
+    | { sigel; sigrng; sigquals; sigmeta; sigattrs; sigopens_and_abbrevs;
+        sigopts;_} -> sigattrs
+let (__proj__Mksigelt__item__sigopens_and_abbrevs :
+  sigelt ->
+    (open_module_or_namespace, module_abbrev) FStar_Pervasives.either
+      Prims.list)
+  =
+  fun projectee ->
+    match projectee with
+    | { sigel; sigrng; sigquals; sigmeta; sigattrs; sigopens_and_abbrevs;
+        sigopts;_} -> sigopens_and_abbrevs
 let (__proj__Mksigelt__item__sigopts :
   sigelt -> FStar_VConfig.vconfig FStar_Pervasives_Native.option) =
   fun projectee ->
     match projectee with
-    | { sigel; sigrng; sigquals; sigmeta; sigattrs; sigopts;_} -> sigopts
+    | { sigel; sigrng; sigquals; sigmeta; sigattrs; sigopens_and_abbrevs;
+        sigopts;_} -> sigopts
 type sigelts = sigelt Prims.list
 type modul =
   {
@@ -2285,6 +2315,7 @@ let (mk_sigelt : sigelt' -> sigelt) =
       sigquals = [];
       sigmeta = default_sigmeta;
       sigattrs = [];
+      sigopens_and_abbrevs = [];
       sigopts = FStar_Pervasives_Native.None
     }
 let (mk_subst : subst_t -> subst_t) = fun s -> s

--- a/ocaml/fstar-lib/generated/FStar_Syntax_Util.ml
+++ b/ocaml/fstar-lib/generated/FStar_Syntax_Util.ml
@@ -3699,6 +3699,7 @@ let (action_as_lb :
             FStar_Syntax_Syntax.Action eff_lid];
           FStar_Syntax_Syntax.sigmeta = FStar_Syntax_Syntax.default_sigmeta;
           FStar_Syntax_Syntax.sigattrs = [];
+          FStar_Syntax_Syntax.sigopens_and_abbrevs = [];
           FStar_Syntax_Syntax.sigopts = FStar_Pervasives_Native.None
         }
 let (mk_reify :
@@ -4624,6 +4625,8 @@ let (extract_attr :
                  (se.FStar_Syntax_Syntax.sigquals);
                FStar_Syntax_Syntax.sigmeta = (se.FStar_Syntax_Syntax.sigmeta);
                FStar_Syntax_Syntax.sigattrs = attrs';
+               FStar_Syntax_Syntax.sigopens_and_abbrevs =
+                 (se.FStar_Syntax_Syntax.sigopens_and_abbrevs);
                FStar_Syntax_Syntax.sigopts = (se.FStar_Syntax_Syntax.sigopts)
              }, t)
 let (is_smt_lemma : FStar_Syntax_Syntax.term -> Prims.bool) =

--- a/ocaml/fstar-lib/generated/FStar_Syntax_Visit.ml
+++ b/ocaml/fstar-lib/generated/FStar_Syntax_Visit.ml
@@ -828,6 +828,8 @@ and (on_sub_sigelt :
         FStar_Syntax_Syntax.sigquals = (se.FStar_Syntax_Syntax.sigquals);
         FStar_Syntax_Syntax.sigmeta = (se.FStar_Syntax_Syntax.sigmeta);
         FStar_Syntax_Syntax.sigattrs = uu___1;
+        FStar_Syntax_Syntax.sigopens_and_abbrevs =
+          (se.FStar_Syntax_Syntax.sigopens_and_abbrevs);
         FStar_Syntax_Syntax.sigopts = (se.FStar_Syntax_Syntax.sigopts)
       }
 let (tie_bu : vfs_t -> vfs_t FStar_Compiler_Effect.ref) =

--- a/ocaml/fstar-lib/generated/FStar_Tactics_Hooks.ml
+++ b/ocaml/fstar-lib/generated/FStar_Tactics_Hooks.ml
@@ -1946,6 +1946,8 @@ let (splice :
                                         FStar_Syntax_Syntax.sigmeta =
                                           FStar_Syntax_Syntax.default_sigmeta;
                                         FStar_Syntax_Syntax.sigattrs = [];
+                                        FStar_Syntax_Syntax.sigopens_and_abbrevs
+                                          = [];
                                         FStar_Syntax_Syntax.sigopts =
                                           FStar_Pervasives_Native.None
                                       }])
@@ -2044,6 +2046,9 @@ let (splice :
                                               (se.FStar_Syntax_Syntax.sigmeta);
                                             FStar_Syntax_Syntax.sigattrs =
                                               (se.FStar_Syntax_Syntax.sigattrs);
+                                            FStar_Syntax_Syntax.sigopens_and_abbrevs
+                                              =
+                                              (se.FStar_Syntax_Syntax.sigopens_and_abbrevs);
                                             FStar_Syntax_Syntax.sigopts =
                                               (se.FStar_Syntax_Syntax.sigopts)
                                           }
@@ -2197,6 +2202,9 @@ let (splice :
                                                 (se.FStar_Syntax_Syntax.sigmeta);
                                               FStar_Syntax_Syntax.sigattrs =
                                                 (se.FStar_Syntax_Syntax.sigattrs);
+                                              FStar_Syntax_Syntax.sigopens_and_abbrevs
+                                                =
+                                                (se.FStar_Syntax_Syntax.sigopens_and_abbrevs);
                                               FStar_Syntax_Syntax.sigopts =
                                                 (se.FStar_Syntax_Syntax.sigopts)
                                             })) in

--- a/ocaml/fstar-lib/generated/FStar_ToSyntax_ToSyntax.ml
+++ b/ocaml/fstar-lib/generated/FStar_ToSyntax_ToSyntax.ml
@@ -1185,6 +1185,8 @@ let rec (generalize_annotated_univs :
                               (se.FStar_Syntax_Syntax.sigmeta);
                             FStar_Syntax_Syntax.sigattrs =
                               (se.FStar_Syntax_Syntax.sigattrs);
+                            FStar_Syntax_Syntax.sigopens_and_abbrevs =
+                              (se.FStar_Syntax_Syntax.sigopens_and_abbrevs);
                             FStar_Syntax_Syntax.sigopts =
                               (se.FStar_Syntax_Syntax.sigopts)
                           }
@@ -1218,6 +1220,8 @@ let rec (generalize_annotated_univs :
                               (se.FStar_Syntax_Syntax.sigmeta);
                             FStar_Syntax_Syntax.sigattrs =
                               (se.FStar_Syntax_Syntax.sigattrs);
+                            FStar_Syntax_Syntax.sigopens_and_abbrevs =
+                              (se.FStar_Syntax_Syntax.sigopens_and_abbrevs);
                             FStar_Syntax_Syntax.sigopts =
                               (se.FStar_Syntax_Syntax.sigopts)
                           }
@@ -1235,6 +1239,8 @@ let rec (generalize_annotated_univs :
           FStar_Syntax_Syntax.sigquals = (s.FStar_Syntax_Syntax.sigquals);
           FStar_Syntax_Syntax.sigmeta = (s.FStar_Syntax_Syntax.sigmeta);
           FStar_Syntax_Syntax.sigattrs = (s.FStar_Syntax_Syntax.sigattrs);
+          FStar_Syntax_Syntax.sigopens_and_abbrevs =
+            (s.FStar_Syntax_Syntax.sigopens_and_abbrevs);
           FStar_Syntax_Syntax.sigopts = (s.FStar_Syntax_Syntax.sigopts)
         }
     | FStar_Syntax_Syntax.Sig_declare_typ
@@ -1260,6 +1266,8 @@ let rec (generalize_annotated_univs :
           FStar_Syntax_Syntax.sigquals = (s.FStar_Syntax_Syntax.sigquals);
           FStar_Syntax_Syntax.sigmeta = (s.FStar_Syntax_Syntax.sigmeta);
           FStar_Syntax_Syntax.sigattrs = (s.FStar_Syntax_Syntax.sigattrs);
+          FStar_Syntax_Syntax.sigopens_and_abbrevs =
+            (s.FStar_Syntax_Syntax.sigopens_and_abbrevs);
           FStar_Syntax_Syntax.sigopts = (s.FStar_Syntax_Syntax.sigopts)
         }
     | FStar_Syntax_Syntax.Sig_let
@@ -1321,6 +1329,8 @@ let rec (generalize_annotated_univs :
           FStar_Syntax_Syntax.sigquals = (s.FStar_Syntax_Syntax.sigquals);
           FStar_Syntax_Syntax.sigmeta = (s.FStar_Syntax_Syntax.sigmeta);
           FStar_Syntax_Syntax.sigattrs = (s.FStar_Syntax_Syntax.sigattrs);
+          FStar_Syntax_Syntax.sigopens_and_abbrevs =
+            (s.FStar_Syntax_Syntax.sigopens_and_abbrevs);
           FStar_Syntax_Syntax.sigopts = (s.FStar_Syntax_Syntax.sigopts)
         }
     | FStar_Syntax_Syntax.Sig_assume
@@ -1346,6 +1356,8 @@ let rec (generalize_annotated_univs :
           FStar_Syntax_Syntax.sigquals = (s.FStar_Syntax_Syntax.sigquals);
           FStar_Syntax_Syntax.sigmeta = (s.FStar_Syntax_Syntax.sigmeta);
           FStar_Syntax_Syntax.sigattrs = (s.FStar_Syntax_Syntax.sigattrs);
+          FStar_Syntax_Syntax.sigopens_and_abbrevs =
+            (s.FStar_Syntax_Syntax.sigopens_and_abbrevs);
           FStar_Syntax_Syntax.sigopts = (s.FStar_Syntax_Syntax.sigopts)
         }
     | FStar_Syntax_Syntax.Sig_effect_abbrev
@@ -1379,6 +1391,8 @@ let rec (generalize_annotated_univs :
           FStar_Syntax_Syntax.sigquals = (s.FStar_Syntax_Syntax.sigquals);
           FStar_Syntax_Syntax.sigmeta = (s.FStar_Syntax_Syntax.sigmeta);
           FStar_Syntax_Syntax.sigattrs = (s.FStar_Syntax_Syntax.sigattrs);
+          FStar_Syntax_Syntax.sigopens_and_abbrevs =
+            (s.FStar_Syntax_Syntax.sigopens_and_abbrevs);
           FStar_Syntax_Syntax.sigopts = (s.FStar_Syntax_Syntax.sigopts)
         }
     | FStar_Syntax_Syntax.Sig_fail
@@ -1402,6 +1416,8 @@ let rec (generalize_annotated_univs :
           FStar_Syntax_Syntax.sigquals = (s.FStar_Syntax_Syntax.sigquals);
           FStar_Syntax_Syntax.sigmeta = (s.FStar_Syntax_Syntax.sigmeta);
           FStar_Syntax_Syntax.sigattrs = (s.FStar_Syntax_Syntax.sigattrs);
+          FStar_Syntax_Syntax.sigopens_and_abbrevs =
+            (s.FStar_Syntax_Syntax.sigopens_and_abbrevs);
           FStar_Syntax_Syntax.sigopts = (s.FStar_Syntax_Syntax.sigopts)
         }
     | FStar_Syntax_Syntax.Sig_new_effect uu___ -> s
@@ -6202,6 +6218,7 @@ let (mk_data_discriminators :
                     quals2
                       [FStar_Syntax_Syntax.OnlyName;
                       FStar_Syntax_Syntax.Discriminator d] in
+                  let uu___2 = FStar_Syntax_DsEnv.opens_and_abbrevs env in
                   {
                     FStar_Syntax_Syntax.sigel =
                       (FStar_Syntax_Syntax.Sig_declare_typ
@@ -6215,6 +6232,7 @@ let (mk_data_discriminators :
                     FStar_Syntax_Syntax.sigmeta =
                       FStar_Syntax_Syntax.default_sigmeta;
                     FStar_Syntax_Syntax.sigattrs = attrs;
+                    FStar_Syntax_Syntax.sigopens_and_abbrevs = uu___2;
                     FStar_Syntax_Syntax.sigopts =
                       FStar_Pervasives_Native.None
                   }))
@@ -6273,6 +6291,8 @@ let (mk_indexed_projector_names :
                               iquals1) in
                           let decl =
                             let uu___1 = FStar_Ident.range_of_lid field_name in
+                            let uu___2 =
+                              FStar_Syntax_DsEnv.opens_and_abbrevs env in
                             {
                               FStar_Syntax_Syntax.sigel =
                                 (FStar_Syntax_Syntax.Sig_declare_typ
@@ -6287,6 +6307,8 @@ let (mk_indexed_projector_names :
                               FStar_Syntax_Syntax.sigmeta =
                                 FStar_Syntax_Syntax.default_sigmeta;
                               FStar_Syntax_Syntax.sigattrs = attrs;
+                              FStar_Syntax_Syntax.sigopens_and_abbrevs =
+                                uu___2;
                               FStar_Syntax_Syntax.sigopts =
                                 FStar_Pervasives_Native.None
                             } in
@@ -6335,6 +6357,8 @@ let (mk_indexed_projector_names :
                                      FStar_Syntax_Syntax.lids1 = uu___4
                                    } in
                                  FStar_Syntax_Syntax.Sig_let uu___3 in
+                               let uu___3 =
+                                 FStar_Syntax_DsEnv.opens_and_abbrevs env in
                                {
                                  FStar_Syntax_Syntax.sigel = uu___2;
                                  FStar_Syntax_Syntax.sigrng = p;
@@ -6342,6 +6366,8 @@ let (mk_indexed_projector_names :
                                  FStar_Syntax_Syntax.sigmeta =
                                    FStar_Syntax_Syntax.default_sigmeta;
                                  FStar_Syntax_Syntax.sigattrs = attrs;
+                                 FStar_Syntax_Syntax.sigopens_and_abbrevs =
+                                   uu___3;
                                  FStar_Syntax_Syntax.sigopts =
                                    FStar_Pervasives_Native.None
                                } in
@@ -6456,6 +6482,7 @@ let (mk_typ_abbrev :
                       let uu___ =
                         FStar_Syntax_Util.deduplicate_terms
                           (FStar_Compiler_List.op_At val_attrs attrs) in
+                      let uu___1 = FStar_Syntax_DsEnv.opens_and_abbrevs env in
                       {
                         FStar_Syntax_Syntax.sigel =
                           (FStar_Syntax_Syntax.Sig_let
@@ -6468,6 +6495,7 @@ let (mk_typ_abbrev :
                         FStar_Syntax_Syntax.sigmeta =
                           FStar_Syntax_Syntax.default_sigmeta;
                         FStar_Syntax_Syntax.sigattrs = uu___;
+                        FStar_Syntax_Syntax.sigopens_and_abbrevs = uu___1;
                         FStar_Syntax_Syntax.sigopts =
                           FStar_Pervasives_Native.None
                       }
@@ -6772,6 +6800,8 @@ let rec (desugar_tycon :
                        let k1 = FStar_Syntax_Subst.close typars1 k in
                        let se =
                          let uu___2 = FStar_Ident.range_of_id id in
+                         let uu___3 =
+                           FStar_Syntax_DsEnv.opens_and_abbrevs env in
                          {
                            FStar_Syntax_Syntax.sigel =
                              (FStar_Syntax_Syntax.Sig_inductive_typ
@@ -6790,6 +6820,7 @@ let rec (desugar_tycon :
                            FStar_Syntax_Syntax.sigmeta =
                              FStar_Syntax_Syntax.default_sigmeta;
                            FStar_Syntax_Syntax.sigattrs = d_attrs;
+                           FStar_Syntax_Syntax.sigopens_and_abbrevs = uu___3;
                            FStar_Syntax_Syntax.sigopts =
                              FStar_Pervasives_Native.None
                          } in
@@ -6909,6 +6940,8 @@ let rec (desugar_tycon :
                                (se.FStar_Syntax_Syntax.sigmeta);
                              FStar_Syntax_Syntax.sigattrs =
                                (se.FStar_Syntax_Syntax.sigattrs);
+                             FStar_Syntax_Syntax.sigopens_and_abbrevs =
+                               (se.FStar_Syntax_Syntax.sigopens_and_abbrevs);
                              FStar_Syntax_Syntax.sigopts =
                                (se.FStar_Syntax_Syntax.sigopts)
                            }
@@ -7007,6 +7040,8 @@ let rec (desugar_tycon :
                                        | FStar_Syntax_Syntax.Effect -> false
                                        | uu___4 -> true)) in
                              let uu___3 = FStar_Ident.range_of_id id in
+                             let uu___4 =
+                               FStar_Syntax_DsEnv.opens_and_abbrevs env in
                              {
                                FStar_Syntax_Syntax.sigel =
                                  (FStar_Syntax_Syntax.Sig_effect_abbrev
@@ -7025,6 +7060,8 @@ let rec (desugar_tycon :
                                FStar_Syntax_Syntax.sigmeta =
                                  FStar_Syntax_Syntax.default_sigmeta;
                                FStar_Syntax_Syntax.sigattrs = [];
+                               FStar_Syntax_Syntax.sigopens_and_abbrevs =
+                                 uu___4;
                                FStar_Syntax_Syntax.sigopts =
                                  FStar_Pervasives_Native.None
                              }
@@ -7136,17 +7173,19 @@ let rec (desugar_tycon :
                                       FStar_Syntax_Syntax.sigquals = uu___8;
                                       FStar_Syntax_Syntax.sigmeta = uu___9;
                                       FStar_Syntax_Syntax.sigattrs = uu___10;
-                                      FStar_Syntax_Syntax.sigopts = uu___11;_},
+                                      FStar_Syntax_Syntax.sigopens_and_abbrevs
+                                        = uu___11;
+                                      FStar_Syntax_Syntax.sigopts = uu___12;_},
                                     binders, t, quals1)
                                    ->
                                    let t1 =
-                                     let uu___12 =
+                                     let uu___13 =
                                        typars_of_binders env1 binders in
-                                     match uu___12 with
+                                     match uu___13 with
                                      | (env2, tpars1) ->
-                                         let uu___13 =
+                                         let uu___14 =
                                            push_tparams env2 tpars1 in
-                                         (match uu___13 with
+                                         (match uu___14 with
                                           | (env_tps, tpars2) ->
                                               let t2 = desugar_typ env_tps t in
                                               let tpars3 =
@@ -7154,15 +7193,15 @@ let rec (desugar_tycon :
                                                   tpars2 in
                                               FStar_Syntax_Subst.close tpars3
                                                 t2) in
-                                   let uu___12 =
-                                     let uu___13 =
-                                       let uu___14 =
+                                   let uu___13 =
+                                     let uu___14 =
+                                       let uu___15 =
                                          FStar_Ident.range_of_lid id in
                                        mk_typ_abbrev env1 d id uvs tpars
                                          (FStar_Pervasives_Native.Some k) t1
-                                         [id] quals1 uu___14 in
-                                     ([], uu___13) in
-                                   [uu___12]
+                                         [id] quals1 uu___15 in
+                                     ([], uu___14) in
+                                   [uu___13]
                                | FStar_Pervasives.Inl
                                    ({
                                       FStar_Syntax_Syntax.sigel =
@@ -7181,7 +7220,9 @@ let rec (desugar_tycon :
                                         tname_quals;
                                       FStar_Syntax_Syntax.sigmeta = uu___6;
                                       FStar_Syntax_Syntax.sigattrs = uu___7;
-                                      FStar_Syntax_Syntax.sigopts = uu___8;_},
+                                      FStar_Syntax_Syntax.sigopens_and_abbrevs
+                                        = uu___8;
+                                      FStar_Syntax_Syntax.sigopts = uu___9;_},
                                     constrs, tconstr, quals1)
                                    ->
                                    let mk_tot t =
@@ -7197,8 +7238,8 @@ let rec (desugar_tycon :
                                        t.FStar_Parser_AST.range
                                        t.FStar_Parser_AST.level in
                                    let tycon = (tname, tpars, k) in
-                                   let uu___9 = push_tparams env1 tpars in
-                                   (match uu___9 with
+                                   let uu___10 = push_tparams env1 tpars in
+                                   (match uu___10 with
                                     | (env_tps, tps) ->
                                         let data_tpars =
                                           FStar_Compiler_List.map
@@ -7221,19 +7262,19 @@ let rec (desugar_tycon :
                                                }) tps in
                                         let tot_tconstr = mk_tot tconstr in
                                         let val_attrs =
-                                          let uu___10 =
+                                          let uu___11 =
                                             FStar_Syntax_DsEnv.lookup_letbinding_quals_and_attrs
                                               env0 tname in
                                           FStar_Compiler_Effect.op_Bar_Greater
-                                            uu___10
+                                            uu___11
                                             FStar_Pervasives_Native.snd in
-                                        let uu___10 =
-                                          let uu___11 =
+                                        let uu___11 =
+                                          let uu___12 =
                                             FStar_Compiler_Effect.op_Bar_Greater
                                               constrs
                                               (FStar_Compiler_List.map
-                                                 (fun uu___12 ->
-                                                    match uu___12 with
+                                                 (fun uu___13 ->
+                                                    match uu___13 with
                                                     | (id, payload,
                                                        cons_attrs) ->
                                                         let t =
@@ -7244,11 +7285,11 @@ let rec (desugar_tycon :
                                                           | FStar_Pervasives_Native.Some
                                                               (FStar_Parser_AST.VpOfNotation
                                                               t1) ->
-                                                              let uu___13 =
-                                                                let uu___14 =
-                                                                  let uu___15
+                                                              let uu___14 =
+                                                                let uu___15 =
+                                                                  let uu___16
                                                                     =
-                                                                    let uu___16
+                                                                    let uu___17
                                                                     =
                                                                     FStar_Parser_AST.mk_binder
                                                                     (FStar_Parser_AST.NoName
@@ -7256,27 +7297,27 @@ let rec (desugar_tycon :
                                                                     t1.FStar_Parser_AST.range
                                                                     t1.FStar_Parser_AST.level
                                                                     FStar_Pervasives_Native.None in
-                                                                    [uu___16] in
-                                                                  (uu___15,
+                                                                    [uu___17] in
+                                                                  (uu___16,
                                                                     tot_tconstr) in
                                                                 FStar_Parser_AST.Product
-                                                                  uu___14 in
+                                                                  uu___15 in
                                                               FStar_Parser_AST.mk_term
-                                                                uu___13
+                                                                uu___14
                                                                 t1.FStar_Parser_AST.range
                                                                 t1.FStar_Parser_AST.level
                                                           | FStar_Pervasives_Native.Some
                                                               (FStar_Parser_AST.VpRecord
-                                                              uu___13) ->
+                                                              uu___14) ->
                                                               failwith
                                                                 "Impossible: [VpRecord _] should have disappeared after [desugar_tycon_variant_record]"
                                                           | FStar_Pervasives_Native.None
                                                               -> tconstr in
                                                         let t1 =
-                                                          let uu___13 =
+                                                          let uu___14 =
                                                             close env_tps t in
                                                           desugar_term
-                                                            env_tps uu___13 in
+                                                            env_tps uu___14 in
                                                         let name =
                                                           FStar_Syntax_DsEnv.qualify
                                                             env1 id in
@@ -7284,44 +7325,44 @@ let rec (desugar_tycon :
                                                           FStar_Compiler_Effect.op_Bar_Greater
                                                             tname_quals
                                                             (FStar_Compiler_List.collect
-                                                               (fun uu___13
+                                                               (fun uu___14
                                                                   ->
-                                                                  match uu___13
+                                                                  match uu___14
                                                                   with
                                                                   | FStar_Syntax_Syntax.RecordType
                                                                     fns ->
                                                                     [
                                                                     FStar_Syntax_Syntax.RecordConstructor
                                                                     fns]
-                                                                  | uu___14
+                                                                  | uu___15
                                                                     -> [])) in
                                                         let ntps =
                                                           FStar_Compiler_List.length
                                                             data_tpars in
-                                                        let uu___13 =
-                                                          let uu___14 =
-                                                            let uu___15 =
-                                                              let uu___16 =
-                                                                let uu___17 =
-                                                                  let uu___18
+                                                        let uu___14 =
+                                                          let uu___15 =
+                                                            let uu___16 =
+                                                              let uu___17 =
+                                                                let uu___18 =
+                                                                  let uu___19
                                                                     =
-                                                                    let uu___19
+                                                                    let uu___20
                                                                     =
                                                                     FStar_Compiler_Effect.op_Bar_Greater
                                                                     t1
                                                                     FStar_Syntax_Util.name_function_binders in
                                                                     FStar_Syntax_Syntax.mk_Total
-                                                                    uu___19 in
+                                                                    uu___20 in
                                                                   FStar_Syntax_Util.arrow
                                                                     data_tpars
-                                                                    uu___18 in
+                                                                    uu___19 in
                                                                 {
                                                                   FStar_Syntax_Syntax.lid1
                                                                     = name;
                                                                   FStar_Syntax_Syntax.us1
                                                                     = univs;
                                                                   FStar_Syntax_Syntax.t1
-                                                                    = uu___17;
+                                                                    = uu___18;
                                                                   FStar_Syntax_Syntax.ty_lid
                                                                     = tname;
                                                                   FStar_Syntax_Syntax.num_ty_params
@@ -7331,14 +7372,14 @@ let rec (desugar_tycon :
                                                                     mutuals1
                                                                 } in
                                                               FStar_Syntax_Syntax.Sig_datacon
-                                                                uu___16 in
-                                                            let uu___16 =
+                                                                uu___17 in
+                                                            let uu___17 =
                                                               FStar_Ident.range_of_lid
                                                                 name in
-                                                            let uu___17 =
-                                                              let uu___18 =
-                                                                let uu___19 =
-                                                                  let uu___20
+                                                            let uu___18 =
+                                                              let uu___19 =
+                                                                let uu___20 =
+                                                                  let uu___21
                                                                     =
                                                                     FStar_Compiler_List.map
                                                                     (desugar_term
@@ -7346,70 +7387,78 @@ let rec (desugar_tycon :
                                                                     cons_attrs in
                                                                   FStar_Compiler_List.op_At
                                                                     d_attrs
-                                                                    uu___20 in
+                                                                    uu___21 in
                                                                 FStar_Compiler_List.op_At
                                                                   val_attrs
-                                                                  uu___19 in
+                                                                  uu___20 in
                                                               FStar_Syntax_Util.deduplicate_terms
-                                                                uu___18 in
+                                                                uu___19 in
+                                                            let uu___19 =
+                                                              FStar_Syntax_DsEnv.opens_and_abbrevs
+                                                                env1 in
                                                             {
                                                               FStar_Syntax_Syntax.sigel
-                                                                = uu___15;
-                                                              FStar_Syntax_Syntax.sigrng
                                                                 = uu___16;
+                                                              FStar_Syntax_Syntax.sigrng
+                                                                = uu___17;
                                                               FStar_Syntax_Syntax.sigquals
                                                                 = quals2;
                                                               FStar_Syntax_Syntax.sigmeta
                                                                 =
                                                                 FStar_Syntax_Syntax.default_sigmeta;
                                                               FStar_Syntax_Syntax.sigattrs
-                                                                = uu___17;
+                                                                = uu___18;
+                                                              FStar_Syntax_Syntax.sigopens_and_abbrevs
+                                                                = uu___19;
                                                               FStar_Syntax_Syntax.sigopts
                                                                 =
                                                                 FStar_Pervasives_Native.None
                                                             } in
-                                                          (tps, uu___14) in
-                                                        (name, uu___13))) in
+                                                          (tps, uu___15) in
+                                                        (name, uu___14))) in
                                           FStar_Compiler_Effect.op_Less_Bar
-                                            FStar_Compiler_List.split uu___11 in
-                                        (match uu___10 with
+                                            FStar_Compiler_List.split uu___12 in
+                                        (match uu___11 with
                                          | (constrNames, constrs1) ->
-                                             ((let uu___12 =
+                                             ((let uu___13 =
                                                  FStar_Options.debug_at_level_no_module
                                                    (FStar_Options.Other
                                                       "attrs") in
-                                               if uu___12
+                                               if uu___13
                                                then
-                                                 let uu___13 =
+                                                 let uu___14 =
                                                    FStar_Ident.string_of_lid
                                                      tname in
-                                                 let uu___14 =
-                                                   let uu___15 =
-                                                     FStar_Compiler_List.map
-                                                       FStar_Syntax_Print.term_to_string
-                                                       val_attrs in
-                                                   FStar_String.concat ", "
-                                                     uu___15 in
                                                  let uu___15 =
                                                    let uu___16 =
                                                      FStar_Compiler_List.map
                                                        FStar_Syntax_Print.term_to_string
-                                                       d_attrs in
+                                                       val_attrs in
                                                    FStar_String.concat ", "
                                                      uu___16 in
+                                                 let uu___16 =
+                                                   let uu___17 =
+                                                     FStar_Compiler_List.map
+                                                       FStar_Syntax_Print.term_to_string
+                                                       d_attrs in
+                                                   FStar_String.concat ", "
+                                                     uu___17 in
                                                  FStar_Compiler_Util.print3
                                                    "Adding attributes to type %s: val_attrs=[@@%s] attrs=[@@%s]\n"
-                                                   uu___13 uu___14 uu___15
+                                                   uu___14 uu___15 uu___16
                                                else ());
-                                              (let uu___12 =
-                                                 let uu___13 =
-                                                   let uu___14 =
+                                              (let uu___13 =
+                                                 let uu___14 =
+                                                   let uu___15 =
                                                      FStar_Ident.range_of_lid
                                                        tname in
-                                                   let uu___15 =
+                                                   let uu___16 =
                                                      FStar_Syntax_Util.deduplicate_terms
                                                        (FStar_Compiler_List.op_At
                                                           val_attrs d_attrs) in
+                                                   let uu___17 =
+                                                     FStar_Syntax_DsEnv.opens_and_abbrevs
+                                                       env1 in
                                                    {
                                                      FStar_Syntax_Syntax.sigel
                                                        =
@@ -7431,20 +7480,22 @@ let rec (desugar_tycon :
                                                               = constrNames
                                                           });
                                                      FStar_Syntax_Syntax.sigrng
-                                                       = uu___14;
+                                                       = uu___15;
                                                      FStar_Syntax_Syntax.sigquals
                                                        = tname_quals;
                                                      FStar_Syntax_Syntax.sigmeta
                                                        =
                                                        FStar_Syntax_Syntax.default_sigmeta;
                                                      FStar_Syntax_Syntax.sigattrs
-                                                       = uu___15;
+                                                       = uu___16;
+                                                     FStar_Syntax_Syntax.sigopens_and_abbrevs
+                                                       = uu___17;
                                                      FStar_Syntax_Syntax.sigopts
                                                        =
                                                        FStar_Pervasives_Native.None
                                                    } in
-                                                 ([], uu___13) in
-                                               uu___12 :: constrs1))))
+                                                 ([], uu___14) in
+                                               uu___13 :: constrs1))))
                                | uu___4 -> failwith "impossible")) in
                      let sigelts =
                        FStar_Compiler_Effect.op_Bar_Greater tps_sigelts
@@ -7624,6 +7675,7 @@ let (push_reflect_effect :
               [FStar_Syntax_Syntax.Assumption;
               FStar_Syntax_Syntax.Reflectable effect_name] in
             let refl_decl =
+              let uu___1 = FStar_Syntax_DsEnv.opens_and_abbrevs env in
               {
                 FStar_Syntax_Syntax.sigel =
                   (FStar_Syntax_Syntax.Sig_declare_typ
@@ -7637,6 +7689,7 @@ let (push_reflect_effect :
                 FStar_Syntax_Syntax.sigmeta =
                   FStar_Syntax_Syntax.default_sigmeta;
                 FStar_Syntax_Syntax.sigattrs = [];
+                FStar_Syntax_Syntax.sigopens_and_abbrevs = uu___1;
                 FStar_Syntax_Syntax.sigopts = FStar_Pervasives_Native.None
               } in
             FStar_Syntax_DsEnv.push_sigelt env refl_decl
@@ -8370,6 +8423,9 @@ let rec (desugar_effect :
                                                 = extraction_mode
                                             } in
                                         let se =
+                                          let uu___5 =
+                                            FStar_Syntax_DsEnv.opens_and_abbrevs
+                                              env2 in
                                           {
                                             FStar_Syntax_Syntax.sigel = sigel;
                                             FStar_Syntax_Syntax.sigrng =
@@ -8380,6 +8436,8 @@ let rec (desugar_effect :
                                               FStar_Syntax_Syntax.default_sigmeta;
                                             FStar_Syntax_Syntax.sigattrs =
                                               d_attrs;
+                                            FStar_Syntax_Syntax.sigopens_and_abbrevs
+                                              = uu___5;
                                             FStar_Syntax_Syntax.sigopts =
                                               FStar_Pervasives_Native.None
                                           } in
@@ -8582,6 +8640,9 @@ and (desugar_redefine_effect :
                                        trans_qual1
                                          (FStar_Pervasives_Native.Some mname) in
                                      FStar_Compiler_List.map uu___6 quals in
+                                   let uu___6 =
+                                     FStar_Syntax_DsEnv.opens_and_abbrevs
+                                       env2 in
                                    {
                                      FStar_Syntax_Syntax.sigel =
                                        (FStar_Syntax_Syntax.Sig_new_effect
@@ -8592,6 +8653,8 @@ and (desugar_redefine_effect :
                                      FStar_Syntax_Syntax.sigmeta =
                                        FStar_Syntax_Syntax.default_sigmeta;
                                      FStar_Syntax_Syntax.sigattrs = d_attrs;
+                                     FStar_Syntax_Syntax.sigopens_and_abbrevs
+                                       = uu___6;
                                      FStar_Syntax_Syntax.sigopts =
                                        FStar_Pervasives_Native.None
                                    } in
@@ -8629,6 +8692,9 @@ and (desugar_redefine_effect :
                                        [FStar_Syntax_Syntax.Assumption;
                                        FStar_Syntax_Syntax.Reflectable mname] in
                                      let refl_decl =
+                                       let uu___6 =
+                                         FStar_Syntax_DsEnv.opens_and_abbrevs
+                                           env4 in
                                        {
                                          FStar_Syntax_Syntax.sigel =
                                            (FStar_Syntax_Syntax.Sig_declare_typ
@@ -8646,6 +8712,8 @@ and (desugar_redefine_effect :
                                          FStar_Syntax_Syntax.sigmeta =
                                            FStar_Syntax_Syntax.default_sigmeta;
                                          FStar_Syntax_Syntax.sigattrs = [];
+                                         FStar_Syntax_Syntax.sigopens_and_abbrevs
+                                           = uu___6;
                                          FStar_Syntax_Syntax.sigopts =
                                            FStar_Pervasives_Native.None
                                        } in
@@ -8707,10 +8775,14 @@ and (desugar_decl_maybe_fail_attr :
                                FStar_Syntax_Syntax.sigmeta =
                                  (se.FStar_Syntax_Syntax.sigmeta);
                                FStar_Syntax_Syntax.sigattrs = uu___3;
+                               FStar_Syntax_Syntax.sigopens_and_abbrevs =
+                                 (se.FStar_Syntax_Syntax.sigopens_and_abbrevs);
                                FStar_Syntax_Syntax.sigopts =
                                  (se.FStar_Syntax_Syntax.sigopts)
                              }) ses in
                       let se =
+                        let uu___3 =
+                          FStar_Syntax_DsEnv.opens_and_abbrevs env1 in
                         {
                           FStar_Syntax_Syntax.sigel =
                             (FStar_Syntax_Syntax.Sig_fail
@@ -8725,6 +8797,7 @@ and (desugar_decl_maybe_fail_attr :
                           FStar_Syntax_Syntax.sigmeta =
                             FStar_Syntax_Syntax.default_sigmeta;
                           FStar_Syntax_Syntax.sigattrs = attrs;
+                          FStar_Syntax_Syntax.sigopens_and_abbrevs = uu___3;
                           FStar_Syntax_Syntax.sigopts =
                             FStar_Pervasives_Native.None
                         } in
@@ -8797,6 +8870,7 @@ and (desugar_decl_core :
             let p1 = trans_pragma p in
             (FStar_Syntax_Util.process_pragma p1 d.FStar_Parser_AST.drange;
              (let se =
+                let uu___1 = FStar_Syntax_DsEnv.opens_and_abbrevs env in
                 {
                   FStar_Syntax_Syntax.sigel =
                     (FStar_Syntax_Syntax.Sig_pragma p1);
@@ -8805,6 +8879,7 @@ and (desugar_decl_core :
                   FStar_Syntax_Syntax.sigmeta =
                     FStar_Syntax_Syntax.default_sigmeta;
                   FStar_Syntax_Syntax.sigattrs = d_attrs;
+                  FStar_Syntax_Syntax.sigopens_and_abbrevs = uu___1;
                   FStar_Syntax_Syntax.sigopts = FStar_Pervasives_Native.None
                 } in
               (env, [se])))
@@ -8951,7 +9026,9 @@ and (desugar_decl_core :
                                 FStar_Syntax_Syntax.sigquals = uu___5;
                                 FStar_Syntax_Syntax.sigmeta = uu___6;
                                 FStar_Syntax_Syntax.sigattrs = uu___7;
-                                FStar_Syntax_Syntax.sigopts = uu___8;_} ->
+                                FStar_Syntax_Syntax.sigopens_and_abbrevs =
+                                  uu___8;
+                                FStar_Syntax_Syntax.sigopts = uu___9;_} ->
                                 true
                             | uu___3 -> false) ses in
                      match bndl with
@@ -9044,6 +9121,8 @@ and (desugar_decl_core :
                                  FStar_Syntax_Syntax.tac = uu___10
                                } in
                              FStar_Syntax_Syntax.Sig_splice uu___9 in
+                           let uu___9 =
+                             FStar_Syntax_DsEnv.opens_and_abbrevs env1 in
                            {
                              FStar_Syntax_Syntax.sigel = uu___8;
                              FStar_Syntax_Syntax.sigrng =
@@ -9052,6 +9131,8 @@ and (desugar_decl_core :
                              FStar_Syntax_Syntax.sigmeta =
                                FStar_Syntax_Syntax.default_sigmeta;
                              FStar_Syntax_Syntax.sigattrs = [];
+                             FStar_Syntax_Syntax.sigopens_and_abbrevs =
+                               uu___9;
                              FStar_Syntax_Syntax.sigopts =
                                FStar_Pervasives_Native.None
                            } in
@@ -9085,6 +9166,8 @@ and (desugar_decl_core :
                                  (se.FStar_Syntax_Syntax.sigmeta);
                                FStar_Syntax_Syntax.sigattrs =
                                  (se.FStar_Syntax_Syntax.sigattrs);
+                               FStar_Syntax_Syntax.sigopens_and_abbrevs =
+                                 (se.FStar_Syntax_Syntax.sigopens_and_abbrevs);
                                FStar_Syntax_Syntax.sigopts =
                                  (se.FStar_Syntax_Syntax.sigopts)
                              }
@@ -9108,6 +9191,8 @@ and (desugar_decl_core :
                                FStar_Syntax_Syntax.sigmeta =
                                  (se.FStar_Syntax_Syntax.sigmeta);
                                FStar_Syntax_Syntax.sigattrs = uu___4;
+                               FStar_Syntax_Syntax.sigopens_and_abbrevs =
+                                 (se.FStar_Syntax_Syntax.sigopens_and_abbrevs);
                                FStar_Syntax_Syntax.sigopts =
                                  (se.FStar_Syntax_Syntax.sigopts)
                              }
@@ -9274,6 +9359,8 @@ and (desugar_decl_core :
                                   FStar_Syntax_Util.deduplicate_terms
                                     (FStar_Compiler_List.op_At val_attrs
                                        top_attrs) in
+                                let uu___6 =
+                                  FStar_Syntax_DsEnv.opens_and_abbrevs env in
                                 {
                                   FStar_Syntax_Syntax.sigel =
                                     (FStar_Syntax_Syntax.Sig_let
@@ -9287,6 +9374,8 @@ and (desugar_decl_core :
                                   FStar_Syntax_Syntax.sigmeta =
                                     FStar_Syntax_Syntax.default_sigmeta;
                                   FStar_Syntax_Syntax.sigattrs = uu___5;
+                                  FStar_Syntax_Syntax.sigopens_and_abbrevs =
+                                    uu___6;
                                   FStar_Syntax_Syntax.sigopts =
                                     FStar_Pervasives_Native.None
                                 } in
@@ -9454,23 +9543,28 @@ and (desugar_decl_core :
         | FStar_Parser_AST.Assume (id, t) ->
             let f = desugar_formula env t in
             let lid = FStar_Syntax_DsEnv.qualify env id in
-            (env,
-              [{
-                 FStar_Syntax_Syntax.sigel =
-                   (FStar_Syntax_Syntax.Sig_assume
-                      {
-                        FStar_Syntax_Syntax.lid3 = lid;
-                        FStar_Syntax_Syntax.us3 = [];
-                        FStar_Syntax_Syntax.phi1 = f
-                      });
-                 FStar_Syntax_Syntax.sigrng = (d.FStar_Parser_AST.drange);
-                 FStar_Syntax_Syntax.sigquals =
-                   [FStar_Syntax_Syntax.Assumption];
-                 FStar_Syntax_Syntax.sigmeta =
-                   FStar_Syntax_Syntax.default_sigmeta;
-                 FStar_Syntax_Syntax.sigattrs = d_attrs;
-                 FStar_Syntax_Syntax.sigopts = FStar_Pervasives_Native.None
-               }])
+            let uu___ =
+              let uu___1 =
+                let uu___2 = FStar_Syntax_DsEnv.opens_and_abbrevs env in
+                {
+                  FStar_Syntax_Syntax.sigel =
+                    (FStar_Syntax_Syntax.Sig_assume
+                       {
+                         FStar_Syntax_Syntax.lid3 = lid;
+                         FStar_Syntax_Syntax.us3 = [];
+                         FStar_Syntax_Syntax.phi1 = f
+                       });
+                  FStar_Syntax_Syntax.sigrng = (d.FStar_Parser_AST.drange);
+                  FStar_Syntax_Syntax.sigquals =
+                    [FStar_Syntax_Syntax.Assumption];
+                  FStar_Syntax_Syntax.sigmeta =
+                    FStar_Syntax_Syntax.default_sigmeta;
+                  FStar_Syntax_Syntax.sigattrs = d_attrs;
+                  FStar_Syntax_Syntax.sigopens_and_abbrevs = uu___2;
+                  FStar_Syntax_Syntax.sigopts = FStar_Pervasives_Native.None
+                } in
+              [uu___1] in
+            (env, uu___)
         | FStar_Parser_AST.Val (id, t) ->
             let quals = d.FStar_Parser_AST.quals in
             let t1 = let uu___ = close_fun env t in desugar_term env uu___ in
@@ -9484,6 +9578,7 @@ and (desugar_decl_core :
               let uu___ =
                 FStar_Compiler_List.map
                   (trans_qual1 FStar_Pervasives_Native.None) quals1 in
+              let uu___1 = FStar_Syntax_DsEnv.opens_and_abbrevs env in
               {
                 FStar_Syntax_Syntax.sigel =
                   (FStar_Syntax_Syntax.Sig_declare_typ
@@ -9497,6 +9592,7 @@ and (desugar_decl_core :
                 FStar_Syntax_Syntax.sigmeta =
                   FStar_Syntax_Syntax.default_sigmeta;
                 FStar_Syntax_Syntax.sigattrs = d_attrs;
+                FStar_Syntax_Syntax.sigopens_and_abbrevs = uu___1;
                 FStar_Syntax_Syntax.sigopts = FStar_Pervasives_Native.None
               } in
             let env1 = FStar_Syntax_DsEnv.push_sigelt env se in (env1, [se])
@@ -9524,6 +9620,7 @@ and (desugar_decl_core :
             let qual = [FStar_Syntax_Syntax.ExceptionConstructor] in
             let top_attrs = d_attrs in
             let se =
+              let uu___ = FStar_Syntax_DsEnv.opens_and_abbrevs env in
               {
                 FStar_Syntax_Syntax.sigel =
                   (FStar_Syntax_Syntax.Sig_datacon
@@ -9542,9 +9639,11 @@ and (desugar_decl_core :
                 FStar_Syntax_Syntax.sigmeta =
                   FStar_Syntax_Syntax.default_sigmeta;
                 FStar_Syntax_Syntax.sigattrs = top_attrs;
+                FStar_Syntax_Syntax.sigopens_and_abbrevs = uu___;
                 FStar_Syntax_Syntax.sigopts = FStar_Pervasives_Native.None
               } in
             let se' =
+              let uu___ = FStar_Syntax_DsEnv.opens_and_abbrevs env in
               {
                 FStar_Syntax_Syntax.sigel =
                   (FStar_Syntax_Syntax.Sig_bundle
@@ -9557,6 +9656,7 @@ and (desugar_decl_core :
                 FStar_Syntax_Syntax.sigmeta =
                   FStar_Syntax_Syntax.default_sigmeta;
                 FStar_Syntax_Syntax.sigattrs = top_attrs;
+                FStar_Syntax_Syntax.sigopens_and_abbrevs = uu___;
                 FStar_Syntax_Syntax.sigopts = FStar_Pervasives_Native.None
               } in
             let env1 = FStar_Syntax_DsEnv.push_sigelt env se' in
@@ -9627,6 +9727,7 @@ and (desugar_decl_core :
               (match uu___1 with
                | (lift_wp, lift) ->
                    let se =
+                     let uu___2 = FStar_Syntax_DsEnv.opens_and_abbrevs env in
                      {
                        FStar_Syntax_Syntax.sigel =
                          (FStar_Syntax_Syntax.Sig_sub_effect
@@ -9646,6 +9747,7 @@ and (desugar_decl_core :
                        FStar_Syntax_Syntax.sigmeta =
                          FStar_Syntax_Syntax.default_sigmeta;
                        FStar_Syntax_Syntax.sigattrs = top_attrs;
+                       FStar_Syntax_Syntax.sigopens_and_abbrevs = uu___2;
                        FStar_Syntax_Syntax.sigopts =
                          FStar_Pervasives_Native.None
                      } in
@@ -9669,19 +9771,24 @@ and (desugar_decl_core :
                        FStar_Syntax_Syntax.kind =
                          FStar_Pervasives_Native.None
                      } in
-                   (env,
-                     [{
-                        FStar_Syntax_Syntax.sigel =
-                          (FStar_Syntax_Syntax.Sig_sub_effect sub_eff);
-                        FStar_Syntax_Syntax.sigrng =
-                          (d.FStar_Parser_AST.drange);
-                        FStar_Syntax_Syntax.sigquals = [];
-                        FStar_Syntax_Syntax.sigmeta =
-                          FStar_Syntax_Syntax.default_sigmeta;
-                        FStar_Syntax_Syntax.sigattrs = top_attrs;
-                        FStar_Syntax_Syntax.sigopts =
-                          FStar_Pervasives_Native.None
-                      }])
+                   let uu___2 =
+                     let uu___3 =
+                       let uu___4 = FStar_Syntax_DsEnv.opens_and_abbrevs env in
+                       {
+                         FStar_Syntax_Syntax.sigel =
+                           (FStar_Syntax_Syntax.Sig_sub_effect sub_eff);
+                         FStar_Syntax_Syntax.sigrng =
+                           (d.FStar_Parser_AST.drange);
+                         FStar_Syntax_Syntax.sigquals = [];
+                         FStar_Syntax_Syntax.sigmeta =
+                           FStar_Syntax_Syntax.default_sigmeta;
+                         FStar_Syntax_Syntax.sigattrs = top_attrs;
+                         FStar_Syntax_Syntax.sigopens_and_abbrevs = uu___4;
+                         FStar_Syntax_Syntax.sigopts =
+                           FStar_Pervasives_Native.None
+                       } in
+                     [uu___3] in
+                   (env, uu___2)
                | uu___2 ->
                    failwith
                      "Impossible! unexpected lift_op for lift to a layered effect")
@@ -9709,6 +9816,7 @@ and (desugar_decl_core :
                         FStar_Pervasives_Native.None
                     } in
                   FStar_Syntax_Syntax.Sig_polymonadic_bind uu___3 in
+                let uu___3 = FStar_Syntax_DsEnv.opens_and_abbrevs env in
                 {
                   FStar_Syntax_Syntax.sigel = uu___2;
                   FStar_Syntax_Syntax.sigrng = (d.FStar_Parser_AST.drange);
@@ -9716,6 +9824,7 @@ and (desugar_decl_core :
                   FStar_Syntax_Syntax.sigmeta =
                     FStar_Syntax_Syntax.default_sigmeta;
                   FStar_Syntax_Syntax.sigattrs = top_attrs;
+                  FStar_Syntax_Syntax.sigopens_and_abbrevs = uu___3;
                   FStar_Syntax_Syntax.sigopts = FStar_Pervasives_Native.None
                 } in
               [uu___1] in
@@ -9742,6 +9851,7 @@ and (desugar_decl_core :
                         FStar_Pervasives_Native.None
                     } in
                   FStar_Syntax_Syntax.Sig_polymonadic_subcomp uu___3 in
+                let uu___3 = FStar_Syntax_DsEnv.opens_and_abbrevs env in
                 {
                   FStar_Syntax_Syntax.sigel = uu___2;
                   FStar_Syntax_Syntax.sigrng = (d.FStar_Parser_AST.drange);
@@ -9749,6 +9859,7 @@ and (desugar_decl_core :
                   FStar_Syntax_Syntax.sigmeta =
                     FStar_Syntax_Syntax.default_sigmeta;
                   FStar_Syntax_Syntax.sigattrs = top_attrs;
+                  FStar_Syntax_Syntax.sigopens_and_abbrevs = uu___3;
                   FStar_Syntax_Syntax.sigopts = FStar_Pervasives_Native.None
                 } in
               [uu___1] in
@@ -9772,6 +9883,7 @@ and (desugar_decl_core :
                 FStar_Compiler_List.map
                   (trans_qual1 FStar_Pervasives_Native.None)
                   d.FStar_Parser_AST.quals in
+              let uu___2 = FStar_Syntax_DsEnv.opens_and_abbrevs env in
               {
                 FStar_Syntax_Syntax.sigel = uu___;
                 FStar_Syntax_Syntax.sigrng = (d.FStar_Parser_AST.drange);
@@ -9779,6 +9891,7 @@ and (desugar_decl_core :
                 FStar_Syntax_Syntax.sigmeta =
                   FStar_Syntax_Syntax.default_sigmeta;
                 FStar_Syntax_Syntax.sigattrs = top_attrs;
+                FStar_Syntax_Syntax.sigopens_and_abbrevs = uu___2;
                 FStar_Syntax_Syntax.sigopts = FStar_Pervasives_Native.None
               } in
             let env1 = FStar_Syntax_DsEnv.push_sigelt env se in (env1, [se])
@@ -10158,6 +10271,8 @@ let (add_modul_to_env :
                       (se.FStar_Syntax_Syntax.sigmeta);
                     FStar_Syntax_Syntax.sigattrs =
                       (se.FStar_Syntax_Syntax.sigattrs);
+                    FStar_Syntax_Syntax.sigopens_and_abbrevs =
+                      (se.FStar_Syntax_Syntax.sigopens_and_abbrevs);
                     FStar_Syntax_Syntax.sigopts =
                       (se.FStar_Syntax_Syntax.sigopts)
                   } in

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_DMFF.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_DMFF.ml
@@ -65,6 +65,8 @@ let (mk_toplevel_definition :
               (sig_ctx.FStar_Syntax_Syntax.sigmeta);
             FStar_Syntax_Syntax.sigattrs =
               (sig_ctx.FStar_Syntax_Syntax.sigattrs);
+            FStar_Syntax_Syntax.sigopens_and_abbrevs =
+              (sig_ctx.FStar_Syntax_Syntax.sigopens_and_abbrevs);
             FStar_Syntax_Syntax.sigopts =
               (sig_ctx.FStar_Syntax_Syntax.sigopts)
           }, uu___1))
@@ -185,6 +187,8 @@ let (gen_wps_for_free :
                            });
                         FStar_Syntax_Syntax.sigattrs =
                           (sigelt.FStar_Syntax_Syntax.sigattrs);
+                        FStar_Syntax_Syntax.sigopens_and_abbrevs =
+                          (sigelt.FStar_Syntax_Syntax.sigopens_and_abbrevs);
                         FStar_Syntax_Syntax.sigopts =
                           (sigelt.FStar_Syntax_Syntax.sigopts)
                       } in
@@ -4493,6 +4497,9 @@ let (cps_and_elaborate :
                                                           FStar_Syntax_Syntax.sigattrs
                                                             =
                                                             (sigelt.FStar_Syntax_Syntax.sigattrs);
+                                                          FStar_Syntax_Syntax.sigopens_and_abbrevs
+                                                            =
+                                                            (sigelt.FStar_Syntax_Syntax.sigopens_and_abbrevs);
                                                           FStar_Syntax_Syntax.sigopts
                                                             =
                                                             (sigelt.FStar_Syntax_Syntax.sigopts)
@@ -4525,6 +4532,9 @@ let (cps_and_elaborate :
                                                (uu___14.FStar_Syntax_Syntax.sigmeta);
                                              FStar_Syntax_Syntax.sigattrs =
                                                (uu___14.FStar_Syntax_Syntax.sigattrs);
+                                             FStar_Syntax_Syntax.sigopens_and_abbrevs
+                                               =
+                                               (uu___14.FStar_Syntax_Syntax.sigopens_and_abbrevs);
                                              FStar_Syntax_Syntax.sigopts =
                                                (uu___14.FStar_Syntax_Syntax.sigopts)
                                            } in

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_Env.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_Env.ml
@@ -2665,16 +2665,18 @@ let (lookup_qname : env -> FStar_Ident.lident -> qninfo) =
                              FStar_Syntax_Syntax.sigquals = uu___7;
                              FStar_Syntax_Syntax.sigmeta = uu___8;
                              FStar_Syntax_Syntax.sigattrs = uu___9;
-                             FStar_Syntax_Syntax.sigopts = uu___10;_})
+                             FStar_Syntax_Syntax.sigopens_and_abbrevs =
+                               uu___10;
+                             FStar_Syntax_Syntax.sigopts = uu___11;_})
                             ->
                             FStar_Compiler_Util.find_map ses
                               (fun se ->
-                                 let uu___11 =
+                                 let uu___12 =
                                    FStar_Compiler_Effect.op_Bar_Greater
                                      (FStar_Syntax_Util.lids_of_sigelt se)
                                      (FStar_Compiler_Util.for_some
                                         (FStar_Ident.lid_equals lid)) in
-                                 if uu___11
+                                 if uu___12
                                  then
                                    cache
                                      ((FStar_Pervasives.Inr
@@ -2951,12 +2953,13 @@ let (try_lookup_lid_aux :
                       FStar_Syntax_Syntax.sigquals = uu___6;
                       FStar_Syntax_Syntax.sigmeta = uu___7;
                       FStar_Syntax_Syntax.sigattrs = uu___8;
-                      FStar_Syntax_Syntax.sigopts = uu___9;_},
+                      FStar_Syntax_Syntax.sigopens_and_abbrevs = uu___9;
+                      FStar_Syntax_Syntax.sigopts = uu___10;_},
                     FStar_Pervasives_Native.None)
                    ->
-                   let uu___10 =
-                     let uu___11 = inst_tscheme1 (uvs, t) in (uu___11, rng) in
-                   FStar_Pervasives_Native.Some uu___10
+                   let uu___11 =
+                     let uu___12 = inst_tscheme1 (uvs, t) in (uu___12, rng) in
+                   FStar_Pervasives_Native.Some uu___11
                | FStar_Pervasives.Inr
                    ({
                       FStar_Syntax_Syntax.sigel =
@@ -2968,29 +2971,30 @@ let (try_lookup_lid_aux :
                       FStar_Syntax_Syntax.sigquals = qs;
                       FStar_Syntax_Syntax.sigmeta = uu___2;
                       FStar_Syntax_Syntax.sigattrs = uu___3;
-                      FStar_Syntax_Syntax.sigopts = uu___4;_},
+                      FStar_Syntax_Syntax.sigopens_and_abbrevs = uu___4;
+                      FStar_Syntax_Syntax.sigopts = uu___5;_},
                     FStar_Pervasives_Native.None)
                    ->
-                   let uu___5 =
-                     let uu___6 = in_cur_mod env1 l in uu___6 = Yes in
-                   if uu___5
+                   let uu___6 =
+                     let uu___7 = in_cur_mod env1 l in uu___7 = Yes in
+                   if uu___6
                    then
-                     let uu___6 =
+                     let uu___7 =
                        (FStar_Compiler_Effect.op_Bar_Greater qs
                           (FStar_Compiler_List.contains
                              FStar_Syntax_Syntax.Assumption))
                          || env1.is_iface in
-                     (if uu___6
+                     (if uu___7
                       then
-                        let uu___7 =
-                          let uu___8 = inst_tscheme1 (uvs, t) in
-                          (uu___8, rng) in
-                        FStar_Pervasives_Native.Some uu___7
+                        let uu___8 =
+                          let uu___9 = inst_tscheme1 (uvs, t) in
+                          (uu___9, rng) in
+                        FStar_Pervasives_Native.Some uu___8
                       else FStar_Pervasives_Native.None)
                    else
-                     (let uu___7 =
-                        let uu___8 = inst_tscheme1 (uvs, t) in (uu___8, rng) in
-                      FStar_Pervasives_Native.Some uu___7)
+                     (let uu___8 =
+                        let uu___9 = inst_tscheme1 (uvs, t) in (uu___9, rng) in
+                      FStar_Pervasives_Native.Some uu___8)
                | FStar_Pervasives.Inr
                    ({
                       FStar_Syntax_Syntax.sigel =
@@ -3006,26 +3010,27 @@ let (try_lookup_lid_aux :
                       FStar_Syntax_Syntax.sigquals = uu___5;
                       FStar_Syntax_Syntax.sigmeta = uu___6;
                       FStar_Syntax_Syntax.sigattrs = uu___7;
-                      FStar_Syntax_Syntax.sigopts = uu___8;_},
+                      FStar_Syntax_Syntax.sigopens_and_abbrevs = uu___8;
+                      FStar_Syntax_Syntax.sigopts = uu___9;_},
                     FStar_Pervasives_Native.None)
                    ->
                    (match tps with
                     | [] ->
-                        let uu___9 =
-                          let uu___10 = inst_tscheme1 (uvs, k) in
-                          (uu___10, rng) in
-                        FStar_Pervasives_Native.Some uu___9
-                    | uu___9 ->
                         let uu___10 =
-                          let uu___11 =
-                            let uu___12 =
-                              let uu___13 =
-                                let uu___14 = FStar_Syntax_Syntax.mk_Total k in
-                                FStar_Syntax_Util.flat_arrow tps uu___14 in
-                              (uvs, uu___13) in
-                            inst_tscheme1 uu___12 in
+                          let uu___11 = inst_tscheme1 (uvs, k) in
                           (uu___11, rng) in
-                        FStar_Pervasives_Native.Some uu___10)
+                        FStar_Pervasives_Native.Some uu___10
+                    | uu___10 ->
+                        let uu___11 =
+                          let uu___12 =
+                            let uu___13 =
+                              let uu___14 =
+                                let uu___15 = FStar_Syntax_Syntax.mk_Total k in
+                                FStar_Syntax_Util.flat_arrow tps uu___15 in
+                              (uvs, uu___14) in
+                            inst_tscheme1 uu___13 in
+                          (uu___12, rng) in
+                        FStar_Pervasives_Native.Some uu___11)
                | FStar_Pervasives.Inr
                    ({
                       FStar_Syntax_Syntax.sigel =
@@ -3041,26 +3046,27 @@ let (try_lookup_lid_aux :
                       FStar_Syntax_Syntax.sigquals = uu___5;
                       FStar_Syntax_Syntax.sigmeta = uu___6;
                       FStar_Syntax_Syntax.sigattrs = uu___7;
-                      FStar_Syntax_Syntax.sigopts = uu___8;_},
+                      FStar_Syntax_Syntax.sigopens_and_abbrevs = uu___8;
+                      FStar_Syntax_Syntax.sigopts = uu___9;_},
                     FStar_Pervasives_Native.Some us)
                    ->
                    (match tps with
                     | [] ->
-                        let uu___9 =
-                          let uu___10 = inst_tscheme_with (uvs, k) us in
-                          (uu___10, rng) in
-                        FStar_Pervasives_Native.Some uu___9
-                    | uu___9 ->
                         let uu___10 =
-                          let uu___11 =
-                            let uu___12 =
-                              let uu___13 =
-                                let uu___14 = FStar_Syntax_Syntax.mk_Total k in
-                                FStar_Syntax_Util.flat_arrow tps uu___14 in
-                              (uvs, uu___13) in
-                            inst_tscheme_with uu___12 us in
+                          let uu___11 = inst_tscheme_with (uvs, k) us in
                           (uu___11, rng) in
-                        FStar_Pervasives_Native.Some uu___10)
+                        FStar_Pervasives_Native.Some uu___10
+                    | uu___10 ->
+                        let uu___11 =
+                          let uu___12 =
+                            let uu___13 =
+                              let uu___14 =
+                                let uu___15 = FStar_Syntax_Syntax.mk_Total k in
+                                FStar_Syntax_Util.flat_arrow tps uu___15 in
+                              (uvs, uu___14) in
+                            inst_tscheme_with uu___13 us in
+                          (uu___12, rng) in
+                        FStar_Pervasives_Native.Some uu___11)
                | FStar_Pervasives.Inr se ->
                    let uu___1 =
                      match se with
@@ -3071,7 +3077,8 @@ let (try_lookup_lid_aux :
                           FStar_Syntax_Syntax.sigquals = uu___4;
                           FStar_Syntax_Syntax.sigmeta = uu___5;
                           FStar_Syntax_Syntax.sigattrs = uu___6;
-                          FStar_Syntax_Syntax.sigopts = uu___7;_},
+                          FStar_Syntax_Syntax.sigopens_and_abbrevs = uu___7;
+                          FStar_Syntax_Syntax.sigopts = uu___8;_},
                         FStar_Pervasives_Native.None) ->
                          lookup_type_of_let us_opt
                            (FStar_Pervasives_Native.fst se) lid
@@ -3221,18 +3228,19 @@ let (try_lookup_val_decl :
               FStar_Syntax_Syntax.sigquals = q;
               FStar_Syntax_Syntax.sigmeta = uu___3;
               FStar_Syntax_Syntax.sigattrs = uu___4;
-              FStar_Syntax_Syntax.sigopts = uu___5;_},
+              FStar_Syntax_Syntax.sigopens_and_abbrevs = uu___5;
+              FStar_Syntax_Syntax.sigopts = uu___6;_},
             FStar_Pervasives_Native.None),
-           uu___6)
+           uu___7)
           ->
-          let uu___7 =
-            let uu___8 =
-              let uu___9 =
-                let uu___10 = FStar_Ident.range_of_lid lid in
-                FStar_Syntax_Subst.set_use_range uu___10 t in
-              (uvs, uu___9) in
-            (uu___8, q) in
-          FStar_Pervasives_Native.Some uu___7
+          let uu___8 =
+            let uu___9 =
+              let uu___10 =
+                let uu___11 = FStar_Ident.range_of_lid lid in
+                FStar_Syntax_Subst.set_use_range uu___11 t in
+              (uvs, uu___10) in
+            (uu___9, q) in
+          FStar_Pervasives_Native.Some uu___8
       | uu___1 -> FStar_Pervasives_Native.None
 let (lookup_val_decl :
   env ->
@@ -3254,12 +3262,13 @@ let (lookup_val_decl :
               FStar_Syntax_Syntax.sigquals = uu___3;
               FStar_Syntax_Syntax.sigmeta = uu___4;
               FStar_Syntax_Syntax.sigattrs = uu___5;
-              FStar_Syntax_Syntax.sigopts = uu___6;_},
+              FStar_Syntax_Syntax.sigopens_and_abbrevs = uu___6;
+              FStar_Syntax_Syntax.sigopts = uu___7;_},
             FStar_Pervasives_Native.None),
-           uu___7)
+           uu___8)
           ->
-          let uu___8 = FStar_Ident.range_of_lid lid in
-          inst_tscheme_with_range uu___8 (uvs, t)
+          let uu___9 = FStar_Ident.range_of_lid lid in
+          inst_tscheme_with_range uu___9 (uvs, t)
       | uu___1 ->
           let uu___2 = name_not_found lid in
           let uu___3 = FStar_Ident.range_of_lid lid in
@@ -3286,12 +3295,13 @@ let (lookup_datacon :
               FStar_Syntax_Syntax.sigquals = uu___6;
               FStar_Syntax_Syntax.sigmeta = uu___7;
               FStar_Syntax_Syntax.sigattrs = uu___8;
-              FStar_Syntax_Syntax.sigopts = uu___9;_},
+              FStar_Syntax_Syntax.sigopens_and_abbrevs = uu___9;
+              FStar_Syntax_Syntax.sigopts = uu___10;_},
             FStar_Pervasives_Native.None),
-           uu___10)
+           uu___11)
           ->
-          let uu___11 = FStar_Ident.range_of_lid lid in
-          inst_tscheme_with_range uu___11 (uvs, t)
+          let uu___12 = FStar_Ident.range_of_lid lid in
+          inst_tscheme_with_range uu___12 (uvs, t)
       | uu___1 ->
           let uu___2 = name_not_found lid in
           let uu___3 = FStar_Ident.range_of_lid lid in
@@ -3320,12 +3330,13 @@ let (lookup_and_inst_datacon :
                 FStar_Syntax_Syntax.sigquals = uu___6;
                 FStar_Syntax_Syntax.sigmeta = uu___7;
                 FStar_Syntax_Syntax.sigattrs = uu___8;
-                FStar_Syntax_Syntax.sigopts = uu___9;_},
+                FStar_Syntax_Syntax.sigopens_and_abbrevs = uu___9;
+                FStar_Syntax_Syntax.sigopts = uu___10;_},
               FStar_Pervasives_Native.None),
-             uu___10)
+             uu___11)
             ->
-            let uu___11 = inst_tscheme_with (uvs, t) us in
-            FStar_Compiler_Effect.op_Bar_Greater uu___11
+            let uu___12 = inst_tscheme_with (uvs, t) us in
+            FStar_Compiler_Effect.op_Bar_Greater uu___12
               FStar_Pervasives_Native.snd
         | uu___1 ->
             let uu___2 = name_not_found lid in
@@ -3354,9 +3365,10 @@ let (datacons_of_typ :
               FStar_Syntax_Syntax.sigquals = uu___8;
               FStar_Syntax_Syntax.sigmeta = uu___9;
               FStar_Syntax_Syntax.sigattrs = uu___10;
-              FStar_Syntax_Syntax.sigopts = uu___11;_},
-            uu___12),
-           uu___13)
+              FStar_Syntax_Syntax.sigopens_and_abbrevs = uu___11;
+              FStar_Syntax_Syntax.sigopts = uu___12;_},
+            uu___13),
+           uu___14)
           -> (true, dcs)
       | uu___1 -> (false, [])
 let (typ_of_datacon : env -> FStar_Ident.lident -> FStar_Ident.lident) =
@@ -3378,9 +3390,10 @@ let (typ_of_datacon : env -> FStar_Ident.lident -> FStar_Ident.lident) =
               FStar_Syntax_Syntax.sigquals = uu___7;
               FStar_Syntax_Syntax.sigmeta = uu___8;
               FStar_Syntax_Syntax.sigattrs = uu___9;
-              FStar_Syntax_Syntax.sigopts = uu___10;_},
-            uu___11),
-           uu___12)
+              FStar_Syntax_Syntax.sigopens_and_abbrevs = uu___10;
+              FStar_Syntax_Syntax.sigopts = uu___11;_},
+            uu___12),
+           uu___13)
           -> l
       | uu___1 ->
           let uu___2 =
@@ -3814,26 +3827,27 @@ let (lookup_effect_abbrev :
                 FStar_Syntax_Syntax.sigquals = quals;
                 FStar_Syntax_Syntax.sigmeta = uu___3;
                 FStar_Syntax_Syntax.sigattrs = uu___4;
-                FStar_Syntax_Syntax.sigopts = uu___5;_},
+                FStar_Syntax_Syntax.sigopens_and_abbrevs = uu___5;
+                FStar_Syntax_Syntax.sigopts = uu___6;_},
               FStar_Pervasives_Native.None),
-             uu___6)
+             uu___7)
             ->
             let lid1 =
-              let uu___7 =
-                let uu___8 = FStar_Ident.range_of_lid lid in
-                let uu___9 =
-                  let uu___10 = FStar_Ident.range_of_lid lid0 in
-                  FStar_Compiler_Range_Type.use_range uu___10 in
-                FStar_Compiler_Range_Type.set_use_range uu___8 uu___9 in
-              FStar_Ident.set_lid_range lid uu___7 in
-            let uu___7 =
+              let uu___8 =
+                let uu___9 = FStar_Ident.range_of_lid lid in
+                let uu___10 =
+                  let uu___11 = FStar_Ident.range_of_lid lid0 in
+                  FStar_Compiler_Range_Type.use_range uu___11 in
+                FStar_Compiler_Range_Type.set_use_range uu___9 uu___10 in
+              FStar_Ident.set_lid_range lid uu___8 in
+            let uu___8 =
               FStar_Compiler_Effect.op_Bar_Greater quals
                 (FStar_Compiler_Util.for_some
-                   (fun uu___8 ->
-                      match uu___8 with
+                   (fun uu___9 ->
+                      match uu___9 with
                       | FStar_Syntax_Syntax.Irreducible -> true
-                      | uu___9 -> false)) in
-            if uu___7
+                      | uu___10 -> false)) in
+            if uu___8
             then FStar_Pervasives_Native.None
             else
               (let insts =
@@ -3842,54 +3856,54 @@ let (lookup_effect_abbrev :
                      (FStar_Compiler_List.length univs)
                  then univ_insts
                  else
-                   (let uu___10 =
-                      let uu___11 =
-                        let uu___12 = get_range env1 in
-                        FStar_Compiler_Range_Ops.string_of_range uu___12 in
-                      let uu___12 = FStar_Syntax_Print.lid_to_string lid1 in
-                      let uu___13 =
+                   (let uu___11 =
+                      let uu___12 =
+                        let uu___13 = get_range env1 in
+                        FStar_Compiler_Range_Ops.string_of_range uu___13 in
+                      let uu___13 = FStar_Syntax_Print.lid_to_string lid1 in
+                      let uu___14 =
                         FStar_Compiler_Effect.op_Bar_Greater
                           (FStar_Compiler_List.length univ_insts)
                           FStar_Compiler_Util.string_of_int in
                       FStar_Compiler_Util.format3
                         "(%s) Unexpected instantiation of effect %s with %s universes"
-                        uu___11 uu___12 uu___13 in
-                    failwith uu___10) in
+                        uu___12 uu___13 uu___14 in
+                    failwith uu___11) in
                match (binders, univs) with
-               | ([], uu___9) ->
+               | ([], uu___10) ->
                    failwith
                      "Unexpected effect abbreviation with no arguments"
-               | (uu___9, uu___10::uu___11::uu___12) ->
-                   let uu___13 =
-                     let uu___14 = FStar_Syntax_Print.lid_to_string lid1 in
-                     let uu___15 =
+               | (uu___10, uu___11::uu___12::uu___13) ->
+                   let uu___14 =
+                     let uu___15 = FStar_Syntax_Print.lid_to_string lid1 in
+                     let uu___16 =
                        FStar_Compiler_Effect.op_Less_Bar
                          FStar_Compiler_Util.string_of_int
                          (FStar_Compiler_List.length univs) in
                      FStar_Compiler_Util.format2
                        "Unexpected effect abbreviation %s; polymorphic in %s universes"
-                       uu___14 uu___15 in
-                   failwith uu___13
-               | uu___9 ->
-                   let uu___10 =
-                     let uu___11 =
-                       let uu___12 = FStar_Syntax_Util.arrow binders c in
-                       (univs, uu___12) in
-                     inst_tscheme_with uu___11 insts in
-                   (match uu___10 with
-                    | (uu___11, t) ->
+                       uu___15 uu___16 in
+                   failwith uu___14
+               | uu___10 ->
+                   let uu___11 =
+                     let uu___12 =
+                       let uu___13 = FStar_Syntax_Util.arrow binders c in
+                       (univs, uu___13) in
+                     inst_tscheme_with uu___12 insts in
+                   (match uu___11 with
+                    | (uu___12, t) ->
                         let t1 =
-                          let uu___12 = FStar_Ident.range_of_lid lid1 in
-                          FStar_Syntax_Subst.set_use_range uu___12 t in
-                        let uu___12 =
-                          let uu___13 = FStar_Syntax_Subst.compress t1 in
-                          uu___13.FStar_Syntax_Syntax.n in
-                        (match uu___12 with
+                          let uu___13 = FStar_Ident.range_of_lid lid1 in
+                          FStar_Syntax_Subst.set_use_range uu___13 t in
+                        let uu___13 =
+                          let uu___14 = FStar_Syntax_Subst.compress t1 in
+                          uu___14.FStar_Syntax_Syntax.n in
+                        (match uu___13 with
                          | FStar_Syntax_Syntax.Tm_arrow
                              { FStar_Syntax_Syntax.bs1 = binders1;
                                FStar_Syntax_Syntax.comp = c1;_}
                              -> FStar_Pervasives_Native.Some (binders1, c1)
-                         | uu___13 -> failwith "Impossible")))
+                         | uu___14 -> failwith "Impossible")))
         | uu___1 -> FStar_Pervasives_Native.None
 let (norm_eff_name : env -> FStar_Ident.lident -> FStar_Ident.lident) =
   fun env1 ->
@@ -4004,9 +4018,10 @@ let (lookup_effect_quals :
               FStar_Syntax_Syntax.sigquals = q;
               FStar_Syntax_Syntax.sigmeta = uu___3;
               FStar_Syntax_Syntax.sigattrs = uu___4;
-              FStar_Syntax_Syntax.sigopts = uu___5;_},
-            uu___6),
-           uu___7)
+              FStar_Syntax_Syntax.sigopens_and_abbrevs = uu___5;
+              FStar_Syntax_Syntax.sigopts = uu___6;_},
+            uu___7),
+           uu___8)
           -> q
       | uu___1 -> []
 let (lookup_projector :
@@ -4056,15 +4071,16 @@ let (is_projector : env -> FStar_Ident.lident -> Prims.bool) =
               FStar_Syntax_Syntax.sigquals = quals;
               FStar_Syntax_Syntax.sigmeta = uu___3;
               FStar_Syntax_Syntax.sigattrs = uu___4;
-              FStar_Syntax_Syntax.sigopts = uu___5;_},
-            uu___6),
-           uu___7)
+              FStar_Syntax_Syntax.sigopens_and_abbrevs = uu___5;
+              FStar_Syntax_Syntax.sigopts = uu___6;_},
+            uu___7),
+           uu___8)
           ->
           FStar_Compiler_Util.for_some
-            (fun uu___8 ->
-               match uu___8 with
-               | FStar_Syntax_Syntax.Projector uu___9 -> true
-               | uu___9 -> false) quals
+            (fun uu___9 ->
+               match uu___9 with
+               | FStar_Syntax_Syntax.Projector uu___10 -> true
+               | uu___10 -> false) quals
       | uu___1 -> false
 let (is_datacon : env -> FStar_Ident.lident -> Prims.bool) =
   fun env1 ->
@@ -4080,9 +4096,10 @@ let (is_datacon : env -> FStar_Ident.lident -> Prims.bool) =
               FStar_Syntax_Syntax.sigquals = uu___3;
               FStar_Syntax_Syntax.sigmeta = uu___4;
               FStar_Syntax_Syntax.sigattrs = uu___5;
-              FStar_Syntax_Syntax.sigopts = uu___6;_},
-            uu___7),
-           uu___8)
+              FStar_Syntax_Syntax.sigopens_and_abbrevs = uu___6;
+              FStar_Syntax_Syntax.sigopts = uu___7;_},
+            uu___8),
+           uu___9)
           -> true
       | uu___1 -> false
 let (is_record : env -> FStar_Ident.lident -> Prims.bool) =
@@ -4099,16 +4116,17 @@ let (is_record : env -> FStar_Ident.lident -> Prims.bool) =
               FStar_Syntax_Syntax.sigquals = quals;
               FStar_Syntax_Syntax.sigmeta = uu___3;
               FStar_Syntax_Syntax.sigattrs = uu___4;
-              FStar_Syntax_Syntax.sigopts = uu___5;_},
-            uu___6),
-           uu___7)
+              FStar_Syntax_Syntax.sigopens_and_abbrevs = uu___5;
+              FStar_Syntax_Syntax.sigopts = uu___6;_},
+            uu___7),
+           uu___8)
           ->
           FStar_Compiler_Util.for_some
-            (fun uu___8 ->
-               match uu___8 with
-               | FStar_Syntax_Syntax.RecordType uu___9 -> true
-               | FStar_Syntax_Syntax.RecordConstructor uu___9 -> true
-               | uu___9 -> false) quals
+            (fun uu___9 ->
+               match uu___9 with
+               | FStar_Syntax_Syntax.RecordType uu___10 -> true
+               | FStar_Syntax_Syntax.RecordConstructor uu___10 -> true
+               | uu___10 -> false) quals
       | uu___1 -> false
 let (qninfo_is_action : qninfo -> Prims.bool) =
   fun qninfo1 ->
@@ -4120,15 +4138,16 @@ let (qninfo_is_action : qninfo -> Prims.bool) =
             FStar_Syntax_Syntax.sigquals = quals;
             FStar_Syntax_Syntax.sigmeta = uu___2;
             FStar_Syntax_Syntax.sigattrs = uu___3;
-            FStar_Syntax_Syntax.sigopts = uu___4;_},
-          uu___5),
-         uu___6)
+            FStar_Syntax_Syntax.sigopens_and_abbrevs = uu___4;
+            FStar_Syntax_Syntax.sigopts = uu___5;_},
+          uu___6),
+         uu___7)
         ->
         FStar_Compiler_Util.for_some
-          (fun uu___7 ->
-             match uu___7 with
-             | FStar_Syntax_Syntax.Action uu___8 -> true
-             | uu___8 -> false) quals
+          (fun uu___8 ->
+             match uu___8 with
+             | FStar_Syntax_Syntax.Action uu___9 -> true
+             | uu___9 -> false) quals
     | uu___ -> false
 let (is_action : env -> FStar_Ident.lident -> Prims.bool) =
   fun env1 ->
@@ -4225,9 +4244,10 @@ let (num_inductive_ty_params :
               FStar_Syntax_Syntax.sigquals = uu___8;
               FStar_Syntax_Syntax.sigmeta = uu___9;
               FStar_Syntax_Syntax.sigattrs = uu___10;
-              FStar_Syntax_Syntax.sigopts = uu___11;_},
-            uu___12),
-           uu___13)
+              FStar_Syntax_Syntax.sigopens_and_abbrevs = uu___11;
+              FStar_Syntax_Syntax.sigopts = uu___12;_},
+            uu___13),
+           uu___14)
           -> FStar_Pervasives_Native.Some (FStar_Compiler_List.length tps)
       | uu___1 -> FStar_Pervasives_Native.None
 let (num_inductive_uniform_ty_params :
@@ -4252,21 +4272,22 @@ let (num_inductive_uniform_ty_params :
               FStar_Syntax_Syntax.sigquals = uu___8;
               FStar_Syntax_Syntax.sigmeta = uu___9;
               FStar_Syntax_Syntax.sigattrs = uu___10;
-              FStar_Syntax_Syntax.sigopts = uu___11;_},
-            uu___12),
-           uu___13)
+              FStar_Syntax_Syntax.sigopens_and_abbrevs = uu___11;
+              FStar_Syntax_Syntax.sigopts = uu___12;_},
+            uu___13),
+           uu___14)
           ->
           (match num_uniform with
            | FStar_Pervasives_Native.None ->
-               let uu___14 =
-                 let uu___15 =
-                   let uu___16 = FStar_Ident.string_of_lid lid in
+               let uu___15 =
+                 let uu___16 =
+                   let uu___17 = FStar_Ident.string_of_lid lid in
                    FStar_Compiler_Util.format1
                      "Internal error: Inductive %s is not decorated with its uniform type parameters"
-                     uu___16 in
-                 (FStar_Errors_Codes.Fatal_UnexpectedInductivetype, uu___15) in
-               let uu___15 = FStar_Ident.range_of_lid lid in
-               FStar_Errors.raise_error uu___14 uu___15
+                     uu___17 in
+                 (FStar_Errors_Codes.Fatal_UnexpectedInductivetype, uu___16) in
+               let uu___16 = FStar_Ident.range_of_lid lid in
+               FStar_Errors.raise_error uu___15 uu___16
            | FStar_Pervasives_Native.Some n -> FStar_Pervasives_Native.Some n)
       | uu___1 -> FStar_Pervasives_Native.None
 let (effect_decl_opt :

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_NBE.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_NBE.ml
@@ -470,9 +470,10 @@ let (is_constr : FStar_TypeChecker_Env.qninfo -> Prims.bool) =
             FStar_Syntax_Syntax.sigquals = uu___2;
             FStar_Syntax_Syntax.sigmeta = uu___3;
             FStar_Syntax_Syntax.sigattrs = uu___4;
-            FStar_Syntax_Syntax.sigopts = uu___5;_},
-          uu___6),
-         uu___7)
+            FStar_Syntax_Syntax.sigopens_and_abbrevs = uu___5;
+            FStar_Syntax_Syntax.sigopts = uu___6;_},
+          uu___7),
+         uu___8)
         -> true
     | uu___ -> false
 let (translate_univ :
@@ -1872,16 +1873,17 @@ and (translate_fv :
                            FStar_Syntax_Syntax.sigquals = uu___4;
                            FStar_Syntax_Syntax.sigmeta = uu___5;
                            FStar_Syntax_Syntax.sigattrs = uu___6;
-                           FStar_Syntax_Syntax.sigopts = uu___7;_},
+                           FStar_Syntax_Syntax.sigopens_and_abbrevs = uu___7;
+                           FStar_Syntax_Syntax.sigopts = uu___8;_},
                          _us_opt),
                         _rng)
                        ->
                        (debug1
-                          (fun uu___9 ->
-                             let uu___10 =
+                          (fun uu___10 ->
+                             let uu___11 =
                                FStar_Syntax_Print.fv_to_string fvar in
                              FStar_Compiler_Util.print1
-                               "(1) Decided to unfold %s\n" uu___10);
+                               "(1) Decided to unfold %s\n" uu___11);
                         (let lbm = find_let lbs fvar in
                          match lbm with
                          | FStar_Pervasives_Native.Some lb ->
@@ -1889,14 +1891,14 @@ and (translate_fv :
                                is_rec &&
                                  ((cfg.core_cfg).FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.zeta
                              then
-                               let uu___9 = let_rec_arity lb in
-                               (match uu___9 with
+                               let uu___10 = let_rec_arity lb in
+                               (match uu___10 with
                                 | (ar, lst) ->
-                                    let uu___10 =
-                                      let uu___11 =
+                                    let uu___11 =
+                                      let uu___12 =
                                         FStar_Syntax_Syntax.range_of_fv fvar in
-                                      mk_rt uu___11 in
-                                    FStar_Compiler_Effect.op_Less_Bar uu___10
+                                      mk_rt uu___12 in
+                                    FStar_Compiler_Effect.op_Less_Bar uu___11
                                       (FStar_TypeChecker_NBETerm.TopLevelRec
                                          (lb, ar, lst, [])))
                              else translate_letbinding cfg bs lb
@@ -1942,16 +1944,17 @@ and (translate_fv :
                            FStar_Syntax_Syntax.sigquals = uu___4;
                            FStar_Syntax_Syntax.sigmeta = uu___5;
                            FStar_Syntax_Syntax.sigattrs = uu___6;
-                           FStar_Syntax_Syntax.sigopts = uu___7;_},
+                           FStar_Syntax_Syntax.sigopens_and_abbrevs = uu___7;
+                           FStar_Syntax_Syntax.sigopts = uu___8;_},
                          _us_opt),
                         _rng)
                        ->
                        (debug1
-                          (fun uu___9 ->
-                             let uu___10 =
+                          (fun uu___10 ->
+                             let uu___11 =
                                FStar_Syntax_Print.fv_to_string fvar in
                              FStar_Compiler_Util.print1
-                               "(1) Decided to unfold %s\n" uu___10);
+                               "(1) Decided to unfold %s\n" uu___11);
                         (let lbm = find_let lbs fvar in
                          match lbm with
                          | FStar_Pervasives_Native.Some lb ->
@@ -1959,14 +1962,14 @@ and (translate_fv :
                                is_rec &&
                                  ((cfg.core_cfg).FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.zeta
                              then
-                               let uu___9 = let_rec_arity lb in
-                               (match uu___9 with
+                               let uu___10 = let_rec_arity lb in
+                               (match uu___10 with
                                 | (ar, lst) ->
-                                    let uu___10 =
-                                      let uu___11 =
+                                    let uu___11 =
+                                      let uu___12 =
                                         FStar_Syntax_Syntax.range_of_fv fvar in
-                                      mk_rt uu___11 in
-                                    FStar_Compiler_Effect.op_Less_Bar uu___10
+                                      mk_rt uu___12 in
+                                    FStar_Compiler_Effect.op_Less_Bar uu___11
                                       (FStar_TypeChecker_NBETerm.TopLevelRec
                                          (lb, ar, lst, [])))
                              else translate_letbinding cfg bs lb

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_Normalize.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_Normalize.ml
@@ -2067,15 +2067,16 @@ let (should_unfold :
                         FStar_Syntax_Syntax.sigquals = qs;
                         FStar_Syntax_Syntax.sigmeta = uu___3;
                         FStar_Syntax_Syntax.sigattrs = uu___4;
-                        FStar_Syntax_Syntax.sigopts = uu___5;_},
-                      uu___6),
-                     uu___7),
-                    uu___8, uu___9, uu___10, uu___11, uu___12) when
+                        FStar_Syntax_Syntax.sigopens_and_abbrevs = uu___5;
+                        FStar_Syntax_Syntax.sigopts = uu___6;_},
+                      uu___7),
+                     uu___8),
+                    uu___9, uu___10, uu___11, uu___12, uu___13) when
                      FStar_Compiler_List.contains
                        FStar_Syntax_Syntax.HasMaskedEffect qs
                      ->
                      (FStar_TypeChecker_Cfg.log_unfolding cfg
-                        (fun uu___14 ->
+                        (fun uu___15 ->
                            FStar_Compiler_Util.print_string
                              " >> HasMaskedEffect, not unfolding\n");
                       no)
@@ -2102,10 +2103,11 @@ let (should_unfold :
                         FStar_Syntax_Syntax.sigquals = qs;
                         FStar_Syntax_Syntax.sigmeta = uu___3;
                         FStar_Syntax_Syntax.sigattrs = uu___4;
-                        FStar_Syntax_Syntax.sigopts = uu___5;_},
-                      uu___6),
-                     uu___7),
-                    uu___8, uu___9, uu___10, uu___11, uu___12) when
+                        FStar_Syntax_Syntax.sigopens_and_abbrevs = uu___5;
+                        FStar_Syntax_Syntax.sigopts = uu___6;_},
+                      uu___7),
+                     uu___8),
+                    uu___9, uu___10, uu___11, uu___12, uu___13) when
                      (is_rec &&
                         (Prims.op_Negation
                            (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.zeta))
@@ -2114,7 +2116,7 @@ let (should_unfold :
                           (cfg.FStar_TypeChecker_Cfg.steps).FStar_TypeChecker_Cfg.zeta_full)
                      ->
                      (FStar_TypeChecker_Cfg.log_unfolding cfg
-                        (fun uu___14 ->
+                        (fun uu___15 ->
                            FStar_Compiler_Util.print_string
                              " >> It's a recursive definition but we're not doing Zeta, not unfolding\n");
                       no)
@@ -9229,6 +9231,8 @@ let rec (elim_uvars :
           FStar_Syntax_Syntax.sigquals = (s.FStar_Syntax_Syntax.sigquals);
           FStar_Syntax_Syntax.sigmeta = (s.FStar_Syntax_Syntax.sigmeta);
           FStar_Syntax_Syntax.sigattrs = sigattrs;
+          FStar_Syntax_Syntax.sigopens_and_abbrevs =
+            (s.FStar_Syntax_Syntax.sigopens_and_abbrevs);
           FStar_Syntax_Syntax.sigopts = (s.FStar_Syntax_Syntax.sigopts)
         } in
       match s1.FStar_Syntax_Syntax.sigel with
@@ -9262,6 +9266,8 @@ let rec (elim_uvars :
                    (s1.FStar_Syntax_Syntax.sigmeta);
                  FStar_Syntax_Syntax.sigattrs =
                    (s1.FStar_Syntax_Syntax.sigattrs);
+                 FStar_Syntax_Syntax.sigopens_and_abbrevs =
+                   (s1.FStar_Syntax_Syntax.sigopens_and_abbrevs);
                  FStar_Syntax_Syntax.sigopts =
                    (s1.FStar_Syntax_Syntax.sigopts)
                })
@@ -9283,6 +9289,8 @@ let rec (elim_uvars :
             FStar_Syntax_Syntax.sigquals = (s1.FStar_Syntax_Syntax.sigquals);
             FStar_Syntax_Syntax.sigmeta = (s1.FStar_Syntax_Syntax.sigmeta);
             FStar_Syntax_Syntax.sigattrs = (s1.FStar_Syntax_Syntax.sigattrs);
+            FStar_Syntax_Syntax.sigopens_and_abbrevs =
+              (s1.FStar_Syntax_Syntax.sigopens_and_abbrevs);
             FStar_Syntax_Syntax.sigopts = (s1.FStar_Syntax_Syntax.sigopts)
           }
       | FStar_Syntax_Syntax.Sig_datacon
@@ -9314,6 +9322,8 @@ let rec (elim_uvars :
                    (s1.FStar_Syntax_Syntax.sigmeta);
                  FStar_Syntax_Syntax.sigattrs =
                    (s1.FStar_Syntax_Syntax.sigattrs);
+                 FStar_Syntax_Syntax.sigopens_and_abbrevs =
+                   (s1.FStar_Syntax_Syntax.sigopens_and_abbrevs);
                  FStar_Syntax_Syntax.sigopts =
                    (s1.FStar_Syntax_Syntax.sigopts)
                })
@@ -9340,6 +9350,8 @@ let rec (elim_uvars :
                    (s1.FStar_Syntax_Syntax.sigmeta);
                  FStar_Syntax_Syntax.sigattrs =
                    (s1.FStar_Syntax_Syntax.sigattrs);
+                 FStar_Syntax_Syntax.sigopens_and_abbrevs =
+                   (s1.FStar_Syntax_Syntax.sigopens_and_abbrevs);
                  FStar_Syntax_Syntax.sigopts =
                    (s1.FStar_Syntax_Syntax.sigopts)
                })
@@ -9387,6 +9399,8 @@ let rec (elim_uvars :
             FStar_Syntax_Syntax.sigquals = (s1.FStar_Syntax_Syntax.sigquals);
             FStar_Syntax_Syntax.sigmeta = (s1.FStar_Syntax_Syntax.sigmeta);
             FStar_Syntax_Syntax.sigattrs = (s1.FStar_Syntax_Syntax.sigattrs);
+            FStar_Syntax_Syntax.sigopens_and_abbrevs =
+              (s1.FStar_Syntax_Syntax.sigopens_and_abbrevs);
             FStar_Syntax_Syntax.sigopts = (s1.FStar_Syntax_Syntax.sigopts)
           }
       | FStar_Syntax_Syntax.Sig_assume
@@ -9411,6 +9425,8 @@ let rec (elim_uvars :
                    (s1.FStar_Syntax_Syntax.sigmeta);
                  FStar_Syntax_Syntax.sigattrs =
                    (s1.FStar_Syntax_Syntax.sigattrs);
+                 FStar_Syntax_Syntax.sigopens_and_abbrevs =
+                   (s1.FStar_Syntax_Syntax.sigopens_and_abbrevs);
                  FStar_Syntax_Syntax.sigopts =
                    (s1.FStar_Syntax_Syntax.sigopts)
                })
@@ -9624,6 +9640,8 @@ let rec (elim_uvars :
                              (s1.FStar_Syntax_Syntax.sigmeta);
                            FStar_Syntax_Syntax.sigattrs =
                              (s1.FStar_Syntax_Syntax.sigattrs);
+                           FStar_Syntax_Syntax.sigopens_and_abbrevs =
+                             (s1.FStar_Syntax_Syntax.sigopens_and_abbrevs);
                            FStar_Syntax_Syntax.sigopts =
                              (s1.FStar_Syntax_Syntax.sigopts)
                          })))
@@ -9655,6 +9673,8 @@ let rec (elim_uvars :
             FStar_Syntax_Syntax.sigquals = (s1.FStar_Syntax_Syntax.sigquals);
             FStar_Syntax_Syntax.sigmeta = (s1.FStar_Syntax_Syntax.sigmeta);
             FStar_Syntax_Syntax.sigattrs = (s1.FStar_Syntax_Syntax.sigattrs);
+            FStar_Syntax_Syntax.sigopens_and_abbrevs =
+              (s1.FStar_Syntax_Syntax.sigopens_and_abbrevs);
             FStar_Syntax_Syntax.sigopts = (s1.FStar_Syntax_Syntax.sigopts)
           }
       | FStar_Syntax_Syntax.Sig_effect_abbrev
@@ -9684,6 +9704,8 @@ let rec (elim_uvars :
                    (s1.FStar_Syntax_Syntax.sigmeta);
                  FStar_Syntax_Syntax.sigattrs =
                    (s1.FStar_Syntax_Syntax.sigattrs);
+                 FStar_Syntax_Syntax.sigopens_and_abbrevs =
+                   (s1.FStar_Syntax_Syntax.sigopens_and_abbrevs);
                  FStar_Syntax_Syntax.sigopts =
                    (s1.FStar_Syntax_Syntax.sigopts)
                })
@@ -9722,6 +9744,8 @@ let rec (elim_uvars :
                         (s1.FStar_Syntax_Syntax.sigmeta);
                       FStar_Syntax_Syntax.sigattrs =
                         (s1.FStar_Syntax_Syntax.sigattrs);
+                      FStar_Syntax_Syntax.sigopens_and_abbrevs =
+                        (s1.FStar_Syntax_Syntax.sigopens_and_abbrevs);
                       FStar_Syntax_Syntax.sigopts =
                         (s1.FStar_Syntax_Syntax.sigopts)
                     }))
@@ -9755,6 +9779,8 @@ let rec (elim_uvars :
                         (s1.FStar_Syntax_Syntax.sigmeta);
                       FStar_Syntax_Syntax.sigattrs =
                         (s1.FStar_Syntax_Syntax.sigattrs);
+                      FStar_Syntax_Syntax.sigopens_and_abbrevs =
+                        (s1.FStar_Syntax_Syntax.sigopens_and_abbrevs);
                       FStar_Syntax_Syntax.sigopts =
                         (s1.FStar_Syntax_Syntax.sigopts)
                     }))

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_Positivity.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_Positivity.ml
@@ -483,6 +483,8 @@ let (mark_uniform_type_parameters :
                             (tc.FStar_Syntax_Syntax.sigmeta);
                           FStar_Syntax_Syntax.sigattrs =
                             (tc.FStar_Syntax_Syntax.sigattrs);
+                          FStar_Syntax_Syntax.sigopens_and_abbrevs =
+                            (tc.FStar_Syntax_Syntax.sigopens_and_abbrevs);
                           FStar_Syntax_Syntax.sigopts =
                             (tc.FStar_Syntax_Syntax.sigopts)
                         })))) in
@@ -516,6 +518,8 @@ let (mark_uniform_type_parameters :
                    (sig1.FStar_Syntax_Syntax.sigmeta);
                  FStar_Syntax_Syntax.sigattrs =
                    (sig1.FStar_Syntax_Syntax.sigattrs);
+                 FStar_Syntax_Syntax.sigopens_and_abbrevs =
+                   (sig1.FStar_Syntax_Syntax.sigopens_and_abbrevs);
                  FStar_Syntax_Syntax.sigopts =
                    (sig1.FStar_Syntax_Syntax.sigopts)
                })

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_Tc.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_Tc.ml
@@ -362,6 +362,8 @@ let (tc_decl_attributes :
             FStar_Syntax_Syntax.sigquals = (se.FStar_Syntax_Syntax.sigquals);
             FStar_Syntax_Syntax.sigmeta = (se.FStar_Syntax_Syntax.sigmeta);
             FStar_Syntax_Syntax.sigattrs = uu___1;
+            FStar_Syntax_Syntax.sigopens_and_abbrevs =
+              (se.FStar_Syntax_Syntax.sigopens_and_abbrevs);
             FStar_Syntax_Syntax.sigopts = (se.FStar_Syntax_Syntax.sigopts)
           }
 let (tc_inductive' :
@@ -789,6 +791,8 @@ let (store_sigopts :
       FStar_Syntax_Syntax.sigquals = (se.FStar_Syntax_Syntax.sigquals);
       FStar_Syntax_Syntax.sigmeta = (se.FStar_Syntax_Syntax.sigmeta);
       FStar_Syntax_Syntax.sigattrs = (se.FStar_Syntax_Syntax.sigattrs);
+      FStar_Syntax_Syntax.sigopens_and_abbrevs =
+        (se.FStar_Syntax_Syntax.sigopens_and_abbrevs);
       FStar_Syntax_Syntax.sigopts = uu___
     }
 let (tc_decls_knot :
@@ -1089,6 +1093,8 @@ let (tc_sig_let :
                           FStar_Syntax_Syntax.sigmeta =
                             (se.FStar_Syntax_Syntax.sigmeta);
                           FStar_Syntax_Syntax.sigattrs = attrs;
+                          FStar_Syntax_Syntax.sigopens_and_abbrevs =
+                            (se.FStar_Syntax_Syntax.sigopens_and_abbrevs);
                           FStar_Syntax_Syntax.sigopts =
                             (se.FStar_Syntax_Syntax.sigopts)
                         } in
@@ -1532,6 +1538,8 @@ let (tc_sig_let :
                                FStar_Syntax_Syntax.sigmeta =
                                  (se1.FStar_Syntax_Syntax.sigmeta);
                                FStar_Syntax_Syntax.sigattrs = attrs1;
+                               FStar_Syntax_Syntax.sigopens_and_abbrevs =
+                                 (se1.FStar_Syntax_Syntax.sigopens_and_abbrevs);
                                FStar_Syntax_Syntax.sigopts =
                                  (se1.FStar_Syntax_Syntax.sigopts)
                              } in
@@ -1596,6 +1604,9 @@ let (tc_sig_let :
                                        (se2.FStar_Syntax_Syntax.sigmeta);
                                      FStar_Syntax_Syntax.sigattrs =
                                        (se2.FStar_Syntax_Syntax.sigattrs);
+                                     FStar_Syntax_Syntax.sigopens_and_abbrevs
+                                       =
+                                       (se2.FStar_Syntax_Syntax.sigopens_and_abbrevs);
                                      FStar_Syntax_Syntax.sigopts =
                                        (se2.FStar_Syntax_Syntax.sigopts)
                                    } in
@@ -1788,6 +1799,9 @@ let (tc_sig_let :
                                         (se2.FStar_Syntax_Syntax.sigmeta);
                                       FStar_Syntax_Syntax.sigattrs =
                                         (se2.FStar_Syntax_Syntax.sigattrs);
+                                      FStar_Syntax_Syntax.sigopens_and_abbrevs
+                                        =
+                                        (se2.FStar_Syntax_Syntax.sigopens_and_abbrevs);
                                       FStar_Syntax_Syntax.sigopts =
                                         (se2.FStar_Syntax_Syntax.sigopts)
                                     }, lbs3)))
@@ -2467,6 +2481,8 @@ let (tc_decl' :
                                    (se2.FStar_Syntax_Syntax.sigmeta);
                                  FStar_Syntax_Syntax.sigattrs =
                                    (se2.FStar_Syntax_Syntax.sigattrs);
+                                 FStar_Syntax_Syntax.sigopens_and_abbrevs =
+                                   (se2.FStar_Syntax_Syntax.sigopens_and_abbrevs);
                                  FStar_Syntax_Syntax.sigopts =
                                    (se2.FStar_Syntax_Syntax.sigopts)
                                } in
@@ -2492,6 +2508,8 @@ let (tc_decl' :
                           (sigbndle.FStar_Syntax_Syntax.sigmeta);
                         FStar_Syntax_Syntax.sigattrs =
                           (se2.FStar_Syntax_Syntax.sigattrs);
+                        FStar_Syntax_Syntax.sigopens_and_abbrevs =
+                          (sigbndle.FStar_Syntax_Syntax.sigopens_and_abbrevs);
                         FStar_Syntax_Syntax.sigopts =
                           (sigbndle.FStar_Syntax_Syntax.sigopts)
                       } in
@@ -2539,6 +2557,8 @@ let (tc_decl' :
                                  (se2.FStar_Syntax_Syntax.sigmeta);
                                FStar_Syntax_Syntax.sigattrs =
                                  (se2.FStar_Syntax_Syntax.sigattrs);
+                               FStar_Syntax_Syntax.sigopens_and_abbrevs =
+                                 (se2.FStar_Syntax_Syntax.sigopens_and_abbrevs);
                                FStar_Syntax_Syntax.sigopts =
                                  (se2.FStar_Syntax_Syntax.sigopts)
                              };
@@ -2555,6 +2575,8 @@ let (tc_decl' :
                                  (se2.FStar_Syntax_Syntax.sigmeta);
                                FStar_Syntax_Syntax.sigattrs =
                                  (se2.FStar_Syntax_Syntax.sigattrs);
+                               FStar_Syntax_Syntax.sigopens_and_abbrevs =
+                                 (se2.FStar_Syntax_Syntax.sigopens_and_abbrevs);
                                FStar_Syntax_Syntax.sigopts =
                                  (se2.FStar_Syntax_Syntax.sigopts)
                              }] in
@@ -2584,6 +2606,8 @@ let (tc_decl' :
                                      });
                                   FStar_Syntax_Syntax.sigattrs =
                                     (sigelt.FStar_Syntax_Syntax.sigattrs);
+                                  FStar_Syntax_Syntax.sigopens_and_abbrevs =
+                                    (sigelt.FStar_Syntax_Syntax.sigopens_and_abbrevs);
                                   FStar_Syntax_Syntax.sigopts =
                                     (sigelt.FStar_Syntax_Syntax.sigopts)
                                 })) in
@@ -2734,6 +2758,9 @@ let (tc_decl' :
                                           (se2.FStar_Syntax_Syntax.sigmeta);
                                         FStar_Syntax_Syntax.sigattrs =
                                           (se2.FStar_Syntax_Syntax.sigattrs);
+                                        FStar_Syntax_Syntax.sigopens_and_abbrevs
+                                          =
+                                          (se2.FStar_Syntax_Syntax.sigopens_and_abbrevs);
                                         FStar_Syntax_Syntax.sigopts =
                                           (se2.FStar_Syntax_Syntax.sigopts)
                                       }) in
@@ -2760,6 +2787,9 @@ let (tc_decl' :
                                       (se2.FStar_Syntax_Syntax.sigmeta);
                                     FStar_Syntax_Syntax.sigattrs =
                                       (se2.FStar_Syntax_Syntax.sigattrs);
+                                    FStar_Syntax_Syntax.sigopens_and_abbrevs
+                                      =
+                                      (se2.FStar_Syntax_Syntax.sigopens_and_abbrevs);
                                     FStar_Syntax_Syntax.sigopts =
                                       (se2.FStar_Syntax_Syntax.sigopts)
                                   } in
@@ -2784,6 +2814,8 @@ let (tc_decl' :
                         (se2.FStar_Syntax_Syntax.sigmeta);
                       FStar_Syntax_Syntax.sigattrs =
                         (se2.FStar_Syntax_Syntax.sigattrs);
+                      FStar_Syntax_Syntax.sigopens_and_abbrevs =
+                        (se2.FStar_Syntax_Syntax.sigopens_and_abbrevs);
                       FStar_Syntax_Syntax.sigopts =
                         (se2.FStar_Syntax_Syntax.sigopts)
                     } in
@@ -2802,6 +2834,8 @@ let (tc_decl' :
                      (se2.FStar_Syntax_Syntax.sigmeta);
                    FStar_Syntax_Syntax.sigattrs =
                      (se2.FStar_Syntax_Syntax.sigattrs);
+                   FStar_Syntax_Syntax.sigopens_and_abbrevs =
+                     (se2.FStar_Syntax_Syntax.sigopens_and_abbrevs);
                    FStar_Syntax_Syntax.sigopts =
                      (se2.FStar_Syntax_Syntax.sigopts)
                  } in
@@ -2953,6 +2987,9 @@ let (tc_decl' :
                                          (se2.FStar_Syntax_Syntax.sigmeta);
                                        FStar_Syntax_Syntax.sigattrs =
                                          (se2.FStar_Syntax_Syntax.sigattrs);
+                                       FStar_Syntax_Syntax.sigopens_and_abbrevs
+                                         =
+                                         (se2.FStar_Syntax_Syntax.sigopens_and_abbrevs);
                                        FStar_Syntax_Syntax.sigopts =
                                          (se2.FStar_Syntax_Syntax.sigopts)
                                      }) in
@@ -2998,6 +3035,8 @@ let (tc_decl' :
                                (se2.FStar_Syntax_Syntax.sigmeta);
                              FStar_Syntax_Syntax.sigattrs =
                                (se2.FStar_Syntax_Syntax.sigattrs);
+                             FStar_Syntax_Syntax.sigopens_and_abbrevs =
+                               (se2.FStar_Syntax_Syntax.sigopens_and_abbrevs);
                              FStar_Syntax_Syntax.sigopts =
                                (se2.FStar_Syntax_Syntax.sigopts)
                            } in
@@ -3193,6 +3232,8 @@ let (tc_decl' :
                                 (se2.FStar_Syntax_Syntax.sigmeta);
                               FStar_Syntax_Syntax.sigattrs =
                                 (se2.FStar_Syntax_Syntax.sigattrs);
+                              FStar_Syntax_Syntax.sigopens_and_abbrevs =
+                                (se2.FStar_Syntax_Syntax.sigopens_and_abbrevs);
                               FStar_Syntax_Syntax.sigopts =
                                 (se2.FStar_Syntax_Syntax.sigopts)
                             }], [], env0))))
@@ -3371,6 +3412,8 @@ let (tc_decl' :
                                 (se2.FStar_Syntax_Syntax.sigmeta);
                               FStar_Syntax_Syntax.sigattrs =
                                 (se2.FStar_Syntax_Syntax.sigattrs);
+                              FStar_Syntax_Syntax.sigopens_and_abbrevs =
+                                (se2.FStar_Syntax_Syntax.sigopens_and_abbrevs);
                               FStar_Syntax_Syntax.sigopts =
                                 (se2.FStar_Syntax_Syntax.sigopts)
                             }], [], env0))))
@@ -3413,6 +3456,8 @@ let (tc_decl' :
                               (sp.FStar_Syntax_Syntax.sigmeta);
                             FStar_Syntax_Syntax.sigattrs =
                               (se2.FStar_Syntax_Syntax.sigattrs);
+                            FStar_Syntax_Syntax.sigopens_and_abbrevs =
+                              (sp.FStar_Syntax_Syntax.sigopens_and_abbrevs);
                             FStar_Syntax_Syntax.sigopts =
                               (sp.FStar_Syntax_Syntax.sigopts)
                           }) ses
@@ -3706,6 +3751,9 @@ let (tc_decl' :
                                            (se2.FStar_Syntax_Syntax.sigmeta);
                                          FStar_Syntax_Syntax.sigattrs =
                                            (se2.FStar_Syntax_Syntax.sigattrs);
+                                         FStar_Syntax_Syntax.sigopens_and_abbrevs
+                                           =
+                                           (se2.FStar_Syntax_Syntax.sigopens_and_abbrevs);
                                          FStar_Syntax_Syntax.sigopts =
                                            (se2.FStar_Syntax_Syntax.sigopts)
                                        }) in
@@ -3755,6 +3803,9 @@ let (tc_decl' :
                                         (se2.FStar_Syntax_Syntax.sigmeta);
                                       FStar_Syntax_Syntax.sigattrs =
                                         (se2.FStar_Syntax_Syntax.sigattrs);
+                                      FStar_Syntax_Syntax.sigopens_and_abbrevs
+                                        =
+                                        (se2.FStar_Syntax_Syntax.sigopens_and_abbrevs);
                                       FStar_Syntax_Syntax.sigopts =
                                         (se2.FStar_Syntax_Syntax.sigopts)
                                     } in
@@ -3789,6 +3840,8 @@ let (tc_decl' :
                           (se2.FStar_Syntax_Syntax.sigmeta);
                         FStar_Syntax_Syntax.sigattrs =
                           (se2.FStar_Syntax_Syntax.sigattrs);
+                        FStar_Syntax_Syntax.sigopens_and_abbrevs =
+                          (se2.FStar_Syntax_Syntax.sigopens_and_abbrevs);
                         FStar_Syntax_Syntax.sigopts =
                           (se2.FStar_Syntax_Syntax.sigopts)
                       } in
@@ -3947,6 +4000,9 @@ let (tc_decl' :
                                            (se2.FStar_Syntax_Syntax.sigmeta);
                                          FStar_Syntax_Syntax.sigattrs =
                                            (se2.FStar_Syntax_Syntax.sigattrs);
+                                         FStar_Syntax_Syntax.sigopens_and_abbrevs
+                                           =
+                                           (se2.FStar_Syntax_Syntax.sigopens_and_abbrevs);
                                          FStar_Syntax_Syntax.sigopts =
                                            (se2.FStar_Syntax_Syntax.sigopts)
                                        }) in
@@ -3994,6 +4050,9 @@ let (tc_decl' :
                                         (se2.FStar_Syntax_Syntax.sigmeta);
                                       FStar_Syntax_Syntax.sigattrs =
                                         (se2.FStar_Syntax_Syntax.sigattrs);
+                                      FStar_Syntax_Syntax.sigopens_and_abbrevs
+                                        =
+                                        (se2.FStar_Syntax_Syntax.sigopens_and_abbrevs);
                                       FStar_Syntax_Syntax.sigopts =
                                         (se2.FStar_Syntax_Syntax.sigopts)
                                     } in
@@ -4027,6 +4086,8 @@ let (tc_decl' :
                           (se2.FStar_Syntax_Syntax.sigmeta);
                         FStar_Syntax_Syntax.sigattrs =
                           (se2.FStar_Syntax_Syntax.sigattrs);
+                        FStar_Syntax_Syntax.sigopens_and_abbrevs =
+                          (se2.FStar_Syntax_Syntax.sigopens_and_abbrevs);
                         FStar_Syntax_Syntax.sigopts =
                           (se2.FStar_Syntax_Syntax.sigopts)
                       } in
@@ -5309,6 +5370,8 @@ let (check_module :
                            (se.FStar_Syntax_Syntax.sigmeta);
                          FStar_Syntax_Syntax.sigattrs =
                            (se.FStar_Syntax_Syntax.sigattrs);
+                         FStar_Syntax_Syntax.sigopens_and_abbrevs =
+                           (se.FStar_Syntax_Syntax.sigopens_and_abbrevs);
                          FStar_Syntax_Syntax.sigopts =
                            (se.FStar_Syntax_Syntax.sigopts)
                        }

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_TcInductive.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_TcInductive.ml
@@ -226,6 +226,9 @@ let (tc_tycon :
                                                        FStar_Syntax_Syntax.sigattrs
                                                          =
                                                          (s.FStar_Syntax_Syntax.sigattrs);
+                                                       FStar_Syntax_Syntax.sigopens_and_abbrevs
+                                                         =
+                                                         (s.FStar_Syntax_Syntax.sigopens_and_abbrevs);
                                                        FStar_Syntax_Syntax.sigopts
                                                          =
                                                          (s.FStar_Syntax_Syntax.sigopts)
@@ -714,6 +717,9 @@ let (tc_data :
                                                        FStar_Syntax_Syntax.sigattrs
                                                          =
                                                          (se.FStar_Syntax_Syntax.sigattrs);
+                                                       FStar_Syntax_Syntax.sigopens_and_abbrevs
+                                                         =
+                                                         (se.FStar_Syntax_Syntax.sigopens_and_abbrevs);
                                                        FStar_Syntax_Syntax.sigopts
                                                          =
                                                          (se.FStar_Syntax_Syntax.sigopts)
@@ -916,6 +922,9 @@ let (generalize_and_inst_within :
                                                       FStar_Syntax_Syntax.sigattrs
                                                         =
                                                         (se.FStar_Syntax_Syntax.sigattrs);
+                                                      FStar_Syntax_Syntax.sigopens_and_abbrevs
+                                                        =
+                                                        (se.FStar_Syntax_Syntax.sigopens_and_abbrevs);
                                                       FStar_Syntax_Syntax.sigopts
                                                         =
                                                         (se.FStar_Syntax_Syntax.sigopts)
@@ -965,8 +974,10 @@ let (generalize_and_inst_within :
                                                    = uu___17;
                                                  FStar_Syntax_Syntax.sigattrs
                                                    = uu___18;
+                                                 FStar_Syntax_Syntax.sigopens_and_abbrevs
+                                                   = uu___19;
                                                  FStar_Syntax_Syntax.sigopts
-                                                   = uu___19;_}
+                                                   = uu___20;_}
                                                  -> (tc, uvs_universes)
                                              | uu___9 ->
                                                  failwith "Impossible")) in
@@ -1040,6 +1051,9 @@ let (generalize_and_inst_within :
                                                      FStar_Syntax_Syntax.sigattrs
                                                        =
                                                        (d.FStar_Syntax_Syntax.sigattrs);
+                                                     FStar_Syntax_Syntax.sigopens_and_abbrevs
+                                                       =
+                                                       (d.FStar_Syntax_Syntax.sigopens_and_abbrevs);
                                                      FStar_Syntax_Syntax.sigopts
                                                        =
                                                        (d.FStar_Syntax_Syntax.sigopts)
@@ -1507,6 +1521,8 @@ let (optimized_haseq_scheme :
                                                     FStar_Syntax_Syntax.default_sigmeta;
                                                   FStar_Syntax_Syntax.sigattrs
                                                     = [];
+                                                  FStar_Syntax_Syntax.sigopens_and_abbrevs
+                                                    = [];
                                                   FStar_Syntax_Syntax.sigopts
                                                     =
                                                     FStar_Pervasives_Native.None
@@ -1864,6 +1880,7 @@ let (unoptimized_haseq_scheme :
                        FStar_Syntax_Syntax.sigmeta =
                          FStar_Syntax_Syntax.default_sigmeta;
                        FStar_Syntax_Syntax.sigattrs = [];
+                       FStar_Syntax_Syntax.sigopens_and_abbrevs = [];
                        FStar_Syntax_Syntax.sigopts =
                          FStar_Pervasives_Native.None
                      } in
@@ -1892,7 +1909,8 @@ let (check_inductive_well_typedness :
                         FStar_Syntax_Syntax.sigquals = uu___4;
                         FStar_Syntax_Syntax.sigmeta = uu___5;
                         FStar_Syntax_Syntax.sigattrs = uu___6;
-                        FStar_Syntax_Syntax.sigopts = uu___7;_} -> true
+                        FStar_Syntax_Syntax.sigopens_and_abbrevs = uu___7;
+                        FStar_Syntax_Syntax.sigopts = uu___8;_} -> true
                     | uu___2 -> false)) in
           match uu___ with
           | (tys, datas) ->
@@ -1908,7 +1926,9 @@ let (check_inductive_well_typedness :
                               FStar_Syntax_Syntax.sigquals = uu___6;
                               FStar_Syntax_Syntax.sigmeta = uu___7;
                               FStar_Syntax_Syntax.sigattrs = uu___8;
-                              FStar_Syntax_Syntax.sigopts = uu___9;_} ->
+                              FStar_Syntax_Syntax.sigopens_and_abbrevs =
+                                uu___9;
+                              FStar_Syntax_Syntax.sigopts = uu___10;_} ->
                               false
                           | uu___4 -> true)) in
                 if uu___2
@@ -2260,6 +2280,9 @@ let (check_inductive_well_typedness :
                                                                  FStar_Syntax_Syntax.sigattrs
                                                                    =
                                                                    (se.FStar_Syntax_Syntax.sigattrs);
+                                                                 FStar_Syntax_Syntax.sigopens_and_abbrevs
+                                                                   =
+                                                                   (se.FStar_Syntax_Syntax.sigopens_and_abbrevs);
                                                                  FStar_Syntax_Syntax.sigopts
                                                                    =
                                                                    (se.FStar_Syntax_Syntax.sigopts)
@@ -2295,6 +2318,8 @@ let (check_inductive_well_typedness :
                                   FStar_Syntax_Syntax.sigmeta =
                                     FStar_Syntax_Syntax.default_sigmeta;
                                   FStar_Syntax_Syntax.sigattrs = uu___6;
+                                  FStar_Syntax_Syntax.sigopens_and_abbrevs =
+                                    [];
                                   FStar_Syntax_Syntax.sigopts =
                                     FStar_Pervasives_Native.None
                                 } in
@@ -2511,6 +2536,8 @@ let (mk_discriminator_and_indexed_projectors :
                                    FStar_Syntax_Syntax.sigmeta =
                                      FStar_Syntax_Syntax.default_sigmeta;
                                    FStar_Syntax_Syntax.sigattrs = attrs;
+                                   FStar_Syntax_Syntax.sigopens_and_abbrevs =
+                                     [];
                                    FStar_Syntax_Syntax.sigopts =
                                      FStar_Pervasives_Native.None
                                  } in
@@ -2683,6 +2710,8 @@ let (mk_discriminator_and_indexed_projectors :
                                       FStar_Syntax_Syntax.sigmeta =
                                         FStar_Syntax_Syntax.default_sigmeta;
                                       FStar_Syntax_Syntax.sigattrs = attrs;
+                                      FStar_Syntax_Syntax.sigopens_and_abbrevs
+                                        = [];
                                       FStar_Syntax_Syntax.sigopts =
                                         FStar_Pervasives_Native.None
                                     } in
@@ -2841,6 +2870,8 @@ let (mk_discriminator_and_indexed_projectors :
                                                   FStar_Syntax_Syntax.default_sigmeta;
                                                 FStar_Syntax_Syntax.sigattrs
                                                   = attrs1;
+                                                FStar_Syntax_Syntax.sigopens_and_abbrevs
+                                                  = [];
                                                 FStar_Syntax_Syntax.sigopts =
                                                   FStar_Pervasives_Native.None
                                               } in
@@ -3112,6 +3143,8 @@ let (mk_discriminator_and_indexed_projectors :
                                                       FStar_Syntax_Syntax.default_sigmeta;
                                                     FStar_Syntax_Syntax.sigattrs
                                                       = attrs1;
+                                                    FStar_Syntax_Syntax.sigopens_and_abbrevs
+                                                      = [];
                                                     FStar_Syntax_Syntax.sigopts
                                                       =
                                                       FStar_Pervasives_Native.None
@@ -3155,6 +3188,8 @@ let (mk_discriminator_and_indexed_projectors :
                               FStar_Syntax_Syntax.sigmeta =
                                 (se.FStar_Syntax_Syntax.sigmeta);
                               FStar_Syntax_Syntax.sigattrs = uu___;
+                              FStar_Syntax_Syntax.sigopens_and_abbrevs =
+                                (se.FStar_Syntax_Syntax.sigopens_and_abbrevs);
                               FStar_Syntax_Syntax.sigopts =
                                 (se.FStar_Syntax_Syntax.sigopts)
                             } in

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_Util.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_Util.ml
@@ -8405,18 +8405,19 @@ let (try_lookup_record_type :
                            FStar_Syntax_Syntax.sigquals = uu___8;
                            FStar_Syntax_Syntax.sigmeta = uu___9;
                            FStar_Syntax_Syntax.sigattrs = uu___10;
-                           FStar_Syntax_Syntax.sigopts = uu___11;_}
+                           FStar_Syntax_Syntax.sigopens_and_abbrevs = uu___11;
+                           FStar_Syntax_Syntax.sigopts = uu___12;_}
                          ->
-                         let uu___12 = FStar_Syntax_Util.arrow_formals t in
-                         (match uu___12 with
+                         let uu___13 = FStar_Syntax_Util.arrow_formals t in
+                         (match uu___13 with
                           | (formals, c) ->
                               if
                                 nparms < (FStar_Compiler_List.length formals)
                               then
-                                let uu___13 =
+                                let uu___14 =
                                   FStar_Compiler_List.splitAt nparms formals in
-                                (match uu___13 with
-                                 | (uu___14, fields) ->
+                                (match uu___14 with
+                                 | (uu___15, fields) ->
                                      let fields1 =
                                        FStar_Compiler_List.filter
                                          (fun b ->
@@ -8424,8 +8425,8 @@ let (try_lookup_record_type :
                                             with
                                             | FStar_Pervasives_Native.Some
                                                 (FStar_Syntax_Syntax.Implicit
-                                                uu___15) -> false
-                                            | uu___15 -> true) fields in
+                                                uu___16) -> false
+                                            | uu___16 -> true) fields in
                                      let fields2 =
                                        FStar_Compiler_List.map
                                          (fun b ->
@@ -8436,13 +8437,13 @@ let (try_lookup_record_type :
                                        FStar_TypeChecker_Env.is_record env
                                          typename in
                                      let r =
-                                       let uu___15 =
+                                       let uu___16 =
                                          FStar_Ident.ident_of_lid dc in
                                        {
                                          FStar_Syntax_DsEnv.typename =
                                            typename;
                                          FStar_Syntax_DsEnv.constrname =
-                                           uu___15;
+                                           uu___16;
                                          FStar_Syntax_DsEnv.parms = [];
                                          FStar_Syntax_DsEnv.fields = fields2;
                                          FStar_Syntax_DsEnv.is_private =
@@ -8452,16 +8453,16 @@ let (try_lookup_record_type :
                                        } in
                                      FStar_Pervasives_Native.Some r)
                               else
-                                ((let uu___15 =
+                                ((let uu___16 =
                                     FStar_Compiler_Util.string_of_int nparms in
-                                  let uu___16 =
-                                    FStar_Syntax_Print.term_to_string t in
                                   let uu___17 =
+                                    FStar_Syntax_Print.term_to_string t in
+                                  let uu___18 =
                                     FStar_Syntax_Print.binders_to_string ", "
                                       formals in
                                   FStar_Compiler_Util.print3
                                     "Not enough formals; nparms=%s; type = %s; formals=%s\n"
-                                    uu___15 uu___16 uu___17);
+                                    uu___16 uu___17 uu___18);
                                  FStar_Pervasives_Native.None))
                      | uu___3 ->
                          ((let uu___5 = FStar_Ident.string_of_lid dc in

--- a/src/fstar/FStar.CheckedFiles.fst
+++ b/src/fstar/FStar.CheckedFiles.fst
@@ -40,7 +40,7 @@ module Dep     = FStar.Parser.Dep
  * detect when loading the cache that the version number is same
  * It needs to be kept in sync with prims.fst
  *)
-let cache_version_number = 57
+let cache_version_number = 58
 
 (*
  * Abbreviation for what we store in the checked files (stages as described below)

--- a/src/fstar/FStar.Interactive.PushHelper.fst
+++ b/src/fstar/FStar.Interactive.PushHelper.fst
@@ -205,7 +205,7 @@ let update_names_from_event cur_mod_str table evt =
   | NTOpen (host, (included, kind)) ->
     if is_cur_mod host then
       CTable.register_open
-        table (kind = DsEnv.Open_module) [] (query_of_lid included)
+        table (kind = FStar.Syntax.Syntax.Open_module) [] (query_of_lid included)
     else
       table
   | NTInclude (host, included) ->

--- a/src/fstar/FStar.Interactive.PushHelper.fsti
+++ b/src/fstar/FStar.Interactive.PushHelper.fsti
@@ -39,7 +39,7 @@ type either_replst = either repl_state repl_state
 // Name tracking; taken directly from IDE
 type name_tracking_event =
 | NTAlias of lid (* host *) * ident (* alias *) * lid (* aliased *)
-| NTOpen of lid (* host *) * DsEnv.open_module_or_namespace (* opened *)
+| NTOpen of lid (* host *) * FStar.Syntax.Syntax.open_module_or_namespace (* opened *)
 | NTInclude of lid (* host *) * lid (* included *)
 | NTBinding of either FStar.Syntax.Syntax.binding TcEnv.sig_binding
 

--- a/src/syntax/FStar.Syntax.DsEnv.fsti
+++ b/src/syntax/FStar.Syntax.DsEnv.fsti
@@ -28,15 +28,9 @@ open FStar.Ident
 module BU = FStar.Compiler.Util
 module S = FStar.Syntax.Syntax
 module U = FStar.Syntax.Util
-
+let open_module_or_namespace = S.open_module_or_namespace
 type used_marker = ref bool
-
-type open_kind =                                          (* matters only for resolving names with some module qualifier *)
-| Open_module                                             (* only opens the module, not the namespace *)
-| Open_namespace                                          (* opens the whole namespace *)
-
-type open_module_or_namespace = (lident * open_kind)      (* lident fully qualified name, already resolved. *)
-
+                                        (* opens the whole namespace *)
 type record_or_dc = {
   typename: lident; (* the namespace part applies to the constructor and fields as well *)
   constrname: ident;
@@ -64,6 +58,7 @@ type foundname =
 val fail_or:  env -> (lident -> option 'a) -> lident -> 'a
 val fail_or2: (ident -> option 'a) -> ident -> 'a
 
+val opens_and_abbrevs :env -> list (either open_module_or_namespace module_abbrev)
 val dep_graph: env -> FStar.Parser.Dep.deps
 val set_dep_graph: env -> FStar.Parser.Dep.deps -> env
 val ds_hooks : env -> dsenv_hooks

--- a/src/syntax/FStar.Syntax.MutRecTy.fst
+++ b/src/syntax/FStar.Syntax.MutRecTy.fst
@@ -76,7 +76,8 @@ let disentangle_abbrevs_from_bundle
        sigquals = quals;
        sigmeta = default_sigmeta;
        sigattrs = sigattrs;
-       sigopts = None; }, []
+       sigopts = None;
+       sigopens_and_abbrevs = [] }, []
    | _ ->
 
     let type_abbrevs = type_abbrev_sigelts |> List.map begin fun x -> match x.sigel with
@@ -233,7 +234,8 @@ let disentangle_abbrevs_from_bundle
                          sigquals = quals;
                          sigmeta = default_sigmeta;
                          sigattrs = sigattrs;
-                         sigopts = None; }
+                         sigopts = None;
+                         sigopens_and_abbrevs = [] }
       in
 
       (new_bundle, unfolded_type_abbrevs)

--- a/src/syntax/FStar.Syntax.Syntax.fst
+++ b/src/syntax/FStar.Syntax.Syntax.fst
@@ -161,7 +161,14 @@ let mk_Tac t =
             })
 
 let default_sigmeta = { sigmeta_active=true; sigmeta_fact_db_ids=[]; sigmeta_admit=false }
-let mk_sigelt (e: sigelt') = { sigel = e; sigrng = Range.dummyRange; sigquals=[]; sigmeta=default_sigmeta; sigattrs = [] ; sigopts = None }
+let mk_sigelt (e: sigelt') = { 
+    sigel = e;
+    sigrng = Range.dummyRange;
+    sigquals=[];
+    sigmeta=default_sigmeta;
+    sigattrs = [] ;
+    sigopts = None;
+    sigopens_and_abbrevs = [] }
 let mk_subst (s:subst_t)   = s
 let extend_subst x s : subst_t = x::s
 let argpos (x:arg) = (fst x).pos

--- a/src/syntax/FStar.Syntax.Syntax.fsti
+++ b/src/syntax/FStar.Syntax.Syntax.fsti
@@ -621,6 +621,14 @@ type sig_metadata = {
                         //Used in DM4Free
 }
 
+
+type open_kind =                                          (* matters only for resolving names with some module qualifier *)
+| Open_module                                             (* only opens the module, not the namespace *)
+| Open_namespace  
+
+type open_module_or_namespace = (lident * open_kind)      (* lident fully qualified name, already resolved. *)
+type module_abbrev = (ident * lident)                     (* module X = A.B.C, where A.B.C is fully qualified and already resolved *)
+
 (*
  * AR: we no longer have Sig_new_effect_for_free
  *     Sig_new_effect, with an eff_decl that has DM4F_eff combinators, with dummy wps plays its part
@@ -710,6 +718,7 @@ and sigelt = {
     sigquals: list qualifier;
     sigmeta:  sig_metadata;
     sigattrs: list attribute;
+    sigopens_and_abbrevs: list (either open_module_or_namespace module_abbrev);
     sigopts:  option vconfig; (* Saving the option context where this sigelt was checked in *)
 }
 

--- a/src/syntax/FStar.Syntax.Util.fst
+++ b/src/syntax/FStar.Syntax.Util.fst
@@ -1743,7 +1743,9 @@ let action_as_lb eff_lid a pos =
     sigquals = [Visible_default ; Action eff_lid];
     sigmeta = default_sigmeta;
     sigattrs = [];
-    sigopts = None; }
+    sigopts = None;
+    sigopens_and_abbrevs = [];
+    }
 
 (* Some reification utilities *)
 let mk_reify t (lopt:option Ident.lident) =

--- a/src/syntax/FStar.Syntax.Visit.fst
+++ b/src/syntax/FStar.Syntax.Visit.fst
@@ -434,6 +434,7 @@ and on_sub_sigelt vfs (se : sigelt) : sigelt =
     sigmeta  = se.sigmeta;
     sigattrs = map (f_term vfs) se.sigattrs;
     sigopts  = se.sigopts;
+    sigopens_and_abbrevs = se.sigopens_and_abbrevs
   }
 
 // Bottom up. The record is a reference so it can be easily cyclic.

--- a/src/tactics/FStar.Tactics.Hooks.fst
+++ b/src/tactics/FStar.Tactics.Hooks.fst
@@ -856,7 +856,9 @@ let splice (env:Env.env) (is_typed:bool) (lids:list Ident.lident) (tau:term) (rn
           sigquals = [S.Visible_default];  // default visibility
           sigmeta = S.default_sigmeta;
           sigattrs = [];
-          sigopts = None}]
+          sigopts = None;
+          sigopens_and_abbrevs=[]
+          }]
       end
       else run_tactic_on_ps tau.pos tau.pos false
              e_unit ()

--- a/src/typechecker/FStar.TypeChecker.TcInductive.fst
+++ b/src/typechecker/FStar.TypeChecker.TcInductive.fst
@@ -505,7 +505,8 @@ let optimized_haseq_scheme (sig_bndle:sigelt) (tcs:list sigelt) (datas:list sige
             sigrng = Range.dummyRange;
             sigmeta = default_sigmeta;
             sigattrs = [];
-            sigopts = None; } ]
+            sigopts = None;
+            sigopens_and_abbrevs = []; } ]
   ) [] axioms in
 
   env.solver.pop "haseq";
@@ -648,7 +649,9 @@ let unoptimized_haseq_scheme (sig_bndle:sigelt) (tcs:list sigelt) (datas:list si
               sigrng = Range.dummyRange;
               sigmeta = default_sigmeta;
               sigattrs = [];
-              sigopts = None; }
+              sigopts = None;
+              sigopens_and_abbrevs = [];
+               }
 
   in
   [se]
@@ -856,7 +859,8 @@ let check_inductive_well_typedness (env:env_t) (ses:list sigelt) (quals:list qua
                     sigrng = Env.get_range env0;
                     sigmeta = default_sigmeta;
                     sigattrs = List.collect (fun s -> s.sigattrs) ses;
-                    sigopts = None; } in
+                    sigopts = None;
+                    sigopens_and_abbrevs=[] } in
 
   sig_bndle, tcs, datas
 
@@ -950,7 +954,8 @@ let mk_discriminator_and_indexed_projectors iquals                   (* Qualifie
                          sigrng = range_of_lid discriminator_name;
                          sigmeta = default_sigmeta;
                          sigattrs = attrs;
-                         sigopts = None; } in
+                         sigopts = None;
+                         sigopens_and_abbrevs=[] } in
             if Env.debug env (Options.Other "LogTypes")
             then BU.print1 "Declaration of a discriminator %s\n"  (Print.sigelt_to_string decl);
 
@@ -993,7 +998,8 @@ let mk_discriminator_and_indexed_projectors iquals                   (* Qualifie
                              sigrng = p;
                              sigmeta = default_sigmeta;
                              sigattrs = attrs;
-                             sigopts = None; } in
+                             sigopts = None;
+                             sigopens_and_abbrevs=[] } in
                 if Env.debug env (Options.Other "LogTypes")
                 then BU.print1 "Implementation of a discriminator %s\n"  (Print.sigelt_to_string impl);
                 (* TODO : Are there some cases where we don't want one of these ? *)
@@ -1049,7 +1055,8 @@ let mk_discriminator_and_indexed_projectors iquals                   (* Qualifie
                        sigrng = range_of_lid field_name;
                        sigmeta = default_sigmeta;
                        sigattrs = attrs;
-                       sigopts = None; } in
+                       sigopts = None;
+                       sigopens_and_abbrevs=[] } in
           if Env.debug env (Options.Other "LogTypes")
           then BU.print1 "Declaration of a projector %s\n"  (Print.sigelt_to_string decl);
           if only_decl
@@ -1096,7 +1103,8 @@ let mk_discriminator_and_indexed_projectors iquals                   (* Qualifie
                            sigrng = p;
                            sigmeta = default_sigmeta;
                            sigattrs = attrs;
-                           sigopts = None; } in
+                           sigopts = None;
+                           sigopens_and_abbrevs=[] } in
               if Env.debug env (Options.Other "LogTypes")
               then BU.print1 "Implementation of a projector %s\n"  (Print.sigelt_to_string impl);
               if no_decl then [impl] else [decl;impl]) |> List.flatten

--- a/ulib/prims.fst
+++ b/ulib/prims.fst
@@ -708,4 +708,4 @@ val string_of_int: int -> Tot string
 (** THIS IS MEANT TO BE KEPT IN SYNC WITH FStar.CheckedFiles.fs
     Incrementing this forces all .checked files to be invalidated *)
 irreducible
-let __cache_version_number__ = 57
+let __cache_version_number__ = 58


### PR DESCRIPTION
We are trying to build a dataset of F* proofs from a repository of source and checked files.
For this, we correlate each sigelt in a checked file with the source term that produced it.
And we want to also be able to recheck that source term in isolation. 
So, we need for each sigelt the desugaring environment used for that source term (the open modules and abbreviations).
This PR adds open modules and abbreviations to every sigelt.

(Note, additionally, we need all the other F* options used to check that definition, but the vonfig is already persisted in the .checked file with the --record_options option)_