### PR TITLE
Normalizer: invalidate memoizations if cfg changes

### DIFF
--- a/examples/typeclasses/Pulse.Class.BoundedIntegers.fst
+++ b/examples/typeclasses/Pulse.Class.BoundedIntegers.fst
@@ -1,0 +1,205 @@
+module Pulse.Class.BoundedIntegers
+
+module TC = FStar.Tactics.Typeclasses
+
+let fits_t (fits:int -> prop) = x:int { fits x }
+
+class bounded_int (t:eqtype) = {
+    fits: int -> prop;
+    v : t -> GTot int;
+    u : fits_t fits -> GTot t;
+    ( + ) : (x:t -> y:t -> Pure t (requires fits (v x + v y)) (ensures fun z -> v z == v x + v y));
+    op_Subtraction : (x:t -> y:t -> Pure t (requires fits (v x - v y)) (ensures fun z -> v z == v x - v y));
+    ( < ) : (x:t -> y:t -> b:bool { b = (v x < v y)});
+    ( <= ) : (x:t -> y:t -> b:bool { b = (v x <= v y)});
+    ( % ) : (x:t -> y:t -> Pure t (requires v y > 0 /\ fits (v x % v y)) (ensures fun z -> v z == v x % v y));
+    [@@@TC.no_method]
+    properties: squash (
+      (forall (x:t). {:pattern v x} fits (v x)) 
+    )
+    (* ...todo, add other ops **)
+}
+
+
+
+instance bounded_int_int : bounded_int int = {
+    fits = (fun _ -> True);
+    v = id;
+    u = id;
+    ( + ) = (fun x y -> Prims.op_Addition x y);
+    op_Subtraction = (fun x y -> Prims.op_Subtraction x y);
+    ( < ) = (fun x y -> Prims.op_LessThan x y);
+    ( <= ) = (fun x y -> Prims.op_LessThanOrEqual x y);
+    ( % ) = (fun x y -> Prims.op_Modulus x y);
+    properties = ()
+}
+
+
+class bounded_unsigned (t:eqtype) = {
+  [@@@TC.no_method]
+  base:bounded_int t;
+  max_bound:t;
+  [@@@TC.no_method]  
+  static_max_bound: bool;
+  [@@@TC.no_method]
+  properties: squash (
+    (forall (x:t). v x >= 0 /\ (static_max_bound ==> v x <= v max_bound)) /\
+    (forall (x:nat). x <= v max_bound ==> fits #t x)
+  )
+}
+
+
+instance bounded_from_bounded_unsigned (t:eqtype) (c:bounded_unsigned t) : bounded_int t = c.base
+
+let safe_add (#t:eqtype) {| c: bounded_unsigned t |} (x y : t)
+  : o:option t { Some? o ==> v (Some?.v o) == v x + v y } 
+  = if c.static_max_bound
+    then (
+      assert ( x <= max_bound);
+      if (y <= max_bound - x) 
+      then Some (x + y)
+      else None
+    )
+    else (
+      if x <= max_bound
+      then (
+        assert (fits #t (v (max_bound #t) - v x));
+        if (y <= max_bound - x)
+        then Some (x + y)
+        else None
+      )
+      else None
+    )
+
+let safe_mod (#t:eqtype) {| c: bounded_unsigned t |} (x : t) (y : t)
+  : Pure (option t)
+         (requires v y > 0)
+         (ensures fun o -> Some? o ==> v (Some?.v o) == v x % v y)
+  = if c.static_max_bound
+    then Some (x % y)
+    else (
+      if y <= max_bound
+      then  (
+        assert (fits #t (v x % v y));
+        Some (x % y)
+      )
+      else None
+    )
+
+let ok (#t:eqtype) {| c:bounded_int t |} (op: int -> int -> int) (x y:t) =
+    c.fits (op (v x) (v y))
+
+let add (#t:eqtype) {| bounded_int t |} (x:t) (y:t { ok (+) x y }) = x + y
+
+let add3 (#t:eqtype) {| bounded_int t |} (x:t) (y:t) (z:t { ok (+) x y /\ ok (+) z (x + y)}) = x + y + z
+
+//Writing the signature of bounded_int.(+) using Pure
+//allows this to work, since the type of (x+y) is not refined
+let add3_alt (#t:eqtype) {| bounded_int t |} (x:t) (y:t) (z:t { ok (+) x y /\ ok (+) (x + y) z}) = x + y + z
+
+instance bounded_int_u32 : bounded_int FStar.UInt32.t = {
+    fits = (fun x -> 0 <= x /\ x < 4294967296);
+    v = (fun x -> FStar.UInt32.v x);
+    u = FStar.UInt32.uint_to_t;
+    ( + ) = (fun x y -> FStar.UInt32.add x y);
+    op_Subtraction = (fun x y -> FStar.UInt32.sub x y);
+    ( < ) = FStar.UInt32.(fun x y -> x <^ y);
+    ( <= ) = FStar.UInt32.(fun x y -> x <=^ y);
+    ( % ) = FStar.UInt32.(fun x y -> x %^ y);
+    properties = ()
+}
+
+instance bounded_unsigned_u32 : bounded_unsigned FStar.UInt32.t = {
+  base = TC.solve;
+  max_bound = 0xfffffffful;
+  static_max_bound = true;
+  properties = ()
+}
+
+instance bounded_int_u64 : bounded_int FStar.UInt64.t = {
+    fits = (fun x -> 0 <= x /\ x <= 0xffffffffffffffff);
+    v = (fun x -> FStar.UInt64.v x);
+    u = FStar.UInt64.uint_to_t;
+    ( + ) = (fun x y -> FStar.UInt64.add x y);
+    op_Subtraction = (fun x y -> FStar.UInt64.sub x y);
+    ( < ) = FStar.UInt64.(fun x y -> x <^ y);
+    ( <= ) = FStar.UInt64.(fun x y -> x <=^ y);
+    ( % ) = FStar.UInt64.(fun x y -> x %^ y);
+    properties = ()
+}
+
+instance bounded_unsigned_u64 : bounded_unsigned FStar.UInt64.t = {
+  base = TC.solve;
+  max_bound = 0xffffffffffffffffuL;
+  static_max_bound = true;
+  properties = ()
+}
+
+let test (t:eqtype) {| _ : bounded_unsigned t |} (x:t) = v x
+
+let add_u32 (x:FStar.UInt32.t) (y:FStar.UInt32.t { ok (+) x y }) = x + y
+
+//Again, parser doesn't allow using (-)
+let sub_u32 (x:FStar.UInt32.t) (y:FStar.UInt32.t { ok op_Subtraction x y}) = x - y
+
+//this work and resolved to int, because of the 1
+let add_nat_1 (x:nat) = x + 1
+
+//But, to add two nats, this fails, since typeclass resolution doesn't consider subtyping
+[@@expect_failure]
+let add_nat (x y:nat) = x + y
+
+let nat_as_int (x:nat) : int = x
+
+instance bounded_int_nat : bounded_int nat = {
+    fits = (fun x -> x >= 0);
+    v = nat_as_int;
+    u = (fun x -> x);
+    ( + ) = (fun x y -> Prims.op_Addition x y);
+    op_Subtraction = (fun x y -> Prims.op_Subtraction x y); //can't write ( - ), it doesn't parse
+    ( < ) = (fun x y -> Prims.op_LessThan x y);
+    ( <= ) = (fun x y -> Prims.op_LessThanOrEqual x y);
+    ( % ) = (fun x y -> Prims.op_Modulus x y);
+    properties = ()
+}
+//with an instance for nat this works
+let add_nat (x y:nat) = x + y
+//but we should find a way to make it work with refinement, otherwise we'll need instances for pos etc. too
+
+let pos_as_int (x:pos) : int = x
+
+instance bounded_int_pos : bounded_int pos = {
+    fits = (fun x -> x > 0);
+    v = pos_as_int;
+    u = (fun x -> x);
+    ( + ) = (fun x y -> Prims.op_Addition x y);
+    op_Subtraction = (fun x y -> Prims.op_Subtraction x y); //can't write ( - ), it doesn't parse
+    ( < ) = (fun x y -> Prims.op_LessThan x y);
+    ( <= ) = (fun x y -> Prims.op_LessThanOrEqual x y);
+    ( % ) = (fun x y -> Prims.op_Modulus x y);
+    properties = ()
+}
+
+// Using a fits predicate as the bounds check allows this class to also accomodate SizeT
+open FStar.SizeT
+instance bounded_int_size_t : bounded_int FStar.SizeT.t = {
+    fits = (fun x -> x >= 0 /\ FStar.SizeT.fits x);
+    v = (fun x -> FStar.SizeT.v x);
+    u = (fun x -> FStar.SizeT.uint_to_t x);
+    ( + ) = (fun x y -> FStar.SizeT.add x y);
+    op_Subtraction = (fun x y -> FStar.SizeT.sub x y);
+    ( < ) = (fun x y -> FStar.SizeT.(x <^ y));
+    ( <= ) = (fun x y -> FStar.SizeT.(x <=^ y));
+    ( % ) = (fun x y -> FStar.SizeT.(x %^ y));
+    properties = ();
+}
+
+instance bounded_unsigned_size_t : bounded_unsigned FStar.SizeT.t = {
+  base = TC.solve;
+  max_bound = 0xffffsz;
+  static_max_bound = false;
+  properties = ()
+}
+
+//we know that size_t can hold at least 2^16
+let size_t_plus_one (x:FStar.SizeT.t { x < 1024sz }) = x + 1sz

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_Cfg.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_Cfg.ml
@@ -1878,54 +1878,70 @@ type cfg =
   strong: Prims.bool ;
   memoize_lazy: Prims.bool ;
   normalize_pure_lets: Prims.bool ;
-  reifying: Prims.bool }
+  reifying: Prims.bool ;
+  compat_memo_ignore_cfg: Prims.bool }
 let (__proj__Mkcfg__item__steps : cfg -> fsteps) =
   fun projectee ->
     match projectee with
     | { steps; tcenv; debug; delta_level; primitive_steps; strong;
-        memoize_lazy; normalize_pure_lets; reifying;_} -> steps
+        memoize_lazy; normalize_pure_lets; reifying;
+        compat_memo_ignore_cfg;_} -> steps
 let (__proj__Mkcfg__item__tcenv : cfg -> FStar_TypeChecker_Env.env) =
   fun projectee ->
     match projectee with
     | { steps; tcenv; debug; delta_level; primitive_steps; strong;
-        memoize_lazy; normalize_pure_lets; reifying;_} -> tcenv
+        memoize_lazy; normalize_pure_lets; reifying;
+        compat_memo_ignore_cfg;_} -> tcenv
 let (__proj__Mkcfg__item__debug : cfg -> debug_switches) =
   fun projectee ->
     match projectee with
     | { steps; tcenv; debug; delta_level; primitive_steps; strong;
-        memoize_lazy; normalize_pure_lets; reifying;_} -> debug
+        memoize_lazy; normalize_pure_lets; reifying;
+        compat_memo_ignore_cfg;_} -> debug
 let (__proj__Mkcfg__item__delta_level :
   cfg -> FStar_TypeChecker_Env.delta_level Prims.list) =
   fun projectee ->
     match projectee with
     | { steps; tcenv; debug; delta_level; primitive_steps; strong;
-        memoize_lazy; normalize_pure_lets; reifying;_} -> delta_level
+        memoize_lazy; normalize_pure_lets; reifying;
+        compat_memo_ignore_cfg;_} -> delta_level
 let (__proj__Mkcfg__item__primitive_steps :
   cfg -> primitive_step FStar_Compiler_Util.psmap) =
   fun projectee ->
     match projectee with
     | { steps; tcenv; debug; delta_level; primitive_steps; strong;
-        memoize_lazy; normalize_pure_lets; reifying;_} -> primitive_steps
+        memoize_lazy; normalize_pure_lets; reifying;
+        compat_memo_ignore_cfg;_} -> primitive_steps
 let (__proj__Mkcfg__item__strong : cfg -> Prims.bool) =
   fun projectee ->
     match projectee with
     | { steps; tcenv; debug; delta_level; primitive_steps; strong;
-        memoize_lazy; normalize_pure_lets; reifying;_} -> strong
+        memoize_lazy; normalize_pure_lets; reifying;
+        compat_memo_ignore_cfg;_} -> strong
 let (__proj__Mkcfg__item__memoize_lazy : cfg -> Prims.bool) =
   fun projectee ->
     match projectee with
     | { steps; tcenv; debug; delta_level; primitive_steps; strong;
-        memoize_lazy; normalize_pure_lets; reifying;_} -> memoize_lazy
+        memoize_lazy; normalize_pure_lets; reifying;
+        compat_memo_ignore_cfg;_} -> memoize_lazy
 let (__proj__Mkcfg__item__normalize_pure_lets : cfg -> Prims.bool) =
   fun projectee ->
     match projectee with
     | { steps; tcenv; debug; delta_level; primitive_steps; strong;
-        memoize_lazy; normalize_pure_lets; reifying;_} -> normalize_pure_lets
+        memoize_lazy; normalize_pure_lets; reifying;
+        compat_memo_ignore_cfg;_} -> normalize_pure_lets
 let (__proj__Mkcfg__item__reifying : cfg -> Prims.bool) =
   fun projectee ->
     match projectee with
     | { steps; tcenv; debug; delta_level; primitive_steps; strong;
-        memoize_lazy; normalize_pure_lets; reifying;_} -> reifying
+        memoize_lazy; normalize_pure_lets; reifying;
+        compat_memo_ignore_cfg;_} -> reifying
+let (__proj__Mkcfg__item__compat_memo_ignore_cfg : cfg -> Prims.bool) =
+  fun projectee ->
+    match projectee with
+    | { steps; tcenv; debug; delta_level; primitive_steps; strong;
+        memoize_lazy; normalize_pure_lets; reifying;
+        compat_memo_ignore_cfg;_} -> compat_memo_ignore_cfg
 let (no_debug_switches : debug_switches) =
   {
     gen = false;
@@ -4661,6 +4677,10 @@ let (config' :
         let uu___1 =
           (Prims.op_Negation steps.pure_subterms_within_computations) ||
             (FStar_Options.normalize_pure_terms_for_extraction ()) in
+        let uu___2 =
+          let uu___3 =
+            FStar_Options.ext_getv "compat:normalizer_memo_ignore_cfg" in
+          uu___3 <> "" in
         {
           steps;
           tcenv = e;
@@ -4670,7 +4690,8 @@ let (config' :
           strong = false;
           memoize_lazy = true;
           normalize_pure_lets = uu___1;
-          reifying = false
+          reifying = false;
+          compat_memo_ignore_cfg = uu___2
         }
 let (config :
   FStar_TypeChecker_Env.step Prims.list -> FStar_TypeChecker_Env.env -> cfg)

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_NBE.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_NBE.ml
@@ -120,7 +120,9 @@ let (reifying_false : config -> config) =
              (uu___.FStar_TypeChecker_Cfg.memoize_lazy);
            FStar_TypeChecker_Cfg.normalize_pure_lets =
              (uu___.FStar_TypeChecker_Cfg.normalize_pure_lets);
-           FStar_TypeChecker_Cfg.reifying = false
+           FStar_TypeChecker_Cfg.reifying = false;
+           FStar_TypeChecker_Cfg.compat_memo_ignore_cfg =
+             (uu___.FStar_TypeChecker_Cfg.compat_memo_ignore_cfg)
          })
     else cfg
 let (reifying_true : config -> config) =
@@ -143,7 +145,9 @@ let (reifying_true : config -> config) =
              (uu___.FStar_TypeChecker_Cfg.memoize_lazy);
            FStar_TypeChecker_Cfg.normalize_pure_lets =
              (uu___.FStar_TypeChecker_Cfg.normalize_pure_lets);
-           FStar_TypeChecker_Cfg.reifying = true
+           FStar_TypeChecker_Cfg.reifying = true;
+           FStar_TypeChecker_Cfg.compat_memo_ignore_cfg =
+             (uu___.FStar_TypeChecker_Cfg.compat_memo_ignore_cfg)
          })
     else cfg
 let (zeta_false : config -> config) =
