### PR TITLE
Fixing #3089, and some unifier fixes

### DIFF
--- a/examples/miniparse/MiniParse.Impl.List.fst
+++ b/examples/miniparse/MiniParse.Impl.List.fst
@@ -325,6 +325,7 @@ let serialize_nlist_impl_inv
     ser == Seq.append (B.as_seq h bl) (serialize (serialize_nlist (n - i) s) ll)
   ))
 
+#push-options "--z3rlimit 128"
 inline_for_extraction
 let serialize_nlist_impl_body
   (n: nat)
@@ -376,6 +377,7 @@ let serialize_nlist_impl_body
     in
     phi ();
     false
+#pop-options
 
 inline_for_extraction
 let serialize_nlist_impl

--- a/examples/miniparse/MiniParse.Impl.List.fst.hints
+++ b/examples/miniparse/MiniParse.Impl.List.fst.hints
@@ -25,7 +25,7 @@
         "typing_FStar.UInt32.v"
       ],
       0,
-      "7a0201f21b0c6a1fe9aeb26b6094ea7b"
+      "edfe40b7ca9bdd2f7af38883d47c94d6"
     ],
     [
       "MiniParse.Impl.List.list_assoc_append",
@@ -48,7 +48,7 @@
         "projection_inverse_Prims.Cons_tl", "projection_inverse_Prims.Nil_a"
       ],
       0,
-      "ed4586caf75a2e9604de6440337123df"
+      "9ffb9ac3d52d18a3796b2695854d6b91"
     ],
     [
       "MiniParse.Impl.List.parse_nlist_impl_inv_false_intro",
@@ -63,24 +63,20 @@
         "refinement_interpretation_Tm_refine_c1424615841f28cac7fc34e92b7ff33c"
       ],
       0,
-      "d7654ab0bc3fc09dc17ddaeade5ad188"
+      "e349e932407c2c1a51896e3e64b2b82f"
     ],
     [
       "MiniParse.Impl.List.parse_nlist_impl_inv_false_intro",
       2,
       2,
-      8,
+      1,
       [
         "@MaxFuel_assumption", "@MaxIFuel_assumption",
         "@fuel_correspondence_FStar.List.Tot.Base.length.fuel_instrumented",
-        "@fuel_irrelevance_FStar.List.Tot.Base.length.fuel_instrumented",
         "@query", "Prims_pretyping_ae567c2fb75be05905677af440075565",
         "b2t_def", "bool_inversion",
         "constructor_distinct_FStar.Pervasives.Native.None",
         "constructor_distinct_FStar.Pervasives.Native.Some",
-        "data_elim_FStar.Pervasives.Native.Mktuple2",
-        "data_elim_FStar.Pervasives.Native.Some", "data_elim_Prims.Cons",
-        "disc_equation_FStar.Pervasives.Native.None",
         "equation_FStar.Monotonic.HyperHeap.hmap",
         "equation_FStar.Monotonic.HyperStack.is_tip",
         "equation_FStar.Monotonic.HyperStack.is_wf_with_ctr_and_tip",
@@ -95,14 +91,9 @@
         "equation_MiniParse.Impl.Base.buffer8",
         "equation_MiniParse.Impl.List.parse_nlist_impl_inv",
         "equation_MiniParse.Spec.Base.byte",
-        "equation_MiniParse.Spec.Base.bytes",
-        "equation_MiniParse.Spec.Base.consumed_length",
-        "equation_MiniParse.Spec.Base.parse",
         "equation_MiniParse.Spec.List.nlist", "equation_Prims.eqtype",
         "equation_Prims.nat",
         "equation_with_fuel_FStar.List.Tot.Base.length.fuel_instrumented",
-        "fuel_guarded_inversion_FStar.Pervasives.Native.option",
-        "fuel_guarded_inversion_FStar.Pervasives.Native.tuple2",
         "fuel_guarded_inversion_MiniParse.Spec.Base.parser_spec",
         "fuel_guarded_inversion_Prims.list",
         "function_token_typing_FStar.Monotonic.Heap.heap",
@@ -113,6 +104,8 @@
         "lemma_LowStar.Monotonic.Buffer.gsub_gsub",
         "lemma_LowStar.Monotonic.Buffer.len_gsub",
         "lemma_LowStar.Monotonic.Buffer.length_as_seq",
+        "lemma_LowStar.Monotonic.Buffer.length_null_1",
+        "lemma_LowStar.Monotonic.Buffer.length_null_2",
         "primitive_Prims.op_Addition", "primitive_Prims.op_AmpAmp",
         "primitive_Prims.op_Equality", "primitive_Prims.op_LessThanOrEqual",
         "primitive_Prims.op_Subtraction",
@@ -122,20 +115,17 @@
         "projection_inverse_FStar.Pervasives.Native.Mktuple2__2",
         "projection_inverse_FStar.Pervasives.Native.Some_a",
         "projection_inverse_FStar.Pervasives.Native.Some_v",
-        "projection_inverse_Prims.Cons_tl",
         "refinement_interpretation_Tm_refine_05e15190c946858f68c69156f585f95a",
         "refinement_interpretation_Tm_refine_414d0a9f578ab0048252f8c8f552b99f",
         "refinement_interpretation_Tm_refine_4b278dbc0dccd817818cfad7ade30d15",
         "refinement_interpretation_Tm_refine_542f9d4f129664613f2483a6c88bc7c2",
         "refinement_interpretation_Tm_refine_573cfed777dae20cc82e8fef9622857e",
         "refinement_interpretation_Tm_refine_709aff84c75b0fff77dcbf3b529649dd",
-        "refinement_interpretation_Tm_refine_9949c4a2a4b08b9d597851f02ea25762",
         "refinement_interpretation_Tm_refine_aa4b3d268075d84252df525db1f85524",
         "refinement_interpretation_Tm_refine_bcad5039c38b342d079249be6e2546dd",
         "refinement_interpretation_Tm_refine_c1424615841f28cac7fc34e92b7ff33c",
         "refinement_interpretation_Tm_refine_c16bc1b61f58b349bf6fc1c94dcaf83b",
         "refinement_interpretation_Tm_refine_f13070840248fced9d9d60d77bdae3ec",
-        "refinement_interpretation_Tm_refine_f1ef48729dd48b5741a77671cc117cd5",
         "refinement_interpretation_Tm_refine_fbb3412f12fd58a91571022d7c9fa36d",
         "refinement_kinding_Tm_refine_4b278dbc0dccd817818cfad7ade30d15",
         "typing_FStar.Map.contains", "typing_FStar.Monotonic.HyperHeap.rid",
@@ -147,13 +137,10 @@
         "typing_LowStar.Buffer.trivial_preorder",
         "typing_LowStar.Monotonic.Buffer.as_seq",
         "typing_LowStar.Monotonic.Buffer.get",
-        "typing_LowStar.Monotonic.Buffer.len",
-        "typing_MiniParse.Spec.Base.parse",
-        "typing_MiniParse.Spec.List.nlist",
-        "typing_MiniParse.Spec.List.parse_nlist"
+        "typing_LowStar.Monotonic.Buffer.len"
       ],
       0,
-      "381a65951caaff1f24b1cf4629dd5455"
+      "c8084ff05c7bc4f94b8bc72e99619b8f"
     ],
     [
       "MiniParse.Impl.List.parse_nlist_impl_body",
@@ -166,7 +153,7 @@
         "refinement_interpretation_Tm_refine_e1b836384cccc70a57286271389ac21b"
       ],
       0,
-      "f9402f0c5eecf8ef0d6d204870802730"
+      "c36e7e3a4b7c26e3d00102765512a084"
     ],
     [
       "MiniParse.Impl.List.parse_nlist_impl_body",
@@ -231,7 +218,6 @@
         "lemma_FStar.Pervasives.invertOption",
         "lemma_FStar.Seq.Base.lemma_eq_elim",
         "lemma_FStar.Seq.Base.lemma_index_create",
-        "lemma_FStar.Seq.Properties.slice_slice",
         "lemma_FStar.UInt32.uv_inv",
         "lemma_LowStar.Monotonic.Buffer.address_liveness_insensitive_buffer",
         "lemma_LowStar.Monotonic.Buffer.as_seq_gsub",
@@ -270,7 +256,6 @@
         "projection_inverse_MiniParse.Spec.Base.Parser_f",
         "refinement_interpretation_Tm_refine_05e15190c946858f68c69156f585f95a",
         "refinement_interpretation_Tm_refine_182efe239776588e16adcd3300cba56d",
-        "refinement_interpretation_Tm_refine_1ba8fd8bb363097813064c67740b2de5",
         "refinement_interpretation_Tm_refine_414d0a9f578ab0048252f8c8f552b99f",
         "refinement_interpretation_Tm_refine_4818621566d3edde8f9c0dac6c867ee2",
         "refinement_interpretation_Tm_refine_4b278dbc0dccd817818cfad7ade30d15",
@@ -283,7 +268,6 @@
         "refinement_interpretation_Tm_refine_a159eda1010dc90aa379e2f1cbe8e678",
         "refinement_interpretation_Tm_refine_aabe8ef7ef37279976d54d2b94693003",
         "refinement_interpretation_Tm_refine_c1424615841f28cac7fc34e92b7ff33c",
-        "refinement_interpretation_Tm_refine_d3d07693cd71377864ef84dc97d10ec1",
         "refinement_interpretation_Tm_refine_e1b836384cccc70a57286271389ac21b",
         "refinement_interpretation_Tm_refine_f13070840248fced9d9d60d77bdae3ec",
         "refinement_interpretation_Tm_refine_f1ef48729dd48b5741a77671cc117cd5",
@@ -295,10 +279,9 @@
         "typing_FStar.Monotonic.HyperStack.get_hmap",
         "typing_FStar.Monotonic.HyperStack.get_tip",
         "typing_FStar.Pervasives.Native.uu___is_Some",
-        "typing_FStar.Seq.Base.create", "typing_FStar.Seq.Base.length",
-        "typing_FStar.UInt.fits", "typing_FStar.UInt32.t",
-        "typing_FStar.UInt32.v", "typing_FStar.UInt8.t",
-        "typing_LowStar.Buffer.trivial_preorder",
+        "typing_FStar.Seq.Base.create", "typing_FStar.UInt.fits",
+        "typing_FStar.UInt32.t", "typing_FStar.UInt32.v",
+        "typing_FStar.UInt8.t", "typing_LowStar.Buffer.trivial_preorder",
         "typing_LowStar.Monotonic.Buffer.address_liveness_insensitive_locs",
         "typing_LowStar.Monotonic.Buffer.as_seq",
         "typing_LowStar.Monotonic.Buffer.length",
@@ -314,7 +297,7 @@
         "typing_MiniParse.Spec.List.parse_nlist"
       ],
       0,
