### PR TITLE
ToSyntax: tighten a range

### DIFF
--- a/ocaml/fstar-lib/generated/FStar_ToSyntax_ToSyntax.ml
+++ b/ocaml/fstar-lib/generated/FStar_ToSyntax_ToSyntax.ml
@@ -2887,7 +2887,8 @@ and (desugar_term_maybe_top :
                              " used at an unexpected position" in
                          Prims.op_Hat "Effect " uu___5 in
                        (FStar_Errors_Codes.Fatal_UnexpectedEffect, uu___4) in
-                 FStar_Errors.raise_error err top.FStar_Parser_AST.range)
+                 let uu___2 = FStar_Ident.range_of_lid l in
+                 FStar_Errors.raise_error err uu___2)
         | FStar_Parser_AST.Sum (binders, t) when
             FStar_Compiler_Util.for_all
               (fun uu___1 ->

--- a/src/tosyntax/FStar.ToSyntax.ToSyntax.fst
+++ b/src/tosyntax/FStar.ToSyntax.ToSyntax.fst
@@ -1330,7 +1330,7 @@ and desugar_term_maybe_top (top_level:bool) (env:env_t) (top:term) : S.term * an
               | None -> (Errors.Fatal_ConstructorNotFound, ("Constructor " ^ (string_of_lid l) ^ " not found"))
               | Some _ -> (Errors.Fatal_UnexpectedEffect, ("Effect " ^ (string_of_lid l) ^ " used at an unexpected position"))
             in
-            raise_error err top.range
+            raise_error err (range_of_lid l)
         end
 
     | Sum(binders, t)


### PR DESCRIPTION
When writing
```fstar
let x = A b c d e f g
```
where `A` is some unbound constructor, F* would highlight the entire expression. Now it only highlights A. Same for `effect _ used in unexpected position`, only the effect label will be highlighted.