### PR TITLE
Reflection.Typing: introduce basic sigelt_typing, allow splice_t to return a list

### DIFF
--- a/examples/dsls/bool_refinement/BoolRefinement.fst
+++ b/examples/dsls/bool_refinement/BoolRefinement.fst
@@ -1684,30 +1684,30 @@ let soundness_lemma (f:RT.fstar_top_env)
       ()
       (fun dd -> FStar.Squash.return_squash (soundness dd))
 
-let main (src:src_exp) : RT.dsl_tac_t =
+let main (nm:string) (src:src_exp) : RT.dsl_tac_t =
   fun f ->
   if ln src && closed src
   then 
     let (| src_ty, _ |) = check f [] src in
     soundness_lemma f [] src src_ty;
-    Some (elab_exp src), None, elab_ty src_ty
+    [RT.mk_checked_let f nm (elab_exp src) (elab_ty src_ty)]
   else T.fail "Not locally nameless"
 
 (***** Examples *****)
 
-%splice_t[foo] (main (EBool true))
+%splice_t[foo] (main "foo" (EBool true))
 
 //
 // This emits a subtyping query, bool <: x:bool{true}
 //   which is dispatched to the tc call back and succeeds
 //
-%splice_t[bar] (main (EApp (ELam (TRefineBool (ELam TBool (EBool true))) (EBVar 0))
-                           (EBool false)))
+%splice_t[bar] (main "bar" (EApp (ELam (TRefineBool (ELam TBool (EBool true))) (EBVar 0))
+                                 (EBool false)))
 
 //
 // The query here is bool <: x:bool{false}
 //   which fails as expected
 //
 [@@ expect_failure]
-%splice_t[baz] (main (EApp (ELam (TRefineBool (ELam TBool (EBool false))) (EBVar 0))
-                           (EBool true)))
+%splice_t[baz] (main "baz" (EApp (ELam (TRefineBool (ELam TBool (EBool false))) (EBVar 0))
+                                 (EBool true)))

--- a/examples/dsls/dependent_bool_refinement/DependentBoolRefinement.fst
+++ b/examples/dsls/dependent_bool_refinement/DependentBoolRefinement.fst
@@ -876,12 +876,12 @@ and closed_ty (t:src_ty)
     | TRefineBool e -> closed e
     | TArrow t1 t2 -> closed_ty t1 && closed_ty t2
 
-let main (src:src_exp)
+let main (nm:string) (src:src_exp)
   : RT.dsl_tac_t
   = fun f -> 
       if closed src
       then 
         let (| src_ty, _ |) = check f [] src in
         soundness_lemma f [] src src_ty;
-        Some(elab_exp src), None, elab_ty src_ty
+        [RT.mk_checked_let f nm (elab_exp src) (elab_ty src_ty)]
       else T.fail "Not locally nameless"

--- a/examples/dsls/stlc/STLC.Core.fst
+++ b/examples/dsls/stlc/STLC.Core.fst
@@ -536,25 +536,25 @@ let soundness_lemma (sg:stlc_env)
       ()
       (fun dd -> FStar.Squash.return_squash (soundness dd g))
 
-let main (src:stlc_exp) : RT.dsl_tac_t =
+let main (nm:string) (src:stlc_exp) : RT.dsl_tac_t =
   fun g ->
   if ln src && closed src
   then
     let (| src_ty, d |) = check g [] src in
     soundness_lemma [] src src_ty g;
-    Some (elab_exp src), None, elab_ty src_ty
+    [RT.mk_checked_let g nm (elab_exp src) (elab_ty src_ty)]
   else T.fail "Not locally nameless"
 
 (***** Tests *****)
 
-%splice_t[foo] (main (ELam TUnit (EBVar 0)))
+%splice_t[foo] (main "foo" (ELam TUnit (EBVar 0)))
 
 #push-options "--no_smt"
 let test_id () = assert (foo () == ()) by (T.compute ())
 #pop-options
 
 let bar_s = (ELam TUnit (ELam TUnit (EBVar 1)))
-%splice_t[bar] (main bar_s)
+%splice_t[bar] (main "bar" bar_s)
 
 let baz_s : stlc_exp = EApp bar_s EUnit
-%splice_t[baz] (main bar_s)
+%splice_t[baz] (main "baz" bar_s)

--- a/examples/dsls/stlc/STLC.Infer.fst
+++ b/examples/dsls/stlc/STLC.Infer.fst
@@ -121,25 +121,25 @@ let rec elab_core g (e:stlc_exp R.term)
     | ELam t e -> Core.ELam (read_back g t) (elab_core g e)
     | EApp e1 e2 -> Core.EApp (elab_core g e1) (elab_core g e2)
 
