### PR TITLE
fix(doc/book): typos

### DIFF
--- a/doc/book/part1/part1_getting_off_the_ground.rst
+++ b/doc/book/part1/part1_getting_off_the_ground.rst
@@ -692,7 +692,7 @@ Can you write down some more types for factorial?
 Fibonacci
 .........
 
-Here's a doubly recursive function::
+Here's a doubly recursive function:
 
 .. literalinclude:: ../code/Part1.GettingOffTheGround.fst
    :language: fstar

--- a/doc/book/part1/part1_getting_off_the_ground.rst
+++ b/doc/book/part1/part1_getting_off_the_ground.rst
@@ -694,7 +694,7 @@ Fibonacci
 
 Here's a doubly recursive function::
 
-  .. literalinclude:: ../code/Part1.GettingOffTheGround.fst
+.. literalinclude:: ../code/Part1.GettingOffTheGround.fst
    :language: fstar
    :start-after: SNIPPET_START: fibonacci
    :end-before: SNIPPET_END: fibonacci

--- a/doc/book/part1/part1_inductives.rst
+++ b/doc/book/part1/part1_inductives.rst
@@ -359,7 +359,7 @@ Exercises
 
 Here's the definition of ``append``, a function that concatenates two
 lists. Can you give it a type that proves it always returns a list
-whose length is the sum of the lengths of its arguments.
+whose length is the sum of the lengths of its arguments?
 
 .. literalinclude:: ../code/Part1.Inductives.fst
    :language: fstar

--- a/doc/book/part1/part1_prop_assertions.rst
+++ b/doc/book/part1/part1_prop_assertions.rst
@@ -100,7 +100,7 @@ Propositions defined in ``prop`` need not be decidable. For example,
 for a Turing machine ``tm``, the fact ``halts tm`` can be defined as a
 ``prop``, although it is impossible to decide for an arbitrary ``tm``
 whether ``tm`` halts on all inputs. This is contrast with ``bool``,
-the type of booleans ``{true, false}``. Clearly, one could not defined
+the type of booleans ``{true, false}``. Clearly, one could not define
 ``halts tm`` as a ``bool``, since one would be claiming that for
 ``halts`` is function that for any ``tm`` can decide (by returning
 true or false) whether or not ``tm`` halts on all inputs.
@@ -118,7 +118,7 @@ Propositional connectives
 
 Consider stating that ``factorial n`` always returns a positive
 number, when ``n:nat``. In the :ref:`previous section <Part1_ch1>` we
-learned that one way to this is to give ``factorial`` a type like so.
+learned that one way to do this is to give ``factorial`` a type like so.
 
 .. code-block:: fstar
 

--- a/doc/book/part2/part2.rst
+++ b/doc/book/part2/part2.rst
@@ -102,7 +102,7 @@ learn about indexed inductive types from three related perspectives:
       programming language with structured concurrency <Part2_par>`,
       representing computations as infinitely branching inductively
       defined trees. The example introduces modeling computational
-      effects as monads and and showcases the use of inductive types
+      effects as monads and showcases the use of inductive types
       at higher order.
 
 This section is somewhat more advanced than the first. It also

--- a/doc/book/part4/part4_user_defined_effects.rst.outline
+++ b/doc/book/part4/part4_user_defined_effects.rst.outline
@@ -21,7 +21,7 @@ a section on graded monads
 
 a section on Dijkstra monads generalized from before, as a morphism between computational and spec monad
 
-a section on algebraic effects, with some background on what they're good for and and how we model them
+a section on algebraic effects, with some background on what they're good for and how we model them
 
 etc.
 


### PR DESCRIPTION
Fixes a couple of typos and an incorrectly included fib example