### PR TITLE
Add (Github hosted) action for Nix

### DIFF
--- a/.github/workflows/nix.yaml
+++ b/.github/workflows/nix.yaml
@@ -1,0 +1,17 @@
+# This workflow tests the Nix build of F*. We run it only for PRs (not
+# on every push) and we use Github hosted runners.
+
+name: Nix Build
+
+on:
+  pull_request:
+
+jobs:
+  nix-build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: DeterminateSystems/nix-installer-action@main
+    - uses: DeterminateSystems/magic-nix-cache-action@main
+    - name: Build
+      run: nix build -L


### PR DESCRIPTION
Follow up PR (see https://github.com/FStarLang/FStar/pull/3041#issuecomment-1698043765) adding a (GitHub hosted) GitHub Action that builds F* with Nix.

(the first build will take longer, then things _cough z3 4.8.5 cough_ will be cached)