-let main (e:stlc_exp unit)
+let main (nm:string) (e:stlc_exp unit)
   : RT.dsl_tac_t
   = fun g -> 
       let (| e, _ |) = infer g [] e in
       let e = elab_core g e in
-      Core.main e g
+      Core.main nm e g
 
 (***** Tests *****)
 
 #set-options "--ugly"
 
-%splice_t[foo] (main (ELam () (EBVar 0)))
+%splice_t[foo] (main "foo" (ELam () (EBVar 0)))
 
 #push-options "--no_smt"
 let test_id () = assert (foo () == ()) by (T.compute ())
 #pop-options
 
 let bar_s = (ELam () (ELam () (EBVar 1)))
-%splice_t[bar] (main bar_s)
+%splice_t[bar] (main "bar" bar_s)
 
 let baz_s = EApp bar_s EUnit
-%splice_t[baz] (main bar_s)
+%splice_t[baz] (main "baz" bar_s)

--- a/ocaml/fstar-lib/generated/FStar_CheckedFiles.ml
+++ b/ocaml/fstar-lib/generated/FStar_CheckedFiles.ml
@@ -1,5 +1,5 @@
 open Prims
-let (cache_version_number : Prims.int) = (Prims.of_int (61))
+let (cache_version_number : Prims.int) = (Prims.of_int (62))
 type tc_result =
   {
   checked_module: FStar_Syntax_Syntax.modul ;

--- a/ocaml/fstar-lib/generated/FStar_Reflection_Typing.ml
+++ b/ocaml/fstar-lib/generated/FStar_Reflection_Typing.ml
@@ -1564,12 +1564,98 @@ let (equiv_abs_close :
 type 'g fstar_env_fvs = unit
 type fstar_env = FStar_Reflection_Types.env
 type fstar_top_env = fstar_env
+type ('dummyV0, 'dummyV1) sigelt_typing =
+  | ST_Let of FStar_Reflection_Types.env * FStar_Reflection_Types.fv *
+  FStar_Reflection_Types.typ * FStar_Reflection_Types.term * unit 
+  | ST_Let_Opaque of FStar_Reflection_Types.env * FStar_Reflection_Types.fv *
+  FStar_Reflection_Types.typ * unit 
+let (uu___is_ST_Let :
+  FStar_Reflection_Types.env ->
+    FStar_Reflection_Types.sigelt -> (unit, unit) sigelt_typing -> Prims.bool)
+  =
+  fun uu___ ->
+    fun uu___1 ->
+      fun projectee ->
+        match projectee with
+        | ST_Let (g, fv, ty, tm, _4) -> true
+        | uu___2 -> false
+let (__proj__ST_Let__item__g :
+  FStar_Reflection_Types.env ->
+    FStar_Reflection_Types.sigelt ->
+      (unit, unit) sigelt_typing -> FStar_Reflection_Types.env)
+  =
+  fun uu___ ->
+    fun uu___1 ->
+      fun projectee -> match projectee with | ST_Let (g, fv, ty, tm, _4) -> g
+let (__proj__ST_Let__item__fv :
+  FStar_Reflection_Types.env ->
+    FStar_Reflection_Types.sigelt ->
+      (unit, unit) sigelt_typing -> FStar_Reflection_Types.fv)
+  =
+  fun uu___ ->
+    fun uu___1 ->
+      fun projectee ->
+        match projectee with | ST_Let (g, fv, ty, tm, _4) -> fv
+let (__proj__ST_Let__item__ty :
+  FStar_Reflection_Types.env ->
+    FStar_Reflection_Types.sigelt ->
+      (unit, unit) sigelt_typing -> FStar_Reflection_Types.typ)
+  =
+  fun uu___ ->
+    fun uu___1 ->
+      fun projectee ->
+        match projectee with | ST_Let (g, fv, ty, tm, _4) -> ty
+let (__proj__ST_Let__item__tm :
+  FStar_Reflection_Types.env ->
+    FStar_Reflection_Types.sigelt ->
+      (unit, unit) sigelt_typing -> FStar_Reflection_Types.term)
+  =
+  fun uu___ ->
+    fun uu___1 ->
+      fun projectee ->
+        match projectee with | ST_Let (g, fv, ty, tm, _4) -> tm
+let (uu___is_ST_Let_Opaque :
+  FStar_Reflection_Types.env ->
+    FStar_Reflection_Types.sigelt -> (unit, unit) sigelt_typing -> Prims.bool)
+  =
+  fun uu___ ->
+    fun uu___1 ->
+      fun projectee ->
+        match projectee with
+        | ST_Let_Opaque (g, fv, ty, _3) -> true
+        | uu___2 -> false
+let (__proj__ST_Let_Opaque__item__g :
+  FStar_Reflection_Types.env ->
+    FStar_Reflection_Types.sigelt ->
+      (unit, unit) sigelt_typing -> FStar_Reflection_Types.env)
+  =
+  fun uu___ ->
+    fun uu___1 ->
+      fun projectee ->
+        match projectee with | ST_Let_Opaque (g, fv, ty, _3) -> g
+let (__proj__ST_Let_Opaque__item__fv :
+  FStar_Reflection_Types.env ->
+    FStar_Reflection_Types.sigelt ->
+      (unit, unit) sigelt_typing -> FStar_Reflection_Types.fv)
+  =
+  fun uu___ ->
+    fun uu___1 ->
+      fun projectee ->
+        match projectee with | ST_Let_Opaque (g, fv, ty, _3) -> fv
+let (__proj__ST_Let_Opaque__item__ty :
+  FStar_Reflection_Types.env ->
+    FStar_Reflection_Types.sigelt ->
+      (unit, unit) sigelt_typing -> FStar_Reflection_Types.typ)
+  =
+  fun uu___ ->
+    fun uu___1 ->
+      fun projectee ->
+        match projectee with | ST_Let_Opaque (g, fv, ty, _3) -> ty
 type blob = (Prims.string * FStar_Reflection_Types.term)
-type dsl_tac_result_base_t =
-  (FStar_Reflection_Types.term FStar_Pervasives_Native.option * blob
-    FStar_Pervasives_Native.option * FStar_Reflection_Types.typ)
-type ('g, 'e) well_typed = Obj.t
-type 'g dsl_tac_result_t = dsl_tac_result_base_t
+type 'g sigelt_for =
+  (Prims.bool * FStar_Reflection_Types.sigelt * blob
+    FStar_Pervasives_Native.option)
+type 'g dsl_tac_result_t = unit sigelt_for Prims.list
 type dsl_tac_t =
   fstar_top_env ->
     (unit dsl_tac_result_t, unit) FStar_Tactics_Effect.tac_repr
@@ -1646,3 +1732,145 @@ let (mkif :
                                         FStar_Pervasives_Native.fst
                                         [brt; bre]), [[]; []], ())),
                                 (brty ()))