@@ -230,7 +234,9 @@ let (zeta_false : config -> config) =
           FStar_TypeChecker_Cfg.normalize_pure_lets =
             (cfg_core.FStar_TypeChecker_Cfg.normalize_pure_lets);
           FStar_TypeChecker_Cfg.reifying =
-            (cfg_core.FStar_TypeChecker_Cfg.reifying)
+            (cfg_core.FStar_TypeChecker_Cfg.reifying);
+          FStar_TypeChecker_Cfg.compat_memo_ignore_cfg =
+            (cfg_core.FStar_TypeChecker_Cfg.compat_memo_ignore_cfg)
         } in
       new_config cfg_core'
     else cfg
@@ -3348,7 +3354,9 @@ let (normalize :
               FStar_TypeChecker_Cfg.normalize_pure_lets =
                 (cfg.FStar_TypeChecker_Cfg.normalize_pure_lets);
               FStar_TypeChecker_Cfg.reifying =
-                (cfg.FStar_TypeChecker_Cfg.reifying)
+                (cfg.FStar_TypeChecker_Cfg.reifying);
+              FStar_TypeChecker_Cfg.compat_memo_ignore_cfg =
+                (cfg.FStar_TypeChecker_Cfg.compat_memo_ignore_cfg)
             } in
           (let uu___1 =
              (FStar_TypeChecker_Env.debug env (FStar_Options.Other "NBETop"))
@@ -3457,7 +3465,9 @@ let (normalize_for_unit_test :
             FStar_TypeChecker_Cfg.normalize_pure_lets =
               (cfg.FStar_TypeChecker_Cfg.normalize_pure_lets);
             FStar_TypeChecker_Cfg.reifying =
-              (cfg.FStar_TypeChecker_Cfg.reifying)
+              (cfg.FStar_TypeChecker_Cfg.reifying);
+            FStar_TypeChecker_Cfg.compat_memo_ignore_cfg =
+              (cfg.FStar_TypeChecker_Cfg.compat_memo_ignore_cfg)
           } in
         let cfg2 = new_config cfg1 in
         debug cfg2

--- a/src/typechecker/FStar.TypeChecker.Cfg.fst
+++ b/src/typechecker/FStar.TypeChecker.Cfg.fst
@@ -1585,7 +1585,9 @@ let config' psteps s e =
      strong = false;
      memoize_lazy = true;
      normalize_pure_lets = (not steps.pure_subterms_within_computations) || Options.normalize_pure_terms_for_extraction();
-     reifying = false}
+     reifying = false;
+     compat_memo_ignore_cfg = Options.ext_getv "compat:normalizer_memo_ignore_cfg" <> "";
+   }
 
 let config s e = config' [] s e
 

