### PR TITLE
Revising the encoding of BoxBitVec_n

### DIFF
--- a/ocaml/fstar-lib/generated/FStar_CheckedFiles.ml
+++ b/ocaml/fstar-lib/generated/FStar_CheckedFiles.ml
@@ -1,5 +1,5 @@
 open Prims
-let (cache_version_number : Prims.int) = (Prims.of_int (59))
+let (cache_version_number : Prims.int) = (Prims.of_int (60))
 type tc_result =
   {
   checked_module: FStar_Syntax_Syntax.modul ;

--- a/ocaml/fstar-lib/generated/FStar_SMTEncoding_Encode.ml
+++ b/ocaml/fstar-lib/generated/FStar_SMTEncoding_Encode.ml
@@ -4796,21 +4796,18 @@ and (encode_sigelt' :
              let constructor_or_logic_type_decl c =
                if is_logical
                then
-                 let uu___4 = c in
-                 match uu___4 with
-                 | (name, args, uu___5, uu___6, uu___7) ->
-                     let uu___8 =
-                       let uu___9 =
-                         let uu___10 =
-                           FStar_Compiler_Effect.op_Bar_Greater args
-                             (FStar_Compiler_List.map
-                                (fun uu___11 ->
-                                   match uu___11 with
-                                   | (uu___12, sort, uu___13) -> sort)) in
-                         (name, uu___10, FStar_SMTEncoding_Term.Term_sort,
-                           FStar_Pervasives_Native.None) in
-                       FStar_SMTEncoding_Term.DeclFun uu___9 in
-                     [uu___8]
+                 let uu___4 =
+                   let uu___5 =
+                     let uu___6 =
+                       FStar_Compiler_Effect.op_Bar_Greater
+                         c.FStar_SMTEncoding_Term.constr_fields
+                         (FStar_Compiler_List.map
+                            (fun f -> f.FStar_SMTEncoding_Term.field_sort)) in
+                     ((c.FStar_SMTEncoding_Term.constr_name), uu___6,
+                       FStar_SMTEncoding_Term.Term_sort,
+                       FStar_Pervasives_Native.None) in
+                   FStar_SMTEncoding_Term.DeclFun uu___5 in
+                 [uu___4]
                else
                  (let uu___5 = FStar_Ident.range_of_lid t in
                   FStar_SMTEncoding_Term.constructor_to_decl uu___5 c) in
@@ -5063,13 +5060,27 @@ and (encode_sigelt' :
                                            let uu___12 =
                                              FStar_SMTEncoding_Term.fv_sort
                                                fv in
-                                           (uu___11, uu___12, false))) in
+                                           {
+                                             FStar_SMTEncoding_Term.field_name
+                                               = uu___11;
+                                             FStar_SMTEncoding_Term.field_sort
+                                               = uu___12;
+                                             FStar_SMTEncoding_Term.field_projectible
+                                               = false
+                                           })) in
                                  let uu___11 =
-                                   FStar_SMTEncoding_Env.varops.FStar_SMTEncoding_Env.next_id
-                                     () in
-                                 (tname, uu___10,
-                                   FStar_SMTEncoding_Term.Term_sort, uu___11,
-                                   false) in
+                                   let uu___12 =
+                                     FStar_SMTEncoding_Env.varops.FStar_SMTEncoding_Env.next_id
+                                       () in
+                                   FStar_Pervasives_Native.Some uu___12 in
+                                 {
+                                   FStar_SMTEncoding_Term.constr_name = tname;
+                                   FStar_SMTEncoding_Term.constr_fields =
+                                     uu___10;
+                                   FStar_SMTEncoding_Term.constr_sort =
+                                     FStar_SMTEncoding_Term.Term_sort;
+                                   FStar_SMTEncoding_Term.constr_id = uu___11
+                                 } in
                                constructor_or_logic_type_decl uu___9 in
                              let uu___9 =
                                match vars with
@@ -5267,21 +5278,35 @@ and (encode_sigelt' :
                                    (FStar_Compiler_List.mapi
                                       (fun n ->
                                          fun x ->
-                                           let projectible = true in
                                            let uu___7 =
                                              FStar_SMTEncoding_Env.mk_term_projector_name
                                                d x in
-                                           (uu___7,
-                                             FStar_SMTEncoding_Term.Term_sort,
-                                             projectible))) in
+                                           {
+                                             FStar_SMTEncoding_Term.field_name
+                                               = uu___7;
+                                             FStar_SMTEncoding_Term.field_sort
+                                               =
+                                               FStar_SMTEncoding_Term.Term_sort;
+                                             FStar_SMTEncoding_Term.field_projectible
+                                               = true
+                                           })) in
                                let datacons =
                                  let uu___7 =
                                    let uu___8 =
-                                     FStar_SMTEncoding_Env.varops.FStar_SMTEncoding_Env.next_id
-                                       () in
-                                   (ddconstrsym, fields,
-                                     FStar_SMTEncoding_Term.Term_sort,
-                                     uu___8, true) in
+                                     let uu___9 =
+                                       FStar_SMTEncoding_Env.varops.FStar_SMTEncoding_Env.next_id
+                                         () in
+                                     FStar_Pervasives_Native.Some uu___9 in
+                                   {
+                                     FStar_SMTEncoding_Term.constr_name =
+                                       ddconstrsym;
+                                     FStar_SMTEncoding_Term.constr_fields =
+                                       fields;
+                                     FStar_SMTEncoding_Term.constr_sort =
+                                       FStar_SMTEncoding_Term.Term_sort;
+                                     FStar_SMTEncoding_Term.constr_id =
+                                       uu___8
+                                   } in
                                  let uu___8 =
                                    let uu___9 = FStar_Ident.range_of_lid d in
                                    FStar_SMTEncoding_Term.constructor_to_decl