+let (mk_checked_let :
+  FStar_Reflection_Types.env ->
+    Prims.string ->
+      FStar_Reflection_Types.term ->
+        FStar_Reflection_Types.typ ->
+          (unit sigelt_for, unit) FStar_Tactics_Effect.tac_repr)
+  =
+  fun g ->
+    fun nm ->
+      fun tm ->
+        fun ty ->
+          FStar_Tactics_Effect.tac_bind
+            (FStar_Sealed.seal
+               (Obj.magic
+                  (FStar_Range.mk_range "FStar.Reflection.Typing.fsti"
+                     (Prims.of_int (1833)) (Prims.of_int (11))
+                     (Prims.of_int (1833)) (Prims.of_int (43)))))
+            (FStar_Sealed.seal
+               (Obj.magic
+                  (FStar_Range.mk_range "FStar.Reflection.Typing.fsti"
+                     (Prims.of_int (1833)) (Prims.of_int (46))
+                     (Prims.of_int (1839)) (Prims.of_int (20)))))
+            (Obj.magic
+               (FStar_Tactics_Effect.tac_bind
+                  (FStar_Sealed.seal
+                     (Obj.magic
+                        (FStar_Range.mk_range "FStar.Reflection.Typing.fsti"
+                           (Prims.of_int (1833)) (Prims.of_int (19))
+                           (Prims.of_int (1833)) (Prims.of_int (43)))))
+                  (FStar_Sealed.seal
+                     (Obj.magic
+                        (FStar_Range.mk_range "FStar.Reflection.Typing.fsti"
+                           (Prims.of_int (1833)) (Prims.of_int (11))
+                           (Prims.of_int (1833)) (Prims.of_int (43)))))
+                  (Obj.magic
+                     (FStar_Tactics_Effect.tac_bind
+                        (FStar_Sealed.seal
+                           (Obj.magic
+                              (FStar_Range.mk_range
+                                 "FStar.Reflection.Typing.fsti"
+                                 (Prims.of_int (1833)) (Prims.of_int (20))
+                                 (Prims.of_int (1833)) (Prims.of_int (35)))))
+                        (FStar_Sealed.seal
+                           (Obj.magic
+                              (FStar_Range.mk_range
+                                 "FStar.Reflection.Typing.fsti"
+                                 (Prims.of_int (1833)) (Prims.of_int (19))
+                                 (Prims.of_int (1833)) (Prims.of_int (43)))))
+                        (Obj.magic (FStar_Tactics_V2_Derived.cur_module ()))
+                        (fun uu___ ->
+                           FStar_Tactics_Effect.lift_div_tac
+                             (fun uu___1 ->
+                                FStar_List_Tot_Base.op_At uu___ [nm]))))
+                  (fun uu___ ->
+                     FStar_Tactics_Effect.lift_div_tac
+                       (fun uu___1 ->
+                          FStar_Reflection_V2_Builtins.pack_fv uu___))))
+            (fun fv ->
+               FStar_Tactics_Effect.lift_div_tac
+                 (fun uu___ ->
+                    (true,
+                      (FStar_Reflection_V2_Builtins.pack_sigelt
+                         (FStar_Reflection_V2_Data.Sg_Let
+                            (false,
+                              [FStar_Reflection_V2_Builtins.pack_lb
+                                 {
+                                   FStar_Reflection_V2_Data.lb_fv = fv;
+                                   FStar_Reflection_V2_Data.lb_us = [];
+                                   FStar_Reflection_V2_Data.lb_typ = ty;
+                                   FStar_Reflection_V2_Data.lb_def = tm
+                                 }]))), FStar_Pervasives_Native.None)))
+let (mk_unchecked_let :
+  FStar_Reflection_Types.env ->
+    Prims.string ->
+      FStar_Reflection_Types.term ->
+        FStar_Reflection_Types.typ ->
+          (unit sigelt_for, unit) FStar_Tactics_Effect.tac_repr)
+  =
+  fun g ->
+    fun nm ->
+      fun tm ->
+        fun ty ->
+          FStar_Tactics_Effect.tac_bind
+            (FStar_Sealed.seal
+               (Obj.magic
+                  (FStar_Range.mk_range "FStar.Reflection.Typing.fsti"
+                     (Prims.of_int (1842)) (Prims.of_int (11))
+                     (Prims.of_int (1842)) (Prims.of_int (43)))))
+            (FStar_Sealed.seal
+               (Obj.magic
+                  (FStar_Range.mk_range "FStar.Reflection.Typing.fsti"
+                     (Prims.of_int (1842)) (Prims.of_int (46))
+                     (Prims.of_int (1845)) (Prims.of_int (21)))))
+            (Obj.magic
+               (FStar_Tactics_Effect.tac_bind
+                  (FStar_Sealed.seal
+                     (Obj.magic
+                        (FStar_Range.mk_range "FStar.Reflection.Typing.fsti"
+                           (Prims.of_int (1842)) (Prims.of_int (19))
+                           (Prims.of_int (1842)) (Prims.of_int (43)))))
+                  (FStar_Sealed.seal
+                     (Obj.magic
+                        (FStar_Range.mk_range "FStar.Reflection.Typing.fsti"
+                           (Prims.of_int (1842)) (Prims.of_int (11))
+                           (Prims.of_int (1842)) (Prims.of_int (43)))))
+                  (Obj.magic
+                     (FStar_Tactics_Effect.tac_bind
+                        (FStar_Sealed.seal
+                           (Obj.magic
+                              (FStar_Range.mk_range
+                                 "FStar.Reflection.Typing.fsti"
+                                 (Prims.of_int (1842)) (Prims.of_int (20))
+                                 (Prims.of_int (1842)) (Prims.of_int (35)))))
+                        (FStar_Sealed.seal
+                           (Obj.magic
+                              (FStar_Range.mk_range
+                                 "FStar.Reflection.Typing.fsti"
+                                 (Prims.of_int (1842)) (Prims.of_int (19))
+                                 (Prims.of_int (1842)) (Prims.of_int (43)))))
+                        (Obj.magic (FStar_Tactics_V2_Derived.cur_module ()))
+                        (fun uu___ ->
+                           FStar_Tactics_Effect.lift_div_tac
+                             (fun uu___1 ->
+                                FStar_List_Tot_Base.op_At uu___ [nm]))))
+                  (fun uu___ ->
+                     FStar_Tactics_Effect.lift_div_tac
+                       (fun uu___1 ->
+                          FStar_Reflection_V2_Builtins.pack_fv uu___))))
+            (fun fv ->
+               FStar_Tactics_Effect.lift_div_tac
+                 (fun uu___ ->
+                    (false,
+                      (FStar_Reflection_V2_Builtins.pack_sigelt
+                         (FStar_Reflection_V2_Data.Sg_Let
+                            (false,
+                              [FStar_Reflection_V2_Builtins.pack_lb
+                                 {
+                                   FStar_Reflection_V2_Data.lb_fv = fv;
+                                   FStar_Reflection_V2_Data.lb_us = [];
+                                   FStar_Reflection_V2_Data.lb_typ = ty;
+                                   FStar_Reflection_V2_Data.lb_def = tm
+                                 }]))), FStar_Pervasives_Native.None)))