--- a/src/typechecker/FStar.TypeChecker.Cfg.fsti
+++ b/src/typechecker/FStar.TypeChecker.Cfg.fsti
@@ -123,6 +123,7 @@ type cfg = {
      memoize_lazy : bool;
      normalize_pure_lets: bool;
      reifying : bool;
+     compat_memo_ignore_cfg:bool; (* See #2155, #2161, #2986 *)
 }
 
 (* Profiling primitive operators *)

--- a/src/typechecker/FStar.TypeChecker.Normalize.fst
+++ b/src/typechecker/FStar.TypeChecker.Normalize.fst
@@ -74,8 +74,20 @@ let cases f d = function
   | Some x -> f x
   | None -> d
 
+(* We memoize the normal form of variables in the environment, in
+ * order to implement call-by-need and avoid an exponential explosion,
+ * but we take care to only reuse memoized values when the cfg has not
+ * changed. The main reason is normalization requests, which can "grow"
+ * the set of allowed computations steps, and hence we may memoize
+ * something during the request that is used outside of it. This will
+ * essentially make it invalid. See issue #2155 in Github.
+ *
+ * We compare the cfg with physical equality, so it has to be the
+ * exact same object in memory. See read_memo and set_memo below. *)
+type cfg_memo 'a = memo (Cfg.cfg * 'a)
+
 type closure =