--- a/ocaml/fstar-lib/generated/FStar_SMTEncoding_EncodeTerm.ml
+++ b/ocaml/fstar-lib/generated/FStar_SMTEncoding_EncodeTerm.ml
@@ -915,8 +915,58 @@ and (encode_BitVector_term :
               FStar_Compiler_Util.format1 "BitVector_%s"
                 (Prims.string_of_int sz) in
             let sz_decls =
-              let t_decls = FStar_SMTEncoding_Term.mkBvConstructor sz in
-              FStar_SMTEncoding_Term.mk_decls "" sz_key t_decls [] in
+              let uu___3 = FStar_SMTEncoding_Term.mkBvConstructor sz in
+              match uu___3 with
+              | (t_decls, constr_name, discriminator_name) ->
+                  let uu___4 =
+                    let uu___5 =
+                      let head1 =
+                        FStar_Syntax_Syntax.lid_as_fv
+                          FStar_Parser_Const.bv_t_lid
+                          FStar_Pervasives_Native.None in
+                      let t =
+                        let uu___6 = FStar_Syntax_Syntax.fv_to_tm head1 in
+                        FStar_Syntax_Util.mk_app uu___6
+                          [(tm_sz, FStar_Pervasives_Native.None)] in
+                      encode_term t env in
+                    match uu___5 with
+                    | (bv_t_n, decls) ->
+                        let xsym =
+                          let uu___6 =
+                            let uu___7 =
+                              FStar_SMTEncoding_Env.varops.FStar_SMTEncoding_Env.fresh
+                                env.FStar_SMTEncoding_Env.current_module_name
+                                "x" in
+                            (uu___7, FStar_SMTEncoding_Term.Term_sort) in
+                          FStar_SMTEncoding_Term.mk_fv uu___6 in
+                        let x = FStar_SMTEncoding_Util.mkFreeV xsym in
+                        let x_has_type_bv_t_n =
+                          FStar_SMTEncoding_Term.mk_HasType x bv_t_n in
+                        let ax =
+                          let uu___6 =
+                            let uu___7 =
+                              let uu___8 =
+                                let uu___9 =
+                                  FStar_SMTEncoding_Util.mkApp
+                                    (discriminator_name, [x]) in
+                                (x_has_type_bv_t_n, uu___9) in
+                              FStar_SMTEncoding_Util.mkImp uu___8 in
+                            ([[x_has_type_bv_t_n]], [xsym], uu___7) in
+                          FStar_SMTEncoding_Term.mkForall
+                            head.FStar_Syntax_Syntax.pos uu___6 in
+                        let name =
+                          Prims.op_Hat "typing_inversion_for_" constr_name in
+                        let uu___6 =
+                          FStar_SMTEncoding_Util.mkAssume
+                            (ax, (FStar_Pervasives_Native.Some name), name) in
+                        (decls, uu___6) in
+                  (match uu___4 with
+                   | (decls, typing_inversion) ->
+                       let uu___5 =
+                         FStar_SMTEncoding_Term.mk_decls "" sz_key
+                           (FStar_Compiler_List.op_At t_decls
+                              [typing_inversion]) [] in
+                       FStar_Compiler_List.op_At decls uu___5) in
             let uu___3 =
               match ((head.FStar_Syntax_Syntax.n), args_e) with
               | (FStar_Syntax_Syntax.Tm_fvar fv,

--- a/ocaml/fstar-lib/generated/FStar_SMTEncoding_Term.ml
+++ b/ocaml/fstar-lib/generated/FStar_SMTEncoding_Term.ml
@@ -232,10 +232,52 @@ type fv = (Prims.string * sort * Prims.bool)
 type fvs = (Prims.string * sort * Prims.bool) Prims.list
 type caption = Prims.string FStar_Pervasives_Native.option
 type binders = (Prims.string * sort) Prims.list
-type constructor_field = (Prims.string * sort * Prims.bool)
+type constructor_field =
+  {
+  field_name: Prims.string ;
+  field_sort: sort ;
+  field_projectible: Prims.bool }
+let (__proj__Mkconstructor_field__item__field_name :
+  constructor_field -> Prims.string) =
+  fun projectee ->
+    match projectee with
+    | { field_name; field_sort; field_projectible;_} -> field_name
+let (__proj__Mkconstructor_field__item__field_sort :
+  constructor_field -> sort) =
+  fun projectee ->
+    match projectee with
+    | { field_name; field_sort; field_projectible;_} -> field_sort
+let (__proj__Mkconstructor_field__item__field_projectible :
+  constructor_field -> Prims.bool) =
+  fun projectee ->
+    match projectee with
+    | { field_name; field_sort; field_projectible;_} -> field_projectible
 type constructor_t =
-  (Prims.string * constructor_field Prims.list * sort * Prims.int *
-    Prims.bool)
+  {
+  constr_name: Prims.string ;
+  constr_fields: constructor_field Prims.list ;
+  constr_sort: sort ;
+  constr_id: Prims.int FStar_Pervasives_Native.option }
+let (__proj__Mkconstructor_t__item__constr_name :
+  constructor_t -> Prims.string) =
+  fun projectee ->
+    match projectee with
+    | { constr_name; constr_fields; constr_sort; constr_id;_} -> constr_name
+let (__proj__Mkconstructor_t__item__constr_fields :
+  constructor_t -> constructor_field Prims.list) =
+  fun projectee ->
+    match projectee with
+    | { constr_name; constr_fields; constr_sort; constr_id;_} ->
+        constr_fields
+let (__proj__Mkconstructor_t__item__constr_sort : constructor_t -> sort) =
+  fun projectee ->
+    match projectee with
+    | { constr_name; constr_fields; constr_sort; constr_id;_} -> constr_sort
+let (__proj__Mkconstructor_t__item__constr_id :
+  constructor_t -> Prims.int FStar_Pervasives_Native.option) =
+  fun projectee ->
+    match projectee with
+    | { constr_name; constr_fields; constr_sort; constr_id;_} -> constr_id
 type constructors = constructor_t Prims.list
 type fact_db_id =
   | Name of FStar_Ident.lid 
@@ -1392,10 +1434,7 @@ let (injective_constructor :
             FStar_Compiler_Effect.op_Bar_Greater fields
               (FStar_Compiler_List.mapi
                  (fun i ->
-                    fun uu___1 ->
-                      match uu___1 with
-                      | (uu___2, s, uu___3) ->
-                          let uu___4 = bvar i s in uu___4 norng)) in
+                    fun f -> let uu___1 = bvar i f.field_sort in uu___1 norng)) in
           let bvar_names = FStar_Compiler_List.map fv_of_term bvars in
           let capp = mkApp (name, bvars) norng in
           let uu___1 =
@@ -1404,7 +1443,8 @@ let (injective_constructor :
                  (fun i ->
                     fun uu___2 ->
                       match uu___2 with
-                      | (name1, s, projectible) ->
+                      | { field_name = name1; field_sort = s;
+                          field_projectible = projectible;_} ->
                           let cproj_app = mkApp (name1, [capp]) norng in
                           let proj_name =
                             DeclFun
@@ -1441,98 +1481,111 @@ let (injective_constructor :
 let (constructor_to_decl :
   FStar_Compiler_Range_Type.range -> constructor_t -> decl Prims.list) =
   fun rng ->
-    fun uu___ ->
-      match uu___ with
-      | (name, fields, sort1, id, injective) ->
-          let injective1 = injective || true in
-          let field_sorts =
-            FStar_Compiler_Effect.op_Bar_Greater fields
-              (FStar_Compiler_List.map
-                 (fun uu___1 ->
-                    match uu___1 with | (uu___2, sort2, uu___3) -> sort2)) in
-          let cdecl =
-            DeclFun
-              (name, field_sorts, sort1,
-                (FStar_Pervasives_Native.Some "Constructor")) in
-          let cid = fresh_constructor rng (name, field_sorts, sort1, id) in
-          let disc =
-            let disc_name = Prims.op_Hat "is-" name in
-            let xfv = mk_fv ("x", sort1) in
-            let xx = mkFreeV xfv norng in
-            let disc_eq =
-              let uu___1 =
-                let uu___2 =
-                  let uu___3 =
-                    let uu___4 = constr_id_of_sort sort1 in (uu___4, [xx]) in
-                  mkApp uu___3 norng in
-                let uu___3 =
-                  let uu___4 = FStar_Compiler_Util.string_of_int id in
-                  mkInteger uu___4 norng in
-                (uu___2, uu___3) in
-              mkEq uu___1 norng in
-            let uu___1 =
-              let uu___2 =
-                FStar_Compiler_Effect.op_Bar_Greater fields
-                  (FStar_Compiler_List.mapi
-                     (fun i ->
-                        fun uu___3 ->
-                          match uu___3 with
-                          | (proj, s, projectible) ->
-                              if projectible
-                              then
-                                let uu___4 = mkApp (proj, [xx]) norng in
-                                (uu___4, [])
-                              else
-                                (let fi =
-                                   let uu___5 =
-                                     let uu___6 =
-                                       let uu___7 =
-                                         FStar_Compiler_Util.string_of_int i in
-                                       Prims.op_Hat "f_" uu___7 in
-                                     (uu___6, s) in
-                                   mk_fv uu___5 in
-                                 let uu___5 = mkFreeV fi norng in
-                                 (uu___5, [fi])))) in
-              FStar_Compiler_Effect.op_Bar_Greater uu___2
-                FStar_Compiler_List.split in
-            match uu___1 with
-            | (proj_terms, ex_vars) ->
-                let ex_vars1 = FStar_Compiler_List.flatten ex_vars in
-                let disc_inv_body =
-                  let uu___2 =
-                    let uu___3 = mkApp (name, proj_terms) norng in
-                    (xx, uu___3) in
-                  mkEq uu___2 norng in
-                let disc_inv_body1 =
-                  match ex_vars1 with
-                  | [] -> disc_inv_body
-                  | uu___2 -> mkExists norng ([], ex_vars1, disc_inv_body) in
-                let disc_ax = mkAnd (disc_eq, disc_inv_body1) norng in
-                let def =
-                  mkDefineFun
-                    (disc_name, [xfv], Bool_sort, disc_ax,
-                      (FStar_Pervasives_Native.Some
-                         "Discriminator definition")) in
-                def in
-          let projs =
-            if injective1
-            then injective_constructor rng (name, fields, sort1)
-            else [] in
+    fun constr ->
+      let injective = true in
+      let sort1 = constr.constr_sort in
+      let field_sorts =
+        FStar_Compiler_Effect.op_Bar_Greater constr.constr_fields
+          (FStar_Compiler_List.map (fun f -> f.field_sort)) in
+      let cdecl =
+        DeclFun
+          ((constr.constr_name), field_sorts, (constr.constr_sort),
+            (FStar_Pervasives_Native.Some "Constructor")) in
+      let cid =
+        match constr.constr_id with
+        | FStar_Pervasives_Native.None -> []
+        | FStar_Pervasives_Native.Some id ->
+            let uu___ =
+              fresh_constructor rng
+                ((constr.constr_name), field_sorts, sort1, id) in
+            [uu___] in
+      let disc =
+        let disc_name = Prims.op_Hat "is-" constr.constr_name in
+        let xfv = mk_fv ("x", sort1) in
+        let xx = mkFreeV xfv norng in
+        let uu___ =
           let uu___1 =
-            let uu___2 =
-              let uu___3 =
-                FStar_Compiler_Util.format1 "<start constructor %s>" name in
-              Caption uu___3 in
-            uu___2 :: cdecl :: cid :: projs in
+            FStar_Compiler_Effect.op_Bar_Greater constr.constr_fields
+              (FStar_Compiler_List.mapi
+                 (fun i ->
+                    fun uu___2 ->
+                      match uu___2 with
+                      | { field_name = proj; field_sort = s;
+                          field_projectible = projectible;_} ->
+                          if projectible
+                          then
+                            let uu___3 = mkApp (proj, [xx]) norng in
+                            (uu___3, [])
+                          else
+                            (let fi =
+                               let uu___4 =
+                                 let uu___5 =
+                                   let uu___6 =
+                                     FStar_Compiler_Util.string_of_int i in
+                                   Prims.op_Hat "f_" uu___6 in
+                                 (uu___5, s) in
+                               mk_fv uu___4 in
+                             let uu___4 = mkFreeV fi norng in (uu___4, [fi])))) in
+          FStar_Compiler_Effect.op_Bar_Greater uu___1
+            FStar_Compiler_List.split in
+        match uu___ with
+        | (proj_terms, ex_vars) ->
+            let ex_vars1 = FStar_Compiler_List.flatten ex_vars in
+            let disc_inv_body =
+              let uu___1 =
+                let uu___2 = mkApp ((constr.constr_name), proj_terms) norng in
+                (xx, uu___2) in
+              mkEq uu___1 norng in
+            let disc_inv_body1 =
+              match ex_vars1 with
+              | [] -> disc_inv_body
+              | uu___1 -> mkExists norng ([], ex_vars1, disc_inv_body) in
+            let disc_ax =
+              match constr.constr_id with
+              | FStar_Pervasives_Native.None -> disc_inv_body1
+              | FStar_Pervasives_Native.Some id ->
+                  let disc_eq =
+                    let uu___1 =
+                      let uu___2 =
+                        let uu___3 =
+                          let uu___4 = constr_id_of_sort constr.constr_sort in
+                          (uu___4, [xx]) in
+                        mkApp uu___3 norng in
+                      let uu___3 =
+                        let uu___4 = FStar_Compiler_Util.string_of_int id in
+                        mkInteger uu___4 norng in
+                      (uu___2, uu___3) in
+                    mkEq uu___1 norng in
+                  mkAnd (disc_eq, disc_inv_body1) norng in
+            let def =
+              mkDefineFun
+                (disc_name, [xfv], Bool_sort, disc_ax,
+                  (FStar_Pervasives_Native.Some "Discriminator definition")) in
+            def in
+      let projs =
+        injective_constructor rng
+          ((constr.constr_name), (constr.constr_fields), sort1) in
+      let uu___ =
+        let uu___1 =
           let uu___2 =
-            let uu___3 =
-              let uu___4 =
-                let uu___5 =
-                  FStar_Compiler_Util.format1 "</end constructor %s>" name in
-                Caption uu___5 in
-              [uu___4] in
-            FStar_Compiler_List.op_At [disc] uu___3 in
-          FStar_Compiler_List.op_At uu___1 uu___2
+            FStar_Compiler_Util.format1 "<start constructor %s>"
+              constr.constr_name in
+          Caption uu___2 in
+        [uu___1; cdecl] in
+      let uu___1 =
+        let uu___2 =
+          let uu___3 =
+            let uu___4 =
+              let uu___5 =
+                let uu___6 =
+                  FStar_Compiler_Util.format1 "</end constructor %s>"
+                    constr.constr_name in
+                Caption uu___6 in
+              [uu___5] in
+            FStar_Compiler_List.op_At [disc] uu___4 in
+          FStar_Compiler_List.op_At projs uu___3 in
+        FStar_Compiler_List.op_At cid uu___2 in
+      FStar_Compiler_List.op_At uu___ uu___1
 let (name_binders_inner :
   Prims.string FStar_Pervasives_Native.option ->
     fv Prims.list ->
@@ -1853,25 +1906,41 @@ and (mkPrelude : Prims.string -> Prims.string) =
     let basic =
       Prims.op_Hat z3options
         "(declare-sort FString)\n(declare-fun FString_constr_id (FString) Int)\n\n(declare-sort Term)\n(declare-fun Term_constr_id (Term) Int)\n(declare-sort Dummy_sort)\n(declare-fun Dummy_value () Dummy_sort)\n(declare-datatypes () ((Fuel \n(ZFuel) \n(SFuel (prec Fuel)))))\n(declare-fun MaxIFuel () Fuel)\n(declare-fun MaxFuel () Fuel)\n(declare-fun PreType (Term) Term)\n(declare-fun Valid (Term) Bool)\n(declare-fun HasTypeFuel (Fuel Term Term) Bool)\n(define-fun HasTypeZ ((x Term) (t Term)) Bool\n(HasTypeFuel ZFuel x t))\n(define-fun HasType ((x Term) (t Term)) Bool\n(HasTypeFuel MaxIFuel x t))\n(declare-fun IsTotFun (Term) Bool)\n\n                ;;fuel irrelevance\n(assert (forall ((f Fuel) (x Term) (t Term))\n(! (= (HasTypeFuel (SFuel f) x t)\n(HasTypeZ x t))\n:pattern ((HasTypeFuel (SFuel f) x t)))))\n(declare-fun NoHoist (Term Bool) Bool)\n;;no-hoist\n(assert (forall ((dummy Term) (b Bool))\n(! (= (NoHoist dummy b)\nb)\n:pattern ((NoHoist dummy b)))))\n(define-fun  IsTyped ((x Term)) Bool\n(exists ((t Term)) (HasTypeZ x t)))\n(declare-fun ApplyTF (Term Fuel) Term)\n(declare-fun ApplyTT (Term Term) Term)\n(declare-fun Prec (Term Term) Bool)\n(assert (forall ((x Term) (y Term) (z Term))\n(! (implies (and (Prec x y) (Prec y z))\n(Prec x z))\n                                   :pattern ((Prec x z) (Prec x y)))))\n(assert (forall ((x Term) (y Term))\n(implies (Prec x y)\n(not (Prec y x)))))\n(declare-fun Closure (Term) Term)\n(declare-fun ConsTerm (Term Term) Term)\n(declare-fun ConsFuel (Fuel Term) Term)\n(declare-fun Tm_uvar (Int) Term)\n(define-fun Reify ((x Term)) Term x)\n(declare-fun Prims.precedes (Term Term Term Term) Term)\n(declare-fun Range_const (Int) Term)\n(declare-fun _mul (Int Int) Int)\n(declare-fun _div (Int Int) Int)\n(declare-fun _mod (Int Int) Int)\n(declare-fun __uu__PartialApp () Term)\n(assert (forall ((x Int) (y Int)) (! (= (_mul x y) (* x y)) :pattern ((_mul x y)))))\n(assert (forall ((x Int) (y Int)) (! (= (_div x y) (div x y)) :pattern ((_div x y)))))\n(assert (forall ((x Int) (y Int)) (! (= (_mod x y) (mod x y)) :pattern ((_mod x y)))))\n(declare-fun _rmul (Real Real) Real)\n(declare-fun _rdiv (Real Real) Real)\n(assert (forall ((x Real) (y Real)) (! (= (_rmul x y) (* x y)) :pattern ((_rmul x y)))))\n(assert (forall ((x Real) (y Real)) (! (= (_rdiv x y) (/ x y)) :pattern ((_rdiv x y)))))\n(define-fun Unreachable () Bool false)" in
+    let as_constr uu___ =
+      match uu___ with
+      | (name, fields, sort1, id, _injective) ->
+          let uu___1 =
+            FStar_Compiler_List.map
+              (fun uu___2 ->
+                 match uu___2 with
+                 | (field_name, field_sort, field_projectible) ->
+                     { field_name; field_sort; field_projectible }) fields in
+          {
+            constr_name = name;
+            constr_fields = uu___1;
+            constr_sort = sort1;
+            constr_id = (FStar_Pervasives_Native.Some id)
+          } in
     let constrs =
-      [("FString_const", [("FString_const_proj_0", Int_sort, true)],
-         String_sort, Prims.int_zero, true);
-      ("Tm_type", [], Term_sort, (Prims.of_int (2)), true);
-      ("Tm_arrow", [("Tm_arrow_id", Int_sort, true)], Term_sort,
-        (Prims.of_int (3)), false);
-      ("Tm_unit", [], Term_sort, (Prims.of_int (6)), true);
-      ((FStar_Pervasives_Native.fst boxIntFun),
-        [((FStar_Pervasives_Native.snd boxIntFun), Int_sort, true)],
-        Term_sort, (Prims.of_int (7)), true);
-      ((FStar_Pervasives_Native.fst boxBoolFun),
-        [((FStar_Pervasives_Native.snd boxBoolFun), Bool_sort, true)],
-        Term_sort, (Prims.of_int (8)), true);
-      ((FStar_Pervasives_Native.fst boxStringFun),
-        [((FStar_Pervasives_Native.snd boxStringFun), String_sort, true)],
-        Term_sort, (Prims.of_int (9)), true);
-      ((FStar_Pervasives_Native.fst boxRealFun),
-        [((FStar_Pervasives_Native.snd boxRealFun), (Sort "Real"), true)],
-        Term_sort, (Prims.of_int (10)), true)] in
+      FStar_Compiler_List.map as_constr
+        [("FString_const", [("FString_const_proj_0", Int_sort, true)],
+           String_sort, Prims.int_zero, true);
+        ("Tm_type", [], Term_sort, (Prims.of_int (2)), true);
+        ("Tm_arrow", [("Tm_arrow_id", Int_sort, true)], Term_sort,
+          (Prims.of_int (3)), false);
+        ("Tm_unit", [], Term_sort, (Prims.of_int (6)), true);
+        ((FStar_Pervasives_Native.fst boxIntFun),
+          [((FStar_Pervasives_Native.snd boxIntFun), Int_sort, true)],
+          Term_sort, (Prims.of_int (7)), true);
+        ((FStar_Pervasives_Native.fst boxBoolFun),
+          [((FStar_Pervasives_Native.snd boxBoolFun), Bool_sort, true)],
+          Term_sort, (Prims.of_int (8)), true);
+        ((FStar_Pervasives_Native.fst boxStringFun),
+          [((FStar_Pervasives_Native.snd boxStringFun), String_sort, true)],
+          Term_sort, (Prims.of_int (9)), true);
+        ((FStar_Pervasives_Native.fst boxRealFun),
+          [((FStar_Pervasives_Native.snd boxRealFun), (Sort "Real"), true)],
+          Term_sort, (Prims.of_int (10)), true)] in
     let bcons =
       let uu___ =
         let uu___1 =
@@ -1912,18 +1981,27 @@ let (declToSmt_no_caps : Prims.string -> decl -> Prims.string) =
   fun z3options -> fun decl1 -> declToSmt' false z3options decl1
 let (mkBvConstructor : Prims.int -> decl Prims.list) =
   fun sz ->
-    let uu___ =
+    let constr =
+      let uu___ =
+        let uu___1 = boxBitVecFun sz in FStar_Pervasives_Native.fst uu___1 in
       let uu___1 =
-        let uu___2 = boxBitVecFun sz in FStar_Pervasives_Native.fst uu___2 in
-      let uu___2 =
-        let uu___3 =
-          let uu___4 =
-            let uu___5 = boxBitVecFun sz in
-            FStar_Pervasives_Native.snd uu___5 in
-          (uu___4, (BitVec_sort sz), true) in
-        [uu___3] in
-      (uu___1, uu___2, Term_sort, ((Prims.of_int (12)) + sz), true) in
-    FStar_Compiler_Effect.op_Bar_Greater uu___ (constructor_to_decl norng)
+        let uu___2 =
+          let uu___3 =
+            let uu___4 = boxBitVecFun sz in
+            FStar_Pervasives_Native.snd uu___4 in
+          {
+            field_name = uu___3;
+            field_sort = (BitVec_sort sz);
+            field_projectible = true
+          } in
+        [uu___2] in
+      {
+        constr_name = uu___;
+        constr_fields = uu___1;
+        constr_sort = Term_sort;
+        constr_id = FStar_Pervasives_Native.None
+      } in
+    constructor_to_decl norng constr
 let (__range_c : Prims.int FStar_Compiler_Effect.ref) =
   FStar_Compiler_Util.mk_ref Prims.int_zero
 let (mk_Range_const : unit -> term) =

--- a/ocaml/fstar-lib/generated/FStar_SMTEncoding_Term.ml
+++ b/ocaml/fstar-lib/generated/FStar_SMTEncoding_Term.ml
@@ -1478,6 +1478,8 @@ let (injective_constructor :
                           else [proj_name])) in
           FStar_Compiler_Effect.op_Bar_Greater uu___1
             FStar_Compiler_List.flatten
+let (discriminator_name : constructor_t -> Prims.string) =
+  fun constr -> Prims.op_Hat "is-" constr.constr_name
 let (constructor_to_decl :
   FStar_Compiler_Range_Type.range -> constructor_t -> decl Prims.list) =
   fun rng ->
@@ -1500,7 +1502,7 @@ let (constructor_to_decl :
                 ((constr.constr_name), field_sorts, sort1, id) in
             [uu___] in
       let disc =
-        let disc_name = Prims.op_Hat "is-" constr.constr_name in
+        let disc_name = discriminator_name constr in
         let xfv = mk_fv ("x", sort1) in
         let xx = mkFreeV xfv norng in
         let uu___ =
@@ -1979,7 +1981,8 @@ let (declsToSmt : Prims.string -> decl Prims.list -> Prims.string) =
       FStar_Compiler_Effect.op_Bar_Greater uu___ (FStar_String.concat "\n")
 let (declToSmt_no_caps : Prims.string -> decl -> Prims.string) =
   fun z3options -> fun decl1 -> declToSmt' false z3options decl1
-let (mkBvConstructor : Prims.int -> decl Prims.list) =
+let (mkBvConstructor :
+  Prims.int -> (decl Prims.list * Prims.string * Prims.string)) =
   fun sz ->
     let constr =
       let uu___ =
@@ -2001,7 +2004,8 @@ let (mkBvConstructor : Prims.int -> decl Prims.list) =
         constr_sort = Term_sort;
         constr_id = FStar_Pervasives_Native.None
       } in
-    constructor_to_decl norng constr
+    let uu___ = constructor_to_decl norng constr in
+    (uu___, (constr.constr_name), (discriminator_name constr))
 let (__range_c : Prims.int FStar_Compiler_Effect.ref) =
   FStar_Compiler_Util.mk_ref Prims.int_zero
 let (mk_Range_const : unit -> term) =

--- a/src/fstar/FStar.CheckedFiles.fst
+++ b/src/fstar/FStar.CheckedFiles.fst
@@ -40,7 +40,7 @@ module Dep     = FStar.Parser.Dep
  * detect when loading the cache that the version number is same
  * It needs to be kept in sync with prims.fst
  *)
-let cache_version_number = 59
+let cache_version_number = 60
 
 (*
  * Abbreviation for what we store in the checked files (stages as described below)

--- a/src/smtencoding/FStar.SMTEncoding.Encode.fst
+++ b/src/smtencoding/FStar.SMTEncoding.Encode.fst
@@ -1290,8 +1290,7 @@ and encode_sigelt' (env:env_t) (se:sigelt) : (decls_t * env_t) =
         let is_logical = quals |> BU.for_some (function Logic | Assumption -> true | _ -> false) in
         let constructor_or_logic_type_decl (c:constructor_t) =
             if is_logical
-            then let name, args, _, _, _ = c in
-                 [Term.DeclFun(name, args |> List.map (fun (_, sort, _) -> sort), Term_sort, None)]
+            then [Term.DeclFun(c.constr_name, c.constr_fields |> List.map (fun f -> f.field_sort), Term_sort, None)]
             else constructor_to_decl (Ident.range_of_lid t) c in
         let inversion_axioms env tapp vars =
             if datas |> BU.for_some (fun l -> Env.try_lookup_lid env.tcenv l |> Option.isNone) //Q: Why would this happen?
@@ -1347,12 +1346,13 @@ and encode_sigelt' (env:env_t) (se:sigelt) : (decls_t * env_t) =
             //See: https://github.com/FStarLang/FStar/issues/349
             let tname_decl =
                 constructor_or_logic_type_decl
-                    (tname,
-                     vars |> List.map (fun fv -> (tname^fv_name fv, fv_sort fv,false)),
-                     //The false above is extremely important; it makes sure that type-formers are not injective
-                     Term_sort,
-                     varops.next_id(),
-                     false)
+                  {
+                    constr_name = tname;
+                    constr_fields = vars |> List.map (fun fv -> {field_name=tname^fv_name fv; field_sort=fv_sort fv; field_projectible=false}) ;
+                    //The field_projectible=false above is extremely important; it makes sure that type-formers are not injective
+                    constr_sort=Term_sort;
+                    constr_id=Some (varops.next_id())
+                  }
             in
             let tok_decls, env =
                 match vars with
@@ -1404,14 +1404,16 @@ and encode_sigelt' (env:env_t) (se:sigelt) : (decls_t * env_t) =
         let s_fuel_tm = mkApp("SFuel", [fuel_tm]) in
         let vars, guards, env', binder_decls, names = encode_binders (Some fuel_tm) formals env in
         let fields = names |> List.mapi (fun n x ->
-            let projectible = true in
-//            let projectible = n >= n_tps in //Note: the type parameters are not projectible,
-                                            //i.e., (MkTuple2 int bool 0 false) is only injective in its last two arguments
-                                            //This allows the term to both have type (int * bool)
-                                            //as well as (nat * bool), without leading us to conclude that int=nat
-                                            //Also see https://github.com/FStarLang/FStar/issues/349
-            mk_term_projector_name d x, Term_sort, projectible) in
-        let datacons = (ddconstrsym, fields, Term_sort, varops.next_id(), true) |> Term.constructor_to_decl (Ident.range_of_lid d) in
+            { field_name=mk_term_projector_name d x;
+              field_sort=Term_sort;
+              field_projectible=true })
+        in
+        let datacons = 
+          {constr_name=ddconstrsym;
+           constr_fields=fields;
+           constr_sort=Term_sort;
+           constr_id=Some (varops.next_id())
+           } |> Term.constructor_to_decl (Ident.range_of_lid d) in
         let app = mk_Apply ddtok_tm vars in
         let guard = mk_and_l guards in
         let xvars = List.map mkFreeV vars in

--- a/src/smtencoding/FStar.SMTEncoding.EncodeTerm.fst
+++ b/src/smtencoding/FStar.SMTEncoding.EncodeTerm.fst
@@ -463,6 +463,17 @@ and encode_arith_term env head args_e =
     let sz_key = FStar.Compiler.Util.format1 "BitVector_%s" (string_of_int sz) in
     let sz_decls =
       let t_decls = mkBvConstructor sz in
+      //Typing inversion for bv_t n
+      let bv_t sz = 
+        (* forall (x:Term). HasType x (bv_t n) ==> is-BoxVec#n x *)
+        let bv_t_n = 
+          let head = S.lid_as_fv FStar.Parser.Const.bv_t_lid None in
+          let arg = U.exp_int sz in
+          let t = U.mk_app (S.fv_to_tm head) [arg, None] in
+          encode_term t env
+        in
+        ()
+      in
       mk_decls "" sz_key t_decls []
     in
     (* we need to treat the size argument for zero_extend specially*)

--- a/src/smtencoding/FStar.SMTEncoding.Term.fst
+++ b/src/smtencoding/FStar.SMTEncoding.Term.fst
@@ -582,6 +582,8 @@ let injective_constructor
             else [proj_name])
     |> List.flatten
 
+let discriminator_name constr = "is-"^constr.constr_name
+
 let constructor_to_decl rng constr =
     let injective = true in
     let sort = constr.constr_sort in
@@ -593,7 +595,7 @@ let constructor_to_decl rng constr =
       | Some id -> [fresh_constructor rng (constr.constr_name, field_sorts, sort, id)]
     in
     let disc =
-        let disc_name = "is-"^constr.constr_name in
+        let disc_name = discriminator_name constr in
         let xfv = mk_fv ("x", sort) in
         let xx = mkFreeV xfv norng in
         let proj_terms, ex_vars =
@@ -970,7 +972,9 @@ let mkBvConstructor (sz : int) =
     constr_id=None;
     constr_fields=[{field_projectible=true; field_name=snd (boxBitVecFun sz); field_sort=BitVec_sort sz }]
   } in
-  constructor_to_decl norng constr
+  constructor_to_decl norng constr, 
+  constr.constr_name, 
+  discriminator_name constr
 
 let __range_c = BU.mk_ref 0
 let mk_Range_const () =

--- a/src/smtencoding/FStar.SMTEncoding.Term.fst
+++ b/src/smtencoding/FStar.SMTEncoding.Term.fst
@@ -564,11 +564,11 @@ let injective_constructor
     let bvar_name i = "x_" ^ string_of_int i in
     let bvar_index i = n_bvars - (i + 1) in
     let bvar i s = mkFreeV <| mk_fv (bvar_name i, s) in
-    let bvars = fields |> List.mapi (fun i (_, s, _) -> bvar i s norng) in
+    let bvars = fields |> List.mapi (fun i f -> bvar i f.field_sort norng) in
     let bvar_names = List.map fv_of_term bvars in
     let capp = mkApp(name, bvars) norng in
     fields
-    |> List.mapi (fun i (name, s, projectible) ->
+    |> List.mapi (fun i {field_projectible=projectible; field_name=name; field_sort=s} ->
             let cproj_app = mkApp(name, [capp]) norng in
             let proj_name = DeclFun(name, [sort], s, Some "Projector") in
             if projectible
@@ -582,39 +582,47 @@ let injective_constructor
             else [proj_name])
     |> List.flatten
 
-let constructor_to_decl rng (name, fields, sort, id, injective) =
-    let injective = injective || true in
-    let field_sorts = fields |> List.map (fun (_, sort, _) -> sort) in
-    let cdecl = DeclFun(name, field_sorts, sort, Some "Constructor") in
-    let cid = fresh_constructor rng (name, field_sorts, sort, id) in
+let constructor_to_decl rng constr =
+    let injective = true in
+    let sort = constr.constr_sort in
+    let field_sorts = constr.constr_fields |> List.map (fun f -> f.field_sort) in
+    let cdecl = DeclFun(constr.constr_name, field_sorts, constr.constr_sort, Some "Constructor") in
+    let cid = 
+      match constr.constr_id with
+      | None -> []
+      | Some id -> [fresh_constructor rng (constr.constr_name, field_sorts, sort, id)]
+    in
     let disc =
-        let disc_name = "is-"^name in
+        let disc_name = "is-"^constr.constr_name in
         let xfv = mk_fv ("x", sort) in
         let xx = mkFreeV xfv norng in
-        let disc_eq = mkEq(mkApp(constr_id_of_sort sort, [xx]) norng, mkInteger (string_of_int id) norng) norng in
         let proj_terms, ex_vars =
-            fields
-         |> List.mapi (fun i (proj, s, projectible) ->
+            constr.constr_fields
+         |> List.mapi (fun i {field_projectible=projectible; field_sort=s; field_name=proj} ->
                 if projectible
                 then mkApp(proj, [xx]) norng, []
                 else let fi = mk_fv ("f_" ^ BU.string_of_int i, s) in
                      mkFreeV fi norng, [fi])
          |> List.split in
         let ex_vars = List.flatten ex_vars in
-        let disc_inv_body = mkEq(xx, mkApp(name, proj_terms) norng) norng in
+        let disc_inv_body = mkEq(xx, mkApp(constr.constr_name, proj_terms) norng) norng in
         let disc_inv_body = match ex_vars with
             | [] -> disc_inv_body
             | _ -> mkExists norng ([], ex_vars, disc_inv_body) in
-        let disc_ax = mkAnd(disc_eq, disc_inv_body) norng in
+        let disc_ax =
+          match constr.constr_id with
+          | None -> disc_inv_body
+          | Some id ->
+            let disc_eq = mkEq(mkApp(constr_id_of_sort constr.constr_sort, [xx]) norng, mkInteger (string_of_int id) norng) norng in
+            mkAnd(disc_eq, disc_inv_body) norng in
         let def = mkDefineFun(disc_name, [xfv], Bool_sort,
                     disc_ax,
                     Some "Discriminator definition") in
         def in
-    let projs =
-        if injective
-        then injective_constructor rng (name, fields, sort)
-        else [] in
-    Caption (format1 "<start constructor %s>" name)::cdecl::cid::projs@[disc]@[Caption (format1 "</end constructor %s>" name)]
+    let projs = injective_constructor rng (constr.constr_name, constr.constr_fields, sort) in
+    Caption (format1 "<start constructor %s>" constr.constr_name)::
+    [cdecl]@cid@projs@[disc]
+    @[Caption (format1 "</end constructor %s>" constr.constr_name)]
 
 (****************************************************************************)
 (* Standard SMTLib prelude for F* and some term constructors                *)
@@ -875,14 +883,23 @@ and mkPrelude z3options =
                 (assert (forall ((x Real) (y Real)) (! (= (_rdiv x y) (/ x y)) :pattern ((_rdiv x y)))))\n\
                 (define-fun Unreachable () Bool false)"
    in
-   let constrs : constructors = [("FString_const", ["FString_const_proj_0", Int_sort, true], String_sort, 0, true);
-                                 ("Tm_type",  [], Term_sort, 2, true);
-                                 ("Tm_arrow", [("Tm_arrow_id", Int_sort, true)],  Term_sort, 3, false);
-                                 ("Tm_unit",  [], Term_sort, 6, true);
-                                 (fst boxIntFun,     [snd boxIntFun,  Int_sort, true],   Term_sort, 7, true);
-                                 (fst boxBoolFun,    [snd boxBoolFun, Bool_sort, true],  Term_sort, 8, true);
-                                 (fst boxStringFun,  [snd boxStringFun, String_sort, true], Term_sort, 9, true);
-                                 (fst boxRealFun,    [snd boxRealFun, Sort "Real", true], Term_sort, 10, true)] in
+   let as_constr (name, fields, sort, id, _injective)
+     : constructor_t
+     = { constr_name=name;
+         constr_fields=List.map (fun (field_name, field_sort, field_projectible) -> {field_name; field_sort; field_projectible}) fields;
+         constr_sort=sort;
+         constr_id=Some id }
+   in
+   let constrs : constructors = 
+     List.map as_constr
+       [("FString_const", ["FString_const_proj_0", Int_sort, true], String_sort, 0, true);
+        ("Tm_type",  [], Term_sort, 2, true);
+        ("Tm_arrow", [("Tm_arrow_id", Int_sort, true)],  Term_sort, 3, false);
+        ("Tm_unit",  [], Term_sort, 6, true);
+        (fst boxIntFun,     [snd boxIntFun,  Int_sort, true],   Term_sort, 7, true);
+        (fst boxBoolFun,    [snd boxBoolFun, Bool_sort, true],  Term_sort, 8, true);
+        (fst boxStringFun,  [snd boxStringFun, String_sort, true], Term_sort, 9, true);
+        (fst boxRealFun,    [snd boxRealFun, Sort "Real", true], Term_sort, 10, true)] in
    let bcons = constrs |> List.collect (constructor_to_decl norng)
                        |> List.map (declToSmt z3options) |> String.concat "\n" in
 
@@ -947,9 +964,13 @@ let declToSmt_no_caps z3options decl = declToSmt' false z3options decl
    I am computing them based on the size in this not very robust way.
    z3options are only used by the prelude so passing the empty string should be ok. *)
 let mkBvConstructor (sz : int) =
-    (fst (boxBitVecFun sz),
-        [snd (boxBitVecFun sz), BitVec_sort sz, true], Term_sort, 12+sz, true)
-    |> constructor_to_decl norng
+  let constr : constructor_t = {
+    constr_name=fst (boxBitVecFun sz);
+    constr_sort=Term_sort;
+    constr_id=None;
+    constr_fields=[{field_projectible=true; field_name=snd (boxBitVecFun sz); field_sort=BitVec_sort sz }]
+  } in
+  constructor_to_decl norng constr
 
 let __range_c = BU.mk_ref 0
 let mk_Range_const () =

--- a/src/smtencoding/FStar.SMTEncoding.Term.fsti
+++ b/src/smtencoding/FStar.SMTEncoding.Term.fsti
@@ -264,7 +264,7 @@ val fresh_token: (string * sort) -> int -> decl
 val fresh_constructor : Range.range -> (string * list sort * sort * int) -> decl
 //val constructor_to_decl_aux: bool -> constructor_t -> decls_t
 val constructor_to_decl: Range.range -> constructor_t -> list decl
-val mkBvConstructor: int -> list decl
+val mkBvConstructor: int -> list decl & string & string
 val declToSmt: string -> decl -> string
 val declToSmt_no_caps: string -> decl -> string
 

--- a/src/smtencoding/FStar.SMTEncoding.Term.fsti
+++ b/src/smtencoding/FStar.SMTEncoding.Term.fsti
@@ -93,10 +93,18 @@ and fvs = list fv
 
 type caption = option string
 type binders = list (string * sort)
-type constructor_field = string  //name of the field
-                       * sort    //sort of the field
-                       * bool    //true if the field is projectible
-type constructor_t = (string * list constructor_field * sort * int * bool)
+type constructor_field = {
+  field_name:string;  //name of the field
+  field_sort:sort;    //sort of the field
+  field_projectible:bool//true if the field is projectible
+}
+type constructor_t = {
+  constr_name:string;
+  constr_fields:list constructor_field;
+  constr_sort:sort;
+  constr_id:option int; //Some i, if a term whose head is this constructor is distinct from 
+               //terms with other head constructors
+}
 type constructors  = list constructor_t
 type fact_db_id =
     | Name of Ident.lid

--- a/tests/micro-benchmarks/BoxBitVec.fst
+++ b/tests/micro-benchmarks/BoxBitVec.fst
@@ -1,0 +1,6 @@
+module BoxBitVec
+module U = FStar.UInt
+module BV = FStar.BV
+open FStar.BV
+let test (x:BV.bv_t 3) = BV.bvdiv x 1
+let bv_trivial (input_x : BV.bv_t 3) = assert (BV.bvdiv input_x 1 == input_x)

--- a/ulib/prims.fst
+++ b/ulib/prims.fst
@@ -708,4 +708,4 @@ val string_of_int: int -> Tot string
 (** THIS IS MEANT TO BE KEPT IN SYNC WITH FStar.CheckedFiles.fs
     Incrementing this forces all .checked files to be invalidated *)
 irreducible
-let __cache_version_number__ = 59
+let __cache_version_number__ = 60


### PR DESCRIPTION
Thanks to @bollu for reporting that this simple program fails to check:
```
let bv_trivial (input_x : BV.bv_t 3) = assert (BV.bvdiv input_x 1 == input_x)
```

The problem is that when encoded to SMT, the goal looks something like

```
(BoxBitVec_3 (bvdiv (UnboxBitVec_3 x) (bv2int 1))) = x)
```

This fails, because the encoding doesn't let us prove that (BoxBitVec_3 (UnboxBitVec3 x) == x)

I have now added a typing inversion axiom of the form, for constants N:

```
(forall ((x Term)) (implies (HasType x (FStar.BV.t N)) (is-BoxBitVec_N x)))
```

I also removed what seems like a dangerous axiom saying that the BoxBitVec constructor is fresh, i.e., we had `Term_constr_id (BoxBitVec_N x) == 12 + n`, where 12 was an arbitrary offset from some known constants. This is now gone.

Along the way, I refactored, without any semantic change, the API for encoding constructors to SMT.