### PR TITLE
tactics: exposing ext_options/all_ext_options

### DIFF
--- a/ocaml/fstar-lib/FStar_Tactics_V2_Builtins.ml
+++ b/ocaml/fstar-lib/FStar_Tactics_V2_Builtins.ml
@@ -131,6 +131,8 @@ let get_vconfig             = from_tac_1 "B.get_vconfig" B.get_vconfig
 let set_vconfig             = from_tac_1 "B.set_vconfig" B.set_vconfig
 let t_smt_sync              = from_tac_1 "B.t_smt_sync" B.t_smt_sync
 let free_uvars              = from_tac_1 "B.free_uvars" B.free_uvars
+let ext_options             = from_tac_1 "B.ext_options" B.ext_options
+let all_ext_options         = from_tac_1 "B.all_ext_options" B.all_ext_options
 
 
 type ('env, 't) prop_validity_token = unit

--- a/ocaml/fstar-lib/FStar_Tactics_V2_Builtins.ml
+++ b/ocaml/fstar-lib/FStar_Tactics_V2_Builtins.ml
@@ -131,9 +131,9 @@ let get_vconfig             = from_tac_1 "B.get_vconfig" B.get_vconfig
 let set_vconfig             = from_tac_1 "B.set_vconfig" B.set_vconfig
 let t_smt_sync              = from_tac_1 "B.t_smt_sync" B.t_smt_sync
 let free_uvars              = from_tac_1 "B.free_uvars" B.free_uvars
-let ext_options             = from_tac_1 "B.ext_options" B.ext_options
 let all_ext_options         = from_tac_1 "B.all_ext_options" B.all_ext_options
