### PR TITLE
tactics: ctrl_rewrite: perform rewrite under arrows; fix rewrite under dependent binders

### DIFF
--- a/ocaml/fstar-lib/generated/FStar_Tactics_CtrlRewrite.ml
+++ b/ocaml/fstar-lib/generated/FStar_Tactics_CtrlRewrite.ml
@@ -488,8 +488,8 @@ and (on_subterms :
                                              FStar_Syntax_Subst.closing_of_binders
                                                bs1 in
                                            let bs2 =
-                                             FStar_Syntax_Subst.subst_binders
-                                               subst bs1 in
+                                             FStar_Syntax_Subst.close_binders
+                                               bs1 in
                                            let t3 =
                                              FStar_Syntax_Subst.subst subst
                                                t2 in
@@ -631,9 +631,9 @@ and (on_subterms :
                     ->
                     (match comp.FStar_Syntax_Syntax.n with
                      | FStar_Syntax_Syntax.Total t ->
-                         let uu___1 = FStar_Syntax_Subst.open_term' bs t in
+                         let uu___1 = FStar_Syntax_Subst.open_term bs t in
                          (match uu___1 with
-                          | (bs_orig, t1, subst) ->
+                          | (bs_orig, t1) ->
                               descend_binders tm1 [] []
                                 FStar_Tactics_Types.Continue env bs_orig t1
                                 FStar_Pervasives_Native.None
@@ -658,9 +658,9 @@ and (on_subterms :
                                              }
                                          }))
                      | FStar_Syntax_Syntax.GTotal t ->
-                         let uu___1 = FStar_Syntax_Subst.open_term' bs t in
+                         let uu___1 = FStar_Syntax_Subst.open_term bs t in
                          (match uu___1 with
-                          | (bs_orig, t1, subst) ->
+                          | (bs_orig, t1) ->
                               descend_binders tm1 [] []
                                 FStar_Tactics_Types.Continue env bs_orig t1
                                 FStar_Pervasives_Native.None

--- a/ocaml/fstar-lib/generated/FStar_Tactics_CtrlRewrite.ml
+++ b/ocaml/fstar-lib/generated/FStar_Tactics_CtrlRewrite.ml
@@ -625,10 +625,69 @@ and (on_subterms :
                                       FStar_Syntax_Syntax.b = x1;
                                       FStar_Syntax_Syntax.phi = phi2
                                     }))
