### PR TITLE
Fix Nix build: add `memtrace`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1681202837,
-        "narHash": "sha256-H+Rh19JDwRtpVPAWp64F+rlEtxUWBAQW28eAi3SRSzg=",
+        "lastModified": 1692799911,
+        "narHash": "sha256-3eihraek4qL744EvQXsK1Ha6C3CR7nnT8X2qWap4RNk=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "cfacdce06f30d2b68473a46042957675eebb3401",
+        "rev": "f9e7cf818399d17d347f847525c5a5a8032e4e44",
         "type": "github"
       },
       "original": {
@@ -19,11 +19,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1684385584,
-        "narHash": "sha256-O7y0gK8OLIDqz+LaHJJyeu09IGiXlZIS3+JgEzGmmJA=",
+        "lastModified": 1693158576,
+        "narHash": "sha256-aRTTXkYvhXosGx535iAFUaoFboUrZSYb1Ooih/auGp0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "48a0fb7aab511df92a17cf239c37f2bd2ec9ae3a",
+        "rev": "a999c1cc0c9eb2095729d5aa03e0d8f7ed256780",
         "type": "github"
       },
       "original": {

--- a/ocaml/default.nix
+++ b/ocaml/default.nix
@@ -1,5 +1,5 @@
 { batteries, buildDunePackage, includeBinaryAnnotations ? false
-, installShellFiles, lib, makeWrapper, menhir, menhirLib, ocaml, pprint, ppxlib
+, installShellFiles, lib, makeWrapper, menhir, menhirLib, memtrace, ocaml, pprint, ppxlib
 , ppx_deriving, ppx_deriving_yojson, process, removeReferencesTo, sedlex, stdint
 , version, yojson, zarith }:
 
@@ -35,6 +35,7 @@ buildDunePackage {
     stdint
     yojson
     zarith
+    memtrace
   ];
 
   enableParallelBuilding = true;


### PR DESCRIPTION
Hi, this PR:
 - updates the Nix packages used for building F* (all the dependencies required for building F* are locked in `flake.lock`);
 - add `memtrace` (fixing F* build after @mtzguido's PR #3016).

This should fix Hacl* CI as well.