--- a/ocaml/fstar-lib/generated/FStar_Syntax_Syntax.ml
+++ b/ocaml/fstar-lib/generated/FStar_Syntax_Syntax.ml
@@ -1657,31 +1657,41 @@ type sig_metadata =
   sigmeta_active: Prims.bool ;
   sigmeta_fact_db_ids: Prims.string Prims.list ;
   sigmeta_admit: Prims.bool ;
+  sigmeta_already_checked: Prims.bool ;
   sigmeta_extension_data: (Prims.string * FStar_Compiler_Dyn.dyn) Prims.list }
 let (__proj__Mksig_metadata__item__sigmeta_active :
   sig_metadata -> Prims.bool) =
   fun projectee ->
     match projectee with
     | { sigmeta_active; sigmeta_fact_db_ids; sigmeta_admit;
-        sigmeta_extension_data;_} -> sigmeta_active
+        sigmeta_already_checked; sigmeta_extension_data;_} -> sigmeta_active
 let (__proj__Mksig_metadata__item__sigmeta_fact_db_ids :
   sig_metadata -> Prims.string Prims.list) =
   fun projectee ->
     match projectee with
     | { sigmeta_active; sigmeta_fact_db_ids; sigmeta_admit;
-        sigmeta_extension_data;_} -> sigmeta_fact_db_ids
+        sigmeta_already_checked; sigmeta_extension_data;_} ->
+        sigmeta_fact_db_ids
 let (__proj__Mksig_metadata__item__sigmeta_admit :
   sig_metadata -> Prims.bool) =
   fun projectee ->
     match projectee with
     | { sigmeta_active; sigmeta_fact_db_ids; sigmeta_admit;
-        sigmeta_extension_data;_} -> sigmeta_admit
+        sigmeta_already_checked; sigmeta_extension_data;_} -> sigmeta_admit
+let (__proj__Mksig_metadata__item__sigmeta_already_checked :
+  sig_metadata -> Prims.bool) =
+  fun projectee ->
+    match projectee with
+    | { sigmeta_active; sigmeta_fact_db_ids; sigmeta_admit;
+        sigmeta_already_checked; sigmeta_extension_data;_} ->
+        sigmeta_already_checked
 let (__proj__Mksig_metadata__item__sigmeta_extension_data :
   sig_metadata -> (Prims.string * FStar_Compiler_Dyn.dyn) Prims.list) =
   fun projectee ->
     match projectee with
     | { sigmeta_active; sigmeta_fact_db_ids; sigmeta_admit;
-        sigmeta_extension_data;_} -> sigmeta_extension_data
+        sigmeta_already_checked; sigmeta_extension_data;_} ->
+        sigmeta_extension_data
 type open_kind =
   | Open_module 
   | Open_namespace 