-
+let ext_getv                = from_tac_1 "B.ext_getv" B.ext_getv
+let ext_getns               = from_tac_1 "B.ext_getns" B.ext_getns
 
 type ('env, 't) prop_validity_token = unit
 type ('env, 'sc, 't, 'pats, 'bnds) match_complete_token = unit

--- a/ocaml/fstar-lib/generated/FStar_SMTEncoding_Encode.ml
+++ b/ocaml/fstar-lib/generated/FStar_SMTEncoding_Encode.ml
@@ -5863,11 +5863,10 @@ and (encode_sigelt' :
                                                                     =
                                                                     let uu___41
                                                                     =
-                                                                    FStar_Options.ext_options
-                                                                    "compat" in
-                                                                    FStar_Compiler_List.mem
-                                                                    "2954"
-                                                                    uu___41 in
+                                                                    FStar_Options.ext_getv
+                                                                    "compat:2954" in
+                                                                    uu___41
+                                                                    <> "" in
                                                                     if
                                                                     uu___40
                                                                     then
@@ -5884,11 +5883,10 @@ and (encode_sigelt' :
                                                                     =
                                                                     let uu___40
                                                                     =
-                                                                    FStar_Options.ext_options
-                                                                    "compat" in
-                                                                    FStar_Compiler_List.mem
-                                                                    "2954"
-                                                                    uu___40 in
+                                                                    FStar_Options.ext_getv
+                                                                    "compat:2954" in
+                                                                    uu___40
+                                                                    <> "" in
                                                                     if
                                                                     uu___39
                                                                     then
@@ -6622,11 +6620,10 @@ and (encode_sigelt' :
                                                                     =
                                                                     let uu___37
                                                                     =
-                                                                    FStar_Options.ext_options
-                                                                    "compat" in
-                                                                    FStar_Compiler_List.mem
-                                                                    "2954"
-                                                                    uu___37 in
+                                                                    FStar_Options.ext_getv
+                                                                    "compat:2954" in
+                                                                    uu___37
+                                                                    <> "" in
                                                                     if
                                                                     uu___36
                                                                     then
@@ -6643,11 +6640,10 @@ and (encode_sigelt' :
                                                                     =
                                                                     let uu___36
                                                                     =
-                                                                    FStar_Options.ext_options
-                                                                    "compat" in
-                                                                    FStar_Compiler_List.mem
-                                                                    "2954"
-                                                                    uu___36 in
+                                                                    FStar_Options.ext_getv
+                                                                    "compat:2954" in
+                                                                    uu___36
+                                                                    <> "" in
                                                                     if
                                                                     uu___35
                                                                     then

--- a/ocaml/fstar-lib/generated/FStar_Tactics_V2_Basic.ml
+++ b/ocaml/fstar-lib/generated/FStar_Tactics_V2_Basic.ml
@@ -6787,13 +6787,6 @@ let (free_uvars :
                        u.FStar_Syntax_Syntax.ctx_uvar_head in
                    FStar_BigInt.of_int_fs uu___2)) in
          FStar_Tactics_Monad.ret uvs)
-let (ext_options :
-  Prims.string -> Prims.string Prims.list FStar_Tactics_Monad.tac) =
-  fun ext ->
-    FStar_Tactics_Monad.op_let_Bang FStar_Tactics_Monad.idtac
-      (fun uu___ ->
-         let uu___1 = FStar_Options.ext_options ext in
-         FStar_Tactics_Monad.ret uu___1)
 let (all_ext_options :
   unit -> (Prims.string * Prims.string) Prims.list FStar_Tactics_Monad.tac) =
   fun uu___ ->
@@ -6801,6 +6794,21 @@ let (all_ext_options :
       (fun uu___1 ->
          let uu___2 = FStar_Options.all_ext_options () in
          FStar_Tactics_Monad.ret uu___2)
+let (ext_getv : Prims.string -> Prims.string FStar_Tactics_Monad.tac) =
+  fun k ->
+    FStar_Tactics_Monad.op_let_Bang FStar_Tactics_Monad.idtac
+      (fun uu___ ->
+         let uu___1 = FStar_Options.ext_getv k in
+         FStar_Tactics_Monad.ret uu___1)
+let (ext_getns :
+  Prims.string ->
+    (Prims.string * Prims.string) Prims.list FStar_Tactics_Monad.tac)
+  =
+  fun ns ->
+    FStar_Tactics_Monad.op_let_Bang FStar_Tactics_Monad.idtac
+      (fun uu___ ->
+         let uu___1 = FStar_Options.ext_getns ns in
+         FStar_Tactics_Monad.ret uu___1)
 let (dbg_refl : env -> (unit -> Prims.string) -> unit) =
   fun g ->
     fun msg ->

--- a/ocaml/fstar-lib/generated/FStar_Tactics_V2_Basic.ml
+++ b/ocaml/fstar-lib/generated/FStar_Tactics_V2_Basic.ml
@@ -6787,6 +6787,20 @@ let (free_uvars :
                        u.FStar_Syntax_Syntax.ctx_uvar_head in
                    FStar_BigInt.of_int_fs uu___2)) in
          FStar_Tactics_Monad.ret uvs)
+let (ext_options :
+  Prims.string -> Prims.string Prims.list FStar_Tactics_Monad.tac) =
+  fun ext ->
+    FStar_Tactics_Monad.op_let_Bang FStar_Tactics_Monad.idtac
+      (fun uu___ ->
+         let uu___1 = FStar_Options.ext_options ext in
+         FStar_Tactics_Monad.ret uu___1)
+let (all_ext_options :
+  unit -> (Prims.string * Prims.string) Prims.list FStar_Tactics_Monad.tac) =
+  fun uu___ ->
+    FStar_Tactics_Monad.op_let_Bang FStar_Tactics_Monad.idtac
+      (fun uu___1 ->
+         let uu___2 = FStar_Options.all_ext_options () in
+         FStar_Tactics_Monad.ret uu___2)
 let (dbg_refl : env -> (unit -> Prims.string) -> unit) =
   fun g ->
     fun msg ->

--- a/ocaml/fstar-lib/generated/FStar_Tactics_V2_Interpreter.ml
+++ b/ocaml/fstar-lib/generated/FStar_Tactics_V2_Interpreter.ml
@@ -1764,40 +1764,20 @@ let (uu___193 : unit) =
                                                                     =
                                                                     let uu___167
                                                                     =
-                                                                    let uu___168
-                                                                    =
-                                                                    FStar_Syntax_Embeddings.e_option
-                                                                    FStar_Syntax_Embeddings.e_unit in
-                                                                    let uu___169
-                                                                    =
                                                                     FStar_Syntax_Embeddings.e_list
-                                                                    FStar_Syntax_Embeddings.e_issue in
-                                                                    FStar_Syntax_Embeddings.e_tuple2
-                                                                    uu___168
-                                                                    uu___169 in
+                                                                    FStar_Syntax_Embeddings.e_string in
                                                                     let uu___168
-                                                                    =
-                                                                    let uu___169
-                                                                    =
-                                                                    FStar_TypeChecker_NBETerm.e_option
-                                                                    FStar_TypeChecker_NBETerm.e_unit in
-                                                                    let uu___170
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.e_list
-                                                                    FStar_TypeChecker_NBETerm.e_issue in
-                                                                    FStar_TypeChecker_NBETerm.e_tuple2
-                                                                    uu___169
-                                                                    uu___170 in
-                                                                    FStar_Tactics_V2_InterpFuns.mk_tac_step_2
+                                                                    FStar_TypeChecker_NBETerm.e_string in
+                                                                    FStar_Tactics_V2_InterpFuns.mk_tac_step_1
                                                                     Prims.int_zero
-                                                                    "is_non_informative"
-                                                                    FStar_Tactics_V2_Basic.refl_is_non_informative
-                                                                    FStar_Reflection_V2_Embeddings.e_env
-                                                                    FStar_Reflection_V2_Embeddings.e_term
+                                                                    "ext_options"
+                                                                    FStar_Tactics_V2_Basic.ext_options
+                                                                    FStar_Syntax_Embeddings.e_string
                                                                     uu___167
-                                                                    FStar_Tactics_V2_Basic.refl_is_non_informative
-                                                                    FStar_Reflection_V2_NBEEmbeddings.e_env
-                                                                    FStar_Reflection_V2_NBEEmbeddings.e_term
+                                                                    FStar_Tactics_V2_Basic.ext_options
+                                                                    FStar_TypeChecker_NBETerm.e_string
                                                                     uu___168 in
                                                                     let uu___167
                                                                     =
@@ -1807,40 +1787,28 @@ let (uu___193 : unit) =
                                                                     =
                                                                     let uu___170
                                                                     =
-                                                                    FStar_Syntax_Embeddings.e_option
-                                                                    FStar_Syntax_Embeddings.e_unit in
-                                                                    let uu___171
-                                                                    =
-                                                                    FStar_Syntax_Embeddings.e_list
-                                                                    FStar_Syntax_Embeddings.e_issue in
                                                                     FStar_Syntax_Embeddings.e_tuple2
-                                                                    uu___170
-                                                                    uu___171 in
+                                                                    FStar_Syntax_Embeddings.e_string
+                                                                    FStar_Syntax_Embeddings.e_string in
+                                                                    FStar_Syntax_Embeddings.e_list
+                                                                    uu___170 in
                                                                     let uu___170
                                                                     =
                                                                     let uu___171
                                                                     =
-                                                                    FStar_TypeChecker_NBETerm.e_option
-                                                                    FStar_TypeChecker_NBETerm.e_unit in
-                                                                    let uu___172
-                                                                    =
-                                                                    FStar_TypeChecker_NBETerm.e_list
-                                                                    FStar_TypeChecker_NBETerm.e_issue in
                                                                     FStar_TypeChecker_NBETerm.e_tuple2
-                                                                    uu___171
-                                                                    uu___172 in
-                                                                    FStar_Tactics_V2_InterpFuns.mk_tac_step_3
+                                                                    FStar_TypeChecker_NBETerm.e_string
+                                                                    FStar_TypeChecker_NBETerm.e_string in
+                                                                    FStar_TypeChecker_NBETerm.e_list
+                                                                    uu___171 in
+                                                                    FStar_Tactics_V2_InterpFuns.mk_tac_step_1
                                                                     Prims.int_zero
-                                                                    "check_subtyping"
-                                                                    FStar_Tactics_V2_Basic.refl_check_subtyping
-                                                                    FStar_Reflection_V2_Embeddings.e_env
-                                                                    FStar_Reflection_V2_Embeddings.e_term
-                                                                    FStar_Reflection_V2_Embeddings.e_term
+                                                                    "all_ext_options"
+                                                                    FStar_Tactics_V2_Basic.all_ext_options
+                                                                    FStar_Syntax_Embeddings.e_unit
                                                                     uu___169
-                                                                    FStar_Tactics_V2_Basic.refl_check_subtyping
-                                                                    FStar_Reflection_V2_NBEEmbeddings.e_env
-                                                                    FStar_Reflection_V2_NBEEmbeddings.e_term
-                                                                    FStar_Reflection_V2_NBEEmbeddings.e_term
+                                                                    FStar_Tactics_V2_Basic.all_ext_options
+                                                                    FStar_TypeChecker_NBETerm.e_unit
                                                                     uu___170 in
                                                                     let uu___169
                                                                     =
@@ -1872,17 +1840,15 @@ let (uu___193 : unit) =
                                                                     FStar_TypeChecker_NBETerm.e_tuple2
                                                                     uu___173
                                                                     uu___174 in
-                                                                    FStar_Tactics_V2_InterpFuns.mk_tac_step_3
+                                                                    FStar_Tactics_V2_InterpFuns.mk_tac_step_2
                                                                     Prims.int_zero
-                                                                    "check_equiv"
-                                                                    FStar_Tactics_V2_Basic.refl_check_equiv
+                                                                    "is_non_informative"
+                                                                    FStar_Tactics_V2_Basic.refl_is_non_informative
                                                                     FStar_Reflection_V2_Embeddings.e_env
                                                                     FStar_Reflection_V2_Embeddings.e_term
-                                                                    FStar_Reflection_V2_Embeddings.e_term
                                                                     uu___171
-                                                                    FStar_Tactics_V2_Basic.refl_check_equiv
+                                                                    FStar_Tactics_V2_Basic.refl_is_non_informative
                                                                     FStar_Reflection_V2_NBEEmbeddings.e_env
-                                                                    FStar_Reflection_V2_NBEEmbeddings.e_term
                                                                     FStar_Reflection_V2_NBEEmbeddings.e_term
                                                                     uu___172 in
                                                                     let uu___171
@@ -1893,13 +1859,8 @@ let (uu___193 : unit) =
                                                                     =
                                                                     let uu___174
                                                                     =
-                                                                    let uu___175
-                                                                    =
-                                                                    FStar_Syntax_Embeddings.e_tuple2
-                                                                    FStar_Tactics_Embedding.e_tot_or_ghost
-                                                                    FStar_Reflection_V2_Embeddings.e_term in
                                                                     FStar_Syntax_Embeddings.e_option
-                                                                    uu___175 in
+                                                                    FStar_Syntax_Embeddings.e_unit in
                                                                     let uu___175
                                                                     =
                                                                     FStar_Syntax_Embeddings.e_list
@@ -1911,13 +1872,8 @@ let (uu___193 : unit) =
                                                                     =
                                                                     let uu___175
                                                                     =
-                                                                    let uu___176
-                                                                    =
-                                                                    FStar_TypeChecker_NBETerm.e_tuple2
-                                                                    FStar_Tactics_Embedding.e_tot_or_ghost_nbe
-                                                                    FStar_Reflection_V2_NBEEmbeddings.e_term in
                                                                     FStar_TypeChecker_NBETerm.e_option
-                                                                    uu___176 in
+                                                                    FStar_TypeChecker_NBETerm.e_unit in
                                                                     let uu___176
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.e_list
@@ -1925,15 +1881,17 @@ let (uu___193 : unit) =
                                                                     FStar_TypeChecker_NBETerm.e_tuple2
                                                                     uu___175
                                                                     uu___176 in
-                                                                    FStar_Tactics_V2_InterpFuns.mk_tac_step_2
+                                                                    FStar_Tactics_V2_InterpFuns.mk_tac_step_3
                                                                     Prims.int_zero
-                                                                    "core_compute_term_type"
-                                                                    FStar_Tactics_V2_Basic.refl_core_compute_term_type
+                                                                    "check_subtyping"
+                                                                    FStar_Tactics_V2_Basic.refl_check_subtyping
                                                                     FStar_Reflection_V2_Embeddings.e_env
                                                                     FStar_Reflection_V2_Embeddings.e_term
+                                                                    FStar_Reflection_V2_Embeddings.e_term
                                                                     uu___173
-                                                                    FStar_Tactics_V2_Basic.refl_core_compute_term_type
+                                                                    FStar_Tactics_V2_Basic.refl_check_subtyping
                                                                     FStar_Reflection_V2_NBEEmbeddings.e_env
+                                                                    FStar_Reflection_V2_NBEEmbeddings.e_term
                                                                     FStar_Reflection_V2_NBEEmbeddings.e_term
                                                                     uu___174 in
                                                                     let uu___173
@@ -1966,20 +1924,18 @@ let (uu___193 : unit) =
                                                                     FStar_TypeChecker_NBETerm.e_tuple2
                                                                     uu___177
                                                                     uu___178 in
-                                                                    FStar_Tactics_V2_InterpFuns.mk_tac_step_4
+                                                                    FStar_Tactics_V2_InterpFuns.mk_tac_step_3
                                                                     Prims.int_zero
-                                                                    "core_check_term"
-                                                                    FStar_Tactics_V2_Basic.refl_core_check_term
+                                                                    "check_equiv"
+                                                                    FStar_Tactics_V2_Basic.refl_check_equiv
                                                                     FStar_Reflection_V2_Embeddings.e_env
                                                                     FStar_Reflection_V2_Embeddings.e_term
                                                                     FStar_Reflection_V2_Embeddings.e_term
-                                                                    FStar_Tactics_Embedding.e_tot_or_ghost
                                                                     uu___175
-                                                                    FStar_Tactics_V2_Basic.refl_core_check_term
+                                                                    FStar_Tactics_V2_Basic.refl_check_equiv
                                                                     FStar_Reflection_V2_NBEEmbeddings.e_env
                                                                     FStar_Reflection_V2_NBEEmbeddings.e_term
                                                                     FStar_Reflection_V2_NBEEmbeddings.e_term
-                                                                    FStar_Tactics_Embedding.e_tot_or_ghost_nbe
                                                                     uu___176 in
                                                                     let uu___175
                                                                     =
@@ -1991,14 +1947,9 @@ let (uu___193 : unit) =
                                                                     =
                                                                     let uu___179
                                                                     =
-                                                                    let uu___180
-                                                                    =
                                                                     FStar_Syntax_Embeddings.e_tuple2
                                                                     FStar_Tactics_Embedding.e_tot_or_ghost
                                                                     FStar_Reflection_V2_Embeddings.e_term in
-                                                                    FStar_Syntax_Embeddings.e_tuple2
-                                                                    FStar_Reflection_V2_Embeddings.e_term
-                                                                    uu___180 in
                                                                     FStar_Syntax_Embeddings.e_option
                                                                     uu___179 in
                                                                     let uu___179
@@ -2014,14 +1965,9 @@ let (uu___193 : unit) =
                                                                     =
                                                                     let uu___180
                                                                     =
-                                                                    let uu___181
-                                                                    =
                                                                     FStar_TypeChecker_NBETerm.e_tuple2
                                                                     FStar_Tactics_Embedding.e_tot_or_ghost_nbe
                                                                     FStar_Reflection_V2_NBEEmbeddings.e_term in
-                                                                    FStar_TypeChecker_NBETerm.e_tuple2
-                                                                    FStar_Reflection_V2_NBEEmbeddings.e_term
-                                                                    uu___181 in
                                                                     FStar_TypeChecker_NBETerm.e_option
                                                                     uu___180 in
                                                                     let uu___180
@@ -2033,12 +1979,12 @@ let (uu___193 : unit) =
                                                                     uu___180 in
                                                                     FStar_Tactics_V2_InterpFuns.mk_tac_step_2
                                                                     Prims.int_zero
-                                                                    "tc_term"
-                                                                    FStar_Tactics_V2_Basic.refl_tc_term
+                                                                    "core_compute_term_type"
+                                                                    FStar_Tactics_V2_Basic.refl_core_compute_term_type
                                                                     FStar_Reflection_V2_Embeddings.e_env
                                                                     FStar_Reflection_V2_Embeddings.e_term
                                                                     uu___177
-                                                                    FStar_Tactics_V2_Basic.refl_tc_term
+                                                                    FStar_Tactics_V2_Basic.refl_core_compute_term_type
                                                                     FStar_Reflection_V2_NBEEmbeddings.e_env
                                                                     FStar_Reflection_V2_NBEEmbeddings.e_term
                                                                     uu___178 in
@@ -2051,7 +1997,7 @@ let (uu___193 : unit) =
                                                                     let uu___180
                                                                     =
                                                                     FStar_Syntax_Embeddings.e_option
-                                                                    FStar_Reflection_V2_Embeddings.e_universe in
+                                                                    FStar_Syntax_Embeddings.e_unit in
                                                                     let uu___181
                                                                     =
                                                                     FStar_Syntax_Embeddings.e_list
@@ -2064,7 +2010,7 @@ let (uu___193 : unit) =
                                                                     let uu___181
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.e_option
-                                                                    FStar_Reflection_V2_NBEEmbeddings.e_universe in
+                                                                    FStar_TypeChecker_NBETerm.e_unit in
                                                                     let uu___182
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.e_list
@@ -2072,16 +2018,20 @@ let (uu___193 : unit) =
                                                                     FStar_TypeChecker_NBETerm.e_tuple2
                                                                     uu___181
                                                                     uu___182 in
-                                                                    FStar_Tactics_V2_InterpFuns.mk_tac_step_2
+                                                                    FStar_Tactics_V2_InterpFuns.mk_tac_step_4
                                                                     Prims.int_zero
-                                                                    "universe_of"
-                                                                    FStar_Tactics_V2_Basic.refl_universe_of
+                                                                    "core_check_term"
+                                                                    FStar_Tactics_V2_Basic.refl_core_check_term
                                                                     FStar_Reflection_V2_Embeddings.e_env
                                                                     FStar_Reflection_V2_Embeddings.e_term
+                                                                    FStar_Reflection_V2_Embeddings.e_term
+                                                                    FStar_Tactics_Embedding.e_tot_or_ghost
                                                                     uu___179
-                                                                    FStar_Tactics_V2_Basic.refl_universe_of
+                                                                    FStar_Tactics_V2_Basic.refl_core_check_term
                                                                     FStar_Reflection_V2_NBEEmbeddings.e_env
                                                                     FStar_Reflection_V2_NBEEmbeddings.e_term
+                                                                    FStar_Reflection_V2_NBEEmbeddings.e_term
+                                                                    FStar_Tactics_Embedding.e_tot_or_ghost_nbe
                                                                     uu___180 in
                                                                     let uu___179
                                                                     =
@@ -2091,8 +2041,18 @@ let (uu___193 : unit) =
                                                                     =
                                                                     let uu___182
                                                                     =
+                                                                    let uu___183
+                                                                    =
+                                                                    let uu___184
+                                                                    =
+                                                                    FStar_Syntax_Embeddings.e_tuple2
+                                                                    FStar_Tactics_Embedding.e_tot_or_ghost
+                                                                    FStar_Reflection_V2_Embeddings.e_term in
+                                                                    FStar_Syntax_Embeddings.e_tuple2
+                                                                    FStar_Reflection_V2_Embeddings.e_term
+                                                                    uu___184 in
                                                                     FStar_Syntax_Embeddings.e_option
-                                                                    FStar_Syntax_Embeddings.e_unit in
+                                                                    uu___183 in
                                                                     let uu___183
                                                                     =
                                                                     FStar_Syntax_Embeddings.e_list
@@ -2104,8 +2064,18 @@ let (uu___193 : unit) =
                                                                     =
                                                                     let uu___183
                                                                     =
+                                                                    let uu___184
+                                                                    =
+                                                                    let uu___185
+                                                                    =
+                                                                    FStar_TypeChecker_NBETerm.e_tuple2
+                                                                    FStar_Tactics_Embedding.e_tot_or_ghost_nbe
+                                                                    FStar_Reflection_V2_NBEEmbeddings.e_term in
+                                                                    FStar_TypeChecker_NBETerm.e_tuple2
+                                                                    FStar_Reflection_V2_NBEEmbeddings.e_term
+                                                                    uu___185 in
                                                                     FStar_TypeChecker_NBETerm.e_option
-                                                                    FStar_TypeChecker_NBETerm.e_unit in
+                                                                    uu___184 in
                                                                     let uu___184
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.e_list
@@ -2115,12 +2085,12 @@ let (uu___193 : unit) =
                                                                     uu___184 in
                                                                     FStar_Tactics_V2_InterpFuns.mk_tac_step_2
                                                                     Prims.int_zero
-                                                                    "check_prop_validity"
-                                                                    FStar_Tactics_V2_Basic.refl_check_prop_validity
+                                                                    "tc_term"
+                                                                    FStar_Tactics_V2_Basic.refl_tc_term
                                                                     FStar_Reflection_V2_Embeddings.e_env
                                                                     FStar_Reflection_V2_Embeddings.e_term
                                                                     uu___181
-                                                                    FStar_Tactics_V2_Basic.refl_check_prop_validity
+                                                                    FStar_Tactics_V2_Basic.refl_tc_term
                                                                     FStar_Reflection_V2_NBEEmbeddings.e_env
                                                                     FStar_Reflection_V2_NBEEmbeddings.e_term
                                                                     uu___182 in
@@ -2130,69 +2100,41 @@ let (uu___193 : unit) =
                                                                     =
                                                                     let uu___183
                                                                     =
+                                                                    let uu___184
+                                                                    =
+                                                                    FStar_Syntax_Embeddings.e_option
+                                                                    FStar_Reflection_V2_Embeddings.e_universe in
+                                                                    let uu___185
+                                                                    =
                                                                     FStar_Syntax_Embeddings.e_list
-                                                                    FStar_Reflection_V2_Embeddings.e_pattern in
+                                                                    FStar_Syntax_Embeddings.e_issue in
+                                                                    FStar_Syntax_Embeddings.e_tuple2
+                                                                    uu___184
+                                                                    uu___185 in
                                                                     let uu___184
                                                                     =
                                                                     let uu___185
                                                                     =
-                                                                    let uu___186
-                                                                    =
-                                                                    FStar_Syntax_Embeddings.e_list
-                                                                    FStar_Reflection_V2_Embeddings.e_pattern in
-                                                                    let uu___187
-                                                                    =
-                                                                    let uu___188
-                                                                    =
-                                                                    FStar_Syntax_Embeddings.e_list
-                                                                    FStar_Reflection_V2_Embeddings.e_binding in
-                                                                    FStar_Syntax_Embeddings.e_list
-                                                                    uu___188 in
-                                                                    FStar_Syntax_Embeddings.e_tuple2
-                                                                    uu___186
-                                                                    uu___187 in
-                                                                    FStar_Syntax_Embeddings.e_option
-                                                                    uu___185 in
-                                                                    let uu___185
-                                                                    =
-                                                                    FStar_TypeChecker_NBETerm.e_list
-                                                                    FStar_Reflection_V2_NBEEmbeddings.e_pattern in
-                                                                    let uu___186
-                                                                    =
-                                                                    let uu___187
-                                                                    =
-                                                                    let uu___188
-                                                                    =
-                                                                    FStar_TypeChecker_NBETerm.e_list
-                                                                    FStar_Reflection_V2_NBEEmbeddings.e_pattern in
-                                                                    let uu___189
-                                                                    =
-                                                                    let uu___190
-                                                                    =
-                                                                    FStar_TypeChecker_NBETerm.e_list
-                                                                    FStar_Reflection_V2_NBEEmbeddings.e_binding in
-                                                                    FStar_TypeChecker_NBETerm.e_list
-                                                                    uu___190 in
-                                                                    FStar_TypeChecker_NBETerm.e_tuple2
-                                                                    uu___188
-                                                                    uu___189 in
                                                                     FStar_TypeChecker_NBETerm.e_option
-                                                                    uu___187 in
-                                                                    FStar_Tactics_V2_InterpFuns.mk_tac_step_4
-                                                                    Prims.int_zero
-                                                                    "check_match_complete"
-                                                                    FStar_Tactics_V2_Basic.refl_check_match_complete
-                                                                    FStar_Reflection_V2_Embeddings.e_env
-                                                                    FStar_Reflection_V2_Embeddings.e_term
-                                                                    FStar_Reflection_V2_Embeddings.e_term
-                                                                    uu___183
-                                                                    uu___184
-                                                                    FStar_Tactics_V2_Basic.refl_check_match_complete
-                                                                    FStar_Reflection_V2_NBEEmbeddings.e_env
-                                                                    FStar_Reflection_V2_NBEEmbeddings.e_term
-                                                                    FStar_Reflection_V2_NBEEmbeddings.e_term
+                                                                    FStar_Reflection_V2_NBEEmbeddings.e_universe in
+                                                                    let uu___186
+                                                                    =
+                                                                    FStar_TypeChecker_NBETerm.e_list
+                                                                    FStar_TypeChecker_NBETerm.e_issue in
+                                                                    FStar_TypeChecker_NBETerm.e_tuple2
                                                                     uu___185
                                                                     uu___186 in
+                                                                    FStar_Tactics_V2_InterpFuns.mk_tac_step_2
+                                                                    Prims.int_zero
+                                                                    "universe_of"
+                                                                    FStar_Tactics_V2_Basic.refl_universe_of
+                                                                    FStar_Reflection_V2_Embeddings.e_env
+                                                                    FStar_Reflection_V2_Embeddings.e_term
+                                                                    uu___183
+                                                                    FStar_Tactics_V2_Basic.refl_universe_of
+                                                                    FStar_Reflection_V2_NBEEmbeddings.e_env
+                                                                    FStar_Reflection_V2_NBEEmbeddings.e_term
+                                                                    uu___184 in
                                                                     let uu___183
                                                                     =
                                                                     let uu___184
@@ -2201,13 +2143,8 @@ let (uu___193 : unit) =
                                                                     =
                                                                     let uu___186
                                                                     =
-                                                                    let uu___187
-                                                                    =
-                                                                    FStar_Syntax_Embeddings.e_tuple2
-                                                                    FStar_Reflection_V2_Embeddings.e_term
-                                                                    FStar_Reflection_V2_Embeddings.e_term in
                                                                     FStar_Syntax_Embeddings.e_option
-                                                                    uu___187 in
+                                                                    FStar_Syntax_Embeddings.e_unit in
                                                                     let uu___187
                                                                     =
                                                                     FStar_Syntax_Embeddings.e_list
@@ -2219,13 +2156,8 @@ let (uu___193 : unit) =
                                                                     =
                                                                     let uu___187
                                                                     =
-                                                                    let uu___188
-                                                                    =
-                                                                    FStar_TypeChecker_NBETerm.e_tuple2
-                                                                    FStar_Reflection_V2_NBEEmbeddings.e_term
-                                                                    FStar_Reflection_V2_NBEEmbeddings.e_term in
                                                                     FStar_TypeChecker_NBETerm.e_option
-                                                                    uu___188 in
+                                                                    FStar_TypeChecker_NBETerm.e_unit in
                                                                     let uu___188
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.e_list
@@ -2235,12 +2167,12 @@ let (uu___193 : unit) =
                                                                     uu___188 in
                                                                     FStar_Tactics_V2_InterpFuns.mk_tac_step_2
                                                                     Prims.int_zero
-                                                                    "instantiate_implicits"
-                                                                    FStar_Tactics_V2_Basic.refl_instantiate_implicits
+                                                                    "check_prop_validity"
+                                                                    FStar_Tactics_V2_Basic.refl_check_prop_validity
                                                                     FStar_Reflection_V2_Embeddings.e_env
                                                                     FStar_Reflection_V2_Embeddings.e_term
                                                                     uu___185
-                                                                    FStar_Tactics_V2_Basic.refl_instantiate_implicits
+                                                                    FStar_Tactics_V2_Basic.refl_check_prop_validity
                                                                     FStar_Reflection_V2_NBEEmbeddings.e_env
                                                                     FStar_Reflection_V2_NBEEmbeddings.e_term
                                                                     uu___186 in
@@ -2250,43 +2182,69 @@ let (uu___193 : unit) =
                                                                     =
                                                                     let uu___187
                                                                     =
-                                                                    let uu___188
-                                                                    =
-                                                                    FStar_Syntax_Embeddings.e_option
-                                                                    FStar_Tactics_Embedding.e_unfold_side in
-                                                                    let uu___189
-                                                                    =
                                                                     FStar_Syntax_Embeddings.e_list
-                                                                    FStar_Syntax_Embeddings.e_issue in
-                                                                    FStar_Syntax_Embeddings.e_tuple2
-                                                                    uu___188
-                                                                    uu___189 in
+                                                                    FStar_Reflection_V2_Embeddings.e_pattern in
                                                                     let uu___188
                                                                     =
                                                                     let uu___189
                                                                     =
-                                                                    FStar_TypeChecker_NBETerm.e_option
-                                                                    FStar_Tactics_Embedding.e_unfold_side_nbe in
                                                                     let uu___190
                                                                     =
+                                                                    FStar_Syntax_Embeddings.e_list
+                                                                    FStar_Reflection_V2_Embeddings.e_pattern in
+                                                                    let uu___191
+                                                                    =
+                                                                    let uu___192
+                                                                    =
+                                                                    FStar_Syntax_Embeddings.e_list
+                                                                    FStar_Reflection_V2_Embeddings.e_binding in
+                                                                    FStar_Syntax_Embeddings.e_list
+                                                                    uu___192 in
+                                                                    FStar_Syntax_Embeddings.e_tuple2
+                                                                    uu___190
+                                                                    uu___191 in
+                                                                    FStar_Syntax_Embeddings.e_option
+                                                                    uu___189 in
+                                                                    let uu___189
+                                                                    =
                                                                     FStar_TypeChecker_NBETerm.e_list
-                                                                    FStar_TypeChecker_NBETerm.e_issue in
+                                                                    FStar_Reflection_V2_NBEEmbeddings.e_pattern in
+                                                                    let uu___190
+                                                                    =
+                                                                    let uu___191
+                                                                    =
+                                                                    let uu___192
+                                                                    =
+                                                                    FStar_TypeChecker_NBETerm.e_list
+                                                                    FStar_Reflection_V2_NBEEmbeddings.e_pattern in
+                                                                    let uu___194
+                                                                    =
+                                                                    let uu___195
+                                                                    =
+                                                                    FStar_TypeChecker_NBETerm.e_list
+                                                                    FStar_Reflection_V2_NBEEmbeddings.e_binding in
+                                                                    FStar_TypeChecker_NBETerm.e_list
+                                                                    uu___195 in
                                                                     FStar_TypeChecker_NBETerm.e_tuple2
-                                                                    uu___189
-                                                                    uu___190 in
-                                                                    FStar_Tactics_V2_InterpFuns.mk_tac_step_3
+                                                                    uu___192
+                                                                    uu___194 in
+                                                                    FStar_TypeChecker_NBETerm.e_option
+                                                                    uu___191 in
+                                                                    FStar_Tactics_V2_InterpFuns.mk_tac_step_4
                                                                     Prims.int_zero
-                                                                    "maybe_relate_after_unfolding"
-                                                                    FStar_Tactics_V2_Basic.refl_maybe_relate_after_unfolding
+                                                                    "check_match_complete"
+                                                                    FStar_Tactics_V2_Basic.refl_check_match_complete
                                                                     FStar_Reflection_V2_Embeddings.e_env
                                                                     FStar_Reflection_V2_Embeddings.e_term
                                                                     FStar_Reflection_V2_Embeddings.e_term
                                                                     uu___187
-                                                                    FStar_Tactics_V2_Basic.refl_maybe_relate_after_unfolding
+                                                                    uu___188
+                                                                    FStar_Tactics_V2_Basic.refl_check_match_complete
                                                                     FStar_Reflection_V2_NBEEmbeddings.e_env
                                                                     FStar_Reflection_V2_NBEEmbeddings.e_term
                                                                     FStar_Reflection_V2_NBEEmbeddings.e_term
-                                                                    uu___188 in
+                                                                    uu___189
+                                                                    uu___190 in
                                                                     let uu___187
                                                                     =
                                                                     let uu___188
@@ -2295,8 +2253,13 @@ let (uu___193 : unit) =
                                                                     =
                                                                     let uu___190
                                                                     =
-                                                                    FStar_Syntax_Embeddings.e_option
+                                                                    let uu___191
+                                                                    =
+                                                                    FStar_Syntax_Embeddings.e_tuple2
+                                                                    FStar_Reflection_V2_Embeddings.e_term
                                                                     FStar_Reflection_V2_Embeddings.e_term in
+                                                                    FStar_Syntax_Embeddings.e_option
+                                                                    uu___191 in
                                                                     let uu___191
                                                                     =
                                                                     FStar_Syntax_Embeddings.e_list
@@ -2308,8 +2271,13 @@ let (uu___193 : unit) =
                                                                     =
                                                                     let uu___191
                                                                     =
-                                                                    FStar_TypeChecker_NBETerm.e_option
+                                                                    let uu___192
+                                                                    =
+                                                                    FStar_TypeChecker_NBETerm.e_tuple2
+                                                                    FStar_Reflection_V2_NBEEmbeddings.e_term
                                                                     FStar_Reflection_V2_NBEEmbeddings.e_term in
+                                                                    FStar_TypeChecker_NBETerm.e_option
+                                                                    uu___192 in
                                                                     let uu___192
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.e_list
@@ -2319,12 +2287,12 @@ let (uu___193 : unit) =
                                                                     uu___192 in
                                                                     FStar_Tactics_V2_InterpFuns.mk_tac_step_2
                                                                     Prims.int_zero
-                                                                    "maybe_unfold_head"
-                                                                    FStar_Tactics_V2_Basic.refl_maybe_unfold_head
+                                                                    "instantiate_implicits"
+                                                                    FStar_Tactics_V2_Basic.refl_instantiate_implicits
                                                                     FStar_Reflection_V2_Embeddings.e_env
                                                                     FStar_Reflection_V2_Embeddings.e_term
                                                                     uu___189
-                                                                    FStar_Tactics_V2_Basic.refl_maybe_unfold_head
+                                                                    FStar_Tactics_V2_Basic.refl_instantiate_implicits
                                                                     FStar_Reflection_V2_NBEEmbeddings.e_env
                                                                     FStar_Reflection_V2_NBEEmbeddings.e_term
                                                                     uu___190 in
@@ -2334,9 +2302,93 @@ let (uu___193 : unit) =
                                                                     =
                                                                     let uu___191
                                                                     =
+                                                                    let uu___192
+                                                                    =
+                                                                    FStar_Syntax_Embeddings.e_option
+                                                                    FStar_Tactics_Embedding.e_unfold_side in
+                                                                    let uu___194
+                                                                    =
+                                                                    FStar_Syntax_Embeddings.e_list
+                                                                    FStar_Syntax_Embeddings.e_issue in
+                                                                    FStar_Syntax_Embeddings.e_tuple2
+                                                                    uu___192
+                                                                    uu___194 in
+                                                                    let uu___192
+                                                                    =
+                                                                    let uu___194
+                                                                    =
+                                                                    FStar_TypeChecker_NBETerm.e_option
+                                                                    FStar_Tactics_Embedding.e_unfold_side_nbe in
+                                                                    let uu___195
+                                                                    =
+                                                                    FStar_TypeChecker_NBETerm.e_list
+                                                                    FStar_TypeChecker_NBETerm.e_issue in
+                                                                    FStar_TypeChecker_NBETerm.e_tuple2
+                                                                    uu___194
+                                                                    uu___195 in
+                                                                    FStar_Tactics_V2_InterpFuns.mk_tac_step_3
+                                                                    Prims.int_zero
+                                                                    "maybe_relate_after_unfolding"
+                                                                    FStar_Tactics_V2_Basic.refl_maybe_relate_after_unfolding
+                                                                    FStar_Reflection_V2_Embeddings.e_env
+                                                                    FStar_Reflection_V2_Embeddings.e_term
+                                                                    FStar_Reflection_V2_Embeddings.e_term
+                                                                    uu___191
+                                                                    FStar_Tactics_V2_Basic.refl_maybe_relate_after_unfolding
+                                                                    FStar_Reflection_V2_NBEEmbeddings.e_env
+                                                                    FStar_Reflection_V2_NBEEmbeddings.e_term
+                                                                    FStar_Reflection_V2_NBEEmbeddings.e_term
+                                                                    uu___192 in
+                                                                    let uu___191
+                                                                    =
+                                                                    let uu___192
+                                                                    =
+                                                                    let uu___194
+                                                                    =
+                                                                    let uu___195
+                                                                    =
+                                                                    FStar_Syntax_Embeddings.e_option
+                                                                    FStar_Reflection_V2_Embeddings.e_term in
+                                                                    let uu___196
+                                                                    =
+                                                                    FStar_Syntax_Embeddings.e_list
+                                                                    FStar_Syntax_Embeddings.e_issue in
+                                                                    FStar_Syntax_Embeddings.e_tuple2
+                                                                    uu___195
+                                                                    uu___196 in
+                                                                    let uu___195
+                                                                    =
+                                                                    let uu___196
+                                                                    =
+                                                                    FStar_TypeChecker_NBETerm.e_option
+                                                                    FStar_Reflection_V2_NBEEmbeddings.e_term in
+                                                                    let uu___197
+                                                                    =
+                                                                    FStar_TypeChecker_NBETerm.e_list
+                                                                    FStar_TypeChecker_NBETerm.e_issue in
+                                                                    FStar_TypeChecker_NBETerm.e_tuple2
+                                                                    uu___196
+                                                                    uu___197 in
+                                                                    FStar_Tactics_V2_InterpFuns.mk_tac_step_2
+                                                                    Prims.int_zero
+                                                                    "maybe_unfold_head"
+                                                                    FStar_Tactics_V2_Basic.refl_maybe_unfold_head
+                                                                    FStar_Reflection_V2_Embeddings.e_env
+                                                                    FStar_Reflection_V2_Embeddings.e_term
+                                                                    uu___194
+                                                                    FStar_Tactics_V2_Basic.refl_maybe_unfold_head
+                                                                    FStar_Reflection_V2_NBEEmbeddings.e_env
+                                                                    FStar_Reflection_V2_NBEEmbeddings.e_term
+                                                                    uu___195 in
+                                                                    let uu___194
+                                                                    =
+                                                                    let uu___195
+                                                                    =
+                                                                    let uu___196
+                                                                    =
                                                                     FStar_Syntax_Embeddings.e_list
                                                                     FStar_Syntax_Embeddings.e_string in
-                                                                    let uu___192
+                                                                    let uu___197
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.e_list
                                                                     FStar_TypeChecker_NBETerm.e_string in
@@ -2345,21 +2397,21 @@ let (uu___193 : unit) =
                                                                     "push_open_namespace"
                                                                     FStar_Tactics_V2_Basic.push_open_namespace
                                                                     FStar_Reflection_V2_Embeddings.e_env
-                                                                    uu___191
+                                                                    uu___196
                                                                     FStar_Reflection_V2_Embeddings.e_env
                                                                     FStar_Tactics_V2_Basic.push_open_namespace
                                                                     FStar_Reflection_V2_NBEEmbeddings.e_env
-                                                                    uu___192
+                                                                    uu___197
                                                                     FStar_Reflection_V2_NBEEmbeddings.e_env in
-                                                                    let uu___191
+                                                                    let uu___196
                                                                     =
-                                                                    let uu___192
+                                                                    let uu___197
                                                                     =
-                                                                    let uu___194
+                                                                    let uu___198
                                                                     =
                                                                     FStar_Syntax_Embeddings.e_list
                                                                     FStar_Syntax_Embeddings.e_string in
-                                                                    let uu___195
+                                                                    let uu___199
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.e_list
                                                                     FStar_TypeChecker_NBETerm.e_string in
@@ -2369,63 +2421,63 @@ let (uu___193 : unit) =
                                                                     FStar_Tactics_V2_Basic.push_module_abbrev
                                                                     FStar_Reflection_V2_Embeddings.e_env
                                                                     FStar_Syntax_Embeddings.e_string
-                                                                    uu___194
+                                                                    uu___198
                                                                     FStar_Reflection_V2_Embeddings.e_env
                                                                     FStar_Tactics_V2_Basic.push_module_abbrev
                                                                     FStar_Reflection_V2_NBEEmbeddings.e_env
                                                                     FStar_TypeChecker_NBETerm.e_string
-                                                                    uu___195
+                                                                    uu___199
                                                                     FStar_Reflection_V2_NBEEmbeddings.e_env in
-                                                                    let uu___194
+                                                                    let uu___198
                                                                     =
-                                                                    let uu___195
+                                                                    let uu___199
                                                                     =
-                                                                    let uu___196
+                                                                    let uu___200
                                                                     =
                                                                     FStar_Syntax_Embeddings.e_list
                                                                     FStar_Syntax_Embeddings.e_string in
-                                                                    let uu___197
+                                                                    let uu___201
                                                                     =
-                                                                    let uu___198
+                                                                    let uu___202
                                                                     =
                                                                     FStar_Syntax_Embeddings.e_either
                                                                     FStar_Reflection_V2_Embeddings.e_bv
                                                                     FStar_Reflection_V2_Embeddings.e_fv in
                                                                     FStar_Syntax_Embeddings.e_option
-                                                                    uu___198 in
-                                                                    let uu___198
+                                                                    uu___202 in
+                                                                    let uu___202
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.e_list
                                                                     FStar_TypeChecker_NBETerm.e_string in
-                                                                    let uu___199
+                                                                    let uu___203
                                                                     =
-                                                                    let uu___200
+                                                                    let uu___204
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.e_either
                                                                     FStar_Reflection_V2_NBEEmbeddings.e_bv
                                                                     FStar_Reflection_V2_NBEEmbeddings.e_fv in
                                                                     FStar_TypeChecker_NBETerm.e_option
-                                                                    uu___200 in
+                                                                    uu___204 in
                                                                     FStar_Tactics_V2_InterpFuns.mk_tac_step_2
                                                                     Prims.int_zero
                                                                     "resolve_name"
                                                                     FStar_Tactics_V2_Basic.resolve_name
                                                                     FStar_Reflection_V2_Embeddings.e_env
-                                                                    uu___196
-                                                                    uu___197
+                                                                    uu___200
+                                                                    uu___201
                                                                     FStar_Tactics_V2_Basic.resolve_name
                                                                     FStar_Reflection_V2_NBEEmbeddings.e_env
-                                                                    uu___198
-                                                                    uu___199 in
-                                                                    let uu___196
+                                                                    uu___202
+                                                                    uu___203 in
+                                                                    let uu___200
                                                                     =
-                                                                    let uu___197
+                                                                    let uu___201
                                                                     =
-                                                                    let uu___198
+                                                                    let uu___202
                                                                     =
                                                                     FStar_Syntax_Embeddings.e_list
                                                                     FStar_Syntax_Embeddings.e_issue in
-                                                                    let uu___199
+                                                                    let uu___203
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.e_list
                                                                     FStar_TypeChecker_NBETerm.e_issue in
@@ -2438,7 +2490,7 @@ let (uu___193 : unit) =
                                                                     is;
                                                                     FStar_Tactics_Monad.ret
                                                                     ())
-                                                                    uu___198
+                                                                    uu___202
                                                                     FStar_Syntax_Embeddings.e_unit
                                                                     (fun is
                                                                     ->
@@ -2446,9 +2498,15 @@ let (uu___193 : unit) =
                                                                     is;
                                                                     FStar_Tactics_Monad.ret
                                                                     ())
-                                                                    uu___199
+                                                                    uu___203
                                                                     FStar_TypeChecker_NBETerm.e_unit in
-                                                                    [uu___197] in
+                                                                    [uu___201] in
+                                                                    uu___199
+                                                                    ::
+                                                                    uu___200 in
+                                                                    uu___197
+                                                                    ::
+                                                                    uu___198 in
                                                                     uu___195
                                                                     ::
                                                                     uu___196 in

--- a/ocaml/fstar-lib/generated/FStar_Tactics_V2_Interpreter.ml
+++ b/ocaml/fstar-lib/generated/FStar_Tactics_V2_Interpreter.ml
@@ -1764,52 +1764,44 @@ let (uu___193 : unit) =
                                                                     =
                                                                     let uu___167
                                                                     =
-                                                                    FStar_Syntax_Embeddings.e_list
-                                                                    FStar_Syntax_Embeddings.e_string in
                                                                     let uu___168
-                                                                    =
-                                                                    FStar_TypeChecker_NBETerm.e_list
-                                                                    FStar_TypeChecker_NBETerm.e_string in
-                                                                    FStar_Tactics_V2_InterpFuns.mk_tac_step_1
-                                                                    Prims.int_zero
-                                                                    "ext_options"
-                                                                    FStar_Tactics_V2_Basic.ext_options
-                                                                    FStar_Syntax_Embeddings.e_string
-                                                                    uu___167
-                                                                    FStar_Tactics_V2_Basic.ext_options
-                                                                    FStar_TypeChecker_NBETerm.e_string
-                                                                    uu___168 in
-                                                                    let uu___167
-                                                                    =
-                                                                    let uu___168
-                                                                    =
-                                                                    let uu___169
-                                                                    =
-                                                                    let uu___170
                                                                     =
                                                                     FStar_Syntax_Embeddings.e_tuple2
                                                                     FStar_Syntax_Embeddings.e_string
                                                                     FStar_Syntax_Embeddings.e_string in
                                                                     FStar_Syntax_Embeddings.e_list
-                                                                    uu___170 in
-                                                                    let uu___170
+                                                                    uu___168 in
+                                                                    let uu___168
                                                                     =
-                                                                    let uu___171
+                                                                    let uu___169
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.e_tuple2
                                                                     FStar_TypeChecker_NBETerm.e_string
                                                                     FStar_TypeChecker_NBETerm.e_string in
                                                                     FStar_TypeChecker_NBETerm.e_list
-                                                                    uu___171 in
+                                                                    uu___169 in
                                                                     FStar_Tactics_V2_InterpFuns.mk_tac_step_1
                                                                     Prims.int_zero
                                                                     "all_ext_options"
                                                                     FStar_Tactics_V2_Basic.all_ext_options
                                                                     FStar_Syntax_Embeddings.e_unit
-                                                                    uu___169
+                                                                    uu___167
                                                                     FStar_Tactics_V2_Basic.all_ext_options
                                                                     FStar_TypeChecker_NBETerm.e_unit
-                                                                    uu___170 in
+                                                                    uu___168 in
+                                                                    let uu___167
+                                                                    =
+                                                                    let uu___168
+                                                                    =
+                                                                    FStar_Tactics_V2_InterpFuns.mk_tac_step_1
+                                                                    Prims.int_zero
+                                                                    "ext_getv"
+                                                                    FStar_Tactics_V2_Basic.ext_getv
+                                                                    FStar_Syntax_Embeddings.e_string
+                                                                    FStar_Syntax_Embeddings.e_string
+                                                                    FStar_Tactics_V2_Basic.ext_getv
+                                                                    FStar_TypeChecker_NBETerm.e_string
+                                                                    FStar_TypeChecker_NBETerm.e_string in
                                                                     let uu___169
                                                                     =
                                                                     let uu___170
@@ -1818,38 +1810,28 @@ let (uu___193 : unit) =
                                                                     =
                                                                     let uu___172
                                                                     =
-                                                                    FStar_Syntax_Embeddings.e_option
-                                                                    FStar_Syntax_Embeddings.e_unit in
-                                                                    let uu___173
-                                                                    =
-                                                                    FStar_Syntax_Embeddings.e_list
-                                                                    FStar_Syntax_Embeddings.e_issue in
                                                                     FStar_Syntax_Embeddings.e_tuple2
-                                                                    uu___172
-                                                                    uu___173 in
+                                                                    FStar_Syntax_Embeddings.e_string
+                                                                    FStar_Syntax_Embeddings.e_string in
+                                                                    FStar_Syntax_Embeddings.e_list
+                                                                    uu___172 in
                                                                     let uu___172
                                                                     =
                                                                     let uu___173
                                                                     =
-                                                                    FStar_TypeChecker_NBETerm.e_option
-                                                                    FStar_TypeChecker_NBETerm.e_unit in
-                                                                    let uu___174
-                                                                    =
-                                                                    FStar_TypeChecker_NBETerm.e_list
-                                                                    FStar_TypeChecker_NBETerm.e_issue in
                                                                     FStar_TypeChecker_NBETerm.e_tuple2
-                                                                    uu___173
-                                                                    uu___174 in
-                                                                    FStar_Tactics_V2_InterpFuns.mk_tac_step_2
+                                                                    FStar_TypeChecker_NBETerm.e_string
+                                                                    FStar_TypeChecker_NBETerm.e_string in
+                                                                    FStar_TypeChecker_NBETerm.e_list
+                                                                    uu___173 in
+                                                                    FStar_Tactics_V2_InterpFuns.mk_tac_step_1
                                                                     Prims.int_zero
-                                                                    "is_non_informative"
-                                                                    FStar_Tactics_V2_Basic.refl_is_non_informative
-                                                                    FStar_Reflection_V2_Embeddings.e_env
-                                                                    FStar_Reflection_V2_Embeddings.e_term
+                                                                    "ext_getns"
+                                                                    FStar_Tactics_V2_Basic.ext_getns
+                                                                    FStar_Syntax_Embeddings.e_string
                                                                     uu___171
-                                                                    FStar_Tactics_V2_Basic.refl_is_non_informative
-                                                                    FStar_Reflection_V2_NBEEmbeddings.e_env
-                                                                    FStar_Reflection_V2_NBEEmbeddings.e_term
+                                                                    FStar_Tactics_V2_Basic.ext_getns
+                                                                    FStar_TypeChecker_NBETerm.e_string
                                                                     uu___172 in
                                                                     let uu___171
                                                                     =
@@ -1881,17 +1863,15 @@ let (uu___193 : unit) =
                                                                     FStar_TypeChecker_NBETerm.e_tuple2
                                                                     uu___175
                                                                     uu___176 in
-                                                                    FStar_Tactics_V2_InterpFuns.mk_tac_step_3
+                                                                    FStar_Tactics_V2_InterpFuns.mk_tac_step_2
                                                                     Prims.int_zero
-                                                                    "check_subtyping"
-                                                                    FStar_Tactics_V2_Basic.refl_check_subtyping
+                                                                    "is_non_informative"
+                                                                    FStar_Tactics_V2_Basic.refl_is_non_informative
                                                                     FStar_Reflection_V2_Embeddings.e_env
                                                                     FStar_Reflection_V2_Embeddings.e_term
-                                                                    FStar_Reflection_V2_Embeddings.e_term
                                                                     uu___173
-                                                                    FStar_Tactics_V2_Basic.refl_check_subtyping
+                                                                    FStar_Tactics_V2_Basic.refl_is_non_informative
                                                                     FStar_Reflection_V2_NBEEmbeddings.e_env
-                                                                    FStar_Reflection_V2_NBEEmbeddings.e_term
                                                                     FStar_Reflection_V2_NBEEmbeddings.e_term
                                                                     uu___174 in
                                                                     let uu___173
@@ -1926,13 +1906,13 @@ let (uu___193 : unit) =
                                                                     uu___178 in
                                                                     FStar_Tactics_V2_InterpFuns.mk_tac_step_3
                                                                     Prims.int_zero
-                                                                    "check_equiv"
-                                                                    FStar_Tactics_V2_Basic.refl_check_equiv
+                                                                    "check_subtyping"
+                                                                    FStar_Tactics_V2_Basic.refl_check_subtyping
                                                                     FStar_Reflection_V2_Embeddings.e_env
                                                                     FStar_Reflection_V2_Embeddings.e_term
                                                                     FStar_Reflection_V2_Embeddings.e_term
                                                                     uu___175
-                                                                    FStar_Tactics_V2_Basic.refl_check_equiv
+                                                                    FStar_Tactics_V2_Basic.refl_check_subtyping
                                                                     FStar_Reflection_V2_NBEEmbeddings.e_env
                                                                     FStar_Reflection_V2_NBEEmbeddings.e_term
                                                                     FStar_Reflection_V2_NBEEmbeddings.e_term
@@ -1945,13 +1925,8 @@ let (uu___193 : unit) =
                                                                     =
                                                                     let uu___178
                                                                     =
-                                                                    let uu___179
-                                                                    =
-                                                                    FStar_Syntax_Embeddings.e_tuple2
-                                                                    FStar_Tactics_Embedding.e_tot_or_ghost
-                                                                    FStar_Reflection_V2_Embeddings.e_term in
                                                                     FStar_Syntax_Embeddings.e_option
-                                                                    uu___179 in
+                                                                    FStar_Syntax_Embeddings.e_unit in
                                                                     let uu___179
                                                                     =
                                                                     FStar_Syntax_Embeddings.e_list
@@ -1963,13 +1938,8 @@ let (uu___193 : unit) =
                                                                     =
                                                                     let uu___179
                                                                     =
-                                                                    let uu___180
-                                                                    =
-                                                                    FStar_TypeChecker_NBETerm.e_tuple2
-                                                                    FStar_Tactics_Embedding.e_tot_or_ghost_nbe
-                                                                    FStar_Reflection_V2_NBEEmbeddings.e_term in
                                                                     FStar_TypeChecker_NBETerm.e_option
-                                                                    uu___180 in
+                                                                    FStar_TypeChecker_NBETerm.e_unit in
                                                                     let uu___180
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.e_list
@@ -1977,15 +1947,17 @@ let (uu___193 : unit) =
                                                                     FStar_TypeChecker_NBETerm.e_tuple2
                                                                     uu___179
                                                                     uu___180 in
-                                                                    FStar_Tactics_V2_InterpFuns.mk_tac_step_2
+                                                                    FStar_Tactics_V2_InterpFuns.mk_tac_step_3
                                                                     Prims.int_zero
-                                                                    "core_compute_term_type"
-                                                                    FStar_Tactics_V2_Basic.refl_core_compute_term_type
+                                                                    "check_equiv"
+                                                                    FStar_Tactics_V2_Basic.refl_check_equiv
                                                                     FStar_Reflection_V2_Embeddings.e_env
                                                                     FStar_Reflection_V2_Embeddings.e_term
+                                                                    FStar_Reflection_V2_Embeddings.e_term
                                                                     uu___177
-                                                                    FStar_Tactics_V2_Basic.refl_core_compute_term_type
+                                                                    FStar_Tactics_V2_Basic.refl_check_equiv
                                                                     FStar_Reflection_V2_NBEEmbeddings.e_env
+                                                                    FStar_Reflection_V2_NBEEmbeddings.e_term
                                                                     FStar_Reflection_V2_NBEEmbeddings.e_term
                                                                     uu___178 in
                                                                     let uu___177
@@ -1996,8 +1968,13 @@ let (uu___193 : unit) =
                                                                     =
                                                                     let uu___180
                                                                     =
+                                                                    let uu___181
+                                                                    =
+                                                                    FStar_Syntax_Embeddings.e_tuple2
+                                                                    FStar_Tactics_Embedding.e_tot_or_ghost
+                                                                    FStar_Reflection_V2_Embeddings.e_term in
                                                                     FStar_Syntax_Embeddings.e_option
-                                                                    FStar_Syntax_Embeddings.e_unit in
+                                                                    uu___181 in
                                                                     let uu___181
                                                                     =
                                                                     FStar_Syntax_Embeddings.e_list
@@ -2009,8 +1986,13 @@ let (uu___193 : unit) =
                                                                     =
                                                                     let uu___181
                                                                     =
+                                                                    let uu___182
+                                                                    =
+                                                                    FStar_TypeChecker_NBETerm.e_tuple2
+                                                                    FStar_Tactics_Embedding.e_tot_or_ghost_nbe
+                                                                    FStar_Reflection_V2_NBEEmbeddings.e_term in
                                                                     FStar_TypeChecker_NBETerm.e_option
-                                                                    FStar_TypeChecker_NBETerm.e_unit in
+                                                                    uu___182 in
                                                                     let uu___182
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.e_list
@@ -2018,20 +2000,16 @@ let (uu___193 : unit) =
                                                                     FStar_TypeChecker_NBETerm.e_tuple2
                                                                     uu___181
                                                                     uu___182 in
-                                                                    FStar_Tactics_V2_InterpFuns.mk_tac_step_4
+                                                                    FStar_Tactics_V2_InterpFuns.mk_tac_step_2
                                                                     Prims.int_zero
-                                                                    "core_check_term"
-                                                                    FStar_Tactics_V2_Basic.refl_core_check_term
+                                                                    "core_compute_term_type"
+                                                                    FStar_Tactics_V2_Basic.refl_core_compute_term_type
                                                                     FStar_Reflection_V2_Embeddings.e_env
                                                                     FStar_Reflection_V2_Embeddings.e_term
-                                                                    FStar_Reflection_V2_Embeddings.e_term
-                                                                    FStar_Tactics_Embedding.e_tot_or_ghost
                                                                     uu___179
-                                                                    FStar_Tactics_V2_Basic.refl_core_check_term
+                                                                    FStar_Tactics_V2_Basic.refl_core_compute_term_type
                                                                     FStar_Reflection_V2_NBEEmbeddings.e_env
                                                                     FStar_Reflection_V2_NBEEmbeddings.e_term
-                                                                    FStar_Reflection_V2_NBEEmbeddings.e_term
-                                                                    FStar_Tactics_Embedding.e_tot_or_ghost_nbe
                                                                     uu___180 in
                                                                     let uu___179
                                                                     =
@@ -2041,18 +2019,8 @@ let (uu___193 : unit) =
                                                                     =
                                                                     let uu___182
                                                                     =
-                                                                    let uu___183
-                                                                    =
-                                                                    let uu___184
-                                                                    =
-                                                                    FStar_Syntax_Embeddings.e_tuple2
-                                                                    FStar_Tactics_Embedding.e_tot_or_ghost
-                                                                    FStar_Reflection_V2_Embeddings.e_term in
-                                                                    FStar_Syntax_Embeddings.e_tuple2
-                                                                    FStar_Reflection_V2_Embeddings.e_term
-                                                                    uu___184 in
                                                                     FStar_Syntax_Embeddings.e_option
-                                                                    uu___183 in
+                                                                    FStar_Syntax_Embeddings.e_unit in
                                                                     let uu___183
                                                                     =
                                                                     FStar_Syntax_Embeddings.e_list
@@ -2064,18 +2032,8 @@ let (uu___193 : unit) =
                                                                     =
                                                                     let uu___183
                                                                     =
-                                                                    let uu___184
-                                                                    =
-                                                                    let uu___185
-                                                                    =
-                                                                    FStar_TypeChecker_NBETerm.e_tuple2
-                                                                    FStar_Tactics_Embedding.e_tot_or_ghost_nbe
-                                                                    FStar_Reflection_V2_NBEEmbeddings.e_term in
-                                                                    FStar_TypeChecker_NBETerm.e_tuple2
-                                                                    FStar_Reflection_V2_NBEEmbeddings.e_term
-                                                                    uu___185 in
                                                                     FStar_TypeChecker_NBETerm.e_option
-                                                                    uu___184 in
+                                                                    FStar_TypeChecker_NBETerm.e_unit in
                                                                     let uu___184
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.e_list
@@ -2083,16 +2041,20 @@ let (uu___193 : unit) =
                                                                     FStar_TypeChecker_NBETerm.e_tuple2
                                                                     uu___183
                                                                     uu___184 in
-                                                                    FStar_Tactics_V2_InterpFuns.mk_tac_step_2
+                                                                    FStar_Tactics_V2_InterpFuns.mk_tac_step_4
                                                                     Prims.int_zero
-                                                                    "tc_term"
-                                                                    FStar_Tactics_V2_Basic.refl_tc_term
+                                                                    "core_check_term"
+                                                                    FStar_Tactics_V2_Basic.refl_core_check_term
                                                                     FStar_Reflection_V2_Embeddings.e_env
                                                                     FStar_Reflection_V2_Embeddings.e_term
+                                                                    FStar_Reflection_V2_Embeddings.e_term
+                                                                    FStar_Tactics_Embedding.e_tot_or_ghost
                                                                     uu___181
-                                                                    FStar_Tactics_V2_Basic.refl_tc_term
+                                                                    FStar_Tactics_V2_Basic.refl_core_check_term
                                                                     FStar_Reflection_V2_NBEEmbeddings.e_env
                                                                     FStar_Reflection_V2_NBEEmbeddings.e_term
+                                                                    FStar_Reflection_V2_NBEEmbeddings.e_term
+                                                                    FStar_Tactics_Embedding.e_tot_or_ghost_nbe
                                                                     uu___182 in
                                                                     let uu___181
                                                                     =
@@ -2102,8 +2064,18 @@ let (uu___193 : unit) =
                                                                     =
                                                                     let uu___184
                                                                     =
+                                                                    let uu___185
+                                                                    =
+                                                                    let uu___186
+                                                                    =
+                                                                    FStar_Syntax_Embeddings.e_tuple2
+                                                                    FStar_Tactics_Embedding.e_tot_or_ghost
+                                                                    FStar_Reflection_V2_Embeddings.e_term in
+                                                                    FStar_Syntax_Embeddings.e_tuple2
+                                                                    FStar_Reflection_V2_Embeddings.e_term
+                                                                    uu___186 in
                                                                     FStar_Syntax_Embeddings.e_option
-                                                                    FStar_Reflection_V2_Embeddings.e_universe in
+                                                                    uu___185 in
                                                                     let uu___185
                                                                     =
                                                                     FStar_Syntax_Embeddings.e_list
@@ -2115,8 +2087,18 @@ let (uu___193 : unit) =
                                                                     =
                                                                     let uu___185
                                                                     =
+                                                                    let uu___186
+                                                                    =
+                                                                    let uu___187
+                                                                    =
+                                                                    FStar_TypeChecker_NBETerm.e_tuple2
+                                                                    FStar_Tactics_Embedding.e_tot_or_ghost_nbe
+                                                                    FStar_Reflection_V2_NBEEmbeddings.e_term in
+                                                                    FStar_TypeChecker_NBETerm.e_tuple2
+                                                                    FStar_Reflection_V2_NBEEmbeddings.e_term
+                                                                    uu___187 in
                                                                     FStar_TypeChecker_NBETerm.e_option
-                                                                    FStar_Reflection_V2_NBEEmbeddings.e_universe in
+                                                                    uu___186 in
                                                                     let uu___186
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.e_list
@@ -2126,12 +2108,12 @@ let (uu___193 : unit) =
                                                                     uu___186 in
                                                                     FStar_Tactics_V2_InterpFuns.mk_tac_step_2
                                                                     Prims.int_zero
-                                                                    "universe_of"
-                                                                    FStar_Tactics_V2_Basic.refl_universe_of
+                                                                    "tc_term"
+                                                                    FStar_Tactics_V2_Basic.refl_tc_term
                                                                     FStar_Reflection_V2_Embeddings.e_env
                                                                     FStar_Reflection_V2_Embeddings.e_term
                                                                     uu___183
-                                                                    FStar_Tactics_V2_Basic.refl_universe_of
+                                                                    FStar_Tactics_V2_Basic.refl_tc_term
                                                                     FStar_Reflection_V2_NBEEmbeddings.e_env
                                                                     FStar_Reflection_V2_NBEEmbeddings.e_term
                                                                     uu___184 in
@@ -2144,7 +2126,7 @@ let (uu___193 : unit) =
                                                                     let uu___186
                                                                     =
                                                                     FStar_Syntax_Embeddings.e_option
-                                                                    FStar_Syntax_Embeddings.e_unit in
+                                                                    FStar_Reflection_V2_Embeddings.e_universe in
                                                                     let uu___187
                                                                     =
                                                                     FStar_Syntax_Embeddings.e_list
@@ -2157,7 +2139,7 @@ let (uu___193 : unit) =
                                                                     let uu___187
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.e_option
-                                                                    FStar_TypeChecker_NBETerm.e_unit in
+                                                                    FStar_Reflection_V2_NBEEmbeddings.e_universe in
                                                                     let uu___188
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.e_list
@@ -2167,12 +2149,12 @@ let (uu___193 : unit) =
                                                                     uu___188 in
                                                                     FStar_Tactics_V2_InterpFuns.mk_tac_step_2
                                                                     Prims.int_zero
-                                                                    "check_prop_validity"
-                                                                    FStar_Tactics_V2_Basic.refl_check_prop_validity
+                                                                    "universe_of"
+                                                                    FStar_Tactics_V2_Basic.refl_universe_of
                                                                     FStar_Reflection_V2_Embeddings.e_env
                                                                     FStar_Reflection_V2_Embeddings.e_term
                                                                     uu___185
-                                                                    FStar_Tactics_V2_Basic.refl_check_prop_validity
+                                                                    FStar_Tactics_V2_Basic.refl_universe_of
                                                                     FStar_Reflection_V2_NBEEmbeddings.e_env
                                                                     FStar_Reflection_V2_NBEEmbeddings.e_term
                                                                     uu___186 in
@@ -2182,54 +2164,95 @@ let (uu___193 : unit) =
                                                                     =
                                                                     let uu___187
                                                                     =
+                                                                    let uu___188
+                                                                    =
+                                                                    FStar_Syntax_Embeddings.e_option
+                                                                    FStar_Syntax_Embeddings.e_unit in
+                                                                    let uu___189
+                                                                    =
                                                                     FStar_Syntax_Embeddings.e_list
-                                                                    FStar_Reflection_V2_Embeddings.e_pattern in
+                                                                    FStar_Syntax_Embeddings.e_issue in
+                                                                    FStar_Syntax_Embeddings.e_tuple2
+                                                                    uu___188
+                                                                    uu___189 in
                                                                     let uu___188
                                                                     =
                                                                     let uu___189
                                                                     =
+                                                                    FStar_TypeChecker_NBETerm.e_option
+                                                                    FStar_TypeChecker_NBETerm.e_unit in
                                                                     let uu___190
+                                                                    =
+                                                                    FStar_TypeChecker_NBETerm.e_list
+                                                                    FStar_TypeChecker_NBETerm.e_issue in
+                                                                    FStar_TypeChecker_NBETerm.e_tuple2
+                                                                    uu___189
+                                                                    uu___190 in
+                                                                    FStar_Tactics_V2_InterpFuns.mk_tac_step_2
+                                                                    Prims.int_zero
+                                                                    "check_prop_validity"
+                                                                    FStar_Tactics_V2_Basic.refl_check_prop_validity
+                                                                    FStar_Reflection_V2_Embeddings.e_env
+                                                                    FStar_Reflection_V2_Embeddings.e_term
+                                                                    uu___187
+                                                                    FStar_Tactics_V2_Basic.refl_check_prop_validity
+                                                                    FStar_Reflection_V2_NBEEmbeddings.e_env
+                                                                    FStar_Reflection_V2_NBEEmbeddings.e_term
+                                                                    uu___188 in
+                                                                    let uu___187
+                                                                    =
+                                                                    let uu___188
+                                                                    =
+                                                                    let uu___189
                                                                     =
                                                                     FStar_Syntax_Embeddings.e_list
                                                                     FStar_Reflection_V2_Embeddings.e_pattern in
+                                                                    let uu___190
+                                                                    =
                                                                     let uu___191
                                                                     =
                                                                     let uu___192
+                                                                    =
+                                                                    FStar_Syntax_Embeddings.e_list
+                                                                    FStar_Reflection_V2_Embeddings.e_pattern in
+                                                                    let uu___194
+                                                                    =
+                                                                    let uu___195
                                                                     =
                                                                     FStar_Syntax_Embeddings.e_list
                                                                     FStar_Reflection_V2_Embeddings.e_binding in
                                                                     FStar_Syntax_Embeddings.e_list
-                                                                    uu___192 in
+                                                                    uu___195 in
                                                                     FStar_Syntax_Embeddings.e_tuple2
-                                                                    uu___190
-                                                                    uu___191 in
+                                                                    uu___192
+                                                                    uu___194 in
                                                                     FStar_Syntax_Embeddings.e_option
-                                                                    uu___189 in
-                                                                    let uu___189
-                                                                    =
-                                                                    FStar_TypeChecker_NBETerm.e_list
-                                                                    FStar_Reflection_V2_NBEEmbeddings.e_pattern in
-                                                                    let uu___190
-                                                                    =
+                                                                    uu___191 in
                                                                     let uu___191
                                                                     =
-                                                                    let uu___192
-                                                                    =
                                                                     FStar_TypeChecker_NBETerm.e_list
                                                                     FStar_Reflection_V2_NBEEmbeddings.e_pattern in
+                                                                    let uu___192
+                                                                    =
                                                                     let uu___194
                                                                     =
                                                                     let uu___195
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.e_list
+                                                                    FStar_Reflection_V2_NBEEmbeddings.e_pattern in
+                                                                    let uu___196
+                                                                    =
+                                                                    let uu___197
+                                                                    =
+                                                                    FStar_TypeChecker_NBETerm.e_list
                                                                     FStar_Reflection_V2_NBEEmbeddings.e_binding in
                                                                     FStar_TypeChecker_NBETerm.e_list
-                                                                    uu___195 in
+                                                                    uu___197 in
                                                                     FStar_TypeChecker_NBETerm.e_tuple2
-                                                                    uu___192
-                                                                    uu___194 in
+                                                                    uu___195
+                                                                    uu___196 in
                                                                     FStar_TypeChecker_NBETerm.e_option
-                                                                    uu___191 in
+                                                                    uu___194 in
                                                                     FStar_Tactics_V2_InterpFuns.mk_tac_step_4
                                                                     Prims.int_zero
                                                                     "check_match_complete"
@@ -2237,75 +2260,29 @@ let (uu___193 : unit) =
                                                                     FStar_Reflection_V2_Embeddings.e_env
                                                                     FStar_Reflection_V2_Embeddings.e_term
                                                                     FStar_Reflection_V2_Embeddings.e_term
-                                                                    uu___187
-                                                                    uu___188
+                                                                    uu___189
+                                                                    uu___190
                                                                     FStar_Tactics_V2_Basic.refl_check_match_complete
                                                                     FStar_Reflection_V2_NBEEmbeddings.e_env
                                                                     FStar_Reflection_V2_NBEEmbeddings.e_term
                                                                     FStar_Reflection_V2_NBEEmbeddings.e_term
-                                                                    uu___189
-                                                                    uu___190 in
-                                                                    let uu___187
-                                                                    =
-                                                                    let uu___188
-                                                                    =
+                                                                    uu___191
+                                                                    uu___192 in
                                                                     let uu___189
                                                                     =
                                                                     let uu___190
                                                                     =
                                                                     let uu___191
+                                                                    =
+                                                                    let uu___192
+                                                                    =
+                                                                    let uu___194
                                                                     =
                                                                     FStar_Syntax_Embeddings.e_tuple2
                                                                     FStar_Reflection_V2_Embeddings.e_term
                                                                     FStar_Reflection_V2_Embeddings.e_term in
                                                                     FStar_Syntax_Embeddings.e_option
-                                                                    uu___191 in
-                                                                    let uu___191
-                                                                    =
-                                                                    FStar_Syntax_Embeddings.e_list
-                                                                    FStar_Syntax_Embeddings.e_issue in
-                                                                    FStar_Syntax_Embeddings.e_tuple2
-                                                                    uu___190
-                                                                    uu___191 in
-                                                                    let uu___190
-                                                                    =
-                                                                    let uu___191
-                                                                    =
-                                                                    let uu___192
-                                                                    =
-                                                                    FStar_TypeChecker_NBETerm.e_tuple2
-                                                                    FStar_Reflection_V2_NBEEmbeddings.e_term
-                                                                    FStar_Reflection_V2_NBEEmbeddings.e_term in
-                                                                    FStar_TypeChecker_NBETerm.e_option
-                                                                    uu___192 in
-                                                                    let uu___192
-                                                                    =
-                                                                    FStar_TypeChecker_NBETerm.e_list
-                                                                    FStar_TypeChecker_NBETerm.e_issue in
-                                                                    FStar_TypeChecker_NBETerm.e_tuple2
-                                                                    uu___191
-                                                                    uu___192 in
-                                                                    FStar_Tactics_V2_InterpFuns.mk_tac_step_2
-                                                                    Prims.int_zero
-                                                                    "instantiate_implicits"
-                                                                    FStar_Tactics_V2_Basic.refl_instantiate_implicits
-                                                                    FStar_Reflection_V2_Embeddings.e_env
-                                                                    FStar_Reflection_V2_Embeddings.e_term
-                                                                    uu___189
-                                                                    FStar_Tactics_V2_Basic.refl_instantiate_implicits
-                                                                    FStar_Reflection_V2_NBEEmbeddings.e_env
-                                                                    FStar_Reflection_V2_NBEEmbeddings.e_term
-                                                                    uu___190 in
-                                                                    let uu___189
-                                                                    =
-                                                                    let uu___190
-                                                                    =
-                                                                    let uu___191
-                                                                    =
-                                                                    let uu___192
-                                                                    =
-                                                                    FStar_Syntax_Embeddings.e_option
-                                                                    FStar_Tactics_Embedding.e_unfold_side in
+                                                                    uu___194 in
                                                                     let uu___194
                                                                     =
                                                                     FStar_Syntax_Embeddings.e_list
@@ -2317,8 +2294,13 @@ let (uu___193 : unit) =
                                                                     =
                                                                     let uu___194
                                                                     =
+                                                                    let uu___195
+                                                                    =
+                                                                    FStar_TypeChecker_NBETerm.e_tuple2
+                                                                    FStar_Reflection_V2_NBEEmbeddings.e_term
+                                                                    FStar_Reflection_V2_NBEEmbeddings.e_term in
                                                                     FStar_TypeChecker_NBETerm.e_option
-                                                                    FStar_Tactics_Embedding.e_unfold_side_nbe in
+                                                                    uu___195 in
                                                                     let uu___195
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.e_list
@@ -2326,17 +2308,15 @@ let (uu___193 : unit) =
                                                                     FStar_TypeChecker_NBETerm.e_tuple2
                                                                     uu___194
                                                                     uu___195 in
-                                                                    FStar_Tactics_V2_InterpFuns.mk_tac_step_3
+                                                                    FStar_Tactics_V2_InterpFuns.mk_tac_step_2
                                                                     Prims.int_zero
-                                                                    "maybe_relate_after_unfolding"
-                                                                    FStar_Tactics_V2_Basic.refl_maybe_relate_after_unfolding
+                                                                    "instantiate_implicits"
+                                                                    FStar_Tactics_V2_Basic.refl_instantiate_implicits
                                                                     FStar_Reflection_V2_Embeddings.e_env
                                                                     FStar_Reflection_V2_Embeddings.e_term
-                                                                    FStar_Reflection_V2_Embeddings.e_term
                                                                     uu___191
-                                                                    FStar_Tactics_V2_Basic.refl_maybe_relate_after_unfolding
+                                                                    FStar_Tactics_V2_Basic.refl_instantiate_implicits
                                                                     FStar_Reflection_V2_NBEEmbeddings.e_env
-                                                                    FStar_Reflection_V2_NBEEmbeddings.e_term
                                                                     FStar_Reflection_V2_NBEEmbeddings.e_term
                                                                     uu___192 in
                                                                     let uu___191
@@ -2348,7 +2328,7 @@ let (uu___193 : unit) =
                                                                     let uu___195
                                                                     =
                                                                     FStar_Syntax_Embeddings.e_option
-                                                                    FStar_Reflection_V2_Embeddings.e_term in
+                                                                    FStar_Tactics_Embedding.e_unfold_side in
                                                                     let uu___196
                                                                     =
                                                                     FStar_Syntax_Embeddings.e_list
@@ -2361,7 +2341,7 @@ let (uu___193 : unit) =
                                                                     let uu___196
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.e_option
-                                                                    FStar_Reflection_V2_NBEEmbeddings.e_term in
+                                                                    FStar_Tactics_Embedding.e_unfold_side_nbe in
                                                                     let uu___197
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.e_list
@@ -2369,15 +2349,17 @@ let (uu___193 : unit) =
                                                                     FStar_TypeChecker_NBETerm.e_tuple2
                                                                     uu___196
                                                                     uu___197 in
-                                                                    FStar_Tactics_V2_InterpFuns.mk_tac_step_2
+                                                                    FStar_Tactics_V2_InterpFuns.mk_tac_step_3
                                                                     Prims.int_zero
-                                                                    "maybe_unfold_head"
-                                                                    FStar_Tactics_V2_Basic.refl_maybe_unfold_head
+                                                                    "maybe_relate_after_unfolding"
+                                                                    FStar_Tactics_V2_Basic.refl_maybe_relate_after_unfolding
                                                                     FStar_Reflection_V2_Embeddings.e_env
                                                                     FStar_Reflection_V2_Embeddings.e_term
+                                                                    FStar_Reflection_V2_Embeddings.e_term
                                                                     uu___194
-                                                                    FStar_Tactics_V2_Basic.refl_maybe_unfold_head
+                                                                    FStar_Tactics_V2_Basic.refl_maybe_relate_after_unfolding
                                                                     FStar_Reflection_V2_NBEEmbeddings.e_env
+                                                                    FStar_Reflection_V2_NBEEmbeddings.e_term
                                                                     FStar_Reflection_V2_NBEEmbeddings.e_term
                                                                     uu___195 in
                                                                     let uu___194
@@ -2386,23 +2368,41 @@ let (uu___193 : unit) =
                                                                     =
                                                                     let uu___196
                                                                     =
-                                                                    FStar_Syntax_Embeddings.e_list
-                                                                    FStar_Syntax_Embeddings.e_string in
                                                                     let uu___197
                                                                     =
+                                                                    FStar_Syntax_Embeddings.e_option
+                                                                    FStar_Reflection_V2_Embeddings.e_term in
+                                                                    let uu___198
+                                                                    =
+                                                                    FStar_Syntax_Embeddings.e_list
+                                                                    FStar_Syntax_Embeddings.e_issue in
+                                                                    FStar_Syntax_Embeddings.e_tuple2
+                                                                    uu___197
+                                                                    uu___198 in
+                                                                    let uu___197
+                                                                    =
+                                                                    let uu___198
+                                                                    =
+                                                                    FStar_TypeChecker_NBETerm.e_option
+                                                                    FStar_Reflection_V2_NBEEmbeddings.e_term in
+                                                                    let uu___199
+                                                                    =
                                                                     FStar_TypeChecker_NBETerm.e_list
-                                                                    FStar_TypeChecker_NBETerm.e_string in
+                                                                    FStar_TypeChecker_NBETerm.e_issue in
+                                                                    FStar_TypeChecker_NBETerm.e_tuple2
+                                                                    uu___198
+                                                                    uu___199 in
                                                                     FStar_Tactics_V2_InterpFuns.mk_tac_step_2
                                                                     Prims.int_zero
-                                                                    "push_open_namespace"
-                                                                    FStar_Tactics_V2_Basic.push_open_namespace
+                                                                    "maybe_unfold_head"
+                                                                    FStar_Tactics_V2_Basic.refl_maybe_unfold_head
                                                                     FStar_Reflection_V2_Embeddings.e_env
+                                                                    FStar_Reflection_V2_Embeddings.e_term
                                                                     uu___196
-                                                                    FStar_Reflection_V2_Embeddings.e_env
-                                                                    FStar_Tactics_V2_Basic.push_open_namespace
+                                                                    FStar_Tactics_V2_Basic.refl_maybe_unfold_head
                                                                     FStar_Reflection_V2_NBEEmbeddings.e_env
-                                                                    uu___197
-                                                                    FStar_Reflection_V2_NBEEmbeddings.e_env in
+                                                                    FStar_Reflection_V2_NBEEmbeddings.e_term
+                                                                    uu___197 in
                                                                     let uu___196
                                                                     =
                                                                     let uu___197
@@ -2415,17 +2415,15 @@ let (uu___193 : unit) =
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.e_list
                                                                     FStar_TypeChecker_NBETerm.e_string in
-                                                                    FStar_Tactics_V2_InterpFuns.mk_tac_step_3
+                                                                    FStar_Tactics_V2_InterpFuns.mk_tac_step_2
                                                                     Prims.int_zero
-                                                                    "push_module_abbrev"
-                                                                    FStar_Tactics_V2_Basic.push_module_abbrev
+                                                                    "push_open_namespace"
+                                                                    FStar_Tactics_V2_Basic.push_open_namespace
                                                                     FStar_Reflection_V2_Embeddings.e_env
-                                                                    FStar_Syntax_Embeddings.e_string
                                                                     uu___198
                                                                     FStar_Reflection_V2_Embeddings.e_env
-                                                                    FStar_Tactics_V2_Basic.push_module_abbrev
+                                                                    FStar_Tactics_V2_Basic.push_open_namespace
                                                                     FStar_Reflection_V2_NBEEmbeddings.e_env
-                                                                    FStar_TypeChecker_NBETerm.e_string
                                                                     uu___199
                                                                     FStar_Reflection_V2_NBEEmbeddings.e_env in
                                                                     let uu___198
@@ -2438,37 +2436,21 @@ let (uu___193 : unit) =
                                                                     FStar_Syntax_Embeddings.e_string in
                                                                     let uu___201
                                                                     =
-                                                                    let uu___202
-                                                                    =
-                                                                    FStar_Syntax_Embeddings.e_either
-                                                                    FStar_Reflection_V2_Embeddings.e_bv
-                                                                    FStar_Reflection_V2_Embeddings.e_fv in
-                                                                    FStar_Syntax_Embeddings.e_option
-                                                                    uu___202 in
-                                                                    let uu___202
-                                                                    =
                                                                     FStar_TypeChecker_NBETerm.e_list
                                                                     FStar_TypeChecker_NBETerm.e_string in
-                                                                    let uu___203
-                                                                    =
-                                                                    let uu___204
-                                                                    =
-                                                                    FStar_TypeChecker_NBETerm.e_either
-                                                                    FStar_Reflection_V2_NBEEmbeddings.e_bv
-                                                                    FStar_Reflection_V2_NBEEmbeddings.e_fv in
-                                                                    FStar_TypeChecker_NBETerm.e_option
-                                                                    uu___204 in
-                                                                    FStar_Tactics_V2_InterpFuns.mk_tac_step_2
+                                                                    FStar_Tactics_V2_InterpFuns.mk_tac_step_3
                                                                     Prims.int_zero
-                                                                    "resolve_name"
-                                                                    FStar_Tactics_V2_Basic.resolve_name
+                                                                    "push_module_abbrev"
+                                                                    FStar_Tactics_V2_Basic.push_module_abbrev
                                                                     FStar_Reflection_V2_Embeddings.e_env
+                                                                    FStar_Syntax_Embeddings.e_string
                                                                     uu___200
-                                                                    uu___201
-                                                                    FStar_Tactics_V2_Basic.resolve_name
+                                                                    FStar_Reflection_V2_Embeddings.e_env
+                                                                    FStar_Tactics_V2_Basic.push_module_abbrev
                                                                     FStar_Reflection_V2_NBEEmbeddings.e_env
-                                                                    uu___202
-                                                                    uu___203 in
+                                                                    FStar_TypeChecker_NBETerm.e_string
+                                                                    uu___201
+                                                                    FStar_Reflection_V2_NBEEmbeddings.e_env in
                                                                     let uu___200
                                                                     =
                                                                     let uu___201
@@ -2476,8 +2458,49 @@ let (uu___193 : unit) =
                                                                     let uu___202
                                                                     =
                                                                     FStar_Syntax_Embeddings.e_list
-                                                                    FStar_Syntax_Embeddings.e_issue in
+                                                                    FStar_Syntax_Embeddings.e_string in
                                                                     let uu___203
+                                                                    =
+                                                                    let uu___204
+                                                                    =
+                                                                    FStar_Syntax_Embeddings.e_either
+                                                                    FStar_Reflection_V2_Embeddings.e_bv
+                                                                    FStar_Reflection_V2_Embeddings.e_fv in
+                                                                    FStar_Syntax_Embeddings.e_option
+                                                                    uu___204 in
+                                                                    let uu___204
+                                                                    =
+                                                                    FStar_TypeChecker_NBETerm.e_list
+                                                                    FStar_TypeChecker_NBETerm.e_string in
+                                                                    let uu___205
+                                                                    =
+                                                                    let uu___206
+                                                                    =
+                                                                    FStar_TypeChecker_NBETerm.e_either
+                                                                    FStar_Reflection_V2_NBEEmbeddings.e_bv
+                                                                    FStar_Reflection_V2_NBEEmbeddings.e_fv in
+                                                                    FStar_TypeChecker_NBETerm.e_option
+                                                                    uu___206 in
+                                                                    FStar_Tactics_V2_InterpFuns.mk_tac_step_2
+                                                                    Prims.int_zero
+                                                                    "resolve_name"
+                                                                    FStar_Tactics_V2_Basic.resolve_name
+                                                                    FStar_Reflection_V2_Embeddings.e_env
+                                                                    uu___202
+                                                                    uu___203
+                                                                    FStar_Tactics_V2_Basic.resolve_name
+                                                                    FStar_Reflection_V2_NBEEmbeddings.e_env
+                                                                    uu___204
+                                                                    uu___205 in
+                                                                    let uu___202
+                                                                    =
+                                                                    let uu___203
+                                                                    =
+                                                                    let uu___204
+                                                                    =
+                                                                    FStar_Syntax_Embeddings.e_list
+                                                                    FStar_Syntax_Embeddings.e_issue in
+                                                                    let uu___205
                                                                     =
                                                                     FStar_TypeChecker_NBETerm.e_list
                                                                     FStar_TypeChecker_NBETerm.e_issue in
@@ -2490,7 +2513,7 @@ let (uu___193 : unit) =
                                                                     is;
                                                                     FStar_Tactics_Monad.ret
                                                                     ())
