### PR TITLE
Hashconsed arrows/abstractions in the SMT encoding must be abstracted over their free variables

### DIFF
--- a/examples/layeredeffects/GTWP.fst
+++ b/examples/layeredeffects/GTWP.fst
@@ -56,16 +56,23 @@ let bind (a b : Type) (i:idx) (wc:wp a) (wf:a -> wp b) (c : m a i wc) (f : (x:a 
   | D -> coerce (d_bind #_ #_ #wc #wf (coerce c) f)
 // GM: would be nice to skip the annotations.
 
-let subcomp (a:Type) (i:idx) (wp1 : wp a)
-                             (wp2 : wp a)
-                             (f : m a i wp1)
+let subcomp (a:Type u#aa) (i:idx)
+            (wp1 : wp a)
+            (wp2 : wp a)
+            (f : m a i wp1)
    : Pure (m a i wp2)
           (requires (forall p. wp2 p ==> wp1 p))
           (ensures (fun _ -> True))
    = match i with
      | T -> f
      | G -> f
-     | D -> coerce f
+     | D ->
+       (* This case needs some handholding. *)
+       let f : raise_t (unit -> DIV a wp1) = f in
+       let f : unit -> DIV a wp1 = downgrade_val f in
+       let f : unit -> DIV a wp2 = f in
+       assert_norm (m a i wp2 == raise_t (unit -> DIV a wp2));
+       coerce (raise_val f)
 
 unfold
 let ite_wp #a (w1 w2 : wp a) (b:bool) : wp a =

--- a/ocaml/fstar-lib/generated/FStar_CheckedFiles.ml
+++ b/ocaml/fstar-lib/generated/FStar_CheckedFiles.ml
@@ -1,5 +1,5 @@
 open Prims
-let (cache_version_number : Prims.int) = (Prims.of_int (58))
+let (cache_version_number : Prims.int) = (Prims.of_int (59))
 type tc_result =
   {
   checked_module: FStar_Syntax_Syntax.modul ;

--- a/ocaml/fstar-lib/generated/FStar_SMTEncoding_EncodeTerm.ml
+++ b/ocaml/fstar-lib/generated/FStar_SMTEncoding_EncodeTerm.ml
@@ -1787,53 +1787,53 @@ and (encode_term :
                                     FStar_Compiler_Util.digest_of_string
                                       tkey_hash1)) in
                     let tsym = Prims.op_Hat "Non_total_Tm_arrow_" tkey_hash in
-                    let tdecl =
-                      FStar_SMTEncoding_Term.DeclFun
-                        (tsym, [], FStar_SMTEncoding_Term.Term_sort,
-                          FStar_Pervasives_Native.None) in
-                    let t2 = FStar_SMTEncoding_Util.mkApp (tsym, []) in
-                    let t_kinding =
-                      let a_name =
-                        Prims.op_Hat "non_total_function_typing_" tsym in
-                      let uu___5 =
-                        let uu___6 =
-                          FStar_SMTEncoding_Term.mk_HasType t2
-                            FStar_SMTEncoding_Term.mk_Term_type in
-                        (uu___6,
-                          (FStar_Pervasives_Native.Some
-                             "Typing for non-total arrows"), a_name) in
-                      FStar_SMTEncoding_Util.mkAssume uu___5 in
-                    let fsym =
-                      FStar_SMTEncoding_Term.mk_fv
-                        ("f", FStar_SMTEncoding_Term.Term_sort) in
-                    let f = FStar_SMTEncoding_Util.mkFreeV fsym in
-                    let f_has_t = FStar_SMTEncoding_Term.mk_HasType f t2 in
-                    let t_interp =
-                      let a_name = Prims.op_Hat "pre_typing_" tsym in
-                      let uu___5 =
-                        let uu___6 =
-                          let uu___7 =
-                            let uu___8 =
-                              let uu___9 =
-                                let uu___10 =
-                                  let uu___11 =
-                                    FStar_SMTEncoding_Term.mk_PreType f in
-                                  FStar_SMTEncoding_Term.mk_tester "Tm_arrow"
-                                    uu___11 in
-                                (f_has_t, uu___10) in
-                              FStar_SMTEncoding_Util.mkImp uu___9 in
-                            ([[f_has_t]], [fsym], uu___8) in
-                          let uu___8 =
-                            mkForall_fuel module_name
-                              t0.FStar_Syntax_Syntax.pos in
-                          uu___8 uu___7 in
-                        (uu___6, (FStar_Pervasives_Native.Some a_name),
-                          a_name) in
-                      FStar_SMTEncoding_Util.mkAssume uu___5 in
                     let uu___5 =
-                      FStar_SMTEncoding_Term.mk_decls tsym tkey_hash
-                        [tdecl; t_kinding; t_interp] [] in
-                    (t2, uu___5)))
+                      let fvs =
+                        let uu___6 = FStar_Syntax_Free.names t0 in
+                        FStar_Compiler_Effect.op_Bar_Greater uu___6
+                          FStar_Compiler_Util.set_elements in
+                      let tms =
+                        FStar_Compiler_List.map
+                          (FStar_SMTEncoding_Env.lookup_term_var env) fvs in
+                      let getfv t2 =
+                        match t2.FStar_SMTEncoding_Term.tm with
+                        | FStar_SMTEncoding_Term.FreeV fv -> [fv]
+                        | uu___6 -> [] in
+                      let uu___6 = FStar_Compiler_List.concatMap getfv tms in
+                      let uu___7 =
+                        FStar_Compiler_List.map
+                          (fun uu___8 -> FStar_SMTEncoding_Term.Term_sort)
+                          fvs in
+                      (uu___6, uu___7, tms) in
+                    match uu___5 with
+                    | (arg_vars, arg_sorts, arg_terms) ->
+                        let tdecl =
+                          FStar_SMTEncoding_Term.DeclFun
+                            (tsym, arg_sorts,
+                              FStar_SMTEncoding_Term.Term_sort,
+                              FStar_Pervasives_Native.None) in
+                        let tapp =
+                          FStar_SMTEncoding_Util.mkApp (tsym, arg_terms) in
+                        let t_kinding =
+                          let a_name =
+                            Prims.op_Hat "non_total_function_typing_" tsym in
+                          let uu___6 =
+                            let uu___7 =
+                              let uu___8 =
+                                let uu___9 =
+                                  FStar_SMTEncoding_Term.mk_HasType tapp
+                                    FStar_SMTEncoding_Term.mk_Term_type in
+                                ([], arg_vars, uu___9) in
+                              FStar_SMTEncoding_Term.mkForall
+                                t0.FStar_Syntax_Syntax.pos uu___8 in
+                            (uu___7,
+                              (FStar_Pervasives_Native.Some
+                                 "Typing for non-total arrows"), a_name) in
+                          FStar_SMTEncoding_Util.mkAssume uu___6 in
+                        let uu___6 =
+                          FStar_SMTEncoding_Term.mk_decls tsym tkey_hash
+                            [tdecl; t_kinding] [] in
+                        (tapp, uu___6)))
         | FStar_Syntax_Syntax.Tm_refine uu___2 ->
             let uu___3 =
               let steps =