-      "f7b7bb8491762c20dcc96cf79a58e6cd"
+      "9ae33c2cae04f0a310895798e26f861c"
     ],
     [
       "MiniParse.Impl.List.list_rev",
@@ -349,7 +332,7 @@
         "unit_typing"
       ],
       0,
-      "40ebcfbd2ee0d083813c5d6c5f17fcb3"
+      "6e7e7bc6c0e1406d3e21d6348b350c0d"
     ],
     [
       "MiniParse.Impl.List.parse_nlist_impl",
@@ -358,7 +341,7 @@
       1,
       [ "@query" ],
       0,
-      "3e324dd2fc7df6eb811f05c9fefc90ba"
+      "e2795ecd5bed9895441fbf63e9bae0a7"
     ],
     [
       "MiniParse.Impl.List.parse_nlist_impl",
@@ -373,22 +356,16 @@
         "@fuel_correspondence_MiniParse.Spec.List.parse_nlist_.fuel_instrumented",
         "@fuel_irrelevance_FStar.List.Tot.Base.append.fuel_instrumented",
         "@fuel_irrelevance_FStar.List.Tot.Base.length.fuel_instrumented",
-        "@fuel_irrelevance_MiniParse.Spec.List.parse_nlist_.fuel_instrumented",
         "@query", "FStar.UInt32_pretyping_2ab3c8ba2d08b0172817fc70b5994868",
-        "MiniParse.Spec.Combinators_interpretation_Tm_arrow_21c34ab6214876c3f64c3607461881fc",
-        "MiniParse.Spec.Combinators_interpretation_Tm_arrow_9142d2bae8c7d17f5b41cdeff1cf06fc",
-        "MiniParse.Spec.Combinators_interpretation_Tm_arrow_ac0692899dfa447ad13c5f2aefde77c5",
-        "MiniParse.Spec.Combinators_interpretation_Tm_arrow_fe391d6680769aaad08ee4cff3d82de3",
         "Prims_pretyping_ae567c2fb75be05905677af440075565",
         "Prims_pretyping_f537159ed795b314b4e58c260361ae86",
         "assumption_FStar.Monotonic.HyperHeap.Mod_set_def", "b2t_def",
         "bool_inversion", "bool_typing",
         "constructor_distinct_FStar.Pervasives.Native.None",
         "constructor_distinct_FStar.Pervasives.Native.Some",
-        "constructor_distinct_Prims.Nil", "constructor_distinct_Tm_unit",
+        "constructor_distinct_Prims.Nil",
         "data_elim_FStar.Pervasives.Native.Mktuple2",
         "data_elim_FStar.Pervasives.Native.Some",
-        "data_elim_MiniParse.Spec.Base.Parser",
         "data_typing_intro_Prims.Nil@tok",
         "disc_equation_FStar.Pervasives.Native.None",
         "equation_FStar.HyperStack.ST.equal_domains",
@@ -414,17 +391,12 @@
         "equation_MiniParse.Impl.Base.buffer8",
         "equation_MiniParse.Impl.List.parse_nlist_impl_inv",
         "equation_MiniParse.Impl.List.parse_nlist_impl_inv_easy",
-        "equation_MiniParse.Spec.Base.bare_parser",
         "equation_MiniParse.Spec.Base.bparse",
         "equation_MiniParse.Spec.Base.byte",
         "equation_MiniParse.Spec.Base.bytes",
         "equation_MiniParse.Spec.Base.consumed_length",
         "equation_MiniParse.Spec.Base.parse",
-        "equation_MiniParse.Spec.Combinators.and_then",
-        "equation_MiniParse.Spec.Combinators.and_then_bare",
-        "equation_MiniParse.Spec.Combinators.nondep_then",
         "equation_MiniParse.Spec.Combinators.parse_ret",
-        "equation_MiniParse.Spec.Combinators.parse_synth",
         "equation_MiniParse.Spec.List.nlist",
         "equation_MiniParse.Spec.List.nlist_nil", "equation_Prims.eqtype",
         "equation_Prims.nat",
@@ -436,14 +408,11 @@
         "fuel_guarded_inversion_FStar.Pervasives.Native.tuple2",
         "fuel_guarded_inversion_MiniParse.Spec.Base.parser_spec",
         "function_token_typing_FStar.Monotonic.Heap.heap",
-        "function_token_typing_MiniParse.Spec.Combinators.coerce_to_bare_param_parser",
         "function_token_typing_Prims.__cache_version_number__",
         "function_token_typing_Prims.int",
         "haseqTm_refine_542f9d4f129664613f2483a6c88bc7c2", "int_inversion",
         "int_typing",
         "interpretation_Tm_abs_24c49183d745861a79c9e705ccd478d5",
-        "interpretation_Tm_abs_5a56d64ec9685d0352c27644697b3e56",
-        "kinding_FStar.Pervasives.Native.tuple2@tok",
         "kinding_Prims.list@tok",
         "lemma_FStar.HyperStack.ST.lemma_same_refs_in_all_regions_elim",
         "lemma_FStar.HyperStack.ST.lemma_same_refs_in_all_regions_intro",
@@ -461,8 +430,7 @@
         "lemma_FStar.Set.lemma_equal_intro",
         "lemma_FStar.Set.mem_complement", "lemma_FStar.Set.mem_intersect",
         "lemma_FStar.Set.mem_singleton", "lemma_FStar.Set.mem_subset",
-        "lemma_FStar.Set.mem_union", "lemma_FStar.UInt32.uv_inv",
-        "lemma_FStar.UInt32.vu_inv",
+        "lemma_FStar.Set.mem_union", "lemma_FStar.UInt32.vu_inv",
         "lemma_LowStar.Monotonic.Buffer.as_seq_gsub",
         "lemma_LowStar.Monotonic.Buffer.fresh_frame_loc_not_unused_in_disjoint",
         "lemma_LowStar.Monotonic.Buffer.fresh_frame_modifies",
@@ -518,7 +486,6 @@
         "refinement_interpretation_Tm_refine_542f9d4f129664613f2483a6c88bc7c2",
         "refinement_interpretation_Tm_refine_739d212a992267f1432ab3bdc73fd864",
         "refinement_interpretation_Tm_refine_81e1f865346f448178f28d32322bdafd",
-        "refinement_interpretation_Tm_refine_95482e91a565bbc8d113ac6e95692d97",
         "refinement_interpretation_Tm_refine_9949c4a2a4b08b9d597851f02ea25762",
         "refinement_interpretation_Tm_refine_a1927231ad9d6f77b862af8ebc19ad0a",
         "refinement_interpretation_Tm_refine_aa4b3d268075d84252df525db1f85524",
@@ -530,7 +497,6 @@
         "refinement_interpretation_Tm_refine_fbb3412f12fd58a91571022d7c9fa36d",
         "refinement_kinding_Tm_refine_4b278dbc0dccd817818cfad7ade30d15",
         "refinement_kinding_Tm_refine_542f9d4f129664613f2483a6c88bc7c2",
-        "refinement_kinding_Tm_refine_fbb3412f12fd58a91571022d7c9fa36d",
         "token_correspondence_FStar.List.Tot.Base.length.fuel_instrumented",
         "typing_FStar.List.Tot.Base.rev", "typing_FStar.Map.contains",
         "typing_FStar.Map.domain", "typing_FStar.Map.restrict",
@@ -562,15 +528,12 @@
         "typing_LowStar.Monotonic.Buffer.loc_regions",
         "typing_LowStar.Monotonic.Buffer.loc_union",
         "typing_LowStar.Monotonic.Buffer.mgsub",
-        "typing_MiniParse.Spec.Base.bparse",
         "typing_MiniParse.Spec.Base.parse",
-        "typing_MiniParse.Spec.Combinators.and_then_bare",
         "typing_MiniParse.Spec.List.nlist",
-        "typing_MiniParse.Spec.List.parse_nlist",
-        "typing_Tm_abs_9b0fdcdb7bad65cf740850da64bc002a"
+        "typing_MiniParse.Spec.List.parse_nlist"
       ],
       0,
-      "35cd3331d88037615999c4177ed71ace"
+      "06645c8d20d18be98c8df793fa7dba7b"
     ],
     [
       "MiniParse.Impl.List.serialize_nlist_impl_inv",
@@ -586,7 +549,7 @@
         "typing_FStar.List.Tot.Base.length"
       ],
       0,