@@ -2326,6 +2336,7 @@ let (default_sigmeta : sig_metadata) =
     sigmeta_active = true;
     sigmeta_fact_db_ids = [];
     sigmeta_admit = false;
+    sigmeta_already_checked = false;
     sigmeta_extension_data = []
   }
 let (mk_sigelt : sigelt' -> sigelt) =

--- a/ocaml/fstar-lib/generated/FStar_Tactics_Hooks.ml
+++ b/ocaml/fstar-lib/generated/FStar_Tactics_Hooks.ml
@@ -1794,20 +1794,20 @@ let (splice :
                            let uu___6 =
                              if is_typed
                              then
+                               let e_blob =
+                                 let uu___7 =
+                                   FStar_Syntax_Embeddings.e_tuple2
+                                     FStar_Syntax_Embeddings.e_string
+                                     FStar_Reflection_V2_Embeddings.e_term in
+                                 FStar_Syntax_Embeddings.e_option uu___7 in
                                let uu___7 =
                                  let uu___8 =
                                    let uu___9 =
-                                     FStar_Syntax_Embeddings.e_option
-                                       FStar_Reflection_V2_Embeddings.e_term in
-                                   let uu___10 =
-                                     let uu___11 =
-                                       FStar_Syntax_Embeddings.e_tuple2
-                                         FStar_Syntax_Embeddings.e_string
-                                         FStar_Reflection_V2_Embeddings.e_term in
-                                     FStar_Syntax_Embeddings.e_option uu___11 in
-                                   FStar_Syntax_Embeddings.e_tuple3 uu___9
-                                     uu___10
-                                     FStar_Reflection_V2_Embeddings.e_term in
+                                     FStar_Syntax_Embeddings.e_tuple3
+                                       FStar_Syntax_Embeddings.e_bool
+                                       FStar_Reflection_V2_Embeddings.e_sigelt
+                                       e_blob in
+                                   FStar_Syntax_Embeddings.e_list uu___9 in
                                  FStar_Tactics_V2_Interpreter.run_tactic_on_ps
                                    tau1.FStar_Syntax_Syntax.pos
                                    tau1.FStar_Syntax_Syntax.pos false
@@ -1928,68 +1928,67 @@ let (splice :
                                        (env.FStar_TypeChecker_Env.core_check)
                                    } uu___8 tau1 tactic_already_typed ps in
                                match uu___7 with
-                               | (gs, (tm_opt, blob_opt, typ)) ->
-                                   let e =
-                                     match tm_opt with
-                                     | FStar_Pervasives_Native.None ->
-                                         FStar_Syntax_Syntax.tun
-                                     | FStar_Pervasives_Native.Some t -> t in
-                                   let sig_extension_data =
-                                     match blob_opt with
-                                     | FStar_Pervasives_Native.None -> []
-                                     | FStar_Pervasives_Native.Some (s, blob)
-                                         ->
-                                         let uu___8 =
-                                           let uu___9 =
-                                             FStar_Compiler_Dyn.mkdyn blob in
-                                           (s, uu___9) in
-                                         [uu___8] in
-                                   let lb =
-                                     let uu___8 =
-                                       let uu___9 =
-                                         let uu___10 =
-                                           FStar_Compiler_List.hd lids in
-                                         FStar_Syntax_Syntax.lid_as_fv
-                                           uu___10
-                                           FStar_Pervasives_Native.None in
-                                       FStar_Pervasives.Inr uu___9 in
-                                     FStar_Syntax_Util.mk_letbinding uu___8
-                                       [] typ
-                                       FStar_Parser_Const.effect_Tot_lid e []
-                                       rng in
-                                   (gs,
-                                     [{
-                                        FStar_Syntax_Syntax.sigel =
-                                          (FStar_Syntax_Syntax.Sig_let
-                                             {
-                                               FStar_Syntax_Syntax.lbs1 =
-                                                 (false, [lb]);
-                                               FStar_Syntax_Syntax.lids1 =
-                                                 lids
-                                             });
-                                        FStar_Syntax_Syntax.sigrng = rng;
-                                        FStar_Syntax_Syntax.sigquals =
-                                          [FStar_Syntax_Syntax.Visible_default];
-                                        FStar_Syntax_Syntax.sigmeta =
-                                          {
-                                            FStar_Syntax_Syntax.sigmeta_active
-                                              =
-                                              (FStar_Syntax_Syntax.default_sigmeta.FStar_Syntax_Syntax.sigmeta_active);
-                                            FStar_Syntax_Syntax.sigmeta_fact_db_ids
-                                              =
-                                              (FStar_Syntax_Syntax.default_sigmeta.FStar_Syntax_Syntax.sigmeta_fact_db_ids);
-                                            FStar_Syntax_Syntax.sigmeta_admit
-                                              =
-                                              (FStar_Syntax_Syntax.default_sigmeta.FStar_Syntax_Syntax.sigmeta_admit);
-                                            FStar_Syntax_Syntax.sigmeta_extension_data
-                                              = sig_extension_data
-                                          };
-                                        FStar_Syntax_Syntax.sigattrs = [];
-                                        FStar_Syntax_Syntax.sigopens_and_abbrevs
-                                          = [];
-                                        FStar_Syntax_Syntax.sigopts =
-                                          FStar_Pervasives_Native.None
-                                      }])
+                               | (gs, sig_blobs) ->
+                                   let sigelts =
+                                     FStar_Compiler_Effect.op_Bar_Greater
+                                       sig_blobs
+                                       (FStar_Compiler_List.map
+                                          (fun uu___8 ->
+                                             match uu___8 with
+                                             | (checked, se, blob_opt) ->
+                                                 let uu___9 =
+                                                   let uu___10 =
+                                                     se.FStar_Syntax_Syntax.sigmeta in
+                                                   let uu___11 =
+                                                     match blob_opt with
+                                                     | FStar_Pervasives_Native.Some
+                                                         (s, blob) ->
+                                                         let uu___12 =
+                                                           let uu___13 =
+                                                             FStar_Compiler_Dyn.mkdyn
+                                                               blob in
+                                                           (s, uu___13) in
+                                                         [uu___12]
+                                                     | FStar_Pervasives_Native.None
+                                                         -> [] in
+                                                   {
+                                                     FStar_Syntax_Syntax.sigmeta_active
+                                                       =
+                                                       (uu___10.FStar_Syntax_Syntax.sigmeta_active);
+                                                     FStar_Syntax_Syntax.sigmeta_fact_db_ids
+                                                       =
+                                                       (uu___10.FStar_Syntax_Syntax.sigmeta_fact_db_ids);
+                                                     FStar_Syntax_Syntax.sigmeta_admit
+                                                       =
+                                                       (uu___10.FStar_Syntax_Syntax.sigmeta_admit);
+                                                     FStar_Syntax_Syntax.sigmeta_already_checked
+                                                       = checked;
+                                                     FStar_Syntax_Syntax.sigmeta_extension_data
+                                                       = uu___11
+                                                   } in
+                                                 {
+                                                   FStar_Syntax_Syntax.sigel
+                                                     =
+                                                     (se.FStar_Syntax_Syntax.sigel);
+                                                   FStar_Syntax_Syntax.sigrng
+                                                     =
+                                                     (se.FStar_Syntax_Syntax.sigrng);
+                                                   FStar_Syntax_Syntax.sigquals
+                                                     =
+                                                     (se.FStar_Syntax_Syntax.sigquals);
+                                                   FStar_Syntax_Syntax.sigmeta
+                                                     = uu___9;
+                                                   FStar_Syntax_Syntax.sigattrs
+                                                     =
+                                                     (se.FStar_Syntax_Syntax.sigattrs);
+                                                   FStar_Syntax_Syntax.sigopens_and_abbrevs
+                                                     =
+                                                     (se.FStar_Syntax_Syntax.sigopens_and_abbrevs);
+                                                   FStar_Syntax_Syntax.sigopts
+                                                     =
+                                                     (se.FStar_Syntax_Syntax.sigopts)
+                                                 })) in
+                                   (gs, sigelts)
                              else
                                (let uu___8 =
                                   FStar_Syntax_Embeddings.e_list

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_DMFF.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_DMFF.ml
@@ -184,6 +184,8 @@ let (gen_wps_for_free :
                              FStar_Syntax_Syntax.sigmeta_fact_db_ids =
                                (uu___3.FStar_Syntax_Syntax.sigmeta_fact_db_ids);
                              FStar_Syntax_Syntax.sigmeta_admit = true;
+                             FStar_Syntax_Syntax.sigmeta_already_checked =
+                               (uu___3.FStar_Syntax_Syntax.sigmeta_already_checked);
                              FStar_Syntax_Syntax.sigmeta_extension_data =
                                (uu___3.FStar_Syntax_Syntax.sigmeta_extension_data)
                            });
@@ -4495,6 +4497,9 @@ let (cps_and_elaborate :
                                                                  (uu___16.FStar_Syntax_Syntax.sigmeta_fact_db_ids);
                                                                FStar_Syntax_Syntax.sigmeta_admit
                                                                  = true;
+                                                               FStar_Syntax_Syntax.sigmeta_already_checked
+                                                                 =
+                                                                 (uu___16.FStar_Syntax_Syntax.sigmeta_already_checked);
                                                                FStar_Syntax_Syntax.sigmeta_extension_data
                                                                  =
                                                                  (uu___16.FStar_Syntax_Syntax.sigmeta_extension_data)

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_Tc.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_Tc.ml
@@ -2630,6 +2630,9 @@ let (tc_decl' :
                                          (uu___3.FStar_Syntax_Syntax.sigmeta_fact_db_ids);
                                        FStar_Syntax_Syntax.sigmeta_admit =
                                          true;
+                                       FStar_Syntax_Syntax.sigmeta_already_checked
+                                         =
+                                         (uu___3.FStar_Syntax_Syntax.sigmeta_already_checked);
                                        FStar_Syntax_Syntax.sigmeta_extension_data
                                          =
                                          (uu___3.FStar_Syntax_Syntax.sigmeta_extension_data)
@@ -3624,7 +3627,7 @@ let (tc_decl' :
                     FStar_Compiler_Util.print1
                       "Splice returned sigelts {\n%s\n}\n" uu___5
                   else ());
-                 if is_typed then (ses1, [], env1) else ([], ses1, env1)))
+                 ([], ses1, env1)))
            | FStar_Syntax_Syntax.Sig_let
                { FStar_Syntax_Syntax.lbs1 = lbs;
                  FStar_Syntax_Syntax.lids1 = lids;_}
