### PR TITLE
Revising coercion mechanism to allow for implicit arguments

### DIFF
--- a/ocaml/fstar-lib/generated/FStar_Extraction_ML_Modul.ml
+++ b/ocaml/fstar-lib/generated/FStar_Extraction_ML_Modul.ml
@@ -2328,6 +2328,8 @@ let rec (extract_sig :
                              (env.FStar_TypeChecker_Env.uvar_subtyping);
                            FStar_TypeChecker_Env.intactics =
                              (env.FStar_TypeChecker_Env.intactics);
+                           FStar_TypeChecker_Env.nocoerce =
+                             (env.FStar_TypeChecker_Env.nocoerce);
                            FStar_TypeChecker_Env.tc_term =
                              (env.FStar_TypeChecker_Env.tc_term);
                            FStar_TypeChecker_Env.typeof_tot_or_gtot_term =

--- a/ocaml/fstar-lib/generated/FStar_Interactive_Ide.ml
+++ b/ocaml/fstar-lib/generated/FStar_Interactive_Ide.ml
@@ -168,19 +168,7 @@ let (run_repl_ld_transactions :
           match uu___ with
           | [] -> st1
           | (_id, (task, _st'))::entries ->
-              ((let uu___3 =
-                  let uu___4 =
-                    let uu___5 =
-                      let uu___6 =
-                        let uu___7 =
-                          FStar_Compiler_Effect.op_Bang
-                            FStar_Interactive_PushHelper.repl_stack in
-                        FStar_Compiler_List.hd uu___7 in
-                      FStar_Pervasives_Native.snd uu___6 in
-                    FStar_Pervasives_Native.fst uu___5 in
-                  task = uu___4 in
-                ());
-               debug "Reverting" task;
+              (debug "Reverting" task;
                (let st' =
                   FStar_Interactive_PushHelper.pop_repl
                     "run_repl_ls_transactions" st1 in
@@ -1547,6 +1535,8 @@ let (run_push_without_deps :
                  (uu___.FStar_TypeChecker_Env.uvar_subtyping);
                FStar_TypeChecker_Env.intactics =
                  (uu___.FStar_TypeChecker_Env.intactics);
+               FStar_TypeChecker_Env.nocoerce =
+                 (uu___.FStar_TypeChecker_Env.nocoerce);
                FStar_TypeChecker_Env.tc_term =
                  (uu___.FStar_TypeChecker_Env.tc_term);
                FStar_TypeChecker_Env.typeof_tot_or_gtot_term =

--- a/ocaml/fstar-lib/generated/FStar_Interactive_Legacy.ml
+++ b/ocaml/fstar-lib/generated/FStar_Interactive_Legacy.ml
@@ -97,6 +97,8 @@ let (push_with_kind :
                 (env.FStar_TypeChecker_Env.uvar_subtyping);
               FStar_TypeChecker_Env.intactics =
                 (env.FStar_TypeChecker_Env.intactics);
+              FStar_TypeChecker_Env.nocoerce =
+                (env.FStar_TypeChecker_Env.nocoerce);
               FStar_TypeChecker_Env.tc_term =
                 (env.FStar_TypeChecker_Env.tc_term);
               FStar_TypeChecker_Env.typeof_tot_or_gtot_term =

--- a/ocaml/fstar-lib/generated/FStar_Interactive_PushHelper.ml
+++ b/ocaml/fstar-lib/generated/FStar_Interactive_PushHelper.ml
@@ -92,6 +92,7 @@ let (set_check_kind :
           (env.FStar_TypeChecker_Env.uvar_subtyping);
         FStar_TypeChecker_Env.intactics =
           (env.FStar_TypeChecker_Env.intactics);
+        FStar_TypeChecker_Env.nocoerce = (env.FStar_TypeChecker_Env.nocoerce);
         FStar_TypeChecker_Env.tc_term = (env.FStar_TypeChecker_Env.tc_term);
         FStar_TypeChecker_Env.typeof_tot_or_gtot_term =
           (env.FStar_TypeChecker_Env.typeof_tot_or_gtot_term);

--- a/ocaml/fstar-lib/generated/FStar_SMTEncoding_Encode.ml
+++ b/ocaml/fstar-lib/generated/FStar_SMTEncoding_Encode.ml
@@ -1518,6 +1518,8 @@ let (encode_free_var :
                                       (tcenv_comp.FStar_TypeChecker_Env.uvar_subtyping);
                                     FStar_TypeChecker_Env.intactics =
                                       (tcenv_comp.FStar_TypeChecker_Env.intactics);
+                                    FStar_TypeChecker_Env.nocoerce =
+                                      (tcenv_comp.FStar_TypeChecker_Env.nocoerce);
                                     FStar_TypeChecker_Env.tc_term =
                                       (tcenv_comp.FStar_TypeChecker_Env.tc_term);
                                     FStar_TypeChecker_Env.typeof_tot_or_gtot_term
@@ -2424,6 +2426,8 @@ let (encode_top_level_let :
                     (uu___1.FStar_TypeChecker_Env.uvar_subtyping);
                   FStar_TypeChecker_Env.intactics =
                     (uu___1.FStar_TypeChecker_Env.intactics);
+                  FStar_TypeChecker_Env.nocoerce =
+                    (uu___1.FStar_TypeChecker_Env.nocoerce);
                   FStar_TypeChecker_Env.tc_term =
                     (uu___1.FStar_TypeChecker_Env.tc_term);
                   FStar_TypeChecker_Env.typeof_tot_or_gtot_term =

--- a/ocaml/fstar-lib/generated/FStar_SMTEncoding_EncodeTerm.ml
+++ b/ocaml/fstar-lib/generated/FStar_SMTEncoding_EncodeTerm.ml
@@ -1458,6 +1458,8 @@ and (encode_term :
                               (uu___6.FStar_TypeChecker_Env.uvar_subtyping);
                             FStar_TypeChecker_Env.intactics =
                               (uu___6.FStar_TypeChecker_Env.intactics);
+                            FStar_TypeChecker_Env.nocoerce =
+                              (uu___6.FStar_TypeChecker_Env.nocoerce);
                             FStar_TypeChecker_Env.tc_term =
                               (uu___6.FStar_TypeChecker_Env.tc_term);
                             FStar_TypeChecker_Env.typeof_tot_or_gtot_term =

--- a/ocaml/fstar-lib/generated/FStar_Tactics_CtrlRewrite.ml
+++ b/ocaml/fstar-lib/generated/FStar_Tactics_CtrlRewrite.ml
@@ -96,6 +96,8 @@ let (__do_rewrite :
                                      (env.FStar_TypeChecker_Env.uvar_subtyping);
                                    FStar_TypeChecker_Env.intactics =
                                      (env.FStar_TypeChecker_Env.intactics);
+                                   FStar_TypeChecker_Env.nocoerce =
+                                     (env.FStar_TypeChecker_Env.nocoerce);
                                    FStar_TypeChecker_Env.tc_term =
                                      (env.FStar_TypeChecker_Env.tc_term);
                                    FStar_TypeChecker_Env.typeof_tot_or_gtot_term

--- a/ocaml/fstar-lib/generated/FStar_Tactics_Hooks.ml
+++ b/ocaml/fstar-lib/generated/FStar_Tactics_Hooks.ml
@@ -898,6 +898,8 @@ let rec (traverse_for_spinoff :
                                (env2.FStar_TypeChecker_Env.uvar_subtyping);
                              FStar_TypeChecker_Env.intactics =
                                (env2.FStar_TypeChecker_Env.intactics);
+                             FStar_TypeChecker_Env.nocoerce =
+                               (env2.FStar_TypeChecker_Env.nocoerce);
                              FStar_TypeChecker_Env.tc_term =
                                (env2.FStar_TypeChecker_Env.tc_term);
                              FStar_TypeChecker_Env.typeof_tot_or_gtot_term =
@@ -1855,6 +1857,8 @@ let (splice :
                                        (env.FStar_TypeChecker_Env.uvar_subtyping);
                                      FStar_TypeChecker_Env.intactics =
                                        (env.FStar_TypeChecker_Env.intactics);
+                                     FStar_TypeChecker_Env.nocoerce =
+                                       (env.FStar_TypeChecker_Env.nocoerce);
                                      FStar_TypeChecker_Env.tc_term =
                                        (env.FStar_TypeChecker_Env.tc_term);
                                      FStar_TypeChecker_Env.typeof_tot_or_gtot_term

--- a/ocaml/fstar-lib/generated/FStar_Tactics_Monad.ml
+++ b/ocaml/fstar-lib/generated/FStar_Tactics_Monad.ml
@@ -98,6 +98,8 @@ let (register_goal : FStar_Tactics_Types.goal -> unit) =
                    (env.FStar_TypeChecker_Env.uvar_subtyping);
                  FStar_TypeChecker_Env.intactics =
                    (env.FStar_TypeChecker_Env.intactics);
+                 FStar_TypeChecker_Env.nocoerce =
+                   (env.FStar_TypeChecker_Env.nocoerce);
                  FStar_TypeChecker_Env.tc_term =
                    (env.FStar_TypeChecker_Env.tc_term);
                  FStar_TypeChecker_Env.typeof_tot_or_gtot_term =

--- a/ocaml/fstar-lib/generated/FStar_Tactics_Types.ml
+++ b/ocaml/fstar-lib/generated/FStar_Tactics_Types.ml
@@ -275,6 +275,8 @@ let (goal_of_implicit :
             (env.FStar_TypeChecker_Env.uvar_subtyping);
           FStar_TypeChecker_Env.intactics =
             (env.FStar_TypeChecker_Env.intactics);
+          FStar_TypeChecker_Env.nocoerce =
+            (env.FStar_TypeChecker_Env.nocoerce);
           FStar_TypeChecker_Env.tc_term = (env.FStar_TypeChecker_Env.tc_term);
           FStar_TypeChecker_Env.typeof_tot_or_gtot_term =
             (env.FStar_TypeChecker_Env.typeof_tot_or_gtot_term);

--- a/ocaml/fstar-lib/generated/FStar_Tactics_V1_Basic.ml
+++ b/ocaml/fstar-lib/generated/FStar_Tactics_V1_Basic.ml
@@ -668,6 +668,8 @@ let (tc_unifier_solved_implicits :
                            (env1.FStar_TypeChecker_Env.uvar_subtyping);
                          FStar_TypeChecker_Env.intactics =
                            (env1.FStar_TypeChecker_Env.intactics);
+                         FStar_TypeChecker_Env.nocoerce =
+                           (env1.FStar_TypeChecker_Env.nocoerce);
                          FStar_TypeChecker_Env.tc_term =
                            (env1.FStar_TypeChecker_Env.tc_term);
                          FStar_TypeChecker_Env.typeof_tot_or_gtot_term =
@@ -1324,6 +1326,8 @@ let (__tc :
                     FStar_TypeChecker_Env.uvar_subtyping = false;
                     FStar_TypeChecker_Env.intactics =
                       (e.FStar_TypeChecker_Env.intactics);
+                    FStar_TypeChecker_Env.nocoerce =
+                      (e.FStar_TypeChecker_Env.nocoerce);
                     FStar_TypeChecker_Env.tc_term =
                       (e.FStar_TypeChecker_Env.tc_term);
                     FStar_TypeChecker_Env.typeof_tot_or_gtot_term =
@@ -1467,6 +1471,8 @@ let (__tc_ghost :
                     FStar_TypeChecker_Env.uvar_subtyping = false;
                     FStar_TypeChecker_Env.intactics =
                       (e.FStar_TypeChecker_Env.intactics);
+                    FStar_TypeChecker_Env.nocoerce =
+                      (e.FStar_TypeChecker_Env.nocoerce);
                     FStar_TypeChecker_Env.tc_term =
                       (e.FStar_TypeChecker_Env.tc_term);
                     FStar_TypeChecker_Env.typeof_tot_or_gtot_term =
@@ -1571,6 +1577,8 @@ let (__tc_ghost :
                       (e1.FStar_TypeChecker_Env.uvar_subtyping);
                     FStar_TypeChecker_Env.intactics =
                       (e1.FStar_TypeChecker_Env.intactics);
+                    FStar_TypeChecker_Env.nocoerce =
+                      (e1.FStar_TypeChecker_Env.nocoerce);
                     FStar_TypeChecker_Env.tc_term =
                       (e1.FStar_TypeChecker_Env.tc_term);
                     FStar_TypeChecker_Env.typeof_tot_or_gtot_term =
@@ -1723,6 +1731,8 @@ let (__tc_lax :
                     FStar_TypeChecker_Env.uvar_subtyping = false;
                     FStar_TypeChecker_Env.intactics =
                       (e.FStar_TypeChecker_Env.intactics);
+                    FStar_TypeChecker_Env.nocoerce =
+                      (e.FStar_TypeChecker_Env.nocoerce);
                     FStar_TypeChecker_Env.tc_term =
                       (e.FStar_TypeChecker_Env.tc_term);
                     FStar_TypeChecker_Env.typeof_tot_or_gtot_term =
@@ -1827,6 +1837,8 @@ let (__tc_lax :
                       (e1.FStar_TypeChecker_Env.uvar_subtyping);
                     FStar_TypeChecker_Env.intactics =
                       (e1.FStar_TypeChecker_Env.intactics);
+                    FStar_TypeChecker_Env.nocoerce =
+                      (e1.FStar_TypeChecker_Env.nocoerce);
                     FStar_TypeChecker_Env.tc_term =
                       (e1.FStar_TypeChecker_Env.tc_term);
                     FStar_TypeChecker_Env.typeof_tot_or_gtot_term =
@@ -1932,6 +1944,8 @@ let (__tc_lax :
                       (e2.FStar_TypeChecker_Env.uvar_subtyping);
                     FStar_TypeChecker_Env.intactics =
                       (e2.FStar_TypeChecker_Env.intactics);
+                    FStar_TypeChecker_Env.nocoerce =
+                      (e2.FStar_TypeChecker_Env.nocoerce);
                     FStar_TypeChecker_Env.tc_term =
                       (e2.FStar_TypeChecker_Env.tc_term);
                     FStar_TypeChecker_Env.typeof_tot_or_gtot_term =
@@ -4239,6 +4253,8 @@ let (_t_trefl :
                                       (uu___12.FStar_TypeChecker_Env.uvar_subtyping);
                                     FStar_TypeChecker_Env.intactics =
                                       (uu___12.FStar_TypeChecker_Env.intactics);
+                                    FStar_TypeChecker_Env.nocoerce =
+                                      (uu___12.FStar_TypeChecker_Env.nocoerce);
                                     FStar_TypeChecker_Env.tc_term =
                                       (uu___12.FStar_TypeChecker_Env.tc_term);
                                     FStar_TypeChecker_Env.typeof_tot_or_gtot_term
@@ -4640,6 +4656,8 @@ let (join_goals :
                                     (uu___7.FStar_TypeChecker_Env.uvar_subtyping);
                                   FStar_TypeChecker_Env.intactics =
                                     (uu___7.FStar_TypeChecker_Env.intactics);
+                                  FStar_TypeChecker_Env.nocoerce =
+                                    (uu___7.FStar_TypeChecker_Env.nocoerce);
                                   FStar_TypeChecker_Env.tc_term =
                                     (uu___7.FStar_TypeChecker_Env.tc_term);
                                   FStar_TypeChecker_Env.typeof_tot_or_gtot_term
@@ -5032,6 +5050,8 @@ let (unshelve : FStar_Syntax_Syntax.term -> unit FStar_Tactics_Monad.tac) =
                      (env1.FStar_TypeChecker_Env.uvar_subtyping);
                    FStar_TypeChecker_Env.intactics =
                      (env1.FStar_TypeChecker_Env.intactics);
+                   FStar_TypeChecker_Env.nocoerce =
+                     (env1.FStar_TypeChecker_Env.nocoerce);
                    FStar_TypeChecker_Env.tc_term =
                      (env1.FStar_TypeChecker_Env.tc_term);
                    FStar_TypeChecker_Env.typeof_tot_or_gtot_term =
@@ -5984,6 +6004,9 @@ let (t_destruct :
                                                                     FStar_TypeChecker_Env.intactics
                                                                     =
                                                                     (env1.FStar_TypeChecker_Env.intactics);
+                                                                    FStar_TypeChecker_Env.nocoerce
+                                                                    =
+                                                                    (env1.FStar_TypeChecker_Env.nocoerce);
                                                                     FStar_TypeChecker_Env.tc_term
                                                                     =
                                                                     (env1.FStar_TypeChecker_Env.tc_term);
@@ -7034,6 +7057,8 @@ let (push_bv_dsenv :
                  (e.FStar_TypeChecker_Env.uvar_subtyping);
                FStar_TypeChecker_Env.intactics =
                  (e.FStar_TypeChecker_Env.intactics);
+               FStar_TypeChecker_Env.nocoerce =
+                 (e.FStar_TypeChecker_Env.nocoerce);
                FStar_TypeChecker_Env.tc_term =
                  (e.FStar_TypeChecker_Env.tc_term);
                FStar_TypeChecker_Env.typeof_tot_or_gtot_term =

--- a/ocaml/fstar-lib/generated/FStar_Tactics_V2_Basic.ml
+++ b/ocaml/fstar-lib/generated/FStar_Tactics_V2_Basic.ml
@@ -678,6 +678,8 @@ let (tc_unifier_solved_implicits :
                            (env1.FStar_TypeChecker_Env.uvar_subtyping);
                          FStar_TypeChecker_Env.intactics =
                            (env1.FStar_TypeChecker_Env.intactics);
+                         FStar_TypeChecker_Env.nocoerce =
+                           (env1.FStar_TypeChecker_Env.nocoerce);
                          FStar_TypeChecker_Env.tc_term =
                            (env1.FStar_TypeChecker_Env.tc_term);
                          FStar_TypeChecker_Env.typeof_tot_or_gtot_term =
@@ -1334,6 +1336,8 @@ let (__tc :
                     FStar_TypeChecker_Env.uvar_subtyping = false;
                     FStar_TypeChecker_Env.intactics =
                       (e.FStar_TypeChecker_Env.intactics);
+                    FStar_TypeChecker_Env.nocoerce =
+                      (e.FStar_TypeChecker_Env.nocoerce);
                     FStar_TypeChecker_Env.tc_term =
                       (e.FStar_TypeChecker_Env.tc_term);
                     FStar_TypeChecker_Env.typeof_tot_or_gtot_term =
@@ -1477,6 +1481,8 @@ let (__tc_ghost :
                     FStar_TypeChecker_Env.uvar_subtyping = false;
                     FStar_TypeChecker_Env.intactics =
                       (e.FStar_TypeChecker_Env.intactics);
+                    FStar_TypeChecker_Env.nocoerce =
+                      (e.FStar_TypeChecker_Env.nocoerce);
                     FStar_TypeChecker_Env.tc_term =
                       (e.FStar_TypeChecker_Env.tc_term);
                     FStar_TypeChecker_Env.typeof_tot_or_gtot_term =
@@ -1581,6 +1587,8 @@ let (__tc_ghost :
                       (e1.FStar_TypeChecker_Env.uvar_subtyping);
                     FStar_TypeChecker_Env.intactics =
                       (e1.FStar_TypeChecker_Env.intactics);
+                    FStar_TypeChecker_Env.nocoerce =
+                      (e1.FStar_TypeChecker_Env.nocoerce);
                     FStar_TypeChecker_Env.tc_term =
                       (e1.FStar_TypeChecker_Env.tc_term);
                     FStar_TypeChecker_Env.typeof_tot_or_gtot_term =
@@ -1733,6 +1741,8 @@ let (__tc_lax :
                     FStar_TypeChecker_Env.uvar_subtyping = false;
                     FStar_TypeChecker_Env.intactics =
                       (e.FStar_TypeChecker_Env.intactics);
+                    FStar_TypeChecker_Env.nocoerce =
+                      (e.FStar_TypeChecker_Env.nocoerce);
                     FStar_TypeChecker_Env.tc_term =
                       (e.FStar_TypeChecker_Env.tc_term);
                     FStar_TypeChecker_Env.typeof_tot_or_gtot_term =
@@ -1837,6 +1847,8 @@ let (__tc_lax :
                       (e1.FStar_TypeChecker_Env.uvar_subtyping);
                     FStar_TypeChecker_Env.intactics =
                       (e1.FStar_TypeChecker_Env.intactics);
+                    FStar_TypeChecker_Env.nocoerce =
+                      (e1.FStar_TypeChecker_Env.nocoerce);
                     FStar_TypeChecker_Env.tc_term =
                       (e1.FStar_TypeChecker_Env.tc_term);
                     FStar_TypeChecker_Env.typeof_tot_or_gtot_term =
@@ -1942,6 +1954,8 @@ let (__tc_lax :
                       (e2.FStar_TypeChecker_Env.uvar_subtyping);
                     FStar_TypeChecker_Env.intactics =
                       (e2.FStar_TypeChecker_Env.intactics);
+                    FStar_TypeChecker_Env.nocoerce =
+                      (e2.FStar_TypeChecker_Env.nocoerce);
                     FStar_TypeChecker_Env.tc_term =
                       (e2.FStar_TypeChecker_Env.tc_term);
                     FStar_TypeChecker_Env.typeof_tot_or_gtot_term =
@@ -4296,6 +4310,8 @@ let (_t_trefl :
                                       (uu___12.FStar_TypeChecker_Env.uvar_subtyping);
                                     FStar_TypeChecker_Env.intactics =
                                       (uu___12.FStar_TypeChecker_Env.intactics);
+                                    FStar_TypeChecker_Env.nocoerce =
+                                      (uu___12.FStar_TypeChecker_Env.nocoerce);
                                     FStar_TypeChecker_Env.tc_term =
                                       (uu___12.FStar_TypeChecker_Env.tc_term);
                                     FStar_TypeChecker_Env.typeof_tot_or_gtot_term
@@ -4676,6 +4692,8 @@ let (join_goals :
                           (uu___3.FStar_TypeChecker_Env.uvar_subtyping);
                         FStar_TypeChecker_Env.intactics =
                           (uu___3.FStar_TypeChecker_Env.intactics);
+                        FStar_TypeChecker_Env.nocoerce =
+                          (uu___3.FStar_TypeChecker_Env.nocoerce);
                         FStar_TypeChecker_Env.tc_term =
                           (uu___3.FStar_TypeChecker_Env.tc_term);
                         FStar_TypeChecker_Env.typeof_tot_or_gtot_term =
@@ -5072,6 +5090,8 @@ let (unshelve : FStar_Syntax_Syntax.term -> unit FStar_Tactics_Monad.tac) =
                      (env1.FStar_TypeChecker_Env.uvar_subtyping);
                    FStar_TypeChecker_Env.intactics =
                      (env1.FStar_TypeChecker_Env.intactics);
+                   FStar_TypeChecker_Env.nocoerce =
+                     (env1.FStar_TypeChecker_Env.nocoerce);
                    FStar_TypeChecker_Env.tc_term =
                      (env1.FStar_TypeChecker_Env.tc_term);
                    FStar_TypeChecker_Env.typeof_tot_or_gtot_term =
@@ -6024,6 +6044,9 @@ let (t_destruct :
                                                                     FStar_TypeChecker_Env.intactics
                                                                     =
                                                                     (env1.FStar_TypeChecker_Env.intactics);
+                                                                    FStar_TypeChecker_Env.nocoerce
+                                                                    =
+                                                                    (env1.FStar_TypeChecker_Env.nocoerce);
                                                                     FStar_TypeChecker_Env.tc_term
                                                                     =
                                                                     (env1.FStar_TypeChecker_Env.tc_term);
@@ -6611,6 +6634,8 @@ let (push_bv_dsenv :
                  (e.FStar_TypeChecker_Env.uvar_subtyping);
                FStar_TypeChecker_Env.intactics =
                  (e.FStar_TypeChecker_Env.intactics);
+               FStar_TypeChecker_Env.nocoerce =
+                 (e.FStar_TypeChecker_Env.nocoerce);
                FStar_TypeChecker_Env.tc_term =
                  (e.FStar_TypeChecker_Env.tc_term);
                FStar_TypeChecker_Env.typeof_tot_or_gtot_term =
@@ -7272,6 +7297,8 @@ let (refl_tc_term :
                     (g.FStar_TypeChecker_Env.uvar_subtyping);
                   FStar_TypeChecker_Env.intactics =
                     (g.FStar_TypeChecker_Env.intactics);
+                  FStar_TypeChecker_Env.nocoerce =
+                    (g.FStar_TypeChecker_Env.nocoerce);
                   FStar_TypeChecker_Env.tc_term =
                     (g.FStar_TypeChecker_Env.tc_term);
                   FStar_TypeChecker_Env.typeof_tot_or_gtot_term =
@@ -7375,6 +7402,8 @@ let (refl_tc_term :
                       (g1.FStar_TypeChecker_Env.uvar_subtyping);
                     FStar_TypeChecker_Env.intactics =
                       (g1.FStar_TypeChecker_Env.intactics);
+                    FStar_TypeChecker_Env.nocoerce =
+                      (g1.FStar_TypeChecker_Env.nocoerce);
                     FStar_TypeChecker_Env.tc_term =
                       (g1.FStar_TypeChecker_Env.tc_term);
                     FStar_TypeChecker_Env.typeof_tot_or_gtot_term =
@@ -7806,6 +7835,8 @@ let (refl_instantiate_implicits :
                     (g.FStar_TypeChecker_Env.uvar_subtyping);
                   FStar_TypeChecker_Env.intactics =
                     (g.FStar_TypeChecker_Env.intactics);
+                  FStar_TypeChecker_Env.nocoerce =
+                    (g.FStar_TypeChecker_Env.nocoerce);
                   FStar_TypeChecker_Env.tc_term =
                     (g.FStar_TypeChecker_Env.tc_term);
                   FStar_TypeChecker_Env.typeof_tot_or_gtot_term =
@@ -8030,6 +8061,7 @@ let (push_open_namespace :
             (e.FStar_TypeChecker_Env.uvar_subtyping);
           FStar_TypeChecker_Env.intactics =
             (e.FStar_TypeChecker_Env.intactics);
+          FStar_TypeChecker_Env.nocoerce = (e.FStar_TypeChecker_Env.nocoerce);
           FStar_TypeChecker_Env.tc_term = (e.FStar_TypeChecker_Env.tc_term);
           FStar_TypeChecker_Env.typeof_tot_or_gtot_term =
             (e.FStar_TypeChecker_Env.typeof_tot_or_gtot_term);
@@ -8131,6 +8163,8 @@ let (push_module_abbrev :
               (e.FStar_TypeChecker_Env.uvar_subtyping);
             FStar_TypeChecker_Env.intactics =
               (e.FStar_TypeChecker_Env.intactics);
+            FStar_TypeChecker_Env.nocoerce =
+              (e.FStar_TypeChecker_Env.nocoerce);
             FStar_TypeChecker_Env.tc_term = (e.FStar_TypeChecker_Env.tc_term);
             FStar_TypeChecker_Env.typeof_tot_or_gtot_term =
               (e.FStar_TypeChecker_Env.typeof_tot_or_gtot_term);
@@ -8246,6 +8280,8 @@ let (tac_env : FStar_TypeChecker_Env.env -> FStar_TypeChecker_Env.env) =
               (env2.FStar_TypeChecker_Env.uvar_subtyping);
             FStar_TypeChecker_Env.intactics =
               (env2.FStar_TypeChecker_Env.intactics);
+            FStar_TypeChecker_Env.nocoerce =
+              (env2.FStar_TypeChecker_Env.nocoerce);
             FStar_TypeChecker_Env.tc_term =
               (env2.FStar_TypeChecker_Env.tc_term);
             FStar_TypeChecker_Env.typeof_tot_or_gtot_term =
@@ -8344,6 +8380,8 @@ let (tac_env : FStar_TypeChecker_Env.env -> FStar_TypeChecker_Env.env) =
               (env3.FStar_TypeChecker_Env.uvar_subtyping);
             FStar_TypeChecker_Env.intactics =
               (env3.FStar_TypeChecker_Env.intactics);
+            FStar_TypeChecker_Env.nocoerce =
+              (env3.FStar_TypeChecker_Env.nocoerce);
             FStar_TypeChecker_Env.tc_term =
               (env3.FStar_TypeChecker_Env.tc_term);
             FStar_TypeChecker_Env.typeof_tot_or_gtot_term =
@@ -8443,6 +8481,8 @@ let (tac_env : FStar_TypeChecker_Env.env -> FStar_TypeChecker_Env.env) =
               (env4.FStar_TypeChecker_Env.uvar_subtyping);
             FStar_TypeChecker_Env.intactics =
               (env4.FStar_TypeChecker_Env.intactics);
+            FStar_TypeChecker_Env.nocoerce =
+              (env4.FStar_TypeChecker_Env.nocoerce);
             FStar_TypeChecker_Env.tc_term =
               (env4.FStar_TypeChecker_Env.tc_term);
             FStar_TypeChecker_Env.typeof_tot_or_gtot_term =

--- a/ocaml/fstar-lib/generated/FStar_Tactics_V2_Interpreter.ml
+++ b/ocaml/fstar-lib/generated/FStar_Tactics_V2_Interpreter.ml
@@ -2875,6 +2875,8 @@ let run_tactic_on_ps' :
                              FStar_TypeChecker_Env.uvar_subtyping =
                                (uu___.FStar_TypeChecker_Env.uvar_subtyping);
                              FStar_TypeChecker_Env.intactics = true;
+                             FStar_TypeChecker_Env.nocoerce =
+                               (uu___.FStar_TypeChecker_Env.nocoerce);
                              FStar_TypeChecker_Env.tc_term =
                                (uu___.FStar_TypeChecker_Env.tc_term);
                              FStar_TypeChecker_Env.typeof_tot_or_gtot_term =

--- a/ocaml/fstar-lib/generated/FStar_ToSyntax_ToSyntax.ml
+++ b/ocaml/fstar-lib/generated/FStar_ToSyntax_ToSyntax.ml
@@ -1488,28 +1488,25 @@ let rec (desugar_maybe_non_constant_universe :
          else ();
          FStar_Pervasives.Inl n)
     | FStar_Parser_AST.Op (op_plus, t1::t2::[]) ->
-        ((let uu___3 =
-            let uu___4 = FStar_Ident.string_of_id op_plus in uu___4 = "+" in
-          ());
-         (let u1 = desugar_maybe_non_constant_universe t1 in
-          let u2 = desugar_maybe_non_constant_universe t2 in
-          match (u1, u2) with
-          | (FStar_Pervasives.Inl n1, FStar_Pervasives.Inl n2) ->
-              FStar_Pervasives.Inl (n1 + n2)
-          | (FStar_Pervasives.Inl n, FStar_Pervasives.Inr u) ->
-              let uu___2 = sum_to_universe u n in FStar_Pervasives.Inr uu___2
-          | (FStar_Pervasives.Inr u, FStar_Pervasives.Inl n) ->
-              let uu___2 = sum_to_universe u n in FStar_Pervasives.Inr uu___2
-          | (FStar_Pervasives.Inr u11, FStar_Pervasives.Inr u21) ->
-              let uu___2 =
-                let uu___3 =
-                  let uu___4 = FStar_Parser_AST.term_to_string t in
-                  Prims.op_Hat
-                    "This universe might contain a sum of two universe variables "
-                    uu___4 in
-                (FStar_Errors_Codes.Fatal_UniverseMightContainSumOfTwoUnivVars,
-                  uu___3) in
-              FStar_Errors.raise_error uu___2 t.FStar_Parser_AST.range))
+        let u1 = desugar_maybe_non_constant_universe t1 in
+        let u2 = desugar_maybe_non_constant_universe t2 in
+        (match (u1, u2) with
+         | (FStar_Pervasives.Inl n1, FStar_Pervasives.Inl n2) ->
+             FStar_Pervasives.Inl (n1 + n2)
+         | (FStar_Pervasives.Inl n, FStar_Pervasives.Inr u) ->
+             let uu___2 = sum_to_universe u n in FStar_Pervasives.Inr uu___2
+         | (FStar_Pervasives.Inr u, FStar_Pervasives.Inl n) ->
+             let uu___2 = sum_to_universe u n in FStar_Pervasives.Inr uu___2
+         | (FStar_Pervasives.Inr u11, FStar_Pervasives.Inr u21) ->
+             let uu___2 =
+               let uu___3 =
+                 let uu___4 = FStar_Parser_AST.term_to_string t in
+                 Prims.op_Hat
+                   "This universe might contain a sum of two universe variables "
+                   uu___4 in
+               (FStar_Errors_Codes.Fatal_UniverseMightContainSumOfTwoUnivVars,
+                 uu___3) in
+             FStar_Errors.raise_error uu___2 t.FStar_Parser_AST.range)
     | FStar_Parser_AST.App uu___1 ->
         let rec aux t1 univargs =
           let uu___2 = let uu___3 = unparen t1 in uu___3.FStar_Parser_AST.tm in
@@ -1518,40 +1515,36 @@ let rec (desugar_maybe_non_constant_universe :
               let uarg = desugar_maybe_non_constant_universe targ in
               aux t2 (uarg :: univargs)
           | FStar_Parser_AST.Var max_lid ->
-              ((let uu___5 =
-                  let uu___6 = FStar_Ident.string_of_lid max_lid in
-                  uu___6 = "max" in
-                ());
-               (let uu___4 =
-                  FStar_Compiler_List.existsb
-                    (fun uu___5 ->
-                       match uu___5 with
-                       | FStar_Pervasives.Inr uu___6 -> true
-                       | uu___6 -> false) univargs in
-                if uu___4
-                then
-                  let uu___5 =
-                    let uu___6 =
-                      FStar_Compiler_List.map
-                        (fun uu___7 ->
-                           match uu___7 with
-                           | FStar_Pervasives.Inl n -> int_to_universe n
-                           | FStar_Pervasives.Inr u -> u) univargs in
-                    FStar_Syntax_Syntax.U_max uu___6 in
-                  FStar_Pervasives.Inr uu___5
-                else
-                  (let nargs =
-                     FStar_Compiler_List.map
-                       (fun uu___6 ->
-                          match uu___6 with
-                          | FStar_Pervasives.Inl n -> n
-                          | FStar_Pervasives.Inr uu___7 ->
-                              failwith "impossible") univargs in
-                   let uu___6 =
-                     FStar_Compiler_List.fold_left
-                       (fun m -> fun n -> if m > n then m else n)
-                       Prims.int_zero nargs in
-                   FStar_Pervasives.Inl uu___6)))
+              let uu___4 =
+                FStar_Compiler_List.existsb
+                  (fun uu___5 ->
+                     match uu___5 with
+                     | FStar_Pervasives.Inr uu___6 -> true
+                     | uu___6 -> false) univargs in
+              if uu___4
+              then
+                let uu___5 =
+                  let uu___6 =
+                    FStar_Compiler_List.map
+                      (fun uu___7 ->
+                         match uu___7 with
+                         | FStar_Pervasives.Inl n -> int_to_universe n
+                         | FStar_Pervasives.Inr u -> u) univargs in
+                  FStar_Syntax_Syntax.U_max uu___6 in
+                FStar_Pervasives.Inr uu___5
+              else
+                (let nargs =
+                   FStar_Compiler_List.map
+                     (fun uu___6 ->
+                        match uu___6 with
+                        | FStar_Pervasives.Inl n -> n
+                        | FStar_Pervasives.Inr uu___7 ->
+                            failwith "impossible") univargs in
+                 let uu___6 =
+                   FStar_Compiler_List.fold_left
+                     (fun m -> fun n -> if m > n then m else n)
+                     Prims.int_zero nargs in
+                 FStar_Pervasives.Inl uu___6)
           | uu___3 ->
               let uu___4 =
                 let uu___5 =

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_DeferredImplicits.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_DeferredImplicits.ml
@@ -418,6 +418,8 @@ let solve_goals_with_tac :
                      (env.FStar_TypeChecker_Env.uvar_subtyping);
                    FStar_TypeChecker_Env.intactics =
                      (env.FStar_TypeChecker_Env.intactics);
+                   FStar_TypeChecker_Env.nocoerce =
+                     (env.FStar_TypeChecker_Env.nocoerce);
                    FStar_TypeChecker_Env.tc_term =
                      (env.FStar_TypeChecker_Env.tc_term);
                    FStar_TypeChecker_Env.typeof_tot_or_gtot_term =
@@ -546,6 +548,8 @@ let (solve_deferred_to_tactic_goals :
                                (env1.FStar_TypeChecker_Env.uvar_subtyping);
                              FStar_TypeChecker_Env.intactics =
                                (env1.FStar_TypeChecker_Env.intactics);
+                             FStar_TypeChecker_Env.nocoerce =
+                               (env1.FStar_TypeChecker_Env.nocoerce);
                              FStar_TypeChecker_Env.tc_term =
                                (env1.FStar_TypeChecker_Env.tc_term);
                              FStar_TypeChecker_Env.typeof_tot_or_gtot_term =
@@ -651,6 +655,8 @@ let (solve_deferred_to_tactic_goals :
                                (env2.FStar_TypeChecker_Env.uvar_subtyping);
                              FStar_TypeChecker_Env.intactics =
                                (env2.FStar_TypeChecker_Env.intactics);
+                             FStar_TypeChecker_Env.nocoerce =
+                               (env2.FStar_TypeChecker_Env.nocoerce);
                              FStar_TypeChecker_Env.tc_term =
                                (env2.FStar_TypeChecker_Env.tc_term);
                              FStar_TypeChecker_Env.typeof_tot_or_gtot_term =

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_Env.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_Env.ml
@@ -279,6 +279,7 @@ and env =
   nosynth: Prims.bool ;
   uvar_subtyping: Prims.bool ;
   intactics: Prims.bool ;
+  nocoerce: Prims.bool ;
   tc_term:
     env ->
       FStar_Syntax_Syntax.term ->
@@ -486,7 +487,7 @@ let (__proj__Mkenv__item__solver : env -> solver_t) =
         expected_typ; sigtab; attrtab; instantiate_imp; effects = effects1;
         generalize; letrecs; top_level; check_uvars; use_eq_strict; is_iface;
         admit; lax; lax_universes; phase1; failhard; nosynth; uvar_subtyping;
-        intactics; tc_term; typeof_tot_or_gtot_term; universe_of;
+        intactics; nocoerce; tc_term; typeof_tot_or_gtot_term; universe_of;
         typeof_well_typed_tot_or_gtot_term; teq_nosmt_force;
         subtype_nosmt_force; qtbl_name_and_index; normalized_eff_names;
         fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
@@ -500,7 +501,7 @@ let (__proj__Mkenv__item__range : env -> FStar_Compiler_Range_Type.range) =
         expected_typ; sigtab; attrtab; instantiate_imp; effects = effects1;
         generalize; letrecs; top_level; check_uvars; use_eq_strict; is_iface;
         admit; lax; lax_universes; phase1; failhard; nosynth; uvar_subtyping;
-        intactics; tc_term; typeof_tot_or_gtot_term; universe_of;
+        intactics; nocoerce; tc_term; typeof_tot_or_gtot_term; universe_of;
         typeof_well_typed_tot_or_gtot_term; teq_nosmt_force;
         subtype_nosmt_force; qtbl_name_and_index; normalized_eff_names;
         fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
@@ -514,7 +515,7 @@ let (__proj__Mkenv__item__curmodule : env -> FStar_Ident.lident) =
         expected_typ; sigtab; attrtab; instantiate_imp; effects = effects1;
         generalize; letrecs; top_level; check_uvars; use_eq_strict; is_iface;
         admit; lax; lax_universes; phase1; failhard; nosynth; uvar_subtyping;
-        intactics; tc_term; typeof_tot_or_gtot_term; universe_of;
+        intactics; nocoerce; tc_term; typeof_tot_or_gtot_term; universe_of;
         typeof_well_typed_tot_or_gtot_term; teq_nosmt_force;
         subtype_nosmt_force; qtbl_name_and_index; normalized_eff_names;
         fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
@@ -530,7 +531,7 @@ let (__proj__Mkenv__item__gamma :
         expected_typ; sigtab; attrtab; instantiate_imp; effects = effects1;
         generalize; letrecs; top_level; check_uvars; use_eq_strict; is_iface;
         admit; lax; lax_universes; phase1; failhard; nosynth; uvar_subtyping;
-        intactics; tc_term; typeof_tot_or_gtot_term; universe_of;
+        intactics; nocoerce; tc_term; typeof_tot_or_gtot_term; universe_of;
         typeof_well_typed_tot_or_gtot_term; teq_nosmt_force;
         subtype_nosmt_force; qtbl_name_and_index; normalized_eff_names;
         fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
@@ -544,7 +545,7 @@ let (__proj__Mkenv__item__gamma_sig : env -> sig_binding Prims.list) =
         expected_typ; sigtab; attrtab; instantiate_imp; effects = effects1;
         generalize; letrecs; top_level; check_uvars; use_eq_strict; is_iface;
         admit; lax; lax_universes; phase1; failhard; nosynth; uvar_subtyping;
-        intactics; tc_term; typeof_tot_or_gtot_term; universe_of;
+        intactics; nocoerce; tc_term; typeof_tot_or_gtot_term; universe_of;
         typeof_well_typed_tot_or_gtot_term; teq_nosmt_force;
         subtype_nosmt_force; qtbl_name_and_index; normalized_eff_names;
         fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
@@ -560,7 +561,7 @@ let (__proj__Mkenv__item__gamma_cache :
         expected_typ; sigtab; attrtab; instantiate_imp; effects = effects1;
         generalize; letrecs; top_level; check_uvars; use_eq_strict; is_iface;
         admit; lax; lax_universes; phase1; failhard; nosynth; uvar_subtyping;
-        intactics; tc_term; typeof_tot_or_gtot_term; universe_of;
+        intactics; nocoerce; tc_term; typeof_tot_or_gtot_term; universe_of;
         typeof_well_typed_tot_or_gtot_term; teq_nosmt_force;
         subtype_nosmt_force; qtbl_name_and_index; normalized_eff_names;
         fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
@@ -576,7 +577,7 @@ let (__proj__Mkenv__item__modules :
         expected_typ; sigtab; attrtab; instantiate_imp; effects = effects1;
         generalize; letrecs; top_level; check_uvars; use_eq_strict; is_iface;
         admit; lax; lax_universes; phase1; failhard; nosynth; uvar_subtyping;
-        intactics; tc_term; typeof_tot_or_gtot_term; universe_of;
+        intactics; nocoerce; tc_term; typeof_tot_or_gtot_term; universe_of;
         typeof_well_typed_tot_or_gtot_term; teq_nosmt_force;
         subtype_nosmt_force; qtbl_name_and_index; normalized_eff_names;
         fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
@@ -593,7 +594,7 @@ let (__proj__Mkenv__item__expected_typ :
         expected_typ; sigtab; attrtab; instantiate_imp; effects = effects1;
         generalize; letrecs; top_level; check_uvars; use_eq_strict; is_iface;
         admit; lax; lax_universes; phase1; failhard; nosynth; uvar_subtyping;
-        intactics; tc_term; typeof_tot_or_gtot_term; universe_of;
+        intactics; nocoerce; tc_term; typeof_tot_or_gtot_term; universe_of;
         typeof_well_typed_tot_or_gtot_term; teq_nosmt_force;
         subtype_nosmt_force; qtbl_name_and_index; normalized_eff_names;
         fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
@@ -609,7 +610,7 @@ let (__proj__Mkenv__item__sigtab :
         expected_typ; sigtab; attrtab; instantiate_imp; effects = effects1;
         generalize; letrecs; top_level; check_uvars; use_eq_strict; is_iface;
         admit; lax; lax_universes; phase1; failhard; nosynth; uvar_subtyping;
-        intactics; tc_term; typeof_tot_or_gtot_term; universe_of;
+        intactics; nocoerce; tc_term; typeof_tot_or_gtot_term; universe_of;
         typeof_well_typed_tot_or_gtot_term; teq_nosmt_force;
         subtype_nosmt_force; qtbl_name_and_index; normalized_eff_names;
         fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
@@ -624,7 +625,7 @@ let (__proj__Mkenv__item__attrtab :
         expected_typ; sigtab; attrtab; instantiate_imp; effects = effects1;
         generalize; letrecs; top_level; check_uvars; use_eq_strict; is_iface;
         admit; lax; lax_universes; phase1; failhard; nosynth; uvar_subtyping;
-        intactics; tc_term; typeof_tot_or_gtot_term; universe_of;
+        intactics; nocoerce; tc_term; typeof_tot_or_gtot_term; universe_of;
         typeof_well_typed_tot_or_gtot_term; teq_nosmt_force;
         subtype_nosmt_force; qtbl_name_and_index; normalized_eff_names;
         fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
@@ -638,7 +639,7 @@ let (__proj__Mkenv__item__instantiate_imp : env -> Prims.bool) =
         expected_typ; sigtab; attrtab; instantiate_imp; effects = effects1;
         generalize; letrecs; top_level; check_uvars; use_eq_strict; is_iface;
         admit; lax; lax_universes; phase1; failhard; nosynth; uvar_subtyping;
-        intactics; tc_term; typeof_tot_or_gtot_term; universe_of;
+        intactics; nocoerce; tc_term; typeof_tot_or_gtot_term; universe_of;
         typeof_well_typed_tot_or_gtot_term; teq_nosmt_force;
         subtype_nosmt_force; qtbl_name_and_index; normalized_eff_names;
         fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
@@ -653,7 +654,7 @@ let (__proj__Mkenv__item__effects : env -> effects) =
         expected_typ; sigtab; attrtab; instantiate_imp; effects = effects1;
         generalize; letrecs; top_level; check_uvars; use_eq_strict; is_iface;
         admit; lax; lax_universes; phase1; failhard; nosynth; uvar_subtyping;
-        intactics; tc_term; typeof_tot_or_gtot_term; universe_of;
+        intactics; nocoerce; tc_term; typeof_tot_or_gtot_term; universe_of;
         typeof_well_typed_tot_or_gtot_term; teq_nosmt_force;
         subtype_nosmt_force; qtbl_name_and_index; normalized_eff_names;
         fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
@@ -667,7 +668,7 @@ let (__proj__Mkenv__item__generalize : env -> Prims.bool) =
         expected_typ; sigtab; attrtab; instantiate_imp; effects = effects1;
         generalize; letrecs; top_level; check_uvars; use_eq_strict; is_iface;
         admit; lax; lax_universes; phase1; failhard; nosynth; uvar_subtyping;
-        intactics; tc_term; typeof_tot_or_gtot_term; universe_of;
+        intactics; nocoerce; tc_term; typeof_tot_or_gtot_term; universe_of;
         typeof_well_typed_tot_or_gtot_term; teq_nosmt_force;
         subtype_nosmt_force; qtbl_name_and_index; normalized_eff_names;
         fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
@@ -686,7 +687,7 @@ let (__proj__Mkenv__item__letrecs :
         expected_typ; sigtab; attrtab; instantiate_imp; effects = effects1;
         generalize; letrecs; top_level; check_uvars; use_eq_strict; is_iface;
         admit; lax; lax_universes; phase1; failhard; nosynth; uvar_subtyping;
-        intactics; tc_term; typeof_tot_or_gtot_term; universe_of;
+        intactics; nocoerce; tc_term; typeof_tot_or_gtot_term; universe_of;
         typeof_well_typed_tot_or_gtot_term; teq_nosmt_force;
         subtype_nosmt_force; qtbl_name_and_index; normalized_eff_names;
         fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
@@ -700,7 +701,7 @@ let (__proj__Mkenv__item__top_level : env -> Prims.bool) =
         expected_typ; sigtab; attrtab; instantiate_imp; effects = effects1;
         generalize; letrecs; top_level; check_uvars; use_eq_strict; is_iface;
         admit; lax; lax_universes; phase1; failhard; nosynth; uvar_subtyping;
-        intactics; tc_term; typeof_tot_or_gtot_term; universe_of;
+        intactics; nocoerce; tc_term; typeof_tot_or_gtot_term; universe_of;
         typeof_well_typed_tot_or_gtot_term; teq_nosmt_force;
         subtype_nosmt_force; qtbl_name_and_index; normalized_eff_names;
         fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
@@ -715,7 +716,7 @@ let (__proj__Mkenv__item__check_uvars : env -> Prims.bool) =
         expected_typ; sigtab; attrtab; instantiate_imp; effects = effects1;
         generalize; letrecs; top_level; check_uvars; use_eq_strict; is_iface;
         admit; lax; lax_universes; phase1; failhard; nosynth; uvar_subtyping;
-        intactics; tc_term; typeof_tot_or_gtot_term; universe_of;
+        intactics; nocoerce; tc_term; typeof_tot_or_gtot_term; universe_of;
         typeof_well_typed_tot_or_gtot_term; teq_nosmt_force;
         subtype_nosmt_force; qtbl_name_and_index; normalized_eff_names;
         fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
@@ -730,7 +731,7 @@ let (__proj__Mkenv__item__use_eq_strict : env -> Prims.bool) =
         expected_typ; sigtab; attrtab; instantiate_imp; effects = effects1;
         generalize; letrecs; top_level; check_uvars; use_eq_strict; is_iface;
         admit; lax; lax_universes; phase1; failhard; nosynth; uvar_subtyping;
-        intactics; tc_term; typeof_tot_or_gtot_term; universe_of;
+        intactics; nocoerce; tc_term; typeof_tot_or_gtot_term; universe_of;
         typeof_well_typed_tot_or_gtot_term; teq_nosmt_force;
         subtype_nosmt_force; qtbl_name_and_index; normalized_eff_names;
         fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
@@ -745,7 +746,7 @@ let (__proj__Mkenv__item__is_iface : env -> Prims.bool) =
         expected_typ; sigtab; attrtab; instantiate_imp; effects = effects1;
         generalize; letrecs; top_level; check_uvars; use_eq_strict; is_iface;
         admit; lax; lax_universes; phase1; failhard; nosynth; uvar_subtyping;
-        intactics; tc_term; typeof_tot_or_gtot_term; universe_of;
+        intactics; nocoerce; tc_term; typeof_tot_or_gtot_term; universe_of;
         typeof_well_typed_tot_or_gtot_term; teq_nosmt_force;
         subtype_nosmt_force; qtbl_name_and_index; normalized_eff_names;
         fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
@@ -759,7 +760,7 @@ let (__proj__Mkenv__item__admit : env -> Prims.bool) =
         expected_typ; sigtab; attrtab; instantiate_imp; effects = effects1;
         generalize; letrecs; top_level; check_uvars; use_eq_strict; is_iface;
         admit; lax; lax_universes; phase1; failhard; nosynth; uvar_subtyping;
-        intactics; tc_term; typeof_tot_or_gtot_term; universe_of;
+        intactics; nocoerce; tc_term; typeof_tot_or_gtot_term; universe_of;
         typeof_well_typed_tot_or_gtot_term; teq_nosmt_force;
         subtype_nosmt_force; qtbl_name_and_index; normalized_eff_names;
         fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
@@ -773,7 +774,7 @@ let (__proj__Mkenv__item__lax : env -> Prims.bool) =
         expected_typ; sigtab; attrtab; instantiate_imp; effects = effects1;
         generalize; letrecs; top_level; check_uvars; use_eq_strict; is_iface;
         admit; lax; lax_universes; phase1; failhard; nosynth; uvar_subtyping;
-        intactics; tc_term; typeof_tot_or_gtot_term; universe_of;
+        intactics; nocoerce; tc_term; typeof_tot_or_gtot_term; universe_of;
         typeof_well_typed_tot_or_gtot_term; teq_nosmt_force;
         subtype_nosmt_force; qtbl_name_and_index; normalized_eff_names;
         fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
@@ -787,7 +788,7 @@ let (__proj__Mkenv__item__lax_universes : env -> Prims.bool) =
         expected_typ; sigtab; attrtab; instantiate_imp; effects = effects1;
         generalize; letrecs; top_level; check_uvars; use_eq_strict; is_iface;
         admit; lax; lax_universes; phase1; failhard; nosynth; uvar_subtyping;
-        intactics; tc_term; typeof_tot_or_gtot_term; universe_of;
+        intactics; nocoerce; tc_term; typeof_tot_or_gtot_term; universe_of;
         typeof_well_typed_tot_or_gtot_term; teq_nosmt_force;
         subtype_nosmt_force; qtbl_name_and_index; normalized_eff_names;
         fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
@@ -802,7 +803,7 @@ let (__proj__Mkenv__item__phase1 : env -> Prims.bool) =
         expected_typ; sigtab; attrtab; instantiate_imp; effects = effects1;
         generalize; letrecs; top_level; check_uvars; use_eq_strict; is_iface;
         admit; lax; lax_universes; phase1; failhard; nosynth; uvar_subtyping;
-        intactics; tc_term; typeof_tot_or_gtot_term; universe_of;
+        intactics; nocoerce; tc_term; typeof_tot_or_gtot_term; universe_of;
         typeof_well_typed_tot_or_gtot_term; teq_nosmt_force;
         subtype_nosmt_force; qtbl_name_and_index; normalized_eff_names;
         fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
@@ -816,7 +817,7 @@ let (__proj__Mkenv__item__failhard : env -> Prims.bool) =
         expected_typ; sigtab; attrtab; instantiate_imp; effects = effects1;
         generalize; letrecs; top_level; check_uvars; use_eq_strict; is_iface;
         admit; lax; lax_universes; phase1; failhard; nosynth; uvar_subtyping;
-        intactics; tc_term; typeof_tot_or_gtot_term; universe_of;
+        intactics; nocoerce; tc_term; typeof_tot_or_gtot_term; universe_of;
         typeof_well_typed_tot_or_gtot_term; teq_nosmt_force;
         subtype_nosmt_force; qtbl_name_and_index; normalized_eff_names;
         fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
@@ -830,7 +831,7 @@ let (__proj__Mkenv__item__nosynth : env -> Prims.bool) =
         expected_typ; sigtab; attrtab; instantiate_imp; effects = effects1;
         generalize; letrecs; top_level; check_uvars; use_eq_strict; is_iface;
         admit; lax; lax_universes; phase1; failhard; nosynth; uvar_subtyping;
-        intactics; tc_term; typeof_tot_or_gtot_term; universe_of;
+        intactics; nocoerce; tc_term; typeof_tot_or_gtot_term; universe_of;
         typeof_well_typed_tot_or_gtot_term; teq_nosmt_force;
         subtype_nosmt_force; qtbl_name_and_index; normalized_eff_names;
         fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
@@ -844,7 +845,7 @@ let (__proj__Mkenv__item__uvar_subtyping : env -> Prims.bool) =
         expected_typ; sigtab; attrtab; instantiate_imp; effects = effects1;
         generalize; letrecs; top_level; check_uvars; use_eq_strict; is_iface;
         admit; lax; lax_universes; phase1; failhard; nosynth; uvar_subtyping;
-        intactics; tc_term; typeof_tot_or_gtot_term; universe_of;
+        intactics; nocoerce; tc_term; typeof_tot_or_gtot_term; universe_of;
         typeof_well_typed_tot_or_gtot_term; teq_nosmt_force;
         subtype_nosmt_force; qtbl_name_and_index; normalized_eff_names;
         fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
@@ -859,7 +860,7 @@ let (__proj__Mkenv__item__intactics : env -> Prims.bool) =
         expected_typ; sigtab; attrtab; instantiate_imp; effects = effects1;
         generalize; letrecs; top_level; check_uvars; use_eq_strict; is_iface;
         admit; lax; lax_universes; phase1; failhard; nosynth; uvar_subtyping;
-        intactics; tc_term; typeof_tot_or_gtot_term; universe_of;
+        intactics; nocoerce; tc_term; typeof_tot_or_gtot_term; universe_of;
         typeof_well_typed_tot_or_gtot_term; teq_nosmt_force;
         subtype_nosmt_force; qtbl_name_and_index; normalized_eff_names;
         fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
@@ -867,6 +868,20 @@ let (__proj__Mkenv__item__intactics : env -> Prims.bool) =
         dsenv; nbe; strict_args_tab; erasable_types_tab; enable_defer_to_tac;
         unif_allow_ref_guards; erase_erasable_args; core_check;_} ->
         intactics
+let (__proj__Mkenv__item__nocoerce : env -> Prims.bool) =
+  fun projectee ->
+    match projectee with
+    | { solver; range; curmodule; gamma; gamma_sig; gamma_cache; modules;
+        expected_typ; sigtab; attrtab; instantiate_imp; effects = effects1;
+        generalize; letrecs; top_level; check_uvars; use_eq_strict; is_iface;
+        admit; lax; lax_universes; phase1; failhard; nosynth; uvar_subtyping;
+        intactics; nocoerce; tc_term; typeof_tot_or_gtot_term; universe_of;
+        typeof_well_typed_tot_or_gtot_term; teq_nosmt_force;
+        subtype_nosmt_force; qtbl_name_and_index; normalized_eff_names;
+        fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
+        splice; mpreprocess; postprocess; identifier_info; tc_hooks; 
+        dsenv; nbe; strict_args_tab; erasable_types_tab; enable_defer_to_tac;
+        unif_allow_ref_guards; erase_erasable_args; core_check;_} -> nocoerce
 let (__proj__Mkenv__item__tc_term :
   env ->
     env ->
@@ -880,7 +895,7 @@ let (__proj__Mkenv__item__tc_term :
         expected_typ; sigtab; attrtab; instantiate_imp; effects = effects1;
         generalize; letrecs; top_level; check_uvars; use_eq_strict; is_iface;
         admit; lax; lax_universes; phase1; failhard; nosynth; uvar_subtyping;
-        intactics; tc_term; typeof_tot_or_gtot_term; universe_of;
+        intactics; nocoerce; tc_term; typeof_tot_or_gtot_term; universe_of;
         typeof_well_typed_tot_or_gtot_term; teq_nosmt_force;
         subtype_nosmt_force; qtbl_name_and_index; normalized_eff_names;
         fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
@@ -901,7 +916,7 @@ let (__proj__Mkenv__item__typeof_tot_or_gtot_term :
         expected_typ; sigtab; attrtab; instantiate_imp; effects = effects1;
         generalize; letrecs; top_level; check_uvars; use_eq_strict; is_iface;
         admit; lax; lax_universes; phase1; failhard; nosynth; uvar_subtyping;
-        intactics; tc_term; typeof_tot_or_gtot_term; universe_of;
+        intactics; nocoerce; tc_term; typeof_tot_or_gtot_term; universe_of;
         typeof_well_typed_tot_or_gtot_term; teq_nosmt_force;
         subtype_nosmt_force; qtbl_name_and_index; normalized_eff_names;
         fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
@@ -917,7 +932,7 @@ let (__proj__Mkenv__item__universe_of :
         expected_typ; sigtab; attrtab; instantiate_imp; effects = effects1;
         generalize; letrecs; top_level; check_uvars; use_eq_strict; is_iface;
         admit; lax; lax_universes; phase1; failhard; nosynth; uvar_subtyping;
-        intactics; tc_term; typeof_tot_or_gtot_term; universe_of;
+        intactics; nocoerce; tc_term; typeof_tot_or_gtot_term; universe_of;
         typeof_well_typed_tot_or_gtot_term; teq_nosmt_force;
         subtype_nosmt_force; qtbl_name_and_index; normalized_eff_names;
         fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
@@ -938,7 +953,7 @@ let (__proj__Mkenv__item__typeof_well_typed_tot_or_gtot_term :
         expected_typ; sigtab; attrtab; instantiate_imp; effects = effects1;
         generalize; letrecs; top_level; check_uvars; use_eq_strict; is_iface;
         admit; lax; lax_universes; phase1; failhard; nosynth; uvar_subtyping;
-        intactics; tc_term; typeof_tot_or_gtot_term; universe_of;
+        intactics; nocoerce; tc_term; typeof_tot_or_gtot_term; universe_of;
         typeof_well_typed_tot_or_gtot_term; teq_nosmt_force;
         subtype_nosmt_force; qtbl_name_and_index; normalized_eff_names;
         fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
@@ -956,7 +971,7 @@ let (__proj__Mkenv__item__teq_nosmt_force :
         expected_typ; sigtab; attrtab; instantiate_imp; effects = effects1;
         generalize; letrecs; top_level; check_uvars; use_eq_strict; is_iface;
         admit; lax; lax_universes; phase1; failhard; nosynth; uvar_subtyping;
-        intactics; tc_term; typeof_tot_or_gtot_term; universe_of;
+        intactics; nocoerce; tc_term; typeof_tot_or_gtot_term; universe_of;
         typeof_well_typed_tot_or_gtot_term; teq_nosmt_force;
         subtype_nosmt_force; qtbl_name_and_index; normalized_eff_names;
         fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
@@ -974,7 +989,7 @@ let (__proj__Mkenv__item__subtype_nosmt_force :
         expected_typ; sigtab; attrtab; instantiate_imp; effects = effects1;
         generalize; letrecs; top_level; check_uvars; use_eq_strict; is_iface;
         admit; lax; lax_universes; phase1; failhard; nosynth; uvar_subtyping;
-        intactics; tc_term; typeof_tot_or_gtot_term; universe_of;
+        intactics; nocoerce; tc_term; typeof_tot_or_gtot_term; universe_of;
         typeof_well_typed_tot_or_gtot_term; teq_nosmt_force;
         subtype_nosmt_force; qtbl_name_and_index; normalized_eff_names;
         fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
@@ -993,7 +1008,7 @@ let (__proj__Mkenv__item__qtbl_name_and_index :
         expected_typ; sigtab; attrtab; instantiate_imp; effects = effects1;
         generalize; letrecs; top_level; check_uvars; use_eq_strict; is_iface;
         admit; lax; lax_universes; phase1; failhard; nosynth; uvar_subtyping;
-        intactics; tc_term; typeof_tot_or_gtot_term; universe_of;
+        intactics; nocoerce; tc_term; typeof_tot_or_gtot_term; universe_of;
         typeof_well_typed_tot_or_gtot_term; teq_nosmt_force;
         subtype_nosmt_force; qtbl_name_and_index; normalized_eff_names;
         fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
@@ -1009,7 +1024,7 @@ let (__proj__Mkenv__item__normalized_eff_names :
         expected_typ; sigtab; attrtab; instantiate_imp; effects = effects1;
         generalize; letrecs; top_level; check_uvars; use_eq_strict; is_iface;
         admit; lax; lax_universes; phase1; failhard; nosynth; uvar_subtyping;
-        intactics; tc_term; typeof_tot_or_gtot_term; universe_of;
+        intactics; nocoerce; tc_term; typeof_tot_or_gtot_term; universe_of;
         typeof_well_typed_tot_or_gtot_term; teq_nosmt_force;
         subtype_nosmt_force; qtbl_name_and_index; normalized_eff_names;
         fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
@@ -1025,7 +1040,7 @@ let (__proj__Mkenv__item__fv_delta_depths :
         expected_typ; sigtab; attrtab; instantiate_imp; effects = effects1;
         generalize; letrecs; top_level; check_uvars; use_eq_strict; is_iface;
         admit; lax; lax_universes; phase1; failhard; nosynth; uvar_subtyping;
-        intactics; tc_term; typeof_tot_or_gtot_term; universe_of;
+        intactics; nocoerce; tc_term; typeof_tot_or_gtot_term; universe_of;
         typeof_well_typed_tot_or_gtot_term; teq_nosmt_force;
         subtype_nosmt_force; qtbl_name_and_index; normalized_eff_names;
         fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
@@ -1040,7 +1055,7 @@ let (__proj__Mkenv__item__proof_ns : env -> proof_namespace) =
         expected_typ; sigtab; attrtab; instantiate_imp; effects = effects1;
         generalize; letrecs; top_level; check_uvars; use_eq_strict; is_iface;
         admit; lax; lax_universes; phase1; failhard; nosynth; uvar_subtyping;
-        intactics; tc_term; typeof_tot_or_gtot_term; universe_of;
+        intactics; nocoerce; tc_term; typeof_tot_or_gtot_term; universe_of;
         typeof_well_typed_tot_or_gtot_term; teq_nosmt_force;
         subtype_nosmt_force; qtbl_name_and_index; normalized_eff_names;
         fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
@@ -1059,7 +1074,7 @@ let (__proj__Mkenv__item__synth_hook :
         expected_typ; sigtab; attrtab; instantiate_imp; effects = effects1;
         generalize; letrecs; top_level; check_uvars; use_eq_strict; is_iface;
         admit; lax; lax_universes; phase1; failhard; nosynth; uvar_subtyping;
-        intactics; tc_term; typeof_tot_or_gtot_term; universe_of;
+        intactics; nocoerce; tc_term; typeof_tot_or_gtot_term; universe_of;
         typeof_well_typed_tot_or_gtot_term; teq_nosmt_force;
         subtype_nosmt_force; qtbl_name_and_index; normalized_eff_names;
         fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
@@ -1078,7 +1093,7 @@ let (__proj__Mkenv__item__try_solve_implicits_hook :
         expected_typ; sigtab; attrtab; instantiate_imp; effects = effects1;
         generalize; letrecs; top_level; check_uvars; use_eq_strict; is_iface;
         admit; lax; lax_universes; phase1; failhard; nosynth; uvar_subtyping;
-        intactics; tc_term; typeof_tot_or_gtot_term; universe_of;
+        intactics; nocoerce; tc_term; typeof_tot_or_gtot_term; universe_of;
         typeof_well_typed_tot_or_gtot_term; teq_nosmt_force;
         subtype_nosmt_force; qtbl_name_and_index; normalized_eff_names;
         fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
@@ -1101,7 +1116,7 @@ let (__proj__Mkenv__item__splice :
         expected_typ; sigtab; attrtab; instantiate_imp; effects = effects1;
         generalize; letrecs; top_level; check_uvars; use_eq_strict; is_iface;
         admit; lax; lax_universes; phase1; failhard; nosynth; uvar_subtyping;
-        intactics; tc_term; typeof_tot_or_gtot_term; universe_of;
+        intactics; nocoerce; tc_term; typeof_tot_or_gtot_term; universe_of;
         typeof_well_typed_tot_or_gtot_term; teq_nosmt_force;
         subtype_nosmt_force; qtbl_name_and_index; normalized_eff_names;
         fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
@@ -1120,7 +1135,7 @@ let (__proj__Mkenv__item__mpreprocess :
         expected_typ; sigtab; attrtab; instantiate_imp; effects = effects1;
         generalize; letrecs; top_level; check_uvars; use_eq_strict; is_iface;
         admit; lax; lax_universes; phase1; failhard; nosynth; uvar_subtyping;
-        intactics; tc_term; typeof_tot_or_gtot_term; universe_of;
+        intactics; nocoerce; tc_term; typeof_tot_or_gtot_term; universe_of;
         typeof_well_typed_tot_or_gtot_term; teq_nosmt_force;
         subtype_nosmt_force; qtbl_name_and_index; normalized_eff_names;
         fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
@@ -1141,7 +1156,7 @@ let (__proj__Mkenv__item__postprocess :
         expected_typ; sigtab; attrtab; instantiate_imp; effects = effects1;
         generalize; letrecs; top_level; check_uvars; use_eq_strict; is_iface;
         admit; lax; lax_universes; phase1; failhard; nosynth; uvar_subtyping;
-        intactics; tc_term; typeof_tot_or_gtot_term; universe_of;
+        intactics; nocoerce; tc_term; typeof_tot_or_gtot_term; universe_of;
         typeof_well_typed_tot_or_gtot_term; teq_nosmt_force;
         subtype_nosmt_force; qtbl_name_and_index; normalized_eff_names;
         fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
@@ -1157,7 +1172,7 @@ let (__proj__Mkenv__item__identifier_info :
         expected_typ; sigtab; attrtab; instantiate_imp; effects = effects1;
         generalize; letrecs; top_level; check_uvars; use_eq_strict; is_iface;
         admit; lax; lax_universes; phase1; failhard; nosynth; uvar_subtyping;
-        intactics; tc_term; typeof_tot_or_gtot_term; universe_of;
+        intactics; nocoerce; tc_term; typeof_tot_or_gtot_term; universe_of;
         typeof_well_typed_tot_or_gtot_term; teq_nosmt_force;
         subtype_nosmt_force; qtbl_name_and_index; normalized_eff_names;
         fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
@@ -1172,7 +1187,7 @@ let (__proj__Mkenv__item__tc_hooks : env -> tcenv_hooks) =
         expected_typ; sigtab; attrtab; instantiate_imp; effects = effects1;
         generalize; letrecs; top_level; check_uvars; use_eq_strict; is_iface;
         admit; lax; lax_universes; phase1; failhard; nosynth; uvar_subtyping;
-        intactics; tc_term; typeof_tot_or_gtot_term; universe_of;
+        intactics; nocoerce; tc_term; typeof_tot_or_gtot_term; universe_of;
         typeof_well_typed_tot_or_gtot_term; teq_nosmt_force;
         subtype_nosmt_force; qtbl_name_and_index; normalized_eff_names;
         fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
@@ -1186,7 +1201,7 @@ let (__proj__Mkenv__item__dsenv : env -> FStar_Syntax_DsEnv.env) =
         expected_typ; sigtab; attrtab; instantiate_imp; effects = effects1;
         generalize; letrecs; top_level; check_uvars; use_eq_strict; is_iface;
         admit; lax; lax_universes; phase1; failhard; nosynth; uvar_subtyping;
-        intactics; tc_term; typeof_tot_or_gtot_term; universe_of;
+        intactics; nocoerce; tc_term; typeof_tot_or_gtot_term; universe_of;
         typeof_well_typed_tot_or_gtot_term; teq_nosmt_force;
         subtype_nosmt_force; qtbl_name_and_index; normalized_eff_names;
         fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
@@ -1204,7 +1219,7 @@ let (__proj__Mkenv__item__nbe :
         expected_typ; sigtab; attrtab; instantiate_imp; effects = effects1;
         generalize; letrecs; top_level; check_uvars; use_eq_strict; is_iface;
         admit; lax; lax_universes; phase1; failhard; nosynth; uvar_subtyping;
-        intactics; tc_term; typeof_tot_or_gtot_term; universe_of;
+        intactics; nocoerce; tc_term; typeof_tot_or_gtot_term; universe_of;
         typeof_well_typed_tot_or_gtot_term; teq_nosmt_force;
         subtype_nosmt_force; qtbl_name_and_index; normalized_eff_names;
         fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
@@ -1222,7 +1237,7 @@ let (__proj__Mkenv__item__strict_args_tab :
         expected_typ; sigtab; attrtab; instantiate_imp; effects = effects1;
         generalize; letrecs; top_level; check_uvars; use_eq_strict; is_iface;
         admit; lax; lax_universes; phase1; failhard; nosynth; uvar_subtyping;
-        intactics; tc_term; typeof_tot_or_gtot_term; universe_of;
+        intactics; nocoerce; tc_term; typeof_tot_or_gtot_term; universe_of;
         typeof_well_typed_tot_or_gtot_term; teq_nosmt_force;
         subtype_nosmt_force; qtbl_name_and_index; normalized_eff_names;
         fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
@@ -1238,7 +1253,7 @@ let (__proj__Mkenv__item__erasable_types_tab :
         expected_typ; sigtab; attrtab; instantiate_imp; effects = effects1;
         generalize; letrecs; top_level; check_uvars; use_eq_strict; is_iface;
         admit; lax; lax_universes; phase1; failhard; nosynth; uvar_subtyping;
-        intactics; tc_term; typeof_tot_or_gtot_term; universe_of;
+        intactics; nocoerce; tc_term; typeof_tot_or_gtot_term; universe_of;
         typeof_well_typed_tot_or_gtot_term; teq_nosmt_force;
         subtype_nosmt_force; qtbl_name_and_index; normalized_eff_names;
         fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
@@ -1253,7 +1268,7 @@ let (__proj__Mkenv__item__enable_defer_to_tac : env -> Prims.bool) =
         expected_typ; sigtab; attrtab; instantiate_imp; effects = effects1;
         generalize; letrecs; top_level; check_uvars; use_eq_strict; is_iface;
         admit; lax; lax_universes; phase1; failhard; nosynth; uvar_subtyping;
-        intactics; tc_term; typeof_tot_or_gtot_term; universe_of;
+        intactics; nocoerce; tc_term; typeof_tot_or_gtot_term; universe_of;
         typeof_well_typed_tot_or_gtot_term; teq_nosmt_force;
         subtype_nosmt_force; qtbl_name_and_index; normalized_eff_names;
         fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
@@ -1268,7 +1283,7 @@ let (__proj__Mkenv__item__unif_allow_ref_guards : env -> Prims.bool) =
         expected_typ; sigtab; attrtab; instantiate_imp; effects = effects1;
         generalize; letrecs; top_level; check_uvars; use_eq_strict; is_iface;
         admit; lax; lax_universes; phase1; failhard; nosynth; uvar_subtyping;
-        intactics; tc_term; typeof_tot_or_gtot_term; universe_of;
+        intactics; nocoerce; tc_term; typeof_tot_or_gtot_term; universe_of;
         typeof_well_typed_tot_or_gtot_term; teq_nosmt_force;
         subtype_nosmt_force; qtbl_name_and_index; normalized_eff_names;
         fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
@@ -1283,7 +1298,7 @@ let (__proj__Mkenv__item__erase_erasable_args : env -> Prims.bool) =
         expected_typ; sigtab; attrtab; instantiate_imp; effects = effects1;
         generalize; letrecs; top_level; check_uvars; use_eq_strict; is_iface;
         admit; lax; lax_universes; phase1; failhard; nosynth; uvar_subtyping;
-        intactics; tc_term; typeof_tot_or_gtot_term; universe_of;
+        intactics; nocoerce; tc_term; typeof_tot_or_gtot_term; universe_of;
         typeof_well_typed_tot_or_gtot_term; teq_nosmt_force;
         subtype_nosmt_force; qtbl_name_and_index; normalized_eff_names;
         fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
@@ -1306,7 +1321,7 @@ let (__proj__Mkenv__item__core_check :
         expected_typ; sigtab; attrtab; instantiate_imp; effects = effects1;
         generalize; letrecs; top_level; check_uvars; use_eq_strict; is_iface;
         admit; lax; lax_universes; phase1; failhard; nosynth; uvar_subtyping;
-        intactics; tc_term; typeof_tot_or_gtot_term; universe_of;
+        intactics; nocoerce; tc_term; typeof_tot_or_gtot_term; universe_of;
         typeof_well_typed_tot_or_gtot_term; teq_nosmt_force;
         subtype_nosmt_force; qtbl_name_and_index; normalized_eff_names;
         fv_delta_depths; proof_ns; synth_hook; try_solve_implicits_hook;
@@ -1529,6 +1544,7 @@ let (rename_env : FStar_Syntax_Syntax.subst_t -> env -> env) =
         nosynth = (env1.nosynth);
         uvar_subtyping = (env1.uvar_subtyping);
         intactics = (env1.intactics);
+        nocoerce = (env1.nocoerce);
         tc_term = (env1.tc_term);
         typeof_tot_or_gtot_term = (env1.typeof_tot_or_gtot_term);
         universe_of = (env1.universe_of);
@@ -1589,6 +1605,7 @@ let (set_tc_hooks : env -> tcenv_hooks -> env) =
         nosynth = (env1.nosynth);
         uvar_subtyping = (env1.uvar_subtyping);
         intactics = (env1.intactics);
+        nocoerce = (env1.nocoerce);
         tc_term = (env1.tc_term);
         typeof_tot_or_gtot_term = (env1.typeof_tot_or_gtot_term);
         universe_of = (env1.universe_of);
@@ -1648,6 +1665,7 @@ let (set_dep_graph : env -> FStar_Parser_Dep.deps -> env) =
         nosynth = (e.nosynth);
         uvar_subtyping = (e.uvar_subtyping);
         intactics = (e.intactics);
+        nocoerce = (e.nocoerce);
         tc_term = (e.tc_term);
         typeof_tot_or_gtot_term = (e.typeof_tot_or_gtot_term);
         universe_of = (e.universe_of);
@@ -1801,6 +1819,7 @@ let (initial_env :
                           nosynth = false;
                           uvar_subtyping = true;
                           intactics = false;
+                          nocoerce = false;
                           tc_term;
                           typeof_tot_or_gtot_term;
                           universe_of;
@@ -1971,6 +1990,7 @@ let (push_stack : env -> env) =
        nosynth = (env1.nosynth);
        uvar_subtyping = (env1.uvar_subtyping);
        intactics = (env1.intactics);
+       nocoerce = (env1.nocoerce);
        tc_term = (env1.tc_term);
        typeof_tot_or_gtot_term = (env1.typeof_tot_or_gtot_term);
        universe_of = (env1.universe_of);
@@ -2054,6 +2074,7 @@ let (snapshot : env -> Prims.string -> (tcenv_depth_t * env)) =
                                   nosynth = (env2.nosynth);
                                   uvar_subtyping = (env2.uvar_subtyping);
                                   intactics = (env2.intactics);
+                                  nocoerce = (env2.nocoerce);
                                   tc_term = (env2.tc_term);
                                   typeof_tot_or_gtot_term =
                                     (env2.typeof_tot_or_gtot_term);
@@ -2181,6 +2202,7 @@ let (incr_query_index : env -> env) =
                 nosynth = (env1.nosynth);
                 uvar_subtyping = (env1.uvar_subtyping);
                 intactics = (env1.intactics);
+                nocoerce = (env1.nocoerce);
                 tc_term = (env1.tc_term);
                 typeof_tot_or_gtot_term = (env1.typeof_tot_or_gtot_term);
                 universe_of = (env1.universe_of);
@@ -2241,6 +2263,7 @@ let (incr_query_index : env -> env) =
                 nosynth = (env1.nosynth);
                 uvar_subtyping = (env1.uvar_subtyping);
                 intactics = (env1.intactics);
+                nocoerce = (env1.nocoerce);
                 tc_term = (env1.tc_term);
                 typeof_tot_or_gtot_term = (env1.typeof_tot_or_gtot_term);
                 universe_of = (env1.universe_of);
@@ -2307,6 +2330,7 @@ let (set_range : env -> FStar_Compiler_Range_Type.range -> env) =
           nosynth = (e.nosynth);
           uvar_subtyping = (e.uvar_subtyping);
           intactics = (e.intactics);
+          nocoerce = (e.nocoerce);
           tc_term = (e.tc_term);
           typeof_tot_or_gtot_term = (e.typeof_tot_or_gtot_term);
           universe_of = (e.universe_of);
@@ -2405,6 +2429,7 @@ let (set_current_module : env -> FStar_Ident.lident -> env) =
         nosynth = (env1.nosynth);
         uvar_subtyping = (env1.uvar_subtyping);
         intactics = (env1.intactics);
+        nocoerce = (env1.nocoerce);
         tc_term = (env1.tc_term);
         typeof_tot_or_gtot_term = (env1.typeof_tot_or_gtot_term);
         universe_of = (env1.universe_of);
@@ -5063,6 +5088,7 @@ let (push_sigelt : env -> FStar_Syntax_Syntax.sigelt -> env) =
           nosynth = (env1.nosynth);
           uvar_subtyping = (env1.uvar_subtyping);
           intactics = (env1.intactics);
+          nocoerce = (env1.nocoerce);
           tc_term = (env1.tc_term);
           typeof_tot_or_gtot_term = (env1.typeof_tot_or_gtot_term);
           universe_of = (env1.universe_of);
@@ -5139,6 +5165,7 @@ let (push_new_effect :
             nosynth = (env1.nosynth);
             uvar_subtyping = (env1.uvar_subtyping);
             intactics = (env1.intactics);
+            nocoerce = (env1.nocoerce);
             tc_term = (env1.tc_term);
             typeof_tot_or_gtot_term = (env1.typeof_tot_or_gtot_term);
             universe_of = (env1.universe_of);
@@ -5589,6 +5616,7 @@ let (update_effect_lattice :
              nosynth = (env1.nosynth);
              uvar_subtyping = (env1.uvar_subtyping);
              intactics = (env1.intactics);
+             nocoerce = (env1.nocoerce);
              tc_term = (env1.tc_term);
              typeof_tot_or_gtot_term = (env1.typeof_tot_or_gtot_term);
              universe_of = (env1.universe_of);
@@ -5662,6 +5690,7 @@ let (add_polymonadic_bind :
               nosynth = (env1.nosynth);
               uvar_subtyping = (env1.uvar_subtyping);
               intactics = (env1.intactics);
+              nocoerce = (env1.nocoerce);
               tc_term = (env1.tc_term);
               typeof_tot_or_gtot_term = (env1.typeof_tot_or_gtot_term);
               universe_of = (env1.universe_of);
@@ -5738,6 +5767,7 @@ let (add_polymonadic_subcomp :
                 nosynth = (env1.nosynth);
                 uvar_subtyping = (env1.uvar_subtyping);
                 intactics = (env1.intactics);
+                nocoerce = (env1.nocoerce);
                 tc_term = (env1.tc_term);
                 typeof_tot_or_gtot_term = (env1.typeof_tot_or_gtot_term);
                 universe_of = (env1.universe_of);
@@ -5795,6 +5825,7 @@ let (push_local_binding : env -> FStar_Syntax_Syntax.binding -> env) =
         nosynth = (env1.nosynth);
         uvar_subtyping = (env1.uvar_subtyping);
         intactics = (env1.intactics);
+        nocoerce = (env1.nocoerce);
         tc_term = (env1.tc_term);
         typeof_tot_or_gtot_term = (env1.typeof_tot_or_gtot_term);
         universe_of = (env1.universe_of);
@@ -5864,6 +5895,7 @@ let (pop_bv :
               nosynth = (env1.nosynth);
               uvar_subtyping = (env1.uvar_subtyping);
               intactics = (env1.intactics);
+              nocoerce = (env1.nocoerce);
               tc_term = (env1.tc_term);
               typeof_tot_or_gtot_term = (env1.typeof_tot_or_gtot_term);
               universe_of = (env1.universe_of);
@@ -5977,6 +6009,7 @@ let (set_expected_typ : env -> FStar_Syntax_Syntax.typ -> env) =
         nosynth = (env1.nosynth);
         uvar_subtyping = (env1.uvar_subtyping);
         intactics = (env1.intactics);
+        nocoerce = (env1.nocoerce);
         tc_term = (env1.tc_term);
         typeof_tot_or_gtot_term = (env1.typeof_tot_or_gtot_term);
         universe_of = (env1.universe_of);
@@ -6036,6 +6069,7 @@ let (set_expected_typ_maybe_eq :
           nosynth = (env1.nosynth);
           uvar_subtyping = (env1.uvar_subtyping);
           intactics = (env1.intactics);
+          nocoerce = (env1.nocoerce);
           tc_term = (env1.tc_term);
           typeof_tot_or_gtot_term = (env1.typeof_tot_or_gtot_term);
           universe_of = (env1.universe_of);
@@ -6105,6 +6139,7 @@ let (clear_expected_typ :
        nosynth = (env_.nosynth);
        uvar_subtyping = (env_.uvar_subtyping);
        intactics = (env_.intactics);
+       nocoerce = (env_.nocoerce);
        tc_term = (env_.tc_term);
        typeof_tot_or_gtot_term = (env_.typeof_tot_or_gtot_term);
        universe_of = (env_.universe_of);
@@ -6177,6 +6212,7 @@ let (finish_module : env -> FStar_Syntax_Syntax.modul -> env) =
         nosynth = (env1.nosynth);
         uvar_subtyping = (env1.uvar_subtyping);
         intactics = (env1.intactics);
+        nocoerce = (env1.nocoerce);
         tc_term = (env1.tc_term);
         typeof_tot_or_gtot_term = (env1.typeof_tot_or_gtot_term);
         universe_of = (env1.universe_of);
@@ -6368,6 +6404,7 @@ let (cons_proof_ns : Prims.bool -> env -> name_prefix -> env) =
           nosynth = (e.nosynth);
           uvar_subtyping = (e.uvar_subtyping);
           intactics = (e.intactics);
+          nocoerce = (e.nocoerce);
           tc_term = (e.tc_term);
           typeof_tot_or_gtot_term = (e.typeof_tot_or_gtot_term);
           universe_of = (e.universe_of);
@@ -6430,6 +6467,7 @@ let (set_proof_ns : proof_namespace -> env -> env) =
         nosynth = (e.nosynth);
         uvar_subtyping = (e.uvar_subtyping);
         intactics = (e.intactics);
+        nocoerce = (e.nocoerce);
         tc_term = (e.tc_term);
         typeof_tot_or_gtot_term = (e.typeof_tot_or_gtot_term);
         universe_of = (e.universe_of);

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_Generalize.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_Generalize.ml
@@ -594,12 +594,6 @@ let (generalize' :
   fun env ->
     fun is_rec ->
       fun lecs ->
-        (let uu___2 =
-           FStar_Compiler_List.for_all
-             (fun uu___3 ->
-                match uu___3 with
-                | (l, uu___4, uu___5) -> FStar_Compiler_Util.is_right l) lecs in
-         ());
         (let uu___2 = FStar_TypeChecker_Env.debug env FStar_Options.Low in
          if uu___2
          then

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_Normalize.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_Normalize.ml
@@ -8933,6 +8933,8 @@ let (eta_expand :
                                     (env1.FStar_TypeChecker_Env.uvar_subtyping);
                                   FStar_TypeChecker_Env.intactics =
                                     (env1.FStar_TypeChecker_Env.intactics);
+                                  FStar_TypeChecker_Env.nocoerce =
+                                    (env1.FStar_TypeChecker_Env.nocoerce);
                                   FStar_TypeChecker_Env.tc_term =
                                     (env1.FStar_TypeChecker_Env.tc_term);
                                   FStar_TypeChecker_Env.typeof_tot_or_gtot_term
@@ -9047,6 +9049,8 @@ let (eta_expand :
                             (env1.FStar_TypeChecker_Env.uvar_subtyping);
                           FStar_TypeChecker_Env.intactics =
                             (env1.FStar_TypeChecker_Env.intactics);
+                          FStar_TypeChecker_Env.nocoerce =
+                            (env1.FStar_TypeChecker_Env.nocoerce);
                           FStar_TypeChecker_Env.tc_term =
                             (env1.FStar_TypeChecker_Env.tc_term);
                           FStar_TypeChecker_Env.typeof_tot_or_gtot_term =

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_Rel.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_Rel.ml
@@ -373,6 +373,8 @@ let (copy_uvar :
                 (uu___.FStar_TypeChecker_Env.uvar_subtyping);
               FStar_TypeChecker_Env.intactics =
                 (uu___.FStar_TypeChecker_Env.intactics);
+              FStar_TypeChecker_Env.nocoerce =
+                (uu___.FStar_TypeChecker_Env.nocoerce);
               FStar_TypeChecker_Env.tc_term =
                 (uu___.FStar_TypeChecker_Env.tc_term);
               FStar_TypeChecker_Env.typeof_tot_or_gtot_term =
@@ -699,6 +701,8 @@ let (p_env :
           (uu___.FStar_TypeChecker_Env.uvar_subtyping);
         FStar_TypeChecker_Env.intactics =
           (uu___.FStar_TypeChecker_Env.intactics);
+        FStar_TypeChecker_Env.nocoerce =
+          (uu___.FStar_TypeChecker_Env.nocoerce);
         FStar_TypeChecker_Env.tc_term = (uu___.FStar_TypeChecker_Env.tc_term);
         FStar_TypeChecker_Env.typeof_tot_or_gtot_term =
           (uu___.FStar_TypeChecker_Env.typeof_tot_or_gtot_term);
@@ -6531,6 +6535,8 @@ and (solve_t_flex_rigid_eq :
                                         (env1.FStar_TypeChecker_Env.uvar_subtyping);
                                       FStar_TypeChecker_Env.intactics =
                                         (env1.FStar_TypeChecker_Env.intactics);
+                                      FStar_TypeChecker_Env.nocoerce =
+                                        (env1.FStar_TypeChecker_Env.nocoerce);
                                       FStar_TypeChecker_Env.tc_term =
                                         (env1.FStar_TypeChecker_Env.tc_term);
                                       FStar_TypeChecker_Env.typeof_tot_or_gtot_term
@@ -6874,6 +6880,9 @@ and (solve_t_flex_rigid_eq :
                                                   FStar_TypeChecker_Env.intactics
                                                     =
                                                     (env.FStar_TypeChecker_Env.intactics);
+                                                  FStar_TypeChecker_Env.nocoerce
+                                                    =
+                                                    (env.FStar_TypeChecker_Env.nocoerce);
                                                   FStar_TypeChecker_Env.tc_term
                                                     =
                                                     (env.FStar_TypeChecker_Env.tc_term);
@@ -14399,6 +14408,8 @@ let (check_implicit_solution_and_discharge_guard :
                           (env.FStar_TypeChecker_Env.uvar_subtyping);
                         FStar_TypeChecker_Env.intactics =
                           (env.FStar_TypeChecker_Env.intactics);
+                        FStar_TypeChecker_Env.nocoerce =
+                          (env.FStar_TypeChecker_Env.nocoerce);
                         FStar_TypeChecker_Env.tc_term =
                           (env.FStar_TypeChecker_Env.tc_term);
                         FStar_TypeChecker_Env.typeof_tot_or_gtot_term =
@@ -14877,6 +14888,8 @@ let (resolve_implicits' :
                                               (env.FStar_TypeChecker_Env.uvar_subtyping);
                                             FStar_TypeChecker_Env.intactics =
                                               (env.FStar_TypeChecker_Env.intactics);
+                                            FStar_TypeChecker_Env.nocoerce =
+                                              (env.FStar_TypeChecker_Env.nocoerce);
                                             FStar_TypeChecker_Env.tc_term =
                                               (env.FStar_TypeChecker_Env.tc_term);
                                             FStar_TypeChecker_Env.typeof_tot_or_gtot_term

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_Tc.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_Tc.ml
@@ -107,6 +107,8 @@ let (set_hint_correlator :
               (env.FStar_TypeChecker_Env.uvar_subtyping);
             FStar_TypeChecker_Env.intactics =
               (env.FStar_TypeChecker_Env.intactics);
+            FStar_TypeChecker_Env.nocoerce =
+              (env.FStar_TypeChecker_Env.nocoerce);
             FStar_TypeChecker_Env.tc_term =
               (env.FStar_TypeChecker_Env.tc_term);
             FStar_TypeChecker_Env.typeof_tot_or_gtot_term =
@@ -217,6 +219,8 @@ let (set_hint_correlator :
               (env.FStar_TypeChecker_Env.uvar_subtyping);
             FStar_TypeChecker_Env.intactics =
               (env.FStar_TypeChecker_Env.intactics);
+            FStar_TypeChecker_Env.nocoerce =
+              (env.FStar_TypeChecker_Env.nocoerce);
             FStar_TypeChecker_Env.tc_term =
               (env.FStar_TypeChecker_Env.tc_term);
             FStar_TypeChecker_Env.typeof_tot_or_gtot_term =
@@ -1200,6 +1204,8 @@ let (tc_sig_let :
                             (env1.FStar_TypeChecker_Env.uvar_subtyping);
                           FStar_TypeChecker_Env.intactics =
                             (env1.FStar_TypeChecker_Env.intactics);
+                          FStar_TypeChecker_Env.nocoerce =
+                            (env1.FStar_TypeChecker_Env.nocoerce);
                           FStar_TypeChecker_Env.tc_term =
                             (env1.FStar_TypeChecker_Env.tc_term);
                           FStar_TypeChecker_Env.typeof_tot_or_gtot_term =
@@ -1417,6 +1423,8 @@ let (tc_sig_let :
                                               (env'.FStar_TypeChecker_Env.uvar_subtyping);
                                             FStar_TypeChecker_Env.intactics =
                                               (env'.FStar_TypeChecker_Env.intactics);
+                                            FStar_TypeChecker_Env.nocoerce =
+                                              (env'.FStar_TypeChecker_Env.nocoerce);
                                             FStar_TypeChecker_Env.tc_term =
                                               (env'.FStar_TypeChecker_Env.tc_term);
                                             FStar_TypeChecker_Env.typeof_tot_or_gtot_term
@@ -1678,6 +1686,8 @@ let (tc_sig_let :
                                         (env'1.FStar_TypeChecker_Env.uvar_subtyping);
                                       FStar_TypeChecker_Env.intactics =
                                         (env'1.FStar_TypeChecker_Env.intactics);
+                                      FStar_TypeChecker_Env.nocoerce =
+                                        (env'1.FStar_TypeChecker_Env.nocoerce);
                                       FStar_TypeChecker_Env.tc_term =
                                         (env'1.FStar_TypeChecker_Env.tc_term);
                                       FStar_TypeChecker_Env.typeof_tot_or_gtot_term
@@ -1872,6 +1882,8 @@ let (tc_sig_let :
                                           (env'1.FStar_TypeChecker_Env.uvar_subtyping);
                                         FStar_TypeChecker_Env.intactics =
                                           (env'1.FStar_TypeChecker_Env.intactics);
+                                        FStar_TypeChecker_Env.nocoerce =
+                                          (env'1.FStar_TypeChecker_Env.nocoerce);
                                         FStar_TypeChecker_Env.tc_term =
                                           (env'1.FStar_TypeChecker_Env.tc_term);
                                         FStar_TypeChecker_Env.typeof_tot_or_gtot_term
@@ -2178,6 +2190,8 @@ let (tc_decl' :
                        (env.FStar_TypeChecker_Env.uvar_subtyping);
                      FStar_TypeChecker_Env.intactics =
                        (env.FStar_TypeChecker_Env.intactics);
+                     FStar_TypeChecker_Env.nocoerce =
+                       (env.FStar_TypeChecker_Env.nocoerce);
                      FStar_TypeChecker_Env.tc_term =
                        (env.FStar_TypeChecker_Env.tc_term);
                      FStar_TypeChecker_Env.typeof_tot_or_gtot_term =
@@ -2390,6 +2404,8 @@ let (tc_decl' :
                                       (env1.FStar_TypeChecker_Env.uvar_subtyping);
                                     FStar_TypeChecker_Env.intactics =
                                       (env1.FStar_TypeChecker_Env.intactics);
+                                    FStar_TypeChecker_Env.nocoerce =
+                                      (env1.FStar_TypeChecker_Env.nocoerce);
                                     FStar_TypeChecker_Env.tc_term =
                                       (env1.FStar_TypeChecker_Env.tc_term);
                                     FStar_TypeChecker_Env.typeof_tot_or_gtot_term
@@ -2678,6 +2694,8 @@ let (tc_decl' :
                                          (env.FStar_TypeChecker_Env.uvar_subtyping);
                                        FStar_TypeChecker_Env.intactics =
                                          (env.FStar_TypeChecker_Env.intactics);
+                                       FStar_TypeChecker_Env.nocoerce =
+                                         (env.FStar_TypeChecker_Env.nocoerce);
                                        FStar_TypeChecker_Env.tc_term =
                                          (env.FStar_TypeChecker_Env.tc_term);
                                        FStar_TypeChecker_Env.typeof_tot_or_gtot_term
@@ -2908,6 +2926,8 @@ let (tc_decl' :
                                     (env.FStar_TypeChecker_Env.uvar_subtyping);
                                   FStar_TypeChecker_Env.intactics =
                                     (env.FStar_TypeChecker_Env.intactics);
+                                  FStar_TypeChecker_Env.nocoerce =
+                                    (env.FStar_TypeChecker_Env.nocoerce);
                                   FStar_TypeChecker_Env.tc_term =
                                     (env.FStar_TypeChecker_Env.tc_term);
                                   FStar_TypeChecker_Env.typeof_tot_or_gtot_term
@@ -3136,6 +3156,8 @@ let (tc_decl' :
                                   (env1.FStar_TypeChecker_Env.uvar_subtyping);
                                 FStar_TypeChecker_Env.intactics =
                                   (env1.FStar_TypeChecker_Env.intactics);
+                                FStar_TypeChecker_Env.nocoerce =
+                                  (env1.FStar_TypeChecker_Env.nocoerce);
                                 FStar_TypeChecker_Env.tc_term =
                                   (env1.FStar_TypeChecker_Env.tc_term);
                                 FStar_TypeChecker_Env.typeof_tot_or_gtot_term
@@ -3316,6 +3338,8 @@ let (tc_decl' :
                                   (env1.FStar_TypeChecker_Env.uvar_subtyping);
                                 FStar_TypeChecker_Env.intactics =
                                   (env1.FStar_TypeChecker_Env.intactics);
+                                FStar_TypeChecker_Env.nocoerce =
+                                  (env1.FStar_TypeChecker_Env.nocoerce);
                                 FStar_TypeChecker_Env.tc_term =
                                   (env1.FStar_TypeChecker_Env.tc_term);
                                 FStar_TypeChecker_Env.typeof_tot_or_gtot_term
@@ -3520,6 +3544,8 @@ let (tc_decl' :
                        (env.FStar_TypeChecker_Env.uvar_subtyping);
                      FStar_TypeChecker_Env.intactics =
                        (env.FStar_TypeChecker_Env.intactics);
+                     FStar_TypeChecker_Env.nocoerce =
+                       (env.FStar_TypeChecker_Env.nocoerce);
                      FStar_TypeChecker_Env.tc_term =
                        (env.FStar_TypeChecker_Env.tc_term);
                      FStar_TypeChecker_Env.typeof_tot_or_gtot_term =
@@ -3666,6 +3692,8 @@ let (tc_decl' :
                                       (env.FStar_TypeChecker_Env.uvar_subtyping);
                                     FStar_TypeChecker_Env.intactics =
                                       (env.FStar_TypeChecker_Env.intactics);
+                                    FStar_TypeChecker_Env.nocoerce =
+                                      (env.FStar_TypeChecker_Env.nocoerce);
                                     FStar_TypeChecker_Env.tc_term =
                                       (env.FStar_TypeChecker_Env.tc_term);
                                     FStar_TypeChecker_Env.typeof_tot_or_gtot_term
@@ -3914,6 +3942,8 @@ let (tc_decl' :
                                       (env.FStar_TypeChecker_Env.uvar_subtyping);
                                     FStar_TypeChecker_Env.intactics =
                                       (env.FStar_TypeChecker_Env.intactics);
+                                    FStar_TypeChecker_Env.nocoerce =
+                                      (env.FStar_TypeChecker_Env.nocoerce);
                                     FStar_TypeChecker_Env.tc_term =
                                       (env.FStar_TypeChecker_Env.tc_term);
                                     FStar_TypeChecker_Env.typeof_tot_or_gtot_term
@@ -4238,6 +4268,8 @@ let (add_sigelt_to_env :
                          (env1.FStar_TypeChecker_Env.uvar_subtyping);
                        FStar_TypeChecker_Env.intactics =
                          (env1.FStar_TypeChecker_Env.intactics);
+                       FStar_TypeChecker_Env.nocoerce =
+                         (env1.FStar_TypeChecker_Env.nocoerce);
                        FStar_TypeChecker_Env.tc_term =
                          (env1.FStar_TypeChecker_Env.tc_term);
                        FStar_TypeChecker_Env.typeof_tot_or_gtot_term =
@@ -4348,6 +4380,8 @@ let (add_sigelt_to_env :
                          (env1.FStar_TypeChecker_Env.uvar_subtyping);
                        FStar_TypeChecker_Env.intactics =
                          (env1.FStar_TypeChecker_Env.intactics);
+                       FStar_TypeChecker_Env.nocoerce =
+                         (env1.FStar_TypeChecker_Env.nocoerce);
                        FStar_TypeChecker_Env.tc_term =
                          (env1.FStar_TypeChecker_Env.tc_term);
                        FStar_TypeChecker_Env.typeof_tot_or_gtot_term =
@@ -4458,6 +4492,8 @@ let (add_sigelt_to_env :
                          (env1.FStar_TypeChecker_Env.uvar_subtyping);
                        FStar_TypeChecker_Env.intactics =
                          (env1.FStar_TypeChecker_Env.intactics);
+                       FStar_TypeChecker_Env.nocoerce =
+                         (env1.FStar_TypeChecker_Env.nocoerce);
                        FStar_TypeChecker_Env.tc_term =
                          (env1.FStar_TypeChecker_Env.tc_term);
                        FStar_TypeChecker_Env.typeof_tot_or_gtot_term =
@@ -4568,6 +4604,8 @@ let (add_sigelt_to_env :
                          (env1.FStar_TypeChecker_Env.uvar_subtyping);
                        FStar_TypeChecker_Env.intactics =
                          (env1.FStar_TypeChecker_Env.intactics);
+                       FStar_TypeChecker_Env.nocoerce =
+                         (env1.FStar_TypeChecker_Env.nocoerce);
                        FStar_TypeChecker_Env.tc_term =
                          (env1.FStar_TypeChecker_Env.tc_term);
                        FStar_TypeChecker_Env.typeof_tot_or_gtot_term =
@@ -4972,6 +5010,8 @@ let (tc_partial_modul :
              (env.FStar_TypeChecker_Env.uvar_subtyping);
            FStar_TypeChecker_Env.intactics =
              (env.FStar_TypeChecker_Env.intactics);
+           FStar_TypeChecker_Env.nocoerce =
+             (env.FStar_TypeChecker_Env.nocoerce);
            FStar_TypeChecker_Env.tc_term =
              (env.FStar_TypeChecker_Env.tc_term);
            FStar_TypeChecker_Env.typeof_tot_or_gtot_term =
@@ -5237,6 +5277,8 @@ let (check_module :
                (env.FStar_TypeChecker_Env.uvar_subtyping);
              FStar_TypeChecker_Env.intactics =
                (env.FStar_TypeChecker_Env.intactics);
+             FStar_TypeChecker_Env.nocoerce =
+               (env.FStar_TypeChecker_Env.nocoerce);
              FStar_TypeChecker_Env.tc_term =
                (env.FStar_TypeChecker_Env.tc_term);
              FStar_TypeChecker_Env.typeof_tot_or_gtot_term =

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_TcEffect.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_TcEffect.ml
@@ -6059,6 +6059,9 @@ let (tc_layered_eff_decl :
                                                              FStar_TypeChecker_Env.intactics
                                                                =
                                                                (uu___20.FStar_TypeChecker_Env.intactics);
+                                                             FStar_TypeChecker_Env.nocoerce
+                                                               =
+                                                               (uu___20.FStar_TypeChecker_Env.nocoerce);
                                                              FStar_TypeChecker_Env.tc_term
                                                                =
                                                                (uu___20.FStar_TypeChecker_Env.tc_term);
@@ -8152,6 +8155,9 @@ let (tc_non_layered_eff_decl :
                                                                     FStar_TypeChecker_Env.intactics
                                                                     =
                                                                     (env1.FStar_TypeChecker_Env.intactics);
+                                                                    FStar_TypeChecker_Env.nocoerce
+                                                                    =
+                                                                    (env1.FStar_TypeChecker_Env.nocoerce);
                                                                     FStar_TypeChecker_Env.tc_term
                                                                     =
                                                                     (env1.FStar_TypeChecker_Env.tc_term);
@@ -8438,6 +8444,9 @@ let (tc_non_layered_eff_decl :
                                                                    FStar_TypeChecker_Env.intactics
                                                                     =
                                                                     (uu___24.FStar_TypeChecker_Env.intactics);
+                                                                   FStar_TypeChecker_Env.nocoerce
+                                                                    =
+                                                                    (uu___24.FStar_TypeChecker_Env.nocoerce);
                                                                    FStar_TypeChecker_Env.tc_term
                                                                     =
                                                                     (uu___24.FStar_TypeChecker_Env.tc_term);
@@ -8773,6 +8782,9 @@ let (tc_non_layered_eff_decl :
                                                                     FStar_TypeChecker_Env.intactics
                                                                     =
                                                                     (env1.FStar_TypeChecker_Env.intactics);
+                                                                    FStar_TypeChecker_Env.nocoerce
+                                                                    =
+                                                                    (env1.FStar_TypeChecker_Env.nocoerce);
                                                                     FStar_TypeChecker_Env.tc_term
                                                                     =
                                                                     (env1.FStar_TypeChecker_Env.tc_term);
@@ -9612,6 +9624,8 @@ let (tc_lift :
                                  (env.FStar_TypeChecker_Env.uvar_subtyping);
                                FStar_TypeChecker_Env.intactics =
                                  (env.FStar_TypeChecker_Env.intactics);
+                               FStar_TypeChecker_Env.nocoerce =
+                                 (env.FStar_TypeChecker_Env.nocoerce);
                                FStar_TypeChecker_Env.tc_term =
                                  (env.FStar_TypeChecker_Env.tc_term);
                                FStar_TypeChecker_Env.typeof_tot_or_gtot_term

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_TcTerm.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_TcTerm.ml
@@ -36,6 +36,7 @@ let (instantiate_both :
       FStar_TypeChecker_Env.uvar_subtyping =
         (env.FStar_TypeChecker_Env.uvar_subtyping);
       FStar_TypeChecker_Env.intactics = (env.FStar_TypeChecker_Env.intactics);
+      FStar_TypeChecker_Env.nocoerce = (env.FStar_TypeChecker_Env.nocoerce);
       FStar_TypeChecker_Env.tc_term = (env.FStar_TypeChecker_Env.tc_term);
       FStar_TypeChecker_Env.typeof_tot_or_gtot_term =
         (env.FStar_TypeChecker_Env.typeof_tot_or_gtot_term);
@@ -117,6 +118,7 @@ let (no_inst : FStar_TypeChecker_Env.env -> FStar_TypeChecker_Env.env) =
       FStar_TypeChecker_Env.uvar_subtyping =
         (env.FStar_TypeChecker_Env.uvar_subtyping);
       FStar_TypeChecker_Env.intactics = (env.FStar_TypeChecker_Env.intactics);
+      FStar_TypeChecker_Env.nocoerce = (env.FStar_TypeChecker_Env.nocoerce);
       FStar_TypeChecker_Env.tc_term = (env.FStar_TypeChecker_Env.tc_term);
       FStar_TypeChecker_Env.typeof_tot_or_gtot_term =
         (env.FStar_TypeChecker_Env.typeof_tot_or_gtot_term);
@@ -1094,6 +1096,8 @@ let (guard_letrecs :
                   (env.FStar_TypeChecker_Env.uvar_subtyping);
                 FStar_TypeChecker_Env.intactics =
                   (env.FStar_TypeChecker_Env.intactics);
+                FStar_TypeChecker_Env.nocoerce =
+                  (env.FStar_TypeChecker_Env.nocoerce);
                 FStar_TypeChecker_Env.tc_term =
                   (env.FStar_TypeChecker_Env.tc_term);
                 FStar_TypeChecker_Env.typeof_tot_or_gtot_term =
@@ -1691,6 +1695,8 @@ let rec (tc_term :
                     (env.FStar_TypeChecker_Env.uvar_subtyping);
                   FStar_TypeChecker_Env.intactics =
                     (env.FStar_TypeChecker_Env.intactics);
+                  FStar_TypeChecker_Env.nocoerce =
+                    (env.FStar_TypeChecker_Env.nocoerce);
                   FStar_TypeChecker_Env.tc_term =
                     (env.FStar_TypeChecker_Env.tc_term);
                   FStar_TypeChecker_Env.typeof_tot_or_gtot_term =
@@ -2004,6 +2010,8 @@ and (tc_maybe_toplevel_term :
                             (env'.FStar_TypeChecker_Env.uvar_subtyping);
                           FStar_TypeChecker_Env.intactics =
                             (env'.FStar_TypeChecker_Env.intactics);
+                          FStar_TypeChecker_Env.nocoerce =
+                            (env'.FStar_TypeChecker_Env.nocoerce);
                           FStar_TypeChecker_Env.tc_term =
                             (env'.FStar_TypeChecker_Env.tc_term);
                           FStar_TypeChecker_Env.typeof_tot_or_gtot_term =
@@ -4291,6 +4299,8 @@ and (tc_tactic :
                 (env.FStar_TypeChecker_Env.uvar_subtyping);
               FStar_TypeChecker_Env.intactics =
                 (env.FStar_TypeChecker_Env.intactics);
+              FStar_TypeChecker_Env.nocoerce =
+                (env.FStar_TypeChecker_Env.nocoerce);
               FStar_TypeChecker_Env.tc_term =
                 (env.FStar_TypeChecker_Env.tc_term);
               FStar_TypeChecker_Env.typeof_tot_or_gtot_term =
@@ -4980,6 +4990,8 @@ and (tc_comp :
                   (env.FStar_TypeChecker_Env.uvar_subtyping);
                 FStar_TypeChecker_Env.intactics =
                   (env.FStar_TypeChecker_Env.intactics);
+                FStar_TypeChecker_Env.nocoerce =
+                  (env.FStar_TypeChecker_Env.nocoerce);
                 FStar_TypeChecker_Env.tc_term =
                   (env.FStar_TypeChecker_Env.tc_term);
                 FStar_TypeChecker_Env.typeof_tot_or_gtot_term =
@@ -5487,6 +5499,8 @@ and (tc_abs_expected_function_typ :
                                  (envbody.FStar_TypeChecker_Env.uvar_subtyping);
                                FStar_TypeChecker_Env.intactics =
                                  (envbody.FStar_TypeChecker_Env.intactics);
+                               FStar_TypeChecker_Env.nocoerce =
+                                 (envbody.FStar_TypeChecker_Env.nocoerce);
                                FStar_TypeChecker_Env.tc_term =
                                  (envbody.FStar_TypeChecker_Env.tc_term);
                                FStar_TypeChecker_Env.typeof_tot_or_gtot_term
@@ -5646,6 +5660,8 @@ and (tc_abs_expected_function_typ :
                                (env.FStar_TypeChecker_Env.uvar_subtyping);
                              FStar_TypeChecker_Env.intactics =
                                (env.FStar_TypeChecker_Env.intactics);
+                             FStar_TypeChecker_Env.nocoerce =
+                               (env.FStar_TypeChecker_Env.nocoerce);
                              FStar_TypeChecker_Env.tc_term =
                                (env.FStar_TypeChecker_Env.tc_term);
                              FStar_TypeChecker_Env.typeof_tot_or_gtot_term =
@@ -5757,6 +5773,8 @@ and (tc_abs_expected_function_typ :
                                     (envbody1.FStar_TypeChecker_Env.uvar_subtyping);
                                   FStar_TypeChecker_Env.intactics =
                                     (envbody1.FStar_TypeChecker_Env.intactics);
+                                  FStar_TypeChecker_Env.nocoerce =
+                                    (envbody1.FStar_TypeChecker_Env.nocoerce);
                                   FStar_TypeChecker_Env.tc_term =
                                     (envbody1.FStar_TypeChecker_Env.tc_term);
                                   FStar_TypeChecker_Env.typeof_tot_or_gtot_term
@@ -6349,6 +6367,8 @@ and (tc_abs :
                                     (envbody2.FStar_TypeChecker_Env.uvar_subtyping);
                                   FStar_TypeChecker_Env.intactics =
                                     (envbody2.FStar_TypeChecker_Env.intactics);
+                                  FStar_TypeChecker_Env.nocoerce =
+                                    (envbody2.FStar_TypeChecker_Env.nocoerce);
                                   FStar_TypeChecker_Env.tc_term =
                                     (envbody2.FStar_TypeChecker_Env.tc_term);
                                   FStar_TypeChecker_Env.typeof_tot_or_gtot_term
@@ -10000,6 +10020,9 @@ and (tc_eqn :
                                                                     FStar_TypeChecker_Env.intactics
                                                                     =
                                                                     (uu___16.FStar_TypeChecker_Env.intactics);
+                                                                    FStar_TypeChecker_Env.nocoerce
+                                                                    =
+                                                                    (uu___16.FStar_TypeChecker_Env.nocoerce);
                                                                     FStar_TypeChecker_Env.tc_term
                                                                     =
                                                                     (uu___16.FStar_TypeChecker_Env.tc_term);
@@ -10554,6 +10577,8 @@ and (check_inner_let :
                 (env1.FStar_TypeChecker_Env.uvar_subtyping);
               FStar_TypeChecker_Env.intactics =
                 (env1.FStar_TypeChecker_Env.intactics);
+              FStar_TypeChecker_Env.nocoerce =
+                (env1.FStar_TypeChecker_Env.nocoerce);
               FStar_TypeChecker_Env.tc_term =
                 (env1.FStar_TypeChecker_Env.tc_term);
               FStar_TypeChecker_Env.typeof_tot_or_gtot_term =
@@ -11346,6 +11371,8 @@ and (build_let_rec_env :
                   (env01.FStar_TypeChecker_Env.uvar_subtyping);
                 FStar_TypeChecker_Env.intactics =
                   (env01.FStar_TypeChecker_Env.intactics);
+                FStar_TypeChecker_Env.nocoerce =
+                  (env01.FStar_TypeChecker_Env.nocoerce);
                 FStar_TypeChecker_Env.tc_term =
                   (env01.FStar_TypeChecker_Env.tc_term);
                 FStar_TypeChecker_Env.typeof_tot_or_gtot_term =
@@ -11534,6 +11561,8 @@ and (build_let_rec_env :
                                              (env2.FStar_TypeChecker_Env.uvar_subtyping);
                                            FStar_TypeChecker_Env.intactics =
                                              (env2.FStar_TypeChecker_Env.intactics);
+                                           FStar_TypeChecker_Env.nocoerce =
+                                             (env2.FStar_TypeChecker_Env.nocoerce);
                                            FStar_TypeChecker_Env.tc_term =
                                              (env2.FStar_TypeChecker_Env.tc_term);
                                            FStar_TypeChecker_Env.typeof_tot_or_gtot_term
@@ -11828,6 +11857,8 @@ and (check_let_bound_def :
                            (env11.FStar_TypeChecker_Env.uvar_subtyping);
                          FStar_TypeChecker_Env.intactics =
                            (env11.FStar_TypeChecker_Env.intactics);
+                         FStar_TypeChecker_Env.nocoerce =
+                           (env11.FStar_TypeChecker_Env.nocoerce);
                          FStar_TypeChecker_Env.tc_term =
                            (env11.FStar_TypeChecker_Env.tc_term);
                          FStar_TypeChecker_Env.typeof_tot_or_gtot_term =
@@ -12333,6 +12364,8 @@ let (typeof_tot_or_gtot_term :
                (env.FStar_TypeChecker_Env.uvar_subtyping);
              FStar_TypeChecker_Env.intactics =
                (env.FStar_TypeChecker_Env.intactics);
+             FStar_TypeChecker_Env.nocoerce =
+               (env.FStar_TypeChecker_Env.nocoerce);
              FStar_TypeChecker_Env.tc_term =
                (env.FStar_TypeChecker_Env.tc_term);
              FStar_TypeChecker_Env.typeof_tot_or_gtot_term =
@@ -12510,6 +12543,8 @@ let (level_of_type :
                            (env.FStar_TypeChecker_Env.uvar_subtyping);
                          FStar_TypeChecker_Env.intactics =
                            (env.FStar_TypeChecker_Env.intactics);
+                         FStar_TypeChecker_Env.nocoerce =
+                           (env.FStar_TypeChecker_Env.nocoerce);
                          FStar_TypeChecker_Env.tc_term =
                            (env.FStar_TypeChecker_Env.tc_term);
                          FStar_TypeChecker_Env.typeof_tot_or_gtot_term =
@@ -12907,6 +12942,8 @@ let rec (universe_of_aux :
                            (env2.FStar_TypeChecker_Env.uvar_subtyping);
                          FStar_TypeChecker_Env.intactics =
                            (env2.FStar_TypeChecker_Env.intactics);
+                         FStar_TypeChecker_Env.nocoerce =
+                           (env2.FStar_TypeChecker_Env.nocoerce);
                          FStar_TypeChecker_Env.tc_term =
                            (env2.FStar_TypeChecker_Env.tc_term);
                          FStar_TypeChecker_Env.typeof_tot_or_gtot_term =

--- a/ocaml/fstar-lib/generated/FStar_Universal.ml
+++ b/ocaml/fstar-lib/generated/FStar_Universal.ml
@@ -67,6 +67,8 @@ let with_dsenv_of_tcenv :
                 (tcenv.FStar_TypeChecker_Env.uvar_subtyping);
               FStar_TypeChecker_Env.intactics =
                 (tcenv.FStar_TypeChecker_Env.intactics);
+              FStar_TypeChecker_Env.nocoerce =
+                (tcenv.FStar_TypeChecker_Env.nocoerce);
               FStar_TypeChecker_Env.tc_term =
                 (tcenv.FStar_TypeChecker_Env.tc_term);
               FStar_TypeChecker_Env.typeof_tot_or_gtot_term =
@@ -323,6 +325,7 @@ let (init_env : FStar_Parser_Dep.deps -> FStar_TypeChecker_Env.env) =
           (env.FStar_TypeChecker_Env.uvar_subtyping);
         FStar_TypeChecker_Env.intactics =
           (env.FStar_TypeChecker_Env.intactics);
+        FStar_TypeChecker_Env.nocoerce = (env.FStar_TypeChecker_Env.nocoerce);
         FStar_TypeChecker_Env.tc_term = (env.FStar_TypeChecker_Env.tc_term);
         FStar_TypeChecker_Env.typeof_tot_or_gtot_term =
           (env.FStar_TypeChecker_Env.typeof_tot_or_gtot_term);
@@ -409,6 +412,8 @@ let (init_env : FStar_Parser_Dep.deps -> FStar_TypeChecker_Env.env) =
           (env1.FStar_TypeChecker_Env.uvar_subtyping);
         FStar_TypeChecker_Env.intactics =
           (env1.FStar_TypeChecker_Env.intactics);
+        FStar_TypeChecker_Env.nocoerce =
+          (env1.FStar_TypeChecker_Env.nocoerce);
         FStar_TypeChecker_Env.tc_term = (env1.FStar_TypeChecker_Env.tc_term);
         FStar_TypeChecker_Env.typeof_tot_or_gtot_term =
           (env1.FStar_TypeChecker_Env.typeof_tot_or_gtot_term);
@@ -498,6 +503,8 @@ let (init_env : FStar_Parser_Dep.deps -> FStar_TypeChecker_Env.env) =
           (env2.FStar_TypeChecker_Env.uvar_subtyping);
         FStar_TypeChecker_Env.intactics =
           (env2.FStar_TypeChecker_Env.intactics);
+        FStar_TypeChecker_Env.nocoerce =
+          (env2.FStar_TypeChecker_Env.nocoerce);
         FStar_TypeChecker_Env.tc_term = (env2.FStar_TypeChecker_Env.tc_term);
         FStar_TypeChecker_Env.typeof_tot_or_gtot_term =
           (env2.FStar_TypeChecker_Env.typeof_tot_or_gtot_term);
@@ -587,6 +594,8 @@ let (init_env : FStar_Parser_Dep.deps -> FStar_TypeChecker_Env.env) =
           (env3.FStar_TypeChecker_Env.uvar_subtyping);
         FStar_TypeChecker_Env.intactics =
           (env3.FStar_TypeChecker_Env.intactics);
+        FStar_TypeChecker_Env.nocoerce =
+          (env3.FStar_TypeChecker_Env.nocoerce);
         FStar_TypeChecker_Env.tc_term = (env3.FStar_TypeChecker_Env.tc_term);
         FStar_TypeChecker_Env.typeof_tot_or_gtot_term =
           (env3.FStar_TypeChecker_Env.typeof_tot_or_gtot_term);
@@ -675,6 +684,8 @@ let (init_env : FStar_Parser_Dep.deps -> FStar_TypeChecker_Env.env) =
           (env4.FStar_TypeChecker_Env.uvar_subtyping);
         FStar_TypeChecker_Env.intactics =
           (env4.FStar_TypeChecker_Env.intactics);
+        FStar_TypeChecker_Env.nocoerce =
+          (env4.FStar_TypeChecker_Env.nocoerce);
         FStar_TypeChecker_Env.tc_term = (env4.FStar_TypeChecker_Env.tc_term);
         FStar_TypeChecker_Env.typeof_tot_or_gtot_term =
           (env4.FStar_TypeChecker_Env.typeof_tot_or_gtot_term);

--- a/ocaml/fstar-tests/generated/FStar_Tests_Pars.ml
+++ b/ocaml/fstar-tests/generated/FStar_Tests_Pars.ml
@@ -144,6 +144,8 @@ let (init_once : unit -> unit) =
                (env.FStar_TypeChecker_Env.uvar_subtyping);
              FStar_TypeChecker_Env.intactics =
                (env.FStar_TypeChecker_Env.intactics);
+             FStar_TypeChecker_Env.nocoerce =
+               (env.FStar_TypeChecker_Env.nocoerce);
              FStar_TypeChecker_Env.tc_term =
                (env.FStar_TypeChecker_Env.tc_term);
              FStar_TypeChecker_Env.typeof_tot_or_gtot_term =
@@ -250,6 +252,8 @@ let (init_once : unit -> unit) =
                     (env2.FStar_TypeChecker_Env.uvar_subtyping);
                   FStar_TypeChecker_Env.intactics =
                     (env2.FStar_TypeChecker_Env.intactics);
+                  FStar_TypeChecker_Env.nocoerce =
+                    (env2.FStar_TypeChecker_Env.nocoerce);
                   FStar_TypeChecker_Env.tc_term =
                     (env2.FStar_TypeChecker_Env.tc_term);
                   FStar_TypeChecker_Env.typeof_tot_or_gtot_term =
@@ -403,6 +407,8 @@ let (tc' :
           (tcenv.FStar_TypeChecker_Env.uvar_subtyping);
         FStar_TypeChecker_Env.intactics =
           (tcenv.FStar_TypeChecker_Env.intactics);
+        FStar_TypeChecker_Env.nocoerce =
+          (tcenv.FStar_TypeChecker_Env.nocoerce);
         FStar_TypeChecker_Env.tc_term = (tcenv.FStar_TypeChecker_Env.tc_term);
         FStar_TypeChecker_Env.typeof_tot_or_gtot_term =
           (tcenv.FStar_TypeChecker_Env.typeof_tot_or_gtot_term);
@@ -502,6 +508,8 @@ let (tc_term : FStar_Syntax_Syntax.term -> FStar_Syntax_Syntax.term) =
           (tcenv.FStar_TypeChecker_Env.uvar_subtyping);
         FStar_TypeChecker_Env.intactics =
           (tcenv.FStar_TypeChecker_Env.intactics);
+        FStar_TypeChecker_Env.nocoerce =
+          (tcenv.FStar_TypeChecker_Env.nocoerce);
         FStar_TypeChecker_Env.tc_term = (tcenv.FStar_TypeChecker_Env.tc_term);
         FStar_TypeChecker_Env.typeof_tot_or_gtot_term =
           (tcenv.FStar_TypeChecker_Env.typeof_tot_or_gtot_term);

--- a/src/typechecker/FStar.TypeChecker.Env.fst
+++ b/src/typechecker/FStar.TypeChecker.Env.fst
@@ -145,6 +145,7 @@ let initial_env deps
     lax=false;
     lax_universes=false;
     phase1=false;
+    nocoerce=false;
     failhard=false;
     nosynth=false;
     uvar_subtyping=true;

--- a/src/typechecker/FStar.TypeChecker.Env.fsti
+++ b/src/typechecker/FStar.TypeChecker.Env.fsti
@@ -181,6 +181,7 @@ and env = {
   nosynth        :bool;                         (* don't run synth tactics *)
   uvar_subtyping :bool;
   intactics      :bool;                         (* we are currently running a tactic *)
+  nocoerce       :bool;                         (* do not apply any coercions *)
 
   tc_term :env -> term -> term * lcomp * guard_t; (* typechecker callback; G |- e : C <== g *)
   typeof_tot_or_gtot_term :env -> term -> must_tot -> term * typ * guard_t; (* typechecker callback; G |- e : (G)Tot t <== g *)

--- a/src/typechecker/FStar.TypeChecker.Util.fst
+++ b/src/typechecker/FStar.TypeChecker.Util.fst
@@ -2448,9 +2448,9 @@ let find_coercion (env:Env.env) (checked: lcomp) (exp_t: typ) : option (lid & co
 
 let maybe_coerce_lc env (e:term) (lc:lcomp) (exp_t:term) : term * lcomp * guard_t =
   let should_coerce =
-      env.phase1
+      (env.phase1
     || env.lax
-    || Options.lax ()
+    || Options.lax ()) && not env.nocoerce
   in
   if not should_coerce
   then (e, lc, Env.trivial_guard)

--- a/tests/coercions/IntBV.fst
+++ b/tests/coercions/IntBV.fst
@@ -1,0 +1,16 @@
+module IntBV
+
+open FStar.UInt
+open FStar.BV
+
+[@@coercion]
+let int_to_bv1 (#n : pos) (x : int) : Pure (BV.bv_t n) (requires fits x n) (ensures fun _ -> True)  = BV.int2bv x
+
+let test1 : BV.bv_t 2 = 1
+let test2 : BV.bv_t 3 = 1
+let test3 : BV.bv_t 4 = 1
+
+[@@expect_failure [66]] (* Failed to resolve implicit *)
+let test4 : BV.bv_t _ = 1
+
+let test5 = 1

--- a/tests/coercions/ListSeq.fst
+++ b/tests/coercions/ListSeq.fst
@@ -1,0 +1,8 @@
+module ListSeq
+
+open FStar.Seq
+
+[@@coercion]
+let lseq (#a:Type) (l:list a) : seq a = seq_of_list l
+
+let x : seq int = [1;2;3;4]

--- a/ulib/FStar.Monotonic.HyperHeap.fst
+++ b/ulib/FStar.Monotonic.HyperHeap.fst
@@ -50,7 +50,7 @@ let root_is_not_freeable () = ()
 
 let rid_length r = List.Tot.length (reveal r)
 
-let rid_tail r = elift1_p (tot_to_gtot Cons?.tl) r
+let rid_tail (r:rid{rid_length r > 0}) = elift1_p (tot_to_gtot Cons?.tl) r
 
 let rec includes r1 r2 =
   if r1 = r2 then true


### PR DESCRIPTION
This allows to define coercions like this the one below:
```fstar
[@@coercion]
let int_to_bv1 (#n : pos) (x : int) : Pure (BV.bv_t n) (requires fits x n) (ensures fun _ -> True)  = BV.int2bv x
```
or
```fstar
[@@coercion]
let lseq (#a:Type) (l:list a) : seq a = seq_of_list l

let x : seq int = [1;2;3;4]                                           
```
which are parametrized by an implicit an universes.

The previous mechanism only allowed for coercions of type `a -> b`, where both `a` and `b` had to be top-level names without any arguments (e.g. `term` and `term_view`). This relaxes the shape to allow for coercions of shape `x1:t1 -> ... -> xn:tn -> a a_args -> b b_args`, with any amount of argument before the last one (which should be implicit so they can be solved, but that's not required by this code) and allowing `a` and `b` to be applied to any number of expressions.

I still kept the requirement that `a` and `b` be top-level names to easily distinguish which coercions may apply, and be as efficient as before for the existing cases. It's these two types which define the coercion to apply, there's no backtracking.

Now, when we have a term `e` of type `a ...` and expected type of `b ...`, we will find the coercion `f` (if any) and attempt to typechecked `f e` at type `b ...`. This will instantiate `f`'s implicits and, if it suceeds, we take this elaborated term to be the coerced one.

A different design is possible via typeclasses, but 1) there's a bootstrapping problem to still solve (see #2969 for some related context), 2) they don't work well wrt refinements, while here we can be smarter about them.

cc @bollu who requested this, maybe give this branch a try?