-      "1f4329da665b8aaf61c906bcd84af9df"
+      "092e879b33f010294c0f48d9474ba605"
     ],
     [
       "MiniParse.Impl.List.serialize_nlist_impl_body",
@@ -600,16 +563,13 @@
         "@fuel_correspondence_MiniParse.Spec.List.serialize_nlist_.fuel_instrumented",
         "@fuel_irrelevance_FStar.List.Tot.Base.length.fuel_instrumented",
         "@fuel_irrelevance_MiniParse.Spec.List.parse_nlist_.fuel_instrumented",
+        "@fuel_irrelevance_MiniParse.Spec.List.serialize_nlist_.fuel_instrumented",
         "@query", "FStar.UInt32_pretyping_2ab3c8ba2d08b0172817fc70b5994868",
-        "MiniParse.Spec.List_interpretation_Tm_arrow_238a437bce06087459fa4f78eaed82a2",
-        "Prims_interpretation_Tm_ghost_arrow_0283b8a2a36bbec52abac4e3d837674a",
         "Prims_pretyping_ae567c2fb75be05905677af440075565", "b2t_def",
         "bool_inversion", "bool_typing", "constructor_distinct_BoxInt",
         "constructor_distinct_FStar.Pervasives.Native.None",
         "constructor_distinct_FStar.Pervasives.Native.Some",
-        "constructor_distinct_Tm_unit",
-        "data_elim_FStar.Pervasives.Native.Mktuple2", "data_elim_Prims.Cons",
-        "disc_equation_Prims.Cons",
+        "constructor_distinct_Tm_unit", "disc_equation_Prims.Cons",
         "equation_FStar.Monotonic.HyperHeap.hmap",
         "equation_FStar.Monotonic.HyperStack.is_tip",
         "equation_FStar.Monotonic.HyperStack.is_wf_with_ctr_and_tip",
@@ -627,6 +587,7 @@
         "equation_MiniParse.Spec.Base.byte",
         "equation_MiniParse.Spec.Base.bytes",
         "equation_MiniParse.Spec.Base.serialize",
+        "equation_MiniParse.Spec.Combinators.bare_serialize_nondep_then",
         "equation_MiniParse.Spec.Combinators.bare_serialize_synth",
         "equation_MiniParse.Spec.Combinators.nondep_then",
         "equation_MiniParse.Spec.Combinators.serialize_nondep_then",
@@ -636,18 +597,16 @@
         "equation_MiniParse.Spec.List.synth_nlist_recip",
         "equation_Prims.eqtype", "equation_Prims.nat",
         "equation_with_fuel_FStar.List.Tot.Base.length.fuel_instrumented",
-        "equation_with_fuel_MiniParse.Spec.List.parse_nlist_.fuel_instrumented",
         "equation_with_fuel_MiniParse.Spec.List.serialize_nlist_.fuel_instrumented",
-        "fuel_guarded_inversion_FStar.Pervasives.Native.tuple2",
         "fuel_guarded_inversion_MiniParse.Spec.Base.serializer_spec",
         "fuel_guarded_inversion_Prims.list",
         "function_token_typing_FStar.Monotonic.Heap.heap",
         "function_token_typing_LowStar.Buffer.trivial_preorder",
-        "function_token_typing_MiniParse.Spec.List.synth_nlist_recip",
         "function_token_typing_Prims.__cache_version_number__",
         "int_inversion", "int_typing",
         "interpretation_Tm_abs_5726c850e5adc579388e02f8d1747910",
         "interpretation_Tm_abs_612136ee4143d24977831c80e4f470a1",
+        "interpretation_Tm_abs_84ca3be552b2abb245b330ca14b3d71f",
         "kinding_Prims.list@tok",
         "lemma_FStar.HyperStack.ST.lemma_equal_domains_trans",
         "lemma_FStar.Map.lemma_ContainsDom",
@@ -656,7 +615,6 @@
         "lemma_FStar.Seq.Base.lemma_index_create",
         "lemma_FStar.Seq.Base.lemma_len_append", "lemma_FStar.UInt32.uv_inv",
         "lemma_FStar.UInt32.vu_inv",
-        "lemma_LowStar.Monotonic.Buffer.address_liveness_insensitive_buffer",
         "lemma_LowStar.Monotonic.Buffer.as_seq_gsub",
         "lemma_LowStar.Monotonic.Buffer.gsub_gsub",
         "lemma_LowStar.Monotonic.Buffer.lemma_live_equal_mem_domains",
@@ -669,14 +627,12 @@
         "lemma_LowStar.Monotonic.Buffer.loc_disjoint_includes_r",
         "lemma_LowStar.Monotonic.Buffer.loc_disjoint_sym_",
         "lemma_LowStar.Monotonic.Buffer.loc_disjoint_union_r_",
-        "lemma_LowStar.Monotonic.Buffer.loc_includes_gsub_buffer_l",
         "lemma_LowStar.Monotonic.Buffer.loc_includes_gsub_buffer_r_",
         "lemma_LowStar.Monotonic.Buffer.loc_includes_refl",
         "lemma_LowStar.Monotonic.Buffer.loc_includes_union_l_",
         "lemma_LowStar.Monotonic.Buffer.loc_includes_union_r_",
         "lemma_LowStar.Monotonic.Buffer.loc_union_comm",
         "lemma_LowStar.Monotonic.Buffer.modifies_buffer_elim",
-        "lemma_LowStar.Monotonic.Buffer.modifies_liveness_insensitive_buffer_weak",
         "lemma_LowStar.Monotonic.Buffer.modifies_loc_includes",
         "lemma_LowStar.Monotonic.Buffer.modifies_trans_linear",
         "primitive_Prims.op_Addition", "primitive_Prims.op_AmpAmp",
@@ -685,10 +641,12 @@
         "proj_equation_MiniParse.Spec.Base.Serializer_f",
         "projection_inverse_BoxBool_proj_0",
         "projection_inverse_BoxInt_proj_0",
+        "projection_inverse_FStar.Pervasives.Native.Mktuple2__1",
         "projection_inverse_FStar.Pervasives.Native.Mktuple2__2",
         "projection_inverse_FStar.Pervasives.Native.None_a",
         "projection_inverse_FStar.Pervasives.Native.Some_v",
         "projection_inverse_MiniParse.Spec.Base.Serializer_f",
+        "projection_inverse_Prims.Cons_hd",
         "projection_inverse_Prims.Cons_tl",
         "refinement_interpretation_Tm_refine_05e15190c946858f68c69156f585f95a",
         "refinement_interpretation_Tm_refine_0ea1fba779ad5718e28476faeef94d56",
@@ -711,8 +669,11 @@
         "refinement_interpretation_Tm_refine_f13070840248fced9d9d60d77bdae3ec",
         "refinement_interpretation_Tm_refine_fbb3412f12fd58a91571022d7c9fa36d",
         "refinement_kinding_Tm_refine_4b278dbc0dccd817818cfad7ade30d15",
+        "refinement_kinding_Tm_refine_fbb3412f12fd58a91571022d7c9fa36d",
         "token_correspondence_FStar.List.Tot.Base.length.fuel_instrumented",
         "token_correspondence_MiniParse.Spec.Base.__proj__Serializer__item__f",
+        "token_correspondence_MiniParse.Spec.List.parse_nlist_.fuel_instrumented",
+        "token_correspondence_MiniParse.Spec.List.serialize_nlist_.fuel_instrumented",
         "token_correspondence_MiniParse.Spec.List.synth_nlist_recip",
         "true_interp", "typing_FStar.List.Tot.Base.length",
         "typing_FStar.Map.contains", "typing_FStar.Monotonic.HyperHeap.rid",
@@ -737,7 +698,7 @@
         "typing_MiniParse.Spec.List.serialize_nlist"
       ],
       0,
-      "f8b2a09e55d28bf45a72b378fd1d7eec"
+      "6a29fa70de4b75dd255a911148f1640e"
     ],
     [
       "MiniParse.Impl.List.serialize_nlist_impl",
@@ -746,7 +707,7 @@
       1,
       [ "@query" ],
       0,
-      "735cdf1615e236e352f4f6fcf0836304"
+      "eb97db2d3df06e9ee0d95d7bd528744c"
     ],
     [
       "MiniParse.Impl.List.serialize_nlist_impl",
@@ -929,7 +890,7 @@
         "typing_MiniParse.Spec.List.serialize_nlist"
       ],
       0,
-      "7f1d1995ee940ad9816be7da34a70c74"
+      "24c57657919f8552c1f4b5662fda8b0f"
     ]
   ]
 ]

--- a/examples/miniparse/MiniParse.Tac.Impl.fst.hints
+++ b/examples/miniparse/MiniParse.Tac.Impl.fst.hints
@@ -20,7 +20,7 @@
         "refinement_interpretation_Tm_refine_542f9d4f129664613f2483a6c88bc7c2"
       ],
       0,
-      "cd637f3b556b75dbf2075fd3ef2acc2c"
+      "acbc56673869e5138f8f73ac35983575"
     ],
     [
       "MiniParse.Tac.Impl.r",
@@ -36,7 +36,7 @@
         "projection_inverse_BoxInt_proj_0"
       ],
       0,
-      "2940a27920bc0ecfb0fcbd11fe403f2a"
+      "03f157594bc22b5a518ac87f052de4ac"
     ],
     [
       "MiniParse.Tac.Impl.r'",
@@ -52,7 +52,7 @@
         "projection_inverse_BoxInt_proj_0"
       ],
       0,
-      "d29c37ce5d2593a2ac26ece2b365d7cf"
+      "20a792d79bcd053814ac497e729aa31c"
     ]
   ]
 ]