@@ -4160,13 +4163,17 @@ let (tc_decl :
          let uu___3 = FStar_Syntax_Print.sigelt_to_string se in
          FStar_Compiler_Util.print1 ">>>>>>>>>>>>>>tc_decl %s\n" uu___3
        else ());
-      if (se.FStar_Syntax_Syntax.sigmeta).FStar_Syntax_Syntax.sigmeta_admit
-      then
-        (let old = FStar_Options.admit_smt_queries () in
-         FStar_Options.set_admit_smt_queries true;
-         (let result = tc_decl' env1 se in
-          FStar_Options.set_admit_smt_queries old; result))
-      else tc_decl' env1 se
+      if
+        (se.FStar_Syntax_Syntax.sigmeta).FStar_Syntax_Syntax.sigmeta_already_checked
+      then ([se], [], env1)
+      else
+        if (se.FStar_Syntax_Syntax.sigmeta).FStar_Syntax_Syntax.sigmeta_admit
+        then
+          (let old = FStar_Options.admit_smt_queries () in
+           FStar_Options.set_admit_smt_queries true;
+           (let result = tc_decl' env1 se in
+            FStar_Options.set_admit_smt_queries old; result))
+        else tc_decl' env1 se
 let (add_sigelt_to_env :
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.sigelt -> Prims.bool -> FStar_TypeChecker_Env.env)