-                | FStar_Syntax_Syntax.Tm_arrow uu___1 ->
-                    FStar_Tactics_Monad.ret
-                      ((tm1.FStar_Syntax_Syntax.n),
-                        FStar_Tactics_Types.Continue)
+                | FStar_Syntax_Syntax.Tm_arrow
+                    { FStar_Syntax_Syntax.bs1 = bs;
+                      FStar_Syntax_Syntax.comp = comp;_}
+                    ->
+                    (match comp.FStar_Syntax_Syntax.n with
+                     | FStar_Syntax_Syntax.Total t ->
+                         let uu___1 = FStar_Syntax_Subst.open_term' bs t in
+                         (match uu___1 with
+                          | (bs_orig, t1, subst) ->
+                              descend_binders tm1 [] []
+                                FStar_Tactics_Types.Continue env bs_orig t1
+                                FStar_Pervasives_Native.None
+                                (fun bs1 ->
+                                   fun t2 ->
+                                     fun uu___2 ->
+                                       FStar_Syntax_Syntax.Tm_arrow
+                                         {
+                                           FStar_Syntax_Syntax.bs1 = bs1;
+                                           FStar_Syntax_Syntax.comp =
+                                             {
+                                               FStar_Syntax_Syntax.n =
+                                                 (FStar_Syntax_Syntax.Total
+                                                    t2);
+                                               FStar_Syntax_Syntax.pos =
+                                                 (comp.FStar_Syntax_Syntax.pos);
+                                               FStar_Syntax_Syntax.vars =
+                                                 (comp.FStar_Syntax_Syntax.vars);
+                                               FStar_Syntax_Syntax.hash_code
+                                                 =
+                                                 (comp.FStar_Syntax_Syntax.hash_code)
+                                             }
+                                         }))
+                     | FStar_Syntax_Syntax.GTotal t ->
+                         let uu___1 = FStar_Syntax_Subst.open_term' bs t in
+                         (match uu___1 with
+                          | (bs_orig, t1, subst) ->
+                              descend_binders tm1 [] []
+                                FStar_Tactics_Types.Continue env bs_orig t1
+                                FStar_Pervasives_Native.None
+                                (fun bs1 ->
+                                   fun t2 ->
+                                     fun uu___2 ->
+                                       FStar_Syntax_Syntax.Tm_arrow
+                                         {
+                                           FStar_Syntax_Syntax.bs1 = bs1;
+                                           FStar_Syntax_Syntax.comp =
+                                             {
+                                               FStar_Syntax_Syntax.n =
+                                                 (FStar_Syntax_Syntax.GTotal
+                                                    t2);
+                                               FStar_Syntax_Syntax.pos =
+                                                 (comp.FStar_Syntax_Syntax.pos);
+                                               FStar_Syntax_Syntax.vars =
+                                                 (comp.FStar_Syntax_Syntax.vars);
+                                               FStar_Syntax_Syntax.hash_code
+                                                 =
+                                                 (comp.FStar_Syntax_Syntax.hash_code)
+                                             }
+                                         }))
+                     | uu___1 ->
+                         FStar_Tactics_Monad.ret
+                           ((tm1.FStar_Syntax_Syntax.n),
+                             FStar_Tactics_Types.Continue))
                 | FStar_Syntax_Syntax.Tm_match
                     { FStar_Syntax_Syntax.scrutinee = hd;
                       FStar_Syntax_Syntax.ret_opt = asc_opt;

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_TcTerm.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_TcTerm.ml
@@ -1097,7 +1097,7 @@ let (check_smt_pat :
                 ->
                 (check_pat_fvs t.FStar_Syntax_Syntax.pos env pats bs;
                  check_no_smt_theory_symbols env pats)
-            | uu___1 -> failwith "Impossible"
+            | uu___1 -> failwith "Impossible: check_smt_pat: not Comp"
           else ()
 let (guard_letrecs :
   FStar_TypeChecker_Env.env ->
@@ -5380,7 +5380,9 @@ and (tc_abs_expected_function_typ :
                 | FStar_Syntax_Syntax.Tm_uvar uu___1 ->
                     ((match env.FStar_TypeChecker_Env.letrecs with
                       | [] -> ()
-                      | uu___3 -> failwith "Impossible");
+                      | uu___3 ->
+                          failwith
+                            "Impossible: uvar abs with non-empty environment");
                      (let uu___3 = tc_binders env bs in
                       match uu___3 with
                       | (bs1, envbody, g_env, uu___4) ->
@@ -5404,7 +5406,9 @@ and (tc_abs_expected_function_typ :
                     ->
                     ((match env.FStar_TypeChecker_Env.letrecs with
                       | [] -> ()
-                      | uu___7 -> failwith "Impossible");
+                      | uu___7 ->
+                          failwith
+                            "Impossible: uvar abs with non-empty environment");
                      (let uu___7 = tc_binders env bs in
                       match uu___7 with
                       | (bs1, envbody, g_env, uu___8) ->
@@ -9164,7 +9168,9 @@ and (tc_pat :
                                             -> []
                                         | FStar_Syntax_Syntax.Tm_uinst
                                             (uu___9, us1) -> us1
-                                        | uu___9 -> failwith "Impossible") in
+                                        | uu___9 ->
+                                            failwith
+                                              "Impossible: tc_pat: pattern head not fvar or uinst") in
                                  match pat.FStar_Syntax_Syntax.v with
                                  | FStar_Syntax_Syntax.Pat_cons
                                      (fv1, uu___6, simple_pats) ->
@@ -9180,7 +9186,9 @@ and (tc_pat :
                                        FStar_Syntax_Syntax.p =
                                          (pat.FStar_Syntax_Syntax.p)
                                      }
-                                 | uu___6 -> failwith "Impossible" in
+                                 | uu___6 ->
+                                     failwith
+                                       "Impossible: tc_pat: pat.v expected Pat_cons" in
                                let uu___6 =
                                  reconstruct_nested_pat simple_pat_elab in
                                (bvs, tms, pat_e, uu___6, g, erasable1)))))) in
@@ -10568,7 +10576,7 @@ and (check_top_level_let :
                               FStar_TypeChecker_Common.lcomp_of_comp cres in
                             (uu___5, uu___6,
                               FStar_TypeChecker_Env.trivial_guard)))))))
