### PR TITLE
Pretty-print basic_type_error

### DIFF
--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_Err.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_Err.ml
@@ -343,7 +343,7 @@ let (basic_type_error :
     FStar_Syntax_Syntax.term FStar_Pervasives_Native.option ->
       FStar_Syntax_Syntax.term ->
         FStar_Syntax_Syntax.term ->
-          (FStar_Errors_Codes.raw_error * Prims.string))
+          (FStar_Errors_Codes.raw_error * FStar_Pprint.document Prims.list))
   =
   fun env ->
     fun eopt ->
@@ -355,14 +355,45 @@ let (basic_type_error :
               let msg =
                 match eopt with
                 | FStar_Pervasives_Native.None ->
-                    FStar_Compiler_Util.format2
-                      "Expected type \"%s\"; got type \"%s\"" s1 s2
+                    let uu___1 =
+                      let uu___2 =
+                        let uu___3 = FStar_Errors_Msg.text "Expected type" in
+                        let uu___4 =
+                          FStar_TypeChecker_Normalize.term_to_doc env t1 in
+                        FStar_Pprint.prefix (Prims.of_int (4)) Prims.int_one
+                          uu___3 uu___4 in
+                      let uu___3 =
+                        let uu___4 = FStar_Errors_Msg.text "got type" in
+                        let uu___5 =
+                          FStar_TypeChecker_Normalize.term_to_doc env t2 in
+                        FStar_Pprint.prefix (Prims.of_int (4)) Prims.int_one
+                          uu___4 uu___5 in
+                      FStar_Pprint.op_Hat_Slash_Hat uu___2 uu___3 in
+                    [uu___1]
                 | FStar_Pervasives_Native.Some e ->
                     let uu___1 =
-                      FStar_TypeChecker_Normalize.term_to_string env e in
-                    FStar_Compiler_Util.format3
-                      "Expected type \"%s\"; but \"%s\" has type \"%s\"" s1
-                      uu___1 s2 in
+                      let uu___2 =
+                        let uu___3 = FStar_Errors_Msg.text "Expected type" in
+                        let uu___4 =
+                          FStar_TypeChecker_Normalize.term_to_doc env t1 in
+                        FStar_Pprint.prefix (Prims.of_int (4)) Prims.int_one
+                          uu___3 uu___4 in
+                      let uu___3 =
+                        let uu___4 =
+                          let uu___5 = FStar_Errors_Msg.text "but" in
+                          let uu___6 =
+                            FStar_TypeChecker_Normalize.term_to_doc env e in
+                          FStar_Pprint.prefix (Prims.of_int (4))
+                            Prims.int_one uu___5 uu___6 in
+                        let uu___5 =
+                          let uu___6 = FStar_Errors_Msg.text "has type" in
+                          let uu___7 =
+                            FStar_TypeChecker_Normalize.term_to_doc env t2 in
+                          FStar_Pprint.prefix (Prims.of_int (4))
+                            Prims.int_one uu___6 uu___7 in
+                        FStar_Pprint.op_Hat_Slash_Hat uu___4 uu___5 in
+                      FStar_Pprint.op_Hat_Slash_Hat uu___2 uu___3 in
+                    [uu___1] in
               (FStar_Errors_Codes.Error_TypeError, msg)
 let (occurs_check : (FStar_Errors_Codes.raw_error * Prims.string)) =
   (FStar_Errors_Codes.Fatal_PossibleInfiniteTyp,

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_Rel.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_Rel.ml
@@ -13240,7 +13240,7 @@ let (teq :
               let uu___3 =
                 FStar_TypeChecker_Err.basic_type_error env
                   FStar_Pervasives_Native.None t2 t1 in
-              FStar_Errors.log_issue uu___2 uu___3);
+              FStar_Errors.log_issue_doc uu___2 uu___3);
              FStar_TypeChecker_Common.trivial_guard)
         | FStar_Pervasives_Native.Some g ->
             ((let uu___2 =
@@ -13317,7 +13317,7 @@ let (subtype_fail :
           let uu___1 =
             FStar_TypeChecker_Err.basic_type_error env
               (FStar_Pervasives_Native.Some e) t2 t1 in
-          FStar_Errors.log_issue uu___ uu___1
+          FStar_Errors.log_issue_doc uu___ uu___1
 let (sub_or_eq_comp :
   FStar_TypeChecker_Env.env ->
     Prims.bool ->

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_TcTerm.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_TcTerm.ml
@@ -6066,7 +6066,7 @@ and (tc_abs_check_binders :
                                                  let uu___13 =
                                                    FStar_TypeChecker_Env.get_range
                                                      env1 in
-                                                 FStar_Errors.raise_error
+                                                 FStar_Errors.raise_error_doc
                                                    uu___12 uu___13
                                              | FStar_Pervasives_Native.Some
                                                  g_env -> label_guard g_env) in

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_Util.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_Util.ml
@@ -5948,7 +5948,8 @@ let (weaken_result_typ :
                      FStar_TypeChecker_Err.basic_type_error env
                        (FStar_Pervasives_Native.Some e) t
                        lc.FStar_TypeChecker_Common.res_typ in
-                   FStar_Errors.raise_error uu___2 e.FStar_Syntax_Syntax.pos
+                   FStar_Errors.raise_error_doc uu___2
+                     e.FStar_Syntax_Syntax.pos
                  else
                    (FStar_TypeChecker_Rel.subtype_fail env e
                       lc.FStar_TypeChecker_Common.res_typ t;

--- a/src/typechecker/FStar.TypeChecker.Err.fst
+++ b/src/typechecker/FStar.TypeChecker.Err.fst
@@ -219,9 +219,18 @@ let expected_pattern_of_type env t1 e t2 =
 
 let basic_type_error env eopt t1 t2 =
   let s1, s2 = err_msg_type_strings env t1 t2 in
+  let open FStar.Errors.Msg in
   let msg = match eopt with
-    | None -> format2 "Expected type \"%s\"; got type \"%s\"" s1 s2
-    | Some e -> format3 "Expected type \"%s\"; but \"%s\" has type \"%s\"" s1 (N.term_to_string env e) s2 in
+    | None -> [
+      prefix 4 1 (text "Expected type") (N.term_to_doc env t1) ^/^
+      prefix 4 1 (text "got type") (N.term_to_doc env t2);
+    ]
+    | Some e -> [
+      prefix 4 1 (text "Expected type") (N.term_to_doc env t1) ^/^
+      prefix 4 1 (text "but") (N.term_to_doc env e) ^/^
+      prefix 4 1 (text "has type") (N.term_to_doc env t2);
+    ]
+  in
   (Errors.Error_TypeError, msg)
 
 let occurs_check =

--- a/src/typechecker/FStar.TypeChecker.Rel.fst
+++ b/src/typechecker/FStar.TypeChecker.Rel.fst
@@ -4702,7 +4702,7 @@ let try_teq smt_ok env t1 t2 : option guard_t =
 let teq env t1 t2 : guard_t =
     match try_teq true env t1 t2 with
     | None ->
-        FStar.Errors.log_issue
+        FStar.Errors.log_issue_doc
             (Env.get_range env)
             (Err.basic_type_error env None t2 t1);
         trivial_guard
@@ -4733,7 +4733,7 @@ let get_teq_predicate env t1 t2 =
     | Some g -> Some (abstract_guard (S.mk_binder x) g)
 
 let subtype_fail env e t1 t2 =
-    Errors.log_issue (Env.get_range env) (Err.basic_type_error env (Some e) t2 t1)
+    Errors.log_issue_doc (Env.get_range env) (Err.basic_type_error env (Some e) t2 t1)
 
 let sub_or_eq_comp env (use_eq:bool) c1 c2 =
   Profiling.profile (fun () ->

--- a/src/typechecker/FStar.TypeChecker.TcTerm.fst
+++ b/src/typechecker/FStar.TypeChecker.TcTerm.fst
@@ -2154,7 +2154,7 @@ and tc_abs_check_binders env bs bs_expected use_eq
                 then Rel.teq env t expected_t |> label_guard
                 else match Rel.get_subtyping_prop env expected_t t with
                      | None ->
-                       raise_error (Err.basic_type_error env None expected_t t) (Env.get_range env)
+                       raise_error_doc (Err.basic_type_error env None expected_t t) (Env.get_range env)
                      | Some g_env -> label_guard g_env in
             t, Env.conj_guard g1_env g2_env in
 

--- a/src/typechecker/FStar.TypeChecker.Util.fst
+++ b/src/typechecker/FStar.TypeChecker.Util.fst
@@ -2616,7 +2616,7 @@ let weaken_result_typ env (e:term) (lc:lcomp) (t:typ) (use_eq:bool) : term * lco
          * AR: 11/18: should this always fail hard?
          *)
         if env.failhard
-        then raise_error (Err.basic_type_error env (Some e) t lc.res_typ) e.pos
+        then raise_error_doc (Err.basic_type_error env (Some e) t lc.res_typ) e.pos
         else (
             subtype_fail env e lc.res_typ t; //log a sub-typing error
             e, {lc with res_typ=t}, Env.trivial_guard //and keep going to type-check the result of the program

--- a/tests/error-messages/NegativeTests.False.fst.expected
+++ b/tests/error-messages/NegativeTests.False.fst.expected
@@ -7,16 +7,24 @@
 >>]
 >> Got issues: [
 * Error 12 at NegativeTests.False.fst(30,18-30,41):
-  - Expected type "Prims.l_True \/ Prims.l_True"; but "Prims.Left Prims.T" has type "Prims.sum (*?u1*) _ Prims.l_True"
+  - Expected type Prims.l_True \/ Prims.l_True
+    but Prims.Left Prims.T
+    has type Prims.sum (*?u1*) _ Prims.l_True
 
 * Error 12 at NegativeTests.False.fst(30,18-30,41):
-  - Expected type "Prims.l_True \/ Prims.l_True"; but "Prims.Left Prims.T" has type "Prims.sum Prims.trivial Prims.l_True"
+  - Expected type Prims.l_True \/ Prims.l_True
+    but Prims.Left Prims.T
+    has type Prims.sum Prims.trivial Prims.l_True
 
 * Error 12 at NegativeTests.False.fst(30,42-30,66):
-  - Expected type "Prims.l_True \/ Prims.l_True"; but "Prims.Right Prims.T" has type "Prims.sum Prims.l_True (*?u6*) _"
+  - Expected type Prims.l_True \/ Prims.l_True
+    but Prims.Right Prims.T
+    has type Prims.sum Prims.l_True (*?u6*) _
 
 * Error 12 at NegativeTests.False.fst(30,42-30,66):
-  - Expected type "Prims.l_True \/ Prims.l_True"; but "Prims.Right Prims.T" has type "Prims.sum Prims.l_True Prims.trivial"
+  - Expected type Prims.l_True \/ Prims.l_True
+    but Prims.Right Prims.T
+    has type Prims.sum Prims.l_True Prims.trivial
 
 >>]
 * Warning 240 at NegativeTests.False.fst(21,4-21,7):


### PR DESCRIPTION
Example of after, in Pulse:
<img width="472" alt="Screenshot 2023-09-29 111721" src="https://github.com/FStarLang/FStar/assets/4195583/7ebe1fe5-72d8-4b3e-b516-3c72644233be">
previously this was all in a single line. If it fits in the line width, it will still be in a single line, but it will break as needed. Note `but test2` is in a single line since it fits, if `test2` was bigger it would also break and indent.

I removed the double quotes around the terms... should we maybe keep them? Or use anything else to distinguish terms appearing in the error message. GHC uses some fancy quotes that cannot appear in terms.
```
    • Couldn't match expected type ‘Int’ with actual type ‘Char’
```