--- a/examples/miniparse/MiniParseExample.fst.hints
+++ b/examples/miniparse/MiniParseExample.fst.hints
@@ -62,7 +62,7 @@
         "typing_Tm_abs_faa9e5cff5df42ab6564d6584bf6a1cc"
       ],
       0,
-      "d865068f33464dca1a1ee309540c3bd7"
+      "9d4f58049f53ed5efc56728137ec2ca9"
     ],
     [
       "MiniParseExample.q'",
@@ -125,7 +125,7 @@
         "typing_Tm_abs_faa9e5cff5df42ab6564d6584bf6a1cc"
       ],
       0,
-      "0262b7b4f9661d68bc42adeee940bccc"
+      "a22c423dcd982dd7a0771e319136da75"
     ]
   ]
 ]

--- a/examples/tactics/Canon.fst
+++ b/examples/tactics/Canon.fst
@@ -19,11 +19,6 @@ open FStar.Tactics.V2
 open FStar.Tactics.Canon
 open FStar.Mul
 
-assume val w : int
-assume val x : int
-assume val y : int
-assume val z : int
-
 // Testing the canonicalizer, it should be the only thing needed for this file
 let check_canon () =
     canon ();
@@ -32,11 +27,25 @@ let check_canon () =
             (fun () -> dump "`canon` left the following goals";
                        fail "")
 
-let lem0 =  assert (x * (y * z) == (x * y) * z) by check_canon ()
-let lem0' = assert (w * (x * (y * z)) == ((z * y) * x) * w) by check_canon ()
+let test_neg (b : pos) =
+    assert (b - 1 == b + (-1))
+        by (check_canon ())
 
 // TODO: for now, canon is not enough as we don't collect factors, so we
 // leave the rest to the SMT
+let test_neg2 (b c : pos) =
+    assert (b * (c-1) + b == b*c)
+        by (canon ())
+
+assume val w : int
+assume val x : int
+assume val y : int
+assume val z : int
+
+let lem0 =  assert (x * (y * z) == (x * y) * z) by check_canon ()
+let lem0' = assert (w * (x * (y * z)) == ((z * y) * x) * w) by check_canon ()
+
+// Idem test_neg2
 let lem1 =
     assert ((x + y) * (z + z) == 2 * z * (y + x))
         by canon ()

--- a/examples/tactics/Normalization.fst
+++ b/examples/tactics/Normalization.fst
@@ -62,15 +62,19 @@ let _ = assert True
                 then ()
                 else fail "Test 1")
 
+(* GM, 2023/11/09: this is now no longer true. The unifier does trigger
+primitive steps computations, and the trefl() call above
+will instantiate the RHS with the WHNF of the LHS, which is also 4. *)
+
 (* If we only allow for Delta steps, then there's no primitive computation and we
  * end up with (2 + 1) + 1 *)
-let four' : int = _ by (normalize [delta] (add_2 2))
+(* let four' : int = _ by (normalize [delta] (add_2 2)) *)
 
-let _ = assert True
-            by (let t = def_of four' in
-                if compare_term t (`((2 + 1) + 1)) = FStar.Order.Eq
-                then ()
-                else fail "Test 2")
+(* let _ = assert True *)
+(*             by (let t = def_of four' in *)
+(*                 if compare_term t (`((2 + 1) + 1)) = FStar.Order.Eq *)
+(*                 then () *)
+(*                 else fail "Test 2") *)
 
 (* Here, we allow for primitive computation but don't allow for `add_2` to be expanded to
  * its definition, so the final result is `add_2 1` *)

--- a/ocaml/fstar-lib/generated/FStar_Tactics_Canon.ml
+++ b/ocaml/fstar-lib/generated/FStar_Tactics_Canon.ml
@@ -39,7 +39,7 @@ let rec (canon_point :
       (FStar_Sealed.seal
          (Obj.magic
             (FStar_Range.mk_range "FStar.Tactics.Canon.fst"
-               (Prims.of_int (138)) (Prims.of_int (4)) (Prims.of_int (250))
+               (Prims.of_int (138)) (Prims.of_int (4)) (Prims.of_int (254))
                (Prims.of_int (15)))))
       (FStar_Tactics_Effect.lift_div_tac
          (fun uu___ ->
@@ -1054,7 +1054,7 @@ let rec (canon_point :
                         (Obj.magic
                            (FStar_Range.mk_range "FStar.Tactics.Canon.fst"
                               (Prims.of_int (244)) (Prims.of_int (8))
-                              (Prims.of_int (247)) (Prims.of_int (30)))))
+                              (Prims.of_int (251)) (Prims.of_int (30)))))
                      (Obj.magic
                         (step_lemma
                            (FStar_Reflection_V2_Builtins.pack_ln
@@ -1082,7 +1082,7 @@ let rec (canon_point :
                                          "FStar.Tactics.Canon.fst"
                                          (Prims.of_int (245))
                                          (Prims.of_int (8))
-                                         (Prims.of_int (247))
+                                         (Prims.of_int (251))
                                          (Prims.of_int (30)))))
                                 (Obj.magic
                                    (step_lemma
@@ -1111,7 +1111,7 @@ let rec (canon_point :
                                                     "FStar.Tactics.Canon.fst"
                                                     (Prims.of_int (245))
                                                     (Prims.of_int (17))
-                                                    (Prims.of_int (247))
+                                                    (Prims.of_int (251))
                                                     (Prims.of_int (30)))))
                                            (Obj.magic
                                               (FStar_Tactics_V2_Derived.trefl
@@ -1125,27 +1125,61 @@ let rec (canon_point :
                                                             (FStar_Range.mk_range
                                                                "FStar.Tactics.Canon.fst"
                                                                (Prims.of_int (246))
-                                                               (Prims.of_int (16))
+                                                               (Prims.of_int (19))
                                                                (Prims.of_int (246))
-                                                               (Prims.of_int (35)))))
+                                                               (Prims.of_int (64)))))
                                                       (FStar_Sealed.seal
                                                          (Obj.magic
                                                             (FStar_Range.mk_range
                                                                "FStar.Tactics.Canon.fst"
-                                                               (Prims.of_int (247))
-                                                               (Prims.of_int (8))
-                                                               (Prims.of_int (247))
+                                                               (Prims.of_int (246))
+                                                               (Prims.of_int (67))
+                                                               (Prims.of_int (251))
                                                                (Prims.of_int (30)))))
-                                                      (Obj.magic
-                                                         (canon_point
-                                                            (FStar_Reflection_V2_Arith.Neg
-                                                               b)))
+                                                      (FStar_Tactics_Effect.lift_div_tac
+                                                         (fun uu___3 ->
+                                                            match b with
+                                                            | FStar_Reflection_V2_Arith.Lit
+                                                                n ->
+                                                                FStar_Reflection_V2_Arith.Lit
+                                                                  (- n)
+                                                            | uu___4 ->
+                                                                FStar_Reflection_V2_Arith.Neg
+                                                                  b))
                                                       (fun uu___3 ->
-                                                         (fun r ->
+                                                         (fun negb ->
                                                             Obj.magic
-                                                              (canon_point
-                                                                 (FStar_Reflection_V2_Arith.Plus
+                                                              (FStar_Tactics_Effect.tac_bind
+                                                                 (FStar_Sealed.seal
+                                                                    (
+                                                                    Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "FStar.Tactics.Canon.fst"
+                                                                    (Prims.of_int (250))
+                                                                    (Prims.of_int (16))
+                                                                    (Prims.of_int (250))
+                                                                    (Prims.of_int (32)))))
+                                                                 (FStar_Sealed.seal
+                                                                    (
+                                                                    Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "FStar.Tactics.Canon.fst"
+                                                                    (Prims.of_int (251))
+                                                                    (Prims.of_int (8))
+                                                                    (Prims.of_int (251))
+                                                                    (Prims.of_int (30)))))
+                                                                 (Obj.magic
+                                                                    (
+                                                                    canon_point
+                                                                    negb))
+                                                                 (fun uu___3
+                                                                    ->
+                                                                    (fun r ->
+                                                                    Obj.magic
+                                                                    (canon_point
+                                                                    (FStar_Reflection_V2_Arith.Plus
                                                                     (a, r))))
+                                                                    uu___3)))
                                                            uu___3))) uu___2)))
                                      uu___1))) uu___))
             | uu___ -> Obj.magic (skip ())) uu___)
@@ -1156,14 +1190,14 @@ let (canon_point_entry : unit -> (unit, unit) FStar_Tactics_Effect.tac_repr)
       (FStar_Sealed.seal
          (Obj.magic
             (FStar_Range.mk_range "FStar.Tactics.Canon.fst"
-               (Prims.of_int (264)) (Prims.of_int (4)) (Prims.of_int (264))
-               (Prims.of_int (11)))))
+               (Prims.of_int (268)) (Prims.of_int (4)) (Prims.of_int (268))
+               (Prims.of_int (18)))))
       (FStar_Sealed.seal
          (Obj.magic
             (FStar_Range.mk_range "FStar.Tactics.Canon.fst"
-               (Prims.of_int (264)) (Prims.of_int (12)) (Prims.of_int (273))
+               (Prims.of_int (268)) (Prims.of_int (19)) (Prims.of_int (277))
                (Prims.of_int (48)))))
