### PR TITLE
tactics: ctrl_rewrite: perform rewrite under arrows

### DIFF
--- a/ocaml/fstar-lib/generated/FStar_Tactics_CtrlRewrite.ml
+++ b/ocaml/fstar-lib/generated/FStar_Tactics_CtrlRewrite.ml
@@ -625,10 +625,69 @@ and (on_subterms :
                                       FStar_Syntax_Syntax.b = x1;
                                       FStar_Syntax_Syntax.phi = phi2
                                     }))
-                | FStar_Syntax_Syntax.Tm_arrow uu___1 ->
-                    FStar_Tactics_Monad.ret
-                      ((tm1.FStar_Syntax_Syntax.n),
-                        FStar_Tactics_Types.Continue)
+                | FStar_Syntax_Syntax.Tm_arrow
+                    { FStar_Syntax_Syntax.bs1 = bs;
+                      FStar_Syntax_Syntax.comp = comp;_}
+                    ->
+                    (match comp.FStar_Syntax_Syntax.n with
+                     | FStar_Syntax_Syntax.Total t ->
+                         let uu___1 = FStar_Syntax_Subst.open_term' bs t in
+                         (match uu___1 with
+                          | (bs_orig, t1, subst) ->
+                              descend_binders tm1 [] []
+                                FStar_Tactics_Types.Continue env bs_orig t1
+                                FStar_Pervasives_Native.None
+                                (fun bs1 ->
+                                   fun t2 ->
+                                     fun uu___2 ->
+                                       FStar_Syntax_Syntax.Tm_arrow
+                                         {
+                                           FStar_Syntax_Syntax.bs1 = bs1;
+                                           FStar_Syntax_Syntax.comp =
+                                             {
+                                               FStar_Syntax_Syntax.n =
+                                                 (FStar_Syntax_Syntax.Total
+                                                    t2);
+                                               FStar_Syntax_Syntax.pos =
+                                                 (comp.FStar_Syntax_Syntax.pos);
+                                               FStar_Syntax_Syntax.vars =
+                                                 (comp.FStar_Syntax_Syntax.vars);
+                                               FStar_Syntax_Syntax.hash_code
+                                                 =
+                                                 (comp.FStar_Syntax_Syntax.hash_code)
+                                             }
+                                         }))
+                     | FStar_Syntax_Syntax.GTotal t ->
+                         let uu___1 = FStar_Syntax_Subst.open_term' bs t in
+                         (match uu___1 with
+                          | (bs_orig, t1, subst) ->
+                              descend_binders tm1 [] []
+                                FStar_Tactics_Types.Continue env bs_orig t1
+                                FStar_Pervasives_Native.None
+                                (fun bs1 ->
+                                   fun t2 ->
+                                     fun uu___2 ->
+                                       FStar_Syntax_Syntax.Tm_arrow
+                                         {
+                                           FStar_Syntax_Syntax.bs1 = bs1;
+                                           FStar_Syntax_Syntax.comp =
+                                             {
+                                               FStar_Syntax_Syntax.n =
+                                                 (FStar_Syntax_Syntax.GTotal
+                                                    t2);
+                                               FStar_Syntax_Syntax.pos =
+                                                 (comp.FStar_Syntax_Syntax.pos);
+                                               FStar_Syntax_Syntax.vars =
+                                                 (comp.FStar_Syntax_Syntax.vars);
+                                               FStar_Syntax_Syntax.hash_code
+                                                 =
+                                                 (comp.FStar_Syntax_Syntax.hash_code)
+                                             }
+                                         }))
+                     | uu___1 ->
+                         FStar_Tactics_Monad.ret
+                           ((tm1.FStar_Syntax_Syntax.n),
+                             FStar_Tactics_Types.Continue))
                 | FStar_Syntax_Syntax.Tm_match
                     { FStar_Syntax_Syntax.scrutinee = hd;
                       FStar_Syntax_Syntax.ret_opt = asc_opt;

--- a/src/tactics/FStar.Tactics.CtrlRewrite.fst
+++ b/src/tactics/FStar.Tactics.CtrlRewrite.fst
@@ -324,10 +324,21 @@ and on_subterms
                             | _ -> failwith "Impossible"
                           in
                           Tm_refine {b=x; phi})
-      
-      (* Do nothing (FIXME) *)
-      | Tm_arrow _ ->
-        ret (tm.n, Continue)
+
+      | Tm_arrow { bs = bs; comp = comp } ->
+        (match comp.n with
+        | Total t ->
+          let bs_orig, t, subst = SS.open_term' bs t in
+          descend_binders tm [] [] Continue env bs_orig t None
+                          (fun bs t _ -> Tm_arrow {bs; comp = {comp with n = Total t}})
+        | GTotal t ->
+          let bs_orig, t, subst = SS.open_term' bs t in
+          descend_binders tm [] [] Continue env bs_orig t None
+                          (fun bs t _ -> Tm_arrow {bs; comp = {comp with n = GTotal t}})
+        | _ ->
+          (* Do nothing (FIXME).
+            What should we do for effectful computations? *)
+          ret (tm.n, Continue))
 
       (* Descend on head and branches in parallel. Branches
        * are opened with their contexts extended. Ignore the when clause,

--- a/tests/tactics/RewriteInArrow.fst
+++ b/tests/tactics/RewriteInArrow.fst
@@ -1,0 +1,10 @@
+module RewriteInArrow
+
+module Tac = FStar.Tactics
+
+#push-options "--debug TestBV64x --debug_level TacVerbose"
+
+let lemma_one_is_two (): Lemma (1 == 2) = admit ()
+
+let lemma_revert_ok (x: nat) (some_evidence: squash (x == 1)): unit =
+  assert (1 == 2) by (Tac.revert (); Tac.l_to_r [(`lemma_one_is_two)]; let _ = Tac.intro () in ())


### PR DESCRIPTION
I wanted to perform rewrites on the environment, but when I reverted the environment it wouldn't rewrite. It looks like ctrl_rewrite was missing part of the implementation.

I implemented rewrite for Total and GTotal computations, but it wasn't clear to me what to do for effectful computations. (I assume that they won't occur in reverts, anyway.) How often does this case occur - should it perhaps print a warning?