--- a/src/fstar/FStar.CheckedFiles.fst
+++ b/src/fstar/FStar.CheckedFiles.fst
@@ -39,7 +39,7 @@ module Dep     = FStar.Parser.Dep
  * detect when loading the cache that the version number is same
  * It needs to be kept in sync with prims.fst
  *)
-let cache_version_number = 61
+let cache_version_number = 62
 
 (*
  * Abbreviation for what we store in the checked files (stages as described below)

--- a/src/syntax/FStar.Syntax.Syntax.fst
+++ b/src/syntax/FStar.Syntax.Syntax.fst
@@ -164,6 +164,7 @@ let default_sigmeta = {
     sigmeta_active=true;
     sigmeta_fact_db_ids=[];
     sigmeta_admit=false;
+    sigmeta_already_checked=false;
     sigmeta_extension_data=[]
 }
 let mk_sigelt (e: sigelt') = { 

--- a/src/syntax/FStar.Syntax.Syntax.fsti
+++ b/src/syntax/FStar.Syntax.Syntax.fsti
@@ -621,6 +621,9 @@ type sig_metadata = {
     sigmeta_fact_db_ids:list string;
     sigmeta_admit:bool; //An internal flag to record that a sigelt's SMT proof should be admitted
                         //Used in DM4Free
+    sigmeta_already_checked:bool;
+    // ^ This sigelt was created from a splice_t with a proof of well-typing,
+    // and does not need to be checked again.
     sigmeta_extension_data: list (string & dyn) //each extension can register some data with a sig
 }
 

--- a/ulib/prims.fst
+++ b/ulib/prims.fst
@@ -708,4 +708,4 @@ val string_of_int: int -> Tot string
 (** THIS IS MEANT TO BE KEPT IN SYNC WITH FStar.CheckedFiles.fs
     Incrementing this forces all .checked files to be invalidated *)
 irreducible
-let __cache_version_number__ = 61
+let __cache_version_number__ = 62


### PR DESCRIPTION
This PR updates the expected return type of a `splice_t` call to
  1) return sigelts instead of term+types (so in principle we could do more than letbindings, though the typing rules are not there yet); and 
  2) return any mixture of checked and unchecked declarations, decided a boolean on each one

Note: instead of (2), I first was thinking to only expose `tc_decl` or to produce a proof of typing of these declarations by any manner, but it will not work if we want to return `[s1;s2]` with the typing of `s2` depending on `s1`, since `s1` is not in scope _while_ the splice is running. So, the boolean allows to return `[(true, s1); (false, s2)]`, deferring the checking of `s2` until `s1` has been added to the environment.