-      (Obj.magic (FStar_Tactics_V2_Builtins.norm []))
+      (Obj.magic (FStar_Tactics_V2_Builtins.norm [FStar_Pervasives.primops]))
       (fun uu___1 ->
          (fun uu___1 ->
             Obj.magic
@@ -1171,13 +1205,13 @@ let (canon_point_entry : unit -> (unit, unit) FStar_Tactics_Effect.tac_repr)
                  (FStar_Sealed.seal
                     (Obj.magic
                        (FStar_Range.mk_range "FStar.Tactics.Canon.fst"
-                          (Prims.of_int (265)) (Prims.of_int (12))
-                          (Prims.of_int (265)) (Prims.of_int (23)))))
+                          (Prims.of_int (269)) (Prims.of_int (12))
+                          (Prims.of_int (269)) (Prims.of_int (23)))))
                  (FStar_Sealed.seal
                     (Obj.magic
                        (FStar_Range.mk_range "FStar.Tactics.Canon.fst"
-                          (Prims.of_int (266)) (Prims.of_int (4))
-                          (Prims.of_int (273)) (Prims.of_int (48)))))
+                          (Prims.of_int (270)) (Prims.of_int (4))
+                          (Prims.of_int (277)) (Prims.of_int (48)))))
                  (Obj.magic (FStar_Tactics_V2_Derived.cur_goal ()))
                  (fun uu___2 ->
                     (fun g ->
@@ -1187,14 +1221,14 @@ let (canon_point_entry : unit -> (unit, unit) FStar_Tactics_Effect.tac_repr)
                                (Obj.magic
                                   (FStar_Range.mk_range
                                      "FStar.Tactics.Canon.fst"
-                                     (Prims.of_int (266)) (Prims.of_int (10))
-                                     (Prims.of_int (266)) (Prims.of_int (27)))))
+                                     (Prims.of_int (270)) (Prims.of_int (10))
+                                     (Prims.of_int (270)) (Prims.of_int (27)))))
                             (FStar_Sealed.seal
                                (Obj.magic
                                   (FStar_Range.mk_range
                                      "FStar.Tactics.Canon.fst"
-                                     (Prims.of_int (266)) (Prims.of_int (4))
-                                     (Prims.of_int (273)) (Prims.of_int (48)))))
+                                     (Prims.of_int (270)) (Prims.of_int (4))
+                                     (Prims.of_int (277)) (Prims.of_int (48)))))
                             (Obj.magic
                                (FStar_Reflection_V2_Formula.term_as_formula g))
                             (fun uu___2 ->
@@ -1210,17 +1244,17 @@ let (canon_point_entry : unit -> (unit, unit) FStar_Tactics_Effect.tac_repr)
                                               (Obj.magic
                                                  (FStar_Range.mk_range
                                                     "FStar.Tactics.Canon.fst"
-                                                    (Prims.of_int (268))
+                                                    (Prims.of_int (272))
                                                     (Prims.of_int (20))
-                                                    (Prims.of_int (268))
+                                                    (Prims.of_int (272))
                                                     (Prims.of_int (44)))))
                                            (FStar_Sealed.seal
                                               (Obj.magic
                                                  (FStar_Range.mk_range
                                                     "FStar.Tactics.Canon.fst"
-                                                    (Prims.of_int (268))
+                                                    (Prims.of_int (272))
                                                     (Prims.of_int (14))
-                                                    (Prims.of_int (270))
+                                                    (Prims.of_int (274))
                                                     (Prims.of_int (27)))))
                                            (Obj.magic
                                               (FStar_Reflection_V2_Arith.run_tm
@@ -1236,17 +1270,17 @@ let (canon_point_entry : unit -> (unit, unit) FStar_Tactics_Effect.tac_repr)
                                                              (Obj.magic
                                                                 (FStar_Range.mk_range
                                                                    "FStar.Tactics.Canon.fst"
-                                                                   (Prims.of_int (269))
+                                                                   (Prims.of_int (273))
                                                                    (Prims.of_int (29))
-                                                                   (Prims.of_int (269))
+                                                                   (Prims.of_int (273))
                                                                    (Prims.of_int (42)))))
                                                           (FStar_Sealed.seal
                                                              (Obj.magic
                                                                 (FStar_Range.mk_range
                                                                    "FStar.Tactics.Canon.fst"
-                                                                   (Prims.of_int (269))
+                                                                   (Prims.of_int (273))
                                                                    (Prims.of_int (46))
-                                                                   (Prims.of_int (269))
+                                                                   (Prims.of_int (273))
                                                                    (Prims.of_int (48)))))
                                                           (Obj.magic
                                                              (canon_point e))
@@ -1266,17 +1300,17 @@ let (canon_point_entry : unit -> (unit, unit) FStar_Tactics_Effect.tac_repr)
                                               (Obj.magic
                                                  (FStar_Range.mk_range
                                                     "FStar.Tactics.Canon.fst"
-                                                    (Prims.of_int (273))
+                                                    (Prims.of_int (277))
                                                     (Prims.of_int (13))
-                                                    (Prims.of_int (273))
+                                                    (Prims.of_int (277))
                                                     (Prims.of_int (48)))))
                                            (FStar_Sealed.seal
                                               (Obj.magic
                                                  (FStar_Range.mk_range
                                                     "FStar.Tactics.Canon.fst"
-                                                    (Prims.of_int (273))
+                                                    (Prims.of_int (277))
                                                     (Prims.of_int (8))
-                                                    (Prims.of_int (273))
+                                                    (Prims.of_int (277))
                                                     (Prims.of_int (48)))))
                                            (Obj.magic
                                               (FStar_Tactics_Effect.tac_bind
@@ -1284,9 +1318,9 @@ let (canon_point_entry : unit -> (unit, unit) FStar_Tactics_Effect.tac_repr)
                                                     (Obj.magic
                                                        (FStar_Range.mk_range
                                                           "FStar.Tactics.Canon.fst"
-                                                          (Prims.of_int (273))
+                                                          (Prims.of_int (277))
                                                           (Prims.of_int (31))
-                                                          (Prims.of_int (273))
+                                                          (Prims.of_int (277))
                                                           (Prims.of_int (47)))))
                                                  (FStar_Sealed.seal
                                                     (Obj.magic
@@ -1311,3 +1345,14 @@ let (canon_point_entry : unit -> (unit, unit) FStar_Tactics_Effect.tac_repr)
            uu___1)
 let (canon : unit -> (unit, unit) FStar_Tactics_Effect.tac_repr) =
   fun uu___ -> FStar_Tactics_V2_Derived.pointwise canon_point_entry
+let _ =
+  FStar_Tactics_Native.register_tactic "FStar.Tactics.Canon.canon"
+    (Prims.of_int (2))
+    (fun psc ->
+       fun ncb ->
+         fun args ->
+           FStar_Tactics_V2_InterpFuns.mk_tactic_interpretation_1
+             "FStar.Tactics.Canon.canon (plugin)"
+             (FStar_Tactics_Native.from_tactic_1 canon)
+             FStar_Syntax_Embeddings.e_unit FStar_Syntax_Embeddings.e_unit
+             psc ncb args)

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_Rel.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_Rel.ml
@@ -1608,23 +1608,20 @@ let (whnf :
         FStar_Pervasives_Native.Some uu___1 in
       FStar_Profiling.profile
         (fun uu___1 ->
-           let uu___2 = should_strongly_reduce t in
-           if uu___2
-           then
-             norm
+           let steps =
+             let uu___2 =
+               let uu___3 = should_strongly_reduce t in
+               if uu___3
+               then
+                 [FStar_TypeChecker_Env.Exclude FStar_TypeChecker_Env.Zeta;
+                 FStar_TypeChecker_Env.UnfoldUntil
+                   FStar_Syntax_Syntax.delta_constant]
+               else [FStar_TypeChecker_Env.Weak; FStar_TypeChecker_Env.HNF] in
+             FStar_Compiler_List.op_At uu___2
                [FStar_TypeChecker_Env.Beta;
                FStar_TypeChecker_Env.Reify;
-               FStar_TypeChecker_Env.Exclude FStar_TypeChecker_Env.Zeta;
-               FStar_TypeChecker_Env.UnfoldUntil
-                 FStar_Syntax_Syntax.delta_constant] t
-           else
-             (let uu___4 = FStar_Syntax_Util.unmeta t in
-              norm
-                [FStar_TypeChecker_Env.Beta;
-                FStar_TypeChecker_Env.Reify;
-                FStar_TypeChecker_Env.Weak;
-                FStar_TypeChecker_Env.HNF] uu___4)) uu___
-        "FStar.TypeChecker.Rel.whnf"
+               FStar_TypeChecker_Env.Primops] in
+           norm steps t) uu___ "FStar.TypeChecker.Rel.whnf"
 let norm_arg :
   'uuuuu .
     FStar_TypeChecker_Env.env ->
@@ -2852,133 +2849,158 @@ let rec (head_matches :
       fun t2 ->
         let t11 = FStar_Syntax_Util.unmeta t1 in
         let t21 = FStar_Syntax_Util.unmeta t2 in
-        match ((t11.FStar_Syntax_Syntax.n), (t21.FStar_Syntax_Syntax.n)) with
-        | (FStar_Syntax_Syntax.Tm_lazy
-           { FStar_Syntax_Syntax.blob = uu___;
-             FStar_Syntax_Syntax.lkind = FStar_Syntax_Syntax.Lazy_embedding
-               uu___1;
-             FStar_Syntax_Syntax.ltyp = uu___2;
-             FStar_Syntax_Syntax.rng = uu___3;_},
-           uu___4) ->
-            let uu___5 = FStar_Syntax_Util.unlazy t11 in
-            head_matches env uu___5 t21
-        | (uu___, FStar_Syntax_Syntax.Tm_lazy
-           { FStar_Syntax_Syntax.blob = uu___1;
-             FStar_Syntax_Syntax.lkind = FStar_Syntax_Syntax.Lazy_embedding
-               uu___2;
-             FStar_Syntax_Syntax.ltyp = uu___3;
-             FStar_Syntax_Syntax.rng = uu___4;_})
-            ->
-            let uu___5 = FStar_Syntax_Util.unlazy t21 in
-            head_matches env t11 uu___5
-        | (FStar_Syntax_Syntax.Tm_name x, FStar_Syntax_Syntax.Tm_name y) ->
-            let uu___ = FStar_Syntax_Syntax.bv_eq x y in
-            if uu___
-            then FullMatch
-            else
-              MisMatch
-                (FStar_Pervasives_Native.None, FStar_Pervasives_Native.None)
-        | (FStar_Syntax_Syntax.Tm_fvar f, FStar_Syntax_Syntax.Tm_fvar g) ->
-            let uu___ = FStar_Syntax_Syntax.fv_eq f g in
-            if uu___
-            then FullMatch
-            else
-              (let uu___2 =
-                 let uu___3 =
-                   let uu___4 = fv_delta_depth env f in
-                   FStar_Pervasives_Native.Some uu___4 in
-                 let uu___4 =
-                   let uu___5 = fv_delta_depth env g in
-                   FStar_Pervasives_Native.Some uu___5 in
-                 (uu___3, uu___4) in
-               MisMatch uu___2)
-        | (FStar_Syntax_Syntax.Tm_uinst (f, uu___),
-           FStar_Syntax_Syntax.Tm_uinst (g, uu___1)) ->
-            let uu___2 = head_matches env f g in
-            FStar_Compiler_Effect.op_Bar_Greater uu___2 head_match
-        | (FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_reify uu___),
-           FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_reify uu___1))
-            -> FullMatch
-        | (FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_reify uu___),
-           uu___1) -> HeadMatch true
-        | (uu___, FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_reify
-           uu___1)) -> HeadMatch true
-        | (FStar_Syntax_Syntax.Tm_constant c, FStar_Syntax_Syntax.Tm_constant
-           d) ->
-            let uu___ = FStar_Const.eq_const c d in
-            if uu___
-            then FullMatch
-            else
-              MisMatch
-                (FStar_Pervasives_Native.None, FStar_Pervasives_Native.None)
-        | (FStar_Syntax_Syntax.Tm_uvar (uv, uu___),
-           FStar_Syntax_Syntax.Tm_uvar (uv', uu___1)) ->
-            let uu___2 =
-              FStar_Syntax_Unionfind.equiv
-                uv.FStar_Syntax_Syntax.ctx_uvar_head
-                uv'.FStar_Syntax_Syntax.ctx_uvar_head in
-            if uu___2
-            then FullMatch
-            else
-              MisMatch
-                (FStar_Pervasives_Native.None, FStar_Pervasives_Native.None)
-        | (FStar_Syntax_Syntax.Tm_refine
-           { FStar_Syntax_Syntax.b = x; FStar_Syntax_Syntax.phi = uu___;_},
-           FStar_Syntax_Syntax.Tm_refine
-           { FStar_Syntax_Syntax.b = y; FStar_Syntax_Syntax.phi = uu___1;_})
-            ->
-            let uu___2 =
-              head_matches env x.FStar_Syntax_Syntax.sort
-                y.FStar_Syntax_Syntax.sort in
-            FStar_Compiler_Effect.op_Bar_Greater uu___2 head_match
-        | (FStar_Syntax_Syntax.Tm_refine
-           { FStar_Syntax_Syntax.b = x; FStar_Syntax_Syntax.phi = uu___;_},
-           uu___1) ->
-            let uu___2 = head_matches env x.FStar_Syntax_Syntax.sort t21 in
-            FStar_Compiler_Effect.op_Bar_Greater uu___2 head_match
-        | (uu___, FStar_Syntax_Syntax.Tm_refine
-           { FStar_Syntax_Syntax.b = x; FStar_Syntax_Syntax.phi = uu___1;_})
-            ->
-            let uu___2 = head_matches env t11 x.FStar_Syntax_Syntax.sort in
-            FStar_Compiler_Effect.op_Bar_Greater uu___2 head_match
-        | (FStar_Syntax_Syntax.Tm_type uu___, FStar_Syntax_Syntax.Tm_type
-           uu___1) -> HeadMatch false
-        | (FStar_Syntax_Syntax.Tm_arrow uu___, FStar_Syntax_Syntax.Tm_arrow
-           uu___1) -> HeadMatch false
-        | (FStar_Syntax_Syntax.Tm_app
-           { FStar_Syntax_Syntax.hd = head;
-             FStar_Syntax_Syntax.args = uu___;_},
-           FStar_Syntax_Syntax.Tm_app
-           { FStar_Syntax_Syntax.hd = head';
-             FStar_Syntax_Syntax.args = uu___1;_})
-            ->
-            let uu___2 = head_matches env head head' in
-            FStar_Compiler_Effect.op_Bar_Greater uu___2 head_match
-        | (FStar_Syntax_Syntax.Tm_app
-           { FStar_Syntax_Syntax.hd = head;
-             FStar_Syntax_Syntax.args = uu___;_},
-           uu___1) ->
-            let uu___2 = head_matches env head t21 in
-            FStar_Compiler_Effect.op_Bar_Greater uu___2 head_match
-        | (uu___, FStar_Syntax_Syntax.Tm_app
-           { FStar_Syntax_Syntax.hd = head;
-             FStar_Syntax_Syntax.args = uu___1;_})
-            ->
-            let uu___2 = head_matches env t11 head in
-            FStar_Compiler_Effect.op_Bar_Greater uu___2 head_match
-        | (FStar_Syntax_Syntax.Tm_let uu___, FStar_Syntax_Syntax.Tm_let
-           uu___1) -> HeadMatch true
-        | (FStar_Syntax_Syntax.Tm_match uu___, FStar_Syntax_Syntax.Tm_match
-           uu___1) -> HeadMatch true
-        | (FStar_Syntax_Syntax.Tm_quoted uu___, FStar_Syntax_Syntax.Tm_quoted
-           uu___1) -> HeadMatch true
-        | (FStar_Syntax_Syntax.Tm_abs uu___, FStar_Syntax_Syntax.Tm_abs
-           uu___1) -> HeadMatch true
-        | uu___ ->
-            let uu___1 =
-              let uu___2 = delta_depth_of_term env t11 in
-              let uu___3 = delta_depth_of_term env t21 in (uu___2, uu___3) in
-            MisMatch uu___1
+        (let uu___1 =
+           FStar_Compiler_Effect.op_Less_Bar
+             (FStar_TypeChecker_Env.debug env)
+             (FStar_Options.Other "RelDelta") in
+         if uu___1
+         then
+           ((let uu___3 = FStar_Syntax_Print.term_to_string t11 in
+             let uu___4 = FStar_Syntax_Print.term_to_string t21 in
+             FStar_Compiler_Util.print2 "head_matches %s %s\n" uu___3 uu___4);
+            (let uu___4 = FStar_Syntax_Print.tag_of_term t11 in
+             let uu___5 = FStar_Syntax_Print.tag_of_term t21 in
+             FStar_Compiler_Util.print2 "             %s  -- %s\n" uu___4
+               uu___5))
+         else ());
+        (match ((t11.FStar_Syntax_Syntax.n), (t21.FStar_Syntax_Syntax.n))
+         with
+         | (FStar_Syntax_Syntax.Tm_lazy
+            { FStar_Syntax_Syntax.blob = uu___1;
+              FStar_Syntax_Syntax.lkind = FStar_Syntax_Syntax.Lazy_embedding
+                uu___2;
+              FStar_Syntax_Syntax.ltyp = uu___3;
+              FStar_Syntax_Syntax.rng = uu___4;_},
+            uu___5) ->
+             let uu___6 = FStar_Syntax_Util.unlazy t11 in
+             head_matches env uu___6 t21
+         | (uu___1, FStar_Syntax_Syntax.Tm_lazy
+            { FStar_Syntax_Syntax.blob = uu___2;
+              FStar_Syntax_Syntax.lkind = FStar_Syntax_Syntax.Lazy_embedding
+                uu___3;
+              FStar_Syntax_Syntax.ltyp = uu___4;
+              FStar_Syntax_Syntax.rng = uu___5;_})
+             ->
+             let uu___6 = FStar_Syntax_Util.unlazy t21 in
+             head_matches env t11 uu___6
+         | (FStar_Syntax_Syntax.Tm_lazy li1, FStar_Syntax_Syntax.Tm_lazy li2)
+             ->
+             let uu___1 =
+               FStar_Syntax_Util.eq_lazy_kind li1.FStar_Syntax_Syntax.lkind
+                 li2.FStar_Syntax_Syntax.lkind in
+             if uu___1
+             then HeadMatch false
+             else
+               MisMatch
+                 (FStar_Pervasives_Native.None, FStar_Pervasives_Native.None)
+         | (FStar_Syntax_Syntax.Tm_name x, FStar_Syntax_Syntax.Tm_name y) ->
+             let uu___1 = FStar_Syntax_Syntax.bv_eq x y in
+             if uu___1
+             then FullMatch
+             else
+               MisMatch
+                 (FStar_Pervasives_Native.None, FStar_Pervasives_Native.None)
+         | (FStar_Syntax_Syntax.Tm_fvar f, FStar_Syntax_Syntax.Tm_fvar g) ->
+             let uu___1 = FStar_Syntax_Syntax.fv_eq f g in
+             if uu___1
+             then FullMatch
+             else
+               (let uu___3 =
+                  let uu___4 =
+                    let uu___5 = fv_delta_depth env f in
+                    FStar_Pervasives_Native.Some uu___5 in
+                  let uu___5 =
+                    let uu___6 = fv_delta_depth env g in
+                    FStar_Pervasives_Native.Some uu___6 in
+                  (uu___4, uu___5) in
+                MisMatch uu___3)
+         | (FStar_Syntax_Syntax.Tm_uinst (f, uu___1),
+            FStar_Syntax_Syntax.Tm_uinst (g, uu___2)) ->
+             let uu___3 = head_matches env f g in
+             FStar_Compiler_Effect.op_Bar_Greater uu___3 head_match
+         | (FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_reify uu___1),
+            FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_reify uu___2))
+             -> FullMatch
+         | (FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_reify uu___1),
+            uu___2) -> HeadMatch true
+         | (uu___1, FStar_Syntax_Syntax.Tm_constant (FStar_Const.Const_reify
+            uu___2)) -> HeadMatch true
+         | (FStar_Syntax_Syntax.Tm_constant c,
+            FStar_Syntax_Syntax.Tm_constant d) ->
+             let uu___1 = FStar_Const.eq_const c d in
+             if uu___1
+             then FullMatch
+             else
+               MisMatch
+                 (FStar_Pervasives_Native.None, FStar_Pervasives_Native.None)
+         | (FStar_Syntax_Syntax.Tm_uvar (uv, uu___1),
+            FStar_Syntax_Syntax.Tm_uvar (uv', uu___2)) ->
+             let uu___3 =
+               FStar_Syntax_Unionfind.equiv
+                 uv.FStar_Syntax_Syntax.ctx_uvar_head
+                 uv'.FStar_Syntax_Syntax.ctx_uvar_head in
+             if uu___3
+             then FullMatch
+             else
+               MisMatch
+                 (FStar_Pervasives_Native.None, FStar_Pervasives_Native.None)
+         | (FStar_Syntax_Syntax.Tm_refine
+            { FStar_Syntax_Syntax.b = x; FStar_Syntax_Syntax.phi = uu___1;_},
+            FStar_Syntax_Syntax.Tm_refine
+            { FStar_Syntax_Syntax.b = y; FStar_Syntax_Syntax.phi = uu___2;_})
+             ->
+             let uu___3 =
+               head_matches env x.FStar_Syntax_Syntax.sort
+                 y.FStar_Syntax_Syntax.sort in
+             FStar_Compiler_Effect.op_Bar_Greater uu___3 head_match
+         | (FStar_Syntax_Syntax.Tm_refine
+            { FStar_Syntax_Syntax.b = x; FStar_Syntax_Syntax.phi = uu___1;_},
+            uu___2) ->
+             let uu___3 = head_matches env x.FStar_Syntax_Syntax.sort t21 in
+             FStar_Compiler_Effect.op_Bar_Greater uu___3 head_match
+         | (uu___1, FStar_Syntax_Syntax.Tm_refine
+            { FStar_Syntax_Syntax.b = x; FStar_Syntax_Syntax.phi = uu___2;_})
+             ->
+             let uu___3 = head_matches env t11 x.FStar_Syntax_Syntax.sort in
+             FStar_Compiler_Effect.op_Bar_Greater uu___3 head_match
+         | (FStar_Syntax_Syntax.Tm_type uu___1, FStar_Syntax_Syntax.Tm_type
+            uu___2) -> HeadMatch false
+         | (FStar_Syntax_Syntax.Tm_arrow uu___1, FStar_Syntax_Syntax.Tm_arrow
+            uu___2) -> HeadMatch false
+         | (FStar_Syntax_Syntax.Tm_app
+            { FStar_Syntax_Syntax.hd = head;
+              FStar_Syntax_Syntax.args = uu___1;_},
+            FStar_Syntax_Syntax.Tm_app
+            { FStar_Syntax_Syntax.hd = head';
+              FStar_Syntax_Syntax.args = uu___2;_})
+             ->
+             let uu___3 = head_matches env head head' in
+             FStar_Compiler_Effect.op_Bar_Greater uu___3 head_match
+         | (FStar_Syntax_Syntax.Tm_app
+            { FStar_Syntax_Syntax.hd = head;
+              FStar_Syntax_Syntax.args = uu___1;_},
+            uu___2) ->
+             let uu___3 = head_matches env head t21 in
+             FStar_Compiler_Effect.op_Bar_Greater uu___3 head_match
+         | (uu___1, FStar_Syntax_Syntax.Tm_app
+            { FStar_Syntax_Syntax.hd = head;
+              FStar_Syntax_Syntax.args = uu___2;_})
+             ->
+             let uu___3 = head_matches env t11 head in
+             FStar_Compiler_Effect.op_Bar_Greater uu___3 head_match
+         | (FStar_Syntax_Syntax.Tm_let uu___1, FStar_Syntax_Syntax.Tm_let
+            uu___2) -> HeadMatch true
+         | (FStar_Syntax_Syntax.Tm_match uu___1, FStar_Syntax_Syntax.Tm_match
+            uu___2) -> HeadMatch true
+         | (FStar_Syntax_Syntax.Tm_quoted uu___1,
+            FStar_Syntax_Syntax.Tm_quoted uu___2) -> HeadMatch true
+         | (FStar_Syntax_Syntax.Tm_abs uu___1, FStar_Syntax_Syntax.Tm_abs
+            uu___2) -> HeadMatch true
+         | uu___1 ->
+             let uu___2 =
+               let uu___3 = delta_depth_of_term env t11 in
+               let uu___4 = delta_depth_of_term env t21 in (uu___3, uu___4) in
+             MisMatch uu___2)
 let (head_matches_delta :
   FStar_TypeChecker_Env.env ->
     Prims.bool ->
@@ -3118,6 +3140,7 @@ let (head_matches_delta :
                    let t1' =
                      normalize_refinement
                        [FStar_TypeChecker_Env.UnfoldUntil d2;
+                       FStar_TypeChecker_Env.Primops;
                        FStar_TypeChecker_Env.Weak;
                        FStar_TypeChecker_Env.HNF] env t11 in
                    let uu___2 = made_progress t11 t1' in (t1', t21, uu___2)
@@ -3125,6 +3148,7 @@ let (head_matches_delta :
                    (let t2' =
                       normalize_refinement
                         [FStar_TypeChecker_Env.UnfoldUntil d1;
+                        FStar_TypeChecker_Env.Primops;
                         FStar_TypeChecker_Env.Weak;
                         FStar_TypeChecker_Env.HNF] env t21 in
                     let uu___3 = made_progress t21 t2' in (t11, t2', uu___3)) in
@@ -3141,11 +3165,13 @@ let (head_matches_delta :
                    let t1' =
                      normalize_refinement
                        [FStar_TypeChecker_Env.UnfoldUntil d1;
+                       FStar_TypeChecker_Env.Primops;
                        FStar_TypeChecker_Env.Weak;
                        FStar_TypeChecker_Env.HNF] env t11 in
                    let t2' =
                      normalize_refinement
                        [FStar_TypeChecker_Env.UnfoldUntil d1;
+                       FStar_TypeChecker_Env.Primops;
                        FStar_TypeChecker_Env.Weak;
                        FStar_TypeChecker_Env.HNF] env t21 in
                    let uu___2 =
@@ -4746,6 +4772,18 @@ let (has_typeclass_constraint :
               FStar_Syntax_Unionfind.equiv
                 v.FStar_Syntax_Syntax.ctx_uvar_head
                 u.FStar_Syntax_Syntax.ctx_uvar_head))
+let (lazy_complete_repr : FStar_Syntax_Syntax.lazy_kind -> Prims.bool) =
+  fun k ->
+    match k with
+    | FStar_Syntax_Syntax.Lazy_bv -> true
+    | FStar_Syntax_Syntax.Lazy_namedv -> true
+    | FStar_Syntax_Syntax.Lazy_binder -> true
+    | FStar_Syntax_Syntax.Lazy_letbinding -> true
+    | FStar_Syntax_Syntax.Lazy_fvar -> true
+    | FStar_Syntax_Syntax.Lazy_comp -> true
+    | FStar_Syntax_Syntax.Lazy_sigelt -> true
+    | FStar_Syntax_Syntax.Lazy_universe -> true
+    | uu___ -> false
 let rec (solve : worklist -> solution) =
   fun probs ->
     (let uu___1 =
@@ -11922,8 +11960,47 @@ and (solve_t' : tprob -> worklist -> solution) =
                   (FStar_Errors_Codes.Fatal_UnificationNotWellFormed,
                     uu___10) in
                 FStar_Errors.raise_error uu___9 t1.FStar_Syntax_Syntax.pos
+            | (FStar_Syntax_Syntax.Tm_lazy li1, FStar_Syntax_Syntax.Tm_lazy
+               li2) when
+                (FStar_Syntax_Util.eq_lazy_kind li1.FStar_Syntax_Syntax.lkind
+                   li2.FStar_Syntax_Syntax.lkind)
+                  && (lazy_complete_repr li1.FStar_Syntax_Syntax.lkind)
+                ->
+                let uu___7 =
+                  let uu___8 = FStar_Syntax_Util.unfold_lazy li1 in
+                  let uu___9 = FStar_Syntax_Util.unfold_lazy li2 in
+                  {
+                    FStar_TypeChecker_Common.pid =
+                      (problem.FStar_TypeChecker_Common.pid);
+                    FStar_TypeChecker_Common.lhs = uu___8;
+                    FStar_TypeChecker_Common.relation =
+                      (problem.FStar_TypeChecker_Common.relation);
+                    FStar_TypeChecker_Common.rhs = uu___9;
+                    FStar_TypeChecker_Common.element =
+                      (problem.FStar_TypeChecker_Common.element);
+                    FStar_TypeChecker_Common.logical_guard =
+                      (problem.FStar_TypeChecker_Common.logical_guard);
+                    FStar_TypeChecker_Common.logical_guard_uvar =
+                      (problem.FStar_TypeChecker_Common.logical_guard_uvar);
+                    FStar_TypeChecker_Common.reason =
+                      (problem.FStar_TypeChecker_Common.reason);
+                    FStar_TypeChecker_Common.loc =
+                      (problem.FStar_TypeChecker_Common.loc);
+                    FStar_TypeChecker_Common.rank =
+                      (problem.FStar_TypeChecker_Common.rank)
+                  } in
+                solve_t' uu___7 wl
             | uu___7 ->
-                let uu___8 = FStar_Thunk.mkv "head tag mismatch" in
+                let uu___8 =
+                  FStar_Thunk.mk
+                    (fun uu___9 ->
+                       let uu___10 =
+                         let uu___11 = FStar_Syntax_Print.tag_of_term t1 in
+                         let uu___12 =
+                           let uu___13 = FStar_Syntax_Print.tag_of_term t2 in
+                           Prims.op_Hat " vs " uu___13 in
+                         Prims.op_Hat uu___11 uu___12 in
+                       Prims.op_Hat "head tag mismatch: " uu___10) in
                 giveup wl uu___8 orig))))
 and (solve_c :
   FStar_Syntax_Syntax.comp FStar_TypeChecker_Common.problem ->
@@ -13942,16 +14019,12 @@ let (discharge_guard' :
       fun g ->
         fun use_smt ->
           let debug1 =
-            ((FStar_Compiler_Effect.op_Less_Bar
-                (FStar_TypeChecker_Env.debug env) (FStar_Options.Other "Rel"))
-               ||
-               (FStar_Compiler_Effect.op_Less_Bar
-                  (FStar_TypeChecker_Env.debug env)
-                  (FStar_Options.Other "SMTQuery")))
+            (FStar_Compiler_Effect.op_Less_Bar
+               (FStar_TypeChecker_Env.debug env) (FStar_Options.Other "Rel"))
               ||
               (FStar_Compiler_Effect.op_Less_Bar
                  (FStar_TypeChecker_Env.debug env)
-                 (FStar_Options.Other "Tac")) in
+                 (FStar_Options.Other "SMTQuery")) in
           (let uu___1 =
              FStar_Compiler_Effect.op_Less_Bar
                (FStar_TypeChecker_Env.debug env)

--- a/src/typechecker/FStar.TypeChecker.Rel.fst
+++ b/src/typechecker/FStar.TypeChecker.Rel.fst
@@ -5010,7 +5010,6 @@ let discharge_guard' use_env_range_msg env (g:guard_t) (use_smt:bool) : option g
   let debug =
       (Env.debug env <| Options.Other "Rel")
     || (Env.debug env <| Options.Other "SMTQuery")
-    || (Env.debug env <| Options.Other "Tac")
   in
   if Env.debug env <| Options.Other "ResolveImplicitsHook"
   then BU.print1 "///////////////////ResolveImplicitsHook: discharge_guard'\n\

--- a/src/typechecker/FStar.TypeChecker.Rel.fst
+++ b/src/typechecker/FStar.TypeChecker.Rel.fst
@@ -1289,7 +1289,7 @@ let rec head_matches env t1 t2 : match_result =
     | Tm_lazy ({lkind=Lazy_embedding _}), _ -> head_matches env (U.unlazy t1) t2
     |  _, Tm_lazy({lkind=Lazy_embedding _}) -> head_matches env t1 (U.unlazy t2)
     | Tm_lazy li1, Tm_lazy li2 ->
-      if li1.lkind = li2.lkind
+      if U.eq_lazy_kind li1.lkind li2.lkind
       then HeadMatch false
       else MisMatch(None, None)
 
@@ -4278,7 +4278,7 @@ and solve_t' (problem:tprob) (wl:worklist) : solution =
                             (Print.tag_of_term t1) (Print.tag_of_term t2)
                             (Print.term_to_string t1) (Print.term_to_string t2)) t1.pos
 
-      | Tm_lazy li1, Tm_lazy li2 when li1.lkind = li2.lkind
+      | Tm_lazy li1, Tm_lazy li2 when U.eq_lazy_kind li1.lkind li2.lkind
                                    && lazy_complete_repr li1.lkind ->
         solve_t' ({problem with lhs = U.unfold_lazy li1; rhs = U.unfold_lazy li2}) wl
 

--- a/tests/bug-reports/Bug3089.fst
+++ b/tests/bug-reports/Bug3089.fst
@@ -1,0 +1,42 @@
+module Bug3089
+
+(* Found by Amos Robinson. F* would fail with the error
+
+  * Error 114 at example/No.Norm.fst(32,8-32,12):
+    - Type of pattern (Prims.bool) does not match type of scrutinee (match 0 = 0 with
+      | true -> FStar.List.Tot.Base.hd [Prims.bool; Prims.bool]
+      | _ -> FStar.List.Tot.Base.index (FStar.List.Tot.Base.tl [Prims.bool; Prims.bool]) (0 - 1))
+
+due to not enabling primop reduction in the unifier. Now the `0 = 0` reduces
+as it should. *)
+
+module List = FStar.List.Tot
+
+let rec row (l: list eqtype): Type =
+  match l with
+  | [] -> unit
+  | t :: ts -> t * row ts
+
+let rec index (l: list eqtype) (r: row l) (i: nat { i < List.length l}): List.index l i =
+  match l with
+  | t :: ts ->
+    let r': t * row (List.tl l) = r in
+    match r' with
+    | (r0, rs) ->
+      if i = 0
+      then r0
+      else (
+        // Why coerce required?
+        let res: List.index ts (i - 1) = index ts rs (i - 1) in
+        coerce_eq #_ #(List.index l i) () res)
+
+
+let stepx (b1 b2: bool): bool =
+   let estop =
+         (index [bool; bool]
+         (b1, (b2, ()))
+         0)
+   in
+      match estop with
+      | true -> false
+      | false -> true

--- a/tests/bug-reports/Makefile
+++ b/tests/bug-reports/Makefile
@@ -53,7 +53,7 @@ SHOULD_VERIFY_CLOSED=Bug022.fst Bug024.fst Bug025.fst Bug026.fst Bug026b.fst Bug
   Bug2684a.fst Bug2684b.fst Bug2684c.fst Bug2684d.fst Bug2659b.fst\
   Bug2756.fst MutualRecPositivity.fst Bug2806a.fst Bug2806b.fst Bug2806c.fst Bug2806d.fst Bug2809.fst\
   Bug2849a.fst Bug2849b.fst Bug2045.fst Bug2876.fst Bug2882.fst Bug2895.fst Bug2894.fst \
-	Bug2415.fst Bug3028.fst Bug2954.fst
+	Bug2415.fst Bug3028.fst Bug2954.fst Bug3089.fst
 
 SHOULD_VERIFY_INTERFACE_CLOSED=Bug771.fsti Bug771b.fsti
 SHOULD_VERIFY_AND_WARN_CLOSED=Bug016.fst

--- a/ulib/FStar.Tactics.Canon.fst
+++ b/ulib/FStar.Tactics.Canon.fst
@@ -243,7 +243,11 @@ private let rec canon_point e =
         step_lemma (`minus_is_plus);
         step_lemma (`cong_plus);
         trefl ();
-        let r = canon_point (Neg b) in
+        let negb = match b with | Lit n -> Lit (-n) | _ -> Neg b in
+        // ^ We need to take care wrt literals, since an application (- N)
+        // will get reduced to the literal -N and then neg_minus_one will not
+        // apply.
+        let r = canon_point negb in
         canon_point (Plus a r)
 
     | _ ->
@@ -261,7 +265,7 @@ private let rec canon_point e =
 // maybe having the inner tactic be of type (list a -> tactic a), where
 // the list is the collected results for all child calls.
 let canon_point_entry () : Tac unit =
-    norm [];
+    norm [primops];
     let g = cur_goal () in
     match term_as_formula g with
     | Comp (Eq _) l r ->

--- a/ulib/FStar.Tactics.Canon.fst
+++ b/ulib/FStar.Tactics.Canon.fst
@@ -276,5 +276,6 @@ let canon_point_entry () : Tac unit =
     | _ ->
         fail ("impossible: " ^ term_to_string g)
 
+[@@plugin]
 let canon () : Tac unit =
     pointwise canon_point_entry


### PR DESCRIPTION
#3089 revealed that the unifier is not using primops for its normalization to WHNF, but I believe it should. While it is using primops in some localized places (see e.g. `let equal` around line 4176), it's not the case for the `whnf` function called in `compress_tprob`. Adding `Primops` there fixes the problem in #3089, but uncovers two other issues due to the extra normalization:

1- We are not handling equality of universe values (causing a regression in FStar.Reflection.Typing), or other lazy opaque terms. I fixed by this making the unifier expand lazy terms to their representation, as long as this is sound, i.e. if the repr is complete. This is case for universes, fixing this issue.

2- The unifier cannot match `N` (a literal) with `- X` (a negation, i.e. an application of op_Minus). I made this work by rewriting the problem into `-N` (still a literal) and `X`. This was uncovered by a failing tactic in Vale code. I've added an F* test for it now.

Everest came back green locally.