### PR TITLE
Fixing unfolding logic in coercions

### DIFF
--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_Util.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_Util.ml
@@ -5174,12 +5174,14 @@ let rec (check_erased :
             FStar_Syntax_Syntax.delta_constant;
           FStar_TypeChecker_Env.Exclude FStar_TypeChecker_Env.Zeta;
           FStar_TypeChecker_Env.Primops;
+          FStar_TypeChecker_Env.Unascribe;
+          FStar_TypeChecker_Env.Unmeta;
+          FStar_TypeChecker_Env.Unrefine;
           FStar_TypeChecker_Env.Weak;
           FStar_TypeChecker_Env.HNF;
           FStar_TypeChecker_Env.Iota] in
       let t1 = norm' env t in
-      let t2 = FStar_Syntax_Util.unrefine t1 in
-      let uu___ = FStar_Syntax_Util.head_and_args t2 in
+      let uu___ = FStar_Syntax_Util.head_and_args t1 in
       match uu___ with
       | (h, args) ->
           let h1 = FStar_Syntax_Util.un_uinst h in

--- a/src/typechecker/FStar.TypeChecker.Util.fst
+++ b/src/typechecker/FStar.TypeChecker.Util.fst
@@ -2335,13 +2335,13 @@ type isErased =
     | No
 
 let rec check_erased (env:Env.env) (t:term) : isErased =
-  let norm' = N.normalize [Env.Beta; Env.Eager_unfolding;
-                           Env.UnfoldUntil delta_constant;
-                           Env.Exclude Env.Zeta; Env.Primops;
-                           Env.Weak; Env.HNF; Env.Iota]
+  let norm' = N.normalize [Beta; Eager_unfolding;
+                           UnfoldUntil delta_constant;
+                           Exclude Zeta; Primops;
+                           Unascribe; Unmeta; Unrefine;
+                           Weak; HNF; Iota]
   in
   let t = norm' env t in
-  let t = U.unrefine t in
   let h, args = U.head_and_args t in
   let h = U.un_uinst h in
   let r =


### PR DESCRIPTION
The unrefine after the norm call could miss some further opportunities for unfolding. Instead of that, just add the `Unrefine` flag to the norm call.