-      | uu___ -> failwith "Impossible"
+      | uu___ -> failwith "Impossible: check_top_level_let: not a let"
 and (maybe_intro_smt_lemma :
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.term ->
@@ -11071,7 +11079,8 @@ and (check_top_level_let_rec :
                                               top.FStar_Syntax_Syntax.pos in
                                           (uu___7, cres,
                                             FStar_TypeChecker_Env.trivial_guard)))))))))
-      | uu___ -> failwith "Impossible"
+      | uu___ ->
+          failwith "Impossible: check_top_level_let_rec: not a let rec"
 and (check_inner_let_rec :
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.term ->
@@ -11314,7 +11323,7 @@ and (check_inner_let_rec :
                                                          FStar_TypeChecker_Env.conj_guard
                                                            g_ex guard1 in
                                                        (e, cres6, uu___8))))))))))
-      | uu___ -> failwith "Impossible"
+      | uu___ -> failwith "Impossible: check_inner_let_rec: not a let rec"
 and (build_let_rec_env :
   Prims.bool ->
     FStar_TypeChecker_Env.env ->
@@ -12931,9 +12940,15 @@ let rec (universe_of_aux :
           let rec type_of_head retry env1 hd1 args1 =
             let hd2 = FStar_Syntax_Subst.compress hd1 in
             match hd2.FStar_Syntax_Syntax.n with
-            | FStar_Syntax_Syntax.Tm_unknown -> failwith "Impossible"
-            | FStar_Syntax_Syntax.Tm_bvar uu___1 -> failwith "Impossible"
-            | FStar_Syntax_Syntax.Tm_delayed uu___1 -> failwith "Impossible"
+            | FStar_Syntax_Syntax.Tm_unknown ->
+                failwith
+                  "Impossible: universe_of_aux: Tm_app: unexpected head type"
+            | FStar_Syntax_Syntax.Tm_bvar uu___1 ->
+                failwith
+                  "Impossible: universe_of_aux: Tm_app: unexpected head type"
+            | FStar_Syntax_Syntax.Tm_delayed uu___1 ->
+                failwith
+                  "Impossible: universe_of_aux: Tm_app: unexpected head type"
             | FStar_Syntax_Syntax.Tm_fvar uu___1 ->
                 let uu___2 = universe_of_aux env1 hd2 in (uu___2, args1)
             | FStar_Syntax_Syntax.Tm_name uu___1 ->

--- a/src/tactics/FStar.Tactics.CtrlRewrite.fst
+++ b/src/tactics/FStar.Tactics.CtrlRewrite.fst
@@ -324,10 +324,21 @@ and on_subterms
                             | _ -> failwith "Impossible"
                           in
                           Tm_refine {b=x; phi})
-      
-      (* Do nothing (FIXME) *)
-      | Tm_arrow _ ->
-        ret (tm.n, Continue)
+
+      | Tm_arrow { bs = bs; comp = comp } ->
+        (match comp.n with
+        | Total t ->
+          let bs_orig, t, subst = SS.open_term' bs t in
+          descend_binders tm [] [] Continue env bs_orig t None
+                          (fun bs t _ -> Tm_arrow {bs; comp = {comp with n = Total t}})
+        | GTotal t ->
+          let bs_orig, t, subst = SS.open_term' bs t in
+          descend_binders tm [] [] Continue env bs_orig t None
+                          (fun bs t _ -> Tm_arrow {bs; comp = {comp with n = GTotal t}})
+        | _ ->
+          (* Do nothing (FIXME).
+            What should we do for effectful computations? *)
+          ret (tm.n, Continue))
 
       (* Descend on head and branches in parallel. Branches
        * are opened with their contexts extended. Ignore the when clause,

--- a/src/tactics/FStar.Tactics.CtrlRewrite.fst
+++ b/src/tactics/FStar.Tactics.CtrlRewrite.fst
@@ -280,7 +280,8 @@ and on_subterms
           let! k, k_flag = recurse_option_residual_comp env retyping_subst k recurse in
           let bs = List.rev accum_binders in
           let subst = SS.closing_of_binders bs in
-          let bs = SS.subst_binders subst bs in
+          // For dependent binders, we need to re-compute the substitution incrementally; applying subst to bs doesn't work
+          let bs = SS.close_binders bs in
           let t = SS.subst subst t in
           let k = BU.map_option (SS.subst_residual_comp subst) k in
           ret (rebuild bs t k,
@@ -328,11 +329,11 @@ and on_subterms
       | Tm_arrow { bs = bs; comp = comp } ->
         (match comp.n with
         | Total t ->
-          let bs_orig, t, subst = SS.open_term' bs t in
+          let bs_orig, t = SS.open_term bs t in
           descend_binders tm [] [] Continue env bs_orig t None
                           (fun bs t _ -> Tm_arrow {bs; comp = {comp with n = Total t}})
         | GTotal t ->
-          let bs_orig, t, subst = SS.open_term' bs t in
+          let bs_orig, t = SS.open_term bs t in
           descend_binders tm [] [] Continue env bs_orig t None
                           (fun bs t _ -> Tm_arrow {bs; comp = {comp with n = GTotal t}})
         | _ ->

--- a/src/typechecker/FStar.TypeChecker.TcTerm.fst
+++ b/src/typechecker/FStar.TypeChecker.TcTerm.fst
@@ -481,7 +481,7 @@ let check_smt_pat env t bs c =
         | Comp ({effect_args=[_pre; _post; (pats, _)]}) ->
             check_pat_fvs t.pos env pats bs;
             check_no_smt_theory_symbols env pats
-        | _ -> failwith "Impossible"
+        | _ -> failwith "Impossible: check_smt_pat: not Comp"
 
 (************************************************************************************************************)
 (* Building the environment for the body of a let rec;                                                      *)
@@ -2006,7 +2006,7 @@ and tc_abs_expected_function_typ env (bs:binders) (t0:option (typ * bool)) (body
       | Tm_uvar _
       | Tm_app {hd={n=Tm_uvar _}} ->
         (* expected a uvar; build a function type from the term and unify with it *)
-        let _ = match env.letrecs with | [] -> () | _ -> failwith "Impossible" in
+        let _ = match env.letrecs with | [] -> () | _ -> failwith "Impossible: uvar abs with non-empty environment" in
         let bs, envbody, g_env, _ = tc_binders env bs in
         let envbody, _ = Env.clear_expected_typ envbody in
         Some t, bs, [], None, envbody, body, g_env
@@ -3388,13 +3388,13 @@ and tc_pat env (pat_t:typ) (p0:pat) :
                 match (SS.compress hd).n with
                 | Tm_fvar _ -> []
                 | Tm_uinst(_, us) -> us
-                | _ -> failwith "Impossible"
+                | _ -> failwith "Impossible: tc_pat: pattern head not fvar or uinst"
               in
               match pat.v with
               | Pat_cons(fv, _, simple_pats) ->
                 let nested_pats = aux simple_pats simple_bvs checked_sub_pats in
                 {pat with v=Pat_cons(fv, Some us, nested_pats)}
-              | _ -> failwith "Impossible"
+              | _ -> failwith "Impossible: tc_pat: pat.v expected Pat_cons"
           in
           bvs,
           tms,
@@ -3881,7 +3881,7 @@ and check_top_level_let env e =
          TcComm.lcomp_of_comp cres,
          Env.trivial_guard
 
-     | _ -> failwith "Impossible"
+     | _ -> failwith "Impossible: check_top_level_let: not a let"
 
 and maybe_intro_smt_lemma env lem_typ c2 =
     if U.is_smt_lemma lem_typ
@@ -4065,7 +4065,7 @@ and check_top_level_let_rec env top =
           cres,
           Env.trivial_guard
 
-        | _ -> failwith "Impossible"
+        | _ -> failwith "Impossible: check_top_level_let_rec: not a let rec"
 
 (******************************************************************************)
 (* inner let rec's are never implicitly generalized *)
@@ -4144,7 +4144,7 @@ and check_inner_let_rec env top =
                 e, cres, Env.conj_guard g_ex guard
           end
 
-        | _ -> failwith "Impossible"
+        | _ -> failwith "Impossible: check_inner_let_rec: not a let rec"
 
 (******************************************************************************)
 (* build an environment with recursively bound names.                         *)
@@ -4641,7 +4641,7 @@ let rec universe_of_aux env e : term =
         | Tm_unknown
         | Tm_bvar _
         | Tm_delayed _ ->
-          failwith "Impossible"
+          failwith "Impossible: universe_of_aux: Tm_app: unexpected head type"
         | Tm_fvar _
         | Tm_name _
         | Tm_uvar _

--- a/tests/tactics/RewriteInArrow.fst
+++ b/tests/tactics/RewriteInArrow.fst
@@ -2,9 +2,12 @@ module RewriteInArrow
 
 module Tac = FStar.Tactics
 
-#push-options "--debug TestBV64x --debug_level TacVerbose"
-
 let lemma_one_is_two (): Lemma (1 == 2) = admit ()
 
 let lemma_revert_ok (x: nat) (some_evidence: squash (x == 1)): unit =
   assert (1 == 2) by (Tac.revert (); Tac.l_to_r [(`lemma_one_is_two)]; let _ = Tac.intro () in ())
+
+(* This case of dependent binders was causing issues in ctrl_rewrite *)
+let dependent_binders =
+  assert (let id = fun (a: Type) (x: a) -> x in id Type0 True)
+    by (Tac.pointwise (fun () -> Tac.trefl ()))

--- a/tests/tactics/RewriteInArrow.fst
+++ b/tests/tactics/RewriteInArrow.fst
@@ -1,0 +1,10 @@
+module RewriteInArrow
+
+module Tac = FStar.Tactics
+
+#push-options "--debug TestBV64x --debug_level TacVerbose"
+
+let lemma_one_is_two (): Lemma (1 == 2) = admit ()
+
+let lemma_revert_ok (x: nat) (some_evidence: squash (x == 1)): unit =
+  assert (1 == 2) by (Tac.revert (); Tac.l_to_r [(`lemma_one_is_two)]; let _ = Tac.intro () in ())


### PR DESCRIPTION
I wanted to perform rewrites on the environment, but when I reverted the environment it wouldn't rewrite. It looks like ctrl_rewrite was missing part of the implementation.

Additionally, I believe that the handling of dependent binders in ctrl_rewrite was incorrect. For a function abstraction `fun (a: Type) (x: a) -> x` it was taking the binders `[a: Type; x: a]` and computing a close substitution `[a := bv@1; x := bv@0]`. But we can't apply that substitution to the binders, because the binder `x: a` needs to refer to a with de bruijn index 0, not 1.

At least, this is what I *think* was causing the rewriting problem that I saw. I suspect that this may not have come up often in the past because functions with dependent binders will occur more often in the environment than in the goal.

To rewrite under arrows, I only implemented rewrite for Total and GTotal computations. It wasn't clear to me what to do for effectful computations. (I assume that they won't occur in reverts, anyway.) How often does this case occur - should it perhaps print a warning?

While debugging, I also made some of the "Impossible" errors a little more searchable. (Is there an easier way to track down what threw the impossible?)