### PR TITLE
Nix: fix `make_fstar_version.sh`

### DIFF
--- a/ocaml/default.nix
+++ b/ocaml/default.nix
@@ -50,4 +50,6 @@ buildDunePackage {
     # Meanwhile, they add a dependency to the OCaml compiler and are thus removed by default
     rm $out/lib/ocaml/${ocaml.version}/site-lib/fstar/lib/*.cmt
   '');
+
+  FSTAR_COMMIT = version;
 }

--- a/ocaml/default.nix
+++ b/ocaml/default.nix
@@ -1,7 +1,7 @@
 { batteries, buildDunePackage, includeBinaryAnnotations ? false
-, installShellFiles, lib, makeWrapper, menhir, menhirLib, memtrace, ocaml, pprint, ppxlib
-, ppx_deriving, ppx_deriving_yojson, process, removeReferencesTo, sedlex, stdint
-, version, yojson, zarith }:
+, installShellFiles, lib, makeWrapper, menhir, menhirLib, memtrace, ocaml
+, pprint, ppxlib, ppx_deriving, ppx_deriving_yojson, process, removeReferencesTo
+, sedlex, stdint, version, yojson, zarith }:
 
 buildDunePackage {
   pname = "fstar";
@@ -16,12 +16,8 @@ buildDunePackage {
     patchShebangs fstar-lib/make_fstar_version.sh
   '';
 
-  nativeBuildInputs = [
-    installShellFiles
-    makeWrapper
-    removeReferencesTo
-    menhir
-  ];
+  nativeBuildInputs =
+    [ installShellFiles makeWrapper removeReferencesTo menhir ];
 
   buildInputs = [
     batteries


### PR DESCRIPTION
The call to `make_fstar_version.sh` in Nix doesn't set the commit value properly since the git repository is not available in the Nix sandbox.
In this PR I set the `FSTAR_COMMIT` variable from the Nix expression, so that the script works properly when called.
Sadly, I can't retreive the commit date in a similar way, this one stays "unset".