-                                                                    uu___202
+                                                                    uu___204
                                                                     FStar_Syntax_Embeddings.e_unit
                                                                     (fun is
                                                                     ->
@@ -2498,9 +2521,12 @@ let (uu___193 : unit) =
                                                                     is;
                                                                     FStar_Tactics_Monad.ret
                                                                     ())
-                                                                    uu___203
+                                                                    uu___205
                                                                     FStar_TypeChecker_NBETerm.e_unit in
-                                                                    [uu___201] in
+                                                                    [uu___203] in
+                                                                    uu___201
+                                                                    ::
+                                                                    uu___202 in
                                                                     uu___199
                                                                     ::
                                                                     uu___200 in

--- a/src/basic/FStar.Options.fst
+++ b/src/basic/FStar.Options.fst
@@ -763,10 +763,12 @@ let rec specs_with_types warn_unsafe : list (char * string * opt_type * string) 
 
        ( noshort,
          "ext",
-         Accumulated (SimpleStr "One or more semicolon separated occurrences of colon-separated pairs, \
-                                 e.g., 'pulse:verbose;pulse:debug;foo:bar'"),
-        "\n\t\tThese options are typically interpreted by extensions. \n\t\t\
-         An entry 'e' that is not of the form 'a:b' is treated as 'e:\"\"', i.e., 'e' associated with the empty string");
+         ReverseAccumulated (SimpleStr "One or more semicolon separated occurrences of key-value pairs"),
+         "\n\t\tThese options are set in extensions option map. Keys are usually namespaces separated by \":\".\n\t\t\
+         E.g., 'pulse:verbose=1;my:extension:option=xyz;foo:bar=baz'\n\t\t\
+         These options are typically interpreted by extensions. \n\t\t\
+         Any later use of --ext over the same key overrides the old value.\n\t\t\
+         An entry 'e' that is not of the form 'a=b' is treated as 'e=1', i.e., 'e' associated with string \"1\"");
 
        ( noshort,
          "extract",
@@ -2174,13 +2176,26 @@ let set_vconfig (vcfg:vconfig) : unit =
 
 // --ext "ext1:opt1;ext2:opt2;ext3:opt3"
 // An entry e that is not of the form a:b
-// is treated as e:""
+// is treated as e:"1". We morally reserve the empty
+// string for "disabling" an option.
+//
+// This could all be much more efficient by just storing
+// a hash table in the optionstate.
+
 let parse_ext (s:string) : list (string & string) =
   let exts = Util.split s ";" in
   List.collect (fun s -> 
-    match Util.split s ":" with
+    match Util.split s "=" with
     | [k;v] -> [(k,v)]
-    | _ -> [s, ""]) exts
+    | _ -> [s, "1"]) exts
+
+(* Deduplicates according to keys, favors the last occurrence (consistent
+with "ext" begin ReverseAccumulated *)
+let ext_dedup #a (l : list (string & a)) : list (string & a) =
+  //fold_right (fun (k,v) rest -> (k,v) :: List.filter (fun (k', _) -> k<>k') rest) l []
+  fold_right (fun (k,v) rest -> if List.existsb (fun (k', _) -> k=k') rest
+                                then rest
+                                else (k,v) :: rest) l []
 
 let all_ext_options () : list (string & string) =
   let ext = get_ext () in
@@ -2188,7 +2203,24 @@ let all_ext_options () : list (string & string) =
   | None -> []
   | Some strs ->
     strs |> List.collect parse_ext
+    |> ext_dedup
 
-let ext_options (ext:string) : list string =
+let ext_getv (k:string) : string =
+  let ext = all_ext_options () in
+  (* Get the value from the map, or return "" if not there *)
+  Util.dflt "" (
+    Util.find_map ext (fun (k',v) -> if k = k' then Some v else None))
+
+(* Get a list of all KV pairs that "begin" with k, considered
+as a namespace. *)
+let ext_getns (ns:string) : list (string & string) =
+  let is_prefix s1 s2 =
+    let open FStar.String in
+    let l1 = length s1 in
+    let l2 = length s2 in
+    l2 >= l1 && substring s2 0 l1 = s1
+  in
   let exts = all_ext_options () in
-  List.filter_map (fun (k,v) -> if k = ext then Some v else None) exts
+  exts |>
+  List.filter_map (fun (k',v) ->
+    if k' = ns || is_prefix (ns^":") k' then Some (k',v) else None)

--- a/src/basic/FStar.Options.fsti
+++ b/src/basic/FStar.Options.fsti
@@ -274,5 +274,7 @@ val eager_embedding: ref bool
 
 val get_vconfig : unit -> vconfig
 val set_vconfig : vconfig -> unit
+
 val all_ext_options : unit -> list (string & string)
-val ext_options (ext:string) : list string
+val ext_getv (k:string) : string
+val ext_getns (ns:string) : list (string & string)

--- a/src/smtencoding/FStar.SMTEncoding.Encode.fst
+++ b/src/smtencoding/FStar.SMTEncoding.Encode.fst
@@ -1559,11 +1559,11 @@ and encode_sigelt' (env:env_t) (se:sigelt) : (decls_t * env_t) =
                                     | Tm_fvar fv ->
                                       if BU.for_some (S.fv_eq_lid fv) mutuals
                                       then Some (bs, c)
-                                      else if List.mem "2954" (Options.ext_options "compat")
+                                      else if Options.ext_getv "compat:2954" <> ""
                                       then (warn_compat(); Some (bs, c)) //compatibility mode
                                       else None
                                     | _ ->
-                                      if List.mem "2954" (Options.ext_options "compat")
+                                      if Options.ext_getv "compat:2954" <> ""
                                       then (warn_compat(); Some (bs, c)) //compatibility mode
                                       else None
                                   )

--- a/src/tactics/FStar.Tactics.V2.Basic.fst
+++ b/src/tactics/FStar.Tactics.V2.Basic.fst
@@ -2099,13 +2099,17 @@ let free_uvars (tm : term) : tac (list Z.t)
     let uvs = Syntax.Free.uvars_uncached tm |> BU.set_elements |> List.map (fun u -> Z.of_int_fs (UF.uvar_id u.ctx_uvar_head)) in
     ret uvs
 
-let ext_options (ext:string) : tac (list string)
-  = idtac ;!
-    ret (Options.ext_options ext)
-
 let all_ext_options () : tac (list (string & string))
   = idtac ;!
     ret (Options.all_ext_options ())
+
+let ext_getv (k:string) : tac string
+  = idtac ;!
+    ret (Options.ext_getv k)
+
+let ext_getns (ns:string) : tac (list (string & string))
+  = idtac ;!
+    ret (Options.ext_getns ns)
 
 (***** Builtins used in the meta DSL framework *****)
 

--- a/src/tactics/FStar.Tactics.V2.Basic.fst
+++ b/src/tactics/FStar.Tactics.V2.Basic.fst
@@ -2099,6 +2099,14 @@ let free_uvars (tm : term) : tac (list Z.t)
     let uvs = Syntax.Free.uvars_uncached tm |> BU.set_elements |> List.map (fun u -> Z.of_int_fs (UF.uvar_id u.ctx_uvar_head)) in
     ret uvs
 
+let ext_options (ext:string) : tac (list string)
+  = idtac ;!
+    ret (Options.ext_options ext)
+
+let all_ext_options () : tac (list (string & string))
+  = idtac ;!
+    ret (Options.all_ext_options ())
+
 (***** Builtins used in the meta DSL framework *****)
 
 let dbg_refl (g:env) (msg:unit -> string) =

--- a/src/tactics/FStar.Tactics.V2.Basic.fsti
+++ b/src/tactics/FStar.Tactics.V2.Basic.fsti
@@ -122,8 +122,9 @@ val set_vconfig            : VConfig.vconfig -> tac unit
 val t_smt_sync             : VConfig.vconfig -> tac unit
 val free_uvars             : term -> tac (list Z.t)
 
-val ext_options            : string -> tac (list string)
 val all_ext_options        : unit -> tac (list (string & string))
+val ext_getv               : string -> tac string
+val ext_getns              : string -> tac (list (string & string))
 
 
 (***** Callbacks for the meta DSL framework *****)

--- a/src/tactics/FStar.Tactics.V2.Basic.fsti
+++ b/src/tactics/FStar.Tactics.V2.Basic.fsti
@@ -122,6 +122,9 @@ val set_vconfig            : VConfig.vconfig -> tac unit
 val t_smt_sync             : VConfig.vconfig -> tac unit
 val free_uvars             : term -> tac (list Z.t)
 
+val ext_options            : string -> tac (list string)
+val all_ext_options        : unit -> tac (list (string & string))
+
 
 (***** Callbacks for the meta DSL framework *****)
 let issues = list FStar.Errors.issue

--- a/src/tactics/FStar.Tactics.V2.Interpreter.fst
+++ b/src/tactics/FStar.Tactics.V2.Interpreter.fst
@@ -601,6 +601,14 @@ let () =
         free_uvars RE.e_term (e_list e_int)
         free_uvars NRE.e_term (NBET.e_list NBET.e_int);
 
+      mk_tac_step_1 0 "ext_options"
+        ext_options e_string (e_list e_string)
+        ext_options NBET.e_string (NBET.e_list NBET.e_string);
+
+      mk_tac_step_1 0 "all_ext_options"
+        all_ext_options e_unit (e_list (e_tuple2 e_string e_string))
+        all_ext_options NBET.e_unit NBET.(e_list (e_tuple2 e_string e_string));
+
       // reflection typechecker callbacks (part of the DSL framework)
 
       mk_tac_step_2 0 "is_non_informative"

--- a/src/tactics/FStar.Tactics.V2.Interpreter.fst
+++ b/src/tactics/FStar.Tactics.V2.Interpreter.fst
@@ -601,13 +601,17 @@ let () =
         free_uvars RE.e_term (e_list e_int)
         free_uvars NRE.e_term (NBET.e_list NBET.e_int);
 
-      mk_tac_step_1 0 "ext_options"
-        ext_options e_string (e_list e_string)
-        ext_options NBET.e_string (NBET.e_list NBET.e_string);
-
       mk_tac_step_1 0 "all_ext_options"
         all_ext_options e_unit (e_list (e_tuple2 e_string e_string))
         all_ext_options NBET.e_unit NBET.(e_list (e_tuple2 e_string e_string));
+
+      mk_tac_step_1 0 "ext_getv"
+        ext_getv e_string e_string
+        ext_getv NBET.e_string NBET.e_string;
+
+      mk_tac_step_1 0 "ext_getns"
+        ext_getns e_string (e_list (e_tuple2 e_string e_string))
+        ext_getns NBET.e_string NBET.(e_list (e_tuple2 e_string e_string));
 
       // reflection typechecker callbacks (part of the DSL framework)
 

--- a/tests/bug-reports/Bug2954.fst
+++ b/tests/bug-reports/Bug2954.fst
@@ -1,0 +1,39 @@
+module Bug2954
+
+#set-options "--ext compat:2954"
+
+open FStar.List.Pure
+open FStar.FunctionalExtensionality
+open FStar.Bytes
+
+noeq type comb (n:nat) (ret_type:Type) =
+  | Comb: send: FStar.Bytes.bytes -> cont:((llist FStar.Bytes.bytes n) -> ret_type){is_restricted (llist FStar.Bytes.bytes n) cont} -> comb n ret_type
+
+#push-options "--ifuel 1"
+val fmap_comb_flip: #n:nat -> #b:Type -> #c:Type -> x:comb n b -> f:(y:b{y<<x} -> c) -> comb n c
+let fmap_comb_flip #n x f =
+  let Comb xa fb = x in
+  let cont vb =
+    f (fb vb)
+  in
+  Comb xa (FStar.FunctionalExtensionality.on _ cont)
+#pop-options
+
+val fmap_comb: #n:nat  -> #b:Type -> #c:Type -> (b -> c) -> comb n b -> comb n c
+let fmap_comb #n f x =
+  fmap_comb_flip x f
+
+noeq type comba (n:nat) (ret:Type) =
+  | Abort: comba n ret
+  | Ret: v:ret -> comba n ret
+  | Com: v:comb n (comba n ret) -> comba n ret
+
+#push-options "--ifuel 1"
+val join_comba: #n:nat -> #ret:Type -> comba n (comba n ret) -> comba n ret
+let rec join_comba #n #ret x =
+  match x with
+  | Abort -> Abort
+  | Ret r -> r
+  | Com y ->
+    Com (fmap_comb_flip y join_comba)
+#pop-options

--- a/tests/bug-reports/Makefile
+++ b/tests/bug-reports/Makefile
@@ -53,7 +53,7 @@ SHOULD_VERIFY_CLOSED=Bug022.fst Bug024.fst Bug025.fst Bug026.fst Bug026b.fst Bug
   Bug2684a.fst Bug2684b.fst Bug2684c.fst Bug2684d.fst Bug2659b.fst\
   Bug2756.fst MutualRecPositivity.fst Bug2806a.fst Bug2806b.fst Bug2806c.fst Bug2806d.fst Bug2809.fst\
   Bug2849a.fst Bug2849b.fst Bug2045.fst Bug2876.fst Bug2882.fst Bug2895.fst Bug2894.fst \
-	Bug2415.fst Bug3028.fst
+	Bug2415.fst Bug3028.fst Bug2954.fst
 
 SHOULD_VERIFY_INTERFACE_CLOSED=Bug771.fsti Bug771b.fsti
 SHOULD_VERIFY_AND_WARN_CLOSED=Bug016.fst

--- a/ulib/FStar.Tactics.V2.Builtins.fsti
+++ b/ulib/FStar.Tactics.V2.Builtins.fsti
@@ -439,16 +439,17 @@ val t_smt_sync : vconfig -> Tac unit
 a reflection primitive as it depends on the state of the UF graph. *)
 val free_uvars : term -> Tac (list int)
 
-(* Access the `--ext` options. When called with `k` it returns
-a list of all the extension options registered for `k`, so if
-`--ext k:opt1 --ext k:opt2` was given, this returns ["opt1"; "opt2"]. *)
-val ext_options (ext:string) : Tac (list string)
-
-(* Access the `--ext` options. This returns all of the pairs given,
-so if `--ext k:opt1 --ext m:opt3 --ext k:opt2` was given, this
-returns [("k", "opt1"); ("m"; "opt3"); ("k"; "opt2")]. The order is
-*unspecified*, do not rely on it. *)
+(* Return all k/v pairs in the state. The order is unspecified,
+do not rely on it. *)
 val all_ext_options : unit -> Tac (list (string & string))
+
+(* Lookup a k/v pair in the --ext option state. The empty string
+is returned if the key was unset. *)
+val ext_getv (k:string) : Tac string
+
+(* Return all k/v pairs in the state which are within
+the given namespace. *)
+val ext_getns (ns:string) : Tac (list (string & string))
 
 (***** APIs used in the meta DSL framework *****)
 

--- a/ulib/FStar.Tactics.V2.Builtins.fsti
+++ b/ulib/FStar.Tactics.V2.Builtins.fsti
@@ -439,6 +439,16 @@ val t_smt_sync : vconfig -> Tac unit
 a reflection primitive as it depends on the state of the UF graph. *)
 val free_uvars : term -> Tac (list int)
 
+(* Access the `--ext` options. When called with `k` it returns
+a list of all the extension options registered for `k`, so if
+`--ext k:opt1 --ext k:opt2` was given, this returns ["opt1"; "opt2"]. *)
+val ext_options (ext:string) : Tac (list string)
+
+(* Access the `--ext` options. This returns all of the pairs given,
+so if `--ext k:opt1 --ext m:opt3 --ext k:opt2` was given, this
+returns [("k", "opt1"); ("m"; "opt3"); ("k"; "opt2")]. The order is
+*unspecified*, do not rely on it. *)
+val all_ext_options : unit -> Tac (list (string & string))
 
 (***** APIs used in the meta DSL framework *****)
 


### PR DESCRIPTION
cc @nikswamy, there's no way to access them from tactics otherwise as of yet, right?

Also I wonder if it would be more future proof to provide a KV interface, such as:
```fstar
val get_ext : key:string -> string
```
And writing `--ext k=v` to define one. The key could use dots to separate namespaces purely as a convention. We could maybe define an `ext_options` analogue that looks at the prefix of each key to decide which pairs to return.