### PR TITLE
pretty-printer: consistently print nested tuples with (,) syntax

### DIFF
--- a/ocaml/fstar-lib/generated/FStar_Parser_ToDocument.ml
+++ b/ocaml/fstar-lib/generated/FStar_Parser_ToDocument.ml
@@ -4505,8 +4505,11 @@ and (p_appTerm : FStar_Parser_AST.term -> FStar_Pprint.document) =
                            FStar_Pprint.empty p_argTerm args1 in
                        FStar_Pprint.group uu___4)))
     | FStar_Parser_AST.Construct (lid, args) when
-        (is_general_construction e) &&
-          (let uu___ = (is_dtuple_constructor lid) && (all1_explicit args) in
+        ((is_general_construction e) &&
+           (let uu___ = (is_dtuple_constructor lid) && (all1_explicit args) in
+            Prims.op_Negation uu___))
+          &&
+          (let uu___ = (is_tuple_constructor lid) && (all1_explicit args) in
            Prims.op_Negation uu___)
         ->
         (match args with
@@ -4677,6 +4680,9 @@ and (p_atomicTermNotQUident : FStar_Parser_AST.term -> FStar_Pprint.document)
           FStar_Pprint.op_Hat_Hat FStar_Pprint.bar FStar_Pprint.rparen in
         FStar_Pprint.surround (Prims.of_int (2)) Prims.int_one uu___ uu___1
           uu___2
+    | FStar_Parser_AST.Construct (lid, args) when
+        (is_tuple_constructor lid) && (all1_explicit args) ->
+        let uu___ = p_tmTuple e in FStar_Pprint.parens uu___
     | FStar_Parser_AST.Project (e1, lid) ->
         let uu___ =
           let uu___1 = p_atomicTermNotQUident e1 in

--- a/src/parser/FStar.Parser.ToDocument.fst
+++ b/src/parser/FStar.Parser.ToDocument.fst
@@ -1990,9 +1990,10 @@ and p_appTerm e = match e.tm with
         group (soft_surround_map_or_flow 2 0 head_doc (head_doc ^^ space) break1 empty p_argTerm args)
       )
 
-  (* (explicit) dependent tuples are handled below *)
+  (* (explicit) tuples and dependent tuples are handled below *)
   | Construct (lid, args) when is_general_construction e
-        && not (is_dtuple_constructor lid && all1_explicit args) ->
+        && not (is_dtuple_constructor lid && all1_explicit args)
+        && not (is_tuple_constructor  lid && all1_explicit args) ->
     begin match args with
       | [] -> p_quident lid
       | [arg] -> group (p_quident lid ^/^ p_argTerm arg)
@@ -2074,6 +2075,8 @@ and p_atomicTermNotQUident e = match e.tm with
       surround 2 1 (lparen ^^ bar)
         (separate_map (comma ^^ break1) (fun (e, _) -> p_tmEq e) args)
                    (bar ^^ rparen)
+  | Construct (lid, args) when is_tuple_constructor lid && all1_explicit args ->
+      parens (p_tmTuple e)
   | Project (e, lid) ->
     group (prefix 2 0 (p_atomicTermNotQUident e)  (dot ^^ p_qlident lid))
   | _ ->

--- a/tests/error-messages/Bug3099.fst
+++ b/tests/error-messages/Bug3099.fst
@@ -1,0 +1,11 @@
+(* Test case: nested tuples print strangely in tactic dumps.
+  They look OK with --print_in_place though.
+  (This isn't strictly an error message test, but it is testing debug
+  messages, which are important too.)
+*)
+module Bug3099
+
+module Tac = FStar.Tactics
+
+let check_print_tuples () =
+  assert ((1, (2, (3, 4))) = (1, (2, (3, 4)))) by (Tac.dump "X")

--- a/tests/error-messages/Bug3099.fst.expected
+++ b/tests/error-messages/Bug3099.fst.expected
@@ -1,0 +1,7 @@
+proof-state: State dump @ depth 0 (X):
+Location: Bug3099.fst(11,50-11,64)
+Goal 1/1:
+(_: Prims.unit), (return_val: Prims.eqtype), (_: return_val == Prims.int * Prims.int * Prims.int * Prims.int), (any_result: Prims.bool), (_: true == any_result), (any_result'0: Prims.logical), (_: Prims.l_True == any_result'0) |- _ : Prims.squash ((1, (2, (3, 4))) = (1, (2, (3, 4))))
+
+Verified module: Bug3099
+All verification conditions discharged successfully


### PR DESCRIPTION
The tuple printer `p_tmTuple` was calling `p_tmEq` for values inside the tuple, but `p_tmEq` was printing nested tuples as `Mktuple2`. I've added a check inside `p_tmEq` to call back to the tuple printer, which matches how dependent tuples are printed too.