-  | Clos of env * term * memo (env * term) * bool //memo for lazy evaluation; bool marks whether or not this is a fixpoint
+  | Clos of env * term * cfg_memo (env * term) * bool //memo for lazy evaluation; bool marks whether or not this is a fixpoint
   | Univ of universe                               //universe terms do not have free variables
   | Dummy                                          //Dummy is a placeholder for a binder when doing strong reduction
 and env = list (option binder*closure)
@@ -89,7 +101,7 @@ type branches = list (pat * option term * term)
 type stack_elt =
  | Arg      of closure * aqual * Range.range
  | UnivArgs of list universe * Range.range
- | MemoLazy of memo (env * term)
+ | MemoLazy of cfg_memo (env * term)
  | Match    of env * option match_returns_ascription * branches * option residual_comp * cfg * Range.range
  | Abs      of env * binders * env * option residual_comp * Range.range //the second env is the first one extended with the binders, for reducing the option lcomp
  | App      of env * term * aqual * Range.range
@@ -101,11 +113,20 @@ type stack = list stack_elt
 
 let head_of t = let hd, _ = U.head_and_args_full t in hd
 
-let set_memo cfg (r:memo 'a) (t:'a) =
-  if cfg.memoize_lazy then
-    match !r with
-    | Some _ -> failwith "Unexpected set_memo: thunk already evaluated"
-    | None -> r := Some t
+let read_memo cfg (r:memo (Cfg.cfg * 'a)) : option 'a =
+  match !r with
+  | Some (cfg', a) when BU.physical_equality cfg cfg' ->
+    Some a
+  | _ -> None
+
+let set_memo cfg (r:memo (Cfg.cfg * 'a)) (t:'a) : unit =
+  if cfg.memoize_lazy then begin
+    (* We do this only as a sanity check. The only situation where we
+     * should set a memo again is when the cfg has changed. *)
+    if Option.isSome (read_memo cfg r) then
+      failwith "Unexpected set_memo: thunk already evaluated";
+    r := Some (cfg, t)
+  end
 
 let closure_to_string = function
     | Clos (env, t, _, _) -> BU.format2 "(env=%s elts; %s)" (List.length env |> string_of_int) (Print.term_to_string t)
@@ -1278,7 +1299,7 @@ let rec norm : cfg -> env -> stack -> term -> term =
                    if not fix
                    || cfg.steps.zeta
                    || cfg.steps.zeta_full
-                   then match !r with
+                   then match read_memo cfg r with
                         | Some (env, t') ->
                             log cfg  (fun () -> BU.print2 "Lazy hit: %s cached to %s\n" (Print.term_to_string t) (Print.term_to_string t'));
                             if maybe_weakly_reduced t'
@@ -1452,7 +1473,7 @@ let rec norm : cfg -> env -> stack -> term -> term =
                    let stack =
                      stack |>
                      List.fold_right (fun (a, aq) stack ->
-                       Arg (Clos(env, a, BU.mk_ref (Some ([], a)), false),aq,t.pos)::stack)
+                       Arg (Clos(env, a, BU.mk_ref (Some (cfg, ([], a))), false),aq,t.pos)::stack)
                      norm_args
                    in
                    log cfg  (fun () -> BU.print1 "\tPushed %s arguments\n" (string_of_int <| List.length args));
@@ -1639,7 +1660,7 @@ let rec norm : cfg -> env -> stack -> term -> term =
                     let memo = BU.mk_ref None in
                     let rec_env = (None, Clos(env, fix_f_i, memo, true))::rec_env in
                     rec_env, memo::memos, i + 1) (snd lbs) (env, [], 0) in
-            let _ = List.map2 (fun lb memo -> memo := Some (rec_env, lb.lbdef)) (snd lbs) memos in //tying the knot
+            let _ = List.map2 (fun lb memo -> memo := Some (cfg, (rec_env, lb.lbdef))) (snd lbs) memos in //tying the knot
             // NB: fold_left, since the binding structure of lbs is that righmost is closer, while in the env leftmost
             // is closer. In other words, the last element of lbs is index 0 for body, hence needs to be pushed last.
             let body_env = List.fold_left (fun env lb -> (None, Clos(rec_env, lb.lbdef, BU.mk_ref None, false))::env)
@@ -2672,7 +2693,7 @@ and do_rebuild (cfg:cfg) (env:env) (stack:stack) (t:term) : term =
                   rebuild cfg env_arg stack t
              else let stack = App(env, t, aq, r)::stack in
                   norm cfg env_arg stack tm
-        else begin match !m with
+        else begin match read_memo cfg m with
           | None ->
             if cfg.steps.hnf && not (is_partial_primop_app cfg t)
             then let arg = closure_as_term cfg env_arg tm in
@@ -3030,7 +3051,7 @@ and do_rebuild (cfg:cfg) (env:env) (stack:stack) (t:term) : term =
                 //In that case, do not set the memo reference
                 let env = List.fold_left
                       (fun env (bv, t) -> (Some (S.mk_binder bv),
-                                        Clos([], t, BU.mk_ref (if cfg.steps.hnf then None else Some ([], t)), false))::env)
+                                        Clos([], t, BU.mk_ref (if cfg.steps.hnf then None else Some (cfg, ([], t))), false))::env)
                       env s in
                 norm cfg env stack (guard_when_clause wopt b rest)
         in

--- a/src/typechecker/FStar.TypeChecker.Normalize.fst
+++ b/src/typechecker/FStar.TypeChecker.Normalize.fst
@@ -115,7 +115,9 @@ let head_of t = let hd, _ = U.head_and_args_full t in hd
 
 let read_memo cfg (r:memo (Cfg.cfg * 'a)) : option 'a =
   match !r with
-  | Some (cfg', a) when BU.physical_equality cfg cfg' ->
+  (* We only take this memoized value if the cfg matches the current
+  one, or if we are running in compatibility mode for it. *)
+  | Some (cfg', a) when cfg.compat_memo_ignore_cfg || BU.physical_equality cfg cfg' ->
     Some a
   | _ -> None
 


### PR DESCRIPTION
This is an old problem with the normalizer. 

We first tried to fix it here: https://github.com/FStarLang/FStar/pull/2161, but that lead to several regressions in everest, so we dropped it. Another attempt was here https://github.com/FStarLang/FStar/pull/2175 (which I seem to have later messed up as a PR, the relevant commit is https://github.com/FStarLang/FStar/commit/b860c96c1771ec332157fc95306198755b232615).

This revives the original fix and adds a compatibility option to make sure other projects keep working. I have an everest green and will make follow up PRs soon.

This was part of https://github.com/FStarLang/FStar/pull/2986, splitting it for better documentation.

Fixes #2155.