### PR TITLE
Fixing the escape check to provide better errors

### DIFF
--- a/ocaml/fstar-lib/generated/FStar_Extraction_ML_Term.ml
+++ b/ocaml/fstar-lib/generated/FStar_Extraction_ML_Term.ml
@@ -110,12 +110,12 @@ let err_value_restriction :
           uu___2 uu___3 in
       (FStar_Errors_Codes.Fatal_ValueRestriction, uu___1) in
     fail t.FStar_Syntax_Syntax.pos uu___
-let (err_unexpected_eff :
-  FStar_Extraction_ML_UEnv.uenv ->
-    FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
-      FStar_Extraction_ML_Syntax.mlty ->
-        FStar_Extraction_ML_Syntax.e_tag ->
-          FStar_Extraction_ML_Syntax.e_tag -> unit)
+let err_unexpected_eff :
+  'uuuuu .
+    FStar_Extraction_ML_UEnv.uenv ->
+      FStar_Syntax_Syntax.term' FStar_Syntax_Syntax.syntax ->
+        FStar_Extraction_ML_Syntax.mlty ->
+          FStar_Extraction_ML_Syntax.e_tag -> 'uuuuu -> unit
   =
   fun env ->
     fun t ->
@@ -124,18 +124,46 @@ let (err_unexpected_eff :
           fun f1 ->
             let uu___ =
               let uu___1 =
-                let uu___2 = FStar_Syntax_Print.term_to_string t in
+                let uu___2 =
+                  let uu___3 =
+                    let uu___4 = FStar_Errors_Msg.text "For expression" in
+                    let uu___5 = FStar_Syntax_Print.term_to_doc t in
+                    FStar_Pprint.prefix (Prims.of_int (4)) Prims.int_one
+                      uu___4 uu___5 in
+                  let uu___4 =
+                    let uu___5 = FStar_Errors_Msg.text "of type" in
+                    let uu___6 =
+                      let uu___7 =
+                        let uu___8 =
+                          FStar_Extraction_ML_UEnv.current_module_of_uenv env in
+                        FStar_Extraction_ML_Code.string_of_mlty uu___8 ty in
+                      FStar_Pprint.arbitrary_string uu___7 in
+                    FStar_Pprint.prefix (Prims.of_int (4)) Prims.int_one
+                      uu___5 uu___6 in
+                  FStar_Pprint.op_Hat_Slash_Hat uu___3 uu___4 in
                 let uu___3 =
                   let uu___4 =
-                    FStar_Extraction_ML_UEnv.current_module_of_uenv env in
-                  FStar_Extraction_ML_Code.string_of_mlty uu___4 ty in
-                let uu___4 = FStar_Extraction_ML_Util.eff_to_string f0 in
-                let uu___5 = FStar_Extraction_ML_Util.eff_to_string f1 in
-                FStar_Compiler_Util.format4
-                  "for expression %s of type %s, Expected effect %s; got effect %s"
-                  uu___2 uu___3 uu___4 uu___5 in
+                    let uu___5 =
+                      let uu___6 = FStar_Errors_Msg.text "Expected effect" in
+                      let uu___7 =
+                        let uu___8 =
+                          FStar_Extraction_ML_Util.eff_to_string f0 in
+                        FStar_Pprint.arbitrary_string uu___8 in
+                      FStar_Pprint.prefix (Prims.of_int (4)) Prims.int_one
+                        uu___6 uu___7 in
+                    let uu___6 =
+                      let uu___7 = FStar_Errors_Msg.text "got effect" in
+                      let uu___8 =
+                        let uu___9 =
+                          FStar_Extraction_ML_Util.eff_to_string f0 in
+                        FStar_Pprint.arbitrary_string uu___9 in
+                      FStar_Pprint.prefix (Prims.of_int (4)) Prims.int_one
+                        uu___7 uu___8 in
+                    FStar_Pprint.op_Hat_Slash_Hat uu___5 uu___6 in
+                  [uu___4] in
+                uu___2 :: uu___3 in
               (FStar_Errors_Codes.Warning_ExtractionUnexpectedEffect, uu___1) in
-            FStar_Errors.log_issue t.FStar_Syntax_Syntax.pos uu___
+            FStar_Errors.log_issue_doc t.FStar_Syntax_Syntax.pos uu___
 let err_cannot_extract_effect :
   'uuuuu .
     FStar_Ident.lident ->

--- a/ocaml/fstar-lib/generated/FStar_Tactics_CheckLN.ml
+++ b/ocaml/fstar-lib/generated/FStar_Tactics_CheckLN.ml
@@ -1,0 +1,734 @@
+open Prims
+let rec for_all :
+  'a .
+    ('a -> (Prims.bool, unit) FStar_Tactics_Effect.tac_repr) ->
+      'a Prims.list -> (Prims.bool, unit) FStar_Tactics_Effect.tac_repr
+  =
+  fun uu___1 ->
+    fun uu___ ->
+      (fun p ->
+         fun l ->
+           match l with
+           | [] ->
+               Obj.magic
+                 (Obj.repr
+                    (FStar_Tactics_Effect.lift_div_tac (fun uu___ -> true)))
+           | x::xs ->
+               Obj.magic
+                 (Obj.repr
+                    (FStar_Tactics_Effect.tac_bind
+                       (FStar_Sealed.seal
+                          (Obj.magic
+                             (FStar_Range.mk_range
+                                "FStar.Tactics.CheckLN.fst"
+                                (Prims.of_int (9)) (Prims.of_int (16))
+                                (Prims.of_int (9)) (Prims.of_int (19)))))
+                       (FStar_Sealed.seal
+                          (Obj.magic
+                             (FStar_Range.mk_range
+                                "FStar.Tactics.CheckLN.fst"
+                                (Prims.of_int (9)) (Prims.of_int (13))
+                                (Prims.of_int (9)) (Prims.of_int (48)))))
+                       (Obj.magic (p x))
+                       (fun uu___ ->
+                          (fun uu___ ->
+                             if uu___
+                             then Obj.magic (Obj.repr (for_all p xs))
+                             else
+                               Obj.magic
+                                 (Obj.repr
+                                    (FStar_Tactics_Effect.lift_div_tac
+                                       (fun uu___2 -> false)))) uu___))))
+        uu___1 uu___
+let rec (check :
+  FStar_Tactics_NamedView.term ->
+    (Prims.bool, unit) FStar_Tactics_Effect.tac_repr)
+  =
+  fun t ->
+    FStar_Tactics_Effect.tac_bind
+      (FStar_Sealed.seal
+         (Obj.magic
+            (FStar_Range.mk_range "FStar.Tactics.CheckLN.fst"
+               (Prims.of_int (12)) (Prims.of_int (8)) (Prims.of_int (12))
+               (Prims.of_int (17)))))
+      (FStar_Sealed.seal
+         (Obj.magic
+            (FStar_Range.mk_range "FStar.Tactics.CheckLN.fst"
+               (Prims.of_int (12)) (Prims.of_int (2)) (Prims.of_int (41))
+               (Prims.of_int (21)))))
+      (Obj.magic (FStar_Tactics_NamedView.inspect t))
+      (fun uu___ ->
+         (fun uu___ ->
+            match uu___ with
+            | FStar_Tactics_NamedView.Tv_BVar bv ->
+                Obj.magic
+                  (Obj.repr
+                     (FStar_Tactics_Effect.lift_div_tac (fun uu___1 -> false)))
+            | FStar_Tactics_NamedView.Tv_Const uu___1 ->
+                Obj.magic
+                  (Obj.repr
+                     (FStar_Tactics_Effect.lift_div_tac (fun uu___2 -> true)))
+            | FStar_Tactics_NamedView.Tv_Uvar (uu___1, uu___2) ->
+                Obj.magic
+                  (Obj.repr
+                     (FStar_Tactics_Effect.lift_div_tac (fun uu___3 -> false)))
+            | FStar_Tactics_NamedView.Tv_Var uu___1 ->
+                Obj.magic
+                  (Obj.repr
+                     (FStar_Tactics_Effect.lift_div_tac (fun uu___2 -> true)))
+            | FStar_Tactics_NamedView.Tv_FVar uu___1 ->
+                Obj.magic
+                  (Obj.repr
+                     (FStar_Tactics_Effect.lift_div_tac (fun uu___2 -> true)))
+            | FStar_Tactics_NamedView.Tv_UInst (uu___1, us) ->
+                Obj.magic (Obj.repr (for_all check_u us))
+            | FStar_Tactics_NamedView.Tv_App (hd, (a, q)) ->
+                Obj.magic
+                  (Obj.repr
+                     (FStar_Tactics_Effect.tac_bind
+                        (FStar_Sealed.seal
+                           (Obj.magic
+                              (FStar_Range.mk_range
+                                 "FStar.Tactics.CheckLN.fst"
+                                 (Prims.of_int (24)) (Prims.of_int (27))
+                                 (Prims.of_int (24)) (Prims.of_int (35)))))
+                        (FStar_Sealed.seal
+                           (Obj.magic
+                              (FStar_Range.mk_range
+                                 "FStar.Tactics.CheckLN.fst"
+                                 (Prims.of_int (24)) (Prims.of_int (24))
+                                 (Prims.of_int (24)) (Prims.of_int (59)))))
+                        (Obj.magic (check hd))
+                        (fun uu___1 ->
+                           (fun uu___1 ->
+                              if uu___1
+                              then Obj.magic (Obj.repr (check a))
+                              else
+                                Obj.magic
+                                  (Obj.repr
+                                     (FStar_Tactics_Effect.lift_div_tac
+                                        (fun uu___3 -> false)))) uu___1)))
+            | FStar_Tactics_NamedView.Tv_Abs (b, body) ->
+                Obj.magic
+                  (Obj.repr
+                     (FStar_Tactics_Effect.tac_bind
+                        (FStar_Sealed.seal
+                           (Obj.magic
+                              (FStar_Range.mk_range
+                                 "FStar.Tactics.CheckLN.fst"
+                                 (Prims.of_int (25)) (Prims.of_int (24))
+                                 (Prims.of_int (25)) (Prims.of_int (36)))))
+                        (FStar_Sealed.seal
+                           (Obj.magic
+                              (FStar_Range.mk_range
+                                 "FStar.Tactics.CheckLN.fst"
+                                 (Prims.of_int (25)) (Prims.of_int (21))
+                                 (Prims.of_int (25)) (Prims.of_int (63)))))
+                        (Obj.magic (check b.FStar_Tactics_NamedView.sort))
+                        (fun uu___1 ->
+                           (fun uu___1 ->
+                              if uu___1
+                              then Obj.magic (Obj.repr (check body))
+                              else
+                                Obj.magic
+                                  (Obj.repr
+                                     (FStar_Tactics_Effect.lift_div_tac
+                                        (fun uu___3 -> false)))) uu___1)))
+            | FStar_Tactics_NamedView.Tv_Arrow (b, c) ->
+                Obj.magic
+                  (Obj.repr
+                     (FStar_Tactics_Effect.tac_bind
+                        (FStar_Sealed.seal
+                           (Obj.magic
+                              (FStar_Range.mk_range
+                                 "FStar.Tactics.CheckLN.fst"
+                                 (Prims.of_int (26)) (Prims.of_int (23))
+                                 (Prims.of_int (26)) (Prims.of_int (35)))))
+                        (FStar_Sealed.seal
+                           (Obj.magic
+                              (FStar_Range.mk_range
+                                 "FStar.Tactics.CheckLN.fst"
+                                 (Prims.of_int (26)) (Prims.of_int (20))
+                                 (Prims.of_int (26)) (Prims.of_int (64)))))
+                        (Obj.magic (check b.FStar_Tactics_NamedView.sort))
+                        (fun uu___1 ->
+                           (fun uu___1 ->
+                              if uu___1
+                              then Obj.magic (Obj.repr (check_comp c))
+                              else
+                                Obj.magic
+                                  (Obj.repr
+                                     (FStar_Tactics_Effect.lift_div_tac
+                                        (fun uu___3 -> false)))) uu___1)))
+            | FStar_Tactics_NamedView.Tv_Type u ->
+                Obj.magic (Obj.repr (check_u u))
+            | FStar_Tactics_NamedView.Tv_Refine (b, ref) ->
+                Obj.magic
+                  (Obj.repr
+                     (FStar_Tactics_Effect.tac_bind
+                        (FStar_Sealed.seal
+                           (Obj.magic
+                              (FStar_Range.mk_range
+                                 "FStar.Tactics.CheckLN.fst"
+                                 (Prims.of_int (28)) (Prims.of_int (26))
+                                 (Prims.of_int (28)) (Prims.of_int (38)))))
+                        (FStar_Sealed.seal
+                           (Obj.magic
+                              (FStar_Range.mk_range
+                                 "FStar.Tactics.CheckLN.fst"
+                                 (Prims.of_int (28)) (Prims.of_int (23))
+                                 (Prims.of_int (28)) (Prims.of_int (64)))))
+                        (Obj.magic (check b.FStar_Tactics_NamedView.sort))
+                        (fun uu___1 ->
+                           (fun uu___1 ->
+                              if uu___1
+                              then Obj.magic (Obj.repr (check ref))
+                              else
+                                Obj.magic
+                                  (Obj.repr
+                                     (FStar_Tactics_Effect.lift_div_tac
+                                        (fun uu___3 -> false)))) uu___1)))
+            | FStar_Tactics_NamedView.Tv_Let (recf, attrs, b, def, body) ->
+                Obj.magic
+                  (Obj.repr
+                     (FStar_Tactics_Effect.tac_bind
+                        (FStar_Sealed.seal
+                           (Obj.magic
+                              (FStar_Range.mk_range
+                                 "FStar.Tactics.CheckLN.fst"
+                                 (Prims.of_int (30)) (Prims.of_int (7))
+                                 (Prims.of_int (30)) (Prims.of_int (32)))))
+                        (FStar_Sealed.seal
+                           (Obj.magic
+                              (FStar_Range.mk_range
+                                 "FStar.Tactics.CheckLN.fst"
+                                 (Prims.of_int (30)) (Prims.of_int (4))
+                                 (Prims.of_int (32)) (Prims.of_int (14)))))
+                        (Obj.magic
+                           (FStar_Tactics_Effect.tac_bind
+                              (FStar_Sealed.seal
+                                 (Obj.magic
+                                    (FStar_Range.mk_range
+                                       "FStar.Tactics.CheckLN.fst"
+                                       (Prims.of_int (30))
+                                       (Prims.of_int (11))
+                                       (Prims.of_int (30))
+                                       (Prims.of_int (32)))))
+                              (FStar_Sealed.seal
+                                 (Obj.magic
+                                    (FStar_Range.mk_range
+                                       "FStar.Tactics.CheckLN.fst"
+                                       (Prims.of_int (30)) (Prims.of_int (7))
+                                       (Prims.of_int (30))
+                                       (Prims.of_int (32)))))
+                              (Obj.magic (for_all check attrs))
+                              (fun uu___1 ->
+                                 FStar_Tactics_Effect.lift_div_tac
+                                   (fun uu___2 -> Prims.op_Negation uu___1))))
+                        (fun uu___1 ->
+                           (fun uu___1 ->
+                              if uu___1
+                              then
+                                Obj.magic
+                                  (Obj.repr
+                                     (FStar_Tactics_Effect.lift_div_tac
+                                        (fun uu___2 -> false)))
+                              else
+                                Obj.magic
+                                  (Obj.repr
+                                     (FStar_Tactics_Effect.tac_bind
+                                        (FStar_Sealed.seal
+                                           (Obj.magic
+                                              (FStar_Range.mk_range
+                                                 "FStar.Tactics.CheckLN.fst"
+                                                 (Prims.of_int (31))
+                                                 (Prims.of_int (7))
+                                                 (Prims.of_int (31))
+                                                 (Prims.of_int (22)))))
+                                        (FStar_Sealed.seal
+                                           (Obj.magic
+                                              (FStar_Range.mk_range
+                                                 "FStar.Tactics.CheckLN.fst"
+                                                 (Prims.of_int (31))
+                                                 (Prims.of_int (4))
+                                                 (Prims.of_int (32))
+                                                 (Prims.of_int (14)))))
+                                        (Obj.magic
+                                           (FStar_Tactics_Effect.tac_bind
+                                              (FStar_Sealed.seal
+                                                 (Obj.magic
+                                                    (FStar_Range.mk_range
+                                                       "FStar.Tactics.CheckLN.fst"
+                                                       (Prims.of_int (31))
+                                                       (Prims.of_int (11))
+                                                       (Prims.of_int (31))
+                                                       (Prims.of_int (22)))))
+                                              (FStar_Sealed.seal
+                                                 (Obj.magic
+                                                    (FStar_Range.mk_range
+                                                       "FStar.Tactics.CheckLN.fst"
+                                                       (Prims.of_int (31))
+                                                       (Prims.of_int (7))
+                                                       (Prims.of_int (31))
+                                                       (Prims.of_int (22)))))
+                                              (Obj.magic (check def))
+                                              (fun uu___3 ->
+                                                 FStar_Tactics_Effect.lift_div_tac
+                                                   (fun uu___4 ->
+                                                      Prims.op_Negation
+                                                        uu___3))))
+                                        (fun uu___3 ->
+                                           (fun uu___3 ->
+                                              if uu___3
+                                              then
+                                                Obj.magic
+                                                  (Obj.repr
+                                                     (FStar_Tactics_Effect.lift_div_tac
+                                                        (fun uu___4 -> false)))
+                                              else
+                                                Obj.magic
+                                                  (Obj.repr (check body)))
+                                             uu___3)))) uu___1)))
+            | FStar_Tactics_NamedView.Tv_Match (sc, uu___1, brs) ->
+                Obj.magic
+                  (Obj.repr
+                     (FStar_Tactics_Effect.tac_bind
+                        (FStar_Sealed.seal
+                           (Obj.magic
+                              (FStar_Range.mk_range
+                                 "FStar.Tactics.CheckLN.fst"
+                                 (Prims.of_int (34)) (Prims.of_int (7))
+                                 (Prims.of_int (34)) (Prims.of_int (15)))))
+                        (FStar_Sealed.seal
+                           (Obj.magic
+                              (FStar_Range.mk_range
+                                 "FStar.Tactics.CheckLN.fst"
+                                 (Prims.of_int (34)) (Prims.of_int (4))
+                                 (Prims.of_int (34)) (Prims.of_int (52)))))
+                        (Obj.magic (check sc))
+                        (fun uu___2 ->
+                           (fun uu___2 ->
+                              if uu___2
+                              then
+                                Obj.magic (Obj.repr (for_all check_br brs))
+                              else
+                                Obj.magic
+                                  (Obj.repr
+                                     (FStar_Tactics_Effect.lift_div_tac
+                                        (fun uu___4 -> false)))) uu___2)))
+            | FStar_Tactics_NamedView.Tv_AscribedT (e, t1, uu___1, uu___2) ->
+                Obj.magic
+                  (Obj.repr
+                     (FStar_Tactics_Effect.tac_bind
+                        (FStar_Sealed.seal
+                           (Obj.magic
+                              (FStar_Range.mk_range
+                                 "FStar.Tactics.CheckLN.fst"
+                                 (Prims.of_int (36)) (Prims.of_int (7))
+                                 (Prims.of_int (36)) (Prims.of_int (14)))))
+                        (FStar_Sealed.seal
+                           (Obj.magic
+                              (FStar_Range.mk_range
+                                 "FStar.Tactics.CheckLN.fst"
+                                 (Prims.of_int (36)) (Prims.of_int (4))
+                                 (Prims.of_int (36)) (Prims.of_int (38)))))
+                        (Obj.magic (check e))
+                        (fun uu___3 ->
+                           (fun uu___3 ->
+                              if uu___3
+                              then Obj.magic (Obj.repr (check t1))
+                              else
+                                Obj.magic
+                                  (Obj.repr
+                                     (FStar_Tactics_Effect.lift_div_tac
+                                        (fun uu___5 -> false)))) uu___3)))
+            | FStar_Tactics_NamedView.Tv_AscribedC (e, c, uu___1, uu___2) ->
+                Obj.magic
+                  (Obj.repr
+                     (FStar_Tactics_Effect.tac_bind
+                        (FStar_Sealed.seal
+                           (Obj.magic
+                              (FStar_Range.mk_range
+                                 "FStar.Tactics.CheckLN.fst"
+                                 (Prims.of_int (38)) (Prims.of_int (7))
+                                 (Prims.of_int (38)) (Prims.of_int (14)))))
+                        (FStar_Sealed.seal
+                           (Obj.magic
+                              (FStar_Range.mk_range
+                                 "FStar.Tactics.CheckLN.fst"
+                                 (Prims.of_int (38)) (Prims.of_int (4))
+                                 (Prims.of_int (38)) (Prims.of_int (43)))))
+                        (Obj.magic (check e))
+                        (fun uu___3 ->
+                           (fun uu___3 ->
+                              if uu___3
+                              then Obj.magic (Obj.repr (check_comp c))
+                              else
+                                Obj.magic
+                                  (Obj.repr
+                                     (FStar_Tactics_Effect.lift_div_tac
+                                        (fun uu___5 -> false)))) uu___3)))
+            | FStar_Tactics_NamedView.Tv_Unknown ->
+                Obj.magic
+                  (Obj.repr
+                     (FStar_Tactics_Effect.lift_div_tac (fun uu___1 -> true)))
+            | FStar_Tactics_NamedView.Tv_Unsupp ->
+                Obj.magic
+                  (Obj.repr
+                     (FStar_Tactics_Effect.lift_div_tac (fun uu___1 -> true))))
+           uu___)
+and (check_u :
+  FStar_Tactics_NamedView.universe ->
+    (Prims.bool, unit) FStar_Tactics_Effect.tac_repr)
+  =
+  fun uu___ ->
+    (fun u ->
+       match FStar_Tactics_NamedView.inspect_universe u with
+       | FStar_Tactics_NamedView.Uv_BVar uu___ ->
+           Obj.magic
+             (Obj.repr
+                (FStar_Tactics_Effect.lift_div_tac (fun uu___1 -> false)))
+       | FStar_Tactics_NamedView.Uv_Name uu___ ->
+           Obj.magic
+             (Obj.repr
+                (FStar_Tactics_Effect.lift_div_tac (fun uu___1 -> true)))
+       | FStar_Tactics_NamedView.Uv_Unif uu___ ->
+           Obj.magic
+             (Obj.repr
+                (FStar_Tactics_Effect.lift_div_tac (fun uu___1 -> false)))
+       | FStar_Tactics_NamedView.Uv_Zero ->
+           Obj.magic
+             (Obj.repr
+                (FStar_Tactics_Effect.lift_div_tac (fun uu___ -> true)))
+       | FStar_Tactics_NamedView.Uv_Succ u1 ->
+           Obj.magic (Obj.repr (check_u u1))
+       | FStar_Tactics_NamedView.Uv_Max us ->
+           Obj.magic (Obj.repr (for_all check_u us))
+       | FStar_Tactics_NamedView.Uv_Unk ->
+           Obj.magic
+             (Obj.repr
+                (FStar_Tactics_Effect.lift_div_tac (fun uu___ -> true))))
+      uu___
+and (check_comp :
+  FStar_Tactics_NamedView.comp ->
+    (Prims.bool, unit) FStar_Tactics_Effect.tac_repr)
+  =
+  fun c ->
+    match c with
+    | FStar_Reflection_V2_Data.C_Total typ -> check typ
+    | FStar_Reflection_V2_Data.C_GTotal typ -> check typ
+    | FStar_Reflection_V2_Data.C_Lemma (pre, post, pats) ->
+        FStar_Tactics_Effect.tac_bind
+          (FStar_Sealed.seal
+             (Obj.magic
+                (FStar_Range.mk_range "FStar.Tactics.CheckLN.fst"
+                   (Prims.of_int (56)) (Prims.of_int (7)) (Prims.of_int (56))
+                   (Prims.of_int (22)))))
+          (FStar_Sealed.seal
+             (Obj.magic
+                (FStar_Range.mk_range "FStar.Tactics.CheckLN.fst"
+                   (Prims.of_int (56)) (Prims.of_int (4)) (Prims.of_int (58))
+                   (Prims.of_int (14)))))
+          (Obj.magic
+             (FStar_Tactics_Effect.tac_bind
+                (FStar_Sealed.seal
+                   (Obj.magic
+                      (FStar_Range.mk_range "FStar.Tactics.CheckLN.fst"
+                         (Prims.of_int (56)) (Prims.of_int (11))
+                         (Prims.of_int (56)) (Prims.of_int (22)))))
+                (FStar_Sealed.seal
+                   (Obj.magic
+                      (FStar_Range.mk_range "FStar.Tactics.CheckLN.fst"
+                         (Prims.of_int (56)) (Prims.of_int (7))
+                         (Prims.of_int (56)) (Prims.of_int (22)))))
+                (Obj.magic (check pre))
+                (fun uu___ ->
+                   FStar_Tactics_Effect.lift_div_tac
+                     (fun uu___1 -> Prims.op_Negation uu___))))
+          (fun uu___ ->
+             (fun uu___ ->
+                if uu___
+                then
+                  Obj.magic
+                    (Obj.repr
+                       (FStar_Tactics_Effect.lift_div_tac
+                          (fun uu___1 -> false)))
+                else
+                  Obj.magic
+                    (Obj.repr
+                       (FStar_Tactics_Effect.tac_bind
+                          (FStar_Sealed.seal
+                             (Obj.magic
+                                (FStar_Range.mk_range
+                                   "FStar.Tactics.CheckLN.fst"
+                                   (Prims.of_int (57)) (Prims.of_int (7))
+                                   (Prims.of_int (57)) (Prims.of_int (23)))))
+                          (FStar_Sealed.seal
+                             (Obj.magic
+                                (FStar_Range.mk_range
+                                   "FStar.Tactics.CheckLN.fst"
+                                   (Prims.of_int (57)) (Prims.of_int (4))
+                                   (Prims.of_int (58)) (Prims.of_int (14)))))
+                          (Obj.magic
+                             (FStar_Tactics_Effect.tac_bind
+                                (FStar_Sealed.seal
+                                   (Obj.magic
+                                      (FStar_Range.mk_range
+                                         "FStar.Tactics.CheckLN.fst"
+                                         (Prims.of_int (57))
+                                         (Prims.of_int (11))
+                                         (Prims.of_int (57))
+                                         (Prims.of_int (23)))))
+                                (FStar_Sealed.seal
+                                   (Obj.magic
+                                      (FStar_Range.mk_range
+                                         "FStar.Tactics.CheckLN.fst"
+                                         (Prims.of_int (57))
+                                         (Prims.of_int (7))
+                                         (Prims.of_int (57))
+                                         (Prims.of_int (23)))))
+                                (Obj.magic (check post))
+                                (fun uu___2 ->
+                                   FStar_Tactics_Effect.lift_div_tac
+                                     (fun uu___3 -> Prims.op_Negation uu___2))))
+                          (fun uu___2 ->
+                             (fun uu___2 ->
+                                if uu___2
+                                then
+                                  Obj.magic
+                                    (Obj.repr
+                                       (FStar_Tactics_Effect.lift_div_tac
+                                          (fun uu___3 -> false)))
+                                else Obj.magic (Obj.repr (check pats)))
+                               uu___2)))) uu___)
+    | FStar_Reflection_V2_Data.C_Eff (us, nm, res, args, decrs) ->
+        FStar_Tactics_Effect.tac_bind
+          (FStar_Sealed.seal
+             (Obj.magic
+                (FStar_Range.mk_range "FStar.Tactics.CheckLN.fst"
+                   (Prims.of_int (60)) (Prims.of_int (8)) (Prims.of_int (60))
+                   (Prims.of_int (32)))))
+          (FStar_Sealed.seal
+             (Obj.magic
+                (FStar_Range.mk_range "FStar.Tactics.CheckLN.fst"
+                   (Prims.of_int (60)) (Prims.of_int (5)) (Prims.of_int (64))
+                   (Prims.of_int (9)))))
+          (Obj.magic
+             (FStar_Tactics_Effect.tac_bind
+                (FStar_Sealed.seal
+                   (Obj.magic
+                      (FStar_Range.mk_range "FStar.Tactics.CheckLN.fst"
+                         (Prims.of_int (60)) (Prims.of_int (12))
+                         (Prims.of_int (60)) (Prims.of_int (32)))))
+                (FStar_Sealed.seal
+                   (Obj.magic
+                      (FStar_Range.mk_range "FStar.Tactics.CheckLN.fst"
+                         (Prims.of_int (60)) (Prims.of_int (8))
+                         (Prims.of_int (60)) (Prims.of_int (32)))))
+                (Obj.magic (for_all check_u us))
+                (fun uu___ ->
+                   FStar_Tactics_Effect.lift_div_tac
+                     (fun uu___1 -> Prims.op_Negation uu___))))
+          (fun uu___ ->
+             (fun uu___ ->
+                if uu___
+                then
+                  Obj.magic
+                    (Obj.repr
+                       (FStar_Tactics_Effect.lift_div_tac
+                          (fun uu___1 -> false)))
+                else
+                  Obj.magic
+                    (Obj.repr
+                       (FStar_Tactics_Effect.tac_bind
+                          (FStar_Sealed.seal
+                             (Obj.magic
+                                (FStar_Range.mk_range
+                                   "FStar.Tactics.CheckLN.fst"
+                                   (Prims.of_int (61)) (Prims.of_int (8))
+                                   (Prims.of_int (61)) (Prims.of_int (23)))))
+                          (FStar_Sealed.seal
+                             (Obj.magic
+                                (FStar_Range.mk_range
+                                   "FStar.Tactics.CheckLN.fst"
+                                   (Prims.of_int (61)) (Prims.of_int (5))
+                                   (Prims.of_int (64)) (Prims.of_int (9)))))
+                          (Obj.magic
+                             (FStar_Tactics_Effect.tac_bind
+                                (FStar_Sealed.seal
+                                   (Obj.magic
+                                      (FStar_Range.mk_range
+                                         "FStar.Tactics.CheckLN.fst"
+                                         (Prims.of_int (61))
+                                         (Prims.of_int (12))
+                                         (Prims.of_int (61))
+                                         (Prims.of_int (23)))))
+                                (FStar_Sealed.seal
+                                   (Obj.magic
+                                      (FStar_Range.mk_range
+                                         "FStar.Tactics.CheckLN.fst"
+                                         (Prims.of_int (61))
+                                         (Prims.of_int (8))
+                                         (Prims.of_int (61))
+                                         (Prims.of_int (23)))))
+                                (Obj.magic (check res))
+                                (fun uu___2 ->
+                                   FStar_Tactics_Effect.lift_div_tac
+                                     (fun uu___3 -> Prims.op_Negation uu___2))))
+                          (fun uu___2 ->
+                             (fun uu___2 ->
+                                if uu___2
+                                then
+                                  Obj.magic
+                                    (Obj.repr
+                                       (FStar_Tactics_Effect.lift_div_tac
+                                          (fun uu___3 -> false)))
+                                else
+                                  Obj.magic
+                                    (Obj.repr
+                                       (FStar_Tactics_Effect.tac_bind
+                                          (FStar_Sealed.seal
+                                             (Obj.magic
+                                                (FStar_Range.mk_range
+                                                   "FStar.Tactics.CheckLN.fst"
+                                                   (Prims.of_int (62))
+                                                   (Prims.of_int (8))
+                                                   (Prims.of_int (62))
+                                                   (Prims.of_int (49)))))
+                                          (FStar_Sealed.seal
+                                             (Obj.magic
+                                                (FStar_Range.mk_range
+                                                   "FStar.Tactics.CheckLN.fst"
+                                                   (Prims.of_int (62))
+                                                   (Prims.of_int (5))
+                                                   (Prims.of_int (64))
+                                                   (Prims.of_int (9)))))
+                                          (Obj.magic
+                                             (FStar_Tactics_Effect.tac_bind
+                                                (FStar_Sealed.seal
+                                                   (Obj.magic
+                                                      (FStar_Range.mk_range
+                                                         "FStar.Tactics.CheckLN.fst"
+                                                         (Prims.of_int (62))
+                                                         (Prims.of_int (12))
+                                                         (Prims.of_int (62))
+                                                         (Prims.of_int (49)))))
+                                                (FStar_Sealed.seal
+                                                   (Obj.magic
+                                                      (FStar_Range.mk_range
+                                                         "FStar.Tactics.CheckLN.fst"
+                                                         (Prims.of_int (62))
+                                                         (Prims.of_int (8))
+                                                         (Prims.of_int (62))
+                                                         (Prims.of_int (49)))))
+                                                (Obj.magic
+                                                   (for_all
+                                                      (fun uu___4 ->
+                                                         match uu___4 with
+                                                         | (a, q) -> check a)
+                                                      args))
+                                                (fun uu___4 ->
+                                                   FStar_Tactics_Effect.lift_div_tac
+                                                     (fun uu___5 ->
+                                                        Prims.op_Negation
+                                                          uu___4))))
+                                          (fun uu___4 ->
+                                             (fun uu___4 ->
+                                                if uu___4
+                                                then
+                                                  Obj.magic
+                                                    (Obj.repr
+                                                       (FStar_Tactics_Effect.lift_div_tac
+                                                          (fun uu___5 ->
+                                                             false)))
+                                                else
+                                                  Obj.magic
+                                                    (Obj.repr
+                                                       (FStar_Tactics_Effect.tac_bind
+                                                          (FStar_Sealed.seal
+                                                             (Obj.magic
+                                                                (FStar_Range.mk_range
+                                                                   "FStar.Tactics.CheckLN.fst"
+                                                                   (Prims.of_int (63))
+                                                                   (Prims.of_int (8))
+                                                                   (Prims.of_int (63))
+                                                                   (Prims.of_int (33)))))
+                                                          (FStar_Sealed.seal
+                                                             (Obj.magic
+                                                                (FStar_Range.mk_range
+                                                                   "FStar.Tactics.CheckLN.fst"
+                                                                   (Prims.of_int (63))
+                                                                   (Prims.of_int (5))
+                                                                   (Prims.of_int (64))
+                                                                   (Prims.of_int (9)))))
+                                                          (Obj.magic
+                                                             (FStar_Tactics_Effect.tac_bind
+                                                                (FStar_Sealed.seal
+                                                                   (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "FStar.Tactics.CheckLN.fst"
+                                                                    (Prims.of_int (63))
+                                                                    (Prims.of_int (12))
+                                                                    (Prims.of_int (63))
+                                                                    (Prims.of_int (33)))))
+                                                                (FStar_Sealed.seal
+                                                                   (Obj.magic
+                                                                    (FStar_Range.mk_range
+                                                                    "FStar.Tactics.CheckLN.fst"
+                                                                    (Prims.of_int (63))
+                                                                    (Prims.of_int (8))
+                                                                    (Prims.of_int (63))
+                                                                    (Prims.of_int (33)))))
+                                                                (Obj.magic
+                                                                   (for_all
+                                                                    check
+                                                                    decrs))
+                                                                (fun uu___6
+                                                                   ->
+                                                                   FStar_Tactics_Effect.lift_div_tac
+                                                                    (fun
+                                                                    uu___7 ->
+                                                                    Prims.op_Negation
+                                                                    uu___6))))
+                                                          (fun uu___6 ->
+                                                             FStar_Tactics_Effect.lift_div_tac
+                                                               (fun uu___7 ->
+                                                                  if uu___6
+                                                                  then false
+                                                                  else true)))))
+                                               uu___4)))) uu___2)))) uu___)
+and (check_br :
+  FStar_Tactics_NamedView.branch ->
+    (Prims.bool, unit) FStar_Tactics_Effect.tac_repr)
+  =
+  fun b ->
+    FStar_Tactics_Effect.tac_bind
+      (FStar_Sealed.seal
+         (Obj.magic
+            (FStar_Range.mk_range "FStar.Tactics.CheckLN.fst"
+               (Prims.of_int (68)) (Prims.of_int (15)) (Prims.of_int (68))
+               (Prims.of_int (16)))))
+      (FStar_Sealed.seal
+         (Obj.magic
+            (FStar_Range.mk_range "FStar.Tactics.CheckLN.fst"
+               (Prims.of_int (66)) (Prims.of_int (36)) (Prims.of_int (69))
+               (Prims.of_int (9)))))
+      (FStar_Tactics_Effect.lift_div_tac (fun uu___ -> b))
+      (fun uu___ ->
+         (fun uu___ -> match uu___ with | (p, t) -> Obj.magic (check t))
+           uu___)
+let (check_ln :
+  FStar_Tactics_NamedView.term ->
+    (Prims.bool, unit) FStar_Tactics_Effect.tac_repr)
+  = fun t -> check t
+let _ =
+  FStar_Tactics_Native.register_tactic "FStar.Tactics.CheckLN.check_ln"
+    (Prims.of_int (2))
+    (fun psc ->
+       fun ncb ->
+         fun args ->
+           FStar_Tactics_V2_InterpFuns.mk_tactic_interpretation_1
+             "FStar.Tactics.CheckLN.check_ln (plugin)"
+             (FStar_Tactics_Native.from_tactic_1 check_ln)
+             FStar_Reflection_V2_Embeddings.e_term
+             FStar_Syntax_Embeddings.e_bool psc ncb args)

--- a/ocaml/fstar-lib/generated/FStar_Tactics_NamedView.ml
+++ b/ocaml/fstar-lib/generated/FStar_Tactics_NamedView.ml
@@ -550,24 +550,24 @@ let rec __knot_e_named_term_view _ =
                         FStar_Reflection_V2_Embeddings.e_aqualv) a_100)
                   (fun a_100 ->
                      FStar_Pervasives_Native.Some (Tv_App (hd_99, a_100))))
