### PR TITLE
An --ext option

### DIFF
--- a/ocaml/fstar-lib/generated/FStar_Options.ml
+++ b/ocaml/fstar-lib/generated/FStar_Options.ml
@@ -1082,7 +1082,7 @@ let rec (specs_with_types :
       (Accumulated
          (SimpleStr
             "One or more semicolon separated occurrences of colon-separated pairs, e.g., 'pulse:verbose;pulse:debug;foo:bar', typically interpreted by extensions")),
-      "One or more semicolon separated occurrences of colon-separatied pairs, e.g., 'pulse:verbose;pulse:debug;foo:bar', typically interpreted by extensions");
+      "One or more semicolon separated occurrences of colon-separated pairs, e.g., 'pulse:verbose;pulse:debug;foo:bar', typically interpreted by extensions. \nAn entry 'e' that is not of the form 'a:b' is treated as 'e:\"\"', i.e., 'e' associated with the empty string");
     (FStar_Getopt.noshort, "extract",
       (Accumulated
          (SimpleStr
@@ -2571,7 +2571,7 @@ let (parse_ext : Prims.string -> (Prims.string * Prims.string) Prims.list) =
       (fun s1 ->
          match FStar_Compiler_Util.split s1 ":" with
          | k::v::[] -> [(k, v)]
-         | uu___ -> []) exts
+         | uu___ -> [(s1, "")]) exts
 let (all_ext_options : unit -> (Prims.string * Prims.string) Prims.list) =
   fun uu___ ->
     let ext = get_ext () in
@@ -2580,3 +2580,13 @@ let (all_ext_options : unit -> (Prims.string * Prims.string) Prims.list) =
     | FStar_Pervasives_Native.Some strs ->
         FStar_Compiler_Effect.op_Bar_Greater strs
           (FStar_Compiler_List.collect parse_ext)
+let (ext_options : Prims.string -> Prims.string Prims.list) =
+  fun ext ->
+    let exts = all_ext_options () in
+    FStar_Compiler_List.filter_map
+      (fun uu___ ->
+         match uu___ with
+         | (k, v) ->
+             if k = ext
+             then FStar_Pervasives_Native.Some v
+             else FStar_Pervasives_Native.None) exts

--- a/ocaml/fstar-lib/generated/FStar_Options.ml
+++ b/ocaml/fstar-lib/generated/FStar_Options.ml
@@ -1081,8 +1081,8 @@ let rec (specs_with_types :
     (FStar_Getopt.noshort, "ext",
       (Accumulated
          (SimpleStr
-            "One or more semicolon separated occurrences of colon-separated pairs, e.g., 'pulse:verbose;pulse:debug;foo:bar', typically interpreted by extensions")),
-      "One or more semicolon separated occurrences of colon-separated pairs, e.g., 'pulse:verbose;pulse:debug;foo:bar', typically interpreted by extensions. \nAn entry 'e' that is not of the form 'a:b' is treated as 'e:\"\"', i.e., 'e' associated with the empty string");
+            "One or more semicolon separated occurrences of colon-separated pairs, e.g., 'pulse:verbose;pulse:debug;foo:bar'")),
+      "\n\t\tThese options are typically interpreted by extensions. \n\t\tAn entry 'e' that is not of the form 'a:b' is treated as 'e:\"\"', i.e., 'e' associated with the empty string");
     (FStar_Getopt.noshort, "extract",
       (Accumulated
          (SimpleStr

--- a/src/basic/FStar.Options.fst
+++ b/src/basic/FStar.Options.fst
@@ -765,8 +765,9 @@ let rec specs_with_types warn_unsafe : list (char * string * opt_type * string) 
          "ext",
          Accumulated (SimpleStr "One or more semicolon separated occurrences of colon-separated pairs, \
                                  e.g., 'pulse:verbose;pulse:debug;foo:bar', typically interpreted by extensions"),
-        "One or more semicolon separated occurrences of colon-separatied pairs, \
-         e.g., 'pulse:verbose;pulse:debug;foo:bar', typically interpreted by extensions");
+        "One or more semicolon separated occurrences of colon-separated pairs, \
+         e.g., 'pulse:verbose;pulse:debug;foo:bar', typically interpreted by extensions. \n\
+         An entry 'e' that is not of the form 'a:b' is treated as 'e:\"\"', i.e., 'e' associated with the empty string");
 
        ( noshort,
          "extract",
@@ -2173,12 +2174,14 @@ let set_vconfig (vcfg:vconfig) : unit =
   ()
 
 // --ext "ext1:opt1;ext2:opt2;ext3:opt3"
+// An entry e that is not of the form a:b
+// is treated as e:""
 let parse_ext (s:string) : list (string & string) =
   let exts = Util.split s ";" in
   List.collect (fun s -> 
     match Util.split s ":" with
     | [k;v] -> [(k,v)]
-    | _ -> []) exts
+    | _ -> [s, ""]) exts
 
 let all_ext_options () : list (string & string) =
   let ext = get_ext () in
@@ -2186,3 +2189,7 @@ let all_ext_options () : list (string & string) =
   | None -> []
   | Some strs ->
     strs |> List.collect parse_ext
+
+let ext_options (ext:string) : list string =
+  let exts = all_ext_options () in
+  List.filter_map (fun (k,v) -> if k = ext then Some v else None) exts

--- a/src/basic/FStar.Options.fst
+++ b/src/basic/FStar.Options.fst
@@ -764,9 +764,8 @@ let rec specs_with_types warn_unsafe : list (char * string * opt_type * string) 
        ( noshort,
          "ext",
          Accumulated (SimpleStr "One or more semicolon separated occurrences of colon-separated pairs, \
-                                 e.g., 'pulse:verbose;pulse:debug;foo:bar', typically interpreted by extensions"),
-        "One or more semicolon separated occurrences of colon-separated pairs, \
-         e.g., 'pulse:verbose;pulse:debug;foo:bar', typically interpreted by extensions. \n\
+                                 e.g., 'pulse:verbose;pulse:debug;foo:bar'"),
+        "\n\t\tThese options are typically interpreted by extensions. \n\t\t\
          An entry 'e' that is not of the form 'a:b' is treated as 'e:\"\"', i.e., 'e' associated with the empty string");
 
        ( noshort,

--- a/src/basic/FStar.Options.fsti
+++ b/src/basic/FStar.Options.fsti
@@ -274,3 +274,5 @@ val eager_embedding: ref bool
 
 val get_vconfig : unit -> vconfig
 val set_vconfig : vconfig -> unit
+val all_ext_options : unit -> list (string & string)
+val ext_options (ext:string) : list string


### PR DESCRIPTION
From --help

```
 --ext One or more semicolon separated occurrences of colon-separated pairs, e.g., 'pulse:verbose;pulse:debug;foo:bar'
                These options are typically interpreted by extensions.
                An entry 'e' that is not of the form 'a:b' is treated as 'e:""', i.e., 'e' associated with the empty string
```

With an API in FStar.Options, which allows reading all options, or the options associated with a given extension.

```
val all_ext_options : unit -> list (string & string)
val ext_options (ext:string) : list string
```