@@ -2833,24 +2833,40 @@ and (encode_term :
             (match uu___2 with
              | (bs1, body1, opening) ->
                  let fallback uu___3 =
-                   let f =
-                     FStar_SMTEncoding_Env.varops.FStar_SMTEncoding_Env.fresh
-                       env.FStar_SMTEncoding_Env.current_module_name "Tm_abs" in
-                   let decl =
-                     FStar_SMTEncoding_Term.DeclFun
-                       (f, [], FStar_SMTEncoding_Term.Term_sort,
-                         (FStar_Pervasives_Native.Some
-                            "Imprecise function encoding")) in
                    let uu___4 =
+                     let fvs =
+                       let uu___5 = FStar_Syntax_Free.names t0 in
+                       FStar_Compiler_Effect.op_Bar_Greater uu___5
+                         FStar_Compiler_Util.set_elements in
+                     let tms =
+                       FStar_Compiler_List.map
+                         (FStar_SMTEncoding_Env.lookup_term_var env) fvs in
                      let uu___5 =
-                       FStar_SMTEncoding_Term.mk_fv
-                         (f, FStar_SMTEncoding_Term.Term_sort) in
-                     FStar_Compiler_Effect.op_Less_Bar
-                       FStar_SMTEncoding_Util.mkFreeV uu___5 in
-                   let uu___5 =
-                     FStar_Compiler_Effect.op_Bar_Greater [decl]
-                       FStar_SMTEncoding_Term.mk_decls_trivial in
-                   (uu___4, uu___5) in
+                       FStar_Compiler_List.map
+                         (fun uu___6 -> FStar_SMTEncoding_Term.Term_sort) fvs in
+                     (uu___5, tms) in
+                   match uu___4 with
+                   | (arg_sorts, arg_terms) ->
+                       let f =
+                         FStar_SMTEncoding_Env.varops.FStar_SMTEncoding_Env.fresh
+                           env.FStar_SMTEncoding_Env.current_module_name
+                           "Tm_abs" in
+                       let decl =
+                         FStar_SMTEncoding_Term.DeclFun
+                           (f, arg_sorts, FStar_SMTEncoding_Term.Term_sort,
+                             (FStar_Pervasives_Native.Some
+                                "Imprecise function encoding")) in
+                       let fv =
+                         let uu___5 =
+                           FStar_SMTEncoding_Term.mk_fv
+                             (f, FStar_SMTEncoding_Term.Term_sort) in
+                         FStar_Compiler_Effect.op_Less_Bar
+                           FStar_SMTEncoding_Util.mkFreeV uu___5 in
+                       let fapp = FStar_SMTEncoding_Util.mkApp (f, arg_terms) in
+                       let uu___5 =
+                         FStar_Compiler_Effect.op_Bar_Greater [decl]
+                           FStar_SMTEncoding_Term.mk_decls_trivial in
+                       (fapp, uu___5) in
                  let is_impure rc =
                    let uu___3 =
                      FStar_TypeChecker_Util.is_pure_or_ghost_effect

--- a/ocaml/fstar-lib/generated/FStar_SMTEncoding_Env.ml
+++ b/ocaml/fstar-lib/generated/FStar_SMTEncoding_Env.ml
@@ -669,19 +669,15 @@ let (lookup_term_var :
     fun a ->
       let uu___ = lookup_bvar_binding env a in
       match uu___ with
-      | FStar_Pervasives_Native.None ->
-          let uu___1 = lookup_bvar_binding env a in
-          (match uu___1 with
-           | FStar_Pervasives_Native.None ->
-               let uu___2 =
-                 let uu___3 = FStar_Syntax_Print.bv_to_string a in
-                 let uu___4 = print_env env in
-                 FStar_Compiler_Util.format2
-                   "Bound term variable not found  %s in environment: %s"
-                   uu___3 uu___4 in
-               failwith uu___2
-           | FStar_Pervasives_Native.Some (b, t) -> t)
       | FStar_Pervasives_Native.Some (b, t) -> t
+      | FStar_Pervasives_Native.None ->
+          let uu___1 =
+            let uu___2 = FStar_Syntax_Print.bv_to_string a in
+            let uu___3 = print_env env in
+            FStar_Compiler_Util.format2
+              "Bound term variable not found  %s in environment: %s" uu___2
+              uu___3 in
+          failwith uu___1
 let (mk_fvb :
   FStar_Ident.lident ->
     Prims.string ->

--- a/src/fstar/FStar.CheckedFiles.fst
+++ b/src/fstar/FStar.CheckedFiles.fst
@@ -40,7 +40,7 @@ module Dep     = FStar.Parser.Dep
  * detect when loading the cache that the version number is same
  * It needs to be kept in sync with prims.fst
  *)
-let cache_version_number = 58
+let cache_version_number = 59
 
 (*
  * Abbreviation for what we store in the checked files (stages as described below)

--- a/src/smtencoding/FStar.SMTEncoding.EncodeTerm.fst
+++ b/src/smtencoding/FStar.SMTEncoding.EncodeTerm.fst
@@ -822,20 +822,8 @@ and encode_term (t:typ) (env:env_t) : (term         (* encoding of t, expects t 
                               Some "Typing for non-total arrows",
                               a_name)
              in
-             let fsym = mk_fv ("f", Term_sort) in
-             let f = mkFreeV fsym in
-             let f_has_t = mk_HasType f tapp in
-             let t_interp =
-                 let a_name = "pre_typing_" ^tsym in
-                 Util.mkAssume(mkForall_fuel module_name t0.pos ([[f_has_t]],
-                                                                 [fsym]@arg_vars,
-                                                                 mkImp(f_has_t,
-                                                                 mk_tester "Tm_arrow" (mk_PreType f))),
-                              Some a_name,
-                              a_name)
-             in
 
-             tapp, mk_decls tsym tkey_hash [tdecl; t_kinding; t_interp] []
+             tapp, mk_decls tsym tkey_hash [tdecl ; t_kinding ] []
 
       | Tm_refine _ ->
         let x, f =

--- a/src/smtencoding/FStar.SMTEncoding.EncodeTerm.fst
+++ b/src/smtencoding/FStar.SMTEncoding.EncodeTerm.fst
@@ -677,7 +677,7 @@ and encode_term (t:typ) (env:env_t) : (term         (* encoding of t, expects t 
              let fsym = mk_fv (varops.fresh module_name "f", Term_sort) in
              let f = mkFreeV  fsym in
              let app = mk_Apply f vars in
-             let tcenv_bs = { Env.push_binders env.tcenv binders with lax=true } in
+             let tcenv_bs = { env'.tcenv with lax=true } in
              let pre_opt, res_t = TcUtil.pure_or_ghost_pre_and_post tcenv_bs res in
              let res_pred, decls' = encode_term_pred None res_t env' app in
              let guards, guard_decls = match pre_opt with

--- a/src/smtencoding/FStar.SMTEncoding.Env.fst
+++ b/src/smtencoding/FStar.SMTEncoding.Env.fst
@@ -206,6 +206,9 @@ let fresh_fvar mname x s = let xsym = varops.fresh mname x in xsym, mkFreeV <| m
 let gen_term_var (env:env_t) (x:bv) =
     let ysym = "@x"^(string_of_int env.depth) in
     let y = mkFreeV <| mk_fv (ysym, Term_sort) in
+    (* Note: the encoding of impure function arrows (among other places
+    probably) relies on the fact that this is exactly a FreeV. See getfreeV in
+    FStar.SMTEncoding.EncodeTerm.fst *)
     ysym, y, {env with bvar_bindings=add_bvar_binding (x, y) env.bvar_bindings
                      ; tcenv = Env.push_bv env.tcenv x
                      ; depth = env.depth + 1 }

--- a/src/smtencoding/FStar.SMTEncoding.Env.fst
+++ b/src/smtencoding/FStar.SMTEncoding.Env.fst
@@ -228,13 +228,11 @@ let push_term_var (env:env_t) (x:bv) (t:term) =
 
 let lookup_term_var env a =
     match lookup_bvar_binding env a with
-    | None ->
-        (match lookup_bvar_binding env a with
-         | None -> failwith (BU.format2 "Bound term variable not found  %s in environment: %s"
-                                        (Print.bv_to_string a)
-                                        (print_env env))
-         | Some (b,t) -> t)
     | Some (b,t) -> t
+    | None ->
+      failwith (BU.format2 "Bound term variable not found  %s in environment: %s"
+                           (Print.bv_to_string a)
+                           (print_env env))
 
 (* Qualified term names *)
 let mk_fvb lid fname arity ftok fuel_partial_app thunked =

--- a/src/smtencoding/FStar.SMTEncoding.Term.fsti
+++ b/src/smtencoding/FStar.SMTEncoding.Term.fsti
@@ -88,7 +88,7 @@ type term' =
   | LblPos     of term * string
 and pat  = term
 and term = {tm:term'; freevars:Syntax.memo fvs; rng:Range.range}
-and fv = string * sort * bool
+and fv = string * sort * bool (* bool iff variable must be forced/unthunked *)
 and fvs = list fv
 
 type caption = option string

--- a/tests/bug-reports/Bug3028.fst
+++ b/tests/bug-reports/Bug3028.fst
@@ -1,0 +1,18 @@
+module Bug3028
+
+let mk t = unit -> Dv t
+let mk2 t = mk t
+
+let _ = assert (mk int == mk2 int)
+
+[@@expect_failure]
+let _ = assert (mk int == mk bool)
+
+[@@expect_failure]
+let _ = assert (mk int == mk2 bool)
+
+let mka (x:int) : unit -> Dv int = fun () -> x
+
+[@@expect_failure]
+let test () =
+  assert (mka 1 == mka 2)

--- a/tests/bug-reports/Bug3028.fst
+++ b/tests/bug-reports/Bug3028.fst
@@ -16,3 +16,30 @@ let mka (x:int) : unit -> Dv int = fun () -> x
 [@@expect_failure]
 let test () =
   assert (mka 1 == mka 2)
+
+assume val st : int -> Type
+
+(* This example can trigger the scoping bug shown in the comment in PR
+#3028. The problem is that when we are encoding the arrow `st ii -> Dv
+unit`, `ii` is bound to `reveal i`, so when we generate the typing axiom
+for this impure arrow, we must not attempt to state the typing in terms of
+the encoding ii.
+
+The current patch now just looks at the free variables of the arrows, in
+this case `ii` at type `int`, and states that `Non_total_Tm_arrow_...
+@x0` has type Type whenever `@x0` has type `int`, without considering
+(correctly) the fact that `ii` is `reveal i`.
+
+The encoding of the arrow expression itself is then
+`Non_total_Tm_arrow_... (reveal i)`, as this particular _instance_ is
+indeed applied to `reveal i`.
+
+The only tricky missing bit in the explanation above is that the types
+of the free variables can themselves have free variables. We just
+quantify universally over those, without requiring any typing hypothesis.
+*)
+let t2 : Type =
+  i:Ghost.erased int -> Tot (let ii = Ghost.reveal i in st ii -> Dv unit)
+
+(* Force a query *)
+let _ = assert (forall x. x+1 > x)

--- a/tests/bug-reports/Makefile
+++ b/tests/bug-reports/Makefile
@@ -53,7 +53,7 @@ SHOULD_VERIFY_CLOSED=Bug022.fst Bug024.fst Bug025.fst Bug026.fst Bug026b.fst Bug
   Bug2684a.fst Bug2684b.fst Bug2684c.fst Bug2684d.fst Bug2659b.fst\
   Bug2756.fst MutualRecPositivity.fst Bug2806a.fst Bug2806b.fst Bug2806c.fst Bug2806d.fst Bug2809.fst\
   Bug2849a.fst Bug2849b.fst Bug2045.fst Bug2876.fst Bug2882.fst Bug2895.fst Bug2894.fst \
-	Bug2415.fst
+	Bug2415.fst Bug3028.fst
 
 SHOULD_VERIFY_INTERFACE_CLOSED=Bug771.fsti Bug771b.fsti
 SHOULD_VERIFY_AND_WARN_CLOSED=Bug016.fst

--- a/ulib/prims.fst
+++ b/ulib/prims.fst
@@ -708,4 +708,4 @@ val string_of_int: int -> Tot string
 (** THIS IS MEANT TO BE KEPT IN SYNC WITH FStar.CheckedFiles.fs
     Incrementing this forces all .checked files to be invalidated *)
 irreducible
-let __cache_version_number__ = 58
+let __cache_version_number__ = 59


### PR DESCRIPTION
A bug and a fix in this PR, this was previously accepted:
```fstar
let mk t = unit -> Dv t
let _ = assert (mk int == mk bool)
```
which is clearly pretty bad. The problem was that we were encoding the abstraction `univ -> Dv t` as a single fresh top-level SMT term, with a has computed from its definition. But, this fails to consider that a `t` is free in it, and therefore all `mk _` calls are provably equal by the SMT. Abstractions had a similar issue.

The fix is to make these hashconsed terms dependent on their free variables, so the encoding of `unit -> Dv t` is now a `Term` to `Term` function. This is pretty simple and fixes the problem. Surprisingly there was only a single regressions in the examples.

This PR also removes the pre-typing axiom for impure functions, as we think it's probably not very useful.