-       | ("FStar.Tactics.NamedView.Tv_Abs", bv_102::body_103::[]) ->
+       | ("FStar.Tactics.NamedView.Tv_Abs", b_102::body_103::[]) ->
            FStar_Compiler_Util.bind_opt
-             (FStar_Syntax_Embeddings_Base.extracted_unembed e_binder bv_102)
-             (fun bv_102 ->
+             (FStar_Syntax_Embeddings_Base.extracted_unembed e_binder b_102)
+             (fun b_102 ->
                 FStar_Compiler_Util.bind_opt
                   (FStar_Syntax_Embeddings_Base.extracted_unembed
                      FStar_Reflection_V2_Embeddings.e_term body_103)
                   (fun body_103 ->
-                     FStar_Pervasives_Native.Some (Tv_Abs (bv_102, body_103))))
-       | ("FStar.Tactics.NamedView.Tv_Arrow", bv_105::c_106::[]) ->
+                     FStar_Pervasives_Native.Some (Tv_Abs (b_102, body_103))))
+       | ("FStar.Tactics.NamedView.Tv_Arrow", b_105::c_106::[]) ->
            FStar_Compiler_Util.bind_opt
-             (FStar_Syntax_Embeddings_Base.extracted_unembed e_binder bv_105)
-             (fun bv_105 ->
+             (FStar_Syntax_Embeddings_Base.extracted_unembed e_binder b_105)
+             (fun b_105 ->
                 FStar_Compiler_Util.bind_opt
                   (FStar_Syntax_Embeddings_Base.extracted_unembed
                      FStar_Reflection_V2_Embeddings.e_comp_view c_106)
                   (fun c_106 ->
-                     FStar_Pervasives_Native.Some (Tv_Arrow (bv_105, c_106))))
+                     FStar_Pervasives_Native.Some (Tv_Arrow (b_105, c_106))))
        | ("FStar.Tactics.NamedView.Tv_Type", _0_108::[]) ->
            FStar_Compiler_Util.bind_opt
              (FStar_Syntax_Embeddings_Base.extracted_unembed
@@ -749,20 +749,20 @@ let rec __knot_e_named_term_view _ =
                     FStar_Reflection_V2_Embeddings.e_term
                     FStar_Reflection_V2_Embeddings.e_aqualv) a_151),
                FStar_Pervasives_Native.None)]
-       | Tv_Abs (bv_153, body_154) ->
+       | Tv_Abs (b_153, body_154) ->
            FStar_Syntax_Util.mk_app
              (FStar_Syntax_Syntax.tdataconstr
                 (FStar_Ident.lid_of_str "FStar.Tactics.NamedView.Tv_Abs"))
-             [((FStar_Syntax_Embeddings_Base.extracted_embed e_binder bv_153),
+             [((FStar_Syntax_Embeddings_Base.extracted_embed e_binder b_153),
                 FStar_Pervasives_Native.None);
              ((FStar_Syntax_Embeddings_Base.extracted_embed
                  FStar_Reflection_V2_Embeddings.e_term body_154),
                FStar_Pervasives_Native.None)]
-       | Tv_Arrow (bv_156, c_157) ->
+       | Tv_Arrow (b_156, c_157) ->
            FStar_Syntax_Util.mk_app
              (FStar_Syntax_Syntax.tdataconstr
                 (FStar_Ident.lid_of_str "FStar.Tactics.NamedView.Tv_Arrow"))
-             [((FStar_Syntax_Embeddings_Base.extracted_embed e_binder bv_156),
+             [((FStar_Syntax_Embeddings_Base.extracted_embed e_binder b_156),
                 FStar_Pervasives_Native.None);
              ((FStar_Syntax_Embeddings_Base.extracted_embed
                  FStar_Reflection_V2_Embeddings.e_comp_view c_157),
@@ -920,18 +920,18 @@ let (__proj__Tv_App__item__a :
   fun projectee -> match projectee with | Tv_App (hd, a) -> a
 let (uu___is_Tv_Abs : named_term_view -> Prims.bool) =
   fun projectee ->
-    match projectee with | Tv_Abs (bv1, body) -> true | uu___ -> false
-let (__proj__Tv_Abs__item__bv : named_term_view -> binder) =
-  fun projectee -> match projectee with | Tv_Abs (bv1, body) -> bv1
+    match projectee with | Tv_Abs (b, body) -> true | uu___ -> false
+let (__proj__Tv_Abs__item__b : named_term_view -> binder) =
+  fun projectee -> match projectee with | Tv_Abs (b, body) -> b
 let (__proj__Tv_Abs__item__body : named_term_view -> term) =
-  fun projectee -> match projectee with | Tv_Abs (bv1, body) -> body
+  fun projectee -> match projectee with | Tv_Abs (b, body) -> body
 let (uu___is_Tv_Arrow : named_term_view -> Prims.bool) =
   fun projectee ->
-    match projectee with | Tv_Arrow (bv1, c) -> true | uu___ -> false
-let (__proj__Tv_Arrow__item__bv : named_term_view -> binder) =
-  fun projectee -> match projectee with | Tv_Arrow (bv1, c) -> bv1
+    match projectee with | Tv_Arrow (b, c) -> true | uu___ -> false
+let (__proj__Tv_Arrow__item__b : named_term_view -> binder) =
+  fun projectee -> match projectee with | Tv_Arrow (b, c) -> b
 let (__proj__Tv_Arrow__item__c : named_term_view -> comp) =
-  fun projectee -> match projectee with | Tv_Arrow (bv1, c) -> c
+  fun projectee -> match projectee with | Tv_Arrow (b, c) -> c
 let (uu___is_Tv_Type : named_term_view -> Prims.bool) =
   fun projectee -> match projectee with | Tv_Type _0 -> true | uu___ -> false
 let (__proj__Tv_Type__item___0 : named_term_view -> universe) =

--- a/ocaml/fstar-lib/generated/FStar_Tactics_V2_Basic.ml
+++ b/ocaml/fstar-lib/generated/FStar_Tactics_V2_Basic.ml
@@ -6967,18 +6967,49 @@ let catch_all :
              FStar_Tactics_Result.Success ((FStar_Pervasives.Inl errs), ps))
 let refl_typing_builtin_wrapper :
   'a .
-    (unit -> ('a * (env * FStar_Syntax_Syntax.typ) Prims.list)) ->
-      ('a FStar_Pervasives_Native.option * issues) FStar_Tactics_Monad.tac
+    Prims.string ->
+      (unit -> ('a * (env * FStar_Syntax_Syntax.typ) Prims.list)) ->
+        ('a FStar_Pervasives_Native.option * issues) FStar_Tactics_Monad.tac
   =
-  fun f ->
-    let uu___ =
-      let uu___1 = __refl_typing_builtin_wrapper f in catch_all uu___1 in
-    FStar_Tactics_Monad.op_let_Bang uu___
-      (fun uu___1 ->
-         match uu___1 with
-         | FStar_Pervasives.Inl errs ->
-             FStar_Tactics_Monad.ret (FStar_Pervasives_Native.None, errs)
-         | FStar_Pervasives.Inr r -> FStar_Tactics_Monad.ret r)
+  fun label ->
+    fun f ->
+      let uu___ =
+        let uu___1 =
+          let uu___2 = __refl_typing_builtin_wrapper f in catch_all uu___2 in
+        FStar_Tactics_Monad.op_let_Bang uu___1
+          (fun uu___2 ->
+             match uu___2 with
+             | FStar_Pervasives.Inl errs ->
+                 FStar_Tactics_Monad.ret (FStar_Pervasives_Native.None, errs)
+             | FStar_Pervasives.Inr r -> FStar_Tactics_Monad.ret r) in
+      FStar_Tactics_Monad.op_let_Bang uu___
+        (fun uu___1 ->
+           match uu___1 with
+           | (o, errs) ->
+               let errs1 =
+                 FStar_Compiler_Effect.op_Bar_Greater errs
+                   (FStar_Compiler_List.map
+                      (fun is ->
+                         let uu___2 =
+                           let uu___3 =
+                             let uu___4 =
+                               FStar_Errors_Msg.text
+                                 (Prims.op_Hat "Raised within Tactics." label) in
+                             [uu___4] in
+                           FStar_Compiler_List.op_At
+                             is.FStar_Errors.issue_msg uu___3 in
+                         {
+                           FStar_Errors.issue_msg = uu___2;
+                           FStar_Errors.issue_level =
+                             (is.FStar_Errors.issue_level);
+                           FStar_Errors.issue_range =
+                             (is.FStar_Errors.issue_range);
+                           FStar_Errors.issue_number =
+                             (is.FStar_Errors.issue_number);
+                           FStar_Errors.issue_ctx =
+                             (is.FStar_Errors.issue_ctx)
+                         })) in
+               FStar_Tactics_Monad.ret (o, errs1))
 let (no_uvars_in_term : FStar_Syntax_Syntax.term -> Prims.bool) =
   fun t ->
     (let uu___ =
@@ -7034,7 +7065,7 @@ let (refl_is_non_informative :
       let uu___ = (no_uvars_in_g g) && (no_uvars_in_term t) in
       if uu___
       then
-        refl_typing_builtin_wrapper
+        refl_typing_builtin_wrapper "refl_is_non_informative"
           (fun uu___1 ->
              let g1 =
                FStar_TypeChecker_Env.set_range g t.FStar_Syntax_Syntax.pos in
@@ -7082,7 +7113,7 @@ let (refl_check_relation :
               (no_uvars_in_term t1) in
           if uu___
           then
-            refl_typing_builtin_wrapper
+            refl_typing_builtin_wrapper "refl_check_relation"
               (fun uu___1 ->
                  let g1 =
                    FStar_TypeChecker_Env.set_range g
@@ -7177,7 +7208,7 @@ let (refl_core_compute_term_type :
       let uu___ = (no_uvars_in_g g) && (no_uvars_in_term e) in
       if uu___
       then
-        refl_typing_builtin_wrapper
+        refl_typing_builtin_wrapper "refl_core_compute_term_type"
           (fun uu___1 ->
              let g1 =
                FStar_TypeChecker_Env.set_range g e.FStar_Syntax_Syntax.pos in
@@ -7247,7 +7278,7 @@ let (refl_core_check_term :
               (no_uvars_in_term t) in
           if uu___
           then
-            refl_typing_builtin_wrapper
+            refl_typing_builtin_wrapper "refl_core_check_term"
               (fun uu___1 ->
                  let g1 =
                    FStar_TypeChecker_Env.set_range g
@@ -7313,7 +7344,7 @@ let (refl_core_check_term_at_type :
           ((no_uvars_in_g g) && (no_uvars_in_term e)) && (no_uvars_in_term t) in
         if uu___
         then
-          refl_typing_builtin_wrapper
+          refl_typing_builtin_wrapper "refl_core_check_term_at_type"
             (fun uu___1 ->
                let g1 =
                  FStar_TypeChecker_Env.set_range g e.FStar_Syntax_Syntax.pos in
@@ -7376,7 +7407,7 @@ let (refl_tc_term :
       let uu___ = (no_uvars_in_g g) && (no_uvars_in_term e) in
       if uu___
       then
-        refl_typing_builtin_wrapper
+        refl_typing_builtin_wrapper "refl_tc_term"
           (fun uu___1 ->
              let g1 =
                FStar_TypeChecker_Env.set_range g e.FStar_Syntax_Syntax.pos in
@@ -7740,7 +7771,7 @@ let (refl_universe_of :
       let uu___ = (no_uvars_in_g g) && (no_uvars_in_term e) in
       if uu___
       then
-        refl_typing_builtin_wrapper
+        refl_typing_builtin_wrapper "refl_universe_of"
           (fun uu___1 ->
              let g1 =
                FStar_TypeChecker_Env.set_range g e.FStar_Syntax_Syntax.pos in
@@ -7792,7 +7823,7 @@ let (refl_check_prop_validity :
       let uu___ = (no_uvars_in_g g) && (no_uvars_in_term e) in
       if uu___
       then
-        refl_typing_builtin_wrapper
+        refl_typing_builtin_wrapper "refl_check_prop_validity"
           (fun uu___1 ->
              let g1 =
                FStar_TypeChecker_Env.set_range g e.FStar_Syntax_Syntax.pos in
@@ -7961,7 +7992,7 @@ let (refl_instantiate_implicits :
       let uu___ = (no_uvars_in_g g) && (no_uvars_in_term e) in
       if uu___
       then
-        refl_typing_builtin_wrapper
+        refl_typing_builtin_wrapper "refl_instantiate_implicits"
           (fun uu___1 ->
              let g1 =
                FStar_TypeChecker_Env.set_range g e.FStar_Syntax_Syntax.pos in
@@ -8161,7 +8192,7 @@ let (refl_maybe_relate_after_unfolding :
             (no_uvars_in_term t1) in
         if uu___
         then
-          refl_typing_builtin_wrapper
+          refl_typing_builtin_wrapper "refl_maybe_relate_after_unfolding"
             (fun uu___1 ->
                let g1 =
                  FStar_TypeChecker_Env.set_range g t0.FStar_Syntax_Syntax.pos in
@@ -8201,7 +8232,7 @@ let (refl_maybe_unfold_head :
       let uu___ = (no_uvars_in_g g) && (no_uvars_in_term e) in
       if uu___
       then
-        refl_typing_builtin_wrapper
+        refl_typing_builtin_wrapper "refl_maybe_unfold_head"
           (fun uu___1 ->
              let g1 =
                FStar_TypeChecker_Env.set_range g e.FStar_Syntax_Syntax.pos in

--- a/ocaml/fstar-lib/generated/FStar_TypeChecker_Rel.ml
+++ b/ocaml/fstar-lib/generated/FStar_TypeChecker_Rel.ml
@@ -2259,7 +2259,7 @@ let (solve_prob' :
                                           [uu___5]))
                             | uu___3 -> (fail (); [])))) in
              let wl1 =
-               let g = whnf wl.tcenv (p_guard prob) in
+               let g = whnf (p_env wl prob) (p_guard prob) in
                let uu___1 =
                  let uu___2 = is_flex g in Prims.op_Negation uu___2 in
                if uu___1
@@ -13390,52 +13390,56 @@ let (try_teq :
     fun env ->
       fun t1 ->
         fun t2 ->
-          let uu___ =
-            let uu___1 =
-              let uu___2 = FStar_TypeChecker_Env.current_module env in
-              FStar_Ident.string_of_lid uu___2 in
-            FStar_Pervasives_Native.Some uu___1 in
-          FStar_Profiling.profile
-            (fun uu___1 ->
-               (let uu___3 =
-                  FStar_Compiler_Effect.op_Less_Bar
-                    (FStar_TypeChecker_Env.debug env)
-                    (FStar_Options.Other "Rel") in
-                if uu___3
-                then
-                  let uu___4 = FStar_Syntax_Print.term_to_string t1 in
-                  let uu___5 = FStar_Syntax_Print.term_to_string t2 in
-                  let uu___6 =
-                    FStar_TypeChecker_Env.print_gamma
-                      env.FStar_TypeChecker_Env.gamma in
-                  FStar_Compiler_Util.print3 "try_teq of %s and %s in %s {\n"
-                    uu___4 uu___5 uu___6
-                else ());
-               (let uu___3 =
-                  let uu___4 = FStar_TypeChecker_Env.get_range env in
-                  new_t_problem (empty_worklist env) env t1
-                    FStar_TypeChecker_Common.EQ t2
-                    FStar_Pervasives_Native.None uu___4 in
-                match uu___3 with
-                | (prob, wl) ->
-                    let g =
-                      let uu___4 =
-                        solve_and_commit (singleton wl prob smt_ok)
-                          (fun uu___5 -> FStar_Pervasives_Native.None) in
-                      FStar_Compiler_Effect.op_Less_Bar (with_guard env prob)
-                        uu___4 in
-                    ((let uu___5 =
-                        FStar_Compiler_Effect.op_Less_Bar
-                          (FStar_TypeChecker_Env.debug env)
-                          (FStar_Options.Other "Rel") in
-                      if uu___5
-                      then
-                        let uu___6 =
-                          FStar_Common.string_of_option (guard_to_string env)
-                            g in
-                        FStar_Compiler_Util.print1 "} res = %s\n" uu___6
-                      else ());
-                     g))) uu___ "FStar.TypeChecker.Rel.try_teq"
+          FStar_TypeChecker_Env.def_check_closed_in_env
+            t1.FStar_Syntax_Syntax.pos "try_teq.1" env t1;
+          FStar_TypeChecker_Env.def_check_closed_in_env
+            t2.FStar_Syntax_Syntax.pos "try_teq.2" env t2;
+          (let uu___2 =
+             let uu___3 =
+               let uu___4 = FStar_TypeChecker_Env.current_module env in
+               FStar_Ident.string_of_lid uu___4 in
+             FStar_Pervasives_Native.Some uu___3 in
+           FStar_Profiling.profile
+             (fun uu___3 ->
+                (let uu___5 =
+                   FStar_Compiler_Effect.op_Less_Bar
+                     (FStar_TypeChecker_Env.debug env)
+                     (FStar_Options.Other "Rel") in
+                 if uu___5
+                 then
+                   let uu___6 = FStar_Syntax_Print.term_to_string t1 in
+                   let uu___7 = FStar_Syntax_Print.term_to_string t2 in
+                   let uu___8 =
+                     FStar_TypeChecker_Env.print_gamma
+                       env.FStar_TypeChecker_Env.gamma in
+                   FStar_Compiler_Util.print3
+                     "try_teq of %s and %s in %s {\n" uu___6 uu___7 uu___8
+                 else ());
+                (let uu___5 =
+                   let uu___6 = FStar_TypeChecker_Env.get_range env in
+                   new_t_problem (empty_worklist env) env t1
+                     FStar_TypeChecker_Common.EQ t2
+                     FStar_Pervasives_Native.None uu___6 in
+                 match uu___5 with
+                 | (prob, wl) ->
+                     let g =
+                       let uu___6 =
+                         solve_and_commit (singleton wl prob smt_ok)
+                           (fun uu___7 -> FStar_Pervasives_Native.None) in
+                       FStar_Compiler_Effect.op_Less_Bar
+                         (with_guard env prob) uu___6 in
+                     ((let uu___7 =
+                         FStar_Compiler_Effect.op_Less_Bar
+                           (FStar_TypeChecker_Env.debug env)
+                           (FStar_Options.Other "Rel") in
+                       if uu___7
+                       then
+                         let uu___8 =
+                           FStar_Common.string_of_option
+                             (guard_to_string env) g in
+                         FStar_Compiler_Util.print1 "} res = %s\n" uu___8
+                       else ());
+                      g))) uu___2 "FStar.TypeChecker.Rel.try_teq")
 let (teq :
   FStar_TypeChecker_Env.env ->
     FStar_Syntax_Syntax.typ ->

--- a/src/extraction/FStar.Extraction.ML.Term.fst
+++ b/src/extraction/FStar.Extraction.ML.Term.fst
@@ -97,13 +97,14 @@ let err_value_restriction t =
                     (Print.tag_of_term t) (Print.term_to_string t))
 
 let err_unexpected_eff env t ty f0 f1 =
-    Errors.log_issue t.pos
-      (Warning_ExtractionUnexpectedEffect,
-       BU.format4 "for expression %s of type %s, Expected effect %s; got effect %s"
-                        (Print.term_to_string t)
-                        (Code.string_of_mlty (current_module_of_uenv env) ty)
-                        (eff_to_string f0)
-                        (eff_to_string f1))
+    let open FStar.Errors.Msg in
+    let open FStar.Pprint in
+    Errors.log_issue_doc t.pos
+      (Warning_ExtractionUnexpectedEffect, [
+        prefix 4 1 (text "For expression") (Print.term_to_doc t) ^/^
+        prefix 4 1 (text "of type") (arbitrary_string (Code.string_of_mlty (current_module_of_uenv env) ty));
+        prefix 4 1 (text "Expected effect") (arbitrary_string (eff_to_string f0)) ^/^
+        prefix 4 1 (text "got effect") (arbitrary_string (eff_to_string f0))])
 
 let err_cannot_extract_effect (l:lident) (r:Range.range) (reason:string) (ctxt:string) =
   Errors.raise_error_doc

--- a/src/tactics/FStar.Tactics.V2.Basic.fst
+++ b/src/tactics/FStar.Tactics.V2.Basic.fst
@@ -2198,11 +2198,18 @@ let catch_all (f : tac 'a) : tac (either issues 'a) =
 above (__refl_typing_builtin_wrapper) is meant to catch errors in the
 execution of the primitive we are calling. This second is meant to catch
 errors in the tactic execution, e.g. those related to discharging the
-guards if a synchronous mode (SMTSync/Force) was used. *)
-let refl_typing_builtin_wrapper (f:unit -> 'a & list (env & typ)) : tac (option 'a & issues) =
-  match! catch_all (__refl_typing_builtin_wrapper f) with
-  | Inl errs -> ret (None, errs)
-  | Inr r -> ret r
+guards if a synchronous mode (SMTSync/Force) was used.
+
+This also adds the label to the messages. *)
+let refl_typing_builtin_wrapper (label:string) (f:unit -> 'a & list (env & typ)) : tac (option 'a & issues) =
+  let open FStar.Errors in
+  let! o, errs =
+    match! catch_all (__refl_typing_builtin_wrapper f) with
+    | Inl errs -> ret (None, errs)
+    | Inr r -> ret r
+  in
+  let errs = errs |> List.map (fun is -> { is with issue_msg = is.issue_msg @ [text ("Raised within Tactics." ^ label)] }) in
+  ret (o, errs)
 
 let no_uvars_in_term (t:term) : bool =
   t |> Free.uvars |> BU.set_is_empty &&
@@ -2231,7 +2238,7 @@ let unexpected_uvars_issue r =
 let refl_is_non_informative (g:env) (t:typ) : tac (option unit & issues) =
   if no_uvars_in_g g &&
      no_uvars_in_term t
-  then refl_typing_builtin_wrapper (fun _ ->
+  then refl_typing_builtin_wrapper "refl_is_non_informative" (fun _ ->
          let g = Env.set_range g t.pos in
          dbg_refl g (fun _ ->
            BU.format1 "refl_is_non_informative: %s\n"
@@ -2253,7 +2260,7 @@ let refl_check_relation (g:env) (t0 t1:typ) (rel:relation)
   if no_uvars_in_g g &&
      no_uvars_in_term t0 &&
      no_uvars_in_term t1
-  then refl_typing_builtin_wrapper (fun _ ->
+  then refl_typing_builtin_wrapper "refl_check_relation" (fun _ ->
          let g = Env.set_range g t0.pos in
          dbg_refl g (fun _ ->
            BU.format3 "refl_check_relation: %s %s %s\n"
@@ -2300,7 +2307,7 @@ let refl_norm_type (g:env) (t:typ) : typ =
 let refl_core_compute_term_type (g:env) (e:term) : tac (option (Core.tot_or_ghost & typ) & issues) =
   if no_uvars_in_g g &&
      no_uvars_in_term e
-  then refl_typing_builtin_wrapper (fun _ ->
+  then refl_typing_builtin_wrapper "refl_core_compute_term_type" (fun _ ->
          let g = Env.set_range g e.pos in
          dbg_refl g (fun _ ->
            BU.format1 "refl_core_compute_term_type: %s\n" (Print.term_to_string e));
@@ -2331,7 +2338,7 @@ let refl_core_check_term (g:env) (e:term) (t:typ) (eff:Core.tot_or_ghost)
   if no_uvars_in_g g &&
      no_uvars_in_term e &&
      no_uvars_in_term t
-  then refl_typing_builtin_wrapper (fun _ ->
+  then refl_typing_builtin_wrapper "refl_core_check_term" (fun _ ->
          let g = Env.set_range g e.pos in
          dbg_refl g (fun _ ->
            BU.format3 "refl_core_check_term: term: %s, type: %s, eff: %s\n"
@@ -2357,7 +2364,7 @@ let refl_core_check_term_at_type (g:env) (e:term) (t:typ)
   if no_uvars_in_g g &&
      no_uvars_in_term e &&
      no_uvars_in_term t
-  then refl_typing_builtin_wrapper (fun _ ->
+  then refl_typing_builtin_wrapper "refl_core_check_term_at_type" (fun _ ->
          let g = Env.set_range g e.pos in
          dbg_refl g (fun _ ->
            BU.format2 "refl_core_check_term_at_type: term: %s, type: %s\n"
@@ -2382,7 +2389,7 @@ let refl_core_check_term_at_type (g:env) (e:term) (t:typ)
 let refl_tc_term (g:env) (e:term) : tac (option (term & (Core.tot_or_ghost & typ)) & issues) =
   if no_uvars_in_g g &&
      no_uvars_in_term e
-  then refl_typing_builtin_wrapper (fun _ ->
+  then refl_typing_builtin_wrapper "refl_tc_term" (fun _ ->
     let g = Env.set_range g e.pos in
     dbg_refl g (fun _ ->
       BU.format2 "refl_tc_term@%s: %s\n" (Range.string_of_range e.pos) (Print.term_to_string e));
@@ -2465,7 +2472,7 @@ let refl_universe_of (g:env) (e:term) : tac (option universe & issues) =
 
   if no_uvars_in_g g &&
      no_uvars_in_term e
-  then refl_typing_builtin_wrapper (fun _ ->
+  then refl_typing_builtin_wrapper "refl_universe_of" (fun _ ->
          let g = Env.set_range g e.pos in
          let t, u = U.type_u () in
          let must_tot = false in
@@ -2482,7 +2489,7 @@ let refl_universe_of (g:env) (e:term) : tac (option universe & issues) =
 let refl_check_prop_validity (g:env) (e:term) : tac (option unit & issues) =
   if no_uvars_in_g g &&
      no_uvars_in_term e
-  then refl_typing_builtin_wrapper (fun _ ->
+  then refl_typing_builtin_wrapper "refl_check_prop_validity" (fun _ ->
          let g = Env.set_range g e.pos in
          dbg_refl g (fun _ ->
            BU.format1 "refl_check_prop_validity: %s\n" (Print.term_to_string e));
@@ -2538,7 +2545,7 @@ let refl_check_match_complete (g:env) (sc:term) (scty:typ) (pats : list RD.patte
 let refl_instantiate_implicits (g:env) (e:term) : tac (option (term & typ) & issues) =
   if no_uvars_in_g g &&
      no_uvars_in_term e
-  then refl_typing_builtin_wrapper (fun _ ->
+  then refl_typing_builtin_wrapper "refl_instantiate_implicits" (fun _ ->
     let g = Env.set_range g e.pos in
     dbg_refl g (fun _ ->
       BU.format1 "refl_instantiate_implicits: %s\n" (Print.term_to_string e));
@@ -2583,7 +2590,7 @@ let refl_maybe_relate_after_unfolding (g:env) (t0 t1:typ)
   if no_uvars_in_g g &&
      no_uvars_in_term t0 &&
      no_uvars_in_term t1
-  then refl_typing_builtin_wrapper (fun _ ->
+  then refl_typing_builtin_wrapper "refl_maybe_relate_after_unfolding" (fun _ ->
         let g = Env.set_range g t0.pos in
          dbg_refl g (fun _ ->
            BU.format2 "refl_maybe_relate_after_unfolding: %s and %s {\n"
@@ -2599,7 +2606,7 @@ let refl_maybe_relate_after_unfolding (g:env) (t0 t1:typ)
 let refl_maybe_unfold_head (g:env) (e:term) : tac (option term & issues) =
   if no_uvars_in_g g &&
      no_uvars_in_term e
-  then refl_typing_builtin_wrapper (fun _ ->
+  then refl_typing_builtin_wrapper "refl_maybe_unfold_head" (fun _ ->
     let g = Env.set_range g e.pos in
     dbg_refl g (fun _ ->
       BU.format1 "refl_maybe_unfold_head: %s {\n" (Print.term_to_string e));

--- a/src/typechecker/FStar.TypeChecker.Rel.fst
+++ b/src/typechecker/FStar.TypeChecker.Rel.fst
@@ -1015,7 +1015,7 @@ let solve_prob' resolve_ok prob logical_guard uvis wl =
               [])
     in
     let wl =
-        let g = whnf wl.tcenv (p_guard prob) in
+        let g = whnf (p_env wl prob) (p_guard prob) in
         if not (is_flex g)
         then if resolve_ok
              then wl
@@ -4756,6 +4756,8 @@ let with_guard env prob dopt =
                   implicits=implicits})
 
 let try_teq smt_ok env t1 t2 : option guard_t =
+  def_check_closed_in_env t1.pos "try_teq.1" env t1;
+  def_check_closed_in_env t2.pos "try_teq.2" env t2;
   Profiling.profile
     (fun () ->
       if Env.debug env <| Options.Other "Rel" then

--- a/src/typechecker/FStar.TypeChecker.Rel.fsti
+++ b/src/typechecker/FStar.TypeChecker.Rel.fsti
@@ -60,7 +60,7 @@ val base_and_refinement_maybe_delta : bool -> env -> term -> term * option (bv *
 val base_and_refinement       : env -> term -> term * option (bv * term)
 
 val unrefine   : env -> typ -> typ
-val try_teq    : bool -> env -> typ -> typ -> option guard_t
+val try_teq    : smt_ok:bool -> env -> typ -> typ -> option guard_t
 val teq        : env -> typ -> typ -> guard_t
 val get_teq_predicate : env -> typ -> typ -> option guard_t
 val teq_force  : env -> typ -> typ -> unit

--- a/tests/bug-reports/Bug3102.fst
+++ b/tests/bug-reports/Bug3102.fst
@@ -1,0 +1,56 @@
+module Bug3102
+
+let eqto #a (t:a) : Type = x:a{x==t}
+assume val tt : t:int -> Tot (eqto t)
+
+[@@expect_failure [56]]
+let min =
+  fun (t1:int) ->
+    let e1 = t1 in
+    tt e1
+
+open FStar.Tactics.V2
+
+let test0 : g:env -> t1:term -> t2:term -> Tac (ret_t (subtyping_token g t1 t2)) =
+  fun (g:env) (t1 t2:term) ->
+    let e2 = t2 in
+    check_subtyping g t1 e2
+
+[@@expect_failure [54]]
+// * Error 54 at Bug3102.fst(28,4-28,27):
+//   - (*?u23*) _ g t1 t2 is not equal to the expected type e2
+// Not great... but it does make sense as we wrote an _ that can only
+// mention g t1 and t2, and the escapes check does not trigger in the same way
+// as above
+let test1 : g:env -> t1:term -> t2:term -> Tac (ret_t (subtyping_token g t1 _)) =
+  fun (g:env) (t1 t2:term) ->
+    let e2 = t2 in
+    check_subtyping g t1 e2
+
+[@@expect_failure [54]]
+let test2 : g:env -> t1:term -> t2:term -> Tac _ =
+  fun (g:env) (t1 t2:term) ->
+    let e2 = t2 in
+    check_subtyping g t1 e2
+
+[@@expect_failure [56]]
+let test3 =
+  fun (g:env) (t1 t2:term) ->
+    let e2 = t2 in
+    check_subtyping g t1 e2
+
+assume val ff : x:int -> y:int{y == x}
+
+[@@expect_failure [56]]
+let gg =
+  fun (x:int) ->
+    let z = x in
+    ff z
+
+assume val f : x:int -> Tac (y:int{y == x})
+
+[@@expect_failure [56]]
+let g =
+  fun (x:int) ->
+    let z = x in
+    f z

--- a/tests/bug-reports/Makefile
+++ b/tests/bug-reports/Makefile
@@ -53,7 +53,7 @@ SHOULD_VERIFY_CLOSED=Bug022.fst Bug024.fst Bug025.fst Bug026.fst Bug026b.fst Bug
   Bug2684a.fst Bug2684b.fst Bug2684c.fst Bug2684d.fst Bug2659b.fst\
   Bug2756.fst MutualRecPositivity.fst Bug2806a.fst Bug2806b.fst Bug2806c.fst Bug2806d.fst Bug2809.fst\
   Bug2849a.fst Bug2849b.fst Bug2045.fst Bug2876.fst Bug2882.fst Bug2895.fst Bug2894.fst \
-	Bug2415.fst Bug3028.fst Bug2954.fst Bug3089.fst
+	Bug2415.fst Bug3028.fst Bug2954.fst Bug3089.fst Bug3102.fst
 
 SHOULD_VERIFY_INTERFACE_CLOSED=Bug771.fsti Bug771b.fsti
 SHOULD_VERIFY_AND_WARN_CLOSED=Bug016.fst

--- a/tests/error-messages/Bug3102.fst
+++ b/tests/error-messages/Bug3102.fst
@@ -1,0 +1,51 @@
+module Bug3102
+
+let eqto #a (t:a) : Type = x:a{x==t}
+assume val tt : t:int -> Tot (eqto t)
+
+[@@expect_failure [56]]
+let min =
+  fun (t1:int) ->
+    let e1 = t1 in
+    tt e1
+
+open FStar.Tactics.V2
+
+let test0 : g:env -> t1:term -> t2:term -> Tac (ret_t (subtyping_token g t1 t2)) =
+  fun (g:env) (t1 t2:term) ->
+    let e2 = t2 in
+    check_subtyping g t1 e2
+
+[@@expect_failure [54]]
+let test1 : g:env -> t1:term -> t2:term -> Tac (ret_t (subtyping_token g t1 _)) =
+  fun (g:env) (t1 t2:term) ->
+    let e2 = t2 in
+    check_subtyping g t1 e2
+
+[@@expect_failure [54]]
+let test2 : g:env -> t1:term -> t2:term -> Tac _ =
+  fun (g:env) (t1 t2:term) ->
+    let e2 = t2 in
+    check_subtyping g t1 e2
+
+[@@expect_failure [56]]
+let test3 =
+  fun (g:env) (t1 t2:term) ->
+    let e2 = t2 in
+    check_subtyping g t1 e2
+
+assume val ff : x:int -> y:int{y == x}
+
+[@@expect_failure [56]]
+let gg =
+  fun (x:int) ->
+    let z = x in
+    ff z
+
+assume val f : x:int -> Tac (y:int{y == x})
+
+[@@expect_failure [56]]
+let g =
+  fun (x:int) ->
+    let z = x in
+    f z

--- a/tests/error-messages/Bug3102.fst.expected
+++ b/tests/error-messages/Bug3102.fst.expected
@@ -1,0 +1,36 @@
+>> Got issues: [
+* Error 56 at Bug3102.fst(8,17-10,9):
+  - Bound variable 'e1#154' would escape in the type of this letbinding
+  - Add a type annotation that does not mention it
+
+>>]
+>> Got issues: [
+* Error 54 at Bug3102.fst(23,4-23,27):
+  - (*?u23*) _ g t1 t2 is not equal to the expected type e2
+
+>>]
+>> Got issues: [
+* Error 54 at Bug3102.fst(29,4-29,27):
+  - (*?u20*) _ is not equal to the expected type e2
+
+>>]
+>> Got issues: [
+* Error 56 at Bug3102.fst(33,29-35,27):
+  - Bound variable 'e2#953' would escape in the type of this letbinding
+  - Add a type annotation that does not mention it
+
+>>]
+>> Got issues: [
+* Error 56 at Bug3102.fst(41,16-43,8):
+  - Bound variable 'z#1072' would escape in the type of this letbinding
+  - Add a type annotation that does not mention it
+
+>>]
+>> Got issues: [
+* Error 56 at Bug3102.fst(49,16-51,7):
+  - Bound variable 'z#1156' would escape in the type of this letbinding
+  - Add a type annotation that does not mention it
+
+>>]
+Verified module: Bug3102
+All verification conditions discharged successfully

--- a/ulib/FStar.Tactics.CheckLN.fst
+++ b/ulib/FStar.Tactics.CheckLN.fst
@@ -1,0 +1,72 @@
+module FStar.Tactics.CheckLN
+
+open FStar.Tactics.V2
+open FStar.Tactics.Util
+
+let rec for_all (p : 'a -> Tac bool) (l : list 'a)  : Tac bool =
+  match l with
+  | [] -> true
+  | x::xs -> if p x then for_all p xs else false
+
+let rec check (t:term) : Tac bool =
+  match inspect t with
+  (* We are using the named view, which opens terms
+  as needed on every node. If we reach a bvar, the original
+  term is not LN. *)
+  | Tv_BVar bv -> false
+
+  | Tv_Const _ -> true
+  | Tv_Uvar _ _ -> false (* conservative *)
+
+  | Tv_Var _ -> true
+  | Tv_FVar _ -> true
+  | Tv_UInst _ us -> for_all check_u us
+  | Tv_App hd (a, q) -> if check hd then check a else false
+  | Tv_Abs b body -> if check b.sort then check body else false
+  | Tv_Arrow b c -> if check b.sort then check_comp c else false
+  | Tv_Type u -> check_u u
+  | Tv_Refine b ref -> if check b.sort then check ref else false
+  | Tv_Let recf attrs b def body ->
+    if not (for_all check attrs) then false else
+    if not (check def) then false else
+    check body
+  | Tv_Match sc _ brs -> 
+    if check sc then for_all check_br brs else false
+  | Tv_AscribedT e t _ _ ->
+    if check e then check t else false
+  | Tv_AscribedC e c _ _ ->
+    if check e then check_comp c else false
+
+  | Tv_Unknown -> true
+  | Tv_Unsupp -> true // hm..
+and check_u (u:universe) : Tac bool =
+  match inspect_universe u with
+  | Uv_BVar _ -> false
+  | Uv_Name _ -> true
+  | Uv_Unif _ -> false (* conservative *)
+  | Uv_Zero -> true
+  | Uv_Succ u -> check_u u
+  | Uv_Max us -> for_all check_u us
+  | Uv_Unk -> true
+and check_comp (c:comp) : Tac bool =
+  match c with
+  | C_Total typ -> check typ
+  | C_GTotal typ -> check typ
+  | C_Lemma pre post pats -> 
+    if not (check pre) then false else
+    if not (check post) then false else
+    check pats
+  | C_Eff us nm res args decrs ->
+     if not (for_all check_u us) then false else
+     if not (check res) then false else
+     if not (for_all (fun (a,q) -> check a) args) then false else
+     if not (for_all check decrs) then false else
+     true
+ 
+and check_br (b:branch) : Tac bool =
+  (* Could check the pattern's ascriptions too. *)
+  let (p, t) = b in
+  check t
+
+[@@plugin]
+let check_ln (t:term) : Tac bool = check t

--- a/ulib/FStar.Tactics.CheckLN.fsti
+++ b/ulib/FStar.Tactics.CheckLN.fsti
@@ -1,0 +1,7 @@
+module FStar.Tactics.CheckLN
+
+open FStar.Tactics.V2
+
+(* Checks if a term is locally nameless. *)
+[@@plugin]
+val check_ln (t:term) : Tac bool

--- a/ulib/FStar.Tactics.NamedView.fsti
+++ b/ulib/FStar.Tactics.NamedView.fsti
@@ -97,8 +97,8 @@ type named_term_view =
   | Tv_FVar   : v:fv -> named_term_view
   | Tv_UInst  : v:fv -> us:universes -> named_term_view
   | Tv_App    : hd:term -> a:argv -> named_term_view
-  | Tv_Abs    : bv:binder -> body:term -> named_term_view
-  | Tv_Arrow  : bv:binder -> c:comp -> named_term_view
+  | Tv_Abs    : b:binder -> body:term -> named_term_view
+  | Tv_Arrow  : b:binder -> c:comp -> named_term_view
   | Tv_Type   : universe -> named_term_view
   | Tv_Refine : b:simple_binder -> ref:term -> named_term_view
   | Tv_Const  : vconst -> named_term_view


### PR DESCRIPTION
This fixes #3102, which I should have realized was a variable escaping in the type of the letbinding. But, the error message was bad since it was raising an internal failure instead of properly reporting the escape. A patch in this PR fixes it (https://github.com/FStarLang/FStar/commit/ae3e0cdda57bbbbf5d79ea5c85f99c7e2fc59ac5), and